### PR TITLE
Rewrapped component use emotion 11

### DIFF
--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/react';
 
 import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
@@ -13,7 +13,7 @@ type Props = {
 
 const BlockquoteRow = ({ children }: { children: React.ReactNode }) => (
 	<blockquote
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: row;
 		`}

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, ClassNames } from '@emotion/react';
 
 import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
@@ -22,70 +22,77 @@ const BlockquoteRow = ({ children }: { children: React.ReactNode }) => (
 	</blockquote>
 );
 
-const baseBlockquoteStyles = css`
-	margin-bottom: 16px;
-	${body.medium()};
-	font-style: italic;
-`;
-
-const simpleBlockquoteStyles = css`
-	${baseBlockquoteStyles}
-	margin-top: 16px;
-	margin-right: 0;
-	margin-bottom: 16px;
-	margin-left: 33px;
-`;
-
-const quotedBlockquoteStyles = (palette: Palette) => css`
-	${baseBlockquoteStyles}
-	color: ${palette.text.blockquote};
-`;
-
 export const BlockquoteBlockComponent: React.FC<Props> = ({
 	html,
 	palette,
 	quoted,
-}: Props) => {
-	const {
-		willUnwrap: isUnwrapped,
-		unwrappedHtml,
-		unwrappedElement,
-	} = unwrapHtml({
-		fixes: [
-			{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
-			{
-				prefix: '<blockquote>',
-				suffix: '</blockquote>',
-				unwrappedElement: 'blockquote',
-			},
-			{
-				prefix: '<blockquote class="quoted">',
-				suffix: '</blockquote>',
-				unwrappedElement: 'div',
-			},
-		],
-		html,
-	});
+}: Props) => (
+	<ClassNames>
+		{({ css: _css }) => {
+			const baseBlockquoteStyles = _css`
+			margin-bottom: 16px;
+			${body.medium()};
+			font-style: italic;
+		`;
 
-	if (quoted) {
-		return (
-			<BlockquoteRow>
-				<QuoteIcon colour={palette.fill.blockquoteIcon} size="medium" />
+			const simpleBlockquoteStyles = _css`
+			${baseBlockquoteStyles}
+			margin-top: 16px;
+			margin-right: 0;
+			margin-bottom: 16px;
+			margin-left: 33px;
+		`;
+
+			const quotedBlockquoteStyles = _css`
+			${baseBlockquoteStyles}
+			color: ${palette.text.blockquote};
+		`;
+
+			const {
+				willUnwrap: isUnwrapped,
+				unwrappedHtml,
+				unwrappedElement,
+			} = unwrapHtml({
+				fixes: [
+					{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
+					{
+						prefix: '<blockquote>',
+						suffix: '</blockquote>',
+						unwrappedElement: 'blockquote',
+					},
+					{
+						prefix: '<blockquote class="quoted">',
+						suffix: '</blockquote>',
+						unwrappedElement: 'div',
+					},
+				],
+				html,
+			});
+
+			if (quoted) {
+				return (
+					<BlockquoteRow>
+						<QuoteIcon
+							colour={palette.fill.blockquoteIcon}
+							size="medium"
+						/>
+						<RewrappedComponent
+							isUnwrapped={isUnwrapped}
+							html={unwrappedHtml}
+							elCss={quotedBlockquoteStyles}
+							tagName={unwrappedElement}
+						/>
+					</BlockquoteRow>
+				);
+			}
+			return (
 				<RewrappedComponent
 					isUnwrapped={isUnwrapped}
 					html={unwrappedHtml}
-					elCss={quotedBlockquoteStyles(palette)}
+					elCss={simpleBlockquoteStyles}
 					tagName={unwrappedElement}
 				/>
-			</BlockquoteRow>
-		);
-	}
-	return (
-		<RewrappedComponent
-			isUnwrapped={isUnwrapped}
-			html={unwrappedHtml}
-			elCss={simpleBlockquoteStyles}
-			tagName={unwrappedElement}
-		/>
-	);
-};
+			);
+		}}
+	</ClassNames>
+);

--- a/src/web/components/elements/HighlightBlockComponent.tsx
+++ b/src/web/components/elements/HighlightBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { ClassNames } from '@emotion/react';
 
 import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
@@ -9,37 +9,41 @@ type Props = {
 	html: string;
 };
 
-export const HighlightBlockComponent: React.FC<Props> = ({ html }: Props) => {
-	const {
-		willUnwrap: isUnwrapped,
-		unwrappedHtml,
-		unwrappedElement,
-	} = unwrapHtml({
-		fixes: [
-			{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
-			{
-				prefix: '<blockquote>',
-				suffix: '</blockquote>',
-				unwrappedElement: 'blockquote',
-			},
-		],
-		html,
-	});
+export const HighlightBlockComponent: React.FC<Props> = ({ html }: Props) => (
+	<ClassNames>
+		{({ css }) => {
+			const {
+				willUnwrap: isUnwrapped,
+				unwrappedHtml,
+				unwrappedElement,
+			} = unwrapHtml({
+				fixes: [
+					{ prefix: '<p>', suffix: '</p>', unwrappedElement: 'p' },
+					{
+						prefix: '<blockquote>',
+						suffix: '</blockquote>',
+						unwrappedElement: 'blockquote',
+					},
+				],
+				html,
+			});
 
-	return (
-		<RewrappedComponent
-			isUnwrapped={isUnwrapped}
-			html={unwrappedHtml}
-			elCss={css`
-				${body.medium({ lineHeight: 'tight' })};
-				background-color: ${background.secondary};
-				padding-top: 8px;
-				padding-bottom: 16px;
-				padding-left: 12px;
-				padding-right: 12px;
-				margin-bottom: 16px;
-			`}
-			tagName={unwrappedElement}
-		/>
-	);
-};
+			return (
+				<RewrappedComponent
+					isUnwrapped={isUnwrapped}
+					html={unwrappedHtml}
+					elCss={css`
+						${body.medium({ lineHeight: 'tight' })};
+						background-color: ${background.secondary};
+						padding-top: 8px;
+						padding-bottom: 16px;
+						padding-left: 12px;
+						padding-right: 12px;
+						margin-bottom: 16px;
+					`}
+					tagName={unwrappedElement}
+				/>
+			);
+		}}
+	</ClassNames>
+);

--- a/src/web/components/elements/HighlightBlockComponent.tsx
+++ b/src/web/components/elements/HighlightBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/react';
 
 import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';

--- a/src/web/components/elements/RewrappedComponent.tsx
+++ b/src/web/components/elements/RewrappedComponent.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { jsx as _jsx } from 'react/jsx-runtime';
-import { css, ClassNames, SerializedStyles } from '@emotion/react';
+import { ClassNames } from '@emotion/react';
 
 import { unescapeData } from '@root/src/lib/escapeData';
 
@@ -15,21 +15,21 @@ import { unescapeData } from '@root/src/lib/escapeData';
 export const RewrappedComponent = ({
 	isUnwrapped,
 	html,
-	elCss = css``,
+	elCss = '',
 	tagName,
 }: {
 	isUnwrapped: boolean;
 	html: string;
-	elCss?: SerializedStyles;
+	elCss?: string;
 	tagName: string;
 }) => (
 	<ClassNames>
-		{({ css: _css }) => {
+		{({ css }) => {
 			const element = isUnwrapped ? tagName : 'span';
 
 			// If we implement a span, we want to apply the CSS to the inner element
 			// to ensure we still style correctly
-			const innerElCss = _css`
+			const innerElCss = css`
 				${tagName} {
 					${elCss}
 				}

--- a/src/web/components/elements/RewrappedComponent.tsx
+++ b/src/web/components/elements/RewrappedComponent.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { css } from 'emotion';
+// @ts-ignore
+import { jsx as _jsx } from 'react/jsx-runtime';
+import { css, ClassNames, SerializedStyles } from '@emotion/react';
+
 import { unescapeData } from '@root/src/lib/escapeData';
 
 // Ideally we want to want to avoid an unnecessary 'span' wrapper,
@@ -13,34 +15,36 @@ import { unescapeData } from '@root/src/lib/escapeData';
 export const RewrappedComponent = ({
 	isUnwrapped,
 	html,
-	elCss = '',
+	elCss = css``,
 	tagName,
 }: {
 	isUnwrapped: boolean;
 	html: string;
-	elCss?: string;
+	elCss?: SerializedStyles;
 	tagName: string;
-}) => {
-	const element = isUnwrapped ? tagName : 'span';
+}) => (
+	<ClassNames>
+		{({ css: _css }) => {
+			const element = isUnwrapped ? tagName : 'span';
 
-	// If we implement a span, we want to apply the CSS to the inner element
-	// to ensure we still style correctly
-	const innerElCss = css`
-		${tagName} {
-			${elCss}
-		}
-	`;
+			// If we implement a span, we want to apply the CSS to the inner element
+			// to ensure we still style correctly
+			const innerElCss = _css`
+				${tagName} {
+					${elCss}
+				}
+			`;
 
-	const style = isUnwrapped ? elCss : innerElCss;
+			const style = isUnwrapped ? elCss : innerElCss;
 
-	// Create a react element from the tagName passed in OR
-	// default to <span> if we've not been able to unwrap based on prefix & suffix
-	const ElementComponent = React.createElement(`${element}`, {
-		className: style,
-		dangerouslySetInnerHTML: {
-			__html: unescapeData(html),
-		},
-	});
-
-	return ElementComponent;
-};
+			// Create a react element from the tagName passed in OR
+			// default to <span> if we've not been able to unwrap based on prefix & suffix
+			return _jsx(`${element}`, {
+				className: style,
+				dangerouslySetInnerHTML: {
+					__html: unescapeData(html),
+				},
+			});
+		}}
+	</ClassNames>
+);

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/react';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
@@ -212,7 +212,7 @@ export const TextBlockComponent = ({
 		isLongEnough(remainingLetters)
 	) {
 		return (
-			<p className={paraStyles(format)}>
+			<p css={paraStyles(format)}>
 				<DropCap letter={firstLetter} format={format} />
 				<RewrappedComponent
 					isUnwrapped={isUnwrapped}

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { ClassNames } from '@emotion/react';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
@@ -102,134 +102,141 @@ const sanitiserOptions = {
 	},
 };
 
-const paraStyles = (format: Format) => css`
-	margin-bottom: 16px;
-	${format.theme === Special.Labs ? textSans.medium() : body.medium()};
-
-	ul {
-		margin-bottom: 12px;
-	}
-
-	${from.tablet} {
-		ul {
-			margin-bottom: 16px;
-		}
-	}
-
-	li {
-		margin-bottom: 6px;
-		padding-left: 20px;
-
-		p {
-			display: inline;
-		}
-	}
-
-	li:before {
-		display: inline-block;
-		content: '';
-		border-radius: 6px;
-		height: 12px;
-		width: 12px;
-		margin-right: 8px;
-		background-color: ${neutral[86]};
-		margin-left: -20px;
-	}
-
-	/* Subscript and Superscript styles */
-	sub {
-		bottom: -0.25em;
-	}
-
-	sup {
-		top: -0.5em;
-	}
-
-	sub,
-	sup {
-		font-size: 75%;
-		line-height: 0;
-		position: relative;
-		vertical-align: baseline;
-	}
-
-	[data-dcr-style='bullet'] {
-		display: inline-block;
-		content: '';
-		border-radius: 100%;
-		height: 15.2px;
-		width: 15.2px;
-		margin-right: 0.2px;
-		background-color: ${decidePalette(format).background.bullet};
-	}
-
-	${until.tablet} {
-		/* 	To stop long words going outside of the view port.
-			For compatibility */
-		overflow-wrap: anywhere;
-		word-wrap: break-word;
-	}
-`;
-
 export const TextBlockComponent = ({
 	html,
 	format,
 	forceDropCap,
 	isFirstParagraph,
-}: Props): JSX.Element | null => {
-	const {
-		willUnwrap: isUnwrapped,
-		unwrappedHtml,
-		unwrappedElement,
-	} = unwrapHtml({
-		fixes: [
-			{
-				unwrappedElement: 'p',
-				prefix: '<p>',
-				suffix: '</p>',
-			},
-			{
-				unwrappedElement: 'ul',
-				prefix: '<ul>',
-				suffix: '</ul>',
-			},
-		],
-		html,
-	});
+}: Props): JSX.Element | null => (
+	<ClassNames>
+		{({ css }) => {
+			const paraStyles = css`
+				margin-bottom: 16px;
+				${format.theme === Special.Labs
+					? textSans.medium()
+					: body.medium()};
 
-	const firstLetter = decideDropCapLetter(unwrappedHtml);
-	const remainingLetters = firstLetter
-		? unwrappedHtml.substr(firstLetter.length)
-		: unwrappedHtml;
+				ul {
+					margin-bottom: 12px;
+				}
 
-	if (
-		shouldShowDropCap({
-			format,
-			isFirstParagraph,
-			forceDropCap,
-		}) &&
-		firstLetter &&
-		isLongEnough(remainingLetters)
-	) {
-		return (
-			<p css={paraStyles(format)}>
-				<DropCap letter={firstLetter} format={format} />
+				${from.tablet} {
+					ul {
+						margin-bottom: 16px;
+					}
+				}
+
+				li {
+					margin-bottom: 6px;
+					padding-left: 20px;
+
+					p {
+						display: inline;
+					}
+				}
+
+				li:before {
+					display: inline-block;
+					content: '';
+					border-radius: 6px;
+					height: 12px;
+					width: 12px;
+					margin-right: 8px;
+					background-color: ${neutral[86]};
+					margin-left: -20px;
+				}
+
+				/* Subscript and Superscript styles */
+				sub {
+					bottom: -0.25em;
+				}
+
+				sup {
+					top: -0.5em;
+				}
+
+				sub,
+				sup {
+					font-size: 75%;
+					line-height: 0;
+					position: relative;
+					vertical-align: baseline;
+				}
+
+				[data-dcr-style='bullet'] {
+					display: inline-block;
+					content: '';
+					border-radius: 100%;
+					height: 15.2px;
+					width: 15.2px;
+					margin-right: 0.2px;
+					background-color: ${decidePalette(format).background
+						.bullet};
+				}
+
+				${until.tablet} {
+					/* 	To stop long words going outside of the view port.
+					For compatibility */
+					overflow-wrap: anywhere;
+					word-wrap: break-word;
+				}
+			`;
+
+			const {
+				willUnwrap: isUnwrapped,
+				unwrappedHtml,
+				unwrappedElement,
+			} = unwrapHtml({
+				fixes: [
+					{
+						unwrappedElement: 'p',
+						prefix: '<p>',
+						suffix: '</p>',
+					},
+					{
+						unwrappedElement: 'ul',
+						prefix: '<ul>',
+						suffix: '</ul>',
+					},
+				],
+				html,
+			});
+
+			const firstLetter = decideDropCapLetter(unwrappedHtml);
+			const remainingLetters = firstLetter
+				? unwrappedHtml.substr(firstLetter.length)
+				: unwrappedHtml;
+
+			if (
+				shouldShowDropCap({
+					format,
+					isFirstParagraph,
+					forceDropCap,
+				}) &&
+				firstLetter &&
+				isLongEnough(remainingLetters)
+			) {
+				return (
+					<p css={paraStyles}>
+						<DropCap letter={firstLetter} format={format} />
+						<RewrappedComponent
+							isUnwrapped={isUnwrapped}
+							html={sanitise(remainingLetters, sanitiserOptions)}
+							elCss={paraStyles}
+							tagName="span"
+						/>
+					</p>
+				);
+			}
+
+			return (
 				<RewrappedComponent
 					isUnwrapped={isUnwrapped}
-					html={sanitise(remainingLetters, sanitiserOptions)}
-					elCss={paraStyles(format)}
-					tagName="span"
+					html={sanitise(unwrappedHtml, sanitiserOptions)}
+					elCss={paraStyles}
+					tagName={unwrappedElement || 'p'}
 				/>
-			</p>
-		);
-	}
-
-	return (
-		<RewrappedComponent
-			isUnwrapped={isUnwrapped}
-			html={sanitise(unwrappedHtml, sanitiserOptions)}
-			elCss={paraStyles(format)}
-			tagName={unwrappedElement || 'p'}
-		/>
-	);
-};
+			);
+		}}
+	</ClassNames>
+);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Use Emotion 11 on Rewrapped component (and parent components)
- Use `ClassNames` to be able to convert CSS to string (needed to attache CSS to className in `_jsx`)
- Move defined styles into the component renderer

## Why?
`Rewrapped.tsx` recreates components and injects them with styles. To do this before we would use React.createElement, but now that we use JSX and the CSS is no longer strings by default in Emotion 11, we have to use the HOC `ClassNames` to be able to convert them into strings. In doing so we need to make sure that the definition of the CSS `const` happens within the scope of the component