### PR TITLE
Be more explicit around localStorage availability

### DIFF
--- a/src/web/lib/braze/buildBrazeMessages.ts
+++ b/src/web/lib/braze/buildBrazeMessages.ts
@@ -11,6 +11,7 @@ import {
 	LocalMessageCache,
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
+import { isLocalStorageAvailable } from '@root/src/web/lib/isLocalStorageAvailable';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy, SDK_OPTIONS } from './initialiseAppboy';
 
@@ -43,6 +44,10 @@ export const buildBrazeMessages = async (
 	isSignedIn: boolean,
 	idApiUrl: string,
 ): Promise<BrazeMessagesInterface> => {
+	if (!isLocalStorageAvailable()) {
+		return new NullBrazeMessages();
+	}
+
 	const dependenciesResult = await checkBrazeDependencies(
 		isSignedIn,
 		idApiUrl,
@@ -89,9 +94,9 @@ export const buildBrazeMessages = async (
 			errorHandler,
 		);
 
+		setHasCurrentBrazeUser();
 		appboy.changeUser(dependenciesResult.data.brazeUuid as string);
 		appboy.openSession();
-		setHasCurrentBrazeUser();
 
 		return brazeMessages;
 	} catch {

--- a/src/web/lib/isLocalStorageAvailable.ts
+++ b/src/web/lib/isLocalStorageAvailable.ts
@@ -1,0 +1,1 @@
+export const isLocalStorageAvailable = (): boolean => 'localStorage' in window;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Be more explicit around localStorage availability. If `localStorage` isn’t available then bail early from attempting to show
Braze messages. We rely on localStorage to track whether a user has been eligible for messages and the Braze SDK relies on it too, so check early and return a NullBrazeMessages instance if it’s not available.

### Before

Occasional errors in Sentry which point to attempting to use `localStorage` when it's not available.

### After

Fewer Sentry errors, which should make it easier to spot genuine issues.

