### PR TITLE
Update atoms version to explicitly avoid audio preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@emotion/react": "^11.4.0",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^13.0.0",
+        "@guardian/atoms-rendering": "^14.0.0",
         "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^2.0.0",
         "@guardian/consent-management-platform": "^6.11.3",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -662,6 +662,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						trackUrl={audioAtom.trackUrl}
 						kicker={audioAtom.kicker}
 						title={audioAtom.title}
+						duration={audioAtom.duration}
 						pillar={pillar}
 						contentIsNotSensitive={!CAPI.config.isSensitive}
 						aCastisEnabled={CAPI.config.switches.acast}

--- a/src/web/components/AudioAtomWrapper.tsx
+++ b/src/web/components/AudioAtomWrapper.tsx
@@ -10,6 +10,7 @@ type Props = {
 	trackUrl: string;
 	kicker: string;
 	title?: string | undefined;
+	duration: number;
 	pillar: Theme;
 	contentIsNotSensitive: boolean;
 	aCastisEnabled: boolean;
@@ -22,6 +23,7 @@ export const AudioAtomWrapper = ({
 	kicker,
 	title,
 	pillar,
+	duration,
 	contentIsNotSensitive,
 	aCastisEnabled,
 	readerCanBeShownAds,
@@ -54,6 +56,7 @@ export const AudioAtomWrapper = ({
 			kicker={kicker}
 			title={title}
 			pillar={pillar}
+			duration={duration}
 			shouldUseAcast={shouldUseAcast}
 		/>
 	);

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -121,6 +121,7 @@ export const renderElement = ({
 					trackUrl={element.trackUrl}
 					kicker={element.kicker}
 					title={element.title}
+					duration={element.duration}
 					pillar={format.theme}
 				/>,
 			];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,10 +1612,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-13.0.0.tgz#dc742dd548203f68dbcc34a1d9399feed8100c22"
-  integrity sha512-whyn/2ylRETuWkxOjPlo6Ow6KWq28Jc/Y4A4tDJOFJMfI6sNL6Nxkl7KVNPxVhrJ8ILepmSK1COxdWoPh5Gtpw==
+"@guardian/atoms-rendering@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-14.0.0.tgz#3c4ba3317683013250c112fcf58e05afff40a575"
+  integrity sha512-HQaiRKPK4Qz3JXVrq//5r8UDyF93DGzzdmMx/05jJDY5fdi0sNflqOKbuxHjpen0Vfim+6Rh8+pUVWk0/nsbhA==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR bumps the version of atoms rendering we're using to explicitly avoid preloading audio atom content with `preload="none"`. The reason we're doing this is because clients have different default behaviour for `preload` and some may perform preloading in such a way that Acast interprets it as a listen, meaning our numbers will be inflated.

We've checked this with Acast who have strongly advised this change, and it mirrors previous frontend behaviour too.

### Before
`<audio>`

### After
`<audio preload="none">`

## Why?
As above
