### PR TITLE
Fix spacing for social icons on left-col

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -70,6 +70,10 @@ const metaExtras = (palette: Palette) => css`
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+
+	${between.leftCol.and.wide} {
+		padding-bottom: 6px;
+	}
 `;
 
 const contributorTopBorder = (palette: Palette) => css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes issue where there was no padding below social icons between leftCol & Wide desktop sizing.

### Before
![image](https://user-images.githubusercontent.com/9575458/119337817-29a1ab80-bc87-11eb-9b4b-8a7fbb89e190.png)

### After
![image](https://user-images.githubusercontent.com/9575458/119337881-3c1be500-bc87-11eb-9332-13a1b0a00000.png)

## Why?

Fixes visual bug
