### PR TITLE
Hide sign-in gate on preview

### DIFF
--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -71,6 +71,9 @@ export const isValidTag = (CAPI: CAPIBrowserType): boolean => {
 export const isPaidContent = (CAPI: CAPIBrowserType): boolean =>
 	CAPI.pageType.isPaidContent;
 
+export const isPreview = (CAPI: CAPIBrowserType): boolean =>
+	CAPI.isPreview || false;
+
 export const canShow = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
@@ -87,4 +90,5 @@ export const canShow = (
 	isValidSection(CAPI) &&
 	isValidTag(CAPI) &&
 	!isPaidContent(CAPI) &&
+	!isPreview(CAPI) &&
 	!isIOS9();

--- a/src/web/components/SignInGate/gates/main-control.ts
+++ b/src/web/components/SignInGate/gates/main-control.ts
@@ -9,6 +9,7 @@ import {
 	isValidTag,
 	isIOS9,
 	isPaidContent,
+	isPreview,
 } from '@frontend/web/components/SignInGate/displayRule';
 import { hasUserDismissedGate } from '../dismissGate';
 
@@ -24,6 +25,7 @@ const canShow = (
 	isValidSection(CAPI) &&
 	isValidTag(CAPI) &&
 	!isPaidContent(CAPI) &&
+	!isPreview(CAPI) &&
 	!isIOS9();
 
 export const signInGateComponent: SignInGateComponent = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR hides the sign-in gate from being shown on `preview` (i.e. the viewer that journalists use to preview content in composer before publishing). We've had a few complaints recently about various dismissible components that interrupt editorial workflow and sign-in gate is a part of that.  Since it serves little purpose in preview and as far as I know we don't use `preview` to test it, we may as well just remove it from there. It can also be harder to maintain a signed-in session on preview, which exacerbates the issue.
