### PR TITLE
Update Emotion 11 react components (batch 2)

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -147,12 +147,10 @@ const mobileStickyAdStyles = css`
 
 const AdSlotLabelToggled: React.FC = () => (
 	<div
-		className={cx(
-			'ad-slot__label',
-			'ad-slot__label--toggle',
-			'hidden',
-			adSlotLabelStyles,
+		className={['ad-slot__label', 'ad-slot__label--toggle', 'hidden'].join(
+			' ',
 		)}
+		css={adSlotLabelStyles}
 	>
 		Advertisement
 	</div>
@@ -167,15 +165,15 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					return (
 						<div
 							id="dfp-ad--right"
-							className={cx(
+							className={[
 								'js-ad-slot',
 								'ad-slot',
 								'ad-slot--right',
 								'ad-slot--mpu-banner-ad',
 								'ad-slot--rendered',
 								'js-sticky-mpu',
-								labelStyles,
-							)}
+							].join(' ')}
+							css={labelStyles}
 							data-link-name="ad slot right"
 							data-name="right"
 							// mark: 01303e88-ef1f-462d-9b6e-242419435cec
@@ -195,26 +193,28 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					const MOSTVIEWED_STICKY_HEIGHT = 1059;
 					return (
 						<div
-							className={css`
+							css={css`
 								position: static;
 								height: ${MOSTVIEWED_STICKY_HEIGHT}px;
 							`}
 						>
 							<div
 								id="dfp-ad--right"
-								className={cx(
+								className={[
 									'js-ad-slot',
 									'ad-slot',
 									'ad-slot--right',
 									'ad-slot--mpu-banner-ad',
 									'ad-slot--rendered',
 									'js-sticky-mpu',
+								].join(' ')}
+								css={[
 									css`
 										position: sticky;
 										top: 0;
 									`,
 									labelStyles,
-								)}
+								]}
 								data-link-name="ad slot right"
 								data-name="right"
 								// mark: 01303e88-ef1f-462d-9b6e-242419435cec
@@ -237,26 +237,28 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 		case 'comments': {
 			return (
 				<div
-					className={css`
+					css={css`
 						position: static;
 						height: 100%;
 					`}
 				>
 					<div
 						id="dfp-ad--comments"
-						className={cx(
+						className={[
 							'js-ad-slot',
 							'ad-slot',
 							'ad-slot--comments',
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 							'js-sticky-mpu',
+						].join(' ')}
+						css={[
 							css`
 								position: sticky;
 								top: 0;
 							`,
 							labelStyles,
-						)}
+						]}
 						data-link-name="ad slot comments"
 						data-name="comments"
 						data-mobile={[
@@ -309,18 +311,20 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					<AdSlotLabelToggled />
 					<div
 						id="dfp-ad--top-above-nav"
-						className={cx(
+						className={[
 							'js-ad-slot',
 							'ad-slot',
 							'ad-slot--top-above-nav',
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
+						].join(' ')}
+						css={[
 							css`
 								position: relative;
 							`,
 							labelStyles,
 							adSlotAboveNav,
-						)}
+						]}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
 						// The sizes here come from two places in the frontend code
@@ -353,17 +357,19 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			return (
 				<div
 					id="dfp-ad--mostpop"
-					className={cx(
+					className={[
 						'js-ad-slot',
 						'ad-slot',
 						'ad-slot--mostpop',
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
+					].join(' ')}
+					css={[
 						css`
 							position: relative;
 						`,
 						labelStyles,
-					)}
+					]}
 					data-link-name="ad slot mostpop"
 					data-name="mostpop"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
@@ -409,15 +415,17 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			return (
 				<div
 					id="dfp-ad--merchandising-high"
-					className={cx(
+					className={[
 						'js-ad-slot',
 						'ad-slot',
 						'ad-slot--merchandising-high',
+					].join(' ')}
+					css={[
 						css`
 							position: relative;
 						`,
 						labelStyles,
-					)}
+					]}
 					data-link-name="ad slot merchandising-high"
 					data-name="merchandising-high"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
@@ -435,15 +443,17 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			return (
 				<div
 					id="dfp-ad--merchandising"
-					className={cx(
+					className={[
 						'js-ad-slot',
 						'ad-slot',
 						'ad-slot--merchandising',
+					].join(' ')}
+					css={[
 						css`
 							position: relative;
 						`,
 						labelStyles,
-					)}
+					]}
 					data-link-name="ad slot merchandising"
 					data-name="merchandising"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
@@ -461,12 +471,12 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			return (
 				<div
 					id="dfp-ad--survey"
-					className={cx(
+					className={[
 						'js-ad-slot',
 						'ad-slot',
 						'ad-slot--survey',
-						outOfPageStyles,
-					)}
+					].join(' ')}
+					css={outOfPageStyles}
 					data-link-name="ad slot survey"
 					data-name="survey"
 					data-label="false"
@@ -483,5 +493,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 };
 
 export const MobileStickyContainer: React.FC = () => {
-	return <div className={`mobilesticky-container ${mobileStickyAdStyles}`} />;
+	return (
+		<div className="mobilesticky-container" css={mobileStickyAdStyles} />
+	);
 };

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { headline } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
@@ -75,7 +75,7 @@ export const ArticleBody = ({
 		format.design === Design.DeadBlog
 	) {
 		return (
-			<div className={cx(globalStrongStyles, globalLinkStyles(palette))}>
+			<div css={[globalStrongStyles, globalLinkStyles(palette)]}>
 				<LiveBlogRenderer
 					format={format}
 					blocks={blocks}
@@ -89,13 +89,13 @@ export const ArticleBody = ({
 	}
 	return (
 		<div
-			className={cx(
+			css={[
 				bodyPadding,
 				globalH2Styles(format.display),
 				globalH3Styles(format.display),
 				globalStrongStyles,
 				globalLinkStyles(palette),
-			)}
+			]}
 		>
 			<ArticleRenderer
 				format={format}

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -1,5 +1,6 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
+
 import { labelStyles } from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`
@@ -80,9 +81,5 @@ type Props = {
 };
 
 export const ArticleContainer = ({ children }: Props) => {
-	return (
-		<main className={cx(articleContainer, articleAdStyles)}>
-			{children}
-		</main>
-	);
+	return <main css={[articleContainer, articleAdStyles]}>{children}</main>;
 };

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -1,12 +1,12 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { between, from, until } from '@guardian/src-foundations/mq';
+import { Display, Design, Special } from '@guardian/types';
+import type { Format } from '@guardian/types';
+
 import { Contributor } from '@root/src/web/components/Contributor';
 import { Avatar } from '@root/src/web/components/Avatar';
 import { Counts } from '@root/src/web/components/Counts';
-
 import { Branding } from '@root/src/web/components/Branding';
-import { Display, Design, Special } from '@guardian/types';
-import type { Format } from '@guardian/types';
 import { ShareIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
 
@@ -194,7 +194,7 @@ const shouldShowContributor = (format: Format) => {
 
 const AvatarContainer = ({ children }: { children: React.ReactNode }) => (
 	<div
-		className={css`
+		css={css`
 			width: 140px;
 			height: 140px;
 			margin-top: 6px;
@@ -218,7 +218,7 @@ const AvatarContainer = ({ children }: { children: React.ReactNode }) => (
 
 const RowBelowLeftCol = ({ children }: { children: React.ReactNode }) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: column;
 
@@ -250,8 +250,8 @@ export const ArticleMeta = ({
 
 	const showAvatar = onlyOneContributor && shouldShowAvatar(format);
 	return (
-		<div className={metaContainer(format)}>
-			<div className={cx(meta)}>
+		<div css={metaContainer(format)}>
+			<div css={meta}>
 				{branding && <Branding branding={branding} palette={palette} />}
 				<RowBelowLeftCol>
 					<>
@@ -265,7 +265,7 @@ export const ArticleMeta = ({
 							</AvatarContainer>
 						)}
 						<div
-							className={
+							css={
 								format.theme === Special.Labs
 									? contributorTopBorder(palette)
 									: ''
@@ -286,8 +286,8 @@ export const ArticleMeta = ({
 						</div>
 					</>
 				</RowBelowLeftCol>
-				<div data-print-layout="hide" className={metaFlex}>
-					<div className={metaExtras(palette)}>
+				<div data-print-layout="hide" css={metaFlex}>
+					<div css={metaExtras(palette)}>
 						<ShareIcons
 							pageId={pageId}
 							webTitle={webTitle}
@@ -296,17 +296,11 @@ export const ArticleMeta = ({
 							size="medium"
 						/>
 					</div>
-					<div className={metaNumbers(palette)}>
+					<div css={metaNumbers(palette)}>
 						<Counts>
-							{/* The meta-number classname is needed by Counts.tsx */}
-							<div
-								className="meta-number"
-								id="share-count-root"
-							/>
-							<div
-								className="meta-number"
-								id="comment-count-root"
-							/>
+							{/* The meta-number css is needed by Counts.tsx */}
+							<div css="meta-number" id="share-count-root" />
+							<div css="meta-number" id="comment-count-root" />
 						</Counts>
 					</div>
 				</div>

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -299,8 +299,14 @@ export const ArticleMeta = ({
 					<div css={metaNumbers(palette)}>
 						<Counts>
 							{/* The meta-number css is needed by Counts.tsx */}
-							<div css="meta-number" id="share-count-root" />
-							<div css="meta-number" id="comment-count-root" />
+							<div
+								className="meta-number"
+								id="share-count-root"
+							/>
+							<div
+								className="meta-number"
+								id="comment-count-root"
+							/>
 						</Counts>
 					</div>
 				</div>

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { Badge } from '@frontend/web/components/Badge';
@@ -66,19 +66,19 @@ export const ArticleTitle = ({
 	guardianBaseURL,
 	badge,
 }: Props) => (
-	<div className={cx(sectionStyles, badge && badgeContainer)}>
+	<div css={[sectionStyles, badge && badgeContainer]}>
 		{badge && format.display !== Display.Immersive && (
-			<div className={titleBadgeWrapper}>
+			<div css={titleBadgeWrapper}>
 				<Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
 			</div>
 		)}
 		<div
-			className={cx(
+			css={[
 				badge && marginTop,
 				format.display === Display.Immersive &&
 					format.design !== Design.PrintShop &&
 					immersiveMargins,
-			)}
+			]}
 		>
 			<SeriesSectionLink
 				format={format}

--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 const contributorImage = css`
 	border-radius: 100%;
@@ -21,7 +21,7 @@ export const Avatar: React.FC<{
 		<img
 			src={imageSrc}
 			alt={imageAlt}
-			className={cx(backgroundStyles(palette), contributorImage)}
+			css={[backgroundStyles(palette), contributorImage]}
 		/>
 	);
 };

--- a/src/web/components/BackToTop.tsx
+++ b/src/web/components/BackToTop.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import {
 	brandBackground,
 	brandText,
@@ -57,10 +57,10 @@ const textStyles = css`
 `;
 
 export const BackToTop: React.FC = () => (
-	<a className={link} href="#top">
-		<span className={textStyles}>Back to top</span>
-		<span className={cx('icon-container', iconContainer)}>
-			<i className={icon} />
+	<a css={link} href="#top">
+		<span css={textStyles}>Back to top</span>
+		<span css={iconContainer} className="icon-container">
+			<i css={icon} />
 		</span>
 	</a>
 );

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
@@ -82,7 +82,7 @@ const colourStyles = (palette: Palette) => {
 };
 
 export const Byline = ({ text, palette, format, size }: Props) => (
-	<span className={cx(bylineStyles(size, format), colourStyles(palette))}>
+	<span css={[bylineStyles(size, format), colourStyles(palette)]}>
 		{text}
 	</span>
 );

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -140,28 +140,26 @@ export const Caption = ({
 
 	const defaultCaption = (
 		<figcaption
-			className={cx(
+			css={[
 				captionStyle(palette),
 				shouldLimitWidth && limitedWidth,
 				!isOverlayed && bottomMargin,
 				isOverlayed && overlayedStyles,
-				{
-					[captionPadding]: padCaption,
-				},
-			)}
+				padCaption && captionPadding,
+			]}
 		>
 			<span
-				className={cx(
+				css={[
 					iconStyle(palette),
 					format.display === Display.Immersive &&
 						hideIconBelowLeftCol,
-				)}
+				]}
 			>
 				<TriangleIcon />
 			</span>
 			{captionText && (
 				<span
-					className={captionLink(palette)}
+					css={captionLink(palette)}
 					// eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={{
 						__html: captionText || '',
@@ -180,7 +178,7 @@ export const Caption = ({
 			}
 			return (
 				<figcaption
-					className={cx(
+					css={[
 						css`
 							${textSans.xxsmall({ lineHeight: 'tight' })};
 							color: ${palette.text.caption};
@@ -198,11 +196,11 @@ export const Caption = ({
 						padCaption && captionPadding,
 						shouldLimitWidth && veryLimitedWidth,
 						shouldLimitWidth && bigLeftMargin,
-					)}
+					]}
 				>
 					{captionText && (
 						<span
-							className={captionLink(palette)}
+							css={captionLink(palette)}
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={{
 								__html: captionText || '',

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { Design, Special } from '@guardian/types';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
@@ -117,12 +117,12 @@ const labTitleOrNot = (format: Format) => {
 const StarRatingComponent: React.FC<{ rating: number }> = ({ rating }) => (
 	<>
 		<Hide when="above" breakpoint="desktop">
-			<div className={starWrapper}>
+			<div css={starWrapper}>
 				<StarRating rating={rating} size="small" />
 			</div>
 		</Hide>
 		<Hide when="below" breakpoint="desktop">
-			<div className={starWrapper}>
+			<div css={starWrapper}>
 				<StarRating rating={rating} size="medium" />
 			</div>
 		</Hide>
@@ -275,9 +275,7 @@ export const Card = ({
 								</>
 							</Flex>
 							<div
-								className={cx(
-									isFullCardImage && fullCardImageAgeStyles,
-								)}
+								css={isFullCardImage && fullCardImageAgeStyles}
 							>
 								{standfirst && (
 									<StandfirstWrapper palette={cardPalette}>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { Design, Display } from '@guardian/types';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -71,12 +71,12 @@ export const CardAge = ({
 	}
 
 	return (
-		<span className={cx(ageStyles(format, palette))}>
+		<span css={ageStyles(format, palette)}>
 			<span
-				className={cx(
+				css={
 					format.display === Display.Immersive &&
-						fullCardImageTextStyles,
-				)}
+					fullCardImageTextStyles
+				}
 			>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate}>{displayString}</time>

--- a/src/web/components/Card/components/CardLayout.tsx
+++ b/src/web/components/Card/components/CardLayout.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { until } from '@guardian/src-foundations/mq';
 
@@ -60,13 +60,13 @@ export const CardLayout = ({
 	minWidthInPixels,
 }: Props) => (
 	<div
-		className={cx(
+		css={[
 			css`
 				display: flex;
 			`,
 			decideWidth(minWidthInPixels),
 			decidePosition(imagePosition, alwaysVertical),
-		)}
+		]}
 	>
 		{children}
 	</div>

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
@@ -50,11 +50,11 @@ export const ContentWrapper = ({
 	isFullCardImage,
 }: Props) => (
 	<div
-		className={cx(
+		css={[
 			sizingStyles,
 			coverageStyles(percentage),
 			isFullCardImage && fullCardImageStyles,
-		)}
+		]}
 	>
 		{children}
 	</div>

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -38,7 +38,7 @@ export const ImageWrapper = ({
 }: Props) => {
 	return (
 		<div
-			className={cx(
+			css={[
 				isFullCardImage && cardHeight,
 				css`
 					/* position relative is required here to bound the image overlay */
@@ -61,7 +61,7 @@ export const ImageWrapper = ({
 						object-fit: ${isFullCardImage && 'cover'};
 					}
 				`,
-			)}
+			]}
 		>
 			<>
 				{children}

--- a/src/web/components/Card/components/LI.tsx
+++ b/src/web/components/Card/components/LI.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -85,7 +85,7 @@ export const LI = ({
 
 	return (
 		<li
-			className={cx(
+			css={[
 				liStyles,
 				sizeStyles,
 				showDivider && verticalDivider,
@@ -93,7 +93,7 @@ export const LI = ({
 				bottomMargin && marginBottomStyles,
 				showTopMarginWhenStacked && marginTopStyles,
 				snapAlignStart && snapAlignStartStyles,
-			)}
+			]}
 		>
 			{children}
 		</li>

--- a/src/web/components/Card/components/UL.tsx
+++ b/src/web/components/Card/components/UL.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { until } from '@guardian/src-foundations/mq';
 
@@ -33,11 +33,11 @@ export const UL = ({
 }: Props) => {
 	return (
 		<ul
-			className={cx(
+			css={[
 				ulStyles(direction),
 				showDivider && verticalDivider,
 				bottomMargin && marginBottomStyles,
-			)}
+			]}
 		>
 			{children}
 		</ul>

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { Design, Special } from '@guardian/types';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -138,7 +138,7 @@ export const CardHeadline = ({
 }: Props) => (
 	<>
 		<h4
-			className={cx(
+			css={[
 				format.theme === Special.Labs
 					? labTextStyles(size)
 					: fontStyles(size),
@@ -147,9 +147,9 @@ export const CardHeadline = ({
 					css`
 						line-height: 1; /* Reset line height in full image carousel */
 					`,
-			)}
+			]}
 		>
-			<span className={cx(isFullCardImage && fullCardImageTextStyles)}>
+			<span css={isFullCardImage && fullCardImageTextStyles}>
 				{kickerText && (
 					<Kicker
 						text={kickerText}
@@ -164,7 +164,7 @@ export const CardHeadline = ({
 				)}
 
 				<span
-					className={css`
+					css={css`
 						color: ${palette.text.cardHeadline};
 					`}
 				>

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { Section } from '@root/src/web/components/Section';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
@@ -29,6 +29,32 @@ type Props = {
 	leftColSize?: LeftColSize;
 };
 
+const containerStyles = css`
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	width: 100%;
+`;
+
+const margins = css`
+	margin-top: ${space[2]}px;
+	/*
+   Keep spacing at the bottom of the container consistent at 36px, regardless of
+   breakpoint, based on chat with Harry Fisher
+*/
+	margin-bottom: ${space[9]}px;
+`;
+
+const rightMargin = css`
+	${from.wide} {
+		margin-right: 68px;
+	}
+`;
+
+const padding = css`
+	padding: 0 10px;
+`;
+
 const Container = ({
 	children,
 	padded,
@@ -39,46 +65,18 @@ const Container = ({
 	padded: boolean;
 	verticalMargins: boolean;
 	stretchRight: boolean;
-}) => {
-	const containerStyles = css`
-		display: flex;
-		flex-grow: 1;
-		flex-direction: column;
-		width: 100%;
-	`;
-
-	const margins = css`
-		margin-top: ${space[2]}px;
-		/*
-           Keep spacing at the bottom of the container consistent at 36px, regardless of
-           breakpoint, based on chat with Harry Fisher
-        */
-		margin-bottom: ${space[9]}px;
-	`;
-
-	const rightMargin = css`
-		${from.wide} {
-			margin-right: 68px;
-		}
-	`;
-
-	const padding = css`
-		padding: 0 10px;
-	`;
-
-	return (
-		<div
-			className={cx(
-				containerStyles,
-				padded && padding,
-				verticalMargins && margins,
-				!stretchRight && rightMargin,
-			)}
-		>
-			{children}
-		</div>
-	);
-};
+}) => (
+	<div
+		css={[
+			containerStyles,
+			padded && padding,
+			verticalMargins && margins,
+			!stretchRight && rightMargin,
+		]}
+	>
+		{children}
+	</div>
+);
 
 export const ContainerLayout = ({
 	title,

--- a/src/web/components/Dateline.tsx
+++ b/src/web/components/Dateline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
@@ -52,20 +52,16 @@ export const Dateline: React.FC<{
 	secondaryDateline: string;
 }> = ({ primaryDateline, secondaryDateline }) => {
 	return (
-		<div className={dateline}>
+		<div css={dateline}>
 			{secondaryDateline &&
 			!secondaryDateline.includes(primaryDateline) ? (
-				<div className={cx(toggleClass, dateline)}>
-					<label className={labelStyles} htmlFor="dateToggle">
+				<div css={[toggleClass, dateline]}>
+					<label css={labelStyles} htmlFor="dateToggle">
 						{primaryDateline}
 					</label>
 
-					<input
-						className={toggleClass}
-						type="checkbox"
-						id="dateToggle"
-					/>
-					<p className={pStyle}>{secondaryDateline}</p>
+					<input css={toggleClass} type="checkbox" id="dateToggle" />
+					<p css={pStyle}>{secondaryDateline}</p>
 				</div>
 			) : (
 				primaryDateline

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import {
 	text,
@@ -216,7 +216,7 @@ export const Dropdown = ({
 		<>
 			{noJS ? (
 				<div
-					className={css`
+					css={css`
 						${`#${checkboxID}`} {
 							/* Never show the input */
 							${visuallyHidden}
@@ -234,7 +234,7 @@ export const Dropdown = ({
 				>
 					<label
 						htmlFor={checkboxID}
-						className={buttonStyles(overrideColor)}
+						css={buttonStyles(overrideColor)}
 					>
 						{label}
 					</label>
@@ -244,16 +244,16 @@ export const Dropdown = ({
 						aria-checked="false"
 						tabIndex={-1}
 					/>
-					<ul id={dropdownID} className={ulStyles}>
+					<ul id={dropdownID} css={ulStyles}>
 						{links.map((l, index) => (
 							<li key={l.title}>
 								<a
 									href={l.url}
-									className={cx({
-										[linkStyles]: true,
-										[linkActive]: !!l.isActive,
-										[linkFirst]: index === 0,
-									})}
+									css={[
+										linkStyles,
+										!!l.isActive && linkActive,
+										index === 0 && linkFirst,
+									]}
 									data-link-name={l.dataLinkName}
 								>
 									{l.title}
@@ -266,30 +266,30 @@ export const Dropdown = ({
 				<>
 					<button
 						onClick={handleToggle}
-						className={cx(
+						css={[
 							buttonStyles(overrideColor),
 							isExpanded && buttonExpanded,
-						)}
+						]}
 						aria-expanded={isExpanded ? 'true' : 'false'}
 						data-link-name={dataLinkName}
 						data-cy="dropdown-button"
 					>
 						{label}
 					</button>
-					<div className={isExpanded ? displayBlock : displayNone}>
+					<div css={isExpanded ? displayBlock : displayNone}>
 						{children ? (
 							<>{children}</>
 						) : (
-							<ul className={ulStyles} data-cy="dropdown-options">
+							<ul css={ulStyles} data-cy="dropdown-options">
 								{links.map((l, index) => (
 									<li key={l.title}>
 										<a
 											href={l.url}
-											className={cx({
-												[linkStyles]: true,
-												[linkActive]: !!l.isActive,
-												[linkFirst]: index === 0,
-											})}
+											css={[
+												linkStyles,
+												!!l.isActive && linkActive,
+												index === 0 && linkFirst,
+											]}
 											data-link-name={l.dataLinkName}
 										>
 											{l.title}

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import {
 	brand,
@@ -187,7 +187,7 @@ const FooterLinks: React.FC<{
 		const linkList = linkGroup.map((l: FooterLink, index: number) => (
 			<li key={`${l.url}${index}`}>
 				<a
-					className={cx(footerLink, l.extraClasses)}
+					css={[footerLink, l.extraClasses]}
 					href={l.url}
 					data-link-name={l.dataLinkName}
 				>
@@ -200,13 +200,13 @@ const FooterLinks: React.FC<{
 	});
 
 	const rrLinks = (
-		<div className={readerRevenueLinks}>
+		<div css={readerRevenueLinks}>
 			<div id="reader-revenue-links-footer" />
 		</div>
 	);
 
 	return (
-		<div className={footerList}>
+		<div css={footerList}>
 			{linkGroups}
 			{rrLinks}
 		</div>
@@ -222,11 +222,11 @@ export const Footer: React.FC<{
 }> = ({ pillars, pillar, pageFooter }) => (
 	<footer
 		data-print-layout="hide"
-		className={footer}
+		css={footer}
 		data-link-name="footer"
 		data-component="footer"
 	>
-		<div className={pillarWrap}>
+		<div css={pillarWrap}>
 			<Pillars
 				display={Display.Standard}
 				pillars={pillars}
@@ -235,23 +235,23 @@ export const Footer: React.FC<{
 				dataLinkName="footer"
 			/>
 		</div>
-		<div className={footerItemContainers}>
+		<div css={footerItemContainers}>
 			<iframe
 				title="Guardian Email Sign-up Form"
 				src="https://www.theguardian.com/email/form/footer/today-uk"
 				id="footer__email-form"
-				className={emailSignup}
+				css={emailSignup}
 				data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
 				data-node-uid="2"
 				height="100"
 			/>
 
 			<FooterLinks pageFooter={pageFooter} />
-			<div className={bttPosition}>
+			<div css={bttPosition}>
 				<BackToTop />
 			</div>
 		</div>
-		<div className={copyright}>
+		<div css={copyright}>
 			© {year} Guardian News & Media Limited or its affiliated companies.
 			All rights reserved. (modern)
 		</div>

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -1,7 +1,8 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
+import { Display } from '@guardian/types';
+
 import { AdSlot } from '@root/src/web/components/AdSlot';
 import { Hide } from '@root/src/web/components/Hide';
-import { Display } from '@guardian/types';
 
 const headerWrapper = css`
 	position: static;
@@ -25,13 +26,13 @@ export const HeaderAdSlot: React.FC<{
 	shouldHideAds: boolean;
 	display: Display;
 }> = ({ isAdFreeUser, shouldHideAds, display }) => (
-	<div className={headerWrapper}>
+	<div css={headerWrapper}>
 		<Hide when="below" breakpoint="tablet">
 			<div
-				className={cx({
-					[headerAdWrapper]: true,
-					[headerAdWrapperHidden]: isAdFreeUser || shouldHideAds,
-				})}
+				css={[
+					headerAdWrapper,
+					(isAdFreeUser || shouldHideAds) && headerAdWrapperHidden,
+				]}
 			>
 				<AdSlot position="top-above-nav" display={display} />
 			</div>

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -109,9 +109,9 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 	switch (format.display) {
 		case Display.Immersive:
 			return (
-				<div className={immersiveStyles(format)}>
+				<div css={immersiveStyles(format)}>
 					by{' '}
-					<span className={immersiveLinkStyles(palette)}>
+					<span css={immersiveLinkStyles(palette)}>
 						<BylineLink byline={byline} tags={tags} />
 					</span>
 				</div>
@@ -122,8 +122,8 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 			switch (format.design) {
 				case Design.Interview:
 					return (
-						<div className={wrapperStyles}>
-							<div className={yellowBoxStyles(format)}>
+						<div css={wrapperStyles}>
+							<div css={yellowBoxStyles(format)}>
 								<BylineLink byline={byline} tags={tags} />
 							</div>
 						</div>
@@ -133,13 +133,13 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				case Design.Comment:
 					return (
 						<div
-							className={cx(opinionWrapperStyles, {
-								[authorBylineWithImage]: hasSingleContributor(
-									tags,
-								),
-							})}
+							css={[
+								opinionWrapperStyles,
+								hasSingleContributor(tags) &&
+									authorBylineWithImage,
+							]}
 						>
-							<div className={opinionStyles(palette, format)}>
+							<div css={opinionStyles(palette, format)}>
 								<BylineLink byline={byline} tags={tags} />
 							</div>
 						</div>

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { PulsingDot } from '@root/src/web/components/PulsingDot';
 
@@ -36,9 +36,9 @@ export const Kicker = ({
 		? palette.text.cardKicker
 		: palette.text.linkKicker;
 	return (
-		<span className={kickerStyles(kickerColour)}>
+		<span css={kickerStyles(kickerColour)}>
 			{showPulsingDot && <PulsingDot colour={kickerColour} />}
-			<span className={cx(showSlash && slashStyles)}>{text}</span>
+			<span css={showSlash && slashStyles}>{text}</span>
 		</span>
 	);
 };

--- a/src/web/components/LeftColumn.tsx
+++ b/src/web/components/LeftColumn.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { border } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
@@ -90,16 +90,16 @@ export const LeftColumn = ({
 
 	return (
 		<section
-			className={cx(
+			css={[
 				positionRelative,
 				leftWidth(size),
 				showRightBorder && rightBorder(borderColour),
-			)}
+			]}
 		>
 			<div
-				className={cx(
-					shouldShowPartialBorder && partialRightBorder(borderColour),
-				)}
+				css={
+					shouldShowPartialBorder && partialRightBorder(borderColour)
+				}
 			>
 				{children}
 			</div>

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { headline } from '@guardian/src-foundations/typography';
 
@@ -74,7 +74,7 @@ export const LinkHeadline = ({
 	link,
 	byline,
 }: Props) => (
-	<h4 className={fontStyles(size)}>
+	<h4 css={fontStyles(size)}>
 		{kickerText && (
 			<Kicker
 				text={kickerText}
@@ -90,12 +90,12 @@ export const LinkHeadline = ({
 			// We were passed a link object so headline should be a link, with link styling
 			<>
 				<a
-					className={cx(
+					css={[
 						// Composed styles - order matters for colours
 						linkStyles,
 						showUnderline && textDecorationUnderline,
 						link.visitedColour && visitedStyles(link.visitedColour),
-					)}
+					]}
 					href={link.to}
 					// If link.preventFocus is true, set tabIndex to -1 to ensure this
 					// link is not tabbed to. Useful if there is an outer link to the same

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import SearchIcon from '@frontend/static/icons/search.svg';
 
@@ -91,17 +91,19 @@ const seperatorHideStyles = css`
 `;
 
 const Search = ({
-	className,
 	children,
 	href,
 	dataLinkName,
 }: {
-	className?: string;
 	children: React.ReactNode;
 	href: string;
 	dataLinkName: string;
 }) => (
-	<a href={href} className={className} data-link-name={dataLinkName}>
+	<a
+		href={href}
+		css={[linkTablet({ showAtTablet: false }), searchLinkStyles]}
+		data-link-name={dataLinkName}
+	>
 		{children}
 	</a>
 );
@@ -191,16 +193,13 @@ export const Links = ({
 		},
 	];
 	return (
-		<div data-print-layout="hide" className={linksStyles}>
+		<div data-print-layout="hide" css={linksStyles}>
 			{showSupporterCTA && supporterCTA !== '' && (
 				<>
-					<div className={seperatorStyles} />
+					<div css={seperatorStyles} />
 					<a
 						href={supporterCTA}
-						className={cx(
-							linkTablet({ showAtTablet: false }),
-							linkStyles,
-						)}
+						css={[linkTablet({ showAtTablet: false }), linkStyles]}
 						data-link-name="nav2 : supporter-cta"
 					>
 						Subscriptions
@@ -208,18 +207,18 @@ export const Links = ({
 				</>
 			)}
 
-			<div className={seperatorStyles} />
+			<div css={seperatorStyles} />
 			<a
 				href="https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader"
-				className={cx(linkTablet({ showAtTablet: false }), linkStyles)}
+				css={[linkTablet({ showAtTablet: false }), linkStyles]}
 				data-link-name="nav2 : job-cta"
 			>
 				Search jobs
 			</a>
-			<div className={seperatorHideStyles} />
+			<div css={seperatorHideStyles} />
 
 			{userIsDefined ? (
-				<div className={linkStyles}>
+				<div css={linkStyles}>
 					<ProfileIcon />
 					<Dropdown
 						label="My account"
@@ -230,7 +229,7 @@ export const Links = ({
 				</div>
 			) : (
 				<a
-					className={linkStyles}
+					css={linkStyles}
 					href={`${idUrl}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
 						'guardian_signin_header',
 					)}`}
@@ -241,10 +240,6 @@ export const Links = ({
 			)}
 
 			<Search
-				className={cx(
-					linkTablet({ showAtTablet: false }),
-					searchLinkStyles,
-				)}
 				href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
 				dataLinkName="nav2 : search"
 			>

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { until } from '@guardian/src-foundations/mq';
 import { Display } from '@guardian/types';
@@ -67,10 +67,10 @@ export const MainMedia: React.FC<{
 	host,
 }) => (
 	<div
-		className={cx(
+		css={[
 			mainMedia,
 			format.display === Display.Immersive ? immersiveWrapper : noGutters,
-		)}
+		]}
 	>
 		{elements.map((element, index) =>
 			renderArticleElement({

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -124,7 +124,7 @@ export const MostViewedFooter = ({
 			css={adSlotUnspecifiedWidth}
 		>
 			<div
-				css={cx(stackBelow('leftCol'), mostPopularAdStyle)}
+				css={[stackBelow('leftCol'), mostPopularAdStyle]}
 				data-link-name="most-popular"
 				data-component="most-popular"
 				data-cy-ab-user-in-variant={abTestCypressDataAttr}

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { text } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
@@ -120,19 +120,20 @@ export const MostViewedFooter = ({
 	return (
 		<div
 			data-print-layout="hide"
-			className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}
+			className="content-footer"
+			css={adSlotUnspecifiedWidth}
 		>
 			<div
-				className={cx(stackBelow('leftCol'), mostPopularAdStyle)}
+				css={cx(stackBelow('leftCol'), mostPopularAdStyle)}
 				data-link-name="most-popular"
 				data-component="most-popular"
 				data-cy-ab-user-in-variant={abTestCypressDataAttr}
 				data-cy-ab-runnable-test={variantFromRunnable}
 			>
-				<section className={asideWidth}>
-					<h2 className={headingStyles}>Most popular</h2>
+				<section css={asideWidth}>
+					<h2 css={headingStyles}>Most popular</h2>
 				</section>
-				<section className={stackBelow('desktop')}>
+				<section css={stackBelow('desktop')}>
 					<Lazy margin={300}>
 						<Suspense fallback={<></>}>
 							<MostViewedFooterData
@@ -143,7 +144,7 @@ export const MostViewedFooter = ({
 						</Suspense>
 					</Lazy>
 					<div
-						className={css`
+						css={css`
 							margin: 6px 0 0 10px;
 						`}
 					>

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from, Breakpoint } from '@guardian/src-foundations/mq';
@@ -70,7 +70,7 @@ export const MostViewedFooterData = ({
 		const tabs = 'tabs' in data ? data.tabs : data;
 		return (
 			<div
-				className={css`
+				css={css`
 					width: 100%;
 				`}
 			>
@@ -79,7 +79,7 @@ export const MostViewedFooterData = ({
 					sectionName={sectionName}
 					palette={palette}
 				/>
-				<div className={cx(stackBelow('tablet'), secondTierStyles)}>
+				<div css={[stackBelow('tablet'), secondTierStyles]}>
 					{'mostCommented' in data && (
 						<SecondTierItem
 							trail={decideTrail(data.mostCommented)}

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { neutral, border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -105,7 +105,7 @@ const TabHeading = ({ heading }: { heading: string }) => {
 		default:
 			return (
 				<span
-					className={css`
+					css={css`
 						text-transform: capitalize;
 					`}
 					// "Across The Guardian" has a non-breaking space entity between "The" and "Guardian - Eg. "Across The&nbsp;Guardian"
@@ -122,20 +122,20 @@ export const MostViewedFooterGrid = ({ data, sectionName, palette }: Props) => {
 	return (
 		<div>
 			{Array.isArray(data) && data.length > 1 && (
-				<ul className={tabsContainer} role="tablist">
+				<ul css={tabsContainer} role="tablist">
 					{data.map((tab: TrailTabType, i: number) => {
 						const isSelected = i === selectedTabIndex;
 						const isFirst = i === 0;
 						const selectedStyles = selectedListTabStyles(palette);
 						return (
 							<li
-								className={cx(
+								css={[
 									listTab,
 									isSelected
 										? selectedStyles
 										: unselectedStyles,
 									isFirst && firstTab,
-								)}
+								]}
 								role="tab"
 								aria-selected={isSelected}
 								aria-controls={`tabs-popular-${i}`}
@@ -145,11 +145,11 @@ export const MostViewedFooterGrid = ({ data, sectionName, palette }: Props) => {
 								data-link-name={tab.heading}
 							>
 								<button
-									className={tabButton}
+									css={tabButton}
 									onClick={() => setSelectedTabIndex(i)}
 								>
 									<span
-										className={css`
+										css={css`
 											${visuallyHidden};
 										`}
 									>
@@ -165,9 +165,7 @@ export const MostViewedFooterGrid = ({ data, sectionName, palette }: Props) => {
 			)}
 			{data.map((tab: TrailTabType, i: number) => (
 				<ol
-					className={cx(gridContainer, {
-						[hideList]: i !== selectedTabIndex,
-					})}
+					css={[gridContainer, i !== selectedTabIndex && hideList]}
 					id={`tabs-popular-${i}`}
 					data-cy={`tab-body-${i}`}
 					key={`tabs-popular-${i}`}

--- a/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from } from '@guardian/src-foundations/mq';
 import { brandText, brandAlt } from '@guardian/src-foundations/palette';
@@ -74,12 +74,12 @@ export const CollapseColumnButton: React.FC<{
 	// @ts-ignore
 	<label
 		id={collapseColumnInputId}
-		className={cx(
-			'selectableMenuItem',
+		className="selectableMenuItem"
+		css={[
 			collapseColumnButton,
 			showColumnLinksStyle(columnInputId),
 			hideDesktop,
-		)}
+		]}
 		aria-label={`Toggle ${title}`}
 		htmlFor={columnInputId}
 		aria-haspopup="true"

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -174,7 +174,7 @@ export const Column = ({
 	const collapseColumnInputId = `${column.title}-button`;
 
 	return (
-		<li className={cx(columnStyle, pillarDivider)} role="none">
+		<li css={[columnStyle, pillarDivider]} role="none">
 			{/*
                 IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
 
@@ -209,7 +209,7 @@ export const Column = ({
             */}
 			<input
 				type="checkbox"
-				className={css`
+				css={css`
 					${visuallyHidden};
 				`}
 				id={columnInputId}
@@ -226,12 +226,12 @@ export const Column = ({
 
 			{/* ColumnLinks */}
 			<ul
-				className={cx(
+				css={[
 					columnLinks,
-					{ [firstColumnLinks]: index === 0 },
-					{ [pillarColumnLinks]: !!column.pillar },
+					index === 0 && firstColumnLinks,
+					!!column.pillar && pillarColumnLinks,
 					columnInputId && hideStyles(columnInputId),
-				)}
+				]}
 				role="menu"
 				id={`${column.title.toLowerCase()}Links`}
 				data-cy={`${column.title.toLowerCase()}Links`}
@@ -239,16 +239,15 @@ export const Column = ({
 				{(column.children || []).map((link) => (
 					<li
 						key={link.title.toLowerCase()}
-						className={cx(mainMenuLinkStyle, {
-							[hideDesktop]: !!link.mobileOnly,
-						})}
+						css={[
+							mainMenuLinkStyle,
+							!!link.mobileOnly && hideDesktop,
+						]}
 						role="none"
 					>
 						<a
-							className={cx(
-								'selectableMenuItem',
-								columnLinkTitle,
-							)}
+							className="selectableMenuItem"
+							css={columnLinkTitle}
 							href={link.url}
 							role="menuitem"
 							data-link-name={`nav2 : secondary : ${link.longTitle}`}

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -8,7 +8,7 @@ import { Column } from './Column';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 import { MoreColumn } from './MoreColumn';
 
-const ColumnsStyle = css`
+const columnsStyle = css`
 	box-sizing: border-box;
 	max-width: none;
 	${from.desktop} {
@@ -100,7 +100,7 @@ const brandExtensionLink = css`
 export const Columns: React.FC<{
 	nav: NavType;
 }> = ({ nav }) => (
-	<ul className={ColumnsStyle} role="menubar" data-cy="nav-menu-columns">
+	<ul css={columnsStyle} role="menubar" data-cy="nav-menu-columns">
 		{nav.pillars.map((column, i) => (
 			<Column
 				column={column}
@@ -114,18 +114,13 @@ export const Columns: React.FC<{
 			brandExtensions={nav.brandExtensions}
 			key="more"
 		/>
-		<li className={desktopBrandExtensionColumn} role="none">
-			<ul className={brandExtensionList} role="menu">
+		<li css={desktopBrandExtensionColumn} role="none">
+			<ul css={brandExtensionList} role="menu">
 				{nav.brandExtensions.map((brandExtension) => (
-					<li
-						className={brandExtensionListItem}
-						key={brandExtension.title}
-					>
+					<li css={brandExtensionListItem} key={brandExtension.title}>
 						<a
-							className={cx(
-								'selectableMenuItem',
-								brandExtensionLink,
-							)}
+							className="selectableMenuItem"
+							css={brandExtensionLink}
 							href={brandExtension.url}
 							key={brandExtension.title}
 							role="menuitem"

--- a/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -171,29 +171,26 @@ export const MoreColumn: React.FC<{
 	};
 	return (
 		<li
-			className={cx(columnStyle, pillarDivider, pillarDividerExtended)}
+			css={[columnStyle, pillarDivider, pillarDividerExtended]}
 			role="none"
 		>
 			<ul
-				className={cx(columnLinks, {
-					[pillarColumnLinks]: !!moreColumn.pillar,
-				})}
+				css={[columnLinks, !!moreColumn.pillar && pillarColumnLinks]}
 				role="menu"
 				id={subNavId}
 			>
 				{(moreColumn.children || []).map((link) => (
 					<li
 						key={link.title.toLowerCase()}
-						className={cx(mainMenuLinkStyle, {
-							[hideDesktop]: !!link.mobileOnly,
-						})}
+						css={[
+							mainMenuLinkStyle,
+							!!link.mobileOnly && hideDesktop,
+						]}
 						role="none"
 					>
 						<a
-							className={cx(
-								'selectableMenuItem',
-								columnLinkTitle,
-							)}
+							className="selectableMenuItem"
+							css={columnLinkTitle}
 							href={link.url}
 							role="menuitem"
 							data-link-name={`nav2 : secondary : ${link.longTitle}`}

--- a/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from } from '@guardian/src-foundations/mq';
 import { brandText, brandAlt } from '@guardian/src-foundations/palette';
@@ -75,17 +75,16 @@ export const ReaderRevenueLinks: React.FC<{
 	];
 
 	return (
-		<ul className={hideDesktop} role="menu">
+		<ul css={hideDesktop} role="menu">
 			{links.map((link) => (
 				<li
 					key={link.title.toLowerCase()}
-					className={cx(mainMenuLinkStyle, {
-						[hideDesktop]: !!link.mobileOnly,
-					})}
+					css={[mainMenuLinkStyle, !!link.mobileOnly && hideDesktop]}
 					role="none"
 				>
 					<a
-						className={cx('selectableMenuItem', columnLinkTitle)}
+						className="selectableMenuItem"
+						css={columnLinkTitle}
 						href={link.url}
 						role="menuitem"
 						data-link-name={`nav2 : secondary : ${link.longTitle}`}

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -1,11 +1,10 @@
-import { css, cx } from 'emotion';
+import { css, ThemeProvider } from '@emotion/react';
 
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { Pillars } from '@root/src/web/components/Pillars';
 import { GuardianRoundel } from '@root/src/web/components/GuardianRoundel';
 import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
-import { ThemeProvider } from '@emotion/react';
 import { Button, buttonReaderRevenue } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 
@@ -40,7 +39,7 @@ const minHeight = css`
 
 const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
 	<div
-		className={css`
+		css={css`
 			margin-top: 3px;
 			z-index: 2;
 
@@ -57,7 +56,7 @@ const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
 
 const PositionButton = ({ children }: { children: React.ReactNode }) => (
 	<div
-		className={css`
+		css={css`
 			margin-top: ${space[1]}px;
 			margin-left: ${space[2]}px;
 		`}
@@ -68,7 +67,7 @@ const PositionButton = ({ children }: { children: React.ReactNode }) => (
 
 export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
 	return (
-		<div className={rowStyles}>
+		<div css={rowStyles}>
 			{/*
                 IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
 
@@ -159,11 +158,11 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
 				}}
 			/>
 			<nav
-				className={cx(
+				css={[
 					clearFixStyle,
 					rowStyles,
 					format.display === Display.Immersive && minHeight,
-				)}
+				]}
 				role="navigation"
 				aria-label="Guardian sections"
 				data-component="nav2"
@@ -198,7 +197,7 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
             */}
 				<input
 					type="checkbox"
-					className={css`
+					css={css`
 						${visuallyHidden};
 					`}
 					id={navInputCheckboxId}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -577,7 +577,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<button
 								onClick={prev}
 								aria-label="Move carousel backwards"
-								css={cx(buttonStyle, prevButtonStyle(index))}
+								css={[buttonStyle, prevButtonStyle(index)]}
 								data-link-name={`${arrowName}-prev`}
 							>
 								<SvgChevronLeftSingle />
@@ -585,10 +585,10 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<button
 								onClick={next}
 								aria-label="Move carousel forwards"
-								css={cx(
+								css={[
 									buttonStyle,
 									nextButtonStyle(index, trails.length),
-								)}
+								]}
 								data-link-name={`${arrowName}-next`}
 							>
 								<SvgChevronRightSingle />

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import libDebounce from 'lodash/debounce';
 
 import { headline } from '@guardian/src-foundations/typography';
@@ -281,9 +281,9 @@ const Title = ({
 	palette: Palette;
 	isCuratedContent?: boolean;
 }) => (
-	<h2 className={headerStyles}>
+	<h2 css={headerStyles}>
 		{isCuratedContent ? 'More from ' : ''}
-		<span className={titleStyle(palette, isCuratedContent)}>{title}</span>
+		<span css={titleStyle(palette, isCuratedContent)}>{title}</span>
 	</h2>
 );
 
@@ -377,8 +377,8 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 			palette={palette}
 			isCuratedContent={isCuratedContent}
 		/>
-		<div className={dotsStyle}>
-			{trails.map((value, i) => (
+		<div css={dotsStyle}>
+			{trails.map((_, i) => (
 				<span
 					onClick={() => goToIndex(i)}
 					// This button is not particularly useful for keyboard users as the stories
@@ -386,7 +386,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 					// not available to keyboard
 					aria-hidden="true"
 					key={`dot-${i}`}
-					className={cx(
+					css={[
 						dotStyle,
 						i === index && dotActiveStyle(palette),
 						adjustNumberOfDotsStyle(
@@ -394,7 +394,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 							trails.length,
 							isFullCardImage,
 						),
-					)}
+					]}
 					data-link-name={`${
 						isFullCardImage ? 'carousel-large' : 'carousel-small'
 					}-nav-dot-${i}`}
@@ -524,10 +524,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 	if (isFullCardImage) trails = convertToImmersive(trails);
 
 	return (
-		<div
-			className={wrapperStyle}
-			data-link-name={formatAttrString(heading)}
-		>
+		<div css={wrapperStyle} data-link-name={formatAttrString(heading)}>
 			<LeftColumn showRightBorder={false} showPartialRightBorder={true}>
 				<HeaderAndNav
 					heading={heading}
@@ -539,37 +536,34 @@ export const Carousel: React.FC<OnwardsType> = ({
 					goToIndex={goToIndex}
 				/>
 			</LeftColumn>
-			<div className={cx(buttonContainerStyle, prevButtonContainerStyle)}>
+			<div css={[buttonContainerStyle, prevButtonContainerStyle]}>
 				<button
 					onClick={prev}
 					aria-label="Move carousel backwards"
-					className={cx(buttonStyle, prevButtonStyle(index))}
+					css={[buttonStyle, prevButtonStyle(index)]}
 					data-link-name={`${arrowName}-prev`}
 				>
 					<SvgChevronLeftSingle />
 				</button>
 			</div>
 
-			<div className={cx(buttonContainerStyle, nextButtonContainerStyle)}>
+			<div css={[buttonContainerStyle, nextButtonContainerStyle]}>
 				<button
 					onClick={next}
 					aria-label="Move carousel forwards"
-					className={cx(
-						buttonStyle,
-						nextButtonStyle(index, trails.length),
-					)}
+					css={[buttonStyle, nextButtonStyle(index, trails.length)]}
 					data-link-name={`${arrowName}-next`}
 				>
 					<SvgChevronRightSingle />
 				</button>
 			</div>
 			<div
-				className={containerStyles}
+				css={containerStyles}
 				data-component={ophanComponentName}
 				data-link={formatAttrString(heading)}
 			>
 				<Hide when="above" breakpoint="leftCol">
-					<div className={headerRowStyles}>
+					<div css={headerRowStyles}>
 						<HeaderAndNav
 							heading={heading}
 							trails={trails}
@@ -583,10 +577,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<button
 								onClick={prev}
 								aria-label="Move carousel backwards"
-								className={cx(
-									buttonStyle,
-									prevButtonStyle(index),
-								)}
+								css={cx(buttonStyle, prevButtonStyle(index))}
 								data-link-name={`${arrowName}-prev`}
 							>
 								<SvgChevronLeftSingle />
@@ -594,7 +585,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<button
 								onClick={next}
 								aria-label="Move carousel forwards"
-								className={cx(
+								css={cx(
 									buttonStyle,
 									nextButtonStyle(index, trails.length),
 								)}
@@ -607,7 +598,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 				</Hide>
 
 				<ul
-					className={carouselStyle(isFullCardImage)}
+					css={carouselStyle(isFullCardImage)}
 					ref={carouselRef}
 					data-component={`${variantComponentName} | maxIndex-${maxIndex}`}
 				>

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { brand, brandText } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
@@ -234,15 +234,15 @@ export const Pillars: React.FC<{
 	showLastPillarDivider = true,
 	dataLinkName,
 }) => (
-	<ul data-testid="pillar-list" className={pillarsStyles(display)}>
+	<ul data-testid="pillar-list" css={pillarsStyles(display)}>
 		{pillars.map((p, i) => {
 			const isSelected = p.pillar === pillar;
 			const showDivider =
 				showLastPillarDivider || isNotLastPillar(i, pillars.length);
 			return (
-				<li key={p.title} className={pillarStyle}>
+				<li key={p.title} css={pillarStyle}>
 					<a
-						className={cx(
+						css={[
 							linkStyle(display),
 							pillarUnderline(
 								decidePalette({
@@ -254,7 +254,7 @@ export const Pillars: React.FC<{
 							isTopNav && showMenuUnderlineStyles,
 							isSelected && forceUnderline,
 							showDivider && pillarDivider,
-						)}
+						]}
 						href={p.url}
 						data-link-name={`${dataLinkName} : primary : ${p.title}`}
 					>

--- a/src/web/components/PulsingDot.tsx
+++ b/src/web/components/PulsingDot.tsx
@@ -1,5 +1,4 @@
-import { css, cx } from 'emotion';
-import { keyframes } from '@emotion/core';
+import { css, keyframes } from '@emotion/react';
 
 import { storage } from '@guardian/libs';
 
@@ -46,7 +45,5 @@ export const PulsingDot = ({ colour }: Props) => {
 	// flashingPreference is null if no preference exists and explicitly
 	// false when the reader has said they don't want flashing
 	const flashingEnabled = flashingPreference !== false;
-	return (
-		<span className={cx(dotStyles(colour), flashingEnabled && animate)} />
-	);
+	return <span css={[dotStyles(colour), flashingEnabled && animate]} />;
 };

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import {
@@ -255,7 +255,7 @@ const ReaderRevenueLinksRemote: React.FC<{
 
 	if (SupportHeader && supportHeaderResponse) {
 		return (
-			<div ref={setNode} className={headerStyles}>
+			<div ref={setNode} css={headerStyles}>
 				{/* eslint-disable react/jsx-props-no-spreading */}
 				<SupportHeader {...supportHeaderResponse.module.props} />
 				{/* eslint-enable react/jsx-props-no-spreading */}
@@ -325,14 +325,10 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 
 	if (hideSupportMessaging) {
 		return (
-			<div className={cx(inHeader && headerStyles)}>
-				<div
-					className={cx({
-						[hiddenUntilTablet]: inHeader,
-					})}
-				>
-					<div className={messageStyles(true)}> Thank you </div>
-					<div className={subMessageStyles}>
+			<div css={inHeader && headerStyles}>
+				<div css={inHeader && hiddenUntilTablet}>
+					<div css={messageStyles(true)}> Thank you </div>
+					<div css={subMessageStyles}>
 						Your support powers our independent journalism
 					</div>
 				</div>
@@ -342,7 +338,7 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 
 	const ContributeButton = () => (
 		<a
-			className={linkStyles}
+			css={linkStyles}
 			href={getUrl('contribute')}
 			data-link-name={`${dataLinkNamePrefix}contribute-cta`}
 		>
@@ -351,7 +347,7 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 	);
 	const SubscribeButton = () => (
 		<a
-			className={linkStyles}
+			css={linkStyles}
 			href={getUrl('subscribe')}
 			data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
 		>
@@ -363,28 +359,19 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 		edition === 'UK' ? ContributeButton : SubscribeButton;
 
 	return (
-		<div ref={setNode} className={cx(inHeader && headerStyles)}>
-			<div
-				className={cx({
-					[hiddenUntilTablet]: inHeader,
-				})}
-			>
-				<div className={messageStyles(false)}>
+		<div ref={setNode} css={cx(inHeader && headerStyles)}>
+			<div css={inHeader && hiddenUntilTablet}>
+				<div css={messageStyles(false)}>
 					<span>Support the&nbsp;Guardian</span>
 				</div>
-				<div className={subMessageStyles}>
+				<div css={subMessageStyles}>
 					<div>Available for everyone, funded by readers</div>
 				</div>
 				<PrimaryButton />
 				<SecondaryButton />
 			</div>
 
-			<div
-				className={cx({
-					[hiddenFromTablet]: inHeader,
-					[hidden]: !inHeader,
-				})}
-			>
+			<div css={inHeader ? hiddenFromTablet : hidden}>
 				<PrimaryButton />
 			</div>
 		</div>

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -359,7 +359,7 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 		edition === 'UK' ? ContributeButton : SubscribeButton;
 
 	return (
-		<div ref={setNode} css={cx(inHeader && headerStyles)}>
+		<div ref={setNode} css={inHeader && headerStyles}>
 			<div css={inHeader && hiddenUntilTablet}>
 				<div css={messageStyles(false)}>
 					<span>Support the&nbsp;Guardian</span>

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import {
 	text,
@@ -16,8 +16,6 @@ import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Hide } from '@root/src/web/components/Hide';
 import { Avatar } from '@frontend/web/components/Avatar';
-
-type ColourType = string;
 
 interface Props {
 	richLinkIndex: number;
@@ -44,19 +42,19 @@ const neutralBackground = css`
 	}
 `;
 
-const pillarBackground: (palette: Palette) => ColourType = (palette) => {
+const pillarBackground = (palette: Palette) => {
 	return css`
 		background-color: ${palette.background.richLink};
 	`;
 };
 
-const textColour: (palette: Palette) => ColourType = (palette) => {
+const textColour = (palette: Palette) => {
 	return css`
 		color: ${palette.text.richLink};
 	`;
 };
 
-const richLinkTopBorder: (palette: Palette) => ColourType = (palette) => {
+const richLinkTopBorder = (palette: Palette) => {
 	return css`
 		border-top: 1px;
 		border-top-style: solid;
@@ -99,7 +97,7 @@ const labsRichLinkTitle = css`
 	${textSans.small({ fontWeight: 'bold' })}
 `;
 
-const richLinkReadMore: (palette: Palette) => ColourType = (palette) => {
+const richLinkReadMore = (palette: Palette) => {
 	return css`
 		fill: ${palette.fill.richLink};
 		color: ${palette.text.richLink};
@@ -226,27 +224,21 @@ export const RichLink = ({
 			data-print-layout="hide"
 			data-link-name={`rich-link-${richLinkIndex} | ${richLinkIndex}`}
 			data-component="rich-link"
-			className={pillarBackground(palette)}
+			css={pillarBackground(palette)}
 			data-name={(isPlaceholder && 'placeholder') || ''}
 		>
-			<div className={neutralBackground}>
-				<a className={richLinkLink} href={url}>
-					<div className={richLinkTopBorder(palette)} />
+			<div css={neutralBackground}>
+				<a css={richLinkLink} href={url}>
+					<div css={richLinkTopBorder(palette)} />
 					{showImage && (
 						<div>
-							<img
-								className={imageStyles}
-								src={thumbnailUrl}
-								alt=""
-							/>
+							<img css={imageStyles} src={thumbnailUrl} alt="" />
 						</div>
 					)}
-					<div className={richLinkElements}>
-						<div className={richLinkHeader}>
+					<div css={richLinkElements}>
+						<div css={richLinkHeader}>
 							<div
-								className={cx(
-									isLabs ? labsRichLinkTitle : richLinkTitle,
-								)}
+								css={isLabs ? labsRichLinkTitle : richLinkTitle}
 							>
 								{isOpinion && (
 									<>
@@ -267,14 +259,12 @@ export const RichLink = ({
 								{linkText}
 							</div>
 							{isOpinion && (
-								<div
-									className={cx(byline, textColour(palette))}
-								>
+								<div css={[byline, textColour(palette)]}>
 									{mainContributor}
 								</div>
 							)}
 							{starRating && starRating > 0 && (
-								<div className={starWrapper}>
+								<div css={starWrapper}>
 									<StarRating
 										rating={starRating}
 										size="medium"
@@ -282,13 +272,13 @@ export const RichLink = ({
 								</div>
 							)}
 							{isPaidContent && sponsorName && (
-								<div className={paidForBranding}>
+								<div css={paidForBranding}>
 									Paid for by {sponsorName}
 								</div>
 							)}
 						</div>
 						{isOpinion && contributorImage && (
-							<div className={contributorImageWrapper}>
+							<div css={contributorImageWrapper}>
 								<Avatar
 									imageSrc={contributorImage}
 									imageAlt={mainContributor}
@@ -296,10 +286,10 @@ export const RichLink = ({
 								/>
 							</div>
 						)}
-						<div className={richLinkReadMore(palette)}>
+						<div css={richLinkReadMore(palette)}>
 							<ArrowInCircle />
 							<div
-								className={cx(
+								css={cx(
 									isLabs
 										? labsReadMoreTextStyle
 										: readMoreTextStyle,

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -292,7 +292,7 @@ export const RichLink = ({
 								css={
 									isLabs
 										? labsReadMoreTextStyle
-										: readMoreTextStyle,
+										: readMoreTextStyle
 								}
 							>
 								{readMoreText(contentType)}

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -289,11 +289,11 @@ export const RichLink = ({
 						<div css={richLinkReadMore(palette)}>
 							<ArrowInCircle />
 							<div
-								css={cx(
+								css={
 									isLabs
 										? labsReadMoreTextStyle
 										: readMoreTextStyle,
-								)}
+								}
 							>
 								{readMoreText(contentType)}
 							</div>

--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 
 const hideBelowDesktop = css`
@@ -22,5 +22,5 @@ type Props = {
 };
 
 export const RightColumn = ({ children }: Props) => {
-	return <section className={cx(hideBelowDesktop)}>{children}</section>;
+	return <section css={hideBelowDesktop}>{children}</section>;
 };

--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
@@ -68,19 +68,15 @@ export const Section = ({
 	shouldCenter = true,
 	children,
 }: Props) => (
-	<section
-		className={cx(
-			backgroundColour && setBackgroundColour(backgroundColour),
-		)}
-	>
+	<section css={backgroundColour && setBackgroundColour(backgroundColour)}>
 		<div
 			id={sectionId}
-			className={cx(
+			css={[
 				shouldCenter && center,
 				showSideBorders && sideBorders(borderColour),
 				showTopBorder && topBorder(borderColour),
 				padded && padding,
-			)}
+			]}
 		>
 			{children && children}
 		</div>

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -153,10 +153,10 @@ export const SeriesSectionLink = ({
 						// We have a tag, we're not immersive, show both series and section titles
 						return (
 							// Sometimes the tags/titles are shown inline, sometimes stacked
-							<div className={cx(!badge && rowBelowLeftCol)}>
+							<div css={!badge && rowBelowLeftCol}>
 								<a
 									href={`${guardianBaseURL}/${tag.id}`}
-									className={cx(
+									css={[
 										sectionLabelLink,
 										marginRight,
 										fontStyles(format),
@@ -172,7 +172,7 @@ export const SeriesSectionLink = ({
 													${palette.background
 														.seriesTitle};
 										`,
-									)}
+									]}
 									data-component="series"
 									data-link-name="article series"
 								>
@@ -182,7 +182,7 @@ export const SeriesSectionLink = ({
 								<Hide when="below" breakpoint="tablet">
 									<a
 										href={`${guardianBaseURL}/${sectionUrl}`}
-										className={cx(
+										css={[
 											sectionLabelLink,
 											fontStyles(format),
 											displayBlock,
@@ -199,7 +199,7 @@ export const SeriesSectionLink = ({
 														${palette.background
 															.seriesTitle};
 											`,
-										)}
+										]}
 										data-component="section"
 										data-link-name="article section"
 									>
@@ -211,10 +211,10 @@ export const SeriesSectionLink = ({
 					}
 					// There's no tag so fallback to section title
 					return (
-						<div className={marginBottom}>
+						<div css={marginBottom}>
 							<a
 								href={`${guardianBaseURL}/${sectionUrl}`}
-								className={cx(
+								css={[
 									sectionLabelLink,
 									marginRight,
 									fontStyles(format),
@@ -230,7 +230,7 @@ export const SeriesSectionLink = ({
 												${palette.background
 													.seriesTitle};
 									`,
-								)}
+								]}
 								data-component="section"
 								data-link-name="article section"
 							>
@@ -244,12 +244,10 @@ export const SeriesSectionLink = ({
 						if (!tag) return null; // Just to keep ts happy
 						return (
 							<div
-								className={cx(
-									badge && immersiveTitleBadgeStyle(palette),
-								)}
+								css={badge && immersiveTitleBadgeStyle(palette)}
 							>
 								{badge && (
-									<div className={titleBadgeWrapper}>
+									<div css={titleBadgeWrapper}>
 										<Badge
 											imageUrl={badge.imageUrl}
 											seriesTag={badge.seriesTag}
@@ -258,7 +256,7 @@ export const SeriesSectionLink = ({
 								)}
 
 								<a
-									className={cx(
+									css={[
 										sectionLabelLink,
 										fontStyles(format),
 										invertedStyle,
@@ -274,7 +272,7 @@ export const SeriesSectionLink = ({
 													${palette.background
 														.seriesTitle};
 										`,
-									)}
+									]}
 									href={`${guardianBaseURL}/${tag.id}`}
 									data-component="series"
 									data-link-name="article series"
@@ -296,10 +294,10 @@ export const SeriesSectionLink = ({
 				// We have a tag, we're not immersive, show both series and section titles
 				return (
 					// Sometimes the tags/titles are shown inline, sometimes stacked
-					<div className={cx(!badge && rowBelowLeftCol)}>
+					<div css={!badge && rowBelowLeftCol}>
 						<a
 							href={`${guardianBaseURL}/${tag.id}`}
-							className={cx(
+							css={[
 								sectionLabelLink,
 								css`
 									color: ${palette.text.seriesTitle};
@@ -315,7 +313,7 @@ export const SeriesSectionLink = ({
 										6px 0 0 0
 											${palette.background.seriesTitle};
 								`,
-							)}
+							]}
 							data-component="series"
 							data-link-name="article series"
 						>
@@ -325,7 +323,7 @@ export const SeriesSectionLink = ({
 						<Hide when="below" breakpoint="tablet">
 							<a
 								href={`${guardianBaseURL}/${sectionUrl}`}
-								className={cx(
+								css={[
 									sectionLabelLink,
 									secondaryFontStyles(format),
 									displayBlock,
@@ -335,7 +333,7 @@ export const SeriesSectionLink = ({
 										background-color: ${palette.background
 											.sectionTitle};
 									`,
-								)}
+								]}
 								data-component="section"
 								data-link-name="article section"
 							>
@@ -349,7 +347,7 @@ export const SeriesSectionLink = ({
 			return (
 				<a
 					href={`${guardianBaseURL}/${sectionUrl}`}
-					className={cx(
+					css={[
 						sectionLabelLink,
 						css`
 							color: ${palette.text.sectionTitle};
@@ -359,7 +357,7 @@ export const SeriesSectionLink = ({
 						marginRight,
 						fontStyles(format),
 						breakWord,
-					)}
+					]}
 					data-component="section"
 					data-link-name="article section"
 				>

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
@@ -166,10 +166,7 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 	return (
 		<div
 			data-print-layout="hide"
-			className={cx(
-				nestedStyles(palette),
-				standfirstStyles(format, palette),
-			)}
+			css={[nestedStyles(palette), standfirstStyles(format, palette)]}
 			// eslint-disable-next-line react/no-danger
 			dangerouslySetInnerHTML={{
 				__html: sanitise(standfirst, {

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { space } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -123,9 +123,9 @@ export const SubMeta = ({
 	const hasSectionLinks = subMetaSectionLinks.length > 0;
 	const hasKeywordLinks = subMetaKeywordLinks.length > 0;
 	return (
-		<div data-print-layout="hide" className={bottomPadding}>
+		<div data-print-layout="hide" css={bottomPadding}>
 			{badge && (
-				<div className={badgeWrapper}>
+				<div css={badgeWrapper}>
 					<Badge
 						imageUrl={badge.imageUrl}
 						seriesTag={badge.seriesTag}
@@ -134,23 +134,23 @@ export const SubMeta = ({
 			)}
 			{(hasSectionLinks || hasKeywordLinks) && (
 				<>
-					<span className={labelStyles(palette)}>Topics</span>
-					<div className={listWrapper(palette)}>
+					<span css={labelStyles(palette)}>Topics</span>
+					<div css={listWrapper(palette)}>
 						{hasSectionLinks && (
-							<ul className={listStyleNone}>
+							<ul css={listStyleNone}>
 								{subMetaSectionLinks.map((link, i) => (
 									<li
-										className={cx(
+										css={[
 											listItemStyles(palette),
 											sectionStyles(format),
 											i ===
 												subMetaSectionLinks.length -
 													1 && hideSlash,
-										)}
+										]}
 										key={link.url}
 									>
 										<a
-											className={linkStyles(palette)}
+											css={linkStyles(palette)}
 											href={link.url}
 										>
 											{link.title}
@@ -160,20 +160,20 @@ export const SubMeta = ({
 							</ul>
 						)}
 						{hasKeywordLinks && (
-							<ul className={listStyleNone}>
+							<ul css={listStyleNone}>
 								{subMetaKeywordLinks.map((link, i) => (
 									<li
-										className={cx(
+										css={[
 											listItemStyles(palette),
 											keywordStyles,
 											i ===
 												subMetaKeywordLinks.length -
 													1 && hideSlash,
-										)}
+										]}
 										key={link.url}
 									>
 										<a
-											className={linkStyles(palette)}
+											css={linkStyles(palette)}
 											href={link.url}
 										>
 											{link.title}
@@ -187,7 +187,7 @@ export const SubMeta = ({
 			)}
 			{showBottomSocialButtons && (
 				<div
-					className={css`
+					css={css`
 						display: flex;
 						justify-content: space-between;
 					`}
@@ -206,7 +206,7 @@ export const SubMeta = ({
 						]}
 						size="medium"
 					/>
-					<div className={syndicationButtonOverrides(palette)}>
+					<div css={syndicationButtonOverrides(palette)}>
 						<LinkButton
 							priority="tertiary"
 							size="xsmall"

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { text, news, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -11,7 +11,7 @@ type Props = {
 	currentNavLink: string;
 };
 
-const wrapperCollapsed = css`
+const wrapperCollapsedStyles = css`
 	height: 36px;
 	overflow: hidden;
 
@@ -171,28 +171,22 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 	return (
 		<div
 			data-print-layout="hide"
-			className={cx(
-				{ [wrapperCollapsed]: collapseWrapper },
-				spaceBetween,
-			)}
+			css={[collapseWrapper && wrapperCollapsedStyles, spaceBetween]}
 			data-cy="sub-nav"
 			data-component="sub-nav"
 		>
 			<ul
 				ref={ulRef}
-				className={cx({
-					[collapsedStyles]: !expandSubNav,
-					[expandedStyles]: expandSubNav,
-				})}
+				css={[expandSubNav ? expandedStyles : collapsedStyles]}
 			>
 				{subNavSections.parent && (
 					<li
 						key={subNavSections.parent.url}
-						className={listItemStyles(palette)}
+						css={listItemStyles(palette)}
 					>
 						<a
 							data-src-focus-disabled={true}
-							className={parentLinkStyle}
+							css={parentLinkStyle}
 							href={subNavSections.parent.url}
 						>
 							{subNavSections.parent.title}
@@ -202,9 +196,10 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 				{subNavSections.links.map((link) => (
 					<li key={link.url}>
 						<a
-							className={cx(linkStyle, {
-								[selected]: link.title === currentNavLink,
-							})}
+							css={[
+								linkStyle,
+								link.title === currentNavLink && selected,
+							]}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(
@@ -219,7 +214,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 			{showMore && (
 				<button
 					onClick={() => setIsExpanded(!isExpanded)}
-					className={showMoreStyle}
+					css={showMoreStyle}
 					data-link-name="nav2 : subnav-toggle"
 				>
 					{isExpanded ? 'Less' : 'More'}

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -282,21 +282,21 @@ export const CalloutBlockComponent = ({
 
 	if (submissionSuccess) {
 		return (
-			<figure data-print-layout="hide" className={wrapperStyles}>
+			<figure data-print-layout="hide" css={wrapperStyles}>
 				<details
-					className={cx(calloutDetailsStyles, backgroundColorStyle)}
+					css={[calloutDetailsStyles, backgroundColorStyle]}
 					aria-hidden={true}
 					open={isExpanded}
 				>
-					<summary className={summeryStyles}>
-						<div className={summeryContentWrapper}>
-							<div className={speechBubbleWrapperStyles}>
-								<div className={speechBubbleStyles(palette)}>
+					<summary css={summeryStyles}>
+						<div css={summeryContentWrapper}>
+							<div css={speechBubbleWrapperStyles}>
+								<div css={speechBubbleStyles(palette)}>
 									<h4>Share your story</h4>
 								</div>
 							</div>
-							<div className={headingTextStyles(palette)}>
-								<p className={successTextStyles}>
+							<div css={headingTextStyles(palette)}>
+								<p css={successTextStyles}>
 									Thank you for your contribution
 								</p>
 							</div>
@@ -308,23 +308,21 @@ export const CalloutBlockComponent = ({
 	}
 
 	return (
-		<figure data-print-layout="hide" className={wrapperStyles}>
+		<figure data-print-layout="hide" css={wrapperStyles}>
 			<details
-				className={cx(calloutDetailsStyles, {
-					[backgroundColorStyle]: isExpanded,
-				})}
+				css={[calloutDetailsStyles, isExpanded && backgroundColorStyle]}
 				aria-hidden={true}
 				open={isExpanded}
 			>
-				<summary className={summeryStyles}>
-					<div className={summeryContentWrapper}>
-						<div className={speechBubbleWrapperStyles}>
-							<div className={speechBubbleStyles(palette)}>
+				<summary css={summeryStyles}>
+					<div css={summeryContentWrapper}>
+						<div css={speechBubbleWrapperStyles}>
+							<div css={speechBubbleStyles(palette)}>
 								<h4>Share your story</h4>
 							</div>
 						</div>
-						<div className={headingTextStyles(palette)}>
-							<h4 className={headingTextHeaderStyles}>{title}</h4>
+						<div css={headingTextStyles(palette)}>
+							<h4 css={headingTextHeaderStyles}>{title}</h4>
 							{description && (
 								<div
 									dangerouslySetInnerHTML={{
@@ -335,12 +333,9 @@ export const CalloutBlockComponent = ({
 						</div>
 					</div>
 					{!isExpanded && (
-						<span
-							className={buttonWrapperStyles}
-							aria-hidden="true"
-						>
+						<span css={buttonWrapperStyles} aria-hidden="true">
 							<Button
-								className={css`
+								css={css`
 									/* TODO: need to find an nicer way of dynamically setting svg dimensions */
 									svg {
 										width: 15px !important;
@@ -366,7 +361,7 @@ export const CalloutBlockComponent = ({
 					error={error}
 				/>
 
-				<span className={buttonWrapperStyles} aria-hidden="true">
+				<span css={buttonWrapperStyles} aria-hidden="true">
 					{isExpanded && (
 						<Button
 							iconSide="left"

--- a/src/web/components/elements/DividerBlockComponent.tsx
+++ b/src/web/components/elements/DividerBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
@@ -49,12 +49,12 @@ export const DividerBlockComponent = ({
 	spaceAbove = 'loose',
 }: Props) => (
 	<hr
-		className={cx(
+		css={[
 			baseStyles,
 			size === 'partial' ? sizePartialStyle : sizeFullStyle,
 			spaceAbove === 'loose'
 				? looseSpaceAboveStyle
 				: tightSpaceAboveStyle,
-		)}
+		]}
 	/>
 );

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { until, from, between } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
@@ -50,7 +50,7 @@ const starsWrapper = css`
 `;
 
 const PositionStarRating: React.FC<{ rating: number }> = ({ rating }) => (
-	<div className={starsWrapper}>
+	<div css={starsWrapper}>
 		<StarRating rating={rating} size="large" />
 	</div>
 );
@@ -143,23 +143,21 @@ const ImageTitle: React.FC<{
 		case 'halfWidth':
 		case 'supporting':
 			return (
-				<h2 className={cx(titleWrapper(palette), basicTitlePadding)}>
+				<h2 css={[titleWrapper(palette), basicTitlePadding]}>
 					{title}
 				</h2>
 			);
 		case 'showcase':
 		case 'immersive':
 			return (
-				<h2 className={cx(titleWrapper(palette), moreTitlePadding)}>
-					{title}
-				</h2>
+				<h2 css={[titleWrapper(palette), moreTitlePadding]}>{title}</h2>
 			);
 	}
 };
 
 const Row = ({ children }: { children: React.ReactNode }) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: row;
 		`}
@@ -173,7 +171,7 @@ const CaptionToggle = () => (
 		{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
 		<label
 			htmlFor="the-checkbox"
-			className={css`
+			css={css`
 				position: absolute;
 				right: 5px;
 				width: 32px;
@@ -242,7 +240,7 @@ export const ImageComponent = ({
 	if (isMainMedia && format.display === Display.Immersive && isNotOpinion) {
 		return (
 			<div
-				className={css`
+				css={css`
 					/* These styles depend on the containing layout component wrapping the main media
                     with a div set to 100vh. This is the case for ImmersiveLayout which should
                     always be used if display === 'immersive' */
@@ -274,7 +272,7 @@ export const ImageComponent = ({
 	if (hideCaption) {
 		return (
 			<div
-				className={css`
+				css={css`
 					position: relative;
 
 					img {
@@ -305,7 +303,7 @@ export const ImageComponent = ({
 	return (
 		<>
 			<div
-				className={css`
+				css={css`
 					position: relative;
 
 					img {
@@ -331,7 +329,7 @@ export const ImageComponent = ({
 					<Hide when="above" breakpoint="tablet">
 						<Row>
 							<div
-								className={css`
+								css={css`
 									#the-checkbox {
 										/* Never show the input */
 										display: none;

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { Design } from '@guardian/types';
 import { headline } from '@guardian/src-foundations/typography';
@@ -126,7 +126,7 @@ export const PullQuoteBlockComponent: React.FC<{
 		case Design.Comment:
 			return (
 				<aside
-					className={cx(
+					css={[
 						decidePosition(role, design),
 						css`
 							${headline.xxsmall({ fontWeight: 'light' })};
@@ -150,11 +150,11 @@ export const PullQuoteBlockComponent: React.FC<{
 								background-color: #fbe6d5;
 							}
 						`,
-					)}
+					]}
 				>
 					<QuoteIcon colour={palette.fill.quoteIcon} size="medium" />
 					<blockquote
-						className={css`
+						css={css`
 							display: inline;
 						`}
 						// eslint-disable-next-line react/no-danger
@@ -170,7 +170,7 @@ export const PullQuoteBlockComponent: React.FC<{
 		case Design.PhotoEssay:
 			return (
 				<aside
-					className={cx(
+					css={[
 						decidePosition(role, design),
 						decideFont(role),
 						css`
@@ -183,7 +183,7 @@ export const PullQuoteBlockComponent: React.FC<{
 							padding-bottom: 12px;
 							margin-bottom: 16px;
 						`,
-					)}
+					]}
 				>
 					<QuoteIcon colour={palette.fill.quoteIcon} size="large" />
 					<blockquote
@@ -194,7 +194,7 @@ export const PullQuoteBlockComponent: React.FC<{
 					/>
 					<footer>
 						<cite
-							className={css`
+							css={css`
 								color: ${text.supporting};
 							`}
 						>
@@ -206,7 +206,7 @@ export const PullQuoteBlockComponent: React.FC<{
 		default:
 			return (
 				<aside
-					className={cx(
+					css={[
 						decidePosition(role, design),
 						css`
 							${headline.xxsmall({ fontWeight: 'bold' })};
@@ -229,11 +229,11 @@ export const PullQuoteBlockComponent: React.FC<{
 								background-color: ${neutral[97]};
 							}
 						`,
-					)}
+					]}
 				>
 					<QuoteIcon colour={palette.fill.quoteIcon} size="medium" />
 					<blockquote
-						className={css`
+						css={css`
 							display: inline;
 						`}
 						// eslint-disable-next-line react/no-danger
@@ -243,7 +243,7 @@ export const PullQuoteBlockComponent: React.FC<{
 					/>
 					<footer>
 						<cite
-							className={css`
+							css={css`
 								color: ${palette.text.pullQuoteAttribution};
 							`}
 						>

--- a/src/web/lib/verticalDivider.ts
+++ b/src/web/lib/verticalDivider.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/react';
 
 import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- use `@emotion/react` 
- change `className` to `css`
- remove `cx` as a reference

## Why?
Slowly move over to use Emotion 11
