### PR TITLE
Adding 'section' titles to Labs immersives

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -71,10 +71,9 @@ const fontStyles = (format: Format) => {
 			switch (format.display) {
 				case Display.Immersive:
 					return css`
-						${textSans.xlarge()}
+						${textSans.large({ fontWeight: 'bold' })}
 						line-height: 23px;
 						${from.leftCol} {
-							${textSans.large()}
 							line-height: 20px;
 						}
 					`;
@@ -83,7 +82,6 @@ const fontStyles = (format: Format) => {
 						${textSans.large()}
 						line-height: 23px;
 						${from.leftCol} {
-							${textSans.large()}
 							line-height: 20px;
 						}
 					`;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -66,22 +66,36 @@ const invertedStyle = css`
 `;
 
 const fontStyles = (format: Format) => {
-	if (format.theme === Special.Labs) {
-		return css`
-			${textSans.large()}
-			line-height: 23px;
-			${from.leftCol} {
-				${textSans.large()}
-				line-height: 20px;
+	switch (format.theme) {
+		case Special.Labs:
+			switch (format.display) {
+				case Display.Immersive:
+					return css`
+						${textSans.xlarge()}
+						line-height: 23px;
+						${from.leftCol} {
+							${textSans.large()}
+							line-height: 20px;
+						}
+					`;
+				default:
+					return css`
+						${textSans.large()}
+						line-height: 23px;
+						${from.leftCol} {
+							${textSans.large()}
+							line-height: 20px;
+						}
+					`;
 			}
-		`;
+		default:
+			return css`
+				${headline.xxxsmall({ fontWeight: 'bold' })}
+				${from.wide} {
+					${headline.xxsmall({ fontWeight: 'bold' })}
+				}
+			`;
 	}
-	return css`
-		${headline.xxxsmall({ fontWeight: 'bold' })}
-		${from.wide} {
-			${headline.xxsmall({ fontWeight: 'bold' })}
-		}
-	`;
 };
 
 const secondaryFontStyles = (format: Format) => {

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -143,6 +143,8 @@ export const SeriesSectionLink = ({
 
 	const hasSeriesTag = tag && tag.type === 'Series';
 
+	const isLabs = format.theme === Special.Labs;
+
 	switch (format.display) {
 		case Display.Immersive: {
 			switch (format.design) {
@@ -240,8 +242,9 @@ export const SeriesSectionLink = ({
 					);
 				}
 				default: {
-					if (hasSeriesTag) {
-						if (!tag) return null; // Just to keep ts happy
+					if (hasSeriesTag || isLabs) {
+						const title = tag?.title ? tag.title : sectionLabel;
+						const linkExt = tag?.id ? tag.id : sectionUrl;
 						return (
 							<div
 								css={badge && immersiveTitleBadgeStyle(palette)}
@@ -273,11 +276,11 @@ export const SeriesSectionLink = ({
 														.seriesTitle};
 										`,
 									]}
-									href={`${guardianBaseURL}/${tag.id}`}
+									href={`${guardianBaseURL}/${linkExt}`}
 									data-component="series"
 									data-link-name="article series"
 								>
-									<span>{tag.title}</span>
+									<span>{title}</span>
 								</a>
 							</div>
 						);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
<img width="1101" alt="labs title before" src="https://user-images.githubusercontent.com/3300789/119473336-fa507480-bd42-11eb-8ab9-4ccae3ee2c39.png">

### After
<img width="1064" alt="labs title after" src="https://user-images.githubusercontent.com/3300789/119473351-fd4b6500-bd42-11eb-8413-b59fc8be02bb.png">

## Why?
https://trello.com/c/GJWCkoz0/195-labs-series-tag-added-above-immersive-headline
