### PR TITLE
Temp disable share count cypress test

### DIFF
--- a/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -31,7 +31,8 @@ describe('Interactivity', function () {
 			cy.get('h1').click();
 			cy.get('[data-cy=dropdown-options]').should('not.be.visible');
 		});
-		it('should display the share count for an article', function () {
+		// eslint-disable-next-line mocha/no-skipped-tests
+		it.skip('should display the share count for an article', function () {
 			cy.visit(`/Article?url=${articleUrl}`);
 			cy.get('[data-cy=share-counts]').should('exist');
 		});

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -556,12 +556,14 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			<HydrateOnce rootId="labs-header">
 				<LabsHeader />
 			</HydrateOnce>
-			<Portal rootId="share-count-root">
-				<ShareCount
-					ajaxUrl={CAPI.config.ajaxUrl}
-					pageId={CAPI.pageId}
-				/>
-			</Portal>
+			{CAPI.config.switches.serverShareCounts && (
+				<Portal rootId="share-count-root">
+					<ShareCount
+						ajaxUrl={CAPI.config.ajaxUrl}
+						pageId={CAPI.pageId}
+					/>
+				</Portal>
+			)}
 			{youTubeAtoms.map((youTubeAtom) => (
 				<HydrateOnce rootId={youTubeAtom.elementId}>
 					<YoutubeBlockComponent


### PR DESCRIPTION
* disable Cypress share count test
* respect share count switch (`serverShareCounts`)

Why? - because a Facebook API change has broken our share counts for now. We can turn back on once fixed.
