### PR TITLE
Looser standfirst for labs

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -144,17 +144,25 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 						color: ${palette.text.standfirst};
 					`;
 				default:
-					return css`
-						${format.theme === Special.Labs
-							? textSans.medium()
-							: headline.xxxsmall({
+					switch (format.theme) {
+						case Special.Labs:
+							return css`
+								${textSans.medium()}
+								margin-bottom: ${space[3]}px;
+								max-width: 540px;
+								color: ${palette.text.standfirst};
+							`;
+						default:
+							return css`
+								${headline.xxxsmall({
 									fontWeight: 'bold',
-							  })};
-						line-height: 20px;
-						margin-bottom: ${space[3]}px;
-						max-width: 540px;
-						color: ${palette.text.standfirst};
-					`;
+								})};
+								line-height: 20px;
+								margin-bottom: ${space[3]}px;
+								max-width: 540px;
+								color: ${palette.text.standfirst};
+							`;
+					}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
<img width="1167" alt="standfirst before" src="https://user-images.githubusercontent.com/3300789/119491299-a8fdb080-bd55-11eb-8ff8-d0012a1043ef.png">

### After
<img width="1164" alt="standfirst after" src="https://user-images.githubusercontent.com/3300789/119491314-ae5afb00-bd55-11eb-9024-9a24f87aec18.png">

## Why?
Did not align to designs
https://trello.com/c/2UsDrNUV/198-labs-looser-line-spacing-on-standfirsts
