### PR TITLE
Enable sticky ads in US

### DIFF
--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -13,6 +13,7 @@ import { TopMeta } from '@root/src/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@root/src/amp/components/SubMeta';
 import { pillarPalette_DO_NOT_USE } from '@root/src/lib/pillars';
 import { Ad } from '@root/src/amp/components/Ad';
+import { StickyAd } from '@root/src/amp/components/StickyAd';
 import { findAdSlots } from '@root/src/amp/lib/find-adslots';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
@@ -197,6 +198,15 @@ export const Body: React.FC<{
 			{elements}
 
 			{epic}
+
+			<StickyAd
+				adRegion="US"
+				edition={data.editionId}
+				section={data.sectionName || ''}
+				contentType={adInfo.contentType}
+				config={adConfig}
+				commercialProperties={adInfo.commercialProperties}
+			/>
 
 			<SubMeta
 				sections={data.subMetaSectionLinks}

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -10,9 +10,11 @@ amp-sticky-ad:before {
 	display: block;
 	${textSans.xsmall()};
 	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif;
-	padding: 3px 10px;
+	padding: 3px 10px 0;
 	color: ${text.supporting};
 	text-align: right;
+	line-height: 1;
+	font-size: 0.75rem;
 }`;
 
 export const StickyAd = ({

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -7,6 +7,7 @@ import he from 'he';
 
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
+import { stickyAdLabelCss } from '@root/src/amp/components/StickyAd';
 
 interface RenderToStringResult {
 	html: string;
@@ -97,6 +98,7 @@ export const document = ({
         ${getFontsCss()}
         ${resetCSS}
         ${css}
+		${stickyAdLabelCss}
     </style>
 
     </head>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before

### After

Add the StickyAd component to BodyArticle, so they start appearing. Unfortunately due to restrictions on the <amp-sticky-ad> AMP component, the only way to add the "Advertisement" label was to include it in the global CSS in document.tsx.

Component added in previous PR: https://github.com/guardian/dotcom-rendering/pull/3006


Note: This PR is labelled `donotmerge` since turning this on is currently being confirmed with US ads team

https://user-images.githubusercontent.com/19875457/119694523-323fe080-be45-11eb-8a1e-aa75881afbf6.mov

## Why?

Additional ad revenue opportunity