### PR TITLE
Bump @guardian/braze-components to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^14.0.0",
         "@guardian/automat-client": "^0.2.17",
-        "@guardian/braze-components": "^2.0.0",
+        "@guardian/braze-components": "^2.1.0",
         "@guardian/consent-management-platform": "^6.11.3",
         "@guardian/discussion-rendering": "^7.0.0",
         "@guardian/libs": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,10 +1634,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.17.tgz#253724307312f4d5bc01b5749179193b8a29ae8b"
   integrity sha512-SbNeBjoc1iqt/EZ+zQTy7EbbXbdEHOuKObcseLKWyy/LF+4FQtHNuYxLGQ3zjl6fR7s/nvcnIEBAPrnFv0gcqQ==
 
-"@guardian/braze-components@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-2.0.0.tgz#d8cfcfb342d7a3a827a9b8906f828b15903eb048"
-  integrity sha512-708Gy8n/S4YEAgwYiPlJJzPXJJxjVM8CxGp6oYBjJpIbM4i/A5s0qDaFo3H7ZETOpGBFp7L+sfAuKi+tU0c6PA==
+"@guardian/braze-components@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-2.1.0.tgz#d878bf2d7351fd682ee8e5d588970d18a62efd8a"
+  integrity sha512-PofC9Ao2fjUhT9tQcLh5ZFy4n+AwJE2eDNd2UdKM0pnhnfhqLZV+II3wARKuVc8K+4EjDJLnNOY9UA+NbXgE2Q==
   dependencies:
     "@guardian/src-button" "3.3.0"
     "@guardian/src-foundations" "3.3.0"


### PR DESCRIPTION
## What does this change?

Upgrades to a version of `@guardian/braze-components` which contains a more robust approach to fetching data from the cache. If a message in the cache isn’t valid, we’ll skip over it (see guardian/braze-components#155).

### Before

Invalid Braze messages would clog the cache. If a message at the top of the queue was invalid, it wouldn't get rendered and would prevent messages after it from showing until the cache entry expires.

### After

And invalid message at the top of the cache will be skipped over.

## Why?

This new approach is more robust.