### PR TITLE
Enable picnic stories ads on AMP pages

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -4,6 +4,7 @@ import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
 // Largest size first
 const inlineSizes = [
+	{ width: 320, height: 480 }, // Picnic story
 	{ width: 300, height: 250 }, // MPU
 	{ width: 250, height: 250 }, // Square
 ];
@@ -141,6 +142,7 @@ export const Ad = ({
 						width={width}
 						height={height}
 						data-multi-size={multiSizes}
+						data-multi-size-validation="false"
 						data-npa-on-unknown-consent={true}
 						data-loading-strategy="prefer-viewability-over-views"
 						layout="fixed"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add 320x480 ad size to the AMP Ad component, which allows [picnic stories](https://www.picnic-media.com/solutions/#stories) to be shown. The component falls back to MPU size gracefully as seen below (due to data-multi-size-validation="false" flag).

### Before

### After

https://user-images.githubusercontent.com/19875457/119652765-6c49bc00-be1e-11eb-8b7e-daa4e75402c2.mov

## Why?

More ad revenue
