### PR TITLE
Remove renderToStaticMarkup from timeline block

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -66,11 +66,16 @@ export const Elements = (
 						id={element.id}
 						type={element.label}
 						title={element.title}
-						html={element.html}
 						img={element.img}
 						credit={element.credit}
 						pillar={pillar}
-					/>
+					>
+						<div
+							dangerouslySetInnerHTML={{
+								__html: element.html,
+							}}
+						/>
+					</Expandable>
 				);
 			case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
 				return (
@@ -109,11 +114,16 @@ export const Elements = (
 						id={element.id}
 						type={element.label}
 						title={element.title}
-						html={element.html}
 						img={element.img}
 						credit={element.credit}
 						pillar={pillar}
-					/>
+					>
+						<div
+							dangerouslySetInnerHTML={{
+								__html: element.html,
+							}}
+						/>
+					</Expandable>
 				);
 			case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
 				return (
@@ -129,11 +139,16 @@ export const Elements = (
 						id={element.id}
 						type="Q&A"
 						title={element.title}
-						html={element.html}
 						img={element.img}
 						credit={element.credit}
 						pillar={pillar}
-					/>
+					>
+						<div
+							dangerouslySetInnerHTML={{
+								__html: element.html,
+							}}
+						/>
+					</Expandable>
 				);
 			case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
 				return (

--- a/src/amp/components/Expandable.tsx
+++ b/src/amp/components/Expandable.tsx
@@ -171,10 +171,10 @@ export const Expandable: React.FC<{
 	type: string;
 	title: string;
 	img?: string;
-	html: string;
 	credit?: string;
 	pillar: Theme;
-}> = ({ id, type, title, img, html, credit, pillar }) => (
+	children: React.ReactNode;
+}> = ({ id, type, title, img, children, credit, pillar }) => (
 	<aside css={wrapper(pillar)}>
 		<div css={headers}>
 			<span css={[headerStyle, pillarColour(pillar)]}>{type}</span>
@@ -192,11 +192,7 @@ export const Expandable: React.FC<{
 					height="100"
 				/>
 			)}
-			<div
-				dangerouslySetInnerHTML={{
-					__html: html,
-				}}
-			/>
+			{children}
 			{credit && (
 				<span css={creditStyle}>
 					<span css={iconStyle}>

--- a/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { css } from '@emotion/react';
 
 import { Expandable } from '@root/src/amp/components/Expandable';
@@ -38,34 +37,6 @@ const headingStyle = css`
 	font-weight: bold;
 `;
 
-const getHTML = (events: TimelineEvent[], description?: string): string => {
-	const eventMarkup = events.map((e) => (
-		<li css={eventStyle} key={e.title}>
-			<time css={[eventIconStyle, highlight]}>{e.date}</time>
-			{e.toDate && (
-				<>
-					{' '}
-					- <time css={highlight}>{e.toDate}</time>
-				</>
-			)}
-			<div>
-				<h3 css={headingStyle}>{e.title}</h3>
-				<div
-					dangerouslySetInnerHTML={{
-						__html: e.body || '',
-					}}
-				/>
-			</div>
-		</li>
-	));
-
-	const eventString = renderToStaticMarkup(
-		<ul css={eventsWrapper}>{eventMarkup}</ul>,
-	);
-
-	return (description || '') + eventString;
-};
-
 export const TimelineBlockComponent: React.FC<{
 	id: string;
 	title: string;
@@ -73,11 +44,28 @@ export const TimelineBlockComponent: React.FC<{
 	events: TimelineEvent[];
 	pillar: Theme;
 }> = ({ id, title, description, events, pillar }) => (
-	<Expandable
-		id={id}
-		type="Timeline"
-		title={title}
-		html={getHTML(events, description)}
-		pillar={pillar}
-	/>
+	<Expandable id={id} type="Timeline" title={title} pillar={pillar}>
+		{description || ''}
+		<ul css={eventsWrapper}>
+			{events.map((e) => (
+				<li css={eventStyle} key={e.title}>
+					<time css={[eventIconStyle, highlight]}>{e.date}</time>
+					{e.toDate && (
+						<>
+							{' '}
+							- <time css={highlight}>{e.toDate}</time>
+						</>
+					)}
+					<div>
+						<h3 css={headingStyle}>{e.title}</h3>
+						<div
+							dangerouslySetInnerHTML={{
+								__html: e.body || '',
+							}}
+						/>
+					</div>
+				</li>
+			))}
+		</ul>
+	</Expandable>
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove `renderToStaticMarkup` from `TimelineBlockComponent`

## How?
We are changing `Expandable` as a component to use `children` instead of `html` prop. This means that we can use normal React components as chidren.

## Why?
We are already using `renderToStaticMarkup` in `document.tsx` in amp. There is no need to duplicate the logic.
