### PR TITLE
Keep meta in main col for interactives

### DIFF
--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -71,7 +71,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -84,13 +84,15 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title  border  headline'
 						'.      border  standfirst'
-						'lines  border  media'
-						'meta   border  media'
-						'meta   border  body'
+						'.      border  media'
+						'.      border  media'
+						'.      border  lines'
+						'.      border  meta'
+						'.      border  body'
 						'.      border  .';
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -103,9 +105,11 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title  border  headline'
 						'.      border  standfirst'
-						'lines  border  media'
-						'meta   border  media'
-						'meta   border  body'
+						'.      border  media'
+						'.      border  media'
+						'.      border  lines'
+						'.      border  meta'
+						'.      border  body'
 						'.      border  .';
 				}
 


### PR DESCRIPTION
## What does this change?

Small visual tweak to vanilla interactive pages to keep the main meta within the central grid column.

### Before

<img width="525" alt="Screenshot 2021-05-26 at 15 52 56" src="https://user-images.githubusercontent.com/858402/119685597-68796200-be3d-11eb-9028-8c18a7a6899e.png">

### After
![Screenshot 2021-05-26 at 16 07 23](https://user-images.githubusercontent.com/858402/119685617-6e6f4300-be3d-11eb-9341-0f190b69b757.png)

## Why?

Parity. And will help us identify genuine bugs more easily.
