### PR TITLE
Small tweaks for labs designs

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -122,22 +122,24 @@ const metaContainer = (format: Format) => {
 		case Display.Standard: {
 			switch (format.design) {
 				case Design.PhotoEssay:
-					return format.theme === Special.Labs ? defaultMargins : css`
-						${until.phablet} {
-							margin-left: -20px;
-							margin-right: -20px;
-						}
-						${until.mobileLandscape} {
-							margin-left: -10px;
-							margin-right: -10px;
-						}
-						${from.leftCol} {
-							margin-left: 20px;
-						}
-						${from.wide} {
-							margin-left: 40px;
-						}
-					`;
+					return format.theme === Special.Labs
+						? defaultMargins
+						: css`
+								${until.phablet} {
+									margin-left: -20px;
+									margin-right: -20px;
+								}
+								${until.mobileLandscape} {
+									margin-left: -10px;
+									margin-right: -10px;
+								}
+								${from.leftCol} {
+									margin-left: 20px;
+								}
+								${from.wide} {
+									margin-left: 40px;
+								}
+						  `;
 				default:
 					return defaultMargins;
 			}

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -106,13 +106,23 @@ const metaNumbers = (palette: Palette) => css`
 `;
 
 const metaContainer = (format: Format) => {
+	const defaultMargins = css`
+		${until.phablet} {
+			margin-left: -20px;
+			margin-right: -20px;
+		}
+		${until.mobileLandscape} {
+			margin-left: -10px;
+			margin-right: -10px;
+		}
+	`;
 	switch (format.display) {
 		case Display.Immersive:
 		case Display.Showcase:
 		case Display.Standard: {
 			switch (format.design) {
 				case Design.PhotoEssay:
-					return css`
+					return format.theme === Special.Labs ? defaultMargins : css`
 						${until.phablet} {
 							margin-left: -20px;
 							margin-right: -20px;
@@ -129,16 +139,7 @@ const metaContainer = (format: Format) => {
 						}
 					`;
 				default:
-					return css`
-						${until.phablet} {
-							margin-left: -20px;
-							margin-right: -20px;
-						}
-						${until.mobileLandscape} {
-							margin-left: -10px;
-							margin-right: -10px;
-						}
-					`;
+					return defaultMargins;
 			}
 		}
 	}

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -72,10 +72,13 @@ const immersiveStyles = (format: Format) => css`
 	margin-bottom: ${space[6]}px;
 `;
 
-const immersiveLinkStyles = (palette: Palette) => css`
+const immersiveLinkStyles = (palette: Palette, format: Format) => css`
 	a {
 		color: ${palette.text.headlineByline};
-		border-bottom: 1px solid ${palette.text.headlineByline};
+		border-bottom: 1px solid
+			${format.theme === Special.Labs
+				? palette.border.articleLink
+				: palette.text.headlineByline};
 		text-decoration: none;
 		:hover {
 			border-bottom: 1px solid ${palette.hover.headlineByline};
@@ -111,7 +114,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 			return (
 				<div css={immersiveStyles(format)}>
 					by{' '}
-					<span css={immersiveLinkStyles(palette)}>
+					<span css={immersiveLinkStyles(palette, format)}>
 						<BylineLink byline={byline} tags={tags} />
 					</span>
 				</div>

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -92,9 +92,9 @@ const richLinkTitle = css`
 
 const labsRichLinkTitle = css`
 	${from.wide} {
-		${textSans.medium({ fontWeight: 'bold' })}
+		${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })}
 	}
-	${textSans.small({ fontWeight: 'bold' })}
+	${textSans.small({ fontWeight: 'bold', lineHeight: 'regular' })}
 `;
 
 const richLinkReadMore = (palette: Palette) => {

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -108,6 +108,7 @@ const textByline = (format: Format): string => {
 
 const textHeadlineByline = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[300];
+	if (format.theme === Special.Labs) return BLACK;
 	return pillarPalette[format.theme].main;
 };
 
@@ -618,6 +619,7 @@ const topBarCard = (format: Format): string => {
 };
 
 const hoverHeadlineByline = (format: Format): string => {
+	if (format.theme === Special.Labs) return BLACK;
 	return pillarPalette[format.theme].dark;
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
A few small tweaks to the labs design as per feedback from design:

- Tighter line height on labs rich link headlines as per the design.
- Black byline links on immersives
- Small margin on the meta container for immersive and wide breakpoints 

### Before
![image](https://user-images.githubusercontent.com/8754692/119700079-bcd70e80-be4a-11eb-9bbd-1860b62b17e2.png)
![image](https://user-images.githubusercontent.com/8754692/119794216-3e708000-becf-11eb-98fa-b7f916ad45e1.png)
![image](https://user-images.githubusercontent.com/8754692/119794339-5c3de500-becf-11eb-9ecf-09f6d9796dae.png)


### After
![image](https://user-images.githubusercontent.com/8754692/119700414-16d7d400-be4b-11eb-9967-3b5b3a35f527.png)
![image](https://user-images.githubusercontent.com/8754692/119794275-4a5c4200-becf-11eb-900c-ef891cdb9683.png)
![image](https://user-images.githubusercontent.com/8754692/119794419-6c55c480-becf-11eb-83ff-567a8ac91e53.png)



## Why?
Feedback on consistency with the designs
