### PR TITLE
Render interactive layouts without using iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@emotion/server": "^11.4.0",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^14.0.0",
+        "@guardian/atoms-rendering": "^14.1.0",
         "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^2.0.0",
         "@guardian/consent-management-platform": "^6.11.3",

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -43,6 +43,7 @@ import {
 	ChartAtom,
 	ExplainerAtom,
 	InteractiveAtom,
+	InteractiveLayoutAtom,
 	QandaAtom,
 	GuideAtom,
 	ProfileAtom,
@@ -327,6 +328,17 @@ export const renderElement = ({
 				</ClickToView>,
 			];
 		case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
+			if (format.design === Design.Interactive) {
+				return [
+					true,
+					<InteractiveLayoutAtom
+						id={element.id}
+						elementHtml={element.html}
+						elementJs={element.js}
+						elementCss={element.css}
+					/>,
+				];
+			}
 			return [
 				true,
 				<InteractiveAtom

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,10 +1610,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-14.0.0.tgz#3c4ba3317683013250c112fcf58e05afff40a575"
-  integrity sha512-HQaiRKPK4Qz3JXVrq//5r8UDyF93DGzzdmMx/05jJDY5fdi0sNflqOKbuxHjpen0Vfim+6Rh8+pUVWk0/nsbhA==
+"@guardian/atoms-rendering@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-14.1.0.tgz#eaba7349a87fc09dbbd22ae5ef8dcc5a25d230bc"
+  integrity sha512-01bPJeHcO3EhLzzUPwnSkjMB6o0j6UfWhYdnvL/zBfHef6lf/+ShVEiGpNgdXueYVPH7fPyo4nTDaV8CnmUbKg==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

If the layout/design of the article is 'Interactive', then render interactive atoms in the main document instead of in an iframe.

This may need updated / improved upon as we further investigate interactive articles.

### Before
![image](https://user-images.githubusercontent.com/9575458/119856817-ec4d5000-bf0a-11eb-966e-2a5c6007e5dd.png)

### After
![image](https://user-images.githubusercontent.com/9575458/119856866-f5d6b800-bf0a-11eb-973a-2b748c8dc34d.png)

## Why?

This is how it appears to work in frontend
