### PR TITLE
Environment variable for SDC

### DIFF
--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -126,9 +126,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		return false;
 	};
 
-	const contributionsServiceUrl = process?.env?.SDC_URL
-		? process.env.SDC_URL
-		: CAPI.contributionsServiceUrl;
+	const contributionsServiceUrl =
+		process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;
 
 	return {
 		format: CAPI.format,

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -126,8 +126,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		return false;
 	};
 
-	const contributionsServiceUrl = process?.env?.SDC
-		? process.env.SDC
+	const contributionsServiceUrl = process?.env?.SDC_URL
+		? process.env.SDC_URL
 		: CAPI.contributionsServiceUrl;
 
 	return {

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -126,6 +126,10 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		return false;
 	};
 
+	const contributionsServiceUrl = process?.env?.SDC
+		? process.env.SDC
+		: CAPI.contributionsServiceUrl;
+
 	return {
 		format: CAPI.format,
 		config: {
@@ -192,7 +196,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 				header: CAPI.nav.readerRevenueLinks.header,
 			},
 		},
-		contributionsServiceUrl: CAPI.contributionsServiceUrl,
+		contributionsServiceUrl,
 		isImmersive: CAPI.isImmersive,
 		isPhotoEssay: CAPI.config.isPhotoEssay || false,
 		isSpecialReport: CAPI.isSpecialReport,


### PR DESCRIPTION
[SDC](https://github.com/guardian/support-dotcom-components) serves RR modules, e.g. epic + banner.
When running DCR locally we sometimes need to point it at a specific SDC environment (DEV/CODE/PROD).

If the SDC_URL environment variable is set then DCR uses that.