### PR TITLE
Update quiz atoms rendering v14.2.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -503,6 +503,7 @@ type CAPIBrowserType = {
 	matchUrl?: string;
 	elementsToHydrate: CAPIElement[];
 	isPreview?: boolean;
+	webTitle: string;
 };
 
 interface TagType {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@emotion/server": "^11.4.0",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^14.1.0",
+        "@guardian/atoms-rendering": "^14.2.1",
         "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^2.1.0",
         "@guardian/consent-management-platform": "^6.11.3",

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -188,6 +188,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		shouldHideAds: CAPI.shouldHideAds,
 		isAdFreeUser: CAPI.isAdFreeUser,
 		pageId: CAPI.pageId,
+		webTitle: CAPI.webTitle,
 		tags: CAPI.tags,
 		isCommentable: CAPI.isCommentable,
 		nav: {

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -50,6 +50,7 @@ import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount'
 import { getArticleCountConsent } from '@frontend/web/lib/contributions';
 import { ReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
+import { getSharingUrls } from '@root/src/lib/sharing-urls';
 
 import {
 	cmp,
@@ -600,6 +601,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 								id={quizAtom.id}
 								questions={quizAtom.questions}
 								resultBuckets={quizAtom.resultBuckets}
+								sharingUrls={getSharingUrls(
+									CAPI.pageId,
+									CAPI.webTitle,
+								)}
 							/>
 						)}
 						{quizAtom.quizType === 'knowledge' && (
@@ -607,6 +612,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 								id={quizAtom.id}
 								questions={quizAtom.questions}
 								resultGroups={quizAtom.resultGroups}
+								sharingUrls={getSharingUrls(
+									CAPI.pageId,
+									CAPI.webTitle,
+								)}
 							/>
 						)}
 					</>

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -103,6 +103,8 @@ export const ArticleBody = ({
 				elements={blocks[0] ? blocks[0].elements : []}
 				adTargeting={adTargeting}
 				host={host}
+				pageId={pageId}
+				webTitle={webTitle}
 			/>
 		</div>
 	);

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -114,6 +114,8 @@ export const ShowcaseInterview = () => (
 					})}
 					hideCaption={true}
 					elements={mainMediaElements}
+					pageId="testID"
+					webTitle="story article"
 				/>
 			</ArticleContainer>
 		</Flex>
@@ -163,6 +165,8 @@ export const ShowcaseInterviewNobyline = () => (
 					})}
 					hideCaption={true}
 					elements={mainMediaElements}
+					pageId="testID"
+					webTitle="story article"
 				/>
 			</ArticleContainer>
 		</Flex>
@@ -215,6 +219,8 @@ export const Interview = () => (
 					})}
 					hideCaption={true}
 					elements={mainMediaElements}
+					pageId="testID"
+					webTitle="story article"
 				/>
 			</ArticleContainer>
 		</Flex>
@@ -265,6 +271,8 @@ export const InterviewNoByline = () => (
 					})}
 					hideCaption={true}
 					elements={mainMediaElements}
+					pageId="testID"
+					webTitle="story article"
 				/>
 			</ArticleContainer>
 		</Flex>

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -277,6 +277,8 @@ export const LiveBlock = ({
 							host,
 							adTargeting,
 							index: 0,
+							pageId,
+							webTitle,
 						})}
 				</span>
 			</Header>
@@ -294,6 +296,8 @@ export const LiveBlock = ({
 									host,
 									index,
 									isMainMedia: false,
+									pageId,
+									webTitle,
 								})}
 							</BlockMedia>
 						);
@@ -307,6 +311,8 @@ export const LiveBlock = ({
 								element,
 								isMainMedia: false,
 								index,
+								pageId,
+								webTitle,
 							})}
 						</BlockText>
 					);

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -57,6 +57,8 @@ export const MainMedia: React.FC<{
 	adTargeting?: AdTargeting;
 	starRating?: number;
 	host?: string;
+	pageId: string;
+	webTitle: string;
 }> = ({
 	elements,
 	format,
@@ -65,6 +67,8 @@ export const MainMedia: React.FC<{
 	adTargeting,
 	starRating,
 	host,
+	pageId,
+	webTitle,
 }) => (
 	<div
 		css={[
@@ -83,6 +87,8 @@ export const MainMedia: React.FC<{
 				isMainMedia: true,
 				starRating,
 				hideCaption,
+				pageId,
+				webTitle,
 			}),
 		)}
 	</div>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -76,7 +76,7 @@ const StandardGrid = ({
 
 				grid-column-gap: 10px;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -108,7 +108,7 @@ const StandardGrid = ({
 						  `}
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -140,10 +140,10 @@ const StandardGrid = ({
 						  `}
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
-					Main content 
+					Main content
 					Right Column
 				*/
 				${until.leftCol} {
@@ -506,6 +506,8 @@ export const CommentLayout = ({
 										: undefined
 								}
 								host={host}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
 							/>
 						</div>
 					</GridItem>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -68,7 +68,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 				width: 100%;
 				margin-left: 0;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -91,7 +91,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      .           right-column';
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -114,10 +114,10 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      .           right-column';
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
-					Main content 
+					Main content
 					Right Column
 				*/
 				${until.leftCol} {
@@ -363,6 +363,8 @@ export const ImmersiveLayout = ({
 						}
 						host={host}
 						hideCaption={true}
+						pageId={CAPI.pageId}
+						webTitle={CAPI.webTitle}
 					/>
 				</div>
 				{mainMedia && (

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -107,7 +107,9 @@ const Renderer: React.FC<{
 	palette: Palette;
 	elements: CAPIElement[];
 	host?: string;
-}> = ({ format, palette, elements, host }) => {
+	pageId: string;
+	webTitle: string;
+}> = ({ format, palette, elements, host, pageId, webTitle }) => {
 	// const cleanedElements = elements.map(element =>
 	//     'html' in element ? { ...element, html: clean(element.html) } : element,
 	// );
@@ -122,6 +124,8 @@ const Renderer: React.FC<{
 			host,
 			index,
 			isMainMedia: false,
+			pageId,
+			webTitle,
 		});
 
 		return ok ? (
@@ -233,6 +237,8 @@ export const InteractiveImmersiveLayout = ({
 						}
 						host={host}
 						hideCaption={true}
+						pageId={CAPI.pageId}
+						webTitle={CAPI.webTitle}
 					/>
 				</div>
 				{mainMedia && (
@@ -297,6 +303,8 @@ export const InteractiveImmersiveLayout = ({
 						palette={palette}
 						elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
 						host={host}
+						pageId={CAPI.pageId}
+						webTitle={CAPI.webTitle}
 					/>
 				</main>
 			</Section>

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -427,6 +427,8 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								elements={CAPI.mainMediaElements}
 								adTargeting={adTargeting}
 								host={host}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
 							/>
 						</div>
 					</GridItem>

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -69,10 +69,10 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
-					Main content 
+					Main content
 					Empty border for spacing
 					Right Column
 				*/
@@ -372,6 +372,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								elements={CAPI.mainMediaElements}
 								adTargeting={adTargeting}
 								host={host}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
 							/>
 						</div>
 					</GridItem>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -75,7 +75,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -105,7 +105,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'.      border  .           right-column';
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Main content
@@ -455,6 +455,8 @@ export const ShowcaseLayout = ({
 										: undefined
 								}
 								host={host}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
 							/>
 						</div>
 					</GridItem>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -80,7 +80,7 @@ const StandardGrid = ({
 
 				grid-column-gap: 10px;
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
@@ -113,7 +113,7 @@ const StandardGrid = ({
 						  `}
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column
@@ -146,7 +146,7 @@ const StandardGrid = ({
 						  `}
 				}
 
-				/* 
+				/*
 					Explanation of each unit of grid-template-columns
 
 					Main content
@@ -532,6 +532,8 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								elements={CAPI.mainMediaElements}
 								adTargeting={adTargeting}
 								host={host}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
 							/>
 						</div>
 					</GridItem>

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -15,7 +15,9 @@ export const ArticleRenderer: React.FC<{
 	elements: CAPIElement[];
 	adTargeting?: AdTargeting;
 	host?: string;
-}> = ({ format, palette, elements, adTargeting, host }) => {
+	pageId: string;
+	webTitle: string;
+}> = ({ format, palette, elements, adTargeting, host, pageId, webTitle }) => {
 	const output = elements.map((element, index) => {
 		return renderArticleElement({
 			format,
@@ -25,6 +27,8 @@ export const ArticleRenderer: React.FC<{
 			host,
 			index,
 			isMainMedia: false,
+			pageId,
+			webTitle,
 		});
 	});
 

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -37,6 +37,7 @@ import {
 	WitnessImageBlockComponent,
 	WitnessTextBlockComponent,
 } from '@root/src/web/components/elements/WitnessBlockComponent';
+import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import {
 	AudioAtom,
@@ -65,6 +66,8 @@ type Props = {
 	isMainMedia: boolean;
 	hideCaption?: boolean;
 	starRating?: number;
+	pageId: string;
+	webTitle: string;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -112,6 +115,8 @@ export const renderElement = ({
 	hideCaption,
 	isMainMedia,
 	starRating,
+	pageId,
+	webTitle,
 }: Props): [boolean, JSX.Element] => {
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
@@ -463,6 +468,7 @@ export const renderElement = ({
 							id={element.id}
 							questions={element.questions}
 							resultBuckets={element.resultBuckets}
+							sharingUrls={getSharingUrls(pageId, webTitle)}
 						/>
 					)}
 					{element.quizType === 'knowledge' && (
@@ -470,6 +476,7 @@ export const renderElement = ({
 							id={element.id}
 							questions={element.questions}
 							resultGroups={element.resultGroups}
+							sharingUrls={getSharingUrls(pageId, webTitle)}
 						/>
 					)}
 				</>,
@@ -725,6 +732,8 @@ export const renderArticleElement = ({
 	hideCaption,
 	isMainMedia,
 	starRating,
+	pageId,
+	webTitle,
 }: Props): JSX.Element => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -738,6 +747,8 @@ export const renderArticleElement = ({
 		isMainMedia,
 		hideCaption,
 		starRating,
+		pageId,
+		webTitle,
 	});
 
 	if (!ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,10 +1610,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-14.1.0.tgz#eaba7349a87fc09dbbd22ae5ef8dcc5a25d230bc"
-  integrity sha512-01bPJeHcO3EhLzzUPwnSkjMB6o0j6UfWhYdnvL/zBfHef6lf/+ShVEiGpNgdXueYVPH7fPyo4nTDaV8CnmUbKg==
+"@guardian/atoms-rendering@^14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-14.2.1.tgz#bf540614112d9ce55870ae8e7d37fd6f06585f87"
+  integrity sha512-RoXQfhjOwBZf2sIihTyQm+aMHmFOvaxuKsTfLOKhtOnM2QG6c9U3k8y3oEvNUtP+GPbhETbO+NnodyZsZKHP2g==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Update `@guardian/atoms-rendering`
- Pass down `pageId` and `webTitle`

### Before
![Screenshot 2021-05-28 at 15 28 46](https://user-images.githubusercontent.com/8831403/119999685-e8ccce00-bfc9-11eb-8f04-945fc81c4dc1.png)

### After
![Screenshot 2021-05-28 at 15 25 44](https://user-images.githubusercontent.com/8831403/119999701-ecf8eb80-bfc9-11eb-9767-86cc27b73ea2.png)

## Why?
Final changes to Quiz atoms