### PR TITLE
Prevent reader revenue banner clash with sign-in gate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#648FFF",
         "titleBar.activeForeground": "#000000"
-    },
+      },
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,25 +8,9 @@
         "**/target": true
     },
     "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#648fff",
-        "titleBar.activeForeground": "#15202b",
-        "activityBar.activeBackground": "#97b4ff",
-        "activityBar.activeBorder": "#df003e",
-        "activityBar.background": "#97b4ff",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#df003e",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "statusBar.background": "#648fff",
-        "statusBar.foreground": "#15202b",
-        "statusBarItem.hoverBackground": "#316aff",
-        "titleBar.inactiveBackground": "#648fff99",
-        "titleBar.inactiveForeground": "#15202b99"
+        "titleBar.activeBackground": "#648FFF",
+        "titleBar.activeForeground": "#000000"
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "gitlens.advanced.blame.customArguments": [
-        "--ignore-revs-file",
-        ".git-blame-ignore-revs"
-    ],
-    "peacock.color": "#648FFF"
+    "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,25 @@
         "**/target": true
     },
     "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#648FFF",
-        "titleBar.activeForeground": "#000000"
-	},
+        "titleBar.activeBackground": "#648fff",
+        "titleBar.activeForeground": "#15202b",
+        "activityBar.activeBackground": "#97b4ff",
+        "activityBar.activeBorder": "#df003e",
+        "activityBar.background": "#97b4ff",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#df003e",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "statusBar.background": "#648fff",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#316aff",
+        "titleBar.inactiveBackground": "#648fff99",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
+    "gitlens.advanced.blame.customArguments": [
+        "--ignore-revs-file",
+        ".git-blame-ignore-revs"
+    ],
+    "peacock.color": "#648FFF"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#648FFF",
         "titleBar.activeForeground": "#000000"
-      },
+	},
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -71,7 +71,7 @@ import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/V
 import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
-import { OphanRecordFunction } from '@root/node_modules/@guardian/ab-core/dist/types';
+import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -54,6 +54,7 @@ type CanShowProps = BaseProps & {
 	section: string;
 	isPreview: boolean;
 	idApiUrl: string;
+	signInGateWillShow: boolean;
 };
 
 type ReaderRevenueComponentType =
@@ -135,10 +136,16 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 	subscriptionBannerLastClosedAt,
 	isPreview,
 	idApiUrl,
+	signInGateWillShow,
 }) => {
 	if (!remoteBannerConfig) return { result: false };
 
-	if (shouldHideReaderRevenue || isPaidContent || isPreview) {
+	if (
+		shouldHideReaderRevenue ||
+		isPaidContent ||
+		isPreview ||
+		signInGateWillShow
+	) {
 		// We never serve Reader Revenue banners in this case
 		return { result: false };
 	}

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -18,6 +18,7 @@ import {
 } from '@root/src/web/lib/messagePicker';
 import { CountryCode } from '@guardian/types';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
+import { useSignInGateWillShow } from '@root/src/web/lib/useSignInGateWillShow';
 import { BrazeBanner, canShow as canShowBrazeBanner } from './BrazeBanner';
 
 type Props = {
@@ -73,6 +74,7 @@ const buildRRBannerConfigWith = ({
 		isSignedIn: boolean,
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
+		signInGateWillShow?: boolean = false,
 	): CandidateConfig => {
 		return {
 			candidate: {
@@ -100,6 +102,7 @@ const buildRRBannerConfigWith = ({
 						section: CAPI.config.section,
 						isPreview,
 						idApiUrl: CAPI.config.idApiUrl,
+						signInGateWillShow,
 					}),
 				show: ({ meta, module, email }: BannerProps) => () => (
 					<BannerComponent
@@ -147,6 +150,7 @@ export const StickyBottomBanner = ({
 	isPreview,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
+	const signInGateWillShow = useSignInGateWillShow({ isSignedIn, CAPI });
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();
 		const puzzlesBanner = buildPuzzlesBannerConfig(
@@ -160,6 +164,7 @@ export const StickyBottomBanner = ({
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<CountryCode>,
 			isPreview,
+			signInGateWillShow,
 		);
 		const brazeBanner = buildBrazeBanner(
 			brazeMessages as Promise<BrazeMessagesInterface>,

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -74,7 +74,7 @@ const buildRRBannerConfigWith = ({
 		isSignedIn: boolean,
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
-		signInGateWillShow?: boolean = false,
+		signInGateWillShow?: boolean,
 	): CandidateConfig => {
 		return {
 			candidate: {
@@ -104,13 +104,16 @@ const buildRRBannerConfigWith = ({
 						idApiUrl: CAPI.config.idApiUrl,
 						signInGateWillShow,
 					}),
-				show: ({ meta, module, email }: BannerProps) => () => (
-					<BannerComponent
-						meta={meta}
-						module={module}
-						email={email}
-					/>
-				),
+				show:
+					({ meta, module, email }: BannerProps) =>
+					() =>
+						(
+							<BannerComponent
+								meta={meta}
+								module={module}
+								email={email}
+							/>
+						),
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 		};

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -74,7 +74,7 @@ const buildRRBannerConfigWith = ({
 		isSignedIn: boolean,
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
-		signInGateWillShow?: boolean,
+		signInGateWillShow: boolean = false,
 	): CandidateConfig => {
 		return {
 			candidate: {
@@ -104,16 +104,13 @@ const buildRRBannerConfigWith = ({
 						idApiUrl: CAPI.config.idApiUrl,
 						signInGateWillShow,
 					}),
-				show:
-					({ meta, module, email }: BannerProps) =>
-					() =>
-						(
-							<BannerComponent
-								meta={meta}
-								module={module}
-								email={email}
-							/>
-						),
+				show: ({ meta, module, email }: BannerProps) => () => (
+					<BannerComponent
+						meta={meta}
+						module={module}
+						email={email}
+					/>
+				),
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 		};


### PR DESCRIPTION
## What does this change?
Reader revenue banners are appearing on the page over the top of the sign-in gate, and this should not be happening. This prevents the banners from being shown when the sign-in gate is in the page. 

This is a short-term fix to a problem that will eventually need a more holistic solution.

### Why?
The banner (and any other insert) hierarchy used to be managed by the bannerList in frontend. With the shift to almost all articles now being rendered by DCR, we have lost this means of controlling what is shown and when.
