### PR TITLE
Collapse ad slots

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -52,6 +52,9 @@ const articleAdStyles = css`
 		@media print {
 			display: none !important;
 		}
+		&.ad-slot--collapse {
+			display: none;
+		}
 	}
 	.ad-slot--mostpop {
 		${from.desktop} {

--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -12,6 +12,12 @@ const padding = css`
 	}
 `;
 
+const adStyles = css`
+	& .ad-slot.ad-slot--collapse {
+		display: none;
+	}
+`;
+
 const sideBorders = (colour: string) => css`
 	${from.tablet} {
 		border-left: 1px solid ${colour};
@@ -48,7 +54,12 @@ export const Section = ({
 	shouldCenter = true,
 	children,
 }: Props) => (
-	<section css={backgroundColour && setBackgroundColour(backgroundColour)}>
+	<section
+		css={[
+			adStyles,
+			backgroundColour && setBackgroundColour(backgroundColour),
+		]}
+	>
 		<div
 			id={sectionId}
 			css={[


### PR DESCRIPTION
## What does this change?

#### Background

Specific ad slots can be setup in Google Ad Manager (GAM) to be "excluded" for reasons of sensitivity, controversy or commercial agreements.

DCR does not currently collapse excluded ad slots.

#### Change

The class `.ad-slot--collapse` is added to "excluded" ad slots at runtime by the commercial client side code.

This change adds CSS to collapse "excluded" ad slots via the class `.ad-slot--collapse`.

CSS rules have been added at the container level (i.e. `ArticleContainer` and `Section`) to:
- collapse dynamically created ad slots (e.g. `im` and `carrot` slots)
- collapse fixed slots (e.g. `top-above-nav`, `right` etc)

#### Release Dependency

There is a related frontend PR to improve the naming and behaviour of the previous incarnation of `.ad-slot--collapse`:

https://github.com/guardian/frontend/pull/23865

This PR can be released before Frontend as there will be no functional impact.

Once the Frontend PR is released DCR should start collapsing ads.

#### Before

https://www.theguardian.com/commentisfree/2021/may/07/my-kids-wont-even-pick-up-a-book-and-it-is-definitely-all-my-fault

<img width="640" alt="Screenshot 2021-06-09 at 01 05 35" src="https://user-images.githubusercontent.com/7014230/121352586-ed2bac00-c924-11eb-98b9-d57cd404d1ad.png">

<img width="621" alt="Screenshot 2021-06-09 at 13 12 59" src="https://user-images.githubusercontent.com/7014230/121352622-f4eb5080-c924-11eb-8b87-a79b1a3ec8ec.png">

<img width="1574" alt="Screenshot 2021-06-09 at 01 06 55" src="https://user-images.githubusercontent.com/7014230/121352191-80181680-c924-11eb-8bb2-783f24adc0f5.png">

### After

<img width="636" alt="Screenshot 2021-06-09 at 13 18 56" src="https://user-images.githubusercontent.com/7014230/121353298-9a9ebf80-c925-11eb-9547-8a2bede98611.png">

### Tested

- [x] Locally
- [x] On CODE (optional)