### PR TITLE
Carrot ad in DCR

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { space } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { labelStyles } from '@root/src/web/components/AdSlot';
@@ -15,6 +16,25 @@ const articleContainer = css`
     To mitigate we use z-index
     TODO: find a cleaner solution */
 	z-index: 1;
+`;
+
+const carrotStyles = css`
+	.ad-slot--carrot {
+		float: left;
+		clear: both;
+		width: 140px;
+		margin-right: 20px;
+		margin-bottom: ${space[1]}px;
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			width: 220px;
+		}
+	}
 `;
 
 const articleAdStyles = css`
@@ -73,6 +93,7 @@ const articleAdStyles = css`
 			}
 		}
 	}
+	${carrotStyles}
 	${labelStyles};
 `;
 

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -18,7 +18,7 @@ const articleContainer = css`
 	z-index: 1;
 `;
 
-const carrotStyles = css`
+const carrotAdStyles = css`
 	.ad-slot--carrot {
 		float: left;
 		clear: both;
@@ -93,7 +93,7 @@ const articleAdStyles = css`
 			}
 		}
 	}
-	${carrotStyles}
+	${carrotAdStyles}
 	${labelStyles};
 `;
 

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -18,6 +18,10 @@ const articleContainer = css`
 	z-index: 1;
 `;
 
+/**
+ * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
+ * These styles come mostly from RichLink in DCR.
+ */
 const carrotAdStyles = css`
 	.ad-slot--carrot {
 		float: left;

--- a/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -124,10 +124,9 @@ export const firstParagraphOverlay = (isComment: boolean) => css`
 `;
 
 // This css does 3 things
-// 1. first hide all article conent using display: none; (.article-body-commercial-selector > *)
-// 2. make the sign in gate ((#sign-in-gate), and the first 2 paragraphs of the article visible (.article-body-commercial-selector p:nth-of-type(-n+3))
-// 3. hide any siblings after the sign in gate incase because of the css in 2
-//    a paragraph is still visible (#sign-in-gate ~ *)
+// 1. first hide all article content using display: none; (.article-body-commercial-selector > *)
+// 2. make the sign in gate (#sign-in-gate), and the first 2 paragraphs of the article visible (.article-body-commercial-selector p:nth-of-type(-n+3))
+// 3. hide any siblings after the sign in gate in case a paragraph is still visible (#sign-in-gate ~ *) because of the css in 2
 export const hideElementsCss = `
     .article-body-commercial-selector > * {
         display: none;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Ads style for the carrot ad.

These styles are taking more from the DCR implementation of `RichLink` than the original carrot from frontend, but a mark has been added to find the relevant Sass declarations: `dca5c7dd-dda4-4922-9317-a55a3789fe4c`.


### Before

N/A (No carrot ad)

### After

![carrot ad screenshot](https://user-images.githubusercontent.com/76776/120476235-571de180-c378-11eb-9d8c-978eb7cb928c.png)

## Why?

We are using it for advertising.