### PR TITLE
messagePicker type improvements

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -53,11 +53,11 @@ type EpicProps = {
 
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
-): Promise<CanShowResult> => {
+): Promise<CanShowResult<any>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
 		return {
-			result: true,
+			show: true,
 			meta: forcedBrazeMeta,
 		};
 	}
@@ -67,7 +67,7 @@ export const canShow = async (
 		const message = await brazeMessages.getMessageForEndOfArticle();
 
 		return {
-			result: true,
+			show: true,
 			meta: {
 				dataFromBraze: message.extras,
 				logImpressionWithBraze: () => {
@@ -76,7 +76,7 @@ export const canShow = async (
 			},
 		};
 	} catch (e) {
-		return { result: false };
+		return { show: false };
 	}
 };
 

--- a/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -12,6 +12,8 @@ import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import {
 	ReaderRevenueEpic,
 	canShow as canShowReaderRevenueEpic,
+	CanShowData as RRCanShowData,
+	EpicConfig as RREpicConfig,
 } from './ReaderRevenueEpic';
 import { MaybeBrazeEpic, canShow as canShowBrazeEpic } from './BrazeEpic';
 
@@ -40,7 +42,7 @@ const buildReaderRevenueEpicConfig = ({
 	tags,
 	contributionsServiceUrl,
 	idApiUrl,
-}: any): CandidateConfig => {
+}: RRCanShowData): CandidateConfig<RREpicConfig> => {
 	return {
 		candidate: {
 			id: 'reader-revenue-banner',
@@ -57,7 +59,7 @@ const buildReaderRevenueEpicConfig = ({
 					contributionsServiceUrl,
 					idApiUrl,
 				}),
-			show: (meta: any) => () => {
+			show: (meta: RREpicConfig) => () => {
 				/* eslint-disable-next-line react/jsx-props-no-spreading */
 				return <ReaderRevenueEpic {...meta} />;
 			},
@@ -70,7 +72,7 @@ const buildBrazeEpicConfig = (
 	brazeMessages: Promise<BrazeMessagesInterface>,
 	contributionsServiceUrl: string,
 	countryCode: string,
-): CandidateConfig => {
+): CandidateConfig<any> => {
 	return {
 		candidate: {
 			id: 'braze-epic',

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -40,11 +40,11 @@ const containerStyles = css`
 // - The force-braze-message query string arg is passed
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
-): Promise<CanShowResult> => {
+): Promise<CanShowResult<any>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
 		return {
-			result: true,
+			show: true,
 			meta: forcedBrazeMeta,
 		};
 	}
@@ -68,9 +68,9 @@ export const canShow = async (
 			logButtonClickWithBraze,
 		};
 
-		return { result: true, meta };
+		return { show: true, meta };
 	} catch (e) {
-		return { result: false };
+		return { show: false };
 	}
 };
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -61,9 +61,9 @@ type ReaderRevenueComponentType =
 	| 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
 	| 'ACQUISITIONS_OTHER';
 
-export type CanShowFunctionType = (
+export type CanShowFunctionType<T> = (
 	props: CanShowProps,
-) => Promise<CanShowResult>;
+) => Promise<CanShowResult<T>>;
 
 // TODO specify return type (need to update client to provide this first)
 const buildPayload = ({
@@ -119,7 +119,7 @@ const getBanner = (meta: { [key: string]: any }, url: string): Promise<any> => {
 		.then((response) => response.json());
 };
 
-export const canShowRRBanner: CanShowFunctionType = async ({
+export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	remoteBannerConfig,
 	isSignedIn,
 	asyncCountryCode,
@@ -138,7 +138,7 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 	idApiUrl,
 	signInGateWillShow,
 }) => {
-	if (!remoteBannerConfig) return { result: false };
+	if (!remoteBannerConfig) return { show: false };
 
 	if (
 		shouldHideReaderRevenue ||
@@ -147,7 +147,7 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 		signInGateWillShow
 	) {
 		// We never serve Reader Revenue banners in this case
-		return { result: false };
+		return { show: false };
 	}
 
 	if (
@@ -155,7 +155,7 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 		subscriptionBannerLastClosedAt &&
 		withinLocalNoBannerCachePeriod()
 	) {
-		return { result: false };
+		return { show: false };
 	}
 
 	const countryCode = await asyncCountryCode;
@@ -187,17 +187,17 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 		if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {
 			setLocalNoBannerCachePeriod();
 		}
-		return { result: false };
+		return { show: false };
 	}
 
 	const { module, meta } = json.data;
 
 	const email = isSignedIn ? await getEmail(idApiUrl) : undefined;
 
-	return { result: true, meta: { module, meta, email } };
+	return { show: true, meta: { module, meta, email } };
 };
 
-export const canShowPuzzlesBanner: CanShowFunctionType = async ({
+export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	remoteBannerConfig,
 	isSignedIn,
 	asyncCountryCode,
@@ -220,7 +220,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType = async ({
 
 	if (shouldHideReaderRevenue) {
 		// We never serve Reader Revenue banners in this case
-		return { result: false };
+		return { show: false };
 	}
 
 	if (isPuzzlesPage && remoteBannerConfig) {
@@ -247,16 +247,16 @@ export const canShowPuzzlesBanner: CanShowFunctionType = async ({
 			`${contributionsServiceUrl}/puzzles`,
 		).then((json: { data?: any }) => {
 			if (!json.data) {
-				return { result: false };
+				return { show: false };
 			}
 
 			const { module, meta } = json.data;
 
-			return { result: true, meta: { module, meta } };
+			return { show: true, meta: { module, meta } };
 		});
 	}
 
-	return { result: false };
+	return { show: false };
 };
 
 export type BannerProps = {

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -32,7 +32,7 @@ type Props = {
 type RRBannerConfig = {
 	id: string;
 	BannerComponent: React.FC<BannerProps>;
-	canShowFn: CanShowFunctionType;
+	canShowFn: CanShowFunctionType<BannerProps>;
 	isEnabled: (switches: CAPIType['config']['switches']) => boolean;
 };
 
@@ -47,13 +47,15 @@ const getBannerLastClosedAt = (key: string): string | undefined => {
 
 const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;
 
-const buildCmpBannerConfig = (): CandidateConfig => ({
+const buildCmpBannerConfig = (): CandidateConfig<void> => ({
 	candidate: {
 		id: 'cmpUi',
 		canShow: () =>
 			cmp
 				.willShowPrivacyMessage()
-				.then((result) => ({ result: !!result })),
+				.then((result) =>
+					result ? { show: true, meta: undefined } : { show: false },
+				),
 		show: () => {
 			// New CMP is not a react component and is shown outside of react's world
 			// so render nothing if it will show
@@ -75,7 +77,7 @@ const buildRRBannerConfigWith = ({
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
 		signInGateWillShow: boolean = false,
-	): CandidateConfig => {
+	): CandidateConfig<BannerProps> => {
 		return {
 			candidate: {
 				id,
@@ -133,7 +135,7 @@ const buildReaderRevenueBannerConfig = buildRRBannerConfigWith({
 
 const buildBrazeBanner = (
 	brazeMessages: Promise<BrazeMessagesInterface>,
-): CandidateConfig => ({
+): CandidateConfig<any> => ({
 	candidate: {
 		id: 'braze-banner',
 		canShow: () => canShowBrazeBanner(brazeMessages),

--- a/src/web/lib/messagePicker.test.tsx
+++ b/src/web/lib/messagePicker.test.tsx
@@ -1,5 +1,5 @@
 import { record } from '@root/src/web/browser/ophan/ophan';
-import { pickMessage, CanShowResult } from './messagePicker';
+import { pickMessage, CanShowResult, SlotConfig } from './messagePicker';
 
 jest.mock('@root/src/web/browser/ophan/ophan', () => ({
 	record: jest.fn(),
@@ -21,13 +21,13 @@ describe('pickMessage', () => {
 	it('resolves with the highest priority message which can show', async () => {
 		const MockComponent = () => <div />;
 		const ChosenMockComponent = () => <div />;
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
 					candidate: {
 						id: 'banner-1',
-						canShow: () => Promise.resolve({ result: false }),
+						canShow: () => Promise.resolve({ show: false }),
 						show: () => MockComponent,
 					},
 					timeoutMillis: null,
@@ -35,7 +35,8 @@ describe('pickMessage', () => {
 				{
 					candidate: {
 						id: 'banner-2',
-						canShow: () => Promise.resolve({ result: true }),
+						canShow: () =>
+							Promise.resolve({ show: true, meta: undefined }),
 						show: () => ChosenMockComponent,
 					},
 					timeoutMillis: null,
@@ -43,7 +44,8 @@ describe('pickMessage', () => {
 				{
 					candidate: {
 						id: 'banner-3',
-						canShow: () => Promise.resolve({ result: true }),
+						canShow: () =>
+							Promise.resolve({ show: true, meta: undefined }),
 						show: () => MockComponent,
 					},
 					timeoutMillis: null,
@@ -59,13 +61,13 @@ describe('pickMessage', () => {
 	it('resolves with null if no messages can show', async () => {
 		const MockComponent = () => <div />;
 
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
 					candidate: {
 						id: 'banner-1',
-						canShow: () => Promise.resolve({ result: false }),
+						canShow: () => Promise.resolve({ show: false }),
 						show: () => MockComponent,
 					},
 					timeoutMillis: null,
@@ -73,7 +75,7 @@ describe('pickMessage', () => {
 				{
 					candidate: {
 						id: 'banner-2',
-						canShow: () => Promise.resolve({ result: false }),
+						canShow: () => Promise.resolve({ show: false }),
 						show: () => MockComponent,
 					},
 					timeoutMillis: null,
@@ -89,16 +91,20 @@ describe('pickMessage', () => {
 	it('falls through to a lower priority message when a higher one times out', async () => {
 		const MockComponent = () => <div />;
 		const ChosenMockComponent = () => <div />;
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
 					candidate: {
 						id: 'banner-1',
-						canShow: (): Promise<CanShowResult> =>
+						canShow: (): Promise<CanShowResult<void>> =>
 							new Promise((resolve) =>
 								setTimeout(
-									() => resolve({ result: true }),
+									() =>
+										resolve({
+											show: true,
+											meta: undefined,
+										}),
 									500,
 								),
 							),
@@ -109,7 +115,8 @@ describe('pickMessage', () => {
 				{
 					candidate: {
 						id: 'banner-2',
-						canShow: () => Promise.resolve({ result: true }),
+						canShow: () =>
+							Promise.resolve({ show: true, meta: undefined }),
 						show: () => ChosenMockComponent,
 					},
 					timeoutMillis: null,
@@ -128,16 +135,20 @@ describe('pickMessage', () => {
 		const MockComponent = () => <div />;
 		let timer1;
 		let timer2;
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
 					candidate: {
 						id: 'banner-1',
-						canShow: (): Promise<CanShowResult> =>
+						canShow: (): Promise<CanShowResult<void>> =>
 							new Promise((resolve) => {
 								timer1 = setTimeout(
-									() => resolve({ result: true }),
+									() =>
+										resolve({
+											show: true,
+											meta: undefined,
+										}),
 									500,
 								);
 							}),
@@ -148,10 +159,14 @@ describe('pickMessage', () => {
 				{
 					candidate: {
 						id: 'banner-2',
-						canShow: (): Promise<CanShowResult> =>
+						canShow: (): Promise<CanShowResult<void>> =>
 							new Promise((resolve) => {
 								timer2 = setTimeout(
-									() => resolve({ result: true }),
+									() =>
+										resolve({
+											show: true,
+											meta: undefined,
+										}),
 									500,
 								);
 							}),
@@ -175,7 +190,7 @@ describe('pickMessage', () => {
 	it('passes metadata returned by canShow to show', async () => {
 		const renderComponent = jest.fn(() => () => <div />);
 		const meta = { extra: 'info' };
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
@@ -183,7 +198,7 @@ describe('pickMessage', () => {
 						id: 'banner-1',
 						canShow: () =>
 							Promise.resolve({
-								result: true,
+								show: true,
 								meta,
 							}),
 						show: renderComponent,
@@ -202,16 +217,20 @@ describe('pickMessage', () => {
 	it('sends a message to ophan when a message canShow times out', async () => {
 		const MockComponent = () => <div />;
 		let timer;
-		const config = {
+		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
 				{
 					candidate: {
 						id: 'example-banner',
-						canShow: (): Promise<CanShowResult> =>
+						canShow: (): Promise<CanShowResult<void>> =>
 							new Promise((resolve) => {
 								timer = setTimeout(
-									() => resolve({ result: true }),
+									() =>
+										resolve({
+											show: true,
+											meta: undefined,
+										}),
 									300,
 								);
 							}),


### PR DESCRIPTION
The `messagePicker` logic is used for epic and banner slots. There are quite a few instances of `any` in the RR code, which feels a bit dangerous when making changes.

The main change here is to make the `Candidate` take a type parameter. This is for the `meta` field, which is returned by `canShow` and passed into `show`. Previously it had type `any`.
I'm not sure what the braze epic/banner should have for this type so I've left them as `any`.