### PR TITLE
Revert "Enable picnic stories ads on AMP pages"

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -4,7 +4,6 @@ import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
 // Largest size first
 const inlineSizes = [
-	{ width: 320, height: 480 }, // Picnic story
 	{ width: 300, height: 250 }, // MPU
 	{ width: 250, height: 250 }, // Square
 ];
@@ -142,7 +141,6 @@ export const Ad = ({
 						width={width}
 						height={height}
 						data-multi-size={multiSizes}
-						data-multi-size-validation="false"
 						data-npa-on-unknown-consent={true}
 						data-loading-strategy="prefer-viewability-over-views"
 						layout="fixed"


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3044

Undo adding the 480x320 size to <Ad> component in AMP pages due to unexpected padding issues (intermittent)

![image](https://user-images.githubusercontent.com/19875457/120500162-8bb18d80-c3b8-11eb-8e4e-d9cc1db29b90.png)
