### PR TITLE
Add support for amp interactives

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -18,6 +18,9 @@ const defaultArticleURL =
 const defaultInteractiveURL =
 	'https://www.theguardian.com/environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive';
 
+const defaultAmpInteractiveURL =
+	'https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide';
+
 function buildUrlFromQueryParam(req, defaultURL) {
 	const url = new URL(req.query.url || defaultURL);
 	// searchParams will only work for the first set of query params because 'url' is already a query param itself
@@ -160,6 +163,38 @@ const go = () => {
 		webpackHotServerMiddleware(compiler, {
 			chunkName: `${siteName}.server`,
 			serverRendererOptions: { path: '/Interactive' },
+		}),
+	);
+
+	app.get(
+		'/AMPInteractive',
+		async (req, res, next) => {
+			try {
+				const url = buildUrlFromQueryParam(
+					req,
+					defaultAmpInteractiveURL,
+				);
+				const { html, ...config } = await fetch(
+					ampifyUrl(url),
+				).then((article) => article.json());
+				req.body = config;
+				next();
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(error);
+			}
+		},
+		webpackHotServerMiddleware(compiler, {
+			chunkName: `${siteName}.server`,
+			serverRendererOptions: { path: '/AMPInteractive' },
+		}),
+	);
+
+	app.post(
+		'/AMPInteractive',
+		webpackHotServerMiddleware(compiler, {
+			chunkName: `${siteName}.server`,
+			serverRendererOptions: { path: '/AMPInteractive' },
 		}),
 	);
 

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -32,7 +32,8 @@
         <ul>
             <li><a href="/Article">Article</a></li>
             <li><a href="/AMPArticle">⚡️Article</a></li>
-            <li><a href="/Interactive">Interactive</a></li>
+			<li><a href="/Interactive">Interactive</a></li>
+			<li><a href="/AMPInteractive">⚡️Interactive</a></li>
         </ul>
 
         <h2>Test Articles By Content Type</h2>

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -37,6 +37,8 @@ export default (options: any) => {
 			return renderAMPArticle;
 		case '/Interactive':
 			return renderInteractive;
+		case '/AMPInteractive':
+			return renderAMPArticle;
 	}
 
 	return renderArticle;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds an endpoint for rendering interactives for AMP pages

### Before

### After

![image](https://user-images.githubusercontent.com/9575458/120514253-fbc61080-c3c4-11eb-91c2-5274bb0141e5.png)

## Why?

Supporting interactives for AMP pages will offer SEO & Organic traffic advantages in the future
