### PR TITLE
Ad styles from frontend

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -116,8 +116,8 @@ export const carrotAdStyles = css`
 /**
  * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
  */
-export const fluidAdStyles = css`
-	.ad-slot--fluid {
+const fluidAdStyles = css`
+	&.ad-slot--fluid {
 		min-height: 250px;
 		line-height: 10px;
 		padding: 0;
@@ -214,7 +214,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 								'ad-slot--rendered',
 								'js-sticky-mpu',
 							].join(' ')}
-							css={labelStyles}
+							css={[labelStyles, fluidAdStyles]}
 							data-link-name="ad slot right"
 							data-name="right"
 							// mark: 01303e88-ef1f-462d-9b6e-242419435cec
@@ -255,6 +255,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 										top: 0;
 									`,
 									labelStyles,
+									fluidAdStyles,
 								]}
 								data-link-name="ad slot right"
 								data-name="right"
@@ -299,6 +300,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 								top: 0;
 							`,
 							labelStyles,
+							fluidAdStyles,
 						]}
 						data-link-name="ad slot comments"
 						data-name="comments"
@@ -340,6 +342,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 		}
 		case 'top-above-nav': {
 			const adSlotAboveNav = css`
+				position: relative;
 				margin: 0 auto;
 				min-height: 108px;
 				padding-bottom: 18px;
@@ -359,13 +362,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							css`
-								position: relative;
-							`,
-							labelStyles,
-							adSlotAboveNav,
-						]}
+						css={[labelStyles, fluidAdStyles, adSlotAboveNav]}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
 						// The sizes here come from two places in the frontend code
@@ -410,6 +407,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							position: relative;
 						`,
 						labelStyles,
+						fluidAdStyles,
 					]}
 					data-link-name="ad slot mostpop"
 					data-name="mostpop"
@@ -466,6 +464,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							position: relative;
 						`,
 						labelStyles,
+						fluidAdStyles,
 					]}
 					data-link-name="ad slot merchandising-high"
 					data-name="merchandising-high"
@@ -494,6 +493,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							position: relative;
 						`,
 						labelStyles,
+						fluidAdStyles,
 					]}
 					data-link-name="ad slot merchandising"
 					data-name="merchandising"

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -379,7 +379,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[adSlotAboveNav, adStyles, fluidFullWidthAdStyles]}
+						css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
 						// The sizes here come from two places in the frontend code

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -4,6 +4,7 @@ import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Display } from '@guardian/types';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
 	display: Display;
@@ -86,6 +87,52 @@ export const labelStyles = css`
 		position: fixed;
 		bottom: 0;
 		width: 100%;
+	}
+`;
+
+/**
+ * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
+ * These styles come mostly from RichLink in DCR.
+ */
+export const carrotAdStyles = css`
+	.ad-slot--carrot {
+		float: left;
+		clear: both;
+		width: 140px;
+		margin-right: 20px;
+		margin-bottom: ${space[1]}px;
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			width: 220px;
+		}
+	}
+`;
+
+/**
+ * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
+ */
+export const fluidAdStyles = css`
+	.ad-slot--fluid {
+		min-height: 250px;
+		line-height: 10px;
+		padding: 0;
+		margin: 0;
+
+		&:not(.ad-slot--im):not(.ad-slot--carrot):not(.ad-slot--offset-right) {
+			width: 100%;
+		}
+
+		&.ad-slot--commercial-component-high {
+			&,
+			& > .ad-slot__content > iframe {
+				transition: height 1s;
+			}
+		}
 	}
 `;
 

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -126,13 +126,6 @@ export const fluidAdStyles = css`
 		&:not(.ad-slot--im):not(.ad-slot--carrot):not(.ad-slot--offset-right) {
 			width: 100%;
 		}
-
-		&.ad-slot--commercial-component-high {
-			&,
-			& > .ad-slot__content > iframe {
-				transition: height 1s;
-			}
-		}
 	}
 `;
 

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -122,10 +122,27 @@ const fluidAdStyles = css`
 		line-height: 10px;
 		padding: 0;
 		margin: 0;
+	}
+`;
 
-		&:not(.ad-slot--im):not(.ad-slot--carrot):not(.ad-slot--offset-right) {
-			width: 100%;
-		}
+/**
+ * Usage according to DAP (Digital Ad Production)
+ *
+ * #### Desktop
+ * - `fabric` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-custom` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-expandable` &rarr; `merchandising-high`
+ * - `fabric-third-party` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
+ * - `fabric-video` &rarr; `top-above-nav`,`merchandising-high`
+ * - `fabric-video-expandable` &rarr; `merchandising-high`
+ *
+ * #### Mobile
+ * - `interscroller` &rarr; `top-above-nav`
+ * - `mobile-revealer` &rarr; `top-above-nav`
+ */
+const fluidFullWidthAdStyles = css`
+	&.ad-slot--fluid {
+		width: 100%;
 	}
 `;
 
@@ -185,6 +202,8 @@ const mobileStickyAdStyles = css`
 	}
 `;
 
+const adStyles = [labelStyles, fluidAdStyles];
+
 const AdSlotLabelToggled: React.FC = () => (
 	<div
 		className={['ad-slot__label', 'ad-slot__label--toggle', 'hidden'].join(
@@ -214,7 +233,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 								'ad-slot--rendered',
 								'js-sticky-mpu',
 							].join(' ')}
-							css={[labelStyles, fluidAdStyles]}
+							css={adStyles}
 							data-link-name="ad slot right"
 							data-name="right"
 							// mark: 01303e88-ef1f-462d-9b6e-242419435cec
@@ -254,8 +273,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 										position: sticky;
 										top: 0;
 									`,
-									labelStyles,
-									fluidAdStyles,
+									adStyles,
 								]}
 								data-link-name="ad slot right"
 								data-name="right"
@@ -299,8 +317,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 								position: sticky;
 								top: 0;
 							`,
-							labelStyles,
-							fluidAdStyles,
+							adStyles,
 						]}
 						data-link-name="ad slot comments"
 						data-name="comments"
@@ -362,7 +379,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[labelStyles, fluidAdStyles, adSlotAboveNav]}
+						css={[adSlotAboveNav, adStyles, fluidFullWidthAdStyles]}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
 						// The sizes here come from two places in the frontend code
@@ -406,8 +423,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						css`
 							position: relative;
 						`,
-						labelStyles,
-						fluidAdStyles,
+						adStyles,
 					]}
 					data-link-name="ad slot mostpop"
 					data-name="mostpop"
@@ -463,8 +479,8 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						css`
 							position: relative;
 						`,
-						labelStyles,
-						fluidAdStyles,
+						adStyles,
+						fluidFullWidthAdStyles,
 					]}
 					data-link-name="ad slot merchandising-high"
 					data-name="merchandising-high"
@@ -492,8 +508,8 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						css`
 							position: relative;
 						`,
-						labelStyles,
-						fluidAdStyles,
+						adStyles,
+						fluidFullWidthAdStyles,
 					]}
 					data-link-name="ad slot merchandising"
 					data-name="merchandising"

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -1,8 +1,11 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 
-import { labelStyles } from '@root/src/web/components/AdSlot';
+import {
+	labelStyles,
+	carrotAdStyles,
+	fluidAdStyles,
+} from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`
 	${until.leftCol} {
@@ -16,29 +19,6 @@ const articleContainer = css`
     To mitigate we use z-index
     TODO: find a cleaner solution */
 	z-index: 1;
-`;
-
-/**
- * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
- * These styles come mostly from RichLink in DCR.
- */
-const carrotAdStyles = css`
-	.ad-slot--carrot {
-		float: left;
-		clear: both;
-		width: 140px;
-		margin-right: 20px;
-		margin-bottom: ${space[1]}px;
-		${from.leftCol} {
-			position: relative;
-			margin-left: -160px;
-			width: 140px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-			width: 220px;
-		}
-	}
 `;
 
 const articleAdStyles = css`
@@ -97,6 +77,7 @@ const articleAdStyles = css`
 			}
 		}
 	}
+	${fluidAdStyles};
 	${carrotAdStyles}
 	${labelStyles};
 `;

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -1,11 +1,7 @@
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 
-import {
-	labelStyles,
-	carrotAdStyles,
-	fluidAdStyles,
-} from '@root/src/web/components/AdSlot';
+import { labelStyles, carrotAdStyles } from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`
 	${until.leftCol} {
@@ -77,7 +73,6 @@ const articleAdStyles = css`
 			}
 		}
 	}
-	${fluidAdStyles};
 	${carrotAdStyles};
 	${labelStyles};
 `;

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -78,7 +78,7 @@ const articleAdStyles = css`
 		}
 	}
 	${fluidAdStyles};
-	${carrotAdStyles}
+	${carrotAdStyles};
 	${labelStyles};
 `;
 

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Display } from '@guardian/types';
 
-import { AdSlot, fluidAdStyles } from '@root/src/web/components/AdSlot';
+import { AdSlot } from '@root/src/web/components/AdSlot';
 import { Hide } from '@root/src/web/components/Hide';
 
 const headerWrapper = css`
@@ -31,7 +31,6 @@ export const HeaderAdSlot: React.FC<{
 			<div
 				css={[
 					headerAdWrapper,
-					fluidAdStyles,
 					(isAdFreeUser || shouldHideAds) && headerAdWrapperHidden,
 				]}
 			>

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Display } from '@guardian/types';
 
-import { AdSlot } from '@root/src/web/components/AdSlot';
+import { AdSlot, fluidAdStyles } from '@root/src/web/components/AdSlot';
 import { Hide } from '@root/src/web/components/Hide';
 
 const headerWrapper = css`
@@ -31,6 +31,7 @@ export const HeaderAdSlot: React.FC<{
 			<div
 				css={[
 					headerAdWrapper,
+					fluidAdStyles,
 					(isAdFreeUser || shouldHideAds) && headerAdWrapperHidden,
 				]}
 			>


### PR DESCRIPTION
## What does this change?

Imports the fluid ad styles inside `AdSlot.tsx`, rather than injecting them at runtime via the commercial JS bundle.

### Screenshots

![fabric](https://user-images.githubusercontent.com/76776/121519027-30d2f400-c9bf-11eb-9098-a9c1e3a2d33e.png)

---

![fabric video](https://user-images.githubusercontent.com/76776/121519048-39c3c580-c9bf-11eb-9cd9-12ff210cfd9c.png)

---

![fabric animation](https://user-images.githubusercontent.com/76776/121519074-434d2d80-c9bf-11eb-862e-d403ed6a9ab5.png)


## Why?

The logic was peppered in too many places.
