### PR TITLE
Move hardcoded urls of convenience to index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Visit the [root path of the dev server](http://localhost:3030) for some example 
 
 You can render a specific article by [specifying the production URL in the query string](http://localhost:3030/Article?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
 
-You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to [/ArticleJson](http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
+You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to 
+
+http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey
 
 ### Detailed Setup
 

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -12,17 +12,8 @@ const bodyParser = require('body-parser');
 
 const { siteName, root } = require('./config');
 
-const defaultArticleURL =
-	'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software';
-
-const defaultInteractiveURL =
-	'https://www.theguardian.com/environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive';
-
-const defaultAmpInteractiveURL =
-	'https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide';
-
-function buildUrlFromQueryParam(req, defaultURL) {
-	const url = new URL(req.query.url || defaultURL);
+function buildUrlFromQueryParam(req) {
+	const url = new URL(req.query.url);
 	// searchParams will only work for the first set of query params because 'url' is already a query param itself
 	const searchparams = url.searchParams && url.searchParams.toString();
 	// Reconstruct the parsed url adding .json?dcr which we need to force dcr to return json
@@ -67,7 +58,7 @@ const go = () => {
 		'/Article',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req, defaultArticleURL);
+				const url = buildUrlFromQueryParam(req);
 				const { html, ...config } = await fetch(url).then((article) =>
 					article.json(),
 				);
@@ -97,7 +88,7 @@ const go = () => {
 		'/ArticleJson',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req, defaultArticleURL);
+				const url = buildUrlFromQueryParam(req);
 				const { html, ...config } = await fetch(url).then((article) =>
 					article.json(),
 				);
@@ -119,7 +110,7 @@ const go = () => {
 		'/AMPArticle',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req, defaultArticleURL);
+				const url = buildUrlFromQueryParam(req);
 				const { html, ...config } = await fetch(
 					ampifyUrl(url),
 				).then((article) => article.json());

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -13,6 +13,12 @@ const bodyParser = require('body-parser');
 const { siteName, root } = require('./config');
 
 function buildUrlFromQueryParam(req) {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	if (!req.query.url) {
+		throw new Error('The url query parameter is mandatory');
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	const url = new URL(req.query.url);
 	// searchParams will only work for the first set of query params because 'url' is already a query param itself
 	const searchparams = url.searchParams && url.searchParams.toString();

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -30,10 +30,10 @@
         <h2>Default Endpoints</h2>
 
         <ul>
-            <li><a href="/Article">Article</a></li>
-            <li><a href="/AMPArticle">⚡️Article</a></li>
-			<li><a href="/Interactive">Interactive</a></li>
-			<li><a href="/AMPInteractive">⚡️Interactive</a></li>
+            <li><a href="/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software">Article</a></li>
+            <li><a href="/AMPArticle?url=https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance">⚡️Article</a></li>
+			<li><a href="/Interactive?url=https://www.theguardian.com/environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive">Interactive</a></li>
+			<li><a href="/AMPInteractive?url=https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide">⚡️Interactive</a></li>
         </ul>
 
         <h2>Test Articles By Content Type</h2>


### PR DESCRIPTION
This PR moves the default urls called from index.html (where we keep a collection of hardcoded urls of convenience) from dev-server.js, where they were **totally** out of place to index.html. 

This change also corrects a piece of bad DevEx that had always bothered me: The urls used are no longer hidden from view, thereby demistifying the workings of the dev server for first time developers.

The readme has been updated accordingly.

Example: the default article url now shows in full in the web browser without hidden magic: 

http://localhost:3030/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software

Console error message when missing parameter:

<img width="1201" alt="Screenshot 2021-06-03 at 09 53 59" src="https://user-images.githubusercontent.com/6035518/120618115-aa646280-c452-11eb-961d-04ca4b79f6ab.png">
