### PR TITLE
Fix Subscribe cta in immersive nav

### DIFF
--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -5,7 +5,7 @@ import { Pillars } from '@root/src/web/components/Pillars';
 import { GuardianRoundel } from '@root/src/web/components/GuardianRoundel';
 import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
-import { Button, buttonReaderRevenue } from '@guardian/src-button';
+import { LinkButton, buttonReaderRevenue } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 
 import { Hide } from '@frontend/web/components/Hide';
@@ -171,20 +171,17 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
 					<Hide when="above" breakpoint="tablet">
 						<ThemeProvider theme={buttonReaderRevenue}>
 							<PositionButton>
-								<Button
+								<LinkButton
 									priority="primary"
 									size="small"
 									iconSide="right"
 									icon={<SvgArrowRightStraight />}
 									data-link-name="nav2 : support-cta"
 									data-edition={edition}
-									onClick={() => {
-										window.location.href = subscribeUrl;
-										return false;
-									}}
+									href={subscribeUrl}
 								>
 									Subscribe
-								</Button>
+								</LinkButton>
 							</PositionButton>
 						</ThemeProvider>
 					</Hide>


### PR DESCRIPTION
Currently nothing happens when clicked. This affects immersive layouts, e.g. https://www.theguardian.com/science/2021/jun/03/the-empty-office-what-we-lose-when-we-work-from-home

I'm not sure why it was using an `onClick` handler