### PR TITLE
Enable picnic stories ads on AMP pages [WIP]

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -5,6 +5,7 @@ import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 // Largest size first
 const inlineSizes = [
 	{ width: 300, height: 250 }, // MPU
+	{ width: 320, height: 480 }, // Picnic story
 	{ width: 250, height: 250 }, // Square
 ];
 
@@ -141,6 +142,7 @@ export const Ad = ({
 						width={width}
 						height={height}
 						data-multi-size={multiSizes}
+						data-multi-size-validation="false"
 						data-npa-on-unknown-consent={true}
 						data-loading-strategy="prefer-viewability-over-views"
 						layout="fixed"


### PR DESCRIPTION
## What does this change?

Add 320x480 ad size to the AMP Ad component, which allows picnic stories to be shown. The component falls back to MPU size gracefully as seen below (due to data-multi-size-validation="false" flag).

Note: This branch was previously merged to main, then discovered to have some issues around ad containers staying at 320x480 size when the ad is smaller (see image in revert PR below). The changes were subsequently reverted. This draft PR contains the original work (no longer in main) and will form the base of the fixed picnic changes. The issue is currently unresolved.

Original PR: https://github.com/guardian/dotcom-rendering/pull/3044
Revert PR: https://github.com/guardian/dotcom-rendering/pull/3062

### Before

### After

## Why?
