### PR TITLE
Update to lab 'paid for by' typography

### DIFF
--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -9,8 +9,8 @@ const brandingStyle = css`
 `;
 
 const brandingLabelStyle = css`
-	${textSans.xxsmall({ fontWeight: 'bold' })};
-	color: ${neutral[46]};
+	${textSans.xxsmall()};
+	color: ${neutral[20]};
 `;
 
 const brandingLogoStyle = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
<img width="240" alt="before" src="https://user-images.githubusercontent.com/3300789/120638522-1dc49f00-c468-11eb-8e48-27302583cd47.png">

### After
<img width="233" alt="after" src="https://user-images.githubusercontent.com/3300789/120638534-21f0bc80-c468-11eb-9d2d-c34f9cdaec38.png">

## Why?
https://trello.com/c/KpNP6kbA/242-labs-paid-for-by-text-to-be-333-and-regular-weight
