### PR TITLE
Bump web-vitals library with breaking CLS change

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "reset-css": "^5.0.1",
         "sanitize-html": "^2.3.2",
         "swr": "^0.5.5",
-        "web-vitals": "^1.1.1",
+        "web-vitals": "^2.0.1",
         "youtube-player": "^5.5.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18880,10 +18880,10 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-web-vitals@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.1.tgz#2df535e3355fb7fbe34787b44b736e270e539377"
-  integrity sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ==
+web-vitals@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.0.1.tgz#d122720bd9c8dd69792b19c0f6ab0346861a880f"
+  integrity sha512-niqKyp2T6xF9EzSi+xx+V6qitE0YfagzfUmDAa9qeCrIVeyfzQQ85Uy0ykeRlEVDCCqkhYccoUunNf9ZIQcvtA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## What does this change?

Bump the web-vitals library which contains the new [definition of CLS](https://github.com/GoogleChrome/web-vitals/pull/148) described in https://web.dev/evolving-cls/

In Google search tools, we see a reduction in CLS and increase in Good number of pages, we should see this reflected in our data.