### PR TITLE
Fix comment width bug

### DIFF
--- a/fixtures/manual/discussion-no-top-comments.ts
+++ b/fixtures/manual/discussion-no-top-comments.ts
@@ -1,0 +1,20 @@
+export const discussionNoTopComments = {
+	status: 'ok',
+	page: 1,
+	pages: 0,
+	pageSize: 100,
+	orderBy: 'oldest',
+	discussion: {
+		apiUrl:
+			'https://discussion.guardianapis.com/discussion-api/discussion//p/4v8kk',
+		commentCount: 0,
+		isClosedForComments: true,
+		isClosedForRecommendation: true,
+		isThreaded: true,
+		key: '/p/4v8kk',
+		title: 'Stevie Nicks to release double album of songs from her past',
+		webUrl:
+			'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
+		comments: []
+	},
+};

--- a/fixtures/manual/discussion-no-top-comments.ts
+++ b/fixtures/manual/discussion-no-top-comments.ts
@@ -15,6 +15,6 @@ export const discussionNoTopComments = {
 		title: 'Stevie Nicks to release double album of songs from her past',
 		webUrl:
 			'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
-		comments: []
+		comments: [],
 	},
 };

--- a/fixtures/manual/short-discussion.ts
+++ b/fixtures/manual/short-discussion.ts
@@ -1,0 +1,66 @@
+export const shortDiscussion = {
+	status: 'ok',
+	page: 1,
+	pages: 0,
+	pageSize: 100,
+	orderBy: 'oldest',
+	discussion: {
+		apiUrl:
+			'https://discussion.guardianapis.com/discussion-api/discussion//p/4v8kk',
+		commentCount: 7,
+		isClosedForComments: true,
+		isClosedForRecommendation: true,
+		isThreaded: true,
+		key: '/p/4v8kk',
+		title: 'Stevie Nicks to release double album of songs from her past',
+		topLevelCommentCount: 6,
+		webUrl:
+			'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
+		comments: [
+			{
+				apiUrl:
+					'https://discussion.guardianapis.com/discussion-api/comment/38591122',
+				body: "<p>someone's run out of ideas..!</p>",
+				date: '25 July 2014 9:07am',
+				id: 38591122,
+				isHighlighted: false,
+				isoDateTime: '2014-07-25T08:07:54Z',
+				numRecommends: 0,
+				status: 'visible',
+				userProfile: {
+					apiUrl:
+						'https://discussion.guardianapis.com/discussion-api/profile/12173512',
+					avatar: 'https://avatar.guim.co.uk/user/12173512',
+					badge: [],
+					displayName: 'bellyofcassano',
+					secureAvatarUrl: 'https://avatar.guim.co.uk/user/12173512',
+					userId: '12173512',
+					webUrl: 'https://profile.theguardian.com/user/id/12173512',
+				},
+				webUrl: 'https://discussion.theguardian.com/comment-permalink/38591122',
+			},
+			{
+				apiUrl:
+					'https://discussion.guardianapis.com/discussion-api/comment/38649787',
+				body: '<p>Edge of seventeen.</p>',
+				date: '26 July 2014 6:37pm',
+				id: 38649787,
+				isHighlighted: false,
+				isoDateTime: '2014-07-26T17:37:07Z',
+				numRecommends: 0,
+				status: 'visible',
+				userProfile: {
+					apiUrl:
+						'https://discussion.guardianapis.com/discussion-api/profile/4431346',
+					avatar: 'https://avatar.guim.co.uk/user/4431346',
+					badge: [],
+					displayName: 'halfienoakes',
+					secureAvatarUrl: 'https://avatar.guim.co.uk/user/4431346',
+					userId: '4431346',
+					webUrl: 'https://profile.theguardian.com/user/id/4431346',
+				},
+				webUrl: 'https://discussion.theguardian.com/comment-permalink/38649787',
+			},
+		],
+	},
+};

--- a/fixtures/manual/short-discussion.ts
+++ b/fixtures/manual/short-discussion.ts
@@ -37,7 +37,8 @@ export const shortDiscussion = {
 					userId: '12173512',
 					webUrl: 'https://profile.theguardian.com/user/id/12173512',
 				},
-				webUrl: 'https://discussion.theguardian.com/comment-permalink/38591122',
+				webUrl:
+					'https://discussion.theguardian.com/comment-permalink/38591122',
 			},
 			{
 				apiUrl:
@@ -59,7 +60,8 @@ export const shortDiscussion = {
 					userId: '4431346',
 					webUrl: 'https://profile.theguardian.com/user/id/4431346',
 				},
-				webUrl: 'https://discussion.theguardian.com/comment-permalink/38649787',
+				webUrl:
+					'https://discussion.theguardian.com/comment-permalink/38649787',
 			},
 		],
 	},

--- a/src/web/components/Discussion.stories.tsx
+++ b/src/web/components/Discussion.stories.tsx
@@ -1,0 +1,31 @@
+// import { css } from '@emotion/react';
+import { decidePalette } from '../lib/decidePalette';
+
+import { Discussion } from './Discussion';
+
+export default {
+	component: Discussion,
+	title: 'Components/Discussion',
+};
+export const Basic = () => {
+	return (
+		<div>
+			<Discussion
+				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
+				shortUrlId="/p/4v8kk"
+				isCommentable={true}
+				pillar={3}
+				palette={decidePalette({ design: 0, display: 0, theme: 3 })}
+				discussionD2Uid="zHoBy6HNKsk"
+				discussionApiClientHeader="nextgen"
+				enableDiscussionSwitch={true}
+				isAdFreeUser={false}
+				shouldHideAds={false}
+				beingHydrated={true}
+				display={0}
+			/>
+		</div>
+	);
+};
+
+Basic.story = { name: 'A discussion with short comments' };

--- a/src/web/components/Discussion.stories.tsx
+++ b/src/web/components/Discussion.stories.tsx
@@ -1,4 +1,4 @@
-// import { css } from '@emotion/react';
+import { Design, Display, Pillar } from '@guardian/types';
 import { decidePalette } from '../lib/decidePalette';
 
 import { Discussion } from './Discussion';
@@ -15,7 +15,11 @@ export const Basic = () => {
 				shortUrlId="/p/4v8kk"
 				isCommentable={true}
 				pillar={3}
-				palette={decidePalette({ design: 0, display: 0, theme: 3 })}
+				palette={decidePalette({
+					design: Design.Article,
+					display: Display.Standard,
+					theme: Pillar.Culture,
+				})}
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -177,6 +177,7 @@ export const Discussion = ({
 							${from.leftCol} {
 								padding-left: 10px;
 							}
+							width: 100%;
 							max-width: 100%;
 						`}
 					>
@@ -226,7 +227,7 @@ export const Discussion = ({
 						)}
 
 						{beingHydrated && !isExpanded && (
-							<Lazy margin={300}>
+							<Lazy margin={300} disableFlexStyles={true}>
 								<Comments
 									user={user}
 									baseUrl={discussionApiUrl}

--- a/src/web/components/Lazy.tsx
+++ b/src/web/components/Lazy.tsx
@@ -5,6 +5,7 @@ import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
 type Props = {
 	children: JSX.Element;
 	margin: number;
+	disableFlexStyles?: boolean;
 };
 
 // Ensure the ref wrapper expands. This is used for componenents like
@@ -14,7 +15,7 @@ const flexGrowStyles = css`
 	flex-grow: 1;
 `;
 
-export const Lazy = ({ children, margin }: Props) => {
+export const Lazy = ({ children, margin, disableFlexStyles }: Props) => {
 	const [hasBeenSeen, setRef] = useHasBeenSeen({
 		rootMargin: `${margin}px`,
 	});
@@ -32,7 +33,7 @@ export const Lazy = ({ children, margin }: Props) => {
 	// use for visual regression
 	const renderChildren = hasBeenSeen || Lazy.disabled;
 	return (
-		<div ref={setRef} css={flexGrowStyles}>
+		<div ref={setRef} css={!disableFlexStyles && flexGrowStyles}>
 			{renderChildren && <>{children}</>}
 		</div>
 	);

--- a/src/web/lib/mockRESTCalls.ts
+++ b/src/web/lib/mockRESTCalls.ts
@@ -4,6 +4,8 @@ import { mostRead } from '@root/fixtures/manual/most-read';
 import { mostReadGeo } from '@root/fixtures/manual/most-read-geo';
 import { related } from '@root/fixtures/manual/related';
 import { discussion } from '@root/fixtures/manual/discussion';
+import { shortDiscussion } from '@root/fixtures/manual/short-discussion';
+import { discussionNoTopComments } from '@root/fixtures/manual/discussion-no-top-comments';
 
 import { series } from '@root/fixtures/generated/series';
 import { storyPackage } from '@root/fixtures/generated/story-package';
@@ -196,6 +198,24 @@ export const mockRESTCalls = (): void => {
 					share_count: 273,
 					refreshStatus: true,
 				},
+			},
+			{ overwriteRoutes: false },
+		)
+		// Get 'short' discussion - top comments
+		.get(
+			/.*discussion.theguardian.com\/discussion-api\/discussion\/p\/4v8kk\/topcomments/,
+			{
+				status: 200,
+				body: discussionNoTopComments,
+			},
+			{ overwriteRoutes: false },
+		)
+		// Get 'short' discussion
+		.get(
+			/.*discussion.theguardian.com\/discussion-api\/discussion\/p\/4v8kk/,
+			{
+				status: 200,
+				body: shortDiscussion,
 			},
 			{ overwriteRoutes: false },
 		)


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When there are no top picks comments & no comments which exceed the width of the comment section; the comment section shrinks down to the size of the largest comment. This also occurs if there is only one top comment.

Additionally I've added a story which should prevent this bug from regressing in the future

### Before
(Short Comments)
![image](https://user-images.githubusercontent.com/9575458/120663856-53768180-c482-11eb-9bdf-86ce6eb67223.png)
(Only 1 top comment)
![image](https://user-images.githubusercontent.com/9575458/120665003-502fc580-c483-11eb-93e4-1e54430e5b20.png)

### After
(Short Comments)
![image](https://user-images.githubusercontent.com/9575458/120664857-31313380-c483-11eb-8eb9-ef3148a2f345.png)
(Only 1 top comment)
![image](https://user-images.githubusercontent.com/9575458/120665098-62a9ff00-c483-11eb-932c-b970abb068e4.png)

## Why?

Visual Bug
