### PR TITLE
Add support for interactive & interactive AMP prod URLs

### DIFF
--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -107,7 +107,10 @@ if (process.env.NODE_ENV === 'production') {
 
 	app.post('/Article', logRenderTime, renderArticle);
 	app.post('/AMPArticle', logRenderTime, renderAMPArticle);
+	app.post('/Interactive', logRenderTime, renderInteractive);
+	app.post('/AMPInteractive', logRenderTime, renderAMPArticle);
 
+	// These GET's are for checking any given URL directly from PROD
 	app.get('/Article', logRenderTime, async (req: Request, res: Response) => {
 		// Eg. http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/...
 		try {
@@ -147,7 +150,6 @@ if (process.env.NODE_ENV === 'production') {
 	app.use('/ArticlePerfTest', renderArticlePerfTest);
 	app.use('/AMPArticlePerfTest', renderAMPArticlePerfTest);
 	app.use('/ArticleJson', renderArticleJson);
-	app.use('/Interactive', renderInteractive);
 
 	app.get('/', (req: Request, res: Response) => {
 		try {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds two new prod endpoints

- `/Interactive` for rendering interactives
- `/InteractiveAMP` for rendering AMP interactives

This brings the regular `server.ts` in line with the `dev-server` which has been used for testing these two article types.

### Before

### After

## Why?

Needed for - https://github.com/guardian/frontend/pull/23873
