### PR TITLE
Main media interactive full height

### DIFF
--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -151,6 +151,10 @@ type Props = {
 	isNumberedListTitle?: boolean;
 };
 
+const mainMediaFigureStyles = css`
+	height: 100%;
+`;
+
 export const Figure = ({
 	role = 'inline',
 	children,
@@ -164,7 +168,11 @@ export const Figure = ({
 		// as showcase twitter embeds, then we should remove the role positioning which
 		// currently lives in ImageComponent and hoist it up to here, the same as we're
 		// doing using decidePosition for in-body elements
-		return <figure id={id}>{children}</figure>;
+		return (
+			<figure id={id} css={mainMediaFigureStyles}>
+				{children}
+			</figure>
+		);
 	}
 	return (
 		<figure

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -7,6 +7,7 @@ import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 const mainMedia = css`
+	height: 100%;
 	min-height: 1px;
 	/*
     Thank you IE11, broken in stasis for all eternity.

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -347,6 +347,7 @@ export const renderElement = ({
 			return [
 				true,
 				<InteractiveAtom
+					isMainMedia={isMainMedia}
 					id={element.id}
 					elementHtml={element.html}
 					elementJs={element.js}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Make main media interactives full height

### Example:
https://www.theguardian.com/news/2018/jun/18/are-we-running-out-of-water?dcr

### Before
<img width="1048" alt="Screenshot 2021-06-04 at 10 41 20" src="https://user-images.githubusercontent.com/8831403/120782041-86238700-c521-11eb-8e8c-95e55670868e.png">

### After
<img width="524" alt="Screenshot 2021-06-04 at 10 37 20" src="https://user-images.githubusercontent.com/8831403/120782051-891e7780-c521-11eb-837c-b1bd7455abaf.png">

## Why?
Main media interactives were not full height