### PR TITLE
Revert "Clean interactive atom HTML"

### DIFF
--- a/src/model/clean.ts
+++ b/src/model/clean.ts
@@ -23,6 +23,3 @@ export const clean = compose(
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 	DOMPurify.sanitize,
 );
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-export const sanitiseHTML = (html: string): string => DOMPurify.sanitize(html);

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -54,7 +54,6 @@ import {
 	KnowledgeQuizAtom,
 } from '@guardian/atoms-rendering';
 import { Design, Format } from '@guardian/types';
-import { sanitiseHTML } from '@root/src/model/clean';
 import { Figure } from '../components/Figure';
 
 type Props = {
@@ -334,19 +333,12 @@ export const renderElement = ({
 				</ClickToView>,
 			];
 		case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
-			// Some interactives contain HTML with unclosed tags etc. To
-			// preserve (approximate) parity with Frontend we perform some basic
-			// cleaning.
-			const cleanHTML = element.html
-				? sanitiseHTML(element.html)
-				: element.html;
-
 			if (format.design === Design.Interactive) {
 				return [
 					true,
 					<InteractiveLayoutAtom
 						id={element.id}
-						elementHtml={cleanHTML}
+						elementHtml={element.html}
 						elementJs={element.js}
 						elementCss={element.css}
 					/>,
@@ -356,7 +348,7 @@ export const renderElement = ({
 				true,
 				<InteractiveAtom
 					id={element.id}
-					elementHtml={cleanHTML}
+					elementHtml={element.html}
 					elementJs={element.js}
 					elementCss={element.css}
 				/>,


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3070 as breaks build.