### PR TITLE
Fix storybook build JSDOM error 

### DIFF
--- a/src/model/enhance-interactive-atom-elements.ts
+++ b/src/model/enhance-interactive-atom-elements.ts
@@ -7,12 +7,12 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 	elements.map((element) => {
 		if (
 			element._type ===
-				'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
+			'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
 		)
 			element.html = element.html
 				? sanitiseHTML(element.html)
 				: element.html;
-		return element
+		return element;
 	});
 
 	return elements;

--- a/src/model/enhance-interactive-atom-elements.ts
+++ b/src/model/enhance-interactive-atom-elements.ts
@@ -1,0 +1,33 @@
+import { sanitiseHTML } from '@root/src/model/clean';
+
+// Some interactives contain HTML with unclosed tags etc. To
+// preserve (approximate) parity with Frontend we perform some basic
+// cleaning.
+const enhance = (elements: CAPIElement[]): CAPIElement[] => {
+	elements.map((element) => {
+		if (
+			element._type ===
+				'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
+		)
+			element.html = element.html
+				? sanitiseHTML(element.html)
+				: element.html;
+		return element
+	});
+
+	return elements;
+};
+
+export const enhanceInteractiveAtomElements = (data: CAPIType): CAPIType => {
+	const enhancedBlocks = data.blocks.map((block: Block) => {
+		return {
+			...block,
+			elements: enhance(block.elements),
+		};
+	});
+
+	return {
+		...data,
+		blocks: enhancedBlocks,
+	} as CAPIType;
+};

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -54,7 +54,6 @@ import {
 	KnowledgeQuizAtom,
 } from '@guardian/atoms-rendering';
 import { Design, Format } from '@guardian/types';
-import { sanitiseHTML } from '@root/src/model/clean';
 import { Figure } from '../components/Figure';
 
 type Props = {
@@ -334,19 +333,12 @@ export const renderElement = ({
 				</ClickToView>,
 			];
 		case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
-			// Some interactives contain HTML with unclosed tags etc. To
-			// preserve (approximate) parity with Frontend we perform some basic
-			// cleaning.
-			const cleanHTML = element.html
-				? sanitiseHTML(element.html)
-				: element.html;
-
 			if (format.design === Design.Interactive) {
 				return [
 					true,
 					<InteractiveLayoutAtom
 						id={element.id}
-						elementHtml={cleanHTML}
+						elementHtml={element.html}
 						elementJs={element.js}
 						elementCss={element.css}
 					/>,
@@ -356,7 +348,7 @@ export const renderElement = ({
 				true,
 				<InteractiveAtom
 					id={element.id}
-					elementHtml={cleanHTML}
+					elementHtml={element.html}
 					elementJs={element.js}
 					elementCss={element.css}
 				/>,

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -8,6 +8,7 @@ import { enhanceDots } from '@root/src/model/add-dots';
 import { setIsDev } from '@root/src/model/set-is-dev';
 import { enhanceImages } from '@root/src/model/enhance-images';
 import { enhanceNumberedLists } from '@root/src/model/enhance-numbered-lists';
+import { enhanceInteractiveAtomElements } from '@root/src/model/enhance-interactive-atom-elements';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';
 import { enhanceEmbeds } from '@root/src/model/enhance-embeds';
 import { extract as extractGA } from '@root/src/model/extract-ga';
@@ -27,6 +28,11 @@ class CAPIEnhancer {
 
 	enhanceDots() {
 		this.capi = enhanceDots(this.capi);
+		return this;
+	}
+
+	enhanceInteractiveElements() {
+		this.capi = enhanceInteractiveAtomElements(this.capi);
 		return this;
 	}
 
@@ -67,6 +73,7 @@ const buildCAPI = (body: CAPIType): CAPIType => {
 		.addDividers()
 		.enhanceBlockquotes()
 		.enhanceDots()
+		.enhanceInteractiveElements()
 		.enhanceImages()
 		.enhanceNumberedLists()
 		.enhanceEmbeds().capi;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Move cleaning of `InteractiveAtomBlockElement` from element rendering to enhancer

### Before

### After

## Why?

Inclusion of JSDOM in clientside build would prevent storybook from building
