### PR TITLE
Load braze sdk for all signed in users.

### DIFF
--- a/src/web/lib/braze/checkBrazeDependencies.test.ts
+++ b/src/web/lib/braze/checkBrazeDependencies.test.ts
@@ -14,13 +14,6 @@ jest.mock('./hasRequiredConsents', () => ({
 	},
 }));
 
-let mockHideSupportMessaging: boolean;
-jest.mock('./hideSupportMessaging', () => ({
-	hideSupportMessaging: () => {
-		return mockHideSupportMessaging;
-	},
-}));
-
 describe('checkBrazeDependecies', () => {
 	let windowSpy: jest.SpyInstance<any>;
 
@@ -58,7 +51,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -71,7 +63,6 @@ describe('checkBrazeDependecies', () => {
 			consent: true,
 			isNotPaidContent: true,
 			brazeUuid: 'fake-uuid',
-			userIsGuSupporter: true,
 		});
 	});
 
@@ -91,7 +82,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -122,7 +112,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -155,7 +144,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = null;
 		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -189,7 +177,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.resolve(false);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -204,42 +191,6 @@ describe('checkBrazeDependecies', () => {
 		// Condition to keep TypeScript happy
 		if (!got.isSuccessful) {
 			expect(got.failure.field).toEqual('consent');
-			expect(got.failure.data).toEqual(false);
-		}
-	});
-
-	it('fails if support messaging is not hidden', async () => {
-		setWindow({
-			guardian: {
-				config: {
-					switches: {
-						brazeSwitch: true,
-					},
-					page: {
-						brazeApiKey: 'fake-api-key',
-						isPaidContent: false,
-					},
-				},
-			},
-		});
-		mockBrazeUuid = 'fake-uuid';
-		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = false;
-
-		const isSignedIn = true;
-		const idApiUrl = 'https://idapi.example.com';
-		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
-
-		expect(got.isSuccessful).toEqual(false);
-		expect(got.data).toEqual({
-			brazeSwitch: true,
-			apiKey: 'fake-api-key',
-			consent: true,
-			brazeUuid: 'fake-uuid',
-		});
-		// Condition to keep TypeScript happy
-		if (!got.isSuccessful) {
-			expect(got.failure.field).toEqual('userIsGuSupporter');
 			expect(got.failure.data).toEqual(false);
 		}
 	});
@@ -260,7 +211,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.resolve(true);
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';
@@ -272,7 +222,6 @@ describe('checkBrazeDependecies', () => {
 			apiKey: 'fake-api-key',
 			consent: true,
 			brazeUuid: 'fake-uuid',
-			userIsGuSupporter: true,
 		});
 		// Condition to keep TypeScript happy
 		if (!got.isSuccessful) {
@@ -297,7 +246,6 @@ describe('checkBrazeDependecies', () => {
 		});
 		mockBrazeUuid = 'fake-uuid';
 		mockConsentsPromise = Promise.reject(new Error('something went wrong'));
-		mockHideSupportMessaging = true;
 
 		const isSignedIn = true;
 		const idApiUrl = 'https://idapi.example.com';

--- a/src/web/lib/braze/checkBrazeDependencies.ts
+++ b/src/web/lib/braze/checkBrazeDependencies.ts
@@ -1,6 +1,5 @@
 import { getBrazeUuid } from '@root/src/web/lib/getBrazeUuid';
 import { hasRequiredConsents } from './hasRequiredConsents';
-import { hideSupportMessaging } from './hideSupportMessaging';
 
 type SuccessResult = {
 	isSuccessful: true;
@@ -53,10 +52,6 @@ const buildDependencies = (
 		{
 			name: 'consent',
 			value: hasRequiredConsents(),
-		},
-		{
-			name: 'userIsGuSupporter',
-			value: Promise.resolve(hideSupportMessaging()),
 		},
 		{
 			name: 'isNotPaidContent',

--- a/src/web/lib/braze/hideSupportMessaging.ts
+++ b/src/web/lib/braze/hideSupportMessaging.ts
@@ -1,7 +1,0 @@
-import { getCookie } from '@root/src/web/browser/cookie';
-import { HIDE_SUPPORT_MESSAGING_COOKIE } from '@root/src/web/lib/contributions';
-
-const hideSupportMessaging = () =>
-	getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
-
-export { hideSupportMessaging };


### PR DESCRIPTION
## What does this change?
Requirements for a user to satisfy for the Braze SDK to be loaded (and therefore see Braze components, Banners/Epic).

### Before
Only logged in users who are also supporters would have the Braze SDK loaded.

### After
All logged in users will have the Braze SDK loaded.

## Why?
This is so we can use Braze for marketing to non supporters.
