### PR TITLE
Add vertical space to mobile-only bottom social icons

### DIFF
--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -33,7 +33,7 @@ const liStyles = (size: ShareIconSize) => css`
 	cursor: pointer;
 `;
 
-const hideSyles = css`
+const topMarginStlyes = css`
 	margin-top: 3px;
 `;
 
@@ -167,7 +167,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('whatsApp') && (
 				<Hide when="above" breakpoint="phablet" el="li" key="whatsApp">
-					<span css={[liStyles(size), hideSyles]}>
+					<span css={[liStyles(size), topMarginStlyes]}>
 						<a
 							href={`whatsapp://send?text="${encodeTitle(
 								webTitle,
@@ -187,7 +187,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('messenger') && (
 				<Hide when="above" breakpoint="phablet" el="li" key="messenger">
-					<span css={[liStyles(size), hideSyles]}>
+					<span css={[liStyles(size), topMarginStlyes]}>
 						<a
 							href={`fb-messenger://share?link=${encodeUrl(
 								pageId,

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -33,6 +33,10 @@ const liStyles = (size: ShareIconSize) => css`
 	cursor: pointer;
 `;
 
+const hideSyles = css`
+	margin-top: 3px;
+`;
+
 const iconStyles = ({
 	palette,
 	size,
@@ -163,7 +167,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('whatsApp') && (
 				<Hide when="above" breakpoint="phablet" el="li" key="whatsApp">
-					<span css={liStyles(size)}>
+					<span css={[liStyles(size), hideSyles]}>
 						<a
 							href={`whatsapp://send?text="${encodeTitle(
 								webTitle,
@@ -183,7 +187,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('messenger') && (
 				<Hide when="above" breakpoint="phablet" el="li" key="messenger">
-					<span css={liStyles(size)}>
+					<span css={[liStyles(size), hideSyles]}>
 						<a
 							href={`fb-messenger://share?link=${encodeUrl(
 								pageId,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds 3px of vertical margin to social icons which appear at the bottom of the article on mobile.

### Before
(Article)
![image](https://user-images.githubusercontent.com/9575458/120831997-11b80a80-c558-11eb-8b0c-9b3b3ef768c3.png)
(Labs)
![image](https://user-images.githubusercontent.com/9575458/120832060-21375380-c558-11eb-8099-9a8a895b50b2.png)

### After
(Article)
![image](https://user-images.githubusercontent.com/9575458/120832142-3a400480-c558-11eb-809b-2f341004e186.png)
(Labs)
![image](https://user-images.githubusercontent.com/9575458/120832095-2bf1e880-c558-11eb-93cb-12469bed44f9.png)

## Why?

Visual Bug
