### PR TITLE
Respect interactive nav switch

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -145,7 +145,7 @@ const go = () => {
 		'/Interactive',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req, defaultInteractiveURL);
+				const url = buildUrlFromQueryParam(req);
 				const { html, ...config } = await fetch(
 					url,
 				).then((interactive) => interactive.json());

--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -2,27 +2,7 @@ import { css } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
-
-export const center = css`
-	position: relative;
-	margin: auto;
-
-	${from.tablet} {
-		max-width: 740px;
-	}
-
-	${from.desktop} {
-		max-width: 980px;
-	}
-
-	${from.leftCol} {
-		max-width: 1140px;
-	}
-
-	${from.wide} {
-		max-width: 1300px;
-	}
-`;
+import { center } from '@root/src/web/lib/center';
 
 const padding = css`
 	padding: 0 10px;

--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 
-const center = css`
+export const center = css`
 	position: relative;
 	margin: auto;
 

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -1,48 +1,31 @@
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 
 import {
 	brandBackground,
 	brandBorder,
 	labs,
 	border,
+	brandLine,
 } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
-import { Design, Special } from '@guardian/types';
-import type { Format } from '@guardian/types';
+import { Display, Format, Special } from '@guardian/types';
 
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
-import { MainMedia } from '@root/src/web/components/MainMedia';
-import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
-import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
-import { Caption } from '@root/src/web/components/Caption';
-import { ContainerLayout } from '@root/src/web/components/ContainerLayout';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
-import { renderElement } from '../lib/renderElement';
 
-const hasMainMediaStyles = css`
-	height: 100vh;
-	/**
-    100vw is normally enough but don't let the content shrink vertically too
-    much just in case
-    */
-	min-height: 25rem;
-	${from.desktop} {
-		min-height: 31.25rem;
-	}
-	${from.wide} {
-		min-height: 50rem;
-	}
-`;
+import { renderElement } from '../lib/renderElement';
+import { Header } from '../components/Header';
+import { HeaderAdSlot } from '../components/HeaderAdSlot';
+import { interactiveGlobalStyles } from './lib/interactiveGlobalStyles';
 
 interface Props {
 	CAPI: CAPIType;
@@ -50,57 +33,6 @@ interface Props {
 	format: Format;
 	palette: Palette;
 }
-
-const decideCaption = (mainMedia: ImageBlockElement): string => {
-	const caption = [];
-	if (mainMedia && mainMedia.data && mainMedia.data.caption)
-		caption.push(mainMedia.data.caption);
-	if (
-		mainMedia &&
-		mainMedia.displayCredit &&
-		mainMedia.data &&
-		mainMedia.data.credit
-	)
-		caption.push(mainMedia.data.credit);
-	return caption.join(' ');
-};
-
-const Box = ({
-	palette,
-	children,
-}: {
-	palette: Palette;
-	children: React.ReactNode;
-}) => (
-	<div
-		css={css`
-			/*
-				This pseudo css shows a black box to the right of the headline
-				so that the black background of the inverted text stretches
-				all the way right. But only from mobileLandscape because below
-				that we want to show a gap. To work properly it needs to wrap
-				the healine so it inherits the correct height based on the length
-				of the headline text
-			*/
-			${from.mobileLandscape} {
-				position: relative;
-				:after {
-					content: '';
-					display: block;
-					position: absolute;
-					width: 50%;
-					right: 0;
-					background-color: ${palette.background.headline};
-					${getZIndex('immersiveBlackBox')}
-					top: 0;
-					bottom: 0;
-				}
-			}
-		`}
-	>
-		{children}
-	</div>
-);
 
 const Renderer: React.FC<{
 	format: Format;
@@ -136,6 +68,117 @@ const Renderer: React.FC<{
 	return <div>{output}</div>;
 };
 
+const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
+	// Typically immersives use the slim nav, but this switch is used to force
+	// the full nav - typically during special events such as Project 200, or
+	// the Euros. The motivation is to better onboard new visitors; interactives
+	// often reach readers who are less familiar with the Guardian.
+	const isSlimNav = !CAPI.config.switches.interactiveFullHeaderSwitch;
+
+	if (isSlimNav) {
+		return (
+			<header
+				css={css`
+					${getZIndex('headerWrapper')}
+					order: 0;
+				`}
+			>
+				<Section
+					showSideBorders={true}
+					borderColour={brandLine.primary}
+					showTopBorder={false}
+					padded={false}
+					backgroundColour={brandBackground.primary}
+				>
+					<Nav
+						format={{
+							display: format.display,
+							design: format.design,
+							theme: getCurrentPillar(CAPI),
+						}}
+						nav={NAV}
+						subscribeUrl={
+							CAPI.nav.readerRevenueLinks.header.subscribe
+						}
+						edition={CAPI.editionId}
+					/>
+				</Section>
+			</header>
+		);
+	}
+
+	return (
+		<div>
+			<div data-print-layout="hide">
+				<Stuck>
+					<Section
+						showTopBorder={false}
+						showSideBorders={false}
+						padded={false}
+						shouldCenter={false}
+					>
+						<HeaderAdSlot
+							isAdFreeUser={CAPI.isAdFreeUser}
+							shouldHideAds={CAPI.shouldHideAds}
+							display={format.display}
+						/>
+					</Section>
+				</Stuck>
+				{format.theme !== Special.Labs && (
+					<Section
+						showTopBorder={false}
+						showSideBorders={false}
+						padded={false}
+						backgroundColour={brandBackground.primary}
+					>
+						<Header
+							edition={CAPI.editionId}
+							idUrl={CAPI.config.idUrl}
+							mmaUrl={CAPI.config.mmaUrl}
+							isAnniversary={
+								CAPI.config.switches.anniversaryHeaderSvg
+							}
+						/>
+					</Section>
+				)}
+			</div>
+
+			<Section
+				showSideBorders={true}
+				borderColour={brandLine.primary}
+				showTopBorder={false}
+				padded={false}
+				backgroundColour={brandBackground.primary}
+			>
+				<Nav
+					format={{
+						display: Display.Standard,
+						design: format.design,
+						theme: getCurrentPillar(CAPI),
+					}}
+					nav={NAV}
+					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+					edition={CAPI.editionId}
+				/>
+			</Section>
+
+			{NAV.subNavSections && format.theme !== Special.Labs && (
+				<Section
+					backgroundColour={palette.background.article}
+					padded={false}
+					sectionId="sub-nav-root"
+				>
+					<SubNav
+						subNavSections={NAV.subNavSections}
+						currentNavLink={NAV.currentNavLink}
+						palette={palette}
+					/>
+				</Section>
+			)}
+		</div>
+	);
+};
+
 export const InteractiveImmersiveLayout = ({
 	CAPI,
 	NAV,
@@ -146,150 +189,36 @@ export const InteractiveImmersiveLayout = ({
 		config: { host },
 	} = CAPI;
 
-	const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
-	const captionText = decideCaption(mainMedia);
-
-	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
-
-	const LeftColCaption = () => (
-		<div
-			css={css`
-				margin-top: ${HEADLINE_OFFSET}px;
-				position: absolute;
-				margin-left: 20px;
-			`}
-		>
-			<Caption
-				palette={palette}
-				captionText={captionText}
-				format={format}
-				shouldLimitWidth={true}
-				isLeftCol={true}
-			/>
-		</div>
-	);
-
 	return (
 		<>
+			<Global styles={interactiveGlobalStyles} />
 			<div
 				css={css`
 					background-color: ${palette.background.article};
 				`}
 			>
-				<div
-					css={[
-						mainMedia && hasMainMediaStyles,
-						css`
-							display: flex;
-							flex-direction: column;
-						`,
-					]}
-				>
-					<header
-						css={css`
-							${getZIndex('headerWrapper')}
-							order: 0;
-						`}
-					>
+				<NavHeader
+					CAPI={CAPI}
+					NAV={NAV}
+					format={format}
+					palette={palette}
+				/>
+
+				{format.theme === Special.Labs && (
+					<Stuck>
 						<Section
-							showSideBorders={false}
+							showSideBorders={true}
 							showTopBorder={false}
-							padded={false}
-							backgroundColour={brandBackground.primary}
+							backgroundColour={labs[400]}
+							borderColour={border.primary}
+							sectionId="labs-header"
 						>
-							<Nav
-								format={{
-									...format,
-									theme: getCurrentPillar(CAPI),
-								}}
-								nav={NAV}
-								subscribeUrl={
-									CAPI.nav.readerRevenueLinks.header.subscribe
-								}
-								edition={CAPI.editionId}
-							/>
+							<LabsHeader />
 						</Section>
-					</header>
-
-					{format.theme === Special.Labs && (
-						<Stuck>
-							<Section
-								showSideBorders={true}
-								showTopBorder={false}
-								backgroundColour={labs[400]}
-								borderColour={border.primary}
-								sectionId="labs-header"
-							>
-								<LabsHeader />
-							</Section>
-						</Stuck>
-					)}
-
-					<MainMedia
-						format={format}
-						palette={palette}
-						elements={CAPI.mainMediaElements}
-						adTargeting={undefined}
-						starRating={
-							format.design === Design.Review && CAPI.starRating
-								? CAPI.starRating
-								: undefined
-						}
-						host={host}
-						hideCaption={true}
-						pageId={CAPI.pageId}
-						webTitle={CAPI.webTitle}
-					/>
-				</div>
-				{mainMedia && (
-					<>
-						<div
-							css={css`
-								margin-top: -${HEADLINE_OFFSET}px;
-								/*
-                        This z-index is what ensures the headline title text shows above main media. For
-                        the actual headline we set the z-index deeper in ArticleHeadline itself so that
-                        the text appears above the pseudo Box element
-                    */
-								position: relative;
-								${getZIndex('articleHeadline')};
-							`}
-						>
-							<ContainerLayout
-								verticalMargins={false}
-								padContent={false}
-								padSides={false}
-								leftContent={<LeftColCaption />}
-							>
-								<ArticleTitle
-									format={format}
-									palette={palette}
-									tags={CAPI.tags}
-									sectionLabel={CAPI.sectionLabel}
-									sectionUrl={CAPI.sectionUrl}
-									guardianBaseURL={CAPI.guardianBaseURL}
-									badge={CAPI.badge}
-								/>
-							</ContainerLayout>
-							<Box palette={palette}>
-								<ContainerLayout
-									verticalMargins={false}
-									padContent={false}
-									padSides={false}
-								>
-									<ArticleHeadline
-										format={format}
-										headlineString={CAPI.headline}
-										palette={palette}
-										tags={CAPI.tags}
-										byline={CAPI.author.byline}
-									/>
-								</ContainerLayout>
-							</Box>
-						</div>
-					</>
+					</Stuck>
 				)}
 			</div>
+
 			<Section
 				showTopBorder={false}
 				showSideBorders={false}

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 
 import {
 	neutral,
@@ -47,6 +47,7 @@ import {
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { interactiveGlobalStyles } from './lib/interactiveGlobalStyles';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -242,6 +243,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	return (
 		<>
 			<div data-print-layout="hide">
+				<Global styles={interactiveGlobalStyles} />
 				<>
 					<Stuck>
 						<Section

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -8,4 +8,10 @@ export const interactiveGlobalStyles = css`
 	.gs-container {
 		${center}
 	}
+
+	*,
+	::before,
+	::after {
+		box-sizing: content-box;
+	}
 `;

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+import { center } from '@root/src/web/components/Section';
+
+// Styles expected by interactives from the Frontend days. These shouldn't be
+// used for new interactives though.
+export const interactiveGlobalStyles = css`
+	.gs-container {
+		${center}
+	}
+`;

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { center } from '@root/src/web/components/Section';
+import { center } from '@root/src/web/lib/center';
 
 // Styles expected by interactives from the Frontend days. These shouldn't be
 // used for new interactives though.

--- a/src/web/lib/center.ts
+++ b/src/web/lib/center.ts
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+
+import { from } from '@guardian/src-foundations/mq';
+
+export const center = css`
+	position: relative;
+	margin: auto;
+
+	${from.tablet} {
+		max-width: 740px;
+	}
+
+	${from.desktop} {
+		max-width: 980px;
+	}
+
+	${from.leftCol} {
+		max-width: 1140px;
+	}
+
+	${from.wide} {
+		max-width: 1300px;
+	}
+`;


### PR DESCRIPTION
## What does this change?

Respect the `interactiveFullHeaderSwitch` switch, which toggles slim nav on immersive interactives. As part of this I have also:

* removed some unnecessary code in the immersive interactive layout file
* introduced some basic global interactive styles that are present in Frontend and expected by some interactives

e.g. for https://www.theguardian.com/music/ng-interactive/2021/apr/12/the-months-best-albums...

### Before
![Screenshot 2021-06-04 at 17 18 58](https://user-images.githubusercontent.com/858402/120833441-b850db00-c559-11eb-9ac7-0a7c81923a8f.png)

### After
![Screenshot 2021-06-04 at 17 19 10](https://user-images.githubusercontent.com/858402/120833510-c7d02400-c559-11eb-8c11-a42951b4bb12.png)

## Why?

Parity with Frontend.