### PR TITLE
Pull through branding for cards

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ type Palette = {
 		sectionTitle: Colour;
 		avatar: Colour;
 		card: Colour;
+		cardInvertLogo: boolean;
 		headline: Colour;
 		headlineByline: Colour;
 		bullet: Colour;
@@ -195,22 +196,19 @@ interface EditionCommercialProperties {
 
 type CommercialProperties = { [E in Edition]: EditionCommercialProperties };
 
+type BrandingLogo = {
+	src: string;
+	link: string;
+	label: string;
+	dimensions: { width: number; height: number };
+}
+
 interface Branding {
 	brandingType?: { name: string };
 	sponsorName: string;
-	logo: {
-		src: string;
-		link: string;
-		label: string;
-		dimensions: { width: number; height: number };
-	};
+	logo: BrandingLogo;
 	aboutThisLink: string;
-	logoForDarkBackground?: {
-		src: string;
-		dimensions: { width: number; height: number };
-		link: string;
-		label: string;
-	};
+	logoForDarkBackground?: BrandingLogo;
 }
 
 interface LinkType extends SimpleLinkType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -835,6 +835,7 @@ interface BaseTrailType {
     commentCount?: number;
     starRating?: number;
     linkText?: string;
+	branding?: Branding
 }
 interface TrailType extends BaseTrailType {
 	palette: Palette;

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -716,24 +716,60 @@ export const Media = () => (
 );
 Media.story = { name: 'Media' };
 
-const labBadge1: BadgeType = {
-	seriesTag: 'Tag',
-	imageUrl: `https://static.theguardian.com/commercial/sponsor/22/Mar/2021/c476c5ec-9c79-417f-b10f-e3e48c0dfb72-Saint Agur logo.png`,
+const labsBranding1: Branding = {
+	sponsorName: 'Saint Agur',
+	logo: {
+		src: 'https://static.theguardian.com/commercial/sponsor/22/Mar/2021/c476c5ec-9c79-417f-b10f-e3e48c0dfb72-Saint Agur logo.png',
+		link: 'https://en.wikipedia.org/wiki/Saint_Agur_Blue',
+		label: 'Paid for by',
+		dimensions: {
+			width: 280,
+			height: 180
+		},
+	},
+	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
+}
+
+const labsBranding2: Branding = {
+	sponsorName: 'Lindeman\'s',
+	logo: {
+		src: `https://static.theguardian.com/commercial/sponsor/22/Mar/2021/16adc23f-5a54-4c16-b5a8-85110bb3d6ec-Lindeman's_New_Badge_Brandmark_Gold.png`,
+		link: 'https://www.lindemans.com/en-gb',
+		label: 'Paid for by',
+		dimensions: {
+			width: 280,
+			height: 180
+		},
+	},
+	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
-const labBadge2: BadgeType = {
-	seriesTag: 'Tag',
-	imageUrl: `https://static.theguardian.com/commercial/sponsor/22/Mar/2021/16adc23f-5a54-4c16-b5a8-85110bb3d6ec-Lindeman's_New_Badge_Brandmark_Gold.png`,
+const labsBranding3: Branding = {
+	sponsorName: 'DfE',
+	logo: {
+		src: `https://static.theguardian.com/commercial/sponsor/20/Jan/2021/103af03d-6b40-475b-9595-dff2ab20a0a4-DfE-lockup-Online-TIM.png`,
+		link: 'https://www.gov.uk/government/organisations/department-for-education',
+		label: 'Paid for by',
+		dimensions: {
+			width: 280,
+			height: 180
+		},
+	},
+	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
-const labBadge3: BadgeType = {
-	seriesTag: 'Tag',
-	imageUrl: `https://static.theguardian.com/commercial/sponsor/20/Jan/2021/103af03d-6b40-475b-9595-dff2ab20a0a4-DfE-lockup-Online-TIM.png`,
-};
-
-const labBadge4: BadgeType = {
-	seriesTag: 'Tag',
-	imageUrl: `https://static.theguardian.com/commercial/sponsor/23/Mar/2021/45593146-7e57-4713-8314-2bca9674212b-Thatchers_strap.png`,
+const labsBranding4: Branding = {
+	sponsorName: 'Thatchers',
+	logo: {
+		src: `https://static.theguardian.com/commercial/sponsor/23/Mar/2021/45593146-7e57-4713-8314-2bca9674212b-Thatchers_strap.png`,
+		link: 'https://www.thatcherscider.co.uk/',
+		label: 'Paid for by',
+		dimensions: {
+			width: 280,
+			height: 180
+		},
+	},
+	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
 export const Labs = () => (
@@ -756,7 +792,7 @@ export const Labs = () => (
 							headlineSize="medium"
 							imageUrl={images[0]}
 							imagePosition="top"
-							badge={labBadge1}
+							branding={labsBranding1}
 						/>
 					</LI>
 					<LI
@@ -776,7 +812,7 @@ export const Labs = () => (
 							headlineSize="medium"
 							imageUrl={images[1]}
 							imagePosition="top"
-							badge={labBadge2}
+							branding={labsBranding2}
 						/>
 					</LI>
 					<LI
@@ -796,7 +832,7 @@ export const Labs = () => (
 							headlineSize="medium"
 							imageUrl={images[3]}
 							imagePosition="top"
-							badge={labBadge3}
+							branding={labsBranding3}
 						/>
 					</LI>
 					<LI
@@ -816,7 +852,7 @@ export const Labs = () => (
 							headlineSize="medium"
 							imageUrl={images[2]}
 							imagePosition="top"
-							badge={labBadge4}
+							branding={labsBranding4}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -719,43 +719,48 @@ Media.story = { name: 'Media' };
 const labsBranding1: Branding = {
 	sponsorName: 'Saint Agur',
 	logo: {
-		src: 'https://static.theguardian.com/commercial/sponsor/22/Mar/2021/c476c5ec-9c79-417f-b10f-e3e48c0dfb72-Saint Agur logo.png',
+		src:
+			'https://static.theguardian.com/commercial/sponsor/22/Mar/2021/c476c5ec-9c79-417f-b10f-e3e48c0dfb72-Saint Agur logo.png',
 		link: 'https://en.wikipedia.org/wiki/Saint_Agur_Blue',
 		label: 'Paid for by',
 		dimensions: {
 			width: 280,
-			height: 180
+			height: 180,
 		},
 	},
-	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
-}
+	aboutThisLink:
+		'https://www.theguardian.com/info/2016/jan/25/content-funding',
+};
 
 const labsBranding2: Branding = {
-	sponsorName: 'Lindeman\'s',
+	sponsorName: "Lindeman's",
 	logo: {
 		src: `https://static.theguardian.com/commercial/sponsor/22/Mar/2021/16adc23f-5a54-4c16-b5a8-85110bb3d6ec-Lindeman's_New_Badge_Brandmark_Gold.png`,
 		link: 'https://www.lindemans.com/en-gb',
 		label: 'Paid for by',
 		dimensions: {
 			width: 280,
-			height: 180
+			height: 180,
 		},
 	},
-	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
+	aboutThisLink:
+		'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
 const labsBranding3: Branding = {
 	sponsorName: 'DfE',
 	logo: {
 		src: `https://static.theguardian.com/commercial/sponsor/20/Jan/2021/103af03d-6b40-475b-9595-dff2ab20a0a4-DfE-lockup-Online-TIM.png`,
-		link: 'https://www.gov.uk/government/organisations/department-for-education',
+		link:
+			'https://www.gov.uk/government/organisations/department-for-education',
 		label: 'Paid for by',
 		dimensions: {
 			width: 280,
-			height: 180
+			height: 180,
 		},
 	},
-	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
+	aboutThisLink:
+		'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
 const labsBranding4: Branding = {
@@ -766,10 +771,11 @@ const labsBranding4: Branding = {
 		label: 'Paid for by',
 		dimensions: {
 			width: 280,
-			height: 180
+			height: 180,
 		},
 	},
-	aboutThisLink: 'https://www.theguardian.com/info/2016/jan/25/content-funding',
+	aboutThisLink:
+		'https://www.theguardian.com/info/2016/jan/25/content-funding',
 };
 
 export const Labs = () => (

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -55,8 +55,7 @@ type Props = {
 	// Ophan tracking
 	dataLinkName?: string;
 	// Labs
-	badge?: BadgeType;
-	brand?: string;
+	branding?: Branding;
 };
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
@@ -148,8 +147,7 @@ export const Card = ({
 	alwaysVertical,
 	minWidthInPixels,
 	dataLinkName,
-	badge,
-	brand,
+	branding,
 }: Props) => {
 	// Decide how we position the image on the card
 	let imageCoverage: CardPercentageType | undefined;
@@ -316,7 +314,7 @@ export const Card = ({
 										) : undefined
 									}
 									cardBranding={
-										badge ? (
+										branding ? (
 											<CardBranding
 												branding={branding}
 												palette={cardPalette}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -24,7 +24,7 @@ import { CardFooter } from './components/CardFooter';
 import { TopBar } from './components/TopBar';
 import { CardLink } from './components/CardLink';
 import { CardAge } from './components/CardAge';
-import { LabBadge } from './components/LabBadge';
+import { CardBranding } from './components/CardBranding';
 
 type Props = {
 	linkTo: string;
@@ -317,7 +317,7 @@ export const Card = ({
 									}
 									labBadge={
 										badge ? (
-											<LabBadge
+											<CardBranding
 												badgeForLab={badge.imageUrl}
 												palette={cardPalette}
 												brandName={brand}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -315,12 +315,11 @@ export const Card = ({
 											/>
 										) : undefined
 									}
-									labBadge={
+									cardBranding={
 										badge ? (
 											<CardBranding
-												badgeForLab={badge.imageUrl}
+												branding={branding}
 												palette={cardPalette}
-												brandName={brand}
 											/>
 										) : undefined
 									}

--- a/src/web/components/Card/components/CardBranding.tsx
+++ b/src/web/components/Card/components/CardBranding.tsx
@@ -29,7 +29,7 @@ const paidForStyle = (palette: Palette) => {
 	`;
 };
 
-export const LabBadge = ({ badgeForLab, brandName, palette }: Props) => (
+export const CardBranding = ({ branding, palette }: Props) => (
 	<div css={badgeWrapperStyle}>
 		<div css={paidForStyle(palette)}>Paid for by</div>
 		<span

--- a/src/web/components/Card/components/CardBranding.tsx
+++ b/src/web/components/Card/components/CardBranding.tsx
@@ -12,6 +12,8 @@ const logoImageStyle = css`
 	max-height: 60px;
 	margin-left: ${space[3]}px;
 	vertical-align: middle;
+	height: auto;
+	width: auto;
 `;
 
 const brandingWrapperStyle = css`
@@ -46,7 +48,13 @@ export const CardBranding = ({ branding, palette }: Props) => (
 			rel="nofollow"
 			aria-label={`Visit the ${branding.sponsorName} website`}
 		>
-			<img css={logoImageStyle} src={branding.logo.src} alt={branding.sponsorName} />
+			<img
+				css={logoImageStyle}
+				src={branding.logo.src}
+				alt={branding.sponsorName}
+				width={branding.logo.dimensions.width}
+				height={branding.logo.dimensions.height}
+			/>
 		</a>
 	</div>
 );

--- a/src/web/components/Card/components/CardBranding.tsx
+++ b/src/web/components/Card/components/CardBranding.tsx
@@ -4,25 +4,24 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 type Props = {
-	badgeForLab: string;
-	brandName?: string;
+	branding: Branding;
 	palette: Palette;
 };
 
-const badgeImageStyle = css`
+const logoImageStyle = css`
 	max-height: 60px;
 	margin-left: ${space[3]}px;
 	vertical-align: middle;
 `;
 
-const badgeWrapperStyle = css`
+const brandingWrapperStyle = css`
 	padding-right: ${space[3]}px;
 	padding-bottom: ${space[3]}px;
 	text-align: right;
 	flex: auto;
 `;
 
-const paidForStyle = (palette: Palette) => {
+const labelStyle = (palette: Palette) => {
 	return css`
 		${textSans.xxsmall({ fontWeight: 'bold' })}
 		color: ${palette.text.cardFooter};
@@ -30,18 +29,24 @@ const paidForStyle = (palette: Palette) => {
 };
 
 export const CardBranding = ({ branding, palette }: Props) => (
-	<div css={badgeWrapperStyle}>
-		<div css={paidForStyle(palette)}>Paid for by</div>
+	<div css={brandingWrapperStyle}>
+		<div css={labelStyle(palette)}>{branding.logo.label}</div>
 		<span
 			css={css`
 				${visuallyHidden};
 			`}
 		>
-			{brandName
-				? `This content was paid for by ${brandName} as part of Guardian labs`
-				: 'This content has been paid for by a sponsor as part of Guardian Labs.'}
+			{branding.sponsorName
+				? `This content was paid for by ${branding.sponsorName} and produced by the Guardian Labs team.`
+				: 'This content has been paid for by an advertiser and produced by the Guardian Labs team.'}
 		</span>
-		{/* eslint-disable-next-line jsx-a11y/alt-text */}
-		<img css={badgeImageStyle} alt="" src={badgeForLab} />
+		<a
+			href={branding.logo.link}
+			data-sponsor={branding.sponsorName.toLowerCase()}
+			rel="nofollow"
+			aria-label={`Visit the ${branding.sponsorName} website`}
+		>
+			<img css={logoImageStyle} src={branding.logo.src} alt={branding.sponsorName} />
+		</a>
 	</div>
 );

--- a/src/web/components/Card/components/CardBranding.tsx
+++ b/src/web/components/Card/components/CardBranding.tsx
@@ -25,36 +25,45 @@ const brandingWrapperStyle = css`
 
 const labelStyle = (palette: Palette) => {
 	return css`
-		${textSans.xxsmall({ fontWeight: 'bold' })}
+		${textSans.xxsmall()}
 		color: ${palette.text.cardFooter};
 	`;
 };
 
-export const CardBranding = ({ branding, palette }: Props) => (
-	<div css={brandingWrapperStyle}>
-		<div css={labelStyle(palette)}>{branding.logo.label}</div>
-		<span
-			css={css`
-				${visuallyHidden};
-			`}
-		>
-			{branding.sponsorName
-				? `This content was paid for by ${branding.sponsorName} and produced by the Guardian Labs team.`
-				: 'This content has been paid for by an advertiser and produced by the Guardian Labs team.'}
-		</span>
-		<a
-			href={branding.logo.link}
-			data-sponsor={branding.sponsorName.toLowerCase()}
-			rel="nofollow"
-			aria-label={`Visit the ${branding.sponsorName} website`}
-		>
-			<img
-				css={logoImageStyle}
-				src={branding.logo.src}
-				alt={branding.sponsorName}
-				width={branding.logo.dimensions.width}
-				height={branding.logo.dimensions.height}
-			/>
-		</a>
-	</div>
-);
+const pickLogo = (branding: Branding, palette: Palette): BrandingLogo => {
+	return palette.background.cardInvertLogo && branding.logoForDarkBackground
+		? branding.logoForDarkBackground
+		: branding.logo;
+};
+
+export const CardBranding = ({ branding, palette }: Props) => {
+	const logo = pickLogo(branding, palette);
+	return (
+		<div css={brandingWrapperStyle}>
+			<div css={labelStyle(palette)}>{logo.label}</div>
+			<span
+				css={css`
+					${visuallyHidden};
+				`}
+			>
+				{branding.sponsorName
+					? `This content was paid for by ${branding.sponsorName} and produced by the Guardian Labs team.`
+					: 'This content has been paid for by an advertiser and produced by the Guardian Labs team.'}
+			</span>
+			<a
+				href={logo.link}
+				data-sponsor={branding.sponsorName.toLowerCase()}
+				rel="nofollow"
+				aria-label={`Visit the ${branding.sponsorName} website`}
+			>
+				<img
+					css={logoImageStyle}
+					src={logo.src}
+					alt={branding.sponsorName}
+					width={logo.dimensions.width}
+					height={logo.dimensions.height}
+				/>
+			</a>
+		</div>
+	);
+};

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -10,7 +10,7 @@ type Props = {
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
 	isFullCardImage?: boolean;
-	labBadge?: JSX.Element;
+	cardBranding?: JSX.Element;
 };
 
 const spaceBetween = css`
@@ -47,10 +47,10 @@ export const CardFooter = ({
 	mediaMeta,
 	commentCount,
 	isFullCardImage,
-	labBadge,
+	cardBranding,
 }: Props) => {
-	if (format.theme === Special.Labs && labBadge) {
-		return <footer>{labBadge}</footer>;
+	if (format.theme === Special.Labs && cardBranding) {
+		return <footer>{cardBranding}</footer>;
 	}
 
 	if (

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -37,6 +37,7 @@ export const ExactlyFive = ({ content }: Props) => (
 					mediaDuration={content[0].mediaDuration}
 					commentCount={content[0].commentCount}
 					starRating={content[0].starRating}
+					branding={content[0].branding}
 				/>
 			</LI>
 			<LI
@@ -68,6 +69,7 @@ export const ExactlyFive = ({ content }: Props) => (
 					mediaDuration={content[1].mediaDuration}
 					commentCount={content[1].commentCount}
 					starRating={content[1].starRating}
+					branding={content[1].branding}
 				/>
 			</LI>
 			<LI
@@ -100,6 +102,7 @@ export const ExactlyFive = ({ content }: Props) => (
 							mediaDuration={content[2].mediaDuration}
 							commentCount={content[2].commentCount}
 							starRating={content[2].starRating}
+							branding={content[2].branding}
 						/>
 					</LI>
 					<LI bottomMargin={true} stretch={true}>
@@ -125,6 +128,7 @@ export const ExactlyFive = ({ content }: Props) => (
 							mediaDuration={content[3].mediaDuration}
 							commentCount={content[3].commentCount}
 							starRating={content[3].starRating}
+							branding={content[3].branding}
 						/>
 					</LI>
 					<LI bottomMargin={false} stretch={true}>
@@ -150,6 +154,7 @@ export const ExactlyFive = ({ content }: Props) => (
 							mediaDuration={content[4].mediaDuration}
 							commentCount={content[4].commentCount}
 							starRating={content[4].starRating}
+							branding={content[4].branding}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -60,6 +60,7 @@ export const FourOrLess = ({ content }: Props) => {
 							mediaDuration={trail.mediaDuration}
 							commentCount={trail.commentCount}
 							starRating={trail.starRating}
+							branding={trail.branding}
 						/>
 					</LI>
 				))}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -54,6 +54,7 @@ export const MoreThanFive = ({ content }: Props) => {
 						mediaDuration={content[0].mediaDuration}
 						commentCount={content[0].commentCount}
 						starRating={content[0].starRating}
+						branding={content[0].branding}
 					/>
 				</LI>
 				<LI
@@ -85,6 +86,7 @@ export const MoreThanFive = ({ content }: Props) => {
 						mediaDuration={content[1].mediaDuration}
 						commentCount={content[1].commentCount}
 						starRating={content[1].starRating}
+						branding={content[1].branding}
 					/>
 				</LI>
 				<LI
@@ -116,6 +118,7 @@ export const MoreThanFive = ({ content }: Props) => {
 						mediaDuration={content[2].mediaDuration}
 						commentCount={content[2].commentCount}
 						starRating={content[2].starRating}
+						branding={content[2].branding}
 					/>
 				</LI>
 				<LI
@@ -147,6 +150,7 @@ export const MoreThanFive = ({ content }: Props) => {
 						mediaDuration={content[3].mediaDuration}
 						commentCount={content[3].commentCount}
 						starRating={content[3].starRating}
+						branding={content[3].branding}
 					/>
 				</LI>
 			</UL>
@@ -189,6 +193,7 @@ export const MoreThanFive = ({ content }: Props) => {
 							mediaDuration={trail.mediaDuration}
 							commentCount={trail.commentCount}
 							starRating={trail.starRating}
+							branding={trail.branding}
 						/>
 					</LI>
 				))}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -411,6 +411,7 @@ const backgroundAvatar = (format: Format): string => {
 };
 
 const backgroundCard = (format: Format): string => {
+	// This should be kept in sync with backgroundCardUseInvertedLogo below
 	if (format.theme === Special.SpecialReport) return specialReport[300];
 	switch (format.design) {
 		case Design.Editorial:
@@ -433,6 +434,29 @@ const backgroundCard = (format: Format): string => {
 			}
 		default:
 			return neutral[97];
+	}
+};
+
+const backgroundCardInvertLogo = (format: Format): boolean => {
+	// See backgroundCard above for background colours, this should be kept in sync
+	if (format.theme === Special.SpecialReport) return true;
+	switch (format.design) {
+		case Design.Media:
+			return true;
+		case Design.LiveBlog:
+			switch (format.theme) {
+				case Special.Labs:
+					return false;
+				case Pillar.News:
+				case Pillar.Sport:
+				case Pillar.Opinion:
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				default:
+					return true;
+			}
+		default:
+			return false;
 	}
 };
 
@@ -784,6 +808,7 @@ export const decidePalette = (format: Format): Palette => {
 			sectionTitle: backgroundSectionTitle(format),
 			avatar: backgroundAvatar(format),
 			card: backgroundCard(format),
+			cardInvertLogo: backgroundCardInvertLogo(format),
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This passes through the optional `branding` data we get from CAPI trails for use in cards (i.e. for onward journeys). Some logic around this had been implemented in #2751 but it wasn't wired up from the CAPI data, just in storybook stories. In order to do so, I had to pass through the `Branding` type, which is richer than the one previously used and so I've utilised the properties that is provides (image dimensions, variable label text, inverted logo for dark backgrounds).

### Before
![image](https://user-images.githubusercontent.com/8754692/121012304-8032dd80-c78f-11eb-90e9-80a26e86f8cb.png)


### After
![image](https://user-images.githubusercontent.com/8754692/121011966-23cfbe00-c78f-11eb-8b10-157a06983bc8.png)


## Why?
We noticed that labs articles onward containers (which usually have other labs content in them) were not pulling through the appropriate logo/branding component for the footer of the cards. It's obviously important to make sure the branding is correct on sponsored/paid-for content! It also matches frontend.