### PR TITLE
ELB Scheme set to Internal

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -185,6 +185,7 @@ Resources:
         Ref: Subnets
       SecurityGroups:
       - Ref: LoadBalancerSecurityGroup
+			Scheme: internal
       AccessLoggingPolicy:
         EmitInterval: 5
         Enabled: true


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add `Scheme: internal` to the Cloudformation yaml. Previously this had not been set and was open to the outside world.

