### PR TITLE
Better localStorage check

### DIFF
--- a/src/web/lib/braze/buildBrazeMessages.ts
+++ b/src/web/lib/braze/buildBrazeMessages.ts
@@ -11,7 +11,7 @@ import {
 	LocalMessageCache,
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
-import { isLocalStorageAvailable } from '@root/src/web/lib/isLocalStorageAvailable';
+import { storage } from '@guardian/libs';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy, SDK_OPTIONS } from './initialiseAppboy';
 
@@ -44,7 +44,7 @@ export const buildBrazeMessages = async (
 	isSignedIn: boolean,
 	idApiUrl: string,
 ): Promise<BrazeMessagesInterface> => {
-	if (!isLocalStorageAvailable()) {
+	if (!storage.local.isAvailable()) {
 		return new NullBrazeMessages();
 	}
 

--- a/src/web/lib/isLocalStorageAvailable.ts
+++ b/src/web/lib/isLocalStorageAvailable.ts
@@ -1,1 +1,0 @@
-export const isLocalStorageAvailable = (): boolean => 'localStorage' in window;


### PR DESCRIPTION
## What does this change?

Changes the way we test for localStorage availability before attempting to load the Braze SDK (follow on from #3023).

### Before

`'localStorage' in window;`

### After

`storage.local.isAvailable()` from `@guardian/libs`.

## Why?

We’re still seeing some errors in Sentry where localStorage isn’t available, even with the `localStorage in window` test. Use the test from @guardian/libs instead as it’s more exhaustive.