### PR TITLE
fix dev server endpoint for AMPInteractives

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -167,10 +167,7 @@ const go = () => {
 		'/AMPInteractive',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(
-					req,
-					defaultAmpInteractiveURL,
-				);
+				const url = buildUrlFromQueryParam(req);
 				const { html, ...config } = await fetch(
 					ampifyUrl(url),
 				).then((article) => article.json());


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove reference to `defaultAmpInteractiveURL` as it is no longer defined

### Before

### After

## Why?

Endpoint didn't work
