### PR TITLE
Add Snyk Github Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,31 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+    schedule:
+        - cron: '0 6 * * *'
+    push:
+    workflow_dispatch:
+
+jobs:
+    security:
+        runs-on: ubuntu-latest
+        env:
+            SNYK_COMMAND: test
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v2
+
+            - name: Set command to monitor
+              if: github.ref == 'refs/heads/main'
+              run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+            - name: Run Snyk to check for vulnerabilities
+              uses: snyk/actions/node@0.3.0
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true
+                  command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We want/need Snyk on our repos and projects, but there are a number of
drawbacks to using the existing Github integration, namely that it can
block deployments due to vulnerabilities unrelated to the code changes
in place.

The alternative introduced here is to use the Github Action instead.
This doesn't block anything, the config is version controlled and it
still gives devs the relevant info.
