### PR TITLE
Revert "Revert "Identity | Sign In Gate | Australia Mandatory Test""

### DIFF
--- a/cypress/integration/parallel-1/sign-in-gate.spec.js
+++ b/cypress/integration/parallel-1/sign-in-gate.spec.js
@@ -128,7 +128,7 @@ describe('Sign In Gate Tests', function () {
 		it('should not load the sign in gate if the article is a paid article', function () {
 			visitArticleAndScrollToGateForLazyLoad({
 				url:
-					'https://www.theguardian.com/100-teachers/2021/jan/28/a-day-in-the-life-of-one-of-the-uks-youngest-headteachers',
+					'https://www.theguardian.com/defining-moment/2016/jun/29/challenges-opportunities-life-coach-goals-empower-proactive',
 			});
 
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');

--- a/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -25,6 +25,54 @@ export const mainStandalone = () => {
 };
 mainStandalone.story = { name: 'main_standalone' };
 
+export const mainStandaloneComment = () => {
+	return (
+		<Section>
+			<SignInGateMain
+				guUrl="https://theguardian.com"
+				signInUrl="https://profile.theguardian.com/"
+				dismissGate={() => {}}
+				ophanComponentId="test"
+				isComment={true}
+			/>
+		</Section>
+	);
+};
+mainStandaloneComment.story = { name: 'main_standalone_comment' };
+
+export const mainStandaloneMandatory = () => {
+	return (
+		<Section>
+			<SignInGateMain
+				guUrl="https://theguardian.com"
+				signInUrl="https://profile.theguardian.com/"
+				dismissGate={() => {}}
+				ophanComponentId="test"
+				isMandatory={true}
+			/>
+		</Section>
+	);
+};
+mainStandaloneMandatory.story = { name: 'main_standalone_mandatory' };
+
+export const mainStandaloneMandatoryComment = () => {
+	return (
+		<Section>
+			<SignInGateMain
+				guUrl="https://theguardian.com"
+				signInUrl="https://profile.theguardian.com/"
+				dismissGate={() => {}}
+				ophanComponentId="test"
+				isMandatory={true}
+				isComment={true}
+			/>
+		</Section>
+	);
+};
+mainStandaloneMandatoryComment.story = {
+	name: 'main_standalone_mandatory_comment',
+};
+
 export const fakeSocialStandalone = () => {
 	return (
 		<Section>

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -148,14 +148,14 @@ export const SignInGateSelector = ({
 		}
 	}, [gateSelector]);
 
-	useOnce(() => {
+	useEffect(() => {
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
 				?.canShow(CAPI, !!isSignedIn, currentTest)
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant]);
+	}, [currentTest, gateVariant, CAPI, isSignedIn]);
 
 	if (!currentTest || !gateVariant) {
 		return null;

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -8,6 +8,7 @@ import {
 import { getCookie } from '@frontend/web/browser/cookie';
 import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
 
+import { useOnce } from '@frontend/web/lib/useOnce';
 import {
 	ComponentEventParams,
 	submitViewEventTracking,
@@ -116,40 +117,64 @@ export const SignInGateSelector = ({
 	isSignedIn,
 	CAPI,
 }: SignInGateSelectorProps) => {
-	const [showGate, setShowGate] = useState(true);
+	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [gateVariant, setGateVariant] = useState<
+		SignInGateComponent | undefined
+	>(undefined);
+	const [currentTest, setCurrentTest] = useState<
+		CurrentSignInGateABTest | undefined
+	>(undefined);
+	const [canShowGate, setCanShowGate] = useState(false);
 	const gateSelector = useSignInGateSelector();
 
-	useEffect(() => {
+	useOnce(() => {
 		// this hook will fire when the sign in gate is dismissed
 		// which will happen when the showGate state is set to false
 		// this only happens within the dismissGate method
-		if (showGate === false) {
+		if (isGateDismissed) {
 			document.dispatchEvent(
 				new CustomEvent('dcr:page:article:redisplayed'),
 			);
 		}
-	}, [showGate]);
+	}, [isGateDismissed]);
 
-	if (!gateSelector) {
+	useOnce(() => {
+		const [gateSelectorVariant, gateSelectorTest] = gateSelector;
+		if (gateSelectorVariant && gateSelectorTest) {
+			setGateVariant(gateSelectorVariant);
+			setCurrentTest(gateSelectorTest);
+		}
+	}, [gateSelector]);
+
+	useOnce(() => {
+		if (gateVariant && currentTest) {
+			// eslint-disable-next-line @typescript-eslint/no-floating-promises
+			gateVariant
+				?.canShow(CAPI, !!isSignedIn, currentTest)
+				.then(setCanShowGate);
+		}
+	}, [currentTest, gateVariant]);
+
+	if (!currentTest || !gateVariant) {
 		return null;
 	}
 
-	const [gateVariant, currentTest] = gateSelector;
 	const signInUrl = generateSignInUrl(CAPI, currentTest);
 
 	return (
 		<>
 			{/* Sign In Gate Display Logic */}
-			{showGate &&
-				gateVariant?.canShow(CAPI, !!isSignedIn, currentTest) && (
-					<ShowSignInGate
-						CAPI={CAPI}
-						abTest={currentTest}
-						setShowGate={setShowGate}
-						signInUrl={signInUrl}
-						gateVariant={gateVariant}
-					/>
-				)}
+			{!isGateDismissed && canShowGate && (
+				<ShowSignInGate
+					CAPI={CAPI}
+					abTest={currentTest}
+					setShowGate={(show) => setIsGateDismissed(!show)}
+					signInUrl={signInUrl}
+					gateVariant={gateVariant}
+				/>
+			)}
 		</>
 	);
 };

--- a/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -28,6 +28,7 @@ export const SignInGateMain = ({
 	abTest,
 	ophanComponentId,
 	isComment,
+	isMandatory = false,
 }: SignInGateProps) => {
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-main">
@@ -69,20 +70,21 @@ export const SignInGateMain = ({
 				>
 					Register for free
 				</LinkButton>
-
-				<LinkButton
-					data-cy="sign-in-gate-main_dismiss"
-					data-ignore="global-link-styling"
-					css={laterButton}
-					priority="subdued"
-					size="small"
-					onClick={() => {
-						dismissGate();
-						trackLink(ophanComponentId, 'not-now', abTest);
-					}}
-				>
-					I’ll do it later
-				</LinkButton>
+				{!isMandatory && (
+					<LinkButton
+						data-cy="sign-in-gate-main_dismiss"
+						data-ignore="global-link-styling"
+						css={laterButton}
+						priority="subdued"
+						size="small"
+						onClick={() => {
+							dismissGate();
+							trackLink(ophanComponentId, 'not-now', abTest);
+						}}
+					>
+						I’ll do it later
+					</LinkButton>
+				)}
 			</div>
 
 			<p css={[bodySeparator, bodyBold, signInHeader]}>

--- a/src/web/components/SignInGate/gates/aus-mandatory-control.tsx
+++ b/src/web/components/SignInGate/gates/aus-mandatory-control.tsx
@@ -1,0 +1,42 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
+import { canShowMandatoryAus } from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+
+const SignInGateMain = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMain');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMain };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		isComment,
+	}) => (
+		<Lazy margin={300}>
+			<Suspense fallback={<></>}>
+				<SignInGateMain
+					ophanComponentId={ophanComponentId}
+					dismissGate={dismissGate}
+					guUrl={guUrl}
+					signInUrl={signInUrl}
+					abTest={abTest}
+					isComment={isComment}
+				/>
+			</Suspense>
+		</Lazy>
+	),
+	canShow: canShowMandatoryAus,
+};

--- a/src/web/components/SignInGate/gates/aus-mandatory-variant.tsx
+++ b/src/web/components/SignInGate/gates/aus-mandatory-variant.tsx
@@ -1,0 +1,43 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
+import { canShowMandatoryAus } from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+
+const SignInGateMain = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMain');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMain };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		isComment,
+	}) => (
+		<Lazy margin={300}>
+			<Suspense fallback={<></>}>
+				<SignInGateMain
+					ophanComponentId={ophanComponentId}
+					dismissGate={dismissGate}
+					guUrl={guUrl}
+					signInUrl={signInUrl}
+					abTest={abTest}
+					isComment={isComment}
+					isMandatory={true}
+				/>
+			</Suspense>
+		</Lazy>
+	),
+	canShow: canShowMandatoryAus,
+};

--- a/src/web/components/SignInGate/gates/main-control.ts
+++ b/src/web/components/SignInGate/gates/main-control.ts
@@ -17,16 +17,18 @@ const canShow = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
 	currentTest: CurrentSignInGateABTest,
-): boolean =>
-	!isSignedIn &&
-	!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
-	isNPageOrHigherPageView(3) &&
-	isValidContentType(CAPI) &&
-	isValidSection(CAPI) &&
-	isValidTag(CAPI) &&
-	!isPaidContent(CAPI) &&
-	!isPreview(CAPI) &&
-	!isIOS9();
+): Promise<boolean> =>
+	Promise.resolve(
+		!isSignedIn &&
+			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+			isNPageOrHigherPageView(3) &&
+			isValidContentType(CAPI) &&
+			isValidSection(CAPI) &&
+			isValidTag(CAPI) &&
+			!isPaidContent(CAPI) &&
+			!isPreview(CAPI) &&
+			!isIOS9(),
+	);
 
 export const signInGateComponent: SignInGateComponent = {
 	canShow,

--- a/src/web/components/SignInGate/signInGate.ts
+++ b/src/web/components/SignInGate/signInGate.ts
@@ -3,10 +3,13 @@ import { ABTest } from '@guardian/ab-core';
 // Sign in Gate A/B Tests
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
+import { signInGateAusMandatory } from '@root/src/web/experiments/tests/sign-in-gate-aus-mandatory';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainVariant } from '@root/src/web/components/SignInGate/gates/main-variant';
 import { signInGateComponent as gateMainControl } from '@root/src/web/components/SignInGate/gates/main-control';
+import { signInGateComponent as gateAusMandatoryVariant } from '@root/src/web/components/SignInGate/gates/aus-mandatory-variant';
+import { signInGateComponent as gateAusMandatoryControl } from '@root/src/web/components/SignInGate/gates/aus-mandatory-control';
 import { SignInGateTestMap } from './types';
 
 // component name, should always be sign-in-gate
@@ -20,14 +23,18 @@ export const componentName = 'sign-in-gate';
 export const signInGateTests: ReadonlyArray<ABTest> = [
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateAusMandatory,
 ];
 
 export const signInGateTestVariantToGateMapping: SignInGateTestMap = {
 	'main-control-4': gateMainControl,
 	'main-variant-4': gateMainVariant,
+	'aus-mandatory-gate-control': gateAusMandatoryControl,
+	'aus-mandatory-gate-variant': gateAusMandatoryVariant,
 };
 
 export const signInGateTestIdToComponentId: { [key: string]: string } = {
 	SignInGateMainVariant: 'main_variant_4',
 	SignInGateMainControl: 'main_control_4',
+	SignInGateAusMandatory: 'aus_mandatory',
 };

--- a/src/web/components/SignInGate/types.ts
+++ b/src/web/components/SignInGate/types.ts
@@ -4,7 +4,7 @@ export type SignInGateComponent = {
 		CAPI: CAPIBrowserType,
 		isSignedIn: boolean,
 		currentTest: CurrentSignInGateABTest,
-	) => boolean;
+	) => Promise<boolean>;
 };
 
 export interface SignInGateProps {
@@ -14,6 +14,7 @@ export interface SignInGateProps {
 	ophanComponentId: string;
 	isComment?: boolean;
 	abTest?: CurrentSignInGateABTest;
+	isMandatory?: boolean;
 }
 
 export type CurrentSignInGateABTest = {

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -1,16 +1,18 @@
 import { ABTest } from '@guardian/ab-core';
 import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
-import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
-import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
+import { signInGateMainVariant } from '@frontend/web/experiments/tests/sign-in-gate-main-variant';
+import { signInGateMainControl } from '@frontend/web/experiments/tests/sign-in-gate-main-control';
 import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
-} from '@root/src/web/experiments/tests/newsletter-merch-unit-test';
+} from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
+import { signInGateAusMandatory } from '@frontend/web/experiments/tests/sign-in-gate-aus-mandatory';
 
 export const tests: ABTest[] = [
 	abTestTest,
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateAusMandatory,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 ];

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -13,6 +13,7 @@ const cypressSwitches = {
 	abAbTestTest: true, // Test switch, used for Cypress integration test
 	abSignInGateMainControl: true,
 	abSignInGateMainVariant: true,
+	abSignInGateAusMandatory: true,
 };
 
 // Function to retrieve the switches if running in Cypress

--- a/src/web/experiments/tests/sign-in-gate-aus-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-aus-mandatory.ts
@@ -1,0 +1,30 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const signInGateAusMandatory: ABTest = {
+	id: 'SignInGateAusMandatory',
+	start: '2020-06-07',
+	expiry: '2021-12-01',
+	author: 'Mahesh Makani',
+	description:
+		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for australia only',
+	audience: 0.01,
+	audienceOffset: 0.89,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, AUS only, only users with specific CMP consents. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateAusMandatory',
+	idealOutcome:
+		'We believe that a mandatory sign in gate will increase sign in conversion by 30% vs a dismissable sign in gate.',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'aus-mandatory-gate-control',
+			test: (): void => {},
+		},
+		{
+			id: 'aus-mandatory-gate-variant',
+			test: (): void => {},
+		},
+	],
+};

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -2,12 +2,12 @@ import { ABTest } from '@guardian/ab-core';
 
 export const signInGateMainVariant: ABTest = {
 	id: 'SignInGateMainVariant',
-	start: '2020-05-20',
+	start: '2020-06-09',
 	expiry: '2021-12-01',
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
+	audience: 0.89,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/lib/useSignInGateSelector.ts
+++ b/src/web/lib/useSignInGateSelector.ts
@@ -14,15 +14,16 @@ import {
  * A custom hook to make which selects the sign in gate (component and ab test)
  * to be displayed on the current page
  * */
-export const useSignInGateSelector = ():
-	| [SignInGateComponent, CurrentSignInGateABTest]
-	| null => {
+export const useSignInGateSelector = (): [
+	SignInGateComponent | null,
+	CurrentSignInGateABTest | null,
+] => {
 	const ab = useAB();
 
 	const test: Runnable | null = ab.firstRunnableTest(signInGateTests);
 
 	if (!test) {
-		return null;
+		return [null, null];
 	}
 
 	const currentTest: CurrentSignInGateABTest = {
@@ -35,7 +36,7 @@ export const useSignInGateSelector = ():
 		signInGateTestVariantToGateMapping?.[currentTest.variant];
 
 	if (!gateVariant) {
-		return null;
+		return [null, null];
 	}
 
 	return [gateVariant, currentTest];

--- a/src/web/lib/useSignInGateWillShow.ts
+++ b/src/web/lib/useSignInGateWillShow.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	CurrentSignInGateABTest,
 	SignInGateComponent,
@@ -32,14 +32,14 @@ export const useSignInGateWillShow = ({
 		setCurrentTest(gateSelectorTest);
 	}, [gateSelector]);
 
-	useOnce(() => {
+	useEffect(() => {
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
 				?.canShow(CAPI, !!isSignedIn, currentTest)
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant]);
+	}, [currentTest, gateVariant, CAPI, isSignedIn]);
 
 	return canShowGate && !!gateVariant && !!gateVariant.gate;
 };

--- a/src/web/lib/useSignInGateWillShow.ts
+++ b/src/web/lib/useSignInGateWillShow.ts
@@ -1,5 +1,11 @@
-import { SignInGateSelectorProps } from '@frontend/web/components/SignInGate/types';
-import { useSignInGateSelector } from './useSignInGateSelector';
+import { useState } from 'react';
+import {
+	CurrentSignInGateABTest,
+	SignInGateComponent,
+	SignInGateSelectorProps,
+} from '@frontend/web/components/SignInGate/types';
+import { useOnce } from '@frontend/web/lib/useOnce';
+import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
 
 /**
  * @description
@@ -10,17 +16,30 @@ import { useSignInGateSelector } from './useSignInGateSelector';
 export const useSignInGateWillShow = ({
 	isSignedIn,
 	CAPI,
-}: SignInGateSelectorProps): boolean => {
+}: SignInGateSelectorProps): boolean | undefined => {
+	const [gateVariant, setGateVariant] = useState<
+		SignInGateComponent | null | undefined
+	>(undefined);
+	const [currentTest, setCurrentTest] = useState<
+		CurrentSignInGateABTest | null | undefined
+	>(undefined);
+	const [canShowGate, setCanShowGate] = useState(false);
 	const gateSelector = useSignInGateSelector();
 
-	if (!gateSelector) {
-		return false;
-	}
+	useOnce(() => {
+		const [gateSelectorVariant, gateSelectorTest] = gateSelector;
+		setGateVariant(gateSelectorVariant);
+		setCurrentTest(gateSelectorTest);
+	}, [gateSelector]);
 
-	const [gateVariant, currentTest] = gateSelector;
+	useOnce(() => {
+		if (gateVariant && currentTest) {
+			// eslint-disable-next-line @typescript-eslint/no-floating-promises
+			gateVariant
+				?.canShow(CAPI, !!isSignedIn, currentTest)
+				.then(setCanShowGate);
+		}
+	}, [currentTest, gateVariant]);
 
-	return (
-		gateVariant.canShow(CAPI, !!isSignedIn, currentTest) &&
-		!!gateVariant.gate
-	);
+	return canShowGate && !!gateVariant && !!gateVariant.gate;
 };


### PR DESCRIPTION
Fixes Issue with Australia mandatory gate by using `useEffect` instead of `useOnce` hook. See #3087 for the original PR.