### PR TITLE
Upload snyk results as SARIF to code scanning

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,5 +27,10 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --sarif-file-output=snyk-node.sarif
                   command: ${{ env.SNYK_COMMAND }}
+            - name: Upload result to GitHub Code Scanning
+              if: github.ref != 'refs/heads/main'
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                  sarif_file: snyk-node.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -24,6 +24,7 @@ jobs:
 
             - name: Run Snyk to check for vulnerabilities
               uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,8 +12,6 @@ on:
 jobs:
     security:
         runs-on: ubuntu-latest
-        env:
-            SNYK_COMMAND: test
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2
@@ -28,10 +26,19 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --sarif-file-output=snyk-node.sarif
-                  command: ${{ env.SNYK_COMMAND }}
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
+                  command: test
             - name: Upload result to GitHub Code Scanning
-              if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-node.sarif
+
+            - name: Run Snyk monitor to update snyk.io
+              if: github.ref == 'refs/heads/main'
+              uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies
+                  command: monitor

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
   - [Feedback](#feedback)
 - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Code Quality](#code-quality)
+  - [Snyk Code Scanning](#snyk-code-scanning)
 - [IDE setup](#ide-setup)
   - [Extensions](#extensions)
   - [Auto fix on save](#auto-fix-on-save)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Visit the [root path of the dev server](http://localhost:3030) for some example 
 
 You can render a specific article by [specifying the production URL in the query string](http://localhost:3030/Article?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
 
-You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to 
+You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to
 
 http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey
 
@@ -127,6 +127,9 @@ $ make fix
 See [the makefile](https://github.com/guardian/dotcom-rendering/blob/main/makefile) for the full list.
 
 [Read about testing tools and testing strategy](docs/testing.md).
+
+### Snyk Code Scanning
+There's a Github action set up on the repository to scan for vulnerabilities. This is set to "continue on error" and so will show a green tick regardless. In order to check the vulnerabilities we can use the Github code scanning feature in the security tab and this will list all vulnerabilities for a given branch etc. You should use this if adding/removing/updating packages to see if there are any vulnerabilities.
 
 ## IDE setup
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Upload results from the Snyk Github action as a SARIF file to Github's code scanning. This should make it easier to parse and read errors. 

