### PR TITLE
Use immersive image roles for immersive stories

### DIFF
--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -47,10 +47,12 @@ const convertToImmersive = (CAPI: CAPIType) => {
 			...CAPI.format,
 			display: 'ImmersiveDisplay' as CAPIDisplay,
 		},
-		mainMediaElements: [{
-			...CAPI.mainMediaElements[0],
-			role: 'immersive',
-		}],
+		mainMediaElements: [
+			{
+				...CAPI.mainMediaElements[0],
+				role: 'immersive',
+			},
+		],
 	};
 };
 

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -47,6 +47,10 @@ const convertToImmersive = (CAPI: CAPIType) => {
 			...CAPI.format,
 			display: 'ImmersiveDisplay' as CAPIDisplay,
 		},
+		mainMediaElements: [{
+			...CAPI.mainMediaElements[0],
+			role: 'immersive',
+		}],
 	};
 };
 

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -40,21 +40,28 @@ export default {
 	},
 };
 
-const convertToImmersive = (CAPI: CAPIType) => {
-	return {
-		...CAPI,
-		format: {
-			...CAPI.format,
-			display: 'ImmersiveDisplay' as CAPIDisplay,
-		},
-		mainMediaElements: [
-			{
-				...CAPI.mainMediaElements[0],
-				role: 'immersive',
-			},
-		],
-	};
-};
+function isImageBlockElement(block: CAPIElement): block is ImageBlockElement {
+	return (
+		block._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
+	);
+}
+
+const convertToImmersive = (CAPI: CAPIType) => ({
+	...CAPI,
+	format: {
+		...CAPI.format,
+		display: 'ImmersiveDisplay' as CAPIDisplay,
+	},
+	mainMediaElements: CAPI.mainMediaElements.map((el) => {
+		if (isImageBlockElement(el)) {
+			return {
+				...el,
+				role: 'immersive' as RoleType,
+			};
+		}
+		return el;
+	}),
+});
 
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
 // the client. We need a separate component so that we can make use of useEffect to ensure


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `immersive` role to main media images in the immersive layout stories, so that they more accurately reflect actual immersive image quality.

## Why?
Chromatic was throwing up some diffs on the images for these stories, but we shouldn't dig too much into questions of quality on the stories unless they actually reflect real life!