### PR TITLE
Commercial fix fluid ad styles

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -76,6 +76,9 @@ const articleAdStyles = css`
 			}
 		}
 	}
+	.ad-slot--fluid {
+		width: 100%;
+	}
 	${carrotAdStyles};
 	${labelStyles};
 `;

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -79,8 +79,6 @@ const articleAdStyles = css`
 	.ad-slot--fluid {
 		width: 100%;
 	}
-	${carrotAdStyles};
-	${labelStyles};
 `;
 
 type Props = {
@@ -88,5 +86,16 @@ type Props = {
 };
 
 export const ArticleContainer = ({ children }: Props) => {
-	return <main css={[articleContainer, articleAdStyles]}>{children}</main>;
+	return (
+		<main
+			css={[
+				articleContainer,
+				articleAdStyles,
+				carrotAdStyles,
+				labelStyles,
+			]}
+		>
+			{children}
+		</main>
+	);
 };


### PR DESCRIPTION
## What does this change?

Adds the fluid styles to the main content.

### Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/121563574-896ab700-c9e8-11eb-92ba-ee4c999d756b.png
[after]: https://user-images.githubusercontent.com/76776/121563490-748e2380-c9e8-11eb-94ee-43b20867d0f6.png


## Why?

`top-above-nav` is inserted dynamically inside the content on mobile.
