### PR TITLE
Refactor logo logic out of decidePalette

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,6 @@ type Palette = {
 		sectionTitle: Colour;
 		avatar: Colour;
 		card: Colour;
-		cardInvertLogo: boolean;
 		headline: Colour;
 		headlineByline: Colour;
 		bullet: Colour;

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -318,6 +318,7 @@ export const Card = ({
 											<CardBranding
 												branding={branding}
 												palette={cardPalette}
+												format={format}
 											/>
 										) : undefined
 									}

--- a/src/web/components/Card/components/CardBranding.tsx
+++ b/src/web/components/Card/components/CardBranding.tsx
@@ -2,9 +2,11 @@ import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { decideLogo } from '@root/src/web/lib/decideLogo';
 
 type Props = {
 	branding: Branding;
+	format: Format;
 	palette: Palette;
 };
 
@@ -30,14 +32,8 @@ const labelStyle = (palette: Palette) => {
 	`;
 };
 
-const pickLogo = (branding: Branding, palette: Palette): BrandingLogo => {
-	return palette.background.cardInvertLogo && branding.logoForDarkBackground
-		? branding.logoForDarkBackground
-		: branding.logo;
-};
-
-export const CardBranding = ({ branding, palette }: Props) => {
-	const logo = pickLogo(branding, palette);
+export const CardBranding = ({ branding, format, palette }: Props) => {
+	const logo = decideLogo(format, branding);
 	return (
 		<div css={brandingWrapperStyle}>
 			<div css={labelStyle(palette)}>{logo.label}</div>

--- a/src/web/lib/decideLogo.ts
+++ b/src/web/lib/decideLogo.ts
@@ -1,0 +1,33 @@
+import { Design, Special, Pillar } from '@guardian/types';
+
+const shouldUseLogoForDarkBackground = (format: Format): boolean => {
+	if (format.theme === Special.SpecialReport) return true;
+	switch (format.design) {
+		case Design.Media:
+			return true;
+		case Design.LiveBlog:
+			switch (format.theme) {
+				case Special.Labs:
+					return false;
+				case Pillar.News:
+				case Pillar.Sport:
+				case Pillar.Opinion:
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				default:
+					return true;
+			}
+		default:
+			return false;
+	}
+};
+
+export const decideLogo = (
+	format: Format,
+	branding: Branding,
+): BrandingLogo => {
+	return shouldUseLogoForDarkBackground(format) &&
+		branding.logoForDarkBackground
+		? branding.logoForDarkBackground
+		: branding.logo;
+};

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -411,7 +411,6 @@ const backgroundAvatar = (format: Format): string => {
 };
 
 const backgroundCard = (format: Format): string => {
-	// This should be kept in sync with backgroundCardUseInvertedLogo below
 	if (format.theme === Special.SpecialReport) return specialReport[300];
 	switch (format.design) {
 		case Design.Editorial:
@@ -434,29 +433,6 @@ const backgroundCard = (format: Format): string => {
 			}
 		default:
 			return neutral[97];
-	}
-};
-
-const backgroundCardInvertLogo = (format: Format): boolean => {
-	// See backgroundCard above for background colours, this should be kept in sync
-	if (format.theme === Special.SpecialReport) return true;
-	switch (format.design) {
-		case Design.Media:
-			return true;
-		case Design.LiveBlog:
-			switch (format.theme) {
-				case Special.Labs:
-					return false;
-				case Pillar.News:
-				case Pillar.Sport:
-				case Pillar.Opinion:
-				case Pillar.Lifestyle:
-				case Pillar.Culture:
-				default:
-					return true;
-			}
-		default:
-			return false;
 	}
 };
 
@@ -808,7 +784,6 @@ export const decidePalette = (format: Format): Palette => {
 			sectionTitle: backgroundSectionTitle(format),
 			avatar: backgroundAvatar(format),
 			card: backgroundCard(format),
-			cardInvertLogo: backgroundCardInvertLogo(format),
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Following feedback on #3086 this refactors (out) the logic that was originally included in `decidePalette` for choosing whether to use a logo for a dark background. While this is palette-related, it's not really part of the palette itself - so now lives alone in a new `decideLogo`. 

## Why?
The original implementation felt wrong, this is better.