### PR TITLE
Interactives - Default body CSS

### DIFF
--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -61,7 +61,9 @@ const Renderer: React.FC<{
 		});
 
 		return ok ? (
-			<figure id={'id' in element ? element.id : undefined}>{el}</figure>
+			<figure id={'id' in element ? element.id : undefined} key={index}>
+				{el}
+			</figure>
 		) : null;
 	});
 

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -19,8 +19,12 @@ export const interactiveGlobalStyles = css`
 		For now this works, but we shouldn't support for it for newly made interactives. */
 	body {
 		margin-bottom: 1rem;
+
+		/* stylelint-disable */
 		font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia,
-			serif; /* stylelint-disable-line */
+			serif;
+		/* stylelint-enable */
+
 		font-size: 1.0625rem;
 		line-height: 1.5;
 		font-weight: 400;

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -14,4 +14,14 @@ export const interactiveGlobalStyles = css`
 	::after {
 		box-sizing: content-box;
 	}
+
+	/* There is room for better solution where we don't have to load global  styles onto the body.
+		For now this works, but we shouldn't support for it for newly made interactives. */
+	body {
+		margin-bottom: 1rem;
+		font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif; /* stylelint-disable-line */
+		font-size: 1.0625rem;
+		line-height: 1.5;
+		font-weight: 400;
+	}
 `;

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -19,7 +19,8 @@ export const interactiveGlobalStyles = css`
 		For now this works, but we shouldn't support for it for newly made interactives. */
 	body {
 		margin-bottom: 1rem;
-		font-family: GuardianTextEgyptian,Guardian Text Egyptian Web,Georgia,serif; /* stylelint-disable-line */
+		font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia,
+			serif; /* stylelint-disable-line */
 		font-size: 1.0625rem;
 		line-height: 1.5;
 		font-weight: 400;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds to the default interactives CSS with the default body CSS for text, etc.
This is required for backwards compatibility with many interactives. However we should not support this for new interactives in the future.

Also added `key` to immersive interactive layout to fix warnings

### Before

![image](https://user-images.githubusercontent.com/9575458/121923841-3b7ce880-cd33-11eb-8595-f79dd07b547e.png)

### After

![image](https://user-images.githubusercontent.com/9575458/121923767-286a1880-cd33-11eb-9a80-ba77878f1519.png)

## Why?

Fixes display (especially font) issues
