### PR TITLE
Golden boot + related

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -8,6 +8,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { Display, Design, Format, Special } from '@guardian/types';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
+import { interactiveLegacyClasses } from '@root/src/web/layouts/lib/interactiveLegacyStyling';
 
 type Props = {
 	headlineString: string;
@@ -431,6 +432,27 @@ export const ArticleHeadline = ({
 						>
 							{curly(headlineString)}
 						</h1>
+					);
+				case Design.Interactive:
+					return (
+						<div
+							css={css`
+								position: relative;
+							`}
+						>
+							<h1
+								className={interactiveLegacyClasses.headline}
+								css={[
+									standardFont,
+									topPadding,
+									css`
+										color: ${palette.text.headline};
+									`,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+						</div>
 					);
 				default:
 					return (

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -7,6 +7,7 @@ import { space } from '@guardian/src-foundations';
 import { Hide } from '@frontend/web/components/Hide';
 import { Display, Design, Special } from '@guardian/types';
 import { Badge } from '@frontend/web/components/Badge';
+import { interactiveLegacyClasses } from '@root/src/web/layouts/lib/interactiveLegacyStyling';
 
 type Props = {
 	format: Format;
@@ -376,6 +377,7 @@ export const SeriesSectionLink = ({
 					]}
 					data-component="section"
 					data-link-name="article section"
+					className={interactiveLegacyClasses.labelLink}
 				>
 					<span>{sectionLabel}</span>
 				</a>

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -25,7 +25,7 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
-import { interactiveGlobalStyles } from './lib/interactiveGlobalStyles';
+import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 
 interface Props {
 	CAPI: CAPIType;

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -47,7 +47,10 @@ import {
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
-import { interactiveGlobalStyles } from './lib/interactiveGlobalStyles';
+import {
+	interactiveGlobalStyles,
+	interactiveLegacyClasses,
+} from './lib/interactiveLegacyStyling';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -89,8 +92,8 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.      border  media'
 						'.      border  lines'
 						'.      border  meta'
-						'.      border  body'
-						'.      border  .';
+						'body   body    body'
+						'.      .       .';
 				}
 
 				/*
@@ -110,8 +113,8 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.      border  media'
 						'.      border  lines'
 						'.      border  meta'
-						'.      border  body'
-						'.      border  .';
+						'body   body    body'
+						'.      .       .';
 				}
 
 				${until.leftCol} {
@@ -164,11 +167,11 @@ const maxWidth = css`
 	}
 `;
 
-const articleWidth = css`
+/* const articleWidth = css`
 	${from.desktop} {
 		width: 620px;
 	}
-`;
+`; */
 
 const stretchLines = css`
 	${until.phablet} {
@@ -357,152 +360,159 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
 			>
-				<InteractiveGrid>
-					<GridItem area="title">
-						<ArticleTitle
-							format={format}
-							palette={palette}
-							tags={CAPI.tags}
-							sectionLabel={CAPI.sectionLabel}
-							sectionUrl={CAPI.sectionUrl}
-							guardianBaseURL={CAPI.guardianBaseURL}
-							badge={CAPI.badge}
-						/>
-					</GridItem>
-					<GridItem area="border">
-						{format.theme === Special.Labs ? (
-							<></>
-						) : (
-							<Border palette={palette} />
-						)}
-					</GridItem>
-					<GridItem area="headline">
-						<div css={maxWidth}>
-							<ArticleHeadlinePadding
-								design={format.design}
-								starRating={
-									!!CAPI.starRating || CAPI.starRating === 0
-								}
-							>
-								{age && (
-									<div css={ageWarningMargins}>
-										<AgeWarning age={age} />
-									</div>
-								)}
-								<ArticleHeadline
+				<div className={interactiveLegacyClasses.contentInteractive}>
+					<InteractiveGrid>
+						<GridItem area="title">
+							<div className="content__labels content__labels--not-immersive">
+								<ArticleTitle
 									format={format}
-									headlineString={CAPI.headline}
+									palette={palette}
 									tags={CAPI.tags}
-									byline={CAPI.author.byline}
-									palette={palette}
-								/>
-								{age && (
-									<AgeWarning
-										age={age}
-										isScreenReader={true}
-									/>
-								)}
-							</ArticleHeadlinePadding>
-						</div>
-						{CAPI.starRating || CAPI.starRating === 0 ? (
-							<div css={starWrapper}>
-								<StarRating
-									rating={CAPI.starRating}
-									size="large"
+									sectionLabel={CAPI.sectionLabel}
+									sectionUrl={CAPI.sectionUrl}
+									guardianBaseURL={CAPI.guardianBaseURL}
+									badge={CAPI.badge}
 								/>
 							</div>
-						) : (
-							<></>
-						)}
-					</GridItem>
-					<GridItem area="standfirst">
-						<Standfirst
-							format={format}
-							standfirst={CAPI.standfirst}
-						/>
-					</GridItem>
-					<GridItem area="media">
-						<div css={maxWidth}>
-							<MainMedia
-								format={format}
-								palette={palette}
-								elements={CAPI.mainMediaElements}
-								adTargeting={adTargeting}
-								host={host}
-								pageId={CAPI.pageId}
-								webTitle={CAPI.webTitle}
-							/>
-						</div>
-					</GridItem>
-					<GridItem area="lines">
-						<div css={maxWidth}>
-							<div css={stretchLines}>
-								<GuardianLines
-									count={decideLineCount(format.design)}
-									palette={palette}
-									effect={decideLineEffect(
-										format.design,
-										format.theme,
+						</GridItem>
+						<GridItem area="border">
+							{format.theme === Special.Labs ? (
+								<></>
+							) : (
+								<Border palette={palette} />
+							)}
+						</GridItem>
+						<GridItem area="headline">
+							<div css={maxWidth}>
+								<ArticleHeadlinePadding
+									design={format.design}
+									starRating={
+										!!CAPI.starRating ||
+										CAPI.starRating === 0
+									}
+								>
+									{age && (
+										<div css={ageWarningMargins}>
+											<AgeWarning age={age} />
+										</div>
 									)}
-								/>
+									<ArticleHeadline
+										format={format}
+										headlineString={CAPI.headline}
+										tags={CAPI.tags}
+										byline={CAPI.author.byline}
+										palette={palette}
+									/>
+									{age && (
+										<AgeWarning
+											age={age}
+											isScreenReader={true}
+										/>
+									)}
+								</ArticleHeadlinePadding>
 							</div>
-						</div>
-					</GridItem>
-					<GridItem area="meta">
-						<div css={maxWidth}>
-							<ArticleMeta
-								branding={branding}
+							{CAPI.starRating || CAPI.starRating === 0 ? (
+								<div css={starWrapper}>
+									<StarRating
+										rating={CAPI.starRating}
+										size="large"
+									/>
+								</div>
+							) : (
+								<></>
+							)}
+						</GridItem>
+						<GridItem area="standfirst">
+							<Standfirst
 								format={format}
-								palette={palette}
-								pageId={CAPI.pageId}
-								webTitle={CAPI.webTitle}
-								author={CAPI.author}
-								tags={CAPI.tags}
-								primaryDateline={CAPI.webPublicationDateDisplay}
-								secondaryDateline={
-									CAPI.webPublicationSecondaryDateDisplay
-								}
+								standfirst={CAPI.standfirst}
 							/>
-						</div>
-					</GridItem>
-					<GridItem area="body">
-						<ArticleContainer>
-							<main css={articleWidth}>
-								<ArticleBody
+						</GridItem>
+						<GridItem area="media">
+							<div css={maxWidth}>
+								<MainMedia
 									format={format}
 									palette={palette}
-									blocks={CAPI.blocks}
+									elements={CAPI.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 								/>
-								<GuardianLines
-									data-print-layout="hide"
-									count={4}
-									palette={palette}
-								/>
-								<SubMeta
-									palette={palette}
+							</div>
+						</GridItem>
+						<GridItem area="lines">
+							<div css={maxWidth}>
+								<div css={stretchLines}>
+									<GuardianLines
+										count={decideLineCount(format.design)}
+										palette={palette}
+										effect={decideLineEffect(
+											format.design,
+											format.theme,
+										)}
+									/>
+								</div>
+							</div>
+						</GridItem>
+						<GridItem area="meta">
+							<div css={maxWidth}>
+								<ArticleMeta
+									branding={branding}
 									format={format}
-									subMetaKeywordLinks={
-										CAPI.subMetaKeywordLinks
-									}
-									subMetaSectionLinks={
-										CAPI.subMetaSectionLinks
-									}
+									palette={palette}
 									pageId={CAPI.pageId}
-									webUrl={CAPI.webURL}
 									webTitle={CAPI.webTitle}
-									showBottomSocialButtons={
-										CAPI.showBottomSocialButtons
+									author={CAPI.author}
+									tags={CAPI.tags}
+									primaryDateline={
+										CAPI.webPublicationDateDisplay
 									}
-									badge={CAPI.badge}
+									secondaryDateline={
+										CAPI.webPublicationSecondaryDateDisplay
+									}
 								/>
-							</main>
-						</ArticleContainer>
-					</GridItem>
-				</InteractiveGrid>
+							</div>
+						</GridItem>
+						<GridItem area="body">
+							<ArticleContainer>
+								<main /* css={articleWidth} */>
+									<ArticleBody
+										format={format}
+										palette={palette}
+										blocks={CAPI.blocks}
+										adTargeting={adTargeting}
+										host={host}
+										pageId={CAPI.pageId}
+										webTitle={CAPI.webTitle}
+									/>
+									<GuardianLines
+										data-print-layout="hide"
+										count={4}
+										palette={palette}
+									/>
+									<SubMeta
+										palette={palette}
+										format={format}
+										subMetaKeywordLinks={
+											CAPI.subMetaKeywordLinks
+										}
+										subMetaSectionLinks={
+											CAPI.subMetaSectionLinks
+										}
+										pageId={CAPI.pageId}
+										webUrl={CAPI.webURL}
+										webTitle={CAPI.webTitle}
+										showBottomSocialButtons={
+											CAPI.showBottomSocialButtons
+										}
+										badge={CAPI.badge}
+									/>
+								</main>
+							</ArticleContainer>
+						</GridItem>
+					</InteractiveGrid>
+				</div>
 			</Section>
 
 			<Section

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -167,12 +167,6 @@ const maxWidth = css`
 	}
 `;
 
-/* const articleWidth = css`
-	${from.desktop} {
-		width: 620px;
-	}
-`; */
-
 const stretchLines = css`
 	${until.phablet} {
 		margin-left: -20px;
@@ -476,7 +470,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="body">
 							<ArticleContainer>
-								<main /* css={articleWidth} */>
+								<main>
 									<ArticleBody
 										format={format}
 										palette={palette}

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -357,7 +357,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<div className={interactiveLegacyClasses.contentInteractive}>
 					<InteractiveGrid>
 						<GridItem area="title">
-							<div className="content__labels content__labels--not-immersive">
+							<div
+								className={`${interactiveLegacyClasses.contentLabels} ${interactiveLegacyClasses.contentLabelsNotImmersive}`}
+							>
 								<ArticleTitle
 									format={format}
 									palette={palette}
@@ -471,15 +473,21 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						<GridItem area="body">
 							<ArticleContainer>
 								<main>
-									<ArticleBody
-										format={format}
-										palette={palette}
-										blocks={CAPI.blocks}
-										adTargeting={adTargeting}
-										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-									/>
+									<div
+										className={
+											interactiveLegacyClasses.contentMainColumn
+										}
+									>
+										<ArticleBody
+											format={format}
+											palette={palette}
+											blocks={CAPI.blocks}
+											adTargeting={adTargeting}
+											host={host}
+											pageId={CAPI.pageId}
+											webTitle={CAPI.webTitle}
+										/>
+									</div>
 									<GuardianLines
 										data-print-layout="hide"
 										count={4}

--- a/src/web/layouts/lib/interactiveGlobalStyles.ts
+++ b/src/web/layouts/lib/interactiveGlobalStyles.ts
@@ -9,13 +9,7 @@ export const interactiveGlobalStyles = css`
 		${center}
 	}
 
-	*,
-	::before,
-	::after {
-		box-sizing: content-box;
-	}
-
-	/* There is room for better solution where we don't have to load global  styles onto the body.
+	/* There is room for better solution where we don't have to load global styles onto the body.
 		For now this works, but we shouldn't support for it for newly made interactives. */
 	body {
 		margin-bottom: 1rem;

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -24,3 +24,10 @@ export const interactiveGlobalStyles = css`
 		font-weight: 400;
 	}
 `;
+
+// Classes present in Frontend that we add for legacy interactives.
+export const interactiveLegacyClasses = {
+	contentInteractive: 'content--interactive',
+	headline: 'content__headline',
+	labelLink: 'content__label__link',
+};

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -23,6 +23,21 @@ export const interactiveGlobalStyles = css`
 		line-height: 1.5;
 		font-weight: 400;
 	}
+
+	button,
+	input,
+	optgroup,
+	select,
+	textarea {
+		color: inherit;
+	}
+
+	button,
+	html input[type='button'],
+	input[type='reset'],
+	input[type='submit'] {
+		cursor: pointer;
+	}
 `;
 
 // Classes present in Frontend that we add for legacy interactives.

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -43,6 +43,9 @@ export const interactiveGlobalStyles = css`
 // Classes present in Frontend that we add for legacy interactives.
 export const interactiveLegacyClasses = {
 	contentInteractive: 'content--interactive',
+	contentLabels: 'content__labels',
+	contentLabelsNotImmersive: 'content__labels--not-immersive',
+	contentMainColumn: 'content__main-column--interactive',
 	headline: 'content__headline',
 	labelLink: 'content__label__link',
 };


### PR DESCRIPTION
Note: a lot of the changes are indentation only as have added wrapper divs in places. To review more easily add `?w=1` to the files/review page.

## What does this change?

Various changes to improve interactive display, primarily targeted to fix the Golden Boot page but helping elsewhere too.

To achieve this, changes are made to the layout at larger breakpoints for interactive pages, and some legacy classes are added to some components. Most of these are referenced in:

https://github.com/guardian/interactive-atom-template-2019/blob/main/atoms/default/client/css/_enhancer.scss

(and related files in the template).

This PR also improves the display of cartoons (to widen the body at larger breakpoints as Frontend does) and largely(? - some at least) fixes header image styling in many other interactives too!

### Before
No main image in header and body is too narrow causing the table to overflow.

![Screenshot 2021-06-14 at 17 13 28](https://user-images.githubusercontent.com/858402/121924587-f3aa9100-cd33-11eb-9ce3-60bc19312934.png)

### After
Looks like Frontend.

![Screenshot 2021-06-14 at 17 13 53](https://user-images.githubusercontent.com/858402/121924682-0a50e800-cd34-11eb-9f8e-95f5e6397797.png)

## Why?

Brings us closer to parity with Frontend for the Golden Boot page and other interactives.
