### PR TITLE
Add side padding to video captions

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -25,6 +25,10 @@ const captionStyle = (palette: Palette) => css`
 	${textSans.xxsmall()};
 	word-wrap: break-word;
 	color: ${palette.text.caption};
+	${until.tablet} {
+		padding-left: ${space[2]}px;
+		padding-right: ${space[2]}px;
+	}
 `;
 
 const bottomMargin = css`


### PR DESCRIPTION
## What does this change?

Adds side padding to the `<figcaption>` on mobile devices to maintain parity with frontend.

### Before

<img width="374" alt="Screenshot 2021-06-15 at 11 45 32" src="https://user-images.githubusercontent.com/35331926/122040504-c9a6ac80-cdcf-11eb-9c34-7dc7ac22dd9c.png">

### After

<img width="374" alt="Screenshot 2021-06-15 at 11 45 46" src="https://user-images.githubusercontent.com/35331926/122040537-d4614180-cdcf-11eb-88c9-21af4f22d6e5.png">
