### PR TITLE
Scope legacy styling to avoid breaking nav

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -2,6 +2,16 @@ import { css } from '@emotion/react';
 
 import { center } from '@root/src/web/lib/center';
 
+// Classes present in Frontend that we add for legacy interactives.
+export const interactiveLegacyClasses = {
+	contentInteractive: 'content--interactive',
+	contentLabels: 'content__labels',
+	contentLabelsNotImmersive: 'content__labels--not-immersive',
+	contentMainColumn: 'content__main-column--interactive',
+	headline: 'content__headline',
+	labelLink: 'content__label__link',
+};
+
 // Styles expected by interactives from the Frontend days. These shouldn't be
 // used for new interactives though.
 export const interactiveGlobalStyles = css`
@@ -11,7 +21,7 @@ export const interactiveGlobalStyles = css`
 
 	/* There is room for better solution where we don't have to load global styles onto the body.
 		For now this works, but we shouldn't support for it for newly made interactives. */
-	body {
+	${interactiveLegacyClasses.contentInteractive} {
 		margin-bottom: 1rem;
 
 		/* stylelint-disable */
@@ -39,13 +49,3 @@ export const interactiveGlobalStyles = css`
 		cursor: pointer;
 	}
 `;
-
-// Classes present in Frontend that we add for legacy interactives.
-export const interactiveLegacyClasses = {
-	contentInteractive: 'content--interactive',
-	contentLabels: 'content__labels',
-	contentLabelsNotImmersive: 'content__labels--not-immersive',
-	contentMainColumn: 'content__main-column--interactive',
-	headline: 'content__headline',
-	labelLink: 'content__label__link',
-};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Small fix to the nav - the introduction of some legacy CSS for interactives introduced a scrollbar on the nav.

### Before

![Screenshot 2021-06-15 at 14 40 10](https://user-images.githubusercontent.com/858402/122062810-a687f700-cde7-11eb-84a8-e4a6fa514b1c.png)


### After

(Scollbar gone.)

## Why?

Nav should not have scrollbar.