### PR TITLE
Golden boot extras

### DIFF
--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -473,21 +473,16 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						<GridItem area="body">
 							<ArticleContainer>
 								<main>
-									<div
-										className={
-											interactiveLegacyClasses.contentMainColumn
-										}
-									>
-										<ArticleBody
-											format={format}
-											palette={palette}
-											blocks={CAPI.blocks}
-											adTargeting={adTargeting}
-											host={host}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-										/>
-									</div>
+									<ArticleBody
+										format={format}
+										palette={palette}
+										blocks={CAPI.blocks}
+										adTargeting={adTargeting}
+										host={host}
+										pageId={CAPI.pageId}
+										webTitle={CAPI.webTitle}
+									/>
+
 									<Lines data-print-layout="hide" count={4} />
 									<SubMeta
 										palette={palette}

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -21,7 +21,7 @@ export const interactiveGlobalStyles = css`
 
 	/* There is room for better solution where we don't have to load global styles onto the body.
 		For now this works, but we shouldn't support for it for newly made interactives. */
-	${interactiveLegacyClasses.contentInteractive} {
+	.${interactiveLegacyClasses.contentInteractive} {
 		margin-bottom: 1rem;
 
 		/* stylelint-disable */

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -2,7 +2,8 @@ import { css } from '@emotion/react';
 
 import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
-import { Format } from '@guardian/types';
+import { Design, Format } from '@guardian/types';
+import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -42,6 +43,12 @@ export const ArticleRenderer: React.FC<{
 			className={[
 				'article-body-commercial-selector',
 				'article-body-viewer-selector',
+
+				// Note, this class MUST be on the *direct parent* of the
+				// elements for some legacy interactive styling to work.
+				format.design === Design.Interactive
+					? interactiveLegacyClasses.contentMainColumn
+					: '',
 			].join(' ')}
 			css={commercialPosition}
 		>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Moves a legacy interactive class to be the direct parent of the interactive body elements. 

### Before

![Screenshot 2021-06-15 at 15 15 34](https://user-images.githubusercontent.com/858402/122071122-637d5200-cdee-11eb-9f8f-16ef650e337b.png)

### After
![Screenshot 2021-06-15 at 15 15 16](https://user-images.githubusercontent.com/858402/122071152-6aa46000-cdee-11eb-9444-7e7c0d28e6a4.png)

## Why?
This is quite brittle but also is used a lot in old interactives and also newer ones such as the Golden Boot by CSS selectors to apply left-margin to the body `p` and `h2` elements.