### PR TITLE
Interactive ads (for Golden Boot)

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -19,12 +19,6 @@ const articleContainer = css`
 
 const articleAdStyles = css`
 	.ad-slot {
-		width: 300px;
-		margin: 12px auto;
-		min-width: 160px;
-		min-height: 274px;
-		text-align: center;
-		position: relative;
 		@media print {
 			display: none !important;
 		}
@@ -39,6 +33,12 @@ const articleAdStyles = css`
 		}
 	}
 	.ad-slot--inline {
+		width: 300px;
+		margin: 12px auto;
+		min-width: 160px;
+		min-height: 274px;
+		text-align: center;
+
 		${from.tablet} {
 			margin-right: -100px;
 			width: auto;

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -119,7 +119,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 				}
 
 				${until.leftCol} {
-					grid-template-columns: 1fr; /* Main content */
+					grid-template-columns: minmax(0, 1fr); /* Main content */
 					grid-template-areas:
 						'title'
 						'headline'
@@ -132,7 +132,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 				}
 
 				${until.desktop} {
-					grid-template-columns: 1fr; /* Main content */
+					grid-template-columns: minmax(0, 1fr); /* Main content */
 					grid-template-areas:
 						'title'
 						'headline'
@@ -145,7 +145,7 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				${until.tablet} {
 					grid-column-gap: 0px;
-					grid-template-columns: 1fr; /* Main content */
+					grid-template-columns: minmax(0, 1fr); /* Main content */
 					grid-template-areas:
 						'media'
 						'title'

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
 
 import { center } from '@root/src/web/lib/center';
 
@@ -47,5 +48,11 @@ export const interactiveGlobalStyles = css`
 	input[type='reset'],
 	input[type='submit'] {
 		cursor: pointer;
+	}
+
+	${from.tablet} {
+		.mobile-only {
+			display: none;
+		}
 	}
 `;

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { center } from '@root/src/web/lib/center';
 
@@ -33,6 +33,11 @@ export const interactiveGlobalStyles = css`
 		font-size: 1.0625rem;
 		line-height: 1.5;
 		font-weight: 400;
+
+		::before,
+		::after {
+			box-sizing: content-box;
+		}
 	}
 
 	button,
@@ -48,6 +53,13 @@ export const interactiveGlobalStyles = css`
 	input[type='reset'],
 	input[type='submit'] {
 		cursor: pointer;
+	}
+
+	/* Typically required for ad display. */
+	${until.tablet} {
+		.hide-until-tablet {
+			display: none;
+		}
 	}
 
 	${from.tablet} {


### PR DESCRIPTION
## What does this change?

Some ad fixes for the Golden Boot (and other) interactives. Note, there is still at least one ad issue - some ads are left-aligned rather than centered - which I need to investigate.

**Note, this changes the styling for ad classes which feels risky.**

### Before
(double ad showing, and not right width on tablet+)

![Screenshot 2021-06-16 at 17 13 29](https://user-images.githubusercontent.com/858402/122255594-30a68d00-cec6-11eb-9f1f-414d5ffb68bf.png)

### After
![Screenshot 2021-06-16 at 16 53 04](https://user-images.githubusercontent.com/858402/122255665-4025d600-cec6-11eb-91fe-202389512022.png)

## Why?

Parity.
