### PR TITLE
Fix interactive to full width on tablet/desktop

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -70,6 +70,8 @@ export const ArticleBody = ({
 	pageId,
 	webTitle,
 }: Props) => {
+	const isInteractive = format.design === Design.Interactive;
+
 	if (
 		format.design === Design.LiveBlog ||
 		format.design === Design.DeadBlog
@@ -90,7 +92,7 @@ export const ArticleBody = ({
 	return (
 		<div
 			css={[
-				bodyPadding,
+				isInteractive ? null : bodyPadding,
 				globalH2Styles(format.display),
 				globalH3Styles(format.display),
 				globalStrongStyles,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

A minor tweak to remove right padding on interactives at tablet+desktop breakpoints.

## Why?

Parity.