### PR TITLE
Fix social icons on some interactives

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -48,4 +48,68 @@ export const interactiveGlobalStyles = css`
 	input[type='submit'] {
 		cursor: pointer;
 	}
+
+
+	/* Start social icon support */
+	.meta__social {
+		padding-top: 0.375rem;
+	}
+
+	.social__item {
+		float: left;
+		min-width: 2rem;
+		padding: 0 0.1875rem 0.375rem 0;
+		cursor: pointer;
+
+		.inline-icon__fallback {
+			display: none;
+		}
+
+		.inline-icon {
+			background-color: transparent;
+			border: 1px solid #dcdcdc;
+			transition: fill .3s ease,background-color .3s ease;
+		}
+
+		.social-icon {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			border: 0;
+			min-width: 2rem;
+			max-width: 100%;
+			width: auto;
+			height: 2rem;
+			svg {
+				height: 88%;
+				width: 88%;
+			}
+		}
+
+		.rounded-icon {
+			border-radius: 62.5rem;
+			display: inline-block;
+			vertical-align: middle;
+			position: relative;
+		}
+
+		.centered-icon svg {
+			top: 0;
+			bottom: 0;
+			right: 0;
+			left: 0;
+			margin: auto;
+			position: absolute;
+		}
+	}
+
+	.content__dateline {
+		font-size: 0.75rem;
+		line-height: 1rem;
+		position: relative;
+		box-sizing: border-box;
+		padding-top: 0.125rem;
+		margin-bottom: 0.375rem;
+	}
+	/* End social icon support */
 `;

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -72,7 +72,7 @@ export const interactiveGlobalStyles = css`
 
 		.inline-icon {
 			background-color: transparent;
-			border: 1px solid #dcdcdc;
+			border: 1px solid #dcdcdc; /* stylelint-disable-line */
 			transition: fill 0.3s ease, background-color 0.3s ease;
 		}
 

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -49,7 +49,6 @@ export const interactiveGlobalStyles = css`
 		cursor: pointer;
 	}
 
-
 	/* Start social icon support */
 	.meta__social {
 		padding-top: 0.375rem;
@@ -68,7 +67,7 @@ export const interactiveGlobalStyles = css`
 		.inline-icon {
 			background-color: transparent;
 			border: 1px solid #dcdcdc;
-			transition: fill .3s ease,background-color .3s ease;
+			transition: fill 0.3s ease, background-color 0.3s ease;
 		}
 
 		.social-icon {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds some global CSS required by some interacts to show social icons.
This also shouldn't be something we 'support' going forward for new interactives - but it is useful in supporting older ones.

### Before

![image](https://user-images.githubusercontent.com/9575458/122423312-ba695f80-cf85-11eb-87da-629adc9110d9.png)

### After

![image](https://user-images.githubusercontent.com/9575458/122423361-c5bc8b00-cf85-11eb-9553-361a406521c5.png)

## Why?

Visual parity
