### PR TITLE
Add roundel to all labs navs

### DIFF
--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -12,7 +12,7 @@ import { Hide } from '@frontend/web/components/Hide';
 
 import { clearFix } from '@root/src/lib/mixins';
 
-import { Display } from '@guardian/types';
+import { Display, Special } from '@guardian/types';
 import { navInputCheckboxId, showMoreButtonId, veggieBurgerId } from './config';
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
 
@@ -66,6 +66,9 @@ const PositionButton = ({ children }: { children: React.ReactNode }) => (
 );
 
 export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
+	const displayRoundel =
+		format.display === Display.Immersive || format.theme === Special.Labs;
+
 	return (
 		<div css={rowStyles}>
 			{/*
@@ -212,7 +215,7 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
 				/>
 				<ExpandedMenu nav={nav} display={format.display} />
 			</nav>
-			{format.display === Display.Immersive && (
+			{displayRoundel && (
 				<PositionRoundel>
 					<GuardianRoundel />
 				</PositionRoundel>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -334,10 +334,13 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
-	const formatForNav = format.theme === Special.Labs ? format : {
-		...format,
-		theme: getCurrentPillar(CAPI),
-	}
+	const formatForNav =
+		format.theme === Special.Labs
+			? format
+			: {
+					...format,
+					theme: getCurrentPillar(CAPI),
+			  };
 
 	return (
 		<>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -333,6 +333,12 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const formatForNav = format.theme === Special.Labs ? format : {
+		...format,
+		theme: getCurrentPillar(CAPI),
+	}
+
 	return (
 		<>
 			<div data-print-layout="hide">
@@ -380,10 +386,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			>
 				<Nav
 					nav={NAV}
-					format={{
-						...format,
-						theme: getCurrentPillar(CAPI),
-					}}
+					format={formatForNav}
 					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
 					edition={CAPI.editionId}
 				/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
Roundel missing from non-immersive labs articles:
<img width="1301" alt="before" src="https://user-images.githubusercontent.com/3300789/122766501-877ede80-d299-11eb-84c2-93752648a405.png">

### After
Roundel included on all labs articles:
<img width="1170" alt="Screenshot at Jun 21 14-03-42" src="https://user-images.githubusercontent.com/3300789/122766487-82219400-d299-11eb-950e-9f3a940d8166.png">

## Why?
https://trello.com/c/AoIjFusb/268-labs-roundel-missing-from-header
