### PR TITLE
Upgrade consent-management-platform 6.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@guardian/atoms-rendering": "^14.2.1",
     "@guardian/automat-client": "^0.2.17",
     "@guardian/braze-components": "^2.1.0",
-    "@guardian/consent-management-platform": "^6.11.3",
+    "@guardian/consent-management-platform": "^6.12.0",
     "@guardian/discussion-rendering": "^7.0.0",
     "@guardian/libs": "^2.0.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,10 +1643,12 @@
     "@guardian/src-foundations" "3.3.0"
     "@guardian/src-icons" "3.3.0"
 
-"@guardian/consent-management-platform@^6.11.3":
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.3.tgz#92a7a6221587bcd86851e6a90198ad618f51b1e9"
-  integrity sha512-xKocfioFtkq5v9MuupT1ugo290NfSD4yIMl7m89xek6W+7B2fKjh0cAMHj4u2LQSXmEoyQ76vs2IaB3w5+98ZQ==
+"@guardian/consent-management-platform@^6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.12.0.tgz#7043f73bb2a6e27dc0d1efd2cb4fc6040733c81c"
+  integrity sha512-CbYqgoKo45cKJviJcGic9AvbeBOW3GPvYXJHqZWlpRTGdwVqTHZgangP66U4Mfs5K6Ux8P7vHvoohhwZdk9QQA==
+  dependencies:
+    "@guardian/libs" "^1"
 
 "@guardian/discussion-rendering@^7.0.0":
   version "7.0.0"
@@ -1657,6 +1659,11 @@
     customize-cra "^1.0.0"
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"
+
+"@guardian/libs@^1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
+  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
 
 "@guardian/libs@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## What does this change?
Upgrades cmp library to version 6.12.0

## Why?
Take advantage of performance benefit

Frontend PR: https://github.com/guardian/frontend/pull/23928
