### PR TITLE
Set subnav background colour for immersive interactives

### DIFF
--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -6,6 +6,7 @@ import {
 	labs,
 	border,
 	brandLine,
+	neutral,
 } from '@guardian/src-foundations/palette';
 import { Display, Format, Special } from '@guardian/types';
 import { Lines } from '@guardian/src-ed-lines';
@@ -169,7 +170,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 
 			{NAV.subNavSections && format.theme !== Special.Labs && (
 				<Section
-					backgroundColour={palette.background.article}
+					backgroundColour={neutral[100]}
 					padded={false}
 					sectionId="sub-nav-root"
 				>
@@ -244,7 +245,11 @@ export const InteractiveImmersiveLayout = ({
 			</Section>
 
 			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
+				<Section
+					padded={false}
+					sectionId="sub-nav-root"
+					backgroundColour={neutral[100]}
+				>
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}


### PR DESCRIPTION
## What does this change?

Some interactives override background colours for the body area which can render the subnav unreadable without this change.

### Before
e.g. for https://www.theguardian.com/us-news/ng-interactive/2021/jun/17/tree-rings-america-megadrought-visual


![Screenshot 2021-06-22 at 10 34 27](https://user-images.githubusercontent.com/858402/122901899-ea2db400-d345-11eb-93d8-eed1d79aebcc.png)

### After
![Screenshot 2021-06-22 at 10 34 18](https://user-images.githubusercontent.com/858402/122901927-ef8afe80-d345-11eb-96b1-712cfb62c160.png)

## Why?

Parity.
