### PR TITLE
Only provide legacy styles for legacy interactives

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -459,7 +459,7 @@ interface CAPIType {
 	matchUrl?: string;
 	isSpecialReport: boolean;
 
-	isLegacyInteractive: boolean; // Is an interactive created before the frontend-dcr switchover date
+	isLegacyInteractive?: boolean; // Is an interactive created before the frontend-dcr switchover date
 	anniversaryInteractiveAtom?: InteractiveAtomBlockElement; // TEMPORARY, to be removed following 200th anniversary
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -459,6 +459,7 @@ interface CAPIType {
 	matchUrl?: string;
 	isSpecialReport: boolean;
 
+	isLegacyInteractive: boolean; // Is an interactive created before the frontend-dcr switchover date
 	anniversaryInteractiveAtom?: InteractiveAtomBlockElement; // TEMPORARY, to be removed following 200th anniversary
 }
 

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -25,7 +25,7 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
-import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
+import { interactiveLegacyGlobalStyles } from './lib/interactiveLegacyStyling';
 
 interface Props {
 	CAPI: CAPIType;
@@ -197,7 +197,7 @@ export const InteractiveImmersiveLayout = ({
 	return (
 		<>
 			{CAPI.isLegacyInteractive && (
-				<Global styles={interactiveGlobalStyles} />
+				<Global styles={interactiveLegacyGlobalStyles} />
 			)}
 			<div
 				css={css`

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -196,7 +196,9 @@ export const InteractiveImmersiveLayout = ({
 
 	return (
 		<>
-			<Global styles={interactiveGlobalStyles} />
+			{CAPI.isLegacyInteractive && (
+				<Global styles={interactiveGlobalStyles} />
+			)}
 			<div
 				css={css`
 					background-color: ${palette.background.article};

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -241,7 +241,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	return (
 		<>
 			<div data-print-layout="hide">
-				<Global styles={interactiveGlobalStyles} />
+				{CAPI.isLegacyInteractive && (
+					<Global styles={interactiveGlobalStyles} />
+				)}
 				<>
 					<Stuck>
 						<Section

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -49,7 +49,7 @@ import {
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import {
-	interactiveGlobalStyles,
+	interactiveLegacyGlobalStyles,
 	interactiveLegacyClasses,
 } from './lib/interactiveLegacyStyling';
 
@@ -242,7 +242,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		<>
 			<div data-print-layout="hide">
 				{CAPI.isLegacyInteractive && (
-					<Global styles={interactiveGlobalStyles} />
+					<Global styles={interactiveLegacyGlobalStyles} />
 				)}
 				<>
 					<Stuck>

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -13,15 +13,12 @@ export const interactiveLegacyClasses = {
 	labelLink: 'content__label__link',
 };
 
-// Styles expected by interactives from the Frontend days. These shouldn't be
-// used for new interactives though.
-export const interactiveGlobalStyles = css`
+// Styles expected by interactives from the Frontend days. These only load for legacy interactives
+export const interactiveLegacyGlobalStyles = css`
 	.gs-container {
 		${center}
 	}
 
-	/* There is room for better solution where we don't have to load global styles onto the body.
-		For now this works, but we shouldn't support for it for newly made interactives. */
 	.${interactiveLegacyClasses.contentInteractive} {
 		margin-bottom: 1rem;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR depends on a PR from frontend: https://github.com/guardian/frontend/pull/23923, it should not be merged until after the frontend PR is merged.

Updates interactives so the legacy 'global' styles are only applied if the interactive came out _before_ the switchover date.

## Why?

We don't really want to be supporting these legacy global styles going forward on new interactives.
