### PR TITLE
Bump Source Icons to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@guardian/src-checkbox": "^3.6.0",
     "@guardian/src-ed-lines": "^3.6.0-rc.0",
     "@guardian/src-foundations": "^3.6.0",
-    "@guardian/src-icons": "^3.6.0",
+    "@guardian/src-icons": "^3.7.0",
     "@guardian/src-link": "^3.6.0",
     "@guardian/src-radio": "^3.6.0",
     "@guardian/src-text-area": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,6 +1733,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-3.6.0.tgz#f093cd554f928e189e4d6ac069c6c7b5e65558ff"
   integrity sha512-2j8TrRFyFbFBYGBdfL6ExCh0Bqgga0coi7H40tb3flV4UazyQqAGYuUb2r8Z38MJfTpotcPLxkA0uU6LY7VP7w==
 
+"@guardian/src-icons@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-3.7.0.tgz#580688167d00d9eed601044867d67dcd48b210c6"
+  integrity sha512-5tm8YlQpVGpuBN5hJ2Fi9xWkgCAvfX1IrzpLtLg4pLa6UmP1CIvwjlQocDBWRx2BItifU5UKtEpqiEvJdusK1g==
+
 "@guardian/src-label@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-label/-/src-label-3.6.0.tgz#0d65a7a07875d0b705392ee76157c54d24104cfc"


### PR DESCRIPTION
## What does this change?
Bumps `Src-Icons` to 3.7.0
