### PR TITLE
Refactor `Card` stories

### DIFF
--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -159,6 +159,15 @@ const Recipe = Format(
 	'Recipe',
 );
 
+const Analysis = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Analysis,
+	},
+	'Analysis',
+);
+
 export {
 	Review,
 	Interview,
@@ -176,4 +185,5 @@ export {
 	DeadBlog,
 	PrintShop,
 	Recipe,
+	Analysis,
 };

--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -60,22 +60,22 @@ const Article = Format(
 	'Article',
 );
 
-const Immersive = Format(
+const Letter = Format(
 	{
-		display: Display.Immersive,
+		display: Display.Standard,
 		theme: Pillar.News,
-		design: Design.Article,
+		design: Design.Letter,
 	},
-	'Immersive',
+	'Letter',
 );
 
-const Showcase = Format(
+const Quiz = Format(
 	{
-		display: Display.Showcase,
+		display: Display.Standard,
 		theme: Pillar.News,
-		design: Design.Article,
+		design: Design.Quiz,
 	},
-	'Showcase',
+	'Quiz',
 );
 
 const Editorial = Format(
@@ -166,8 +166,8 @@ export {
 	PhotoEssay,
 	Feature,
 	Article,
-	Immersive,
-	Showcase,
+	Letter,
+	Quiz,
 	Editorial,
 	Interactive,
 	MatchReport,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR ensures the list of stories used to capture all each `Card` variation based on `Design` is complete.

## Why?
Before we were missing some designs and also had two stories that were testing variation in `Display` which is already covered by another list of stories

By ensuring this list matches the [root definition](https://github.com/guardian/types/blob/main/src/format.ts) in the /types repo we improve discoverability and reduce confusion