### PR TITLE
Mandatory signin gate test for US readers

### DIFF
--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -5,6 +5,7 @@ import {
 } from '@frontend/web/lib/dailyArticleCount';
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { getLocale } from '@guardian/libs';
 import { hasUserDismissedGateMoreThanCount } from '@root/src/web/components/SignInGate/dismissGate';
 import { CurrentSignInGateABTest } from './types';
 
@@ -133,3 +134,19 @@ export const canShow = (
 			!isPreview(CAPI) &&
 			!isIOS9(),
 	);
+
+export const canShowMandatoryUs: (
+	CAPI: CAPIBrowserType,
+	isSignedIn: boolean,
+	currentTest: CurrentSignInGateABTest,
+) => Promise<boolean> = async (
+	CAPI: CAPIBrowserType,
+	isSignedIn: boolean,
+	currentTest: CurrentSignInGateABTest,
+) => {
+	return (
+		(await getLocale()) === 'US' &&
+		(await hasRequiredConsents()) &&
+		(await canShow(CAPI, isSignedIn, currentTest))
+	);
+};

--- a/src/web/components/SignInGate/gates/us-mandatory-control.tsx
+++ b/src/web/components/SignInGate/gates/us-mandatory-control.tsx
@@ -1,0 +1,42 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
+import { canShowMandatoryUs } from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+
+const SignInGateMain = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMain');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMain };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		isComment,
+	}) => (
+		<Lazy margin={300}>
+			<Suspense fallback={<></>}>
+				<SignInGateMain
+					ophanComponentId={ophanComponentId}
+					dismissGate={dismissGate}
+					guUrl={guUrl}
+					signInUrl={signInUrl}
+					abTest={abTest}
+					isComment={isComment}
+				/>
+			</Suspense>
+		</Lazy>
+	),
+	canShow: canShowMandatoryUs,
+};

--- a/src/web/components/SignInGate/gates/us-mandatory-variant.tsx
+++ b/src/web/components/SignInGate/gates/us-mandatory-variant.tsx
@@ -1,0 +1,43 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { canShowMandatoryUs } from '@root/src/web/components/SignInGate/displayRule';
+
+const SignInGateMain = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMain');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMain };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate,
+		guUrl,
+		signInUrl,
+		abTest,
+		isComment,
+	}) => (
+		<Lazy margin={300}>
+			<Suspense fallback={<></>}>
+				<SignInGateMain
+					ophanComponentId={ophanComponentId}
+					dismissGate={dismissGate}
+					guUrl={guUrl}
+					signInUrl={signInUrl}
+					abTest={abTest}
+					isComment={isComment}
+					isMandatory={true}
+				/>
+			</Suspense>
+		</Lazy>
+	),
+	canShow: canShowMandatoryUs,
+};

--- a/src/web/components/SignInGate/signInGate.ts
+++ b/src/web/components/SignInGate/signInGate.ts
@@ -3,10 +3,13 @@ import { ABTest } from '@guardian/ab-core';
 // Sign in Gate A/B Tests
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
+import { signInGateUsMandatory } from '@root/src/web/experiments/tests/sign-in-gate-us-mandatory';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainVariant } from '@root/src/web/components/SignInGate/gates/main-variant';
 import { signInGateComponent as gateMainControl } from '@root/src/web/components/SignInGate/gates/main-control';
+import { signInGateComponent as gateUsMandatoryVariant } from '@root/src/web/components/SignInGate/gates/us-mandatory-variant';
+import { signInGateComponent as gateUsMandatoryControl } from '@root/src/web/components/SignInGate/gates/us-mandatory-control';
 import { SignInGateTestMap } from './types';
 
 // component name, should always be sign-in-gate
@@ -20,14 +23,18 @@ export const componentName = 'sign-in-gate';
 export const signInGateTests: ReadonlyArray<ABTest> = [
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateUsMandatory,
 ];
 
 export const signInGateTestVariantToGateMapping: SignInGateTestMap = {
 	'main-control-4': gateMainControl,
 	'main-variant-4': gateMainVariant,
+	'us-mandatory-gate-control': gateUsMandatoryControl,
+	'us-mandatory-gate-variant': gateUsMandatoryVariant,
 };
 
 export const signInGateTestIdToComponentId: { [key: string]: string } = {
 	SignInGateMainVariant: 'main_variant_4',
 	SignInGateMainControl: 'main_control_4',
+	SignInGateUsMandatory: 'us_mandatory',
 };

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -6,11 +6,13 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
+import { signInGateUsMandatory } from '@root/src/web/experiments/tests/sign-in-gate-us-mandatory';
 
 export const tests: ABTest[] = [
 	abTestTest,
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateUsMandatory,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 ];

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
+	audience: 0.85,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.85,
+	audience: 0.89,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-us-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-us-mandatory.ts
@@ -7,8 +7,8 @@ export const signInGateUsMandatory: ABTest = {
 	author: 'Identity Team',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for US only',
-	audience: 0.05,
-	audienceOffset: 0.85,
+	audience: 0.01,
+	audienceOffset: 0.89,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live, US only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/src/web/experiments/tests/sign-in-gate-us-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-us-mandatory.ts
@@ -1,0 +1,30 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const signInGateUsMandatory: ABTest = {
+	id: 'SignInGateUsMandatory',
+	start: '2020-06-28',
+	expiry: '2021-12-01',
+	author: 'Identity Team',
+	description:
+		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for US only',
+	audience: 0.05,
+	audienceOffset: 0.85,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live, US only, only users with specific CMP consents. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateUsMandatory',
+	idealOutcome:
+		'We believe that a mandatory sign in gate will increase sign in conversion by 30% vs a dismissable sign in gate.',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'us-mandatory-gate-control',
+			test: (): void => {},
+		},
+		{
+			id: 'us-mandatory-gate-variant',
+			test: (): void => {},
+		},
+	],
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before

There is no signin gate mandatory test for US readers

### After

There is a signin gate mandatory test for US readers

## Why?

We want to test the signin conversion for US readers when presented with a signin gate without a dismiss button. This is equivalent to the Australia test but for US readers.

The base branch is set to remove-aus-mandatory-gate to make the diff more realistic.  https://github.com/guardian/dotcom-rendering/pull/3132 needs to be merged first. Afterwards, merge this PR against main.