### PR TITLE
Add semantic structure to DCR's markup (Convert `Section` component to allow element name)

### DIFF
--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -76,7 +76,11 @@ export const CommentCount = ({
 	const { short, long } = formatCount(commentCount);
 
 	return (
-		<div css={containerStyles(palette)} data-cy="comment-counts">
+		<data
+			css={containerStyles(palette)}
+			data-cy="comment-counts"
+			value={`${long} comments on this article`}
+		>
 			<a
 				href="#comments"
 				css={linkStyles}
@@ -101,6 +105,6 @@ export const CommentCount = ({
 					{short}
 				</div>
 			</a>
-		</div>
+		</data>
 	);
 };

--- a/src/web/components/ElementContainer.tsx
+++ b/src/web/components/ElementContainer.tsx
@@ -3,8 +3,9 @@ import { ClassNames, css as emoCss } from '@emotion/react';
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { center } from '@root/src/web/lib/center';
-
+// @ts-ignore-start
 import { jsx as _jsx } from 'react/jsx-runtime';
+// @ts-ignore-end
 
 const padding = emoCss`
 	padding: 0 10px;

--- a/src/web/components/ElementContainer.tsx
+++ b/src/web/components/ElementContainer.tsx
@@ -1,10 +1,12 @@
-import { css } from '@emotion/react';
+import { ClassNames, css as emoCss } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { center } from '@root/src/web/lib/center';
 
-const padding = css`
+import { jsx as _jsx } from 'react/jsx-runtime';
+
+const padding = emoCss`
 	padding: 0 10px;
 
 	${from.mobileLandscape} {
@@ -12,24 +14,24 @@ const padding = css`
 	}
 `;
 
-const adStyles = css`
+const adStyles = emoCss`
 	& .ad-slot.ad-slot--collapse {
 		display: none;
 	}
 `;
 
-const sideBorders = (colour: string) => css`
+const sideBorders = (colour: string) => emoCss`
 	${from.tablet} {
 		border-left: 1px solid ${colour};
 		border-right: 1px solid ${colour};
 	}
 `;
 
-const topBorder = (colour: string) => css`
+const topBorder = (colour: string) => emoCss`
 	border-top: 1px solid ${colour};
 `;
 
-const setBackgroundColour = (colour: string) => css`
+const setBackgroundColour = (colour: string) => emoCss`
 	background-color: ${colour};
 `;
 
@@ -42,6 +44,7 @@ type Props = {
 	borderColour?: string;
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
+	element?: string;
 };
 
 export const ElementContainer = ({
@@ -53,23 +56,35 @@ export const ElementContainer = ({
 	backgroundColour,
 	shouldCenter = true,
 	children,
+	element = 'div',
 }: Props) => (
-	<section
-		css={[
-			adStyles,
-			backgroundColour && setBackgroundColour(backgroundColour),
-		]}
-	>
-		<div
-			id={sectionId}
-			css={[
-				shouldCenter && center,
-				showSideBorders && sideBorders(borderColour),
-				showTopBorder && topBorder(borderColour),
-				padded && padding,
-			]}
-		>
-			{children && children}
-		</div>
-	</section>
+	<ClassNames>
+		{({ css }) => {
+			const child = (
+				<section>
+					<div
+						id={sectionId}
+						css={[
+							shouldCenter && center,
+							showSideBorders && sideBorders(borderColour),
+							showTopBorder && topBorder(borderColour),
+							padded && padding,
+						]}
+					>
+						{children && children}
+					</div>
+				</section>
+			);
+			const style = css`
+				${adStyles}
+				${backgroundColour && setBackgroundColour(backgroundColour)}
+			`;
+			// Create a react element from the tagName passed in OR
+			// default to <div>
+			return _jsx(`${element}`, {
+				className: style,
+				children: child,
+			});
+		}}
+	</ClassNames>
 );

--- a/src/web/components/ElementContainer.tsx
+++ b/src/web/components/ElementContainer.tsx
@@ -61,19 +61,17 @@ export const ElementContainer = ({
 	<ClassNames>
 		{({ css }) => {
 			const child = (
-				<section>
-					<div
-						id={sectionId}
-						css={[
-							shouldCenter && center,
-							showSideBorders && sideBorders(borderColour),
-							showTopBorder && topBorder(borderColour),
-							padded && padding,
-						]}
-					>
-						{children && children}
-					</div>
-				</section>
+				<div
+					id={sectionId}
+					css={[
+						shouldCenter && center,
+						showSideBorders && sideBorders(borderColour),
+						showTopBorder && topBorder(borderColour),
+						padded && padding,
+					]}
+				>
+					{children && children}
+				</div>
 			);
 			const style = css`
 				${adStyles}

--- a/src/web/components/ElementContainer.tsx
+++ b/src/web/components/ElementContainer.tsx
@@ -45,7 +45,7 @@ type Props = {
 	borderColour?: string;
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
-	element?: string;
+	element?: 'div' | 'article' | 'aside' | 'nav'; // ElementContainer is generally a top-level wrapper
 };
 
 export const ElementContainer = ({

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -396,6 +396,7 @@ export const CommentLayout = ({
 			<ElementContainer
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
+				element="article"
 			>
 				<StandardGrid display={format.display}>
 					<GridItem area="title">
@@ -583,6 +584,7 @@ export const CommentLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					position="merchandising-high"
@@ -593,11 +595,14 @@ export const CommentLayout = ({
 			{/* Onwards (when signed OUT) */}
 			<div id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedout" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedout"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer sectionId="comments">
+				<ElementContainer sectionId="comments" element="aside">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -618,13 +623,19 @@ export const CommentLayout = ({
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div id="onwards-upper-whensignedin" />
+			<aside id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedin" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedin"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && (
-				<ElementContainer sectionId="most-viewed-footer" />
+				<ElementContainer
+					sectionId="most-viewed-footer"
+					element="aside"
+				/>
 			)}
 
 			<ElementContainer
@@ -632,12 +643,17 @@ export const CommentLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} sectionId="sub-nav-root">
+				<ElementContainer
+					padded={false}
+					sectionId="sub-nav-root"
+					element="nav"
+				>
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -421,6 +421,7 @@ export const ImmersiveLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={palette.background.article}
+				element="article"
 			>
 				<ImmersiveGrid>
 					{/* Above leftCol, the Caption is controled by ContainerLayout ^^ */}
@@ -616,6 +617,7 @@ export const ImmersiveLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					position="merchandising-high"
@@ -624,13 +626,16 @@ export const ImmersiveLayout = ({
 			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
-			<div id="onwards-upper-whensignedout" />
+			<aside id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedout" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedout"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer sectionId="comments">
+				<ElementContainer sectionId="comments" element="aside">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -651,13 +656,19 @@ export const ImmersiveLayout = ({
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div id="onwards-upper-whensignedin" />
+			<aside id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedin" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedin"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && (
-				<ElementContainer sectionId="most-viewed-footer" />
+				<ElementContainer
+					sectionId="most-viewed-footer"
+					element="aside"
+				/>
 			)}
 
 			<ElementContainer
@@ -665,12 +676,17 @@ export const ImmersiveLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} sectionId="sub-nav-root">
+				<ElementContainer
+					padded={false}
+					sectionId="sub-nav-root"
+					element="nav"
+				>
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -122,6 +122,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 						showSideBorders={false}
 						padded={false}
 						shouldCenter={false}
+						element="aside"
 					>
 						<HeaderAdSlot
 							isAdFreeUser={CAPI.isAdFreeUser}
@@ -231,6 +232,7 @@ export const InteractiveImmersiveLayout = ({
 				shouldCenter={false}
 				padded={false}
 				backgroundColour={palette.background.article}
+				element="article"
 			>
 				<main>
 					<Renderer
@@ -249,6 +251,7 @@ export const InteractiveImmersiveLayout = ({
 					padded={false}
 					sectionId="sub-nav-root"
 					backgroundColour={neutral[100]}
+					element="nav"
 				>
 					<SubNav
 						subNavSections={NAV.subNavSections}

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -38,7 +38,6 @@ import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
 import { Nav } from '@frontend/web/components/Nav/Nav';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
-import { AnniversaryAtomComponent } from '@frontend/web/components/AnniversaryAtomComponent';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { getAgeWarning } from '@root/src/lib/age-warning';
@@ -318,18 +317,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					>
 						<Lines count={4} effect="straight" />
 					</ElementContainer>
-					<ElementContainer
-						backgroundColour={brandAltBackground.primary}
-						padded={false}
-						showTopBorder={false}
-						showSideBorders={false}
-					>
-						<AnniversaryAtomComponent
-							anniversaryInteractiveAtom={
-								CAPI.anniversaryInteractiveAtom
-							}
-						/>
-					</ElementContainer>
 				</>
 			) : (
 				<Stuck>
@@ -354,6 +341,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
+				element="article"
 			>
 				<div className={interactiveLegacyClasses.contentInteractive}>
 					<InteractiveGrid>
@@ -514,6 +502,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					data-print-layout="hide"
@@ -523,16 +512,21 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
+					element="aside"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer data-print-layout="hide" sectionId="comments">
+				<ElementContainer
+					data-print-layout="hide"
+					sectionId="comments"
+					element="aside"
+				>
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -553,11 +547,12 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedin"
+					element="aside"
 				/>
 			)}
 
@@ -565,6 +560,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="most-viewed-footer"
+					element="aside"
 				/>
 			)}
 
@@ -574,6 +570,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
@@ -583,6 +580,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
+					element="nav"
 				>
 					<SubNav
 						subNavSections={NAV.subNavSections}

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -219,6 +219,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						showSideBorders={false}
 						padded={false}
 						shouldCenter={false}
+						element="aside"
 					>
 						<HeaderAdSlot
 							isAdFreeUser={CAPI.isAdFreeUser}
@@ -272,6 +273,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							padded={false}
 							sectionId="sub-nav-root"
 							borderColour={palette.border.article}
+							element="nav"
 						>
 							<SubNav
 								subNavSections={NAV.subNavSections}
@@ -362,6 +364,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
+				element="article"
 			>
 				<LiveGrid>
 					<GridItem area="media">
@@ -482,6 +485,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					data-print-layout="hide"
@@ -491,16 +495,21 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
+					element="aside"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer data-print-layout="hide" sectionId="comments">
+				<ElementContainer
+					data-print-layout="hide"
+					sectionId="comments"
+					element="aside"
+				>
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -521,11 +530,12 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedin"
+					element="aside"
 				/>
 			)}
 
@@ -533,6 +543,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="most-viewed-footer"
+					element="aside"
 				/>
 			)}
 
@@ -542,6 +553,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
@@ -551,6 +563,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
+					element="nav"
 				>
 					<SubNav
 						subNavSections={NAV.subNavSections}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -333,6 +333,7 @@ export const ShowcaseLayout = ({
 			) : (
 				// Else, this is a labs article so just show Nav and the Labs header
 				<>
+<<<<<<< HEAD
 					<div>
 						<Stuck zIndex="stickyAdWrapper">
 							<ElementContainer
@@ -371,6 +372,42 @@ export const ShowcaseLayout = ({
 						</Stuck>
 					</div>
 					<Stuck zIndex="stickyAdWrapperLabsHeader">
+=======
+					<Stuck>
+						<ElementContainer
+							showTopBorder={false}
+							showSideBorders={false}
+							padded={false}
+						>
+							<HeaderAdSlot
+								isAdFreeUser={CAPI.isAdFreeUser}
+								shouldHideAds={CAPI.shouldHideAds}
+								display={format.display}
+							/>
+						</ElementContainer>
+					</Stuck>
+					<ElementContainer
+						showSideBorders={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padded={false}
+						backgroundColour={brandBackground.primary}
+					>
+						<Nav
+							nav={NAV}
+							format={{
+								...format,
+								theme: getCurrentPillar(CAPI),
+							}}
+							subscribeUrl={
+								CAPI.nav.readerRevenueLinks.header.subscribe
+							}
+							edition={CAPI.editionId}
+						/>
+					</ElementContainer>
+
+					<Stuck>
+>>>>>>> Rename Section to ElementContainer
 						<ElementContainer
 							showSideBorders={true}
 							showTopBorder={false}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -387,6 +387,7 @@ export const ShowcaseLayout = ({
 			<ElementContainer
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
+				element="article"
 			>
 				<ShowcaseGrid>
 					<GridItem area="title">
@@ -558,6 +559,7 @@ export const ShowcaseLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					position="merchandising-high"
@@ -566,13 +568,16 @@ export const ShowcaseLayout = ({
 			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
-			<div id="onwards-upper-whensignedout" />
+			<aside id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedout" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedout"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer sectionId="comments">
+				<ElementContainer sectionId="comments" element="aside">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -593,13 +598,19 @@ export const ShowcaseLayout = ({
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div id="onwards-upper-whensignedin" />
+			<aside id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<ElementContainer sectionId="onwards-lower-whensignedin" />
+				<ElementContainer
+					sectionId="onwards-lower-whensignedin"
+					element="aside"
+				/>
 			)}
 
 			{!isPaidContent && (
-				<ElementContainer sectionId="most-viewed-footer" />
+				<ElementContainer
+					sectionId="most-viewed-footer"
+					element="aside"
+				/>
 			)}
 
 			<ElementContainer
@@ -607,12 +618,17 @@ export const ShowcaseLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} sectionId="sub-nav-root">
+				<ElementContainer
+					padded={false}
+					sectionId="sub-nav-root"
+					element="nav"
+				>
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -333,7 +333,6 @@ export const ShowcaseLayout = ({
 			) : (
 				// Else, this is a labs article so just show Nav and the Labs header
 				<>
-<<<<<<< HEAD
 					<div>
 						<Stuck zIndex="stickyAdWrapper">
 							<ElementContainer
@@ -372,42 +371,6 @@ export const ShowcaseLayout = ({
 						</Stuck>
 					</div>
 					<Stuck zIndex="stickyAdWrapperLabsHeader">
-=======
-					<Stuck>
-						<ElementContainer
-							showTopBorder={false}
-							showSideBorders={false}
-							padded={false}
-						>
-							<HeaderAdSlot
-								isAdFreeUser={CAPI.isAdFreeUser}
-								shouldHideAds={CAPI.shouldHideAds}
-								display={format.display}
-							/>
-						</ElementContainer>
-					</Stuck>
-					<ElementContainer
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
-						/>
-					</ElementContainer>
-
-					<Stuck>
->>>>>>> Rename Section to ElementContainer
 						<ElementContainer
 							showSideBorders={true}
 							showTopBorder={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -719,7 +719,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
-					element="aside"
+					element="nav"
 				>
 					<SubNav
 						subNavSections={NAV.subNavSections}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -440,6 +440,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
+				element="article"
 			>
 				<StandardGrid isMatchReport={isMatchReport}>
 					<GridItem area="title">
@@ -642,6 +643,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot
 					data-print-layout="hide"
@@ -651,16 +653,21 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
+					element="aside"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<ElementContainer data-print-layout="hide" sectionId="comments">
+				<ElementContainer
+					data-print-layout="hide"
+					sectionId="comments"
+					element="aside"
+				>
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -681,7 +688,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			)}
 
 			{/* Onwards (when signed IN) */}
-			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
+			<aside data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
 				<ElementContainer
 					data-print-layout="hide"
@@ -702,6 +709,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
+				element="aside"
 			>
 				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
@@ -711,6 +719,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
+					element="aside"
 				>
 					<SubNav
 						subNavSections={NAV.subNavSections}


### PR DESCRIPTION
## What does this change?

Adds more semantic structure to the markup in DCR.

We do this by allowing the `Section` element to take the name of an html element. This is because this Component is the highest level component and the one that we want to change to use better semantic meaning. In fact, we remove Section completely as components are either

### Article

> The `<article>` HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication).

### Aside

>The element can be used for typographical effects like pull quotes or sidebars, for advertising, for groups of nav elements, and for other content that is considered separate from the main content of the page.

### Div
Has little semantic meaning, so in the cases where we want to wrap the more semantic elements lower in the structure - `Nav`, `Footer` - we do *not* want to use Section, but the semantic-less Div.


### Before
![image](https://user-images.githubusercontent.com/638051/123234104-91d7ed00-d4d2-11eb-90ab-1917291ed12f.png)

### After

![image](https://user-images.githubusercontent.com/638051/123233804-47ef0700-d4d2-11eb-9cef-921514f2f0bc.png)

