### PR TITLE
Disable AMP link for Interactives

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -274,7 +274,11 @@ export const document = ({ data }: Props): string => {
 		JSON.stringify(makeWindowGuardian(data, cssIDs)),
 	);
 
-	const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
+	// We do not yet support AMP for interactives.
+	const ampLink =
+		CAPI.format.design !== 'InteractiveDesign'
+			? `https://amp.theguardian.com/${data.CAPI.pageId}`
+			: undefined;
 
 	const { openGraphData } = CAPI;
 	const { twitterData } = CAPI;


### PR DESCRIPTION
Disable Disable AMP link for Interactives (which are not yet supported on AMP).

ARTICLE

<img width="1056" alt="Screenshot 2021-06-24 at 12 31 08" src="https://user-images.githubusercontent.com/6035518/123255727-15e89f80-d4e8-11eb-98ea-00b7ce55bb33.png">

INTERACTIVES

<img width="972" alt="Screenshot 2021-06-24 at 12 30 10" src="https://user-images.githubusercontent.com/6035518/123255780-226cf800-d4e8-11eb-8269-a6a00dea7e32.png">

