### PR TITLE
Prevent AMP link for Interactive Pages (detected by ng-interactive) [quick fix]

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -176,7 +176,11 @@ export const htmlTemplate = ({
                 </script>
 
                 <!-- TODO make this conditional when we support more content types -->
-                ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
+                ${
+					ampLink && ampLink.includes('ng-interactive')
+						? `<link rel="amphtml" href="${ampLink}">`
+						: ''
+				}
 
                 ${fontPreloadTags.join('\n')}
 


### PR DESCRIPTION
This is a quick fix (will be upgraded soon)