### PR TITLE
Rename Section to ElementContainer

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { news } from '@guardian/src-foundations';
 import { Display, Design, Pillar, Special } from '@guardian/types';
 
-import { Section } from './Section';
+import { ElementContainer } from './ElementContainer';
 import { ArticleHeadline } from './ArticleHeadline';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
@@ -19,7 +19,7 @@ export default {
 };
 
 export const ArticleStory = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -41,12 +41,12 @@ export const ArticleStory = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 ArticleStory.story = { name: 'Article' };
 
 export const Feature = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -68,12 +68,12 @@ export const Feature = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Feature.story = { name: 'Feature' };
 
 export const ShowcaseInterview = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -119,12 +119,12 @@ export const ShowcaseInterview = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 ShowcaseInterview.story = { name: 'Interview (with showcase)' };
 
 export const ShowcaseInterviewNobyline = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -170,14 +170,14 @@ export const ShowcaseInterviewNobyline = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 ShowcaseInterviewNobyline.story = {
 	name: 'Interview (with showcase and NO BYLINE)',
 };
 
 export const Interview = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -224,12 +224,12 @@ export const Interview = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Interview.story = { name: 'Interview (without showcase)' };
 
 export const InterviewNoByline = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -276,14 +276,14 @@ export const InterviewNoByline = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 InterviewNoByline.story = {
 	name: 'Interview (without showcase with NO BYLINE)',
 };
 
 export const Comment = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -305,12 +305,12 @@ export const Comment = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Comment.story = { name: 'Comment' };
 
 export const Analysis = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -332,12 +332,12 @@ export const Analysis = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Analysis.story = { name: 'Analysis' };
 
 export const Media = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -359,12 +359,12 @@ export const Media = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Media.story = { name: 'Media' };
 
 export const Review = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -386,12 +386,12 @@ export const Review = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Review.story = { name: 'Review' };
 
 export const PhotoEssay = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -413,12 +413,12 @@ export const PhotoEssay = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 PhotoEssay.story = { name: 'PhotoEssay' };
 
 export const Quiz = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -440,12 +440,12 @@ export const Quiz = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Quiz.story = { name: 'Quiz' };
 
 export const Recipe = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -467,12 +467,12 @@ export const Recipe = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Recipe.story = { name: 'Recipe' };
 
 export const Immersive = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -494,12 +494,12 @@ export const Immersive = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Immersive.story = { name: 'Immersive' };
 
 export const ImmersiveNoMainMedia = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -521,12 +521,12 @@ export const ImmersiveNoMainMedia = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 ImmersiveNoMainMedia.story = { name: 'Printshop (with no main media)' };
 
 export const ImmersiveComment = () => (
-	<Section
+	<ElementContainer
 		showSideBorders={false}
 		showTopBorder={false}
 		backgroundColour="orange"
@@ -552,12 +552,12 @@ export const ImmersiveComment = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 ImmersiveComment.story = { name: 'Immersive opinion piece' };
 
 export const Editorial = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -579,12 +579,12 @@ export const Editorial = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Editorial.story = { name: 'Editorial' };
 
 export const MatchReport = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -606,12 +606,12 @@ export const MatchReport = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 MatchReport.story = { name: 'MatchReport' };
 
 export const SpecialReport = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -633,12 +633,12 @@ export const SpecialReport = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 SpecialReport.story = { name: 'SpecialReport' };
 
 export const LiveBlog = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -660,7 +660,7 @@ export const LiveBlog = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 LiveBlog.story = {
 	name: 'LiveBlog',
@@ -678,7 +678,7 @@ LiveBlog.story = {
 };
 
 export const DeadBlog = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -700,6 +700,6 @@ export const DeadBlog = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 DeadBlog.story = { name: 'DeadBlog' };

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -1,4 +1,4 @@
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Caption } from '@frontend/web/components/Caption';
 import { Display, Design, Pillar, Special } from '@guardian/types';
 import { decidePalette } from '../lib/decidePalette';
@@ -21,7 +21,7 @@ export default {
  */
 
 export const Article = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how an Article caption looks"
 			format={{
@@ -35,12 +35,12 @@ export const Article = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Article.story = { name: 'Article' };
 
 export const Analysis = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how an Analysis caption looks"
 			format={{
@@ -54,12 +54,12 @@ export const Analysis = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Analysis.story = { name: 'Analysis' };
 
 export const PhotoEssay = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="<ul><li>This is how a PhotoEssay caption looks</li></ul>"
 			format={{
@@ -73,12 +73,12 @@ export const PhotoEssay = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 PhotoEssay.story = { name: 'PhotoEssay' };
 
 export const SpecialReport = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a SpecialReport caption looks"
 			format={{
@@ -92,12 +92,12 @@ export const SpecialReport = () => (
 				theme: Special.SpecialReport,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 SpecialReport.story = { name: 'SpecialReport' };
 
 export const PhotoEssayLimitedWidth = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="<ul><li>This is how a PhotoEssay caption looks when width is limited</li></ul>"
 			format={{
@@ -112,12 +112,12 @@ export const PhotoEssayLimitedWidth = () => (
 			})}
 			shouldLimitWidth={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 PhotoEssayLimitedWidth.story = { name: 'PhotoEssay with width limited' };
 
 export const Credit = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a Feature caption looks with credit showing"
 			format={{
@@ -133,12 +133,12 @@ export const Credit = () => (
 			credit="Credited to Able Jones"
 			displayCredit={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Credit.story = { name: 'with credit' };
 
 export const WidthLimited = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a caption looks with width limited"
 			format={{
@@ -153,12 +153,12 @@ export const WidthLimited = () => (
 			})}
 			shouldLimitWidth={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 WidthLimited.story = { name: 'with width limited' };
 
 export const Padded = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<Caption
 			captionText="This is how a caption looks when padded"
 			format={{
@@ -173,6 +173,6 @@ export const Padded = () => (
 			})}
 			padCaption={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Padded.story = { name: 'when padded' };

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
@@ -16,7 +16,7 @@ export const Format = (
 	title: string,
 	starRating?: number,
 ) => () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -214,5 +214,5 @@ export const Format = (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -2,7 +2,7 @@
 
 import { Design, Display, Pillar, Special } from '@guardian/types';
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
@@ -24,7 +24,7 @@ export default {
 };
 
 export const News = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -227,12 +227,12 @@ export const News = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 News.story = { name: 'News' };
 
 export const InDepth = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -349,12 +349,12 @@ export const InDepth = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 InDepth.story = { name: 'In Depth' };
 
 export const Related = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -496,12 +496,12 @@ export const Related = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Related.story = { name: 'Related Stories' };
 
 export const Spotlight = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -524,12 +524,12 @@ export const Spotlight = () => (
 				/>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Spotlight.story = { name: 'Spotlight' };
 
 export const Quad = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -629,12 +629,12 @@ export const Quad = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Quad.story = { name: 'Four with image top' };
 
 export const Media = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -712,7 +712,7 @@ export const Media = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Media.story = { name: 'Media' };
 
@@ -779,7 +779,7 @@ const labsBranding4: Branding = {
 };
 
 export const Labs = () => (
-	<Section>
+	<ElementContainer>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
 				<></>
@@ -864,6 +864,6 @@ export const Labs = () => (
 				</UL>
 			</ArticleContainer>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 Labs.story = { name: 'Labs' };

--- a/src/web/components/CardHeadline.stories.tsx
+++ b/src/web/components/CardHeadline.stories.tsx
@@ -1,6 +1,6 @@
 import { Design, Display, Pillar, Special } from '@guardian/types';
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { CardHeadline } from '@frontend/web/components/CardHeadline';
@@ -12,7 +12,7 @@ export default {
 };
 
 export const Article = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how an Article card headline looks"
 			format={{
@@ -26,12 +26,12 @@ export const Article = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Article.story = { name: 'Article' };
 
 export const Analysis = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how an Analysis card headline looks"
 			format={{
@@ -45,12 +45,12 @@ export const Analysis = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Analysis.story = { name: 'Analysis' };
 
 export const Feature = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a Feature card headline looks"
 			format={{
@@ -64,12 +64,12 @@ export const Feature = () => (
 				theme: Pillar.News,
 			})}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Feature.story = { name: 'Feature' };
 
 export const xsmallStory = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a large card headline looks"
 			format={{
@@ -84,12 +84,12 @@ export const xsmallStory = () => (
 			})}
 			size="large"
 		/>
-	</Section>
+	</ElementContainer>
 );
 xsmallStory.story = { name: 'Size | large' };
 
 export const liveStory = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a card headline with a live kicker looks"
 			format={{
@@ -104,12 +104,12 @@ export const liveStory = () => (
 			})}
 			kickerText="Live"
 		/>
-	</Section>
+	</ElementContainer>
 );
 liveStory.story = { name: 'With Live kicker' };
 
 export const noSlash = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a card headline with no kicker slash looks"
 			format={{
@@ -125,12 +125,12 @@ export const noSlash = () => (
 			kickerText="Live"
 			showSlash={false}
 		/>
-	</Section>
+	</ElementContainer>
 );
 noSlash.story = { name: 'With Live kicker but no slash' };
 
 export const pulsingDot = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a card headline with a pulsing dot looks"
 			format={{
@@ -146,12 +146,12 @@ export const pulsingDot = () => (
 			kickerText="Live"
 			showPulsingDot={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 pulsingDot.story = { name: 'With pulsing dot' };
 
 export const cultureVariant = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a Feature card headline with the culture pillar looks"
 			format={{
@@ -166,12 +166,12 @@ export const cultureVariant = () => (
 			})}
 			kickerText="Art and stuff"
 		/>
-	</Section>
+	</ElementContainer>
 );
 cultureVariant.story = { name: 'With a culture kicker' };
 
 export const AnalysisXSmall = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="Xsmall card headline for an Analysis article"
 			format={{
@@ -186,12 +186,12 @@ export const AnalysisXSmall = () => (
 			})}
 			size="large"
 		/>
-	</Section>
+	</ElementContainer>
 );
 AnalysisXSmall.story = { name: 'Underlined | large' };
 
 export const opinionxxxsmall = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how small card headline for opinion articles look"
 			format={{
@@ -207,12 +207,12 @@ export const opinionxxxsmall = () => (
 			showQuotes={true}
 			size="small"
 		/>
-	</Section>
+	</ElementContainer>
 );
 opinionxxxsmall.story = { name: 'Quotes | small' };
 
 export const OpinionKicker = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how an opinion card headline with a kicker and quotes looks"
 			format={{
@@ -229,12 +229,12 @@ export const OpinionKicker = () => (
 			kickerText="George Monbiot"
 			showSlash={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 OpinionKicker.story = { name: 'With an opinion kicker' };
 
 export const SpecialReport = () => (
-	<Section
+	<ElementContainer
 		showTopBorder={false}
 		showSideBorders={false}
 		backgroundColour="grey"
@@ -255,12 +255,12 @@ export const SpecialReport = () => (
 			kickerText="Special Report"
 			showSlash={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 SpecialReport.story = { name: 'with theme SpecialReport' };
 
 export const Busy = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 			format={{
@@ -277,13 +277,13 @@ export const Busy = () => (
 			kickerText="Aerial Yoga"
 			showSlash={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 Busy.story = { name: 'Lifestyle opinion' };
 
 export const Byline = () => (
 	<>
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -299,9 +299,9 @@ export const Byline = () => (
 				byline="Labs byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -317,9 +317,9 @@ export const Byline = () => (
 				byline="News byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -335,9 +335,9 @@ export const Byline = () => (
 				byline="Sport byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -353,9 +353,9 @@ export const Byline = () => (
 				byline="Culture byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -371,9 +371,9 @@ export const Byline = () => (
 				byline="Lifestyle byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section showTopBorder={true} showSideBorders={false}>
+		<ElementContainer showTopBorder={true} showSideBorders={false}>
 			<CardHeadline
 				headlineText="I look life a buffoon. I feel incredible. And then I vomit"
 				format={{
@@ -389,9 +389,9 @@ export const Byline = () => (
 				byline="Opinion byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 		<br />
-		<Section
+		<ElementContainer
 			showTopBorder={true}
 			showSideBorders={false}
 			backgroundColour={specialReport[300]}
@@ -411,7 +411,7 @@ export const Byline = () => (
 				byline="SpecialReport byline"
 				showByline={true}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 Byline.story = { name: 'With byline' };

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { ContainerTitle } from '@root/src/web/components/ContainerTitle';
 import { Hide } from '@root/src/web/components/Hide';
@@ -97,7 +97,7 @@ export const ContainerLayout = ({
 	stretchRight = false,
 	leftColSize,
 }: Props) => (
-	<Section
+	<ElementContainer
 		sectionId={sectionId}
 		showSideBorders={sideBorders}
 		showTopBorder={showTopBorder}
@@ -138,5 +138,5 @@ export const ContainerLayout = ({
 				{children}
 			</Container>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );

--- a/src/web/components/ElementContainer.tsx
+++ b/src/web/components/ElementContainer.tsx
@@ -44,7 +44,7 @@ type Props = {
 	shouldCenter?: boolean;
 };
 
-export const Section = ({
+export const ElementContainer = ({
 	sectionId,
 	showSideBorders = true,
 	showTopBorder = true,

--- a/src/web/components/Figure.stories.tsx
+++ b/src/web/components/Figure.stories.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import { Flex } from '@root/src/web/components/Flex';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
 import { Display, Design, Pillar } from '@guardian/types';
@@ -60,7 +60,7 @@ export default {
 
 export const InlineStory = () => {
 	return (
-		<Section showTopBorder={false}>
+		<ElementContainer showTopBorder={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -76,14 +76,14 @@ export const InlineStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 InlineStory.story = { name: 'Inline' };
 
 export const SupportingStory = () => {
 	return (
-		<Section showTopBorder={false}>
+		<ElementContainer showTopBorder={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -104,14 +104,14 @@ export const SupportingStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 SupportingStory.story = { name: 'Supporting' };
 
 export const ImmersiveStory = () => {
 	return (
-		<Section showTopBorder={false} showSideBorders={false}>
+		<ElementContainer showTopBorder={false} showSideBorders={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -127,14 +127,14 @@ export const ImmersiveStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 ImmersiveStory.story = { name: 'Immersive' };
 
 export const ThumbnailStory = () => {
 	return (
-		<Section showTopBorder={false}>
+		<ElementContainer showTopBorder={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -151,14 +151,14 @@ export const ThumbnailStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 ThumbnailStory.story = { name: 'Thumbnail' };
 
 export const ShowcaseStory = () => {
 	return (
-		<Section showTopBorder={false}>
+		<ElementContainer showTopBorder={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -174,14 +174,14 @@ export const ShowcaseStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 ShowcaseStory.story = { name: 'Showcase' };
 
 export const HalfWidthStory = () => {
 	return (
-		<Section showTopBorder={false}>
+		<ElementContainer showTopBorder={false}>
 			<Flex>
 				<LeftColumn showRightBorder={false}>
 					<></>
@@ -197,7 +197,7 @@ export const HalfWidthStory = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 HalfWidthStory.story = { name: 'HalfWidth' };

--- a/src/web/components/LabsHeader.stories.tsx
+++ b/src/web/components/LabsHeader.stories.tsx
@@ -1,7 +1,7 @@
 import { border, labs } from '@guardian/src-foundations';
 
 import { LabsHeader } from './LabsHeader';
-import { Section } from './Section';
+import { ElementContainer } from './ElementContainer';
 
 export default {
 	component: LabsHeader,
@@ -10,14 +10,14 @@ export default {
 
 export const Default = () => {
 	return (
-		<Section
+		<ElementContainer
 			showSideBorders={true}
 			showTopBorder={false}
 			backgroundColour={labs[400]}
 			borderColour={border.primary}
 		>
 			<LabsHeader />
-		</Section>
+		</ElementContainer>
 	);
 };
 Default.story = { name: 'Default' };

--- a/src/web/components/LeftColumn.stories.tsx
+++ b/src/web/components/LeftColumn.stories.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@root/src/web/components/Flex';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 
 import { LeftColumn } from './LeftColumn';
 import { Placeholder } from './Placeholder';
@@ -13,7 +13,7 @@ export default {
 
 export const PartialRightBorder = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Flex>
 				<LeftColumn
 					showPartialRightBorder={true}
@@ -35,14 +35,14 @@ export const PartialRightBorder = () => {
 					<>Right column content</>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 PartialRightBorder.story = { name: 'Partial right border' };
 
 export const RightBorder = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Flex>
 				<LeftColumn>
 					<>The border to my right should stretch the whole height</>
@@ -58,7 +58,7 @@ export const RightBorder = () => {
 					<>Right column content</>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 RightBorder.story = { name: 'Full right border' };

--- a/src/web/components/LinkHeadline.stories.tsx
+++ b/src/web/components/LinkHeadline.stories.tsx
@@ -1,5 +1,5 @@
 import { Design, Display, Pillar, Special } from '@guardian/types';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 
 import { LinkHeadline } from '@frontend/web/components/LinkHeadline';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
@@ -10,7 +10,7 @@ export default {
 };
 
 export const xsmallStory = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a large headline link looks"
 			palette={decidePalette({
@@ -25,12 +25,12 @@ export const xsmallStory = () => (
 			}}
 			size="large"
 		/>
-	</Section>
+	</ElementContainer>
 );
 xsmallStory.story = { name: 'Size | large' };
 
 export const liveStory = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a live kicker looks"
 			palette={decidePalette({
@@ -45,12 +45,12 @@ export const liveStory = () => (
 			}}
 			kickerText="Live"
 		/>
-	</Section>
+	</ElementContainer>
 );
 liveStory.story = { name: 'With Live kicker' };
 
 export const noSlash = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with no kicker slash looks"
 			palette={decidePalette({
@@ -66,12 +66,12 @@ export const noSlash = () => (
 			kickerText="Live"
 			showSlash={false}
 		/>
-	</Section>
+	</ElementContainer>
 );
 noSlash.story = { name: 'With Live kicker but no slash' };
 
 export const pulsingDot = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a pulsing dot looks"
 			palette={decidePalette({
@@ -87,12 +87,12 @@ export const pulsingDot = () => (
 			kickerText="Live"
 			showPulsingDot={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 pulsingDot.story = { name: 'With pulsing dot' };
 
 export const cultureVariant = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with the culture pillar looks"
 			palette={decidePalette({
@@ -107,12 +107,12 @@ export const cultureVariant = () => (
 			}}
 			kickerText="Art and stuff"
 		/>
-	</Section>
+	</ElementContainer>
 );
 cultureVariant.story = { name: 'With a culture kicker' };
 
 export const opinionxxxsmall = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how small links to opinion articles look"
 			palette={decidePalette({
@@ -129,12 +129,12 @@ export const opinionxxxsmall = () => (
 			size="small"
 			byline="Comment byline"
 		/>
-	</Section>
+	</ElementContainer>
 );
 opinionxxxsmall.story = { name: 'Quotes | small' };
 
 export const OpinionKicker = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how an opinion headline with a kicker looks"
 			palette={decidePalette({
@@ -151,12 +151,12 @@ export const OpinionKicker = () => (
 			kickerText="George Monbiot"
 			showSlash={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 OpinionKicker.story = { name: 'With an opinion kicker' };
 
 export const SpecialReport = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a Special Report headline with a kicker looks"
 			palette={decidePalette({
@@ -173,12 +173,12 @@ export const SpecialReport = () => (
 			kickerText="Special Report"
 			showSlash={true}
 		/>
-	</Section>
+	</ElementContainer>
 );
 SpecialReport.story = { name: 'when Special Report' };
 
 export const InUnderlinedState = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is the underlined state when showUnderline is true"
 			palette={decidePalette({
@@ -200,12 +200,12 @@ export const InUnderlinedState = () => (
 					'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
 			}}
 		/>
-	</Section>
+	</ElementContainer>
 );
 InUnderlinedState.story = { name: 'With showUnderline true' };
 
 export const linkStory = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline looks as a link"
 			palette={decidePalette({
@@ -225,12 +225,12 @@ export const linkStory = () => (
 					'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
 			}}
 		/>
-	</Section>
+	</ElementContainer>
 );
 linkStory.story = { name: 'With linkTo provided' };
 
 export const LiveBlogSizes = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
 			palette={decidePalette({
@@ -306,12 +306,12 @@ export const LiveBlogSizes = () => (
 			showPulsingDot={true}
 			size="tiny"
 		/>
-	</Section>
+	</ElementContainer>
 );
 LiveBlogSizes.story = { name: 'with various sizes' };
 
 export const DeadBlogSizes = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
 			palette={decidePalette({
@@ -387,12 +387,12 @@ export const DeadBlogSizes = () => (
 			showPulsingDot={true}
 			size="tiny"
 		/>
-	</Section>
+	</ElementContainer>
 );
 DeadBlogSizes.story = { name: 'with various sizes' };
 
 export const Updated = () => (
-	<Section showTopBorder={false} showSideBorders={false}>
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText=""
 			palette={decidePalette({
@@ -410,6 +410,6 @@ export const Updated = () => (
 			kickerText="Updated 7m ago"
 			size="tiny"
 		/>
-	</Section>
+	</ElementContainer>
 );
 Updated.story = { name: 'Last updated' };

--- a/src/web/components/MatchNav.stories.tsx
+++ b/src/web/components/MatchNav.stories.tsx
@@ -1,4 +1,4 @@
-import { Section } from './Section';
+import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { RightColumn } from './RightColumn';
@@ -84,7 +84,7 @@ NoComments.story = { name: 'with no comments' };
 
 export const InContext = () => {
 	return (
-		<Section padded={false}>
+		<ElementContainer padded={false}>
 			<Flex>
 				<LeftColumn>
 					<></>
@@ -101,7 +101,7 @@ export const InContext = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 InContext.story = { name: 'when placed in article context' };

--- a/src/web/components/MatchStats.stories.tsx
+++ b/src/web/components/MatchStats.stories.tsx
@@ -1,6 +1,6 @@
 import { matchReport } from '@root/fixtures/generated/match-report';
 
-import { Section } from './Section';
+import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
@@ -22,7 +22,7 @@ Default.story = { name: 'default' };
 
 export const InContext = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Flex>
 				<LeftColumn>
 					<></>
@@ -37,7 +37,7 @@ export const InContext = () => {
 					<></>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 InContext.story = { name: 'when placed in article context' };

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 import { Display, Design, Pillar } from '@guardian/types';
 import { ABProvider } from '@guardian/ab-react';
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 import {
 	responseWithTwoTabs,
@@ -43,7 +43,7 @@ export const withTwoTabs = () => {
 
 	return (
 		<AbProvider>
-			<Section>
+			<ElementContainer>
 				<MostViewedFooter
 					palette={decidePalette({
 						display: Display.Standard,
@@ -54,7 +54,7 @@ export const withTwoTabs = () => {
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
 					display={Display.Standard}
 				/>
-			</Section>
+			</ElementContainer>
 		</AbProvider>
 	);
 };
@@ -68,7 +68,7 @@ export const withOneTabs = () => {
 
 	return (
 		<AbProvider>
-			<Section>
+			<ElementContainer>
 				<MostViewedFooter
 					palette={decidePalette({
 						display: Display.Standard,
@@ -78,7 +78,7 @@ export const withOneTabs = () => {
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
 					display={Display.Standard}
 				/>
-			</Section>
+			</ElementContainer>
 		</AbProvider>
 	);
 };
@@ -92,7 +92,7 @@ export const withNoMostSharedImage = () => {
 
 	return (
 		<AbProvider>
-			<Section>
+			<ElementContainer>
 				<MostViewedFooter
 					palette={decidePalette({
 						display: Display.Standard,
@@ -102,7 +102,7 @@ export const withNoMostSharedImage = () => {
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
 					display={Display.Standard}
 				/>
-			</Section>
+			</ElementContainer>
 		</AbProvider>
 	);
 };

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@root/src/web/components/Flex';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 
 import { mockTab1 } from '../MostViewed.mocks';
 import { MostViewedRight } from './MostViewedRight';
@@ -24,7 +24,7 @@ export const defaultStory = () => {
 	});
 
 	return (
-		<Section>
+		<ElementContainer>
 			<Flex>
 				<LeftColumn
 					showPartialRightBorder={true}
@@ -36,16 +36,16 @@ export const defaultStory = () => {
 					<></>
 				</ArticleContainer>
 				<RightColumn>
-					<Section
+					<ElementContainer
 						showSideBorders={false}
 						showTopBorder={false}
 						padded={false}
 					>
 						<MostViewedRight />
-					</Section>
+					</ElementContainer>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 defaultStory.story = { name: 'default' };
@@ -57,7 +57,7 @@ export const limitItemsStory = () => {
 	});
 
 	return (
-		<Section>
+		<ElementContainer>
 			<Flex>
 				<LeftColumn>
 					<></>
@@ -66,16 +66,16 @@ export const limitItemsStory = () => {
 					<></>
 				</ArticleContainer>
 				<RightColumn>
-					<Section
+					<ElementContainer
 						showSideBorders={false}
 						showTopBorder={false}
 						padded={false}
 					>
 						<MostViewedRight limitItems={3} />
-					</Section>
+					</ElementContainer>
 				</RightColumn>
 			</Flex>
-		</Section>
+		</ElementContainer>
 	);
 };
 limitItemsStory.story = { name: 'with a limit of 3 items' };
@@ -87,9 +87,9 @@ export const outsideContextStory = () => {
 	});
 
 	return (
-		<Section>
+		<ElementContainer>
 			<MostViewedRight />
-		</Section>
+		</ElementContainer>
 	);
 };
 outsideContextStory.story = {

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -3,7 +3,7 @@ import {
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 
 import { Design, Display, Pillar } from '@guardian/types';
 import { nav } from './Nav.mock';
@@ -16,7 +16,7 @@ export default {
 
 export const StandardStory = () => {
 	return (
-		<Section
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
@@ -33,14 +33,14 @@ export const StandardStory = () => {
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 StandardStory.story = { name: 'News Highlighted' };
 
 export const OpinionStory = () => {
 	return (
-		<Section
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
@@ -57,14 +57,14 @@ export const OpinionStory = () => {
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 OpinionStory.story = { name: 'Opinion Highlighted' };
 
 export const ImmersiveStory = () => {
 	return (
-		<Section
+		<ElementContainer
 			showSideBorders={false}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
@@ -81,7 +81,7 @@ export const ImmersiveStory = () => {
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 ImmersiveStory.story = { name: 'Immersive' };

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -1,6 +1,6 @@
 import { Design, Display, Pillar } from '@guardian/types';
 import { breakpoints } from '@guardian/src-foundations/mq';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
@@ -274,7 +274,7 @@ const immersiveTrails = convertToImmersive(trails);
 
 export const Headlines = () => (
 	<>
-		<Section showTopBorder={true}>
+		<ElementContainer showTopBorder={true}>
 			<Carousel
 				heading="More on this story"
 				trails={trails}
@@ -285,8 +285,8 @@ export const Headlines = () => (
 					display: Display.Standard,
 				}}
 			/>
-		</Section>
-		<Section showTopBorder={true}>
+		</ElementContainer>
+		<ElementContainer showTopBorder={true}>
 			<Carousel
 				heading="Sport"
 				trails={trails}
@@ -298,7 +298,7 @@ export const Headlines = () => (
 				}}
 				isCuratedContent={true}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 
@@ -306,7 +306,7 @@ Headlines.story = 'Headlines carousel';
 
 export const Immersive = () => (
 	<>
-		<Section showTopBorder={true}>
+		<ElementContainer showTopBorder={true}>
 			<Carousel
 				heading="More on this story"
 				trails={immersiveTrails}
@@ -318,8 +318,8 @@ export const Immersive = () => (
 				}}
 				isFullCardImage={true}
 			/>
-		</Section>
-		<Section showTopBorder={true}>
+		</ElementContainer>
+		<ElementContainer showTopBorder={true}>
 			<Carousel
 				heading="Sport"
 				trails={immersiveTrails}
@@ -332,7 +332,7 @@ export const Immersive = () => (
 				isFullCardImage={true}
 				isCuratedContent={true}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 
 import {
 	linkAndDescription,
@@ -24,85 +24,85 @@ export default {
 };
 
 export const linkAndDescriptionStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...linkAndDescription} />
-	</Section>
+	</ElementContainer>
 );
 linkAndDescriptionStory.story = { name: 'With link and description' };
 
 export const withLongDescriptionStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...withLongDescription} />
-	</Section>
+	</ElementContainer>
 );
 withLongDescriptionStory.story = { name: 'With long description' };
 
 export const withLinkStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...withLink} />
-	</Section>
+	</ElementContainer>
 );
 withLinkStory.story = { name: 'With link' };
 
 export const oneTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...oneTrail} />
-	</Section>
+	</ElementContainer>
 );
 oneTrailStory.story = { name: 'With one trail' };
 
 export const twoTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...twoTrails} />
-	</Section>
+	</ElementContainer>
 );
 twoTrailStory.story = { name: 'With two trails' };
 
 export const threeTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...threeTrails} />
-	</Section>
+	</ElementContainer>
 );
 threeTrailStory.story = { name: 'With three trails' };
 
 export const fourTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...fourTrails} />
-	</Section>
+	</ElementContainer>
 );
 fourTrailStory.story = { name: 'With four trails' };
 
 export const exactlyFiveStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...fiveTrails} />
-	</Section>
+	</ElementContainer>
 );
 exactlyFiveStory.story = { name: 'with five trails' };
 
 export const sixTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...sixTrails} />
-	</Section>
+	</ElementContainer>
 );
 sixTrailStory.story = { name: 'With six trails' };
 
 export const sevenTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...sevenTrails} />
-	</Section>
+	</ElementContainer>
 );
 sevenTrailStory.story = { name: 'With seven trails' };
 
 export const eightTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...eightTrails} />
-	</Section>
+	</ElementContainer>
 );
 eightTrailStory.story = { name: 'With eight trails' };
 
 export const labsTrailStory = () => (
-	<Section>
+	<ElementContainer>
 		<OnwardsLayout {...labsTrails} />
-	</Section>
+	</ElementContainer>
 );
 labsTrailStory.story = { name: 'With labs trails' };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import { joinUrl } from '@root/src/lib/joinUrl';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 
 import { OnwardsData } from './OnwardsData';
 import { OnwardsLayout } from './OnwardsLayout';
@@ -169,7 +169,7 @@ export const OnwardsUpper = ({
 	return (
 		<div css={onwardsWrapper}>
 			{url && (
-				<Section>
+				<ElementContainer>
 					<OnwardsData
 						url={url}
 						limit={8}
@@ -177,7 +177,7 @@ export const OnwardsUpper = ({
 						Container={OnwardsLayout}
 						format={format}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 		</div>
 	);

--- a/src/web/components/SignInGate/README.md
+++ b/src/web/components/SignInGate/README.md
@@ -256,14 +256,14 @@ In the `SignInGate.stories.tsx` file, simply import the gate design component, a
 ```tsx
 export const mainPatientia = () => {
     return (
-        <Section>
+        <ElementContainer>
             <SignInGatePatientia
                 guUrl="https://theguardian.com"
                 signInUrl="https://profile.theguardian.com/"
                 dismissGate={() => {}}
                 component="test"
             />
-        </Section>
+        </ElementContainer>
     );
 };
 mainPatientia.story = { name: 'patientia_standalone' };

--- a/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -1,4 +1,4 @@
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { SignInGateSelector } from './SignInGateSelector';
 import { SignInGateMain } from './gateDesigns/SignInGateMain';
 import { SignInGateFakeSocial } from './gateDesigns/SignInGateFakeSocial';
@@ -13,21 +13,21 @@ export default {
 
 export const mainStandalone = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 mainStandalone.story = { name: 'main_standalone' };
 
 export const mainStandaloneComment = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
@@ -35,14 +35,14 @@ export const mainStandaloneComment = () => {
 				ophanComponentId="test"
 				isComment={true}
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 mainStandaloneComment.story = { name: 'main_standalone_comment' };
 
 export const mainStandaloneMandatory = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
@@ -50,14 +50,14 @@ export const mainStandaloneMandatory = () => {
 				ophanComponentId="test"
 				isMandatory={true}
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 mainStandaloneMandatory.story = { name: 'main_standalone_mandatory' };
 
 export const mainStandaloneMandatoryComment = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateMain
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
@@ -66,7 +66,7 @@ export const mainStandaloneMandatoryComment = () => {
 				isMandatory={true}
 				isComment={true}
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 mainStandaloneMandatoryComment.story = {
@@ -75,21 +75,21 @@ mainStandaloneMandatoryComment.story = {
 
 export const fakeSocialStandalone = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateFakeSocial
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
 				dismissGate={() => {}}
 				ophanComponentId="test"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 fakeSocialStandalone.story = { name: 'fake_social_standalone' };
 
 export const fakeSocialStandaloneVertical = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<SignInGateFakeSocial
 				guUrl="https://theguardian.com"
 				signInUrl="https://profile.theguardian.com/"
@@ -101,7 +101,7 @@ export const fakeSocialStandaloneVertical = () => {
 					variant: 'fake-social-variant-vertical',
 				}}
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 fakeSocialStandaloneVertical.story = {

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -1,6 +1,6 @@
 import { news } from '@guardian/src-foundations';
 import { Display, Design, Pillar, Special } from '@guardian/types';
-import { Section } from './Section';
+import { ElementContainer } from './ElementContainer';
 
 import { Standfirst } from './Standfirst';
 
@@ -11,7 +11,7 @@ export default {
 
 export const Article = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -20,14 +20,14 @@ export const Article = () => {
 				}}
 				standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Article.story = { name: 'Article' };
 
 export const Comment = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -36,14 +36,14 @@ export const Comment = () => {
 				}}
 				standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Comment.story = { name: 'Comment' };
 
 export const Feature = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -52,14 +52,14 @@ export const Feature = () => {
 				}}
 				standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Feature.story = { name: 'Feature' };
 
 export const Immersive = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Immersive,
@@ -68,14 +68,14 @@ export const Immersive = () => {
 				}}
 				standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Immersive.story = { name: 'Immersive' };
 
 export const Review = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -84,14 +84,14 @@ export const Review = () => {
 				}}
 				standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Review.story = { name: 'Review' };
 
 export const LiveBlog = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -100,7 +100,7 @@ export const LiveBlog = () => {
 				}}
 				standfirst="This is how LiveBlog standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 LiveBlog.story = {
@@ -120,7 +120,7 @@ LiveBlog.story = {
 
 export const DeadBlog = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -129,14 +129,14 @@ export const DeadBlog = () => {
 				}}
 				standfirst="This is how DeadBlog standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 DeadBlog.story = { name: 'DeadBlog' };
 
 export const Interview = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -145,14 +145,14 @@ export const Interview = () => {
 				}}
 				standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Interview.story = { name: 'Interview' };
 
 export const Analysis = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -161,14 +161,14 @@ export const Analysis = () => {
 				}}
 				standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Analysis.story = { name: 'Analysis' };
 
 export const Media = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -177,14 +177,14 @@ export const Media = () => {
 				}}
 				standfirst="This is how Media standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Media.story = { name: 'Media' };
 
 export const Recipe = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -193,14 +193,14 @@ export const Recipe = () => {
 				}}
 				standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Recipe.story = { name: 'Recipe' };
 
 export const MatchReport = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -209,14 +209,14 @@ export const MatchReport = () => {
 				}}
 				standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 MatchReport.story = { name: 'MatchReport' };
 
 export const Quiz = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -225,14 +225,14 @@ export const Quiz = () => {
 				}}
 				standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Quiz.story = { name: 'Quiz' };
 
 export const SpecialReport = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -241,14 +241,14 @@ export const SpecialReport = () => {
 				}}
 				standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 SpecialReport.story = { name: 'SpecialReport' };
 
 export const Editorial = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -257,14 +257,14 @@ export const Editorial = () => {
 				}}
 				standfirst="This is how Editorial standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 Editorial.story = { name: 'Editorial' };
 
 export const PhotoEssay = () => {
 	return (
-		<Section>
+		<ElementContainer>
 			<Standfirst
 				format={{
 					display: Display.Standard,
@@ -273,7 +273,7 @@ export const PhotoEssay = () => {
 				}}
 				standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
 			/>
-		</Section>
+		</ElementContainer>
 	);
 };
 PhotoEssay.story = { name: 'PhotoEssay' };

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 
 import { Display, Design, Pillar } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
-import { Section } from '../Section';
+import { ElementContainer } from '../ElementContainer';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
 import { RightColumn } from '../RightColumn';
@@ -29,7 +29,7 @@ export default {
  */
 
 const Container = ({ children }: { children: React.ReactNode }) => (
-	<Section showTopBorder={false}>
+	<ElementContainer showTopBorder={false}>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -47,7 +47,7 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 				<></>
 			</RightColumn>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 
 export const StandardArticle = () => {

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 
 import { Display, Design, Pillar } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
-import { Section } from '../Section';
+import { ElementContainer } from '../ElementContainer';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
 import { RightColumn } from '../RightColumn';
@@ -23,7 +23,7 @@ export default {
 };
 
 const Container = ({ children }: { children: React.ReactNode }) => (
-	<Section showTopBorder={false}>
+	<ElementContainer showTopBorder={false}>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -41,7 +41,7 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 				<></>
 			</RightColumn>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 
 /**

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -4,7 +4,7 @@ import { Display, Design, Pillar } from '@guardian/types';
 
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
-import { Section } from '../Section';
+import { ElementContainer } from '../ElementContainer';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
 import { RightColumn } from '../RightColumn';
@@ -17,7 +17,7 @@ export default {
 };
 
 const Container = ({ children }: { children: React.ReactNode }) => (
-	<Section showTopBorder={false}>
+	<ElementContainer showTopBorder={false}>
 		<Flex>
 			<LeftColumn>
 				<></>
@@ -34,7 +34,7 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 				<></>
 			</RightColumn>
 		</Flex>
-	</Section>
+	</ElementContainer>
 );
 
 export const Default = () => {

--- a/src/web/examples/Front.stories.tsx
+++ b/src/web/examples/Front.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Header } from '@frontend/web/components/Header';
 import { Footer } from '@frontend/web/components/Footer';
 import { UL } from '@frontend/web/components/Card/components/UL';
@@ -42,7 +42,7 @@ export default {
 
 export const Front = () => (
 	<>
-		<Section
+		<ElementContainer
 			showTopBorder={false}
 			showSideBorders={true}
 			borderColour={brandLine.primary}
@@ -50,8 +50,8 @@ export const Front = () => (
 			backgroundColour={brandBackground.primary}
 		>
 			<Header edition="UK" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandLine.primary}
 			showTopBorder={false}
@@ -68,15 +68,15 @@ export const Front = () => (
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 			showSideBorders={true}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
+		</ElementContainer>
 		<ContainerLayout
 			showTopBorder={false}
 			title="Headlines"
@@ -517,14 +517,14 @@ export const Front = () => (
 				/>
 			</LI>
 		</ContainerLayout>
-		<Section
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			padded={false}
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
@@ -535,7 +535,7 @@ export const Front = () => (
 				pillar={Pillar.News}
 				pillars={NAV.pillars}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 Front.story = { name: 'Example front' };

--- a/src/web/examples/Newsletters.stories.tsx
+++ b/src/web/examples/Newsletters.stories.tsx
@@ -3,7 +3,7 @@
 import { css } from '@emotion/react';
 
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Footer } from '@frontend/web/components/Footer';
 import { UL } from '@frontend/web/components/Card/components/UL';
 import { LI } from '@frontend/web/components/Card/components/LI';
@@ -50,7 +50,7 @@ export default {
 
 export const Newsletters = (): React.ReactNode => (
 	<>
-		<Section
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandLine.primary}
 			showTopBorder={false}
@@ -67,8 +67,8 @@ export const Newsletters = (): React.ReactNode => (
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
-		<Section showTopBorder={false} showSideBorders={true}>
+		</ElementContainer>
+		<ElementContainer showTopBorder={false} showSideBorders={true}>
 			<h1
 				css={css`
 					padding-top: 1.5rem;
@@ -78,7 +78,7 @@ export const Newsletters = (): React.ReactNode => (
 			>
 				Guardian newsletters: sign up
 			</h1>
-		</Section>
+		</ElementContainer>
 		<ContainerLayout
 			title="News Roundups"
 			sideBorders={true}
@@ -145,7 +145,7 @@ export const Newsletters = (): React.ReactNode => (
 				</UL>
 			</UL>
 		</ContainerLayout>
-		<Section
+		<ElementContainer
 			padded={false}
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
@@ -156,7 +156,7 @@ export const Newsletters = (): React.ReactNode => (
 				pillar={Pillar.News}
 				pillars={NAV.pillars}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 Newsletters.story = { name: 'Example email newsletters page' };

--- a/src/web/examples/Sections.stories.tsx
+++ b/src/web/examples/Sections.stories.tsx
@@ -3,7 +3,7 @@
 import { css } from '@emotion/react';
 
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Header } from '@frontend/web/components/Header';
 import { Footer } from '@frontend/web/components/Footer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
@@ -51,7 +51,7 @@ export default {
 
 export const Sections = (): React.ReactNode => (
 	<>
-		<Section
+		<ElementContainer
 			showTopBorder={false}
 			showSideBorders={true}
 			borderColour={brandLine.primary}
@@ -59,8 +59,8 @@ export const Sections = (): React.ReactNode => (
 			backgroundColour={brandBackground.primary}
 		>
 			<Header edition="UK" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandLine.primary}
 			showTopBorder={false}
@@ -77,15 +77,15 @@ export const Sections = (): React.ReactNode => (
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 			showSideBorders={true}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
+		</ElementContainer>
 		<ContainerLayout
 			showTopBorder={false}
 			title="Page Title"
@@ -126,14 +126,14 @@ export const Sections = (): React.ReactNode => (
 		>
 			<Grey />
 		</ContainerLayout>
-		<Section
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			padded={false}
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
@@ -144,7 +144,7 @@ export const Sections = (): React.ReactNode => (
 				pillar={Pillar.News}
 				pillars={NAV.pillars}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 Sections.story = { name: 'Example using different sections' };

--- a/src/web/examples/Writers.stories.tsx
+++ b/src/web/examples/Writers.stories.tsx
@@ -3,7 +3,7 @@
 import { css } from '@emotion/react';
 
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
-import { Section } from '@frontend/web/components/Section';
+import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Header } from '@frontend/web/components/Header';
 import { Footer } from '@frontend/web/components/Footer';
 import { UL } from '@frontend/web/components/Card/components/UL';
@@ -66,7 +66,7 @@ export default {
 
 export const Writers = (): React.ReactNode => (
 	<>
-		<Section
+		<ElementContainer
 			showTopBorder={false}
 			showSideBorders={true}
 			borderColour={brandLine.primary}
@@ -74,8 +74,8 @@ export const Writers = (): React.ReactNode => (
 			backgroundColour={brandBackground.primary}
 		>
 			<Header edition="UK" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			showSideBorders={true}
 			borderColour={brandLine.primary}
 			showTopBorder={false}
@@ -92,15 +92,15 @@ export const Writers = (): React.ReactNode => (
 				subscribeUrl=""
 				edition="UK"
 			/>
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 			showSideBorders={true}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
+		</ElementContainer>
 		<ContainerLayout
 			showTopBorder={false}
 			title="Columnists"
@@ -249,14 +249,14 @@ export const Writers = (): React.ReactNode => (
 				</LI>
 			</UL>
 		</ContainerLayout>
-		<Section
+		<ElementContainer
 			backgroundColour={background.primary}
 			padded={false}
 			showTopBorder={false}
 		>
 			<Lines count={4} effect="straight" />
-		</Section>
-		<Section
+		</ElementContainer>
+		<ElementContainer
 			padded={false}
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
@@ -267,7 +267,7 @@ export const Writers = (): React.ReactNode => (
 				pillar={Pillar.News}
 				pillars={NAV.pillars}
 			/>
-		</Section>
+		</ElementContainer>
 	</>
 );
 Writers.story = { name: 'Example writers page' };

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -26,7 +26,7 @@ import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
@@ -318,7 +318,7 @@ export const CommentLayout = ({
 		<>
 			<div>
 				<Stuck>
-					<Section
+					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
@@ -328,11 +328,11 @@ export const CommentLayout = ({
 							shouldHideAds={CAPI.shouldHideAds}
 							display={format.display}
 						/>
-					</Section>
+					</ElementContainer>
 				</Stuck>
 				<SendToBack>
 					{format.theme !== Special.Labs && (
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -346,10 +346,10 @@ export const CommentLayout = ({
 									CAPI.config.switches.anniversaryHeaderSvg
 								}
 							/>
-						</Section>
+						</ElementContainer>
 					)}
 
-					<Section
+					<ElementContainer
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
@@ -367,10 +367,10 @@ export const CommentLayout = ({
 							}
 							edition={CAPI.editionId}
 						/>
-					</Section>
+					</ElementContainer>
 
 					{NAV.subNavSections && (
-						<Section
+						<ElementContainer
 							backgroundColour={palette.background.article}
 							padded={false}
 							sectionId="sub-nav-root"
@@ -380,20 +380,20 @@ export const CommentLayout = ({
 								currentNavLink={NAV.currentNavLink}
 								palette={palette}
 							/>
-						</Section>
+						</ElementContainer>
 					)}
 
-					<Section
+					<ElementContainer
 						backgroundColour={palette.background.article}
 						padded={false}
 						showTopBorder={false}
 					>
 						<Lines count={4} effect="straight" />
-					</Section>
+					</ElementContainer>
 				</SendToBack>
 			</div>
 
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 			>
@@ -576,9 +576,9 @@ export const CommentLayout = ({
 						</div>
 					</GridItem>
 				</StandardGrid>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
@@ -588,16 +588,16 @@ export const CommentLayout = ({
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedout" />
+				<ElementContainer sectionId="onwards-lower-whensignedout" />
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section sectionId="comments">
+				<ElementContainer sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -614,38 +614,40 @@ export const CommentLayout = ({
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedin" />
+				<ElementContainer sectionId="onwards-lower-whensignedin" />
 			)}
 
-			{!isPaidContent && <Section sectionId="most-viewed-footer" />}
+			{!isPaidContent && (
+				<ElementContainer sectionId="most-viewed-footer" />
+			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
+				<ElementContainer padded={false} sectionId="sub-nav-root">
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
@@ -656,7 +658,7 @@ export const CommentLayout = ({
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper />
 			<MobileStickyContainer />

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -23,7 +23,7 @@ import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -318,7 +318,7 @@ export const ImmersiveLayout = ({
 							order: 0;
 						`}
 					>
-						<Section
+						<ElementContainer
 							showSideBorders={false}
 							showTopBorder={false}
 							padded={false}
@@ -335,12 +335,12 @@ export const ImmersiveLayout = ({
 								}
 								edition={CAPI.editionId}
 							/>
-						</Section>
+						</ElementContainer>
 					</header>
 
 					{format.theme === Special.Labs && (
 						<Stuck>
-							<Section
+							<ElementContainer
 								showSideBorders={true}
 								showTopBorder={false}
 								backgroundColour={labs[400]}
@@ -348,7 +348,7 @@ export const ImmersiveLayout = ({
 								sectionId="labs-header"
 							>
 								<LabsHeader />
-							</Section>
+							</ElementContainer>
 						</Stuck>
 					)}
 
@@ -417,7 +417,7 @@ export const ImmersiveLayout = ({
 					</>
 				)}
 			</div>
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={palette.background.article}
@@ -609,9 +609,9 @@ export const ImmersiveLayout = ({
 						</div>
 					</GridItem>
 				</ImmersiveGrid>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
@@ -621,16 +621,16 @@ export const ImmersiveLayout = ({
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedout" />
+				<ElementContainer sectionId="onwards-lower-whensignedout" />
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section sectionId="comments">
+				<ElementContainer sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -647,38 +647,40 @@ export const ImmersiveLayout = ({
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedin" />
+				<ElementContainer sectionId="onwards-lower-whensignedin" />
 			)}
 
-			{!isPaidContent && <Section sectionId="most-viewed-footer" />}
+			{!isPaidContent && (
+				<ElementContainer sectionId="most-viewed-footer" />
+			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
+				<ElementContainer padded={false} sectionId="sub-nav-root">
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
@@ -689,7 +691,7 @@ export const ImmersiveLayout = ({
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper />
 			<MobileStickyContainer />

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -13,7 +13,7 @@ import { Lines } from '@guardian/src-ed-lines';
 
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
@@ -89,7 +89,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 					order: 0;
 				`}
 			>
-				<Section
+				<ElementContainer
 					showSideBorders={true}
 					borderColour={brandLine.primary}
 					showTopBorder={false}
@@ -108,7 +108,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 						}
 						edition={CAPI.editionId}
 					/>
-				</Section>
+				</ElementContainer>
 			</header>
 		);
 	}
@@ -117,7 +117,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 		<div>
 			<div data-print-layout="hide">
 				<Stuck>
-					<Section
+					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
@@ -128,10 +128,10 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 							shouldHideAds={CAPI.shouldHideAds}
 							display={format.display}
 						/>
-					</Section>
+					</ElementContainer>
 				</Stuck>
 				{format.theme !== Special.Labs && (
-					<Section
+					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
@@ -145,11 +145,11 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 								CAPI.config.switches.anniversaryHeaderSvg
 							}
 						/>
-					</Section>
+					</ElementContainer>
 				)}
 			</div>
 
-			<Section
+			<ElementContainer
 				showSideBorders={true}
 				borderColour={brandLine.primary}
 				showTopBorder={false}
@@ -166,10 +166,10 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
 					edition={CAPI.editionId}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && format.theme !== Special.Labs && (
-				<Section
+				<ElementContainer
 					backgroundColour={neutral[100]}
 					padded={false}
 					sectionId="sub-nav-root"
@@ -179,7 +179,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 		</div>
 	);
@@ -212,7 +212,7 @@ export const InteractiveImmersiveLayout = ({
 
 				{format.theme === Special.Labs && (
 					<Stuck>
-						<Section
+						<ElementContainer
 							showSideBorders={true}
 							showTopBorder={false}
 							backgroundColour={labs[400]}
@@ -220,12 +220,12 @@ export const InteractiveImmersiveLayout = ({
 							sectionId="labs-header"
 						>
 							<LabsHeader />
-						</Section>
+						</ElementContainer>
 					</Stuck>
 				)}
 			</div>
 
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				showSideBorders={false}
 				shouldCenter={false}
@@ -242,10 +242,10 @@ export const InteractiveImmersiveLayout = ({
 						webTitle={CAPI.webTitle}
 					/>
 				</main>
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section
+				<ElementContainer
 					padded={false}
 					sectionId="sub-nav-root"
 					backgroundColour={neutral[100]}
@@ -256,10 +256,10 @@ export const InteractiveImmersiveLayout = ({
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
@@ -270,7 +270,7 @@ export const InteractiveImmersiveLayout = ({
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper />
 			<MobileStickyContainer />

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -29,7 +29,7 @@ import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -244,7 +244,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<Global styles={interactiveGlobalStyles} />
 				<>
 					<Stuck>
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -255,10 +255,10 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								shouldHideAds={CAPI.shouldHideAds}
 								display={format.display}
 							/>
-						</Section>
+						</ElementContainer>
 					</Stuck>
 					{format.theme !== Special.Labs && (
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -272,12 +272,12 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									CAPI.config.switches.anniversaryHeaderSvg
 								}
 							/>
-						</Section>
+						</ElementContainer>
 					)}
 				</>
 			</div>
 
-			<Section
+			<ElementContainer
 				showSideBorders={true}
 				borderColour={brandLine.primary}
 				showTopBorder={false}
@@ -293,10 +293,10 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
 					edition={CAPI.editionId}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && format.theme !== Special.Labs && (
-				<Section
+				<ElementContainer
 					backgroundColour={palette.background.article}
 					padded={false}
 					sectionId="sub-nav-root"
@@ -306,19 +306,19 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{format.theme !== Special.Labs ? (
 				<>
-					<Section
+					<ElementContainer
 						backgroundColour={palette.background.article}
 						padded={false}
 						showTopBorder={false}
 					>
 						<Lines count={4} effect="straight" />
-					</Section>
-					<Section
+					</ElementContainer>
+					<ElementContainer
 						backgroundColour={brandAltBackground.primary}
 						padded={false}
 						showTopBorder={false}
@@ -329,11 +329,11 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								CAPI.anniversaryInteractiveAtom
 							}
 						/>
-					</Section>
+					</ElementContainer>
 				</>
 			) : (
 				<Stuck>
-					<Section
+					<ElementContainer
 						showSideBorders={true}
 						showTopBorder={false}
 						backgroundColour={labs[400]}
@@ -341,7 +341,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						sectionId="labs-header"
 					>
 						<LabsHeader />
-					</Section>
+					</ElementContainer>
 				</Stuck>
 			)}
 
@@ -349,7 +349,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<AdSlot position="survey" display={format.display} />
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
@@ -506,9 +506,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 					</InteractiveGrid>
 				</div>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -520,19 +520,19 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section data-print-layout="hide" sectionId="comments">
+				<ElementContainer data-print-layout="hide" sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -549,26 +549,26 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedin"
 				/>
 			)}
 
 			{!isPaidContent && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="most-viewed-footer"
 				/>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -576,10 +576,10 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
@@ -591,10 +591,10 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					/>
 
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				backgroundColour={brandBackground.primary}
@@ -606,7 +606,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide" />
 			<MobileStickyContainer data-print-layout="hide" />

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -25,7 +25,7 @@ import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
@@ -214,7 +214,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		<>
 			<div data-print-layout="hide">
 				<Stuck>
-					<Section
+					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
@@ -225,10 +225,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							shouldHideAds={CAPI.shouldHideAds}
 							display={format.display}
 						/>
-					</Section>
+					</ElementContainer>
 				</Stuck>
 				<SendToBack>
-					<Section
+					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
@@ -244,9 +244,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									'variant'
 							}
 						/>
-					</Section>
+					</ElementContainer>
 
-					<Section
+					<ElementContainer
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
@@ -264,10 +264,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							}
 							edition={CAPI.editionId}
 						/>
-					</Section>
+					</ElementContainer>
 
 					{NAV.subNavSections && (
-						<Section
+						<ElementContainer
 							backgroundColour={palette.background.article}
 							padded={false}
 							sectionId="sub-nav-root"
@@ -278,17 +278,17 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								currentNavLink={NAV.currentNavLink}
 								palette={palette}
 							/>
-						</Section>
+						</ElementContainer>
 					)}
 
-					<Section
+					<ElementContainer
 						backgroundColour={palette.background.article}
 						padded={false}
 						showTopBorder={false}
 						borderColour={palette.border.article}
 					>
 						<Lines count={4} effect="straight" />
-					</Section>
+					</ElementContainer>
 				</SendToBack>
 			</div>
 			<ContainerLayout
@@ -346,7 +346,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<Standfirst format={format} standfirst={CAPI.standfirst} />
 			</ContainerLayout>
 
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				borderColour={palette.border.article}
 				backgroundColour={palette.background.article}
@@ -356,9 +356,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						height: ${space[4]}px;
 					`}
 				/>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
@@ -474,9 +474,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</div>
 					</GridItem>
 				</LiveGrid>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -488,19 +488,19 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section data-print-layout="hide" sectionId="comments">
+				<ElementContainer data-print-layout="hide" sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -517,26 +517,26 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedin"
 				/>
 			)}
 
 			{!isPaidContent && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="most-viewed-footer"
 				/>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -544,10 +544,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
@@ -558,10 +558,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				backgroundColour={brandBackground.primary}
@@ -573,7 +573,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide" />
 			<MobileStickyContainer data-print-layout="hide" />

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -25,7 +25,7 @@ import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
@@ -258,7 +258,7 @@ export const ShowcaseLayout = ({
 			{format.theme !== Special.Labs ? (
 				<div>
 					<Stuck>
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -268,10 +268,10 @@ export const ShowcaseLayout = ({
 								shouldHideAds={CAPI.shouldHideAds}
 								display={format.display}
 							/>
-						</Section>
+						</ElementContainer>
 					</Stuck>
 					<SendToBack>
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -285,9 +285,9 @@ export const ShowcaseLayout = ({
 									CAPI.config.switches.anniversaryHeaderSvg
 								}
 							/>
-						</Section>
+						</ElementContainer>
 
-						<Section
+						<ElementContainer
 							showSideBorders={true}
 							borderColour={brandLine.primary}
 							showTopBorder={false}
@@ -305,10 +305,10 @@ export const ShowcaseLayout = ({
 								}
 								edition={CAPI.editionId}
 							/>
-						</Section>
+						</ElementContainer>
 
 						{NAV.subNavSections && (
-							<Section
+							<ElementContainer
 								backgroundColour={palette.background.article}
 								padded={false}
 								sectionId="sub-nav-root"
@@ -318,16 +318,16 @@ export const ShowcaseLayout = ({
 									currentNavLink={NAV.currentNavLink}
 									palette={palette}
 								/>
-							</Section>
+							</ElementContainer>
 						)}
 
-						<Section
+						<ElementContainer
 							backgroundColour={palette.background.article}
 							padded={false}
 							showTopBorder={false}
 						>
 							<Lines count={4} effect="straight" />
-						</Section>
+						</ElementContainer>
 					</SendToBack>
 				</div>
 			) : (
@@ -335,7 +335,7 @@ export const ShowcaseLayout = ({
 				<>
 					<div>
 						<Stuck zIndex="stickyAdWrapper">
-							<Section
+							<ElementContainer
 								showTopBorder={false}
 								showSideBorders={false}
 								padded={false}
@@ -345,10 +345,10 @@ export const ShowcaseLayout = ({
 									shouldHideAds={CAPI.shouldHideAds}
 									display={format.display}
 								/>
-							</Section>
+							</ElementContainer>
 						</Stuck>
 						<Stuck zIndex="stickyAdWrapperNav">
-							<Section
+							<ElementContainer
 								showSideBorders={true}
 								borderColour={brandLine.primary}
 								showTopBorder={false}
@@ -367,11 +367,11 @@ export const ShowcaseLayout = ({
 									}
 									edition={CAPI.editionId}
 								/>
-							</Section>
+							</ElementContainer>
 						</Stuck>
 					</div>
 					<Stuck zIndex="stickyAdWrapperLabsHeader">
-						<Section
+						<ElementContainer
 							showSideBorders={true}
 							showTopBorder={false}
 							backgroundColour={labs[400]}
@@ -379,12 +379,12 @@ export const ShowcaseLayout = ({
 							sectionId="labs-header"
 						>
 							<LabsHeader />
-						</Section>
+						</ElementContainer>
 					</Stuck>
 				</>
 			)}
 
-			<Section
+			<ElementContainer
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 			>
@@ -551,9 +551,9 @@ export const ShowcaseLayout = ({
 						</div>
 					</GridItem>
 				</ShowcaseGrid>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
@@ -563,16 +563,16 @@ export const ShowcaseLayout = ({
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedout" />
+				<ElementContainer sectionId="onwards-lower-whensignedout" />
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section sectionId="comments">
+				<ElementContainer sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -589,38 +589,40 @@ export const ShowcaseLayout = ({
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section sectionId="onwards-lower-whensignedin" />
+				<ElementContainer sectionId="onwards-lower-whensignedin" />
 			)}
 
-			{!isPaidContent && <Section sectionId="most-viewed-footer" />}
+			{!isPaidContent && (
+				<ElementContainer sectionId="most-viewed-footer" />
+			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
+				<ElementContainer padded={false} sectionId="sub-nav-root">
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				padded={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
@@ -631,7 +633,7 @@ export const ShowcaseLayout = ({
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper />
 			<MobileStickyContainer />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -28,7 +28,7 @@ import { Standfirst } from '@root/src/web/components/Standfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { Section } from '@root/src/web/components/Section';
+import { ElementContainer } from '@root/src/web/components/ElementContainer';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -347,7 +347,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			<div data-print-layout="hide">
 				<>
 					<Stuck>
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -358,10 +358,10 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								shouldHideAds={CAPI.shouldHideAds}
 								display={format.display}
 							/>
-						</Section>
+						</ElementContainer>
 					</Stuck>
 					{format.theme !== Special.Labs && (
-						<Section
+						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
 							padded={false}
@@ -375,12 +375,12 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									CAPI.config.switches.anniversaryHeaderSvg
 								}
 							/>
-						</Section>
+						</ElementContainer>
 					)}
 				</>
 			</div>
 
-			<Section
+			<ElementContainer
 				showSideBorders={true}
 				borderColour={brandLine.primary}
 				showTopBorder={false}
@@ -393,10 +393,10 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
 					edition={CAPI.editionId}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && format.theme !== Special.Labs && (
-				<Section
+				<ElementContainer
 					backgroundColour={palette.background.article}
 					padded={false}
 					sectionId="sub-nav-root"
@@ -406,20 +406,20 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{format.theme !== Special.Labs ? (
-				<Section
+				<ElementContainer
 					backgroundColour={palette.background.article}
 					padded={false}
 					showTopBorder={false}
 				>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			) : (
 				<Stuck>
-					<Section
+					<ElementContainer
 						showSideBorders={true}
 						showTopBorder={false}
 						backgroundColour={labs[400]}
@@ -427,7 +427,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						sectionId="labs-header"
 					>
 						<LabsHeader />
-					</Section>
+					</ElementContainer>
 				</Stuck>
 			)}
 
@@ -435,7 +435,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<AdSlot position="survey" display={format.display} />
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
@@ -634,9 +634,9 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</div>
 					</GridItem>
 				</StandardGrid>
-			</Section>
+			</ElementContainer>
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -648,19 +648,19 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					position="merchandising-high"
 					display={format.display}
 				/>
-			</Section>
+			</ElementContainer>
 
 			{/* Onwards (when signed OUT) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedout" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedout"
 				/>
 			)}
 
 			{!isPaidContent && showComments && (
-				<Section data-print-layout="hide" sectionId="comments">
+				<ElementContainer data-print-layout="hide" sectionId="comments">
 					<Discussion
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
@@ -677,26 +677,26 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						beingHydrated={false}
 						display={format.display}
 					/>
-				</Section>
+				</ElementContainer>
 			)}
 
 			{/* Onwards (when signed IN) */}
 			<div data-print-layout="hide" id="onwards-upper-whensignedin" />
 			{showOnwardsLower && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="onwards-lower-whensignedin"
 				/>
 			)}
 
 			{!isPaidContent && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					sectionId="most-viewed-footer"
 				/>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				showTopBorder={false}
@@ -704,10 +704,10 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={neutral[93]}
 			>
 				<AdSlot position="merchandising" display={format.display} />
-			</Section>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
-				<Section
+				<ElementContainer
 					data-print-layout="hide"
 					padded={false}
 					sectionId="sub-nav-root"
@@ -718,10 +718,10 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						palette={palette}
 					/>
 					<Lines count={4} effect="straight" />
-				</Section>
+				</ElementContainer>
 			)}
 
-			<Section
+			<ElementContainer
 				data-print-layout="hide"
 				padded={false}
 				backgroundColour={brandBackground.primary}
@@ -733,7 +733,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					pillar={format.theme}
 					pillars={NAV.pillars}
 				/>
-			</Section>
+			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide" />
 			<MobileStickyContainer data-print-layout="hide" />


### PR DESCRIPTION
## What does this change?

As a pre-cursor to functionality change as per https://github.com/guardian/dotcom-rendering/pull/3137 - I am renaming the `Section` Component to `ElementContainer` to better represent its future usage.

There are no other functionality changes in this PR.