### PR TITLE
CMP: rollback to v6.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@guardian/atoms-rendering": "^15.0.0",
     "@guardian/automat-client": "^0.2.17",
     "@guardian/braze-components": "^2.1.0",
-    "@guardian/consent-management-platform": "^6.12.0",
+    "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^7.0.0",
     "@guardian/libs": "^2.0.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,10 +1643,10 @@
     "@guardian/src-foundations" "3.3.0"
     "@guardian/src-icons" "3.3.0"
 
-"@guardian/consent-management-platform@^6.12.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.12.0.tgz#7043f73bb2a6e27dc0d1efd2cb4fc6040733c81c"
-  integrity sha512-CbYqgoKo45cKJviJcGic9AvbeBOW3GPvYXJHqZWlpRTGdwVqTHZgangP66U4Mfs5K6Ux8P7vHvoohhwZdk9QQA==
+"@guardian/consent-management-platform@~6.11.5":
+  version "6.11.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.5.tgz#93681cbf61de0fadb4b65d835d7fc445cb847b31"
+  integrity sha512-ap7b09qk8I/EfoWB3NR8kT63hBpm4ATFGpRicCQ61DLMw2PgCWunMvizdbSmo5wNCQKPFgmX9cfRT5IGfPneKw==
   dependencies:
     "@guardian/libs" "^1"
 


### PR DESCRIPTION
## What does this change?

v6.12.0 introduces errors on callbacks / passbacks with ads

Related to https://github.com/guardian/frontend/pull/23953

## Why?

Ads need to work!