### PR TITLE
Use Data-Component to send Youtube Embed visibility

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -578,11 +578,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						duration={youTubeAtom.duration}
 						mediaTitle={youTubeAtom.mediaTitle}
 						altText={youTubeAtom.altText}
-						/* embedHandler={componentEventHandler(
-							'QANDA_ATOM',
-							qandaAtom.id,
-							'DISLIKE',
-						)} */
 					/>
 				</HydrateOnce>
 			))}

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -578,6 +578,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						duration={youTubeAtom.duration}
 						mediaTitle={youTubeAtom.mediaTitle}
 						altText={youTubeAtom.altText}
+						/* embedHandler={componentEventHandler(
+							'QANDA_ATOM',
+							qandaAtom.id,
+							'DISLIKE',
+						)} */
 					/>
 				</HydrateOnce>
 			))}

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -32,8 +32,6 @@ type Props = {
 	width?: number;
 	duration?: number; // in seconds
 	origin?: string;
-	// eslint-disable-next-line react/no-unused-prop-types
-	embedHandler?: () => void;
 };
 
 const expiredOverlayStyles = (overrideImage: string) => css`
@@ -150,7 +148,7 @@ export const YoutubeBlockComponent = ({
 	};
 
 	return (
-		<div data-chromatic="ignore">
+		<div data-chromatic="ignore" data-component="Youtube_Embed">
 			<YoutubeAtom
 				assetId={assetId}
 				overrideImage={

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -148,7 +148,7 @@ export const YoutubeBlockComponent = ({
 	};
 
 	return (
-		<div data-chromatic="ignore" data-component="Youtube_Embed">
+		<div data-chromatic="ignore" data-component="youtube_embed">
 			<YoutubeAtom
 				assetId={assetId}
 				overrideImage={

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -148,7 +148,7 @@ export const YoutubeBlockComponent = ({
 	};
 
 	return (
-		<div data-chromatic="ignore" data-component="youtube_embed">
+		<div data-chromatic="ignore" data-component="youtube-atom">
 			<YoutubeAtom
 				assetId={assetId}
 				overrideImage={

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -32,6 +32,8 @@ type Props = {
 	width?: number;
 	duration?: number; // in seconds
 	origin?: string;
+	// eslint-disable-next-line react/no-unused-prop-types
+	embedHandler?: () => void;
 };
 
 const expiredOverlayStyles = (overrideImage: string) => css`

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
@@ -29,7 +29,7 @@ export const YoutubeEmbedBlockComponent: React.FC<{
 	`;
 
 	return (
-		<div css={embedContainer}>
+		<div css={embedContainer} data-component="youtube-embed">
 			<MaintainAspectRatio height={height} width={width}>
 				<iframe
 					src={embedUrl}


### PR DESCRIPTION
## What does this change?

Before there was no way to filter which pages had Youtube embeds. This uses the `data-component` attribute to notify Ophan that there is a Youtube embed on that page. This can be tested for metrics etc.

### Before

<img width="268" alt="Screenshot 2021-06-28 at 12 25 46" src="https://user-images.githubusercontent.com/35331926/123629573-560f9100-d80c-11eb-9254-5636032c7942.png">

<img width="242" alt="Screenshot 2021-06-28 at 12 26 17" src="https://user-images.githubusercontent.com/35331926/123629584-59a31800-d80c-11eb-9c31-155d4f1c2857.png">

### After

<img width="513" alt="Screenshot 2021-06-28 at 12 25 35" src="https://user-images.githubusercontent.com/35331926/123629623-64f64380-d80c-11eb-841b-62e2963fa059.png">

<img width="491" alt="Screenshot 2021-06-28 at 12 26 06" src="https://user-images.githubusercontent.com/35331926/123629634-67589d80-d80c-11eb-84cd-8b2fb42f0c14.png">


