### PR TITLE
Update MatchStats to use the codename

### DIFF
--- a/fixtures/generated/match-report.ts
+++ b/fixtures/generated/match-report.ts
@@ -17,6 +17,7 @@ export const matchReport: MatchReportType = {
 	homeTeam: {
 		id: '29',
 		name: 'Leicester',
+		codename: 'LEI',
 		players: [
 			{
 				id: '284907',
@@ -257,6 +258,7 @@ export const matchReport: MatchReportType = {
 	awayTeam: {
 		id: '1006',
 		name: 'Arsenal',
+		codename: 'ARS',
 		players: [
 			{
 				id: '438917',

--- a/index.d.ts
+++ b/index.d.ts
@@ -570,6 +570,7 @@ type UserProfile = {
 type TeamType = {
 	id: string;
 	name: string;
+	codename: string;
 	players: PlayerType[];
 	possession: number;
 	shotsOn: number;

--- a/src/web/components/MatchNav.stories.tsx
+++ b/src/web/components/MatchNav.stories.tsx
@@ -8,6 +8,7 @@ import { MatchNav } from './MatchNav';
 
 const homeTeam: TeamType = {
 	name: 'Liverpool',
+	codename: 'LIV',
 	id: '9',
 	score: 2,
 	crest: 'https://sport.guim.co.uk/football/crests/120/9.png',
@@ -23,6 +24,7 @@ const homeTeam: TeamType = {
 
 const awayTeam: TeamType = {
 	name: 'Atlético',
+	codename: 'ATL',
 	id: '26305',
 	score: 3,
 	crest: 'https://sport.guim.co.uk/football/crests/120/26305.png',

--- a/src/web/components/MatchStats.tsx
+++ b/src/web/components/MatchStats.tsx
@@ -194,12 +194,12 @@ export const MatchStats = ({ home, away }: Props) => (
 							sections={[
 								{
 									value: home.possession,
-									label: home.name.slice(0, 3).toUpperCase(),
+									label: home.codename,
 									color: home.colours,
 								},
 								{
 									value: away.possession,
-									label: away.name.slice(0, 3).toUpperCase(),
+									label: away.codename,
 									color: away.colours,
 								},
 							].reverse()}


### PR DESCRIPTION
A `codename` attribute was added to team metadata here: https://github.com/guardian/frontend/pull/23958 , we are now consuming it to display a better MatchStats widget.

BEFORE:

<img width="661" alt="BEFORE" src="https://user-images.githubusercontent.com/6035518/123639583-4138fa80-d818-11eb-8a00-7878de392cd9.png">


AFTER:

<img width="647" alt="AFTER" src="https://user-images.githubusercontent.com/6035518/123639597-4433eb00-d818-11eb-820f-b226e8c8696b.png">


