### PR TITLE
Keep empty elements in AMP

### DIFF
--- a/src/model/clean.ts
+++ b/src/model/clean.ts
@@ -16,7 +16,6 @@ export const clean = compose(
 	(s: string) =>
 		minify(s, {
 			collapseWhitespace: true,
-			removeEmptyElements: true,
 			minifyCSS: true,
 			minifyJS: true,
 		}),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes a configuration option for our use of `html-minifier`. For AMP only we were applying this minification rule to remove empty elements. However there are at least some HTML snippets we receive from CAPI that contain empty elements, and validly so. For example the interactive for the  golden boot in Euro  2020 has only a placeholder <div>, ready to be populated clientside. As far as we can tell this minification does not serve much purpose, so we're removing  to  allow these kinds of interactives.

(Note that there are some other options needing to be applied to the interactive below in order to get it to display, but this is the first step)

### Before
![image](https://user-images.githubusercontent.com/8754692/123640330-f79cdf80-d818-11eb-9905-f333b7cc1887.png)


### After
![image](https://user-images.githubusercontent.com/8754692/123640643-4a769700-d819-11eb-9a57-85ab5e121920.png)


## Why?
Closer to AMP support for interactives.
