### PR TITLE
add `ConsentState` type from CMP

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -72,6 +72,7 @@ import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockC
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
+import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,
@@ -332,7 +333,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	// *   Google Analytics   *
 	// ************************
 	useEffect(() => {
-		onConsentChange((state: any) => {
+		onConsentChange((state: ConsentState) => {
 			const consentGiven = getConsentFor('google-analytics', state);
 			if (consentGiven) {
 				Promise.all([


### PR DESCRIPTION
## What does this change?

Adds missing type

## Why?

Type safety! It’s better to use `ConsentState` than `any`!