### PR TITLE
Use text sans for labs interactive elements

### DIFF
--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { css } from '@emotion/react';
-import { body } from '@guardian/src-foundations/typography';
+import { body, textSans } from '@guardian/src-foundations/typography';
+import { Special } from '@guardian/types'
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Placeholder } from '@root/src/web/components/Placeholder';
@@ -90,8 +91,10 @@ const getMinHeight = (role: RoleType, loaded: boolean) => {
 	}
 	return `${decideHeight(role)}px`;
 };
-const wrapperStyle = (role: RoleType, loaded: boolean) => css`
-	${body.medium()};
+const wrapperStyle = (format: Format, role: RoleType, loaded: boolean) => css`
+	${format.theme === Special.Labs
+		? textSans.medium()
+		: body.medium()};
 	background-color: ${neutral[100]};
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
@@ -274,7 +277,7 @@ export const InteractiveBlockComponent = ({
 			<div
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 				ref={wrapperRef}
-				css={wrapperStyle(role, loaded)}
+				css={wrapperStyle(format, role, loaded)}
 			>
 				{!loaded && (
 					<>

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { css } from '@emotion/react';
 import { body, textSans } from '@guardian/src-foundations/typography';
-import { Special } from '@guardian/types'
+import { Special } from '@guardian/types';
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Placeholder } from '@root/src/web/components/Placeholder';
@@ -92,9 +92,7 @@ const getMinHeight = (role: RoleType, loaded: boolean) => {
 	return `${decideHeight(role)}px`;
 };
 const wrapperStyle = (format: Format, role: RoleType, loaded: boolean) => css`
-	${format.theme === Special.Labs
-		? textSans.medium()
-		: body.medium()};
+	${format.theme === Special.Labs ? textSans.medium() : body.medium()};
 	background-color: ${neutral[100]};
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Avoids the font used in interactives on labs pieces being overridden to serif on DCR.

### Before
![image](https://user-images.githubusercontent.com/8754692/123768938-aea06600-d8c0-11eb-97ce-10c782bf9615.png)

### After
![image](https://user-images.githubusercontent.com/8754692/123768673-70a34200-d8c0-11eb-81b9-16125a96799b.png)


## Why?
There's some quizzes that are built as interactives that will be closer to being supported on DCR with this - but generally it seems like a more sensible default to apply to labs interactives anyway.