### PR TITLE
Render zero stars in cards

### DIFF
--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -31,7 +31,7 @@ const ReviewWithStars = Format(
 		design: Design.Review,
 	},
 	'Review',
-	0 // star rating
+	0, // star rating
 );
 
 const Interview = Format(

--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -24,6 +24,16 @@ const Review = Format(
 	'Review',
 );
 
+const ReviewWithStars = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Review,
+	},
+	'Review',
+	0 // star rating
+);
+
 const Interview = Format(
 	{
 		display: Display.Standard,
@@ -170,6 +180,7 @@ const Analysis = Format(
 
 export {
 	Review,
+	ReviewWithStars,
 	Interview,
 	Comment,
 	PhotoEssay,

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -11,7 +11,7 @@ import { UL } from './components/UL';
 import { LI } from './components/LI';
 import { images, standfirsts } from './Card.mocks';
 
-export const Format = (format: Format, title: string) => () => (
+export const Format = (format: Format, title: string, starRating?: number) => () => (
 	<Section>
 		<Flex>
 			<LeftColumn showRightBorder={false}>
@@ -39,6 +39,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 					<LI
@@ -66,6 +67,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 					<LI
@@ -93,6 +95,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 					<LI
@@ -120,6 +123,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 				</UL>
@@ -144,6 +148,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 					<LI
@@ -171,6 +176,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 					<LI
@@ -198,6 +204,7 @@ export const Format = (format: Format, title: string) => () => (
 							isFullCardImage={
 								format.display === Display.Immersive
 							}
+							starRating={starRating}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -11,7 +11,11 @@ import { UL } from './components/UL';
 import { LI } from './components/LI';
 import { images, standfirsts } from './Card.mocks';
 
-export const Format = (format: Format, title: string, starRating?: number) => () => (
+export const Format = (
+	format: Format,
+	title: string,
+	starRating?: number,
+) => () => (
 	<Section>
 		<Flex>
 			<LeftColumn showRightBorder={false}>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -204,11 +204,11 @@ export const Card = ({
 									role="presentation"
 								/>
 								<>
-									{starRating && (
+									{starRating !== undefined ? (
 										<StarRatingComponent
 											rating={starRating}
 										/>
-									)}
+									): null}
 								</>
 							</ImageWrapper>
 						)}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -208,7 +208,7 @@ export const Card = ({
 										<StarRatingComponent
 											rating={starRating}
 										/>
-									): null}
+									) : null}
 								</>
 							</ImageWrapper>
 						)}

--- a/src/web/components/StarRating/StarRating.stories.tsx
+++ b/src/web/components/StarRating/StarRating.stories.tsx
@@ -26,6 +26,9 @@ AllSizes.story = { name: 'All stars sizes' };
 
 export const SmallStory = () => (
 	<>
+		<h1>0 Star</h1>
+		<StarRating rating={0} size="small" />
+		<br />
 		<h1>1 Star</h1>
 		<StarRating rating={1} size="small" />
 		<br />
@@ -46,6 +49,9 @@ SmallStory.story = { name: 'Small stars' };
 
 export const MediumStory = () => (
 	<>
+		<h1>0 Star</h1>
+		<StarRating rating={0} size="medium" />
+		<br />
 		<h1>1 Star</h1>
 		<StarRating rating={1} size="medium" />
 		<br />
@@ -66,6 +72,9 @@ MediumStory.story = { name: 'Medium stars' };
 
 export const LargeStory = () => (
 	<>
+		<h1>0 Star</h1>
+		<StarRating rating={0} size="large" />
+		<br />
 		<h1>1 Star</h1>
 		<StarRating rating={1} size="large" />
 		<br />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This updates the Card component to use a ternary rather than `&&`, which means that a zero star rating is rendered as a  StarRatingComponent with zero stars, rather than the number zero. I've also added some stories for zero star reviews.

### Before
![image](https://user-images.githubusercontent.com/8754692/123784202-18c00780-d8cf-11eb-94ba-7b322aa9f72e.png)


### After
![image](https://user-images.githubusercontent.com/8754692/123784155-0e057280-d8cf-11eb-88a0-ece648bc6020.png)


## Why?
Zero star reviews are rare but legitimate! We should  render them  correctly  on cards, as we already do on the articles themselves.