### PR TITLE
Richlink Image Enhancement

### DIFF
--- a/cypress/fixtures/richLink.json
+++ b/cypress/fixtures/richLink.json
@@ -77,7 +77,23 @@
     }
   ],
   "cardStyle": "news",
-  "thumbnailUrl": "https://i.guim.co.uk/img/media/4d8c85672b7e5d09752b0d1dfe23a6976032197e/0_100_3000_1800/master/3000.jpg?width=460&quality=85&auto=format&fit=max&s=f5e48ed68f1dccfedcea7a2fd5b95048",
+  "thumbnailUrl": "https://i.guim.co.uk/img/media/b0c5baa3696fe6f4923387b3b9554bdea19aa0d4/77_689_2384_1430/master/2384.jpg?width=460&quality=85&auto=format&fit=max&s=a629c14a8102608c75c8f5062de3df58",
+  "imageAsset": {
+	"index": 1,
+	"fields": {
+		"displayCredit": "true",
+		"source": "PA",
+		"photographer": "Danny Lawson",
+		"isMaster": "true",
+		"altText": "Tracy Brabin",
+		"height": "1430",
+		"credit": "Photograph: Danny Lawson/PA",
+		"mediaId": "b0c5baa3696fe6f4923387b3b9554bdea19aa0d4",
+		"width": "2384"
+	},
+  	"mediaType": "Image",
+  	"url": "https://media.guim.co.uk/b0c5baa3696fe6f4923387b3b9554bdea19aa0d4/77_689_2384_1430/master/2384.jpg"
+  },
   "headline": "Michel Barnier tells UK: ignore EU regulatory standards at your peril",
   "contentType": "Article",
   "contributorImage": "https://i.guim.co.uk/img/uploads/2017/12/26/Jennifer_Rankin,_L.png?width=173&quality=85&auto=format&fit=max&s=129bebba84d667d2bc74490d46c10f8f",

--- a/src/web/components/DefaultRichLink.tsx
+++ b/src/web/components/DefaultRichLink.tsx
@@ -9,6 +9,13 @@ type DefaultProps = {
 	isPlaceholder?: boolean;
 };
 
+const defaultImageData = {
+	thumbnailUrl: '',
+	altText: '',
+	width: '',
+	height: '',
+};
+
 export const DefaultRichLink: React.FC<DefaultProps> = ({
 	index,
 	headlineText,
@@ -19,7 +26,7 @@ export const DefaultRichLink: React.FC<DefaultProps> = ({
 		<RichLink
 			richLinkIndex={index}
 			cardStyle="news"
-			thumbnailUrl=""
+			imageData={defaultImageData}
 			headlineText={headlineText}
 			contentType="article"
 			url={url}

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -7,10 +7,16 @@ import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
 
 import { RichLink } from './RichLink';
 
-const someImage =
-	'https://i.guim.co.uk/img/media/268d42accabbe8168fdbdee51ad31ab2f156b211/137_0_2088_1253/master/2088.jpg?width=460&quality=85&auto=format&fit=max&s=cf5abc39fb2af7a56b10306df21ab8e6';
 const someContributor =
 	'https://i.guim.co.uk/img/uploads/2017/10/09/Oliver-Wainwright,-L.png?width=300&quality=85&auto=format&fit=max&s=e1aa270c46b716e34c4783ced3376cc9';
+
+const someImageData = {
+	thumbnailUrl:
+		'https://i.guim.co.uk/img/media/268d42accabbe8168fdbdee51ad31ab2f156b211/137_0_2088_1253/master/2088.jpg?width=460&quality=85&auto=format&fit=max&s=cf5abc39fb2af7a56b10306df21ab8e6',
+	altText: 'What a lovely arch in this image',
+	width: '1600',
+	height: '900',
+};
 
 export default {
 	component: RichLink,
@@ -24,7 +30,7 @@ export const Article = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="article"
 					url=""
@@ -48,7 +54,7 @@ export const Network = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="special-report"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="network"
 					url=""
@@ -78,7 +84,7 @@ export const SectionStory = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="live"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="section"
 					url=""
@@ -105,7 +111,7 @@ export const Inline = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link when inline"
 					contentType="section"
 					url=""
@@ -132,7 +138,7 @@ export const ImageContent = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="dead"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="imageContent"
 					url=""
@@ -162,7 +168,7 @@ export const Interactive = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="feature"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="interactive"
 					url=""
@@ -191,7 +197,7 @@ export const Gallery = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="gallery"
 					url=""
@@ -221,7 +227,7 @@ export const Video = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="video"
 					url=""
@@ -252,7 +258,7 @@ export const Audio = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="podcast"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="audio"
 					url=""
@@ -276,7 +282,7 @@ export const LiveBlog = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="media"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="liveBlog"
 					url=""
@@ -306,7 +312,7 @@ export const Tag = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="analysis"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="tag"
 					url=""
@@ -330,7 +336,7 @@ export const Index = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="review"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="index"
 					url=""
@@ -361,7 +367,7 @@ export const Crossword = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="letters"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="crossword"
 					url=""
@@ -385,7 +391,7 @@ export const Survey = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="survey"
 					url=""
@@ -409,7 +415,7 @@ export const Signup = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="signup"
 					url=""
@@ -434,7 +440,7 @@ export const Userid = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="editorial"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="userid"
 					url=""
@@ -458,7 +464,7 @@ export const PaidFor = () => {
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
-					thumbnailUrl={someImage}
+					imageData={someImageData}
 					headlineText="Rich link headline"
 					contentType="userid"
 					url=""

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -20,7 +20,7 @@ import { Avatar } from '@frontend/web/components/Avatar';
 interface Props {
 	richLinkIndex: number;
 	cardStyle: RichLinkCardType;
-	thumbnailUrl: string;
+	imageData: RichLinkImageData;
 	headlineText: string;
 	contentType: ContentType;
 	url: string;
@@ -30,6 +30,12 @@ interface Props {
 	sponsorName: string;
 	contributorImage?: string;
 	isPlaceholder?: boolean; // use 'true' for server-side default prior to client-side enrichment
+}
+export interface RichLinkImageData {
+	thumbnailUrl: string;
+	altText: string;
+	width: string;
+	height: string;
 }
 
 const neutralBackground = css`
@@ -195,7 +201,7 @@ const imageStyles = css`
 export const RichLink = ({
 	richLinkIndex,
 	cardStyle,
-	thumbnailUrl,
+	imageData,
 	headlineText,
 	contentType,
 	url,
@@ -211,7 +217,10 @@ export const RichLink = ({
 		cardStyle === 'letters' ? `${headlineText} | Letters ` : headlineText;
 
 	const imageCardStyles = ['news', 'letters', 'media', 'feature'];
-	const showImage = thumbnailUrl && imageCardStyles.includes(cardStyle);
+	const showImage =
+		imageData &&
+		imageData.thumbnailUrl &&
+		imageCardStyles.includes(cardStyle);
 	const isPaidContent = tags
 		? tags.filter((t) => t.id === 'tone/advertisement-features').length > 0
 		: false;
@@ -232,7 +241,13 @@ export const RichLink = ({
 					<div css={richLinkTopBorder(palette)} />
 					{showImage && (
 						<div>
-							<img css={imageStyles} src={thumbnailUrl} alt="" />
+							<img
+								css={imageStyles}
+								src={imageData.thumbnailUrl}
+								alt={imageData.altText}
+								width={imageData.width}
+								height={imageData.height}
+							/>
 						</div>
 					)}
 					<div css={richLinkElements}>

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -1,4 +1,4 @@
-import { RichLink } from '@root/src/web/components/RichLink';
+import { RichLink, RichLinkImageData } from '@root/src/web/components/RichLink';
 import { DefaultRichLink } from '@root/src/web/components/DefaultRichLink';
 
 import { useApi } from '@root/src/web/lib/useApi';
@@ -23,6 +23,24 @@ interface CAPIRichLinkType {
 	format: CAPIFormat;
 	starRating?: number;
 	contributorImage?: string;
+	imageAsset: ImageAsset;
+}
+interface ImageAsset {
+	index: number;
+	fields: ImageAssetFields;
+	mediaType: string;
+	url: string;
+}
+interface ImageAssetFields {
+	displayCredit: string;
+	source: string;
+	photographer: string;
+	isMaster: string;
+	altText: string;
+	height: string;
+	credit: string;
+	mediaId: string;
+	width: string;
 }
 
 const buildUrl: (element: RichLinkBlockElement, ajaxUrl: string) => string = (
@@ -58,11 +76,19 @@ export const RichLinkComponent = ({
 		// Only render once data is available
 		return null;
 	}
+
+	const richLinkImageData: RichLinkImageData = {
+		thumbnailUrl: data.thumbnailUrl,
+		altText: data.imageAsset.fields.altText,
+		width: data.imageAsset.fields.width,
+		height: data.imageAsset.fields.height,
+	};
+
 	return (
 		<RichLink
 			richLinkIndex={richLinkIndex}
 			cardStyle={data.cardStyle}
-			thumbnailUrl={data.thumbnailUrl}
+			imageData={richLinkImageData}
 			headlineText={data.headline}
 			contentType={data.contentType}
 			url={data.url}

--- a/src/web/lib/mockRESTCalls.ts
+++ b/src/web/lib/mockRESTCalls.ts
@@ -92,6 +92,23 @@ const richLinkCard = {
 	cardStyle: 'news',
 	thumbnailUrl:
 		'https://i.guim.co.uk/img/media/0847eccb8898d4e91499f8a68c4cfdb454f91382/101_177_3650_2191/master/3650.jpg?width=460&quality=85&auto=format&fit=max&s=ca06880ab92aee625f7b6f691bf3e8c5',
+	imageAsset: {
+		index: 2,
+		fields: {
+			displayCredit: 'true',
+			source: 'RMV/REX/Shutterstock',
+			photographer: 'RMV/REX/Shutterstock',
+			isMaster: 'true',
+			altText: 'Eminem performing at Bonnaroo festival in June.',
+			height: '2191',
+			credit: 'Photograph: RMV/REX/Shutterstock',
+			mediaId: '0847eccb8898d4e91499f8a68c4cfdb454f91382',
+			width: '3650',
+		},
+		mediaType: 'Image',
+		url:
+			'https://media.guim.co.uk/0847eccb8898d4e91499f8a68c4cfdb454f91382/101_177_3650_2191/master/3650.jpg',
+	},
 	headline: 'Eminem attacks Donald Trump on surprise album Kamikaze',
 	contentType: 'Article',
 	contributorImage:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Update richlink images to include alttext, width, and height by passing in this information through the endpoint in the Frontend repo.

This update is further to this endpoint enrichment change: https://github.com/guardian/frontend/pull/23967

### Before
Images were being served without width and height (which can cause layout shift)
Images were not being served with alt text (very bad for accessibility)

### After
images have width, height, and alttext attributes

## Why?
To avoid layout shift and increase accessibility (and keep lighthouse happy)
https://trello.com/c/0f2QE0hw/2899-add-image-dimensions-to-rich-links-on-dcr-and-review-others
