### PR TITLE
Allow amp interactive canonical

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -274,9 +274,11 @@ export const document = ({ data }: Props): string => {
 		JSON.stringify(makeWindowGuardian(data, cssIDs)),
 	);
 
-	// We do not yet support AMP for interactives.
+	const hasAmpInteractiveTag = CAPI.tags.some((tag) => tag.id === 'tracking/platformfunctional/ampinteractive')
+
+	// Only include AMP link for interactives which have the 'ampinteractive' tag
 	const ampLink =
-		CAPI.format.design !== 'InteractiveDesign'
+		CAPI.format.design !== 'InteractiveDesign' || hasAmpInteractiveTag
 			? `https://amp.theguardian.com/${data.CAPI.pageId}`
 			: undefined;
 

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -274,7 +274,9 @@ export const document = ({ data }: Props): string => {
 		JSON.stringify(makeWindowGuardian(data, cssIDs)),
 	);
 
-	const hasAmpInteractiveTag = CAPI.tags.some((tag) => tag.id === 'tracking/platformfunctional/ampinteractive')
+	const hasAmpInteractiveTag = CAPI.tags.some(
+		(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',
+	);
 
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
 	const ampLink =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Allows interactives with the `ampinteractive` tag to have an AMP canonical

## Why?

Lets google find the page
