### PR TITLE
Update atoms-rendering for update quiz fonts

### DIFF
--- a/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -54,7 +54,7 @@ describe('Interactivity', function () {
 				cy.contains('Lifestyle');
 				cy.get('[data-component="most-popular"]').scrollIntoView({
 					duration: 300,
-					offset: { top: 50 },
+					offset: { top: 150 },
 				});
 				cy.wait('@getMostReadGeo');
 				cy.wait('@getMostRead');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^15.0.0",
+    "@guardian/atoms-rendering": "^16.0.0",
     "@guardian/automat-client": "^0.2.17",
     "@guardian/braze-components": "^2.1.0",
     "@guardian/consent-management-platform": "~6.11.5",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -607,6 +607,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 									CAPI.pageId,
 									CAPI.webTitle,
 								)}
+								theme={format.theme}
 							/>
 						)}
 						{quizAtom.quizType === 'knowledge' && (
@@ -618,6 +619,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 									CAPI.pageId,
 									CAPI.webTitle,
 								)}
+								theme={format.theme}
 							/>
 						)}
 					</>

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -470,6 +470,7 @@ export const renderElement = ({
 							questions={element.questions}
 							resultBuckets={element.resultBuckets}
 							sharingUrls={getSharingUrls(pageId, webTitle)}
+							theme={format.theme}
 						/>
 					)}
 					{element.quizType === 'knowledge' && (
@@ -478,6 +479,7 @@ export const renderElement = ({
 							questions={element.questions}
 							resultGroups={element.resultGroups}
 							sharingUrls={getSharingUrls(pageId, webTitle)}
+							theme={format.theme}
 						/>
 					)}
 				</>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,10 +1622,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-15.0.0.tgz#7fc5b3502cae3f4ab44ae86b1ee311fe3931801f"
-  integrity sha512-oN8HWXmSLTt2FujBhKMLK6jKCI3XAIT17W8n+G40OzfM8aLZdZ1MpLQE0hDPNrkSpIt5+YLngSYBSW1r7Sr0RA==
+"@guardian/atoms-rendering@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-16.0.0.tgz#ebcd09cb3fc631fc69f9c466215702c567300612"
+  integrity sha512-Li1rHM2ERvPngPTjqCb26XeIcbxNuk0UV6n5qqz//rZlqbPmnuywzHl9QhsnAFV7dPZhnMbxPILz2mdZOtZNPQ==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps atoms-rendering to 16.0.0 to pick up the updated fonts for quiz atoms. This update gives us consistent serif fonts on question/answers for normal content and consistent sans-serif for labs content.
