### PR TITLE
Add event listener for resetting hydration state between pageviews

### DIFF
--- a/src/web/components/HydrateOnce.tsx
+++ b/src/web/components/HydrateOnce.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, SetStateAction } from 'react';
 import ReactDOM from 'react-dom';
 
 import { initPerf } from '@root/src/web/browser/initPerf';
@@ -11,6 +11,29 @@ type Props = {
 
 const isReady = (dependencies: unknown[]): boolean => {
 	return dependencies.every((dep) => dep !== undefined);
+};
+
+const resetHydrationStateEventName = 'resetHydrationState';
+
+// HOF required to enable removeEventListener
+const setAlreadyHydratedToFalse = () => (
+	setAlreadyHydrated: (value: SetStateAction<boolean>) => void,
+) => {
+	setAlreadyHydrated(false);
+};
+
+// For use in storybook for clicking between components
+export const fireAndResetHydrationState = () => {
+	const event = document.createEvent('HTMLEvents');
+	event.initEvent(resetHydrationStateEventName, true, true);
+	window.dispatchEvent(event);
+	// Remove the event listener, it'll be added again
+	// once hydration has happened
+	window.removeEventListener(
+		resetHydrationStateEventName,
+		setAlreadyHydratedToFalse,
+		false,
+	);
 };
 
 /**
@@ -34,8 +57,8 @@ export const HydrateOnce = ({ rootId, children, waitFor = [] }: Props) => {
 	setAlreadyHydrated(true);
 	// @ts-ignore
 	if (window.STORYBOOK_ENV) {
-		window.addEventListener('storybook:reset', () =>
-			setAlreadyHydrated(false),
+		window.addEventListener(resetHydrationStateEventName, () =>
+			setAlreadyHydratedToFalse()(setAlreadyHydrated),
 		);
 	}
 	return null;

--- a/src/web/components/HydrateOnce.tsx
+++ b/src/web/components/HydrateOnce.tsx
@@ -32,5 +32,11 @@ export const HydrateOnce = ({ rootId, children, waitFor = [] }: Props) => {
 		end();
 	});
 	setAlreadyHydrated(true);
+	// @ts-ignore
+	if (window.STORYBOOK_ENV) {
+		window.addEventListener('storybook:reset', () =>
+			setAlreadyHydrated(false),
+		);
+	}
 	return null;
 };

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -29,6 +29,7 @@ import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
+import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -67,10 +68,7 @@ const convertToImmersive = (CAPI: CAPIType) => ({
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
-	const event = document.createEvent('HTMLEvents');
-	event.initEvent('storybook:reset', true, true);
-	window.dispatchEvent(event);
-
+	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -67,8 +67,11 @@ const convertToImmersive = (CAPI: CAPIType) => ({
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
-	const NAV = extractNAV(ServerCAPI.nav);
+	const event = document.createEvent('HTMLEvents');
+	event.initEvent('storybook:reset', true, true);
+	window.dispatchEvent(event);
 
+	const NAV = extractNAV(ServerCAPI.nav);
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		BootReact({ CAPI, NAV: makeGuardianBrowserNav(NAV) });

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -26,6 +26,7 @@ import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
+import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -51,6 +52,7 @@ const convertToShowcase = (CAPI: CAPIType) => {
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
 
 	useEffect(() => {

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -29,6 +29,7 @@ import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
+import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -58,6 +59,7 @@ const convertToStandard = (CAPI: CAPIType) => {
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
 
 	useEffect(() => {


### PR DESCRIPTION
- When changing between stories in storybook, the hydration state was not reset
- But the 'server render' *was* reset, and so the 'portals' do not end up being rehydrated
- Therefore things like 'comment count' would not show up when clicking between layout files

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before

![2021-06-29 17 40 18](https://user-images.githubusercontent.com/638051/123836051-2d1cf800-d901-11eb-9e3d-7f2dfb8c8eba.gif)


### After

![2021-06-29 17 40 41](https://user-images.githubusercontent.com/638051/123836070-33ab6f80-d901-11eb-9ac6-8ea055d85af0.gif)


## Why?
