### PR TITLE
Double up on scrollIntoView to reduce flakiness

### DIFF
--- a/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -52,9 +52,14 @@ describe('Interactivity', function () {
 			it('should change the list of most viewed items when a tab is clicked', function () {
 				cy.visit(`/Article?url=${articleUrl}`);
 				cy.contains('Lifestyle');
+				// Double up the scrollIntoView to reduce flakiness
+				// with things loading in the meantime
 				cy.get('[data-component="most-popular"]').scrollIntoView({
 					duration: 300,
-					offset: { top: 50 },
+					offset: { top: 100 },
+				});
+				cy.get('[data-component="most-popular"]').scrollIntoView({
+					offset: { top: 0 },
 				});
 				cy.wait('@getMostReadGeo');
 				cy.wait('@getMostRead');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before

### After

## Why?
