### PR TITLE
Restore semantic story layout

### DIFF
--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -22,16 +22,7 @@ const Review = Format(
 		design: Design.Review,
 	},
 	'Review',
-);
-
-const ReviewWithStars = Format(
-	{
-		display: Display.Standard,
-		theme: Pillar.News,
-		design: Design.Review,
-	},
-	'Review',
-	0, // star rating
+	0 // star rating
 );
 
 const Interview = Format(

--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -171,7 +171,6 @@ const Analysis = Format(
 
 export {
 	Review,
-	ReviewWithStars,
 	Interview,
 	Comment,
 	PhotoEssay,

--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -22,7 +22,7 @@ const Review = Format(
 		design: Design.Review,
 	},
 	'Review',
-	0 // star rating
+	0, // star rating
 );
 
 const Interview = Format(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the additional Card story I added in #3149 and just adds stars to the standard `Review` `Card.Design` story. As pointed out by @oliverlloyd we should ideally try and maintain the list of stories within `Design` as a one-to-one mapping with the possible values of `Format.Design` for semantics and  to avoid confusion.
