### PR TITLE
Fix labs sticky ad scroll

### DIFF
--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -333,40 +333,44 @@ export const ShowcaseLayout = ({
 			) : (
 				// Else, this is a labs article so just show Nav and the Labs header
 				<>
-					<Stuck>
-						<Section
-							showTopBorder={false}
-							showSideBorders={false}
-							padded={false}
-						>
-							<HeaderAdSlot
-								isAdFreeUser={CAPI.isAdFreeUser}
-								shouldHideAds={CAPI.shouldHideAds}
-								display={format.display}
-							/>
-						</Section>
-					</Stuck>
-					<Section
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
-						/>
-					</Section>
-
-					<Stuck>
+					<div>
+						<Stuck zIndex="stickyAdWrapper">
+							<Section
+								showTopBorder={false}
+								showSideBorders={false}
+								padded={false}
+							>
+								<HeaderAdSlot
+									isAdFreeUser={CAPI.isAdFreeUser}
+									shouldHideAds={CAPI.shouldHideAds}
+									display={format.display}
+								/>
+							</Section>
+						</Stuck>
+						<Stuck zIndex="stickyAdWrapperNav">
+							<Section
+								showSideBorders={true}
+								borderColour={brandLine.primary}
+								showTopBorder={false}
+								padded={false}
+								backgroundColour={brandBackground.primary}
+							>
+								<Nav
+									nav={NAV}
+									format={{
+										...format,
+										theme: getCurrentPillar(CAPI),
+									}}
+									subscribeUrl={
+										CAPI.nav.readerRevenueLinks.header
+											.subscribe
+									}
+									edition={CAPI.editionId}
+								/>
+							</Section>
+						</Stuck>
+					</div>
+					<Stuck zIndex="stickyAdWrapperLabsHeader">
 						<Section
 							showSideBorders={true}
 							showTopBorder={false}

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -8,17 +8,21 @@ type Props = {
 	children?: React.ReactNode;
 };
 
+type StuckProps = Props & {
+	zIndex?: string;
+};
+
 // The advert is stuck to the top of the container as we scroll
 // until we hit the bottom of the wrapper that contains
 // the top banner and the header/navigation
 // We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
 // classes are tightly coupled.
-const stickyAdWrapper = css`
+const stickyAdWrapper = (zIndex = 'stickyAdWrapper') => css`
 	background-color: white;
 	border-bottom: 0.0625rem solid ${border.secondary};
 	position: sticky;
 	top: 0;
-	${getZIndex('stickyAdWrapper')}
+	${getZIndex(zIndex)}
 `;
 
 const headerWrapper = css`
@@ -39,8 +43,8 @@ const bannerWrapper = css`
 	top: auto !important;
 `;
 
-export const Stuck = ({ children }: Props) => (
-	<div css={stickyAdWrapper}>{children}</div>
+export const Stuck = ({ children, zIndex }: StuckProps) => (
+	<div css={stickyAdWrapper(zIndex)}>{children}</div>
 );
 
 export const SendToBack = ({ children }: Props) => (

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,12 +2,14 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 15;');
-		expect(getZIndex('dropdown')).toBe('z-index: 14;');
-		expect(getZIndex('burger')).toBe('z-index: 13;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 12;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 11;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 10;');
+		expect(getZIndex('banner')).toBe('z-index: 17;');
+		expect(getZIndex('dropdown')).toBe('z-index: 16;');
+		expect(getZIndex('burger')).toBe('z-index: 15;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 14;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 13;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 12;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 11;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 10;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 9;');
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -30,8 +30,10 @@ const indices = [
 	'expanded-veggie-menu-wrapper',
 	'expanded-veggie-menu',
 
-	// Header
+	// Headers with sticky ads
+	'stickyAdWrapperLabsHeader',
 	'stickyAdWrapper',
+	'stickyAdWrapperNav',
 
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix an issue with the sticky ad at the top of a labs showcase article sliding behind the teal Glabs bar, then overlaying the article. Achieve this by allowing `Stuck` components to optionally take a `zIndex` prop which allows the ad, nav and Glabs header to be set to indices independent of each other.

### Before

![before](https://user-images.githubusercontent.com/8000415/123979969-120dbf00-d9b9-11eb-839e-84885f0c40a8.gif)


### After

![after](https://user-images.githubusercontent.com/8000415/123980001-1a65fa00-d9b9-11eb-9049-abc41dc0e699.gif)


## Why?

Stop the bottom portion of the sticky ad from sticking underneath the GLabs bar
