### PR TITLE
Handle Special Report Interview Headlines

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -228,6 +228,60 @@ export const Interview = () => (
 );
 Interview.story = { name: 'Interview (without showcase)' };
 
+export const InterviewSpecialReport = () => (
+	<ElementContainer>
+		<Flex>
+			<LeftColumn>
+				<></>
+			</LeftColumn>
+			<ArticleContainer>
+				<ArticleHeadline
+					headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+					palette={decidePalette({
+						display: Display.Standard,
+						design: Design.Interview,
+						theme: Special.SpecialReport,
+					})}
+					format={{
+						display: Display.Standard,
+						design: Design.Interview,
+						theme: Special.SpecialReport,
+					}}
+					tags={[]}
+					byline="Byline text"
+				/>
+				<Standfirst
+					format={{
+						display: Display.Standard,
+						design: Design.Interview,
+						theme: Special.SpecialReport,
+					}}
+					standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
+				/>
+				<MainMedia
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Special.SpecialReport,
+					}}
+					palette={decidePalette({
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Special.SpecialReport,
+					})}
+					hideCaption={true}
+					elements={mainMediaElements}
+					pageId="testID"
+					webTitle="story article"
+				/>
+			</ArticleContainer>
+		</Flex>
+	</ElementContainer>
+);
+InterviewSpecialReport.story = {
+	name: 'Interview Special Report (without showcase)',
+};
+
 export const InterviewNoByline = () => (
 	<ElementContainer>
 		<Flex>

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -35,7 +35,10 @@ const textHeadline = (format: Format): string => {
 		case Display.Showcase:
 		case Display.NumberedList:
 		case Display.Standard: {
-			if (format.theme === Special.SpecialReport)
+			if (
+				format.theme === Special.SpecialReport &&
+				format.design !== Design.Interview
+			)
 				return specialReport[100];
 			switch (format.design) {
 				case Design.Review:


### PR DESCRIPTION
## What does this change?

Special Report Interview Headlines need special handling as their background colour is inverted.

+ new story to cover it

### Before
![image](https://user-images.githubusercontent.com/638051/124131244-83ac4280-da77-11eb-9597-2cfdffcac7ba.png)

### After
![image](https://user-images.githubusercontent.com/638051/124131204-78f1ad80-da77-11eb-8186-b3a6ab510bc4.png)
