### PR TITLE
Keep the console tidy!

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -1,3 +1,5 @@
+import { log } from '@guardian/libs';
+
 export const initPerf = (
 	name: string,
 ): { start: () => void; end: () => number; clear: () => void } => {
@@ -25,7 +27,7 @@ export const initPerf = (
 		perf.measure(name, startKey, endKey);
 
 		// eslint-disable-next-line no-console
-		console.log(JSON.stringify(perf.getEntriesByName(name)));
+		log('dotcom', JSON.stringify(perf.getEntriesByName(name)));
 
 		const measureEntries = perf.getEntriesByName(name, 'measure');
 		const timeTakenFloat =


### PR DESCRIPTION
## What does this change?

Requires developers to register to the proper team to see console logs.

For example, Dotcom devs can use:
```ts
window.guardian.logger.subscribeTo('dotcom');
```

# Screenshot comparison table

| Before      | After (subscribed) | After (unsubscribed)
|-------------|--------------------|---------------------
| ![before][] | ![after][]         | _empty console_

[before]: https://user-images.githubusercontent.com/76776/124258290-396ca500-dafb-11eb-9d5d-c4290494c84f.png
[after]: https://user-images.githubusercontent.com/76776/124259175-3aea9d00-dafc-11eb-87ca-f14092ad68e2.png

## Why?

It’s nicer when we work together :)
