### PR TITLE
Prevent catastrophic failure if getEntriesByName doesn't exist

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -7,8 +7,8 @@ export const initPerf = (
 	const startKey = `${name}-start`;
 	const endKey = `${name}-end`;
 
-	if (!perf) {
-		// Return noops if window.performance does not exist
+	if (!perf || !perf.getEntriesByName) {
+		// Return noops if window.performance or the required functions don't exist
 		return {
 			start: () => {},
 			end: () => 0,


### PR DESCRIPTION
## What does this change?

Checks for existence of perf function in browser before using it.

### Before

Safari 10 fails to load any JS

### After

Safari 10 loads JS


