### PR TITLE
Fix Broken Timelines

### DIFF
--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -556,6 +556,7 @@ export const renderElement = ({
 					title={element.title}
 					pillar={format.theme}
 					events={element.events}
+					description={element.description}
 					likeHandler={() => {}}
 					dislikeHandler={() => {}}
 					expandCallback={() => {}}


### PR DESCRIPTION
## What does this change?

Some timelines have started to appear broken (descriptions being replaced with duplicate events) with the introduction of the `ElementRender`, this adds the missing prop in that class which has fixed the timeline atoms.

### Before

<img width="771" alt="Screenshot 2021-07-05 at 12 39 10" src="https://user-images.githubusercontent.com/35331926/124466731-d2671e80-dd8e-11eb-8f2e-d96c7ade9979.png">

### After

<img width="687" alt="Screenshot 2021-07-05 at 12 41 29" src="https://user-images.githubusercontent.com/35331926/124466763-dbf08680-dd8e-11eb-98f5-d530dc594791.png">

## Why?

'Cos it was broken