### PR TITLE
Send labels for epic insert + view events

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -44,9 +44,13 @@ export const submitComponentEvent = (
 	ophanRecord({ componentEvent });
 };
 
+export interface SdcTestMeta extends TestMeta {
+	labels?: string[];
+}
+
 export const sendOphanComponentEvent = (
 	action: OphanAction,
-	testMeta: TestMeta,
+	testMeta: SdcTestMeta,
 	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
 ): void => {
 	const {
@@ -55,6 +59,7 @@ export const sendOphanComponentEvent = (
 		componentType,
 		products = [],
 		campaignCode,
+		labels,
 	} = testMeta;
 
 	const componentEvent: OphanComponentEvent = {
@@ -63,6 +68,7 @@ export const sendOphanComponentEvent = (
 			products,
 			campaignCode,
 			id: testMeta.campaignId || testMeta.campaignCode,
+			labels,
 		},
 		abTest: {
 			name: abTestName,

--- a/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -23,7 +23,7 @@ import {
 	OphanComponentEvent,
 	sendOphanComponentEvent,
 	submitComponentEvent,
-	TestMeta,
+	SdcTestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { Metadata } from '@guardian/automat-client/dist/types';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
@@ -34,7 +34,7 @@ import { useHasBeenSeen } from '../../lib/useHasBeenSeen';
 type HasBeenSeen = [boolean, (el: HTMLDivElement) => void];
 
 type PreEpicConfig = {
-	meta: TestMeta;
+	meta: SdcTestMeta;
 	module: {
 		url: string;
 		props: { [key: string]: any };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Send labels for epic insert + view events. This is so we can use the labels field to distinguish "super mode" epic views from ordinary views.

In discussing this, we noticed that the `TestMeta` type is only used by us (contributions) and probably doesn't belong along with the other ophan types. In fact, we actually also provide the same data to the modules themselves through the props, so to avoid double sending it and also having to make tweaks across dcr and frontend, we've created a ticket to update the components to send their own events and remove the `meta` object from the platforms. For the time being, this PR will do the job though! 