### PR TITLE
Stop Inverse Headings Being Cut Off

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -74,6 +74,7 @@ const invertedFont = css`
 	line-height: 42px;
 	${until.tablet} {
 		${headline.small({ fontWeight: 'bold' })};
+		line-height: 35px;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Previously, when inverse headlines were viewed in mobile format any hanging letters would be cut off at the bottom. The changes the line height below tablet size to stop this from happening.

### Before

<img width="329" alt="Screenshot 2021-07-06 at 09 39 50" src="https://user-images.githubusercontent.com/35331926/124573574-9640c600-de41-11eb-84de-02855ff27daf.png">

### After

<img width="329" alt="Screenshot 2021-07-06 at 09 54 26" src="https://user-images.githubusercontent.com/35331926/124573598-9b9e1080-de41-11eb-85e7-e2b85d7288cf.png">

## Why?

Looks better innit.