### PR TITLE
Activate Sub-Parent For Genre

### DIFF
--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -98,7 +98,7 @@ const linkStyle = css`
 `;
 
 const selected = css`
-	font-weight: 700;
+	font-weight: 700 !important;
 `;
 
 const spaceBetween = css`

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -98,7 +98,7 @@ const linkStyle = css`
 `;
 
 const selected = css`
-	font-weight: 700 !important;
+	font-weight: 700;
 `;
 
 const spaceBetween = css`
@@ -127,8 +127,10 @@ const showMoreStyle = css`
 `;
 
 const parentLinkStyle = css`
+	.li {
+		font-weight: 700;
+	}
 	${linkStyle};
-	font-weight: 700;
 `;
 
 const listItemStyles = (palette: Palette) => css`
@@ -204,17 +206,18 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 				{subNavSections.links.map((link) => (
 					<li key={link.url}>
 						<a
-							css={[
-								linkStyle,
-								link.title === currentNavLink && selected,
-							]}
+							css={linkStyle}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(
 								link.url,
 							)}`}
 						>
-							{link.title}
+							{link.title === currentNavLink ? (
+								<span css={selected}>{link.title}</span>
+							) : (
+								link.title
+							)}
 						</a>
 					</li>
 				))}

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -126,13 +126,6 @@ const showMoreStyle = css`
 	}
 `;
 
-const parentLinkStyle = css`
-	.li {
-		font-weight: 700;
-	}
-	${linkStyle};
-`;
-
 const listItemStyles = (palette: Palette) => css`
 	:after {
 		content: '';
@@ -196,7 +189,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 					>
 						<a
 							data-src-focus-disabled={true}
-							css={parentLinkStyle}
+							css={linkStyle}
 							href={subNavSections.parent.url}
 						>
 							{subNavSections.parent.title}


### PR DESCRIPTION
## What does this change?

**Update:** The use of `!important` has been removed. 

Subnavs are not being highlighted for the correct article. Bizarrely this behaviour works for mobile but the CSS gets overridden on larger displays.

### Before

![Screenshot 2021-07-06 at 16 39 16](https://user-images.githubusercontent.com/35331926/124629490-67464680-de79-11eb-9bc4-4a9c81578842.png)

### After

![Screenshot 2021-07-06 at 16 40 08](https://user-images.githubusercontent.com/35331926/124629511-6d3c2780-de79-11eb-9504-a641e7178f4f.png)

## Why?

Looks better.