### PR TITLE
Dynamically load components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -813,16 +813,6 @@ interface CalloutBlockLoadable extends ComponentNameChunkMap {
     addWhen: CalloutBlockElement['_type'];
 }
 
-interface QABlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-QABlockComponent';
-    addWhen: QABlockElement['_type'];
-}
-
-interface TimelineBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-TimelineBlockComponent';
-    addWhen: TimelineBlockElement['_type'];
-}
-
 interface DocumentBlockLoadable extends ComponentNameChunkMap {
     chunkName: 'elements-DocumentBlockComponent';
     addWhen: DocumentBlockElement['_type'];

--- a/index.d.ts
+++ b/index.d.ts
@@ -827,7 +827,7 @@ interface InstagramBlockLoadable extends ComponentNameChunkMap {
     addWhen: InstagramBlockElement['_type'];
 }
 interface MapBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-MapBlockComponent';
+    chunkName: 'elements-MapEmbedBlockComponent';
     addWhen: MapBlockElement['_type'];
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -808,6 +808,11 @@ interface InteractiveBlockLoadable extends ComponentNameChunkMap {
     addWhen: InteractiveBlockElement['_type'];
 }
 
+interface InteractiveContentsBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-InteractiveContentsBlockComponent';
+    addWhen: InteractiveContentsBlockElement['_type'];
+}
+
 interface CalloutBlockLoadable extends ComponentNameChunkMap {
     chunkName: 'elements-CalloutBlockComponent';
     addWhen: CalloutBlockElement['_type'];
@@ -851,6 +856,7 @@ type LoadableComponents = [
 	YoutubeBlockLoadable,
 	RichLinkBlockLoadable,
 	InteractiveBlockLoadable,
+	InteractiveContentsBlockLoadable,
 	CalloutBlockLoadable,
 	DocumentBlockLoadable,
 	EmbedBlockLoadable,

--- a/index.d.ts
+++ b/index.d.ts
@@ -803,13 +803,73 @@ interface RichLinkBlockLoadable extends ComponentNameChunkMap {
     addWhen: RichLinkBlockElement['_type'];
 }
 
-interface InteractiveBlockLoadaable extends ComponentNameChunkMap {
+interface InteractiveBlockLoadable extends ComponentNameChunkMap {
     chunkName: 'elements-InteractiveBlockComponent';
     addWhen: InteractiveBlockElement['_type'];
 }
 
+interface CalloutBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-CalloutBlockComponent';
+    addWhen: CalloutBlockElement['_type'];
+}
+
+interface QABlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-QABlockComponent';
+    addWhen: QABlockElement['_type'];
+}
+
+interface TimelineBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-TimelineBlockComponent';
+    addWhen: TimelineBlockElement['_type'];
+}
+
+interface DocumentBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-DocumentBlockComponent';
+    addWhen: DocumentBlockElement['_type'];
+}
+interface EmbedBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-EmbedBlockComponent';
+    addWhen: EmbedBlockElement['_type'];
+}
+
+interface InstagramBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-InstagramBlockComponent';
+    addWhen: InstagramBlockElement['_type'];
+}
+interface MapBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-MapBlockComponent';
+    addWhen: MapBlockElement['_type'];
+}
+
+interface SpotifyBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-SpotifyBlockComponent';
+    addWhen: SpotifyBlockElement['_type'];
+}
+
+interface FacebookVideoBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-FacebookVideoBlockComponent';
+    addWhen: VideoFacebookBlockElement['_type'];
+}
+interface VineBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-VineBlockComponent';
+    addWhen: VineBlockElement['_type'];
+}
+
 // There are docs on loadable in ./docs/loadable-components.md
-type LoadableComponents = [EditionDropdownLoadable, YoutubeBlockLoadable, RichLinkBlockLoadable, InteractiveBlockLoadaable]
+type LoadableComponents = [
+	EditionDropdownLoadable,
+	YoutubeBlockLoadable,
+	RichLinkBlockLoadable,
+	InteractiveBlockLoadable,
+	CalloutBlockLoadable,
+	DocumentBlockLoadable,
+	EmbedBlockLoadable,
+	InstagramBlockLoadable,
+	MapBlockLoadable,
+	SpotifyBlockLoadable,
+	FacebookVideoBlockLoadable,
+	VineBlockLoadable,
+]
 
 interface CarouselImagesMap {
 	'300'?: string;

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -4,7 +4,6 @@ import { useAB } from '@guardian/ab-react';
 import { tests } from '@frontend/web/experiments/ab-tests';
 import { ShareCount } from '@frontend/web/components/ShareCount';
 import { MostViewedFooter } from '@frontend/web/components/MostViewed/MostViewedFooter/MostViewedFooter';
-import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { SlotBodyEnd } from '@root/src/web/components/SlotBodyEnd/SlotBodyEnd';
 import { Links } from '@frontend/web/components/Links';
@@ -61,14 +60,6 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { updateIframeHeight } from '@root/src/web/browser/updateIframeHeight';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import { LabsHeader } from '@root/src/web/components/LabsHeader';
-import { DocumentBlockComponent } from '@root/src/web/components/elements/DocumentBlockComponent';
-import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
-import { UnsafeEmbedBlockComponent } from '@root/src/web/components/elements/UnsafeEmbedBlockComponent';
-import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
-import { MapEmbedBlockComponent } from '@root/src/web/components/elements/MapEmbedBlockComponent';
-import { SpotifyBlockComponent } from '@root/src/web/components/elements/SpotifyBlockComponent';
-import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
-import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
@@ -426,6 +417,186 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		},
 		{
 			resolveComponent: (module) => module.InteractiveBlockComponent,
+		},
+	);
+
+	const CalloutBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.CalloutBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/CalloutBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.CalloutBlockComponent,
+		},
+	);
+
+	const DocumentBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.DocumentBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/DocumentBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.DocumentBlockComponent,
+		},
+	);
+
+	const EmbedBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.EmbedBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/EmbedBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.EmbedBlockComponent,
+		},
+	);
+
+	const UnsafeEmbedBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.EmbedBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/UnsafeEmbedBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.UnsafeEmbedBlockComponent,
+		},
+	);
+
+	const InstagramBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.InstagramBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/InstagramBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.InstagramBlockComponent,
+		},
+	);
+
+	const MapEmbedBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.MapBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/MapEmbedBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.MapEmbedBlockComponent,
+		},
+	);
+
+	const SpotifyBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.SpotifyBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/SpotifyBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.SpotifyBlockComponent,
+		},
+	);
+
+	const VideoFacebookBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.VideoFacebookBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/VideoFacebookBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.VideoFacebookBlockComponent,
+		},
+	);
+
+	const VineBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.VineBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/VineBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.VineBlockComponent,
 		},
 	);
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -60,7 +60,6 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { updateIframeHeight } from '@root/src/web/browser/updateIframeHeight';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import { LabsHeader } from '@root/src/web/components/LabsHeader';
-import { InteractiveContentsBlockElement } from '@root/src/web/components/elements/InteractiveContentsBlockElement';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
@@ -429,6 +428,26 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		},
 		{
 			resolveComponent: (module) => module.InteractiveBlockComponent,
+		},
+	);
+
+	const InteractiveContentsBlockElement = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/InteractiveContentsBlockElement'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.InteractiveContentsBlockElement,
 		},
 	);
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -447,7 +447,8 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			return Promise.reject();
 		},
 		{
-			resolveComponent: (module) => module.InteractiveContentsBlockElement,
+			resolveComponent: (module) =>
+				module.InteractiveContentsBlockElement,
 		},
 	);
 

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -117,6 +117,11 @@ export const document = ({ data }: Props): string => {
 				'model.dotcomrendering.pageElements.InteractiveBlockElement',
 		},
 		{
+			chunkName: 'elements-InteractiveContentsBlockComponent',
+			addWhen:
+				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+		},
+		{
 			chunkName: 'elements-CalloutBlockComponent',
 			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
 		},

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -116,6 +116,39 @@ export const document = ({ data }: Props): string => {
 			addWhen:
 				'model.dotcomrendering.pageElements.InteractiveBlockElement',
 		},
+		{
+			chunkName: 'elements-CalloutBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
+		},
+		{
+			chunkName: 'elements-DocumentBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.DocumentBlockElement',
+		},
+		{
+			chunkName: 'elements-EmbedBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+		},
+		{
+			chunkName: 'elements-InstagramBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+		},
+		{
+			chunkName: 'elements-MapBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
+		},
+		{
+			chunkName: 'elements-SpotifyBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
+		},
+		{
+			chunkName: 'elements-FacebookVideoBlockComponent',
+			addWhen:
+				'model.dotcomrendering.pageElements.VideoFacebookBlockElement',
+		},
+		{
+			chunkName: 'elements-VineBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.VineBlockElement',
+		},
 	];
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -133,7 +133,7 @@ export const document = ({ data }: Props): string => {
 			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
 		},
 		{
-			chunkName: 'elements-MapBlockComponent',
+			chunkName: 'elements-MapEmbedBlockComponent',
 			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
 		},
 		{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
We were dynamically loading: 
-EditionDropdown
-YoutubeBlock
-RichLinkBlock
-InteractiveBlock

### After
We are dynamically loading:
-EditionDropdown
-YoutubeBlock
-RichLinkBlock
-InteractiveBlock
-CalloutBlock
-QABlock
-TimelineBlock
-DocumentBlock
-EmbedBlock
-InstagramBlock
-MapBlock
-SpotifyBlock
-FacebookVideoBlock
-VineBlock

## Why?
Page speed and core web vitals: Load javascript bundles based on the needs of the article 
