### PR TITLE
Allow iframes in interactive sanitisation

### DIFF
--- a/src/model/clean.ts
+++ b/src/model/clean.ts
@@ -23,5 +23,6 @@ export const clean = compose(
 	DOMPurify.sanitize,
 );
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-export const sanitiseHTML = (html: string): string => DOMPurify.sanitize(html);
+export const sanitiseHTML = (html: string, opts?: any): string =>
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	DOMPurify.sanitize(html, opts);

--- a/src/model/enhance-interactive-atom-elements.ts
+++ b/src/model/enhance-interactive-atom-elements.ts
@@ -10,7 +10,8 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 			'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
 		)
 			element.html = element.html
-				? sanitiseHTML(element.html)
+				? // Allow iframes, this is for youtube embeds in interactives, etc
+				  sanitiseHTML(element.html, { ADD_TAGS: ['iframe'] })
 				: element.html;
 		return element;
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Iframes were being removed as part of the interactive sanitisation

### Before

![image](https://user-images.githubusercontent.com/9575458/124746322-a2e41d80-df18-11eb-9912-5888fd232306.png)

### After

![image](https://user-images.githubusercontent.com/9575458/124746257-92cc3e00-df18-11eb-944d-7d6e492a11f2.png)

## Why?

Missing content
