### PR TITLE
Center legacy container class

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -541,7 +541,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		<React.StrictMode>
 			{[
 				CAPI.config.switches.commercialMetrics,
-				window.guardian.config.ophan !== undefined,
+				window.guardian.config?.ophan !== undefined,
 			].every(Boolean) && (
 				<CommercialMetrics
 					browserId={browserId}

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -16,6 +16,7 @@ export const interactiveLegacyClasses = {
 // Styles expected by interactives from the Frontend days. These shouldn't be
 // used for new interactives though.
 export const interactiveGlobalStyles = css`
+	.fc-container__inner,
 	.gs-container {
 		${center}
 	}


### PR DESCRIPTION
## What does this change?

Center legacy container class. Note, this doesn't achieve parity, but is acceptable now.

### Before (extends too wide)

![Screenshot 2021-07-08 at 10 40 22](https://user-images.githubusercontent.com/858402/124900746-47c62f80-dfd9-11eb-8f69-50d30aa633e9.png)

### After (same as other containers)
![Screenshot 2021-07-08 at 10 39 47](https://user-images.githubusercontent.com/858402/124900804-53b1f180-dfd9-11eb-85a9-27ccea74829b.png)


## Why?

Used (among others) by documentaries to center the 'More documentaries' container below the main video.