### PR TITLE
Add Obituary Design Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,8 @@ type CAPIDesign =
 	| 'QuizDesign'
 	| 'InteractiveDesign'
 	| 'PhotoEssayDesign'
-	| 'PrintShopDesign';
+	| 'PrintShopDesign'
+	| 'ObituaryDesign';
 
 // CAPIDisplay is the display information passed through from CAPI and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@guardian/src-radio": "^3.6.0",
     "@guardian/src-text-area": "^3.6.0",
     "@guardian/src-text-input": "^3.6.0",
-    "@guardian/types": "^6.1.0",
+    "@guardian/types": "^7.0.0",
     "@hkdobrev/run-if-changed": "^0.3.1",
     "@loadable/component": "^5.14.1",
     "@loadable/server": "^5.14.2",

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2108,6 +2108,7 @@
                 "LiveBlogDesign",
                 "MatchReportDesign",
                 "MediaDesign",
+                "ObituaryDesign",
                 "PhotoEssayDesign",
                 "PrintShopDesign",
                 "QuizDesign",

--- a/src/web/lib/decideDesign.ts
+++ b/src/web/lib/decideDesign.ts
@@ -40,6 +40,8 @@ export const decideDesign = (format: CAPIFormat): Design => {
 			return Design.PhotoEssay;
 		case 'PrintShopDesign':
 			return Design.PrintShop;
+		case 'ObituaryDesign':
+			return Design.Obituary;
 		default:
 			return Design.Article;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,10 +1798,10 @@
     "@guardian/src-helpers" "^3.6.0"
     "@guardian/src-icons" "^3.6.0"
 
-"@guardian/types@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.1.0.tgz#5189c34c5cc4da1e549f70706c78276fa69ef7d3"
-  integrity sha512-CP1bmqOutfG/hLQrAzBaqj9EitCNPJQ1qTyHfiCAElFsWKofYuEzMgHYM2ut5nSrkSC+n0AhXUt3qItl+2A3eQ==
+"@guardian/types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-7.0.0.tgz#9800b8cfdb6add97883b2f04c9ab8373fa29b19b"
+  integrity sha512-mS12S8DhXajFMqtgSuFktA/6dCvpJO3EuT00g7sA5FUglzfUFVHAPhvrX8qlUUZK4oaEHrPf/XkLQBGVrNLzoQ==
 
 "@hapi/hoek@^9.0.0":
   version "9.1.0"


### PR DESCRIPTION
## What does this change?
Adds the Obituary Design Type to DCR. The bump was made in TS types repo and scala CAPI client but not reflected in DCR causing 500s on PROD.

## Before

![image](https://user-images.githubusercontent.com/638051/125044269-b5cf2d00-e093-11eb-93d2-2302e50859d1.png)

## After

![image](https://user-images.githubusercontent.com/638051/125044531-f2028d80-e093-11eb-9cdf-245d8a811e43.png)
