### PR TITLE
Use the correct element Chunk Name for Facebook Video in Loadable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -843,7 +843,7 @@ interface SpotifyBlockLoadable extends ComponentNameChunkMap {
 }
 
 interface FacebookVideoBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-FacebookVideoBlockComponent';
+    chunkName: 'elements-VideoFacebookBlockComponent';
     addWhen: VideoFacebookBlockElement['_type'];
 }
 interface VineBlockLoadable extends ComponentNameChunkMap {

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -146,7 +146,7 @@ export const document = ({ data }: Props): string => {
 			addWhen: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
 		},
 		{
-			chunkName: 'elements-FacebookVideoBlockComponent',
+			chunkName: 'elements-VideoFacebookBlockComponent',
 			addWhen:
 				'model.dotcomrendering.pageElements.VideoFacebookBlockElement',
 		},


### PR DESCRIPTION
## What does this change?
Loadable chunk extractor gets the chunk using a filename, but it seemed we'd got the filename slightly wrong and therefore loadable couldn't find it on the server-side and was failing.

