### PR TITLE
Fix Braze Epic Rendering

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -101,7 +101,7 @@ const buildEpicProps = (
 			return null;
 		},
 		(variant) => {
-			const pageTracking = {
+			const tracking = {
 				ophanPageId: window.guardian.config.ophan.pageViewId,
 				platformId: 'GUARDIAN_WEB',
 				clientName: 'dcr',
@@ -117,10 +117,6 @@ const buildEpicProps = (
 				abTestVariant: '',
 				campaignCode: '',
 				componentType: 'ACQUISITIONS_EPIC',
-			};
-
-			const tracking = {
-				...pageTracking,
 			};
 
 			const articleCounts = {

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -44,10 +44,15 @@ type Tracking = {
 	referrerUrl: string;
 };
 
+type ArticleCounts = {
+	for52Weeks: number;
+	forTargetedWeeks: number;
+};
+
 type EpicProps = {
 	variant: Variant;
 	tracking: Tracking;
-	numArticles: number;
+	articleCounts: ArticleCounts;
 	countryCode: string;
 };
 
@@ -101,13 +106,29 @@ const buildEpicProps = (
 				platformId: 'GUARDIAN_WEB',
 				clientName: 'dcr',
 				referrerUrl: window.location.origin + window.location.pathname,
+
+				// We need to pass these props in order to pass the
+				// ContributionsEpic validation. This doesn't feel
+				// great, so I think a better solution will be to create our own
+				// epic component, with the same look and feel, in
+				// @guardian/braze-components which doesn't have the same prop
+				// requirements.
+				abTestName: '',
+				abTestVariant: '',
+				campaignCode: '',
+				componentType: 'ACQUISITIONS_EPIC',
 			};
 
 			const tracking = {
 				...pageTracking,
 			};
 
-			return { variant, tracking, numArticles: 0, countryCode };
+			const articleCounts = {
+				for52Weeks: 0,
+				forTargetedWeeks: 0,
+			};
+
+			return { variant, tracking, articleCounts, countryCode };
 		},
 	)(variantResult);
 };

--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -19,6 +19,7 @@ describe('parseBrazeEpicParams', () => {
 		};
 
 		const expected = ok({
+			name: 'CONTROL',
 			heading: 'Example Heading',
 			paragraphs: ['Paragraph 1', 'Paragraph 2', 'Paragraph 3'],
 			highlightedText: 'Example highlighted text',
@@ -44,6 +45,7 @@ describe('parseBrazeEpicParams', () => {
 		};
 
 		const expected = ok({
+			name: 'CONTROL',
 			heading: 'Example Heading',
 			paragraphs: ['First paragraph', 'Another paragraph'],
 			highlightedText: 'Example highlighted text',
@@ -68,6 +70,7 @@ describe('parseBrazeEpicParams', () => {
 		};
 
 		const expected = ok({
+			name: 'CONTROL',
 			paragraphs: ['Paragraph 1', 'Paragraph 2', 'Paragraph 3'],
 			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
 			ophanComponentId: 'epic_123',

--- a/src/web/lib/braze/parseBrazeEpicParams.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.ts
@@ -27,6 +27,7 @@ export type Variant = {
 		baseUrl: string;
 	};
 	ophanComponentId: string;
+	name: string;
 };
 
 const parseParagraphs = (dataFromBraze: EpicDataFromBraze): string[] => {
@@ -67,6 +68,7 @@ export const parseBrazeEpicParams = (
 	}
 
 	const variant = {
+		name: 'CONTROL', // A name is required by the ContributionsEpic component
 		heading: dataFromBraze.heading,
 		paragraphs,
 		highlightedText: dataFromBraze.highlightedText,


### PR DESCRIPTION
## What does this change?

Short term fix for an issue where some [additional validation was added to the `ContributionsEpic` component] which Braze uses to render epic messages. This adds some missing params required by the validation (which I don't think are actually used in our case) to get the epic rendering again.

Slightly longer term this has made really clear the fragility of relying on the support-dotcom-components epic for Braze messages. We're going to migrate our own version of the epic into `@guardian/braze-components` which will make us more robust to issues like this.

### Before

Braze campaigns using the Epic component not rendering.

### After

Braze campaigns using the Epic component rendering as expected.

## Why?
