### PR TITLE
remove multiple lines on subnav

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -659,7 +659,7 @@ export const CommentLayout = ({
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -692,7 +692,7 @@ export const ImmersiveLayout = ({
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -258,7 +258,7 @@ export const InteractiveImmersiveLayout = ({
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -588,7 +588,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						palette={palette}
 					/>
 
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -570,7 +570,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -634,7 +634,7 @@ export const ShowcaseLayout = ({
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -726,7 +726,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
 					/>
-					<Lines count={4} effect="straight" />
+					<Lines count={1} effect="straight" />
 				</ElementContainer>
 			)}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
layouts included 4 horizontal lines in the sub nav, which didn't match the expected design.
![incorrect-subnav](https://user-images.githubusercontent.com/45561419/125495812-92c52b39-7663-47b4-a865-7303dc84a233.png)

### After
layouts have only a single horizontal line in the subnav.
<img width="1559" alt="Screenshot 2021-07-13 at 18 08 17" src="https://user-images.githubusercontent.com/45561419/125495723-318d409e-5713-4eaf-90af-fecf5c4e4197.png">

## Why?
fix layouts to match intended designs.

some notes:
- i validated layouts using `make dev` as well as storybook, ensuring all the layout types defined in DecideLayout.tsx were correctly updated (amp layouts not affected by this issue).
- i was uneasy about having to make the same change in multiple locations. we wondered if it is something that could be encapsulated within subnav - @nicl?
