### PR TITLE
Add test around checking Braze dependencies when user isn't signed in

### DIFF
--- a/src/web/lib/braze/checkBrazeDependencies.test.ts
+++ b/src/web/lib/braze/checkBrazeDependencies.test.ts
@@ -161,6 +161,38 @@ describe('checkBrazeDependecies', () => {
 		}
 	});
 
+	it('fails when the user is not signed in', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockConsentsPromise = Promise.resolve(true);
+
+		const isSignedIn = false;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeUuid');
+			expect(got.failure.data).toEqual(null);
+		}
+	});
+
 	it('fails if the required consents are not given', async () => {
 		setWindow({
 			guardian: {


### PR DESCRIPTION
## What does this change?

Adds a missing test scenario to `checkBrazeDependencies.test.ts`. I noticed this case was missing while working on something related.

### Before

No test coverage for the scenario where we're checking the dependencies needed to load the Braze web SDK and the user isn't signed in.

### After

Test coverage for the scenario above.

## Why?

Increased confidence when making changes to this code.
