### PR TITLE
Allow scripts in interactive atom HTML

### DIFF
--- a/src/model/enhance-interactive-atom-elements.ts
+++ b/src/model/enhance-interactive-atom-elements.ts
@@ -4,19 +4,18 @@ import { sanitiseHTML } from '@root/src/model/clean';
 // preserve (approximate) parity with Frontend we perform some basic
 // cleaning.
 const enhance = (elements: CAPIElement[]): CAPIElement[] => {
-	elements.map((element) => {
+	return elements.map((element) => {
 		if (
 			element._type ===
 			'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
-		)
+		) {
 			element.html = element.html
-				? // Allow iframes, this is for youtube embeds in interactives, etc
-				  sanitiseHTML(element.html, { ADD_TAGS: ['iframe'] })
+				? sanitiseHTML(element.html, { ADD_TAGS: ['iframe', 'script'] })
 				: element.html;
+		}
+
 		return element;
 	});
-
-	return elements;
 };
 
 export const enhanceInteractiveAtomElements = (data: CAPIType): CAPIType => {


### PR DESCRIPTION
## What does this change?

Allow scripts in interactive atom HTML

### Before
![Screenshot 2021-07-15 at 10 08 06](https://user-images.githubusercontent.com/858402/125762591-595396d3-ac34-43ae-b681-05aaabcfb748.png)

### After
![Screenshot 2021-07-15 at 10 07 48](https://user-images.githubusercontent.com/858402/125762621-02a0f160-0915-4144-b29a-a02c94e417a2.png)

## Why?

Some require this, e.g.

https://www.theguardian.com/destination-nsw-road-trips/ng-interactive/2021/mar/12/from-vineyards-to-waterfalls-and-sand-dunes-12-road-trips-to-seek-out-in-nsw
