### PR TITLE
Bump @braze/web-sdk-core NPM package to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "*": "lint"
   },
   "dependencies": {
-    "@braze/web-sdk-core": "3.2.0",
+    "@braze/web-sdk-core": "3.3.0",
     "@cypress/skip-test": "^2.6.0",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,10 +1316,10 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@braze/web-sdk-core@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@braze/web-sdk-core/-/web-sdk-core-3.2.0.tgz#9168ffecc9301a3f9bf816050b0937798458235d"
-  integrity sha512-43lBSQGIZnmbA82jm5Y0yhXiWRIX60UmVD94BET82pNnY3zqGv5Az4/JaWq0E7Eq3Xrh20yXt/ZPb9mExH46Og==
+"@braze/web-sdk-core@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk-core/-/web-sdk-core-3.3.0.tgz#bfe299938525fd8501625fded49467b37db65e65"
+  integrity sha512-Gs5S4DkTlJsjxZzHeIw27jX1FfoaeM4IflxXx6l2ISXbIRP/UH4wlGUtp3Yvvf8gIwKjdLurekplcRMPvuF1gg==
 
 "@chromaui/localtunnel@^2.0.2":
   version "2.0.2"


### PR DESCRIPTION
## What does this change?

Bumps the version of [`@braze/web-sdk-core`](https://www.npmjs.com/package/@braze/web-sdk-core) we're using to the latest version.

### Before

v3.2.0

### After

v3.3.0

## Notes

Here's a banner rendering via the the upgraded SDK on code:

![Screenshot 2021-07-15 at 14 19 34](https://user-images.githubusercontent.com/379839/125795051-99fcde82-0fca-4de0-92ee-2ad9f9597c24.png)

