### PR TITLE
Add tests for interactive atom enhancer

### DIFF
--- a/src/model/enhance-interactive-atom-elements.test.ts
+++ b/src/model/enhance-interactive-atom-elements.test.ts
@@ -1,0 +1,44 @@
+import { enhance } from './enhance-interactive-atom-elements';
+
+const getData = (): InteractiveAtomBlockElement => ({
+	_type: 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+	elementId: 'socrates',
+	url: 'example.com/boom',
+	id: 'socrates-abc',
+	js: '',
+	html: '',
+});
+
+describe('Enhance interactive atoms', () => {
+	it('cleans dirty HTML', () => {
+		const data = getData();
+		data.html = '<div foo</div>';
+		const got = enhance([data])[0] as InteractiveAtomBlockElement;
+
+		expect(got.html).toBe('<div></div>');
+	});
+
+	it('preserves scripts', () => {
+		const data = getData();
+		data.html = 'Foo bar <script></script>';
+		const got = enhance([data])[0] as InteractiveAtomBlockElement;
+
+		expect(got.html).toBe('Foo bar <script></script>');
+	});
+
+	it('preserves iframes', () => {
+		const data = getData();
+		data.html = 'Foo bar <iframe></iframe>';
+		const got = enhance([data])[0] as InteractiveAtomBlockElement;
+
+		expect(got.html).toBe('Foo bar <iframe></iframe>');
+	});
+
+	it('preserves data-attributes', () => {
+		const data = getData();
+		data.html = '<div data-foo="bar">All the stuff...</div>';
+		const got = enhance([data])[0] as InteractiveAtomBlockElement;
+
+		expect(got.html).toBe('<div data-foo="bar">All the stuff...</div>');
+	});
+});

--- a/src/model/enhance-interactive-atom-elements.ts
+++ b/src/model/enhance-interactive-atom-elements.ts
@@ -3,14 +3,16 @@ import { sanitiseHTML } from '@root/src/model/clean';
 // Some interactives contain HTML with unclosed tags etc. To
 // preserve (approximate) parity with Frontend we perform some basic
 // cleaning.
-const enhance = (elements: CAPIElement[]): CAPIElement[] => {
+export const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 	return elements.map((element) => {
 		if (
 			element._type ===
 			'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
 		) {
 			element.html = element.html
-				? sanitiseHTML(element.html, { ADD_TAGS: ['iframe', 'script'] })
+				? sanitiseHTML(element.html, {
+						ADD_TAGS: ['iframe', 'script'],
+				  })
 				: element.html;
 		}
 


### PR DESCRIPTION
## What does this change? + Why

Originally started to ensure we didn't strip data-attributes (reported as an issue by visuals), but turns out we don't (so the issue must be further up/Frontend or tooling perhaps?) but I think the tests are useful in any case.