### PR TITLE
Add some interactive legacy figure classes

### DIFF
--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -25,7 +25,10 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
-import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
+import {
+	interactiveGlobalStyles,
+	interactiveLegacyFigureClasses,
+} from './lib/interactiveLegacyStyling';
 
 interface Props {
 	CAPI: CAPIType;
@@ -64,6 +67,9 @@ const Renderer: React.FC<{
 			<figure
 				id={'elementId' in element ? element.elementId : undefined}
 				key={index}
+				className={
+					interactiveLegacyFigureClasses.get(element._type) || ''
+				}
 			>
 				{el}
 			</figure>

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -3,6 +3,14 @@ import { from, until } from '@guardian/src-foundations/mq';
 
 import { center } from '@root/src/web/lib/center';
 
+// Classes present in Frontend on figure wrapping elements for certain element types.
+export const interactiveLegacyFigureClasses = new Map([
+	[
+		'model.dotcomrendering.pageElements.InteractiveBlockElement',
+		'element-interactive',
+	],
+]);
+
 // Classes present in Frontend that we add for legacy interactives.
 export const interactiveLegacyClasses = {
 	contentInteractive: 'content--interactive',


### PR DESCRIPTION
## What does this change? + Why

Adds a wrapper class to interactive block elements on immersive interactive pages, as expected by some of these to work, e.g.

https://www.theguardian.com/climate-academy/ng-interactive/2020/nov/16/regenerative-agriculture-soil-and-mushrooms-help-solve-climate-crisis

Note, in this specific case, it fixes some things but the interactive still has issues on DCR.