### PR TITLE
Update owners + PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @gtrufitt @shtukas @liywjl @jlieb10 @nitro-marky @OllysCoding
+*       @jlieb10 @nitro-marky @OllysCoding @lucymonie @DavidLawes @nicl

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
 ## What does this change?
 
+## Why?
+
 ### Before
 
 ### After
-
-## Why?


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Update owners + PR template.

## Why?

To reflect current team, and bump the 'Why' section in the PR template.
