### PR TITLE
Use `palette` for the background on `InteractiveBlockComponent`

### DIFF
--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -90,12 +90,17 @@ const getMinHeight = (role: RoleType, loaded: boolean) => {
 	}
 	return `${decideHeight(role)}px`;
 };
-const wrapperStyle = (
-	format: Format,
-	role: RoleType,
-	loaded: boolean,
-	palette: Palette,
-) => css`
+const wrapperStyle = ({
+	format,
+	role,
+	loaded,
+	palette,
+}: {
+	format: Format;
+	role: RoleType;
+	loaded: boolean;
+	palette: Palette;
+}) => css`
 	${format.theme === Special.Labs ? textSans.medium() : body.medium()};
 	background-color: ${palette.background.article};
 	min-height: ${getMinHeight(role, loaded)};
@@ -279,7 +284,7 @@ export const InteractiveBlockComponent = ({
 			<div
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 				ref={wrapperRef}
-				css={wrapperStyle(format, role, loaded, palette)}
+				css={wrapperStyle({ format, role, loaded, palette })}
 			>
 				{!loaded && (
 					<>

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import { body, textSans } from '@guardian/src-foundations/typography';
 import { Special } from '@guardian/types';
 import { space } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
 import { Placeholder } from '@root/src/web/components/Placeholder';
 import { Caption } from '@root/src/web/components/Caption';
 import libDebounce from 'lodash.debounce';
@@ -91,9 +90,14 @@ const getMinHeight = (role: RoleType, loaded: boolean) => {
 	}
 	return `${decideHeight(role)}px`;
 };
-const wrapperStyle = (format: Format, role: RoleType, loaded: boolean) => css`
+const wrapperStyle = (
+	format: Format,
+	role: RoleType,
+	loaded: boolean,
+	palette: Palette,
+) => css`
 	${format.theme === Special.Labs ? textSans.medium() : body.medium()};
-	background-color: ${neutral[100]};
+	background-color: ${palette.background.article};
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
 `;
@@ -275,7 +279,7 @@ export const InteractiveBlockComponent = ({
 			<div
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 				ref={wrapperRef}
-				css={wrapperStyle(format, role, loaded)}
+				css={wrapperStyle(format, role, loaded, palette)}
 			>
 				{!loaded && (
 					<>


### PR DESCRIPTION
## What?
Replaces the hard-coded white background for `InteractiveBlockComponent`s with `palette.background.article`

## Why?
Because not every article has a white background and so when the container is larger than the iframe you get undesired whiteness, such as this bar shown below.

This was raised on the dotcom channel as affecting embeds in some recent [articles on Pegasus](https://www.theguardian.com/news/2021/jul/18/huge-data-leak-shatters-lie-innocent-need-not-fear-surveillance).

### Before
<img width="699" alt="Screenshot 2021-07-19 at 13 22 51" src="https://user-images.githubusercontent.com/1336821/126160602-4febab86-4094-44c4-ae60-005ba9cbb339.png">

### After
<img width="699" alt="Screenshot 2021-07-19 at 13 23 23" src="https://user-images.githubusercontent.com/1336821/126160601-27a015fc-ea9b-4399-bc11-a265f583e062.png">