### PR TITLE
Remove tags when linking bylines, so there cannot be duplicates

### DIFF
--- a/src/amp/components/topMeta/Byline.stories.tsx
+++ b/src/amp/components/topMeta/Byline.stories.tsx
@@ -1,0 +1,63 @@
+import { Byline } from './Byline';
+
+const guardianBaseURL = 'https://theguardian.com';
+
+export const SingleByline = () => (
+	<Byline
+		byline="Eva Smith and friends"
+		guardianBaseURL={guardianBaseURL}
+		tags={[
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+		]}
+	/>
+);
+
+SingleByline.story = { name: 'Byline with single contributor tag' };
+
+export const MultipleByline = () => (
+	<Byline
+		byline="Eva Smith and Duncan Campbell"
+		guardianBaseURL={guardianBaseURL}
+		tags={[
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+			{
+				id: 'duncan-campbell',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+		]}
+	/>
+);
+
+MultipleByline.story = { name: 'Byline with multiple contributors' };
+
+const MultipleDuplicateByline = () => (
+	<Byline
+		byline="Eva Smith and Duncan Campbell"
+		guardianBaseURL={guardianBaseURL}
+		tags={[
+			{
+				id: 'duncan-campbell',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+			{
+				id: 'duncan-campbell-1',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+		]}
+	/>
+);
+
+MultipleDuplicateByline.story = {
+	name: 'Byline w/ contributors with identical names',
+};

--- a/src/amp/components/topMeta/Byline.stories.tsx
+++ b/src/amp/components/topMeta/Byline.stories.tsx
@@ -2,6 +2,11 @@ import { Byline } from './Byline';
 
 const guardianBaseURL = 'https://theguardian.com';
 
+export default {
+	component: Byline,
+	title: 'AMP/Components/topMeta/Byline',
+};
+
 export const SingleByline = () => (
 	<Byline
 		byline="Eva Smith and friends"
@@ -39,9 +44,9 @@ export const MultipleByline = () => (
 
 MultipleByline.story = { name: 'Byline with multiple contributors' };
 
-const MultipleDuplicateByline = () => (
+export const MultipleDuplicateByline = () => (
 	<Byline
-		byline="Eva Smith and Duncan Campbell"
+		byline="Duncan Campbell and Duncan Campbell"
 		guardianBaseURL={guardianBaseURL}
 		tags={[
 			{

--- a/src/amp/components/topMeta/Byline.test.tsx
+++ b/src/amp/components/topMeta/Byline.test.tsx
@@ -14,14 +14,13 @@ describe('Byline', () => {
 			},
 		];
 
-		const { container, debug } = render(
+		const { container } = render(
 			<Byline
 				byline={byline}
 				guardianBaseURL={guardianBaseURL}
 				tags={tags}
 			/>,
 		);
-		debug();
 
 		const links = container.querySelectorAll('a');
 

--- a/src/amp/components/topMeta/Byline.test.tsx
+++ b/src/amp/components/topMeta/Byline.test.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react';
+import { Byline } from './Byline';
+
+describe('Byline', () => {
+	const guardianBaseURL = 'https://theguardian.com';
+
+	it('should link a single tag by linking name tokens with Contributor tag titles', () => {
+		const byline = 'Eva Smith and friends';
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+		];
+
+		const { container, debug } = render(
+			<Byline
+				byline={byline}
+				guardianBaseURL={guardianBaseURL}
+				tags={tags}
+			/>,
+		);
+		debug();
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(1);
+		expect(links.item(0).href).toBe('https://theguardian.com/eva-smith');
+	});
+
+	it('should link multiple tags by linking name tokens with Contributor tag titles', () => {
+		const byline = 'Eva Smith and Duncan Porter';
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+			{
+				id: 'duncan-porter',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+		];
+		const { container } = render(
+			<Byline
+				byline={byline}
+				guardianBaseURL={guardianBaseURL}
+				tags={tags}
+			/>,
+		);
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(2);
+		expect(links.item(0).href).toBe('https://theguardian.com/eva-smith');
+		expect(links.item(1).href).toBe(
+			'https://theguardian.com/duncan-porter',
+		);
+	});
+
+	it('should not reuse a contributor tag, to successfully disambiguate identical names', () => {
+		const byline = 'Duncan Porter and Duncan Porter';
+		const tags = [
+			{
+				id: 'duncan-porter',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+			{
+				id: 'duncan-porter-1',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+		];
+
+		const { container } = render(
+			<Byline
+				byline={byline}
+				guardianBaseURL={guardianBaseURL}
+				tags={tags}
+			/>,
+		);
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(2);
+		expect(links.item(0).href).toBe(
+			'https://theguardian.com/duncan-porter',
+		);
+		expect(links.item(1).href).toBe(
+			'https://theguardian.com/duncan-porter-1',
+		);
+	});
+});

--- a/src/amp/components/topMeta/Byline.test.tsx
+++ b/src/amp/components/topMeta/Byline.test.tsx
@@ -30,7 +30,7 @@ describe('Byline', () => {
 	});
 
 	it('should link multiple tags by linking name tokens with Contributor tag titles', () => {
-		const byline = 'Eva Smith and Duncan Porter';
+		const byline = 'Eva Smith and Duncan Campbell';
 		const tags = [
 			{
 				id: 'eva-smith',
@@ -38,9 +38,9 @@ describe('Byline', () => {
 				title: 'Eva Smith',
 			},
 			{
-				id: 'duncan-porter',
+				id: 'duncan-campbell',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 		];
 		const { container } = render(
@@ -57,22 +57,22 @@ describe('Byline', () => {
 		expect(links.length).toBe(2);
 		expect(links.item(0).href).toBe('https://theguardian.com/eva-smith');
 		expect(links.item(1).href).toBe(
-			'https://theguardian.com/duncan-porter',
+			'https://theguardian.com/duncan-campbell',
 		);
 	});
 
 	it('should not reuse a contributor tag, to successfully disambiguate identical names', () => {
-		const byline = 'Duncan Porter and Duncan Porter';
+		const byline = 'Duncan Campbell and Duncan Campbell';
 		const tags = [
 			{
-				id: 'duncan-porter',
+				id: 'duncan-campbell',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 			{
-				id: 'duncan-porter-1',
+				id: 'duncan-campbell-1',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 		];
 
@@ -89,10 +89,10 @@ describe('Byline', () => {
 		expect(container).toHaveTextContent(byline);
 		expect(links.length).toBe(2);
 		expect(links.item(0).href).toBe(
-			'https://theguardian.com/duncan-porter',
+			'https://theguardian.com/duncan-campbell',
 		);
 		expect(links.item(1).href).toBe(
-			'https://theguardian.com/duncan-porter-1',
+			'https://theguardian.com/duncan-campbell-1',
 		);
 	});
 });

--- a/src/amp/components/topMeta/Byline.tsx
+++ b/src/amp/components/topMeta/Byline.tsx
@@ -1,4 +1,5 @@
 import { bylineTokens } from '@root/src/amp/lib/byline-tokens';
+import { getBylineComponentsFromTokens } from '@root/src/lib/byline';
 
 type Props = {
 	byline?: string;
@@ -14,33 +15,21 @@ export const Byline = ({ byline, tags, guardianBaseURL }: Props) => {
 	const contributorTags = tags.filter((tag) => tag.type === 'Contributor');
 	const tokens = bylineTokens(byline, contributorTags);
 
-	const [linkedByline] = tokens.reduce(
-		([bylines, remainingTags], token) => {
-			const matchedTagIndex = remainingTags.findIndex(
-				(tag) => tag.title === token,
-			);
+	const bylineComponents = getBylineComponentsFromTokens(tokens, tags);
 
-			if (matchedTagIndex === -1) {
-				return [bylines.concat(token), remainingTags];
-			}
-
-			const matchedTag = remainingTags[matchedTagIndex];
-			const bylineElement = (
-				<a
-					key={matchedTag.id}
-					href={`${guardianBaseURL}/${matchedTag.id}`}
-				>
-					{matchedTag.title}
-				</a>
-			);
-
-			// We've used this tag, so remove it from the list of possible tags.
-			remainingTags.splice(matchedTagIndex, 1);
-
-			return [bylines.concat(bylineElement), remainingTags];
-		},
-		[[] as (JSX.Element | string)[], tags],
-	);
+	const linkedByline = bylineComponents.map((bylineComponent) => {
+		if (typeof bylineComponent === 'string') {
+			return bylineComponent;
+		}
+		return (
+			<a
+				key={bylineComponent.tag.id}
+				href={`${guardianBaseURL}/${bylineComponent.tag.id}`}
+			>
+				{bylineComponent.tag.title}
+			</a>
+		);
+	});
 
 	return <>{linkedByline}</>;
 };

--- a/src/amp/components/topMeta/Byline.tsx
+++ b/src/amp/components/topMeta/Byline.tsx
@@ -14,11 +14,18 @@ export const Byline = ({ byline, tags, guardianBaseURL }: Props) => {
 	const contributorTags = tags.filter((tag) => tag.type === 'Contributor');
 	const tokens = bylineTokens(byline, contributorTags);
 
-	const linkedByline = tokens.map((token) => {
-		const matchedTag = contributorTags.find((tag) => tag.title === token);
+	const [linkedByline] = tokens.reduce(
+		([bylines, remainingTags], token) => {
+			const matchedTagIndex = remainingTags.findIndex(
+				(tag) => tag.title === token,
+			);
 
-		if (matchedTag) {
-			return (
+			if (matchedTagIndex === -1) {
+				return [bylines.concat(token), remainingTags];
+			}
+
+			const matchedTag = remainingTags[matchedTagIndex];
+			const bylineElement = (
 				<a
 					key={matchedTag.id}
 					href={`${guardianBaseURL}/${matchedTag.id}`}
@@ -26,10 +33,14 @@ export const Byline = ({ byline, tags, guardianBaseURL }: Props) => {
 					{matchedTag.title}
 				</a>
 			);
-		}
 
-		return token;
-	});
+			// We've used this tag, so remove it from the list of possible tags.
+			remainingTags.splice(matchedTagIndex, 1);
+
+			return [bylines.concat(bylineElement), remainingTags];
+		},
+		[[] as (JSX.Element | string)[], tags],
+	);
 
 	return <>{linkedByline}</>;
 };

--- a/src/lib/byline.test.ts
+++ b/src/lib/byline.test.ts
@@ -1,0 +1,77 @@
+import { getBylineComponentsFromTokens } from './byline';
+
+describe('Byline utilities', () => {
+	it('should link a single tag by linking name tokens with Contributor tag titles', () => {
+		const bylineTokens = ['Eva Smith', 'and friends'];
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+		];
+
+		const bylineComponents = getBylineComponentsFromTokens(
+			bylineTokens,
+			tags,
+		);
+
+		expect(bylineComponents).toEqual([
+			{ tag: tags[0], token: 'Eva Smith' },
+			'and friends',
+		]);
+	});
+
+	it('should link multiple tags by linking name tokens with Contributor tag titles', () => {
+		const bylineTokens = ['Eva Smith', ' and ', 'Duncan Campbell'];
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+			{
+				id: 'duncan-campbell',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+		];
+		const bylineComponents = getBylineComponentsFromTokens(
+			bylineTokens,
+			tags,
+		);
+
+		expect(bylineComponents).toEqual([
+			{ tag: tags[0], token: 'Eva Smith' },
+			' and ',
+			{ tag: tags[1], token: 'Duncan Campbell' },
+		]);
+	});
+
+	it('should not reuse a contributor tag, to successfully disambiguate identical names', () => {
+		const bylineTokens = ['Duncan Campbell', ' and ', 'Duncan Campbell'];
+		const tags = [
+			{
+				id: 'duncan-campbell',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+			{
+				id: 'duncan-campbell-1',
+				type: 'Contributor',
+				title: 'Duncan Campbell',
+			},
+		];
+
+		const bylineComponents = getBylineComponentsFromTokens(
+			bylineTokens,
+			tags,
+		);
+
+		expect(bylineComponents).toEqual([
+			{ tag: tags[0], token: 'Duncan Campbell' },
+			' and ',
+			{ tag: tags[1], token: 'Duncan Campbell' },
+		]);
+	});
+});

--- a/src/lib/byline.ts
+++ b/src/lib/byline.ts
@@ -1,0 +1,44 @@
+export const getContributorTags = (tags: TagType[]): TagType[] => {
+	return tags.filter((t) => t.type === 'Contributor');
+};
+
+export const getContributorTagsForToken = (
+	tags: TagType[],
+	token: string,
+): TagType[] => {
+	return getContributorTags(tags).filter((t) => t.title === token);
+};
+
+type BylineComponent = { token: string; tag: TagType } | string;
+
+export const getBylineComponentsFromTokens = (
+	tokens: string[],
+	tags: TagType[],
+): BylineComponent[] => {
+	const [bylineComponents] = tokens.reduce(
+		([bylines, remainingTags], token) => {
+			const [firstContributorTag] = getContributorTagsForToken(
+				remainingTags,
+				token,
+			);
+			if (!firstContributorTag) {
+				return [bylines.concat(token), remainingTags];
+			}
+
+			// We've used this tag, so remove it from the list of possible tags.
+			// This ensures we don't use the same contributor tag when two identical
+			// names with different contributor tags are used.
+			const newRemainingTags = remainingTags.filter(
+				(tag) => !(tag.id === firstContributorTag.id),
+			);
+
+			return [
+				bylines.concat({ tag: firstContributorTag, token }),
+				newRemainingTags,
+			];
+		},
+		[[], tags] as [BylineComponent[], TagType[]],
+	);
+
+	return bylineComponents;
+};

--- a/src/web/components/BylineLink.test.tsx
+++ b/src/web/components/BylineLink.test.tsx
@@ -1,9 +1,6 @@
 import { render } from '@testing-library/react';
-import {
-	bylineAsTokens,
-	BylineLink,
-	getContributorTagsForToken,
-} from './BylineLink';
+import { getContributorTagsForToken } from '@root/src/lib/byline';
+import { bylineAsTokens, BylineLink } from './BylineLink';
 
 describe('bylineAsTokens', () => {
 	it('Correctly performs the standard one contributor case', () => {

--- a/src/web/components/BylineLink.test.tsx
+++ b/src/web/components/BylineLink.test.tsx
@@ -1,4 +1,9 @@
-import { bylineAsTokens, getContributorTagsForToken } from './BylineLink';
+import { render } from '@testing-library/react';
+import {
+	bylineAsTokens,
+	BylineLink,
+	getContributorTagsForToken,
+} from './BylineLink';
 
 describe('bylineAsTokens', () => {
 	it('Correctly performs the standard one contributor case', () => {
@@ -70,5 +75,82 @@ describe('bylineAsTokens', () => {
 		];
 		expect(bylineAsTokens(byline, tags)).toEqual(tokensExpected);
 		expect(bylineAsTokens(byline, tags.reverse())).toEqual(tokensExpected);
+	});
+});
+
+describe('BylineLink', () => {
+	it('should link a single tag by linking name tokens with Contributor tag titles', () => {
+		const byline = 'Eva Smith and friends';
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+		];
+
+		const { container, debug } = render(
+			<BylineLink byline={byline} tags={tags} />,
+		);
+		debug();
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(1);
+		expect(links.item(0).href).toContain(tags[0].id);
+	});
+
+	it('should link multiple tags by linking name tokens with Contributor tag titles', () => {
+		const byline = 'Eva Smith and Duncan Porter';
+		const tags = [
+			{
+				id: 'eva-smith',
+				type: 'Contributor',
+				title: 'Eva Smith',
+			},
+			{
+				id: 'duncan-porter',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+		];
+		const { container } = render(
+			<BylineLink byline={byline} tags={tags} />,
+		);
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(2);
+		expect(links.item(0).href).toContain(tags[0].id);
+		expect(links.item(1).href).toContain(tags[1].id);
+	});
+
+	it('should not reuse a contributor tag, to successfully disambiguate identical names', () => {
+		const byline = 'Duncan Porter and Duncan Porter';
+		const tags = [
+			{
+				id: 'duncan-porter',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+			{
+				id: 'duncan-porter-1',
+				type: 'Contributor',
+				title: 'Duncan Porter',
+			},
+		];
+
+		const { container } = render(
+			<BylineLink byline={byline} tags={tags} />,
+		);
+
+		const links = container.querySelectorAll('a');
+
+		expect(container).toHaveTextContent(byline);
+		expect(links.length).toBe(2);
+		expect(links.item(0).href).toContain(tags[0].id);
+		expect(links.item(1).href).toContain(tags[1].id);
 	});
 });

--- a/src/web/components/BylineLink.test.tsx
+++ b/src/web/components/BylineLink.test.tsx
@@ -89,10 +89,9 @@ describe('BylineLink', () => {
 			},
 		];
 
-		const { container, debug } = render(
+		const { container } = render(
 			<BylineLink byline={byline} tags={tags} />,
 		);
-		debug();
 
 		const links = container.querySelectorAll('a');
 
@@ -102,7 +101,7 @@ describe('BylineLink', () => {
 	});
 
 	it('should link multiple tags by linking name tokens with Contributor tag titles', () => {
-		const byline = 'Eva Smith and Duncan Porter';
+		const byline = 'Eva Smith and Duncan Campbell';
 		const tags = [
 			{
 				id: 'eva-smith',
@@ -110,9 +109,9 @@ describe('BylineLink', () => {
 				title: 'Eva Smith',
 			},
 			{
-				id: 'duncan-porter',
+				id: 'duncan-campbell',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 		];
 		const { container } = render(
@@ -128,17 +127,17 @@ describe('BylineLink', () => {
 	});
 
 	it('should not reuse a contributor tag, to successfully disambiguate identical names', () => {
-		const byline = 'Duncan Porter and Duncan Porter';
+		const byline = 'Duncan Campbell and Duncan Campbell';
 		const tags = [
 			{
-				id: 'duncan-porter',
+				id: 'duncan-campbell',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 			{
-				id: 'duncan-porter-1',
+				id: 'duncan-campbell-1',
 				type: 'Contributor',
-				title: 'Duncan Porter',
+				title: 'Duncan Campbell',
 			},
 		];
 

--- a/src/web/components/BylineLink.tsx
+++ b/src/web/components/BylineLink.tsx
@@ -1,19 +1,11 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import {
+	getBylineComponentsFromTokens,
+	getContributorTags,
+} from '@root/src/lib/byline';
 
 type Props = {
 	byline: string;
 	tags: TagType[];
-};
-
-const getContributorTags = (tags: TagType[]): TagType[] => {
-	return tags.filter((t) => t.type === 'Contributor');
-};
-
-export const getContributorTagsForToken = (
-	tags: TagType[],
-	token: string,
-): TagType[] => {
-	return getContributorTags(tags).filter((t) => t.title === token);
 };
 
 const applyCleverOrderingForMatching = (titles: string[]): string[] => {
@@ -84,35 +76,20 @@ const ContributorLink: React.FC<{
 export const BylineLink = ({ byline, tags }: Props) => {
 	const tokens = bylineAsTokens(byline, tags);
 
-	const [renderedTokens] = tokens.reduce(
-		([bylines, remainingTags], token) => {
-			const [firstContributorTag] = getContributorTagsForToken(
-				remainingTags,
-				token,
-			);
-			if (!firstContributorTag) {
-				return [bylines.concat(token), remainingTags];
-			}
+	const bylineComponents = getBylineComponentsFromTokens(tokens, tags);
 
-			const bylineElement = (
-				<ContributorLink
-					contributor={token}
-					contributorTagId={firstContributorTag.id}
-					key={firstContributorTag.id}
-				/>
-			);
-
-			// We've used this tag, so remove it from the list of possible tags.
-			// This ensures we don't use the same contributor tag when two identical
-			// names with different contributor tags are used.
-			const newRemainingTags = remainingTags.filter(
-				(tag) => !(tag.id === firstContributorTag.id),
-			);
-
-			return [bylines.concat(bylineElement), newRemainingTags];
-		},
-		[[], tags] as [(EmotionJSX.Element | string)[], TagType[]],
-	);
+	const renderedTokens = bylineComponents.map((bylineComponent) => {
+		if (typeof bylineComponent === 'string') {
+			return bylineComponent;
+		}
+		return (
+			<ContributorLink
+				contributor={bylineComponent.token}
+				contributorTagId={bylineComponent.tag.id}
+				key={bylineComponent.tag.id}
+			/>
+		);
+	});
 
 	return <>{renderedTokens}</>;
 };

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -159,6 +159,35 @@ export const MultipleStory = () => {
 };
 MultipleStory.story = { name: 'Immersive with multiple contributors' };
 
+export const MultipleDuplicateStory = () => {
+	return (
+		<HeadlineByline
+			format={{
+				display: Display.Immersive,
+				design: Design.Article,
+				theme: Pillar.Lifestyle,
+			}}
+			byline="Duncan Porter and Duncan Porter"
+			tags={[
+				{
+					id: '1',
+					type: 'Contributor',
+					title: 'Duncan Porter',
+				},
+				{
+					id: '2',
+					type: 'Contributor',
+					title: 'Duncan Porter',
+				},
+			]}
+		/>
+	);
+};
+MultipleDuplicateStory.story = {
+	name:
+		'Immersive with multiple contributors with distinct tags but identical names',
+};
+
 export const noBylineStory = () => {
 	return (
 		<HeadlineByline

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -167,17 +167,17 @@ export const MultipleDuplicateStory = () => {
 				design: Design.Article,
 				theme: Pillar.Lifestyle,
 			}}
-			byline="Duncan Porter and Duncan Porter"
+			byline="Duncan Campbell and Duncan Campbell"
 			tags={[
 				{
 					id: '1',
 					type: 'Contributor',
-					title: 'Duncan Porter',
+					title: 'Duncan Campbell',
 				},
 				{
 					id: '2',
 					type: 'Contributor',
-					title: 'Duncan Porter',
+					title: 'Duncan Campbell',
 				},
 			]}
 		/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR removes tags that have already been referenced when linking bylines, to ensure that we don't accidentally mis-link when we have two people with the same name, but different tags.

The assumption here is that bylines only ever happen to the same person once. If that's not true, this'll break.

## Why?

We've seen this issue in production. From Charlotte Naughton:

_> Hi there. This hasn't been a big deal, so haven't mentioned it before, but we can't check bylines in preview, just get an error message. Then something like this comes along, and we need to know we've got the Duncans in the right order! Is this problem fixable?
https://viewer.gutools.co.uk/preview/commentisfree/2021/jul/20/proposed-secrecy-law-journalism-spying-home-office-public-interest-whistleblowing_

### Before

<img width="807" alt="Screenshot 2021-07-20 at 14 29 33" src="https://user-images.githubusercontent.com/7767575/126332698-8b92e1fd-cdb7-47af-9575-8cc701c338c4.png">

### After

<img width="807" alt="Screenshot 2021-07-20 at 14 32 20" src="https://user-images.githubusercontent.com/7767575/126332952-d67f958a-0f7c-41b8-975f-cc4f347fafc0.png">

### Dev notes

The last commit is optional – it consolidates code that's common to both AMP and Web components to avoid duplication, but the diff is a bit larger as a result.