### PR TITLE
Bump web-vitals to v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "reset-css": "^5.0.1",
     "sanitize-html": "^2.3.2",
     "swr": "^0.5.5",
-    "web-vitals": "^1.1.1",
+    "web-vitals": "^1.1.2",
     "youtube-player": "^5.5.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20983,10 +20983,10 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-web-vitals@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.1.tgz#2df535e3355fb7fbe34787b44b736e270e539377"
-  integrity sha512-jYOaqu01Ny1NvMwJ3dBJDUOJ2PGWknZWH4AUnvFOscvbdHMERIKT2TlgiAey5rVyfOePG7so2JcXXZdSnBvioQ==
+web-vitals@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
+  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps to the latest v1 of `web-vitals`, [`v1.1.2`](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v112-2021-05-05).

> ### v1.1.2 (2021-05-05)
>
> - Ignore negative TTFB values in Firefox ([#147](https://github.com/GoogleChrome/web-vitals/pull/147))
> - Add workaround for Safari FCP bug ([#145](https://github.com/GoogleChrome/web-vitals/pull/145))
> - Add more extensive FID feature detect ([#143](https://github.com/GoogleChrome/web-vitals/pull/143))

## Why?

Ignores negative TTFB values. `frontend` [is already on v1.1.2](https://github.com/guardian/frontend/blob/c48a178a48e6643133493f69228ae9d1920d9640/yarn.lock#L13576).

## Further work

There is a new [`v2`](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v210-2021-07-01), which brings in breaking changes:

> ### v2.1.0 (2021-07-01)
> 
> - Add batch reporting support and guidance ([#166](https://github.com/GoogleChrome/web-vitals/pull/166)
> 
> ### v2.0.1 (2021-06-02)
> 
> - Detect getEntriesByName support before calling ([#158](https://github.com/GoogleChrome/web-vitals/pull/158)
> 
> ### v2.0.0 (2021-06-01)
> 
> - **[BREAKING]** Update CLS to max session window 5s cap 1s gap ([#148](https://github.com/GoogleChrome/web-vitals/pull/148))
> - Ensure CLS is only reported if page was visible ([#149](https://github.com/GoogleChrome/web-vitals/pull/149))
> - Only report CLS when FCP is reported ([#154](https://github.com/GoogleChrome/web-vitals/pull/154))
> - Update the unique ID version prefix ([#157](https://github.com/GoogleChrome/web-vitals/pull/157)
> 
