### PR TITLE
Record Message Picker timings for the Braze Epic

### DIFF
--- a/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -89,6 +89,7 @@ const buildBrazeEpicConfig = (
 			),
 		},
 		timeoutMillis: 5000,
+		reportTiming: true,
 	};
 };
 

--- a/src/web/lib/messagePicker.ts
+++ b/src/web/lib/messagePicker.ts
@@ -32,10 +32,10 @@ export type SlotConfig = {
 	name: string;
 };
 
-const recordMessageTimeoutInOphan = (messageId: string, slotName: string) =>
+const recordMessageTimeoutInOphan = (candidateId: string, slotName: string) =>
 	record({
 		component: `${slotName}-picker-timeout-dcr`,
-		value: messageId,
+		value: candidateId,
 	});
 
 const timeoutify = <T>(


### PR DESCRIPTION
## What does this change?

This PR adds the capability to record time taken to get an answer for the `canShow` method of message picker candidates. The functionality is configurable per candidate. This PR also enables this for the Braze Epic. Data is recorded via the Ophan tracker and is available to query in `pageview.interactions`. The `component` will be `messagePicker-canShow-<candidate ID>`, in this case `messagePicker-canShow-braze-epic`. The value is the time taken in milliseconds.

## Why?

We want to gather data on how quickly we're typically able to know when there's a Braze epic message to show with a view to potentially reducing the timeout we wrap around this functionality (we're planning in some scenarios to move Braze higher in the epic message candidate priority list, and the timeout potentially blocks lower priority candidates from showing when there isn't a Braze epic message).
