### PR TITLE
Support sponsorship regionally on AMP

### DIFF
--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -48,7 +48,7 @@ const brandingLogoStyle = css`
 	padding: 10px 0;
 `;
 
-export const Branding: React.FC<{
+export const BrandingItem: React.FC<{
 	branding: Branding;
 	pillar: Theme;
 }> = ({ branding, pillar }) => {
@@ -75,3 +75,19 @@ export const Branding: React.FC<{
 		</div>
 	);
 };
+
+export const Branding: React.FC<{
+	commercialProperties: CommercialProperties;
+	pillar: Theme;
+}> = ({ commercialProperties, pillar }) => (
+	<>
+		{Object.keys(commercialProperties).map((editionId) => {
+			const { branding } = commercialProperties[editionId as Edition];
+			return branding !== undefined ? (
+				<div className={`branding branding-${editionId.toLowerCase()}`}>
+					<BrandingItem branding={branding} pillar={pillar} />
+				</div>
+			) : null;
+		})}
+	</>
+);

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -1,22 +1,8 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { pillarPalette_DO_NOT_USE, neutralBorder } from '@root/src/lib/pillars';
-
-export const brandingCss = `
-	.branding-uk, .branding-us, .branding-au, .branding-int {
-		display: none;
-	}
-
-	.amp-iso-country-gb .branding-uk,
-	.amp-iso-country-us .branding-us,
-	.amp-iso-country-au .branding-au,
-	.amp-geo-group-eea:not(.amp-iso-country-gb) .branding-int,
-	.amp-geo-no-group .branding-int {
-		display: block;
-	}
-`;
 
 const LinkStyle = (pillar: Theme) => css`
 	a {
@@ -79,15 +65,52 @@ export const BrandingItem: React.FC<{
 export const Branding: React.FC<{
 	commercialProperties: CommercialProperties;
 	pillar: Theme;
-}> = ({ commercialProperties, pillar }) => (
-	<>
-		{Object.keys(commercialProperties).map((editionId) => {
-			const { branding } = commercialProperties[editionId as Edition];
-			return branding !== undefined ? (
-				<div className={`branding branding-${editionId.toLowerCase()}`}>
-					<BrandingItem branding={branding} pillar={pillar} />
-				</div>
-			) : null;
-		})}
-	</>
-);
+}> = ({ commercialProperties, pillar }) => {
+	const brandingStyles = css`
+		display: none;
+	`;
+	const gbStyles = css`
+		.amp-iso-country-gb & {
+			display: block;
+		}
+	`;
+	const usStyles = css`
+		.amp-iso-country-us & {
+			display: block;
+		}
+	`;
+	const auStyles = css`
+		.amp-iso-country-au & {
+			display: block;
+		}
+	`;
+	const intStyles = css`
+		.amp-geo-group-eea:not(.amp-iso-country-gb) &,
+		.amp-geo-no-group & {
+			display: block;
+		}
+	`;
+	const editionStyles: Record<Edition, SerializedStyles> = {
+		UK: gbStyles,
+		US: usStyles,
+		AU: auStyles,
+		INT: intStyles,
+	};
+	return (
+		<>
+			{Object.keys(commercialProperties).map((editionId) => {
+				const { branding } = commercialProperties[editionId as Edition];
+				return branding !== undefined ? (
+					<div
+						css={[
+							brandingStyles,
+							editionStyles[editionId as Edition],
+						]}
+					>
+						<BrandingItem branding={branding} pillar={pillar} />
+					</div>
+				) : null;
+			})}
+		</>
+	);
+};

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -69,7 +69,7 @@ export const Branding: React.FC<{
 	const brandingStyles = css`
 		display: none;
 	`;
-	const gbStyles = css`
+	const ukStyles = css`
 		.amp-iso-country-gb & {
 			display: block;
 		}
@@ -91,7 +91,7 @@ export const Branding: React.FC<{
 		}
 	`;
 	const editionStyles: Record<Edition, SerializedStyles> = {
-		UK: gbStyles,
+		UK: ukStyles,
 		US: usStyles,
 		AU: auStyles,
 		INT: intStyles,

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -34,7 +34,7 @@ const brandingLogoStyle = css`
 	padding: 10px 0;
 `;
 
-export const BrandingItem: React.FC<{
+const BrandingItem: React.FC<{
 	branding: Branding;
 	pillar: Theme;
 }> = ({ branding, pillar }) => {

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -4,6 +4,20 @@ import { textSans } from '@guardian/src-foundations/typography';
 
 import { pillarPalette_DO_NOT_USE, neutralBorder } from '@root/src/lib/pillars';
 
+export const brandingCss = `
+	.branding-uk, .branding-us, .branding-au, .branding-int {
+		display: none;
+	}
+
+	.amp-iso-country-gb .branding-uk,
+	.amp-iso-country-us .branding-us,
+	.amp-iso-country-au .branding-au,
+	.amp-geo-group-eea:not(.amp-iso-country-gb) .branding-int,
+	.amp-geo-no-group .branding-int {
+		display: block;
+	}
+`;
+
 const LinkStyle = (pillar: Theme) => css`
 	a {
 		color: ${pillarPalette_DO_NOT_USE[pillar].dark};

--- a/src/amp/components/topMeta/TopMetaAnalysis.tsx
+++ b/src/amp/components/topMeta/TopMetaAnalysis.tsx
@@ -91,10 +91,6 @@ export const TopMetaAnalysis: React.FC<{
 	adTargeting?: AdTargeting;
 	pillar: Theme;
 }> = ({ articleData, adTargeting, pillar }) => {
-	const { branding } = articleData.commercialProperties[
-		articleData.editionId
-	];
-
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (
@@ -124,7 +120,10 @@ export const TopMetaAnalysis: React.FC<{
 
 			<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			{branding && <Branding branding={branding} pillar={pillar} />}
+			<Branding
+				commercialProperties={articleData.commercialProperties}
+				pillar={pillar}
+			/>
 
 			<div css={bylineStyle(pillar)}>
 				<Byline

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -93,18 +93,10 @@ export const TopMetaNews: React.FC<{
 
 			<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			{Object.keys(articleData.commercialProperties).map((editionId) => {
-				const { branding } = articleData.commercialProperties[
-					editionId as Edition
-				];
-				return branding !== undefined ? (
-					<div
-						className={`branding branding-${editionId.toLowerCase()}`}
-					>
-						<Branding branding={branding} pillar={pillar} />
-					</div>
-				) : null;
-			})}
+			<Branding
+				commercialProperties={articleData.commercialProperties}
+				pillar={pillar}
+			/>
 
 			<div css={bylineStyle(pillar)}>
 				<Byline

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -64,10 +64,6 @@ export const TopMetaNews: React.FC<{
 	adTargeting?: AdTargeting;
 	pillar: Theme;
 }> = ({ articleData, adTargeting, pillar }) => {
-	const { branding } = articleData.commercialProperties[
-		articleData.editionId
-	];
-
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (
@@ -97,7 +93,18 @@ export const TopMetaNews: React.FC<{
 
 			<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			{branding && <Branding branding={branding} pillar={pillar} />}
+			{Object.keys(articleData.commercialProperties).map((editionId) => {
+				const { branding } = articleData.commercialProperties[
+					editionId as Edition
+				];
+				return branding !== undefined ? (
+					<div
+						className={`branding branding-${editionId.toLowerCase()}`}
+					>
+						<Branding branding={branding} pillar={pillar} />
+					</div>
+				) : null;
+			})}
 
 			<div css={bylineStyle(pillar)}>
 				<Byline

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -104,10 +104,6 @@ export const TopMetaOpinion: React.FC<{
 	articleData: ArticleModel;
 	pillar: Theme;
 }> = ({ articleData, pillar }) => {
-	const { branding } = articleData.commercialProperties[
-		articleData.editionId
-	];
-
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (
@@ -123,7 +119,10 @@ export const TopMetaOpinion: React.FC<{
 
 			<h1 css={headerStyle}>{articleData.headline}</h1>
 
-			{branding && <Branding branding={branding} pillar={pillar} />}
+			<Branding
+				commercialProperties={articleData.commercialProperties}
+				pillar={pillar}
+			/>
 
 			<BylineMeta articleData={articleData} pillar={pillar} />
 

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -8,7 +8,6 @@ import he from 'he';
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
 import { stickyAdLabelCss } from '@root/src/amp/components/StickyAd';
-import { brandingCss } from '../components/topMeta/Branding';
 
 interface RenderToStringResult {
 	html: string;
@@ -99,7 +98,6 @@ export const document = ({
         ${resetCSS}
         ${css}
 		${stickyAdLabelCss}
-		${brandingCss}
     </style>
 
     </head>

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -8,6 +8,7 @@ import he from 'he';
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
 import { stickyAdLabelCss } from '@root/src/amp/components/StickyAd';
+import { brandingCss } from '../components/topMeta/Branding';
 
 interface RenderToStringResult {
 	html: string;
@@ -98,6 +99,7 @@ export const document = ({
         ${resetCSS}
         ${css}
 		${stickyAdLabelCss}
+		${brandingCss}
     </style>
 
     </head>


### PR DESCRIPTION
## What does this change?

This PR fixes a bug where the sponsorship branding that targets regions outside the US does not display on cached AMP pages. This is achieved by including all possible regional sponsorships on the page and using the `amp-iso-country-*` and `amp-geo-group-*` css classes to display the correct sponsorship for the region.

## Why?

Googles build the AMP cache based on the US version of the site, so cached AMP pages always target the US edition. This means that sponsorships that target regions outside the US were not displayed on these cached pages. By using AMP geo classes we can select which regional branding to show.