### PR TITLE
Use The Correct Pillar Colour When Highlighting On The Subnav

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -859,6 +859,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
 							palette={palette}
+							format={format}
 						/>
 					</>
 				</HydrateOnce>

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -206,7 +206,7 @@ export const SubNav = ({
 				{subNavSections.links.map((link) => (
 					<li key={link.url}>
 						<a
-							css={[linkStyle(format)]}
+							css={linkStyle(format)}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -4,11 +4,13 @@ import { css } from '@emotion/react';
 import { text, news, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
 	subNavSections: SubNavType;
 	palette: Palette;
 	currentNavLink: string;
+	format: Format;
 };
 
 const wrapperCollapsedStyles = css`
@@ -76,13 +78,13 @@ const fontStyle = css`
 	}
 `;
 
-const linkStyle = css`
+const linkStyle = (format: Format) => css`
 	${fontStyle};
 	float: left;
 	text-decoration: none;
 
 	:hover {
-		text-decoration: underline;
+		color: ${decidePalette(format).text.articleLinkHover};
 	}
 
 	:focus {
@@ -148,7 +150,12 @@ const listItemStyles = (palette: Palette) => css`
 const trimLeadingSlash = (url: string): string =>
 	url.substr(0, 1) === '/' ? url.slice(1) : url;
 
-export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
+export const SubNav = ({
+	subNavSections,
+	palette,
+	currentNavLink,
+	format,
+}: Props) => {
 	const [showMore, setShowMore] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const ulRef = useRef<HTMLUListElement>(null);
@@ -189,7 +196,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 					>
 						<a
 							data-src-focus-disabled={true}
-							css={linkStyle}
+							css={linkStyle(format)}
 							href={subNavSections.parent.url}
 						>
 							{subNavSections.parent.title}
@@ -199,7 +206,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 				{subNavSections.links.map((link) => (
 					<li key={link.url}>
 						<a
-							css={linkStyle}
+							css={[linkStyle(format)]}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -379,6 +379,7 @@ export const CommentLayout = ({
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
 								palette={palette}
+								format={format}
 							/>
 						</ElementContainer>
 					)}
@@ -658,6 +659,7 @@ export const CommentLayout = ({
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -691,6 +691,7 @@ export const ImmersiveLayout = ({
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -184,6 +184,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}
@@ -262,6 +263,7 @@ export const InteractiveImmersiveLayout = ({
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -304,6 +304,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}
@@ -586,6 +587,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -279,6 +279,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
 								palette={palette}
+								format={format}
 							/>
 						</ElementContainer>
 					)}
@@ -569,6 +570,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -317,6 +317,7 @@ export const ShowcaseLayout = ({
 									subNavSections={NAV.subNavSections}
 									currentNavLink={NAV.currentNavLink}
 									palette={palette}
+									format={format}
 								/>
 							</ElementContainer>
 						)}
@@ -633,6 +634,7 @@ export const ShowcaseLayout = ({
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -405,6 +405,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}
@@ -725,6 +726,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
 						palette={palette}
+						format={format}
 					/>
 				</ElementContainer>
 			)}


### PR DESCRIPTION
## What does this change?

It removes text decoration when highlighting a subnav item and brings in the pillar highlighting colour. It also refactors other components that use the subnav and passes the Format as a prop for future refactoring in the subnav.

## Why?

Parity with Frontend.

### Before

<img width="921" alt="Screenshot 2021-07-20 at 14 55 16" src="https://user-images.githubusercontent.com/35331926/126337745-f99f045a-72b6-4da8-bccb-40f5daaecd9c.png">

### After

<img width="938" alt="Screenshot 2021-07-20 at 14 54 13" src="https://user-images.githubusercontent.com/35331926/126337775-355d84b6-d84c-4fe5-ba69-06d148190175.png">

