### PR TITLE
Fix missing fields on RichLinkComponent

### DIFF
--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -79,9 +79,9 @@ export const RichLinkComponent = ({
 
 	const richLinkImageData: RichLinkImageData = {
 		thumbnailUrl: data.thumbnailUrl,
-		altText: data.imageAsset.fields.altText,
-		width: data.imageAsset.fields.width,
-		height: data.imageAsset.fields.height,
+		altText: data.imageAsset?.fields.altText,
+		width: data.imageAsset?.fields.width,
+		height: data.imageAsset?.fields.height,
 	};
 
 	return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Quick fix for no `fields` on imageAsset, further investigation should be carried out to ensure that we're more forgiving for missing data

## Why?
Client side error was blocking hydration:

![image](https://user-images.githubusercontent.com/9575458/126484910-815c8105-90e6-41e0-8804-119e5ce8f172.png)


### Before
![image](https://user-images.githubusercontent.com/9575458/126484875-6813b691-da01-4daa-9e54-44aed05a1593.png)

### After
![image](https://user-images.githubusercontent.com/9575458/126484836-0f97f41a-6c90-4196-bb24-bff35c921421.png)
