### PR TITLE
ensure compatibility with custom boot script interactives

### DIFF
--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -285,6 +285,7 @@ export const InteractiveBlockComponent = ({
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 				ref={wrapperRef}
 				css={wrapperStyle({ format, role, loaded, palette })}
+				data-alt={alt} // for compatibility with custom boot scripts
 			>
 				{!loaded && (
 					<>


### PR DESCRIPTION
## What does this change?
Interactives with custom boot scripts failed to render, this fixes the issue (albeit there will probably be some styling/layout issues in the content that is actually rendered).

## Why?
To support interactive migration to DCR.

### Before
Interactive failed to render:

<img width="1001" alt="Screenshot 2021-07-22 at 10 52 35" src="https://user-images.githubusercontent.com/45561419/126621268-738812d4-ee23-4458-ac81-a902ee3554cc.png">

### After
Interactive renders:

<img width="906" alt="Screenshot 2021-07-22 at 10 53 23" src="https://user-images.githubusercontent.com/45561419/126621244-3eae5754-b769-43f6-a19d-c676e7fb61d0.png">

