### PR TITLE
Add regional support to paid for branding

### DIFF
--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -3,6 +3,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { pillarPalette_DO_NOT_USE, neutralBorder } from '@root/src/lib/pillars';
+import { isEdition } from '@root/src/amp/lib/edition';
 
 const LinkStyle = (pillar: Theme) => css`
 	a {
@@ -98,19 +99,16 @@ export const BrandingRegionContainer: React.FC<{
 	};
 	return (
 		<>
-			{Object.keys(commercialProperties).map((editionId) => {
-				const { branding } = commercialProperties[editionId as Edition];
-				return branding !== undefined ? (
-					<div
-						css={[
-							brandingStyles,
-							editionStyles[editionId as Edition],
-						]}
-					>
-						{children(branding)}
-					</div>
-				) : null;
-			})}
+			{Object.keys(commercialProperties)
+				.filter(isEdition)
+				.map((editionId) => {
+					const { branding } = commercialProperties[editionId];
+					return branding !== undefined ? (
+						<div css={[brandingStyles, editionStyles[editionId]]}>
+							{children(branding)}
+						</div>
+					) : null;
+				})}
 		</>
 	);
 };

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -34,7 +34,7 @@ const brandingLogoStyle = css`
 	padding: 10px 0;
 `;
 
-const BrandingItem: React.FC<{
+export const Branding: React.FC<{
 	branding: Branding;
 	pillar: Theme;
 }> = ({ branding, pillar }) => {
@@ -62,10 +62,10 @@ const BrandingItem: React.FC<{
 	);
 };
 
-export const Branding: React.FC<{
+export const BrandingRegionContainer: React.FC<{
+	children: (branding: Branding) => React.ReactNode;
 	commercialProperties: CommercialProperties;
-	pillar: Theme;
-}> = ({ commercialProperties, pillar }) => {
+}> = ({ children, commercialProperties }) => {
 	const brandingStyles = css`
 		display: none;
 	`;
@@ -107,7 +107,7 @@ export const Branding: React.FC<{
 							editionStyles[editionId as Edition],
 						]}
 					>
-						<BrandingItem branding={branding} pillar={pillar} />
+						{children(branding)}
 					</div>
 				) : null;
 			})}

--- a/src/amp/components/topMeta/TopMetaAnalysis.tsx
+++ b/src/amp/components/topMeta/TopMetaAnalysis.tsx
@@ -15,7 +15,10 @@ import { Standfirst } from '@root/src/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@root/src/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
-import { Branding } from '@root/src/amp/components/topMeta/Branding';
+import {
+	Branding,
+	BrandingRegionContainer,
+} from '@root/src/amp/components/topMeta/Branding';
 import { StarRating } from '@root/src/amp/components/StarRating';
 
 const headerStyle = css`
@@ -120,10 +123,11 @@ export const TopMetaAnalysis: React.FC<{
 
 			<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			<Branding
+			<BrandingRegionContainer
 				commercialProperties={articleData.commercialProperties}
-				pillar={pillar}
-			/>
+			>
+				{(branding) => <Branding branding={branding} pillar={pillar} />}
+			</BrandingRegionContainer>
 
 			<div css={bylineStyle(pillar)}>
 				<Byline

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -14,7 +14,10 @@ import { Standfirst } from '@root/src/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@root/src/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
-import { Branding } from '@root/src/amp/components/topMeta/Branding';
+import {
+	Branding,
+	BrandingRegionContainer,
+} from '@root/src/amp/components/topMeta/Branding';
 import { StarRating } from '@root/src/amp/components/StarRating';
 
 const headerStyle = css`
@@ -93,10 +96,11 @@ export const TopMetaNews: React.FC<{
 
 			<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			<Branding
+			<BrandingRegionContainer
 				commercialProperties={articleData.commercialProperties}
-				pillar={pillar}
-			/>
+			>
+				{(branding) => <Branding branding={branding} pillar={pillar} />}
+			</BrandingRegionContainer>
 
 			<div css={bylineStyle(pillar)}>
 				<Byline

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -13,7 +13,10 @@ import { Standfirst } from '@root/src/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@root/src/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
-import { Branding } from '@root/src/amp/components/topMeta/Branding';
+import {
+	Branding,
+	BrandingRegionContainer,
+} from '@root/src/amp/components/topMeta/Branding';
 
 const headerStyle = css`
 	${headline.small()};
@@ -119,10 +122,11 @@ export const TopMetaOpinion: React.FC<{
 
 			<h1 css={headerStyle}>{articleData.headline}</h1>
 
-			<Branding
+			<BrandingRegionContainer
 				commercialProperties={articleData.commercialProperties}
-				pillar={pillar}
-			/>
+			>
+				{(branding) => <Branding branding={branding} pillar={pillar} />}
+			</BrandingRegionContainer>
 
 			<BylineMeta articleData={articleData} pillar={pillar} />
 

--- a/src/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/src/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -14,6 +14,7 @@ import { PaidForBand } from '@root/src/amp/components/topMeta/PaidForBand';
 
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
+import { BrandingRegionContainer } from './Branding';
 
 const headerStyle = css`
 	${textSans.xlarge()};
@@ -84,46 +85,44 @@ const Headline: React.FC<{
 export const TopMetaPaidContent: React.FC<{
 	articleData: ArticleModel;
 	pillar: Theme;
-}> = ({ articleData, pillar }) => {
-	const { branding } = articleData.commercialProperties[
-		articleData.editionId
-	];
+}> = ({ articleData, pillar }) => (
+	<header>
+		<PaidForBand />
 
-	return (
-		<header>
-			<PaidForBand />
+		{articleData.mainMediaElements.map((element, i) => (
+			<MainMedia key={i} element={element} pillar={pillar} />
+		))}
 
-			{articleData.mainMediaElements.map((element, i) => (
-				<MainMedia key={i} element={element} pillar={pillar} />
-			))}
+		<Headline headlineText={articleData.headline} />
 
-			<Headline headlineText={articleData.headline} />
+		<BrandingRegionContainer
+			commercialProperties={articleData.commercialProperties}
+		>
+			{(branding) => <PaidForByLogo branding={branding} />}
+		</BrandingRegionContainer>
 
-			{!!branding && <PaidForByLogo branding={branding} />}
+		<Standfirst text={articleData.standfirst} pillar={pillar} />
 
-			<Standfirst text={articleData.standfirst} pillar={pillar} />
-
-			<div css={bylineStyle}>
-				<Byline
-					byline={articleData.author.byline}
-					tags={articleData.tags}
-					guardianBaseURL={articleData.guardianBaseURL}
-				/>
-			</div>
-
-			<TopMetaExtras
-				sharingUrls={getSharingUrls(
-					articleData.pageId,
-					articleData.webTitle,
-				)}
-				pillar={pillar}
-				ageWarning={getAgeWarning(
-					articleData.tags,
-					articleData.webPublicationDate,
-				)}
-				webPublicationDate={articleData.webPublicationDateDisplay}
-				twitterHandle={articleData.author.twitterHandle}
+		<div css={bylineStyle}>
+			<Byline
+				byline={articleData.author.byline}
+				tags={articleData.tags}
+				guardianBaseURL={articleData.guardianBaseURL}
 			/>
-		</header>
-	);
-};
+		</div>
+
+		<TopMetaExtras
+			sharingUrls={getSharingUrls(
+				articleData.pageId,
+				articleData.webTitle,
+			)}
+			pillar={pillar}
+			ageWarning={getAgeWarning(
+				articleData.tags,
+				articleData.webPublicationDate,
+			)}
+			webPublicationDate={articleData.webPublicationDateDisplay}
+			twitterHandle={articleData.author.twitterHandle}
+		/>
+	</header>
+);

--- a/src/amp/lib/edition.ts
+++ b/src/amp/lib/edition.ts
@@ -1,0 +1,8 @@
+/**
+ * Determine if a string is one of the permitted edition strings
+ *
+ * @param s The string to test
+ */
+export function isEdition(s: string): s is Edition {
+	return ['UK', 'US', 'INT', 'AU'].includes(s);
+}


### PR DESCRIPTION
## What does this change?

As a follow-up to [#3200](https://github.com/guardian/dotcom-rendering/pull/3200), add regional support to "Paid For By" branding components, fixing a bug where cached AMP pages only display US branding. This is achieved by pulling out the required logic for adding correct region classes into a `BrandingRegionContainer` that handles this logic of applying the correct region classes.

## Why?

Paid For By branding suffers from the same problem as sponsorship branding, with AMP pages being cached in the US. The logic that is used for applying the classes to each region for sponsorship branding can be used for Paid For By branding, hence a common container component that can wrap both.

