### PR TITLE
Bump CWV To 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "reset-css": "^5.0.1",
     "sanitize-html": "^2.3.2",
     "swr": "^0.5.5",
-    "web-vitals": "^1.1.2",
+    "web-vitals": "^2.1.0",
     "youtube-player": "^5.5.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20983,10 +20983,10 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-web-vitals@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
-  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
+web-vitals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.0.tgz#ebf5428875ab5bfc1056c2e80cd177001287de7b"
+  integrity sha512-npEyJP8jHf3J71t1tRTEtz9FeKp8H2udWJUUq5ykfPhhstr//TUxiYhIEzLNwk4zv2ybAilMn7v7N6Mxmuitmg==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates CWV to 2.1.0 which purports to have a breaking change, though we do not use this part of the code, therefore it should have no effect on us. Either way the data coming in will be monitored to make sure it's as expected.

## Why?

It changes the way CLS is recorded which should hopefully see some improvements in our data.

