### PR TITLE
make skip to main content smaller

### DIFF
--- a/src/web/components/AccessibleSkipButton.tsx
+++ b/src/web/components/AccessibleSkipButton.tsx
@@ -7,10 +7,10 @@ export const AccessibleSkipButton = () => {
 		<a
 			href="#maincontent"
 			css={css`
-				${textSans.xlarge()}
-				height: 65px;
-				top: -65px;
-				line-height: 55px;
+				${textSans.medium()}
+				height: 40px;
+				top: -40px;
+				line-height: 30px;
 				overflow: hidden;
 				padding: 0;
 				position: absolute;
@@ -19,6 +19,7 @@ export const AccessibleSkipButton = () => {
 				text-align: center;
 				margin: 0;
 				text-decoration: none;
+				color: ${neutral[0]};
 				&:focus,
 				&:active {
 					border: 5px solid ${border.focusHalo};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes Skip to main content button smaller

## Why?
Too big before

### Before
![image](https://user-images.githubusercontent.com/20658471/127011717-26bb4e48-6158-4fb9-8983-0c77621539a7.png)


### After
![image](https://user-images.githubusercontent.com/20658471/127011754-0bf2a070-82f5-4235-a044-e2cedc7cb78c.png)
