### PR TITLE
extend legacy interactive figure classes

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -7,7 +7,7 @@ import { center } from '@root/src/web/lib/center';
 export const interactiveLegacyFigureClasses = new Map([
 	[
 		'model.dotcomrendering.pageElements.InteractiveBlockElement',
-		'element-interactive',
+		'element-interactive element interactive',
 	],
 ]);
 


### PR DESCRIPTION
Some legacy interactive figures require additional classes in order for the page to correctly render, this change adds the known missing classes.

## What does this change?
Adds more classes on legacy interactive figures: `element` and `interactive`

## Why?
Some legacy interactive immersives rely on classes to render. Without these extra classes legacy interactive immersives cannot be rendered via dcr.

### Before
Interactive does not render via dcr:
<img width="964" alt="Screenshot 2021-07-27 at 16 41 16" src="https://user-images.githubusercontent.com/45561419/127184390-74c772aa-39f8-4e1f-b6b6-c1de631b6fa7.png">


### After
Interactive renders via dcr:
<img width="1032" alt="Screenshot 2021-07-27 at 16 43 07" src="https://user-images.githubusercontent.com/45561419/127184681-f0fac74f-035c-4252-84e4-aee98045592a.png">

