### PR TITLE
Stop recording timing data for Braze epic canShow

### DIFF
--- a/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -89,7 +89,6 @@ const buildBrazeEpicConfig = (
 			),
 		},
 		timeoutMillis: 5000,
-		reportTiming: true,
 	};
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

In #3199 we added the option to record canShow timings to the messagePicker and enabled this option for the Braze epic. This PR turns off the recording.

## Why?

We've got several days worth of data to look at now which is plenty.
