### PR TITLE
Move AMP regional classes out of components

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -1,6 +1,10 @@
 import { ClassNames } from '@emotion/react';
 
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
+import {
+	noDisplayClass,
+	regionClasses,
+} from '@root/src/amp/lib/region-classes';
 
 // Largest size first
 const inlineSizes = [
@@ -102,61 +106,35 @@ export const Ad = ({
 
 	return (
 		<ClassNames>
-			{({ css, cx }) => {
-				const adClass = css`
-					display: none;
-				`;
-
-				const usAdRegionClass = css`
-					.amp-geo-group-us & {
-						display: block;
-					}
-				`;
-
-				const auAdRegionClass = css`
-					.amp-geo-group-au & {
-						display: block;
-					}
-				`;
-
-				const rowAdRegionClass = css`
-					.amp-geo-group-eea & {
-						display: block;
-					}
-					.amp-geo-no-group & {
-						display: block;
-					}
-				`;
-
-				const adRegionClasses = {
-					US: usAdRegionClass,
-					AU: auAdRegionClass,
-					ROW: rowAdRegionClass,
-				};
-
-				return (
-					<amp-ad
-						class={cx(adClass, adRegionClasses[adRegion])}
-						data-block-on-consent=""
-						width={width}
-						height={height}
-						data-multi-size={multiSizes}
-						data-npa-on-unknown-consent={true}
-						data-loading-strategy="prefer-viewability-over-views"
-						layout="fixed"
-						type="doubleclick"
-						json={stringify(
-							adJson(commercialProperties[edition].adTargeting),
-						)}
-						data-slot={ampData(section, contentType)}
-						rtc-config={realTimeConfig(
-							adRegion,
-							config.usePrebid,
-							config.usePermutive,
-						)}
-					/>
-				);
-			}}
+			{({ css, cx }) => (
+				<amp-ad
+					class={cx(
+						css`
+							${noDisplayClass.styles}
+						`,
+						css`
+							${regionClasses[adRegion].styles}
+						`,
+					)}
+					data-block-on-consent=""
+					width={width}
+					height={height}
+					data-multi-size={multiSizes}
+					data-npa-on-unknown-consent={true}
+					data-loading-strategy="prefer-viewability-over-views"
+					layout="fixed"
+					type="doubleclick"
+					json={stringify(
+						adJson(commercialProperties[edition].adTargeting),
+					)}
+					data-slot={ampData(section, contentType)}
+					rtc-config={realTimeConfig(
+						adRegion,
+						config.usePrebid,
+						config.usePermutive,
+					)}
+				/>
+			)}
 		</ClassNames>
 	);
 };

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -1,10 +1,7 @@
 import { ClassNames } from '@emotion/react';
 
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
-import {
-	noDisplayClass,
-	regionClasses,
-} from '@root/src/amp/lib/region-classes';
+import { regionClasses } from '@root/src/amp/lib/region-classes';
 
 // Largest size first
 const inlineSizes = [
@@ -109,9 +106,6 @@ export const Ad = ({
 			{({ css, cx }) => (
 				<amp-ad
 					class={cx(
-						css`
-							${noDisplayClass.styles}
-						`,
 						css`
 							${regionClasses[adRegion].styles}
 						`,

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { css, SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
+import {
+	noDisplayClass,
+	regionClasses,
+} from '@root/src/amp/lib/region-classes';
 
 import { pillarPalette_DO_NOT_USE, neutralBorder } from '@root/src/lib/pillars';
 
@@ -65,52 +69,17 @@ export const Branding: React.FC<{
 export const BrandingRegionContainer: React.FC<{
 	children: (branding: Branding) => React.ReactNode;
 	commercialProperties: CommercialProperties;
-}> = ({ children, commercialProperties }) => {
-	const brandingStyles = css`
-		display: none;
-	`;
-	const ukStyles = css`
-		.amp-iso-country-gb & {
-			display: block;
-		}
-	`;
-	const usStyles = css`
-		.amp-iso-country-us & {
-			display: block;
-		}
-	`;
-	const auStyles = css`
-		.amp-iso-country-au & {
-			display: block;
-		}
-	`;
-	const intStyles = css`
-		.amp-geo-group-eea:not(.amp-iso-country-gb) &,
-		.amp-geo-no-group & {
-			display: block;
-		}
-	`;
-	const editionStyles: Record<Edition, SerializedStyles> = {
-		UK: ukStyles,
-		US: usStyles,
-		AU: auStyles,
-		INT: intStyles,
-	};
-	return (
-		<>
-			{Object.keys(commercialProperties).map((editionId) => {
-				const { branding } = commercialProperties[editionId as Edition];
-				return branding !== undefined ? (
-					<div
-						css={[
-							brandingStyles,
-							editionStyles[editionId as Edition],
-						]}
-					>
-						{children(branding)}
-					</div>
-				) : null;
-			})}
-		</>
-	);
-};
+}> = ({ children, commercialProperties }) => (
+	<>
+		{Object.keys(commercialProperties).map((editionId) => {
+			const { branding } = commercialProperties[editionId as Edition];
+			return branding !== undefined ? (
+				<div
+					css={[noDisplayClass, regionClasses[editionId as Edition]]}
+				>
+					{children(branding)}
+				</div>
+			) : null;
+		})}
+	</>
+);

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -68,16 +68,16 @@ export const BrandingRegionContainer: React.FC<{
 	children: (branding: Branding) => React.ReactNode;
 	commercialProperties: CommercialProperties;
 }> = ({ children, commercialProperties }) => (
-  <>
-    {Object.keys(commercialProperties)
-      .filter(isEdition)
-      .map((editionId) => {
-        const { branding } = commercialProperties[editionId];
-        return branding !== undefined ? (
-          <div css={[brandingStyles, editionStyles[editionId]]}>
-            {children(branding)}
-          </div>
-        ) : null;
-      })}
-  </>
+	<>
+		{Object.keys(commercialProperties)
+			.filter(isEdition)
+			.map((editionId) => {
+				const { branding } = commercialProperties[editionId];
+				return branding !== undefined ? (
+					<div css={regionClasses[editionId]}>
+						{children(branding)}
+					</div>
+				) : null;
+			})}
+	</>
 );

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
-import {
-	noDisplayClass,
-	regionClasses,
-} from '@root/src/amp/lib/region-classes';
+import { regionClasses } from '@root/src/amp/lib/region-classes';
 
 import { pillarPalette_DO_NOT_USE, neutralBorder } from '@root/src/lib/pillars';
 
@@ -74,9 +71,7 @@ export const BrandingRegionContainer: React.FC<{
 		{Object.keys(commercialProperties).map((editionId) => {
 			const { branding } = commercialProperties[editionId as Edition];
 			return branding !== undefined ? (
-				<div
-					css={[noDisplayClass, regionClasses[editionId as Edition]]}
-				>
+				<div css={regionClasses[editionId as Edition]}>
 					{children(branding)}
 				</div>
 			) : null;

--- a/src/amp/lib/region-classes.ts
+++ b/src/amp/lib/region-classes.ts
@@ -65,7 +65,12 @@ const internationalRegionClass = css`
 	}
 `;
 
-/** Dictionary mapping region code to the associated AMP region style */
+/**
+ * Dictionary mapping region code to the associated AMP region style
+ *
+ * E.g. Applying `regionClasses["US"]` to an element will only display the
+ * element if the user is accessing the AMP page from the US
+ * */
 export const regionClasses = {
 	UK: ukRegionClass,
 	US: usRegionClass,

--- a/src/amp/lib/region-classes.ts
+++ b/src/amp/lib/region-classes.ts
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
  * from Great Britain
  */
 const ukRegionClass = css`
+	display: none;
 	.amp-iso-country-gb & {
 		display: block;
 	}
@@ -14,6 +15,7 @@ const ukRegionClass = css`
  * Class that will display an element if the user accesses the AMP page from US
  */
 const usRegionClass = css`
+	display: none;
 	.amp-iso-country-us & {
 		display: block;
 	}
@@ -24,6 +26,7 @@ const usRegionClass = css`
  * from Australia
  */
 const auRegionClass = css`
+	display: none;
 	.amp-iso-country-au & {
 		display: block;
 	}
@@ -38,6 +41,7 @@ const auRegionClass = css`
  *
  */
 const rowRegionClass = css`
+	display: none;
 	.amp-geo-group-eea & {
 		display: block;
 	}
@@ -54,18 +58,11 @@ const rowRegionClass = css`
  * Area EXCEPT Great Britain or where no AMP geo group is assigned
  */
 const internationalRegionClass = css`
+	display: none;
 	.amp-geo-group-eea:not(.amp-iso-country-gb) &,
 	.amp-geo-no-group & {
 		display: block;
 	}
-`;
-
-/**
- * Class that can be applied to all regions to ensure that when not in the
- * correct AMP region all other regions aren't displayed
- */
-export const noDisplayClass = css`
-	display: none;
 `;
 
 /** Dictionary mapping region code to the associated AMP region style */

--- a/src/amp/lib/region-classes.ts
+++ b/src/amp/lib/region-classes.ts
@@ -1,23 +1,42 @@
 import { css } from '@emotion/react';
 
+/**
+ * Class that will display an element if the user accesses the AMP page
+ * from Great Britain
+ */
 const ukRegionClass = css`
 	.amp-iso-country-gb & {
 		display: block;
 	}
 `;
 
+/**
+ * Class that will display an element if the user accesses the AMP page from US
+ */
 const usRegionClass = css`
 	.amp-iso-country-us & {
 		display: block;
 	}
 `;
 
+/**
+ * Class that will display an element if the user accesses the AMP page
+ * from Australia
+ */
 const auRegionClass = css`
 	.amp-iso-country-au & {
 		display: block;
 	}
 `;
 
+/**
+ * Class that will display an element if the user accesses the AMP page from
+ * the region denoted as "Rest of World"
+ *
+ * Currently this region is set to any access either from the European Economic
+ * Area or where no AMP geo group is assigned
+ *
+ */
 const rowRegionClass = css`
 	.amp-geo-group-eea & {
 		display: block;
@@ -27,6 +46,13 @@ const rowRegionClass = css`
 	}
 `;
 
+/**
+ * Class that will display an element if the user accesses the AMP page from
+ * the region denoted as "International"
+ *
+ * Currently this region is set to any access from the European Economic
+ * Area EXCEPT Great Britain or where no AMP geo group is assigned
+ */
 const internationalRegionClass = css`
 	.amp-geo-group-eea:not(.amp-iso-country-gb) &,
 	.amp-geo-no-group & {
@@ -34,10 +60,15 @@ const internationalRegionClass = css`
 	}
 `;
 
+/**
+ * Class that can be applied to all regions to ensure that when not in the
+ * correct AMP region all other regions aren't displayed
+ */
 export const noDisplayClass = css`
 	display: none;
 `;
 
+/** Dictionary mapping region code to the associated AMP region style */
 export const regionClasses = {
 	UK: ukRegionClass,
 	US: usRegionClass,

--- a/src/amp/lib/region-classes.ts
+++ b/src/amp/lib/region-classes.ts
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+
+const ukRegionClass = css`
+	.amp-iso-country-gb & {
+		display: block;
+	}
+`;
+
+const usRegionClass = css`
+	.amp-iso-country-us & {
+		display: block;
+	}
+`;
+
+const auRegionClass = css`
+	.amp-iso-country-au & {
+		display: block;
+	}
+`;
+
+const rowRegionClass = css`
+	.amp-geo-group-eea & {
+		display: block;
+	}
+	.amp-geo-no-group & {
+		display: block;
+	}
+`;
+
+const internationalRegionClass = css`
+	.amp-geo-group-eea:not(.amp-iso-country-gb) &,
+	.amp-geo-no-group & {
+		display: block;
+	}
+`;
+
+export const noDisplayClass = css`
+	display: none;
+`;
+
+export const regionClasses = {
+	UK: ukRegionClass,
+	US: usRegionClass,
+	AU: auRegionClass,
+	INT: internationalRegionClass,
+	ROW: rowRegionClass,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Pull the AMP classes used to render conditionally in different regions out of their definitions within components and share them across those that use them. Currently in AMP these components are branding and ads.

## Why?

Region classes are used across branding and ad components. Therefore it makes sense to pull these out into common constants that can be used by any components that need to be rendered regionally, or reused in the future by new components that need to display conditionally in regions.
