### PR TITLE
ROTA: Broken embeds due to code not compatible with loadable components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -843,6 +843,11 @@ interface VineBlockLoadable extends ComponentNameChunkMap {
     addWhen: VineBlockElement['_type'];
 }
 
+interface InstagramBlockLoadable extends ComponentNameChunkMap {
+    chunkName: 'elements-InstagramBlockComponent';
+    addWhen: InstagramBlockElement['_type'];
+}
+
 // There are docs on loadable in ./docs/loadable-components.md
 type LoadableComponents = [
 	EditionDropdownLoadable,
@@ -856,6 +861,7 @@ type LoadableComponents = [
 	SpotifyBlockLoadable,
 	FacebookVideoBlockLoadable,
 	VineBlockLoadable,
+	InstagramBlockLoadable,
 ]
 
 interface CarouselImagesMap {

--- a/index.d.ts
+++ b/index.d.ts
@@ -823,15 +823,7 @@ interface DocumentBlockLoadable extends ComponentNameChunkMap {
     chunkName: 'elements-DocumentBlockComponent';
     addWhen: DocumentBlockElement['_type'];
 }
-interface EmbedBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-EmbedBlockComponent';
-    addWhen: EmbedBlockElement['_type'];
-}
 
-interface InstagramBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-InstagramBlockComponent';
-    addWhen: InstagramBlockElement['_type'];
-}
 interface MapBlockLoadable extends ComponentNameChunkMap {
     chunkName: 'elements-MapEmbedBlockComponent';
     addWhen: MapBlockElement['_type'];
@@ -860,8 +852,6 @@ type LoadableComponents = [
 	InteractiveContentsBlockLoadable,
 	CalloutBlockLoadable,
 	DocumentBlockLoadable,
-	EmbedBlockLoadable,
-	InstagramBlockLoadable,
 	MapBlockLoadable,
 	SpotifyBlockLoadable,
 	FacebookVideoBlockLoadable,

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -60,6 +60,9 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { updateIframeHeight } from '@root/src/web/browser/updateIframeHeight';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import { LabsHeader } from '@root/src/web/components/LabsHeader';
+import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
+import { UnsafeEmbedBlockComponent } from '@root/src/web/components/elements/UnsafeEmbedBlockComponent';
+import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
@@ -489,66 +492,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		},
 		{
 			resolveComponent: (module) => module.DocumentBlockComponent,
-		},
-	);
-
-	const EmbedBlockComponent = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.EmbedBlockElement',
-				).length > 0
-			) {
-				return import(
-					'@frontend/web/components/elements/EmbedBlockComponent'
-				);
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) => module.EmbedBlockComponent,
-		},
-	);
-
-	const UnsafeEmbedBlockComponent = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.EmbedBlockElement',
-				).length > 0
-			) {
-				return import(
-					'@frontend/web/components/elements/UnsafeEmbedBlockComponent'
-				);
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) => module.UnsafeEmbedBlockComponent,
-		},
-	);
-
-	const InstagramBlockComponent = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.InstagramBlockElement',
-				).length > 0
-			) {
-				return import(
-					'@frontend/web/components/elements/InstagramBlockComponent'
-				);
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) => module.InstagramBlockComponent,
 		},
 	);
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -62,7 +62,6 @@ import { ClickToView } from '@root/src/web/components/ClickToView';
 import { LabsHeader } from '@root/src/web/components/LabsHeader';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { UnsafeEmbedBlockComponent } from '@root/src/web/components/elements/UnsafeEmbedBlockComponent';
-import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
@@ -572,6 +571,26 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		},
 		{
 			resolveComponent: (module) => module.VineBlockComponent,
+		},
+	);
+
+	const InstagramBlockComponent = loadable(
+		() => {
+			if (
+				CAPI.elementsToHydrate.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.InstagramBlockElement',
+				).length > 0
+			) {
+				return import(
+					'@frontend/web/components/elements/InstagramBlockComponent'
+				);
+			}
+			return Promise.reject();
+		},
+		{
+			resolveComponent: (module) => module.InstagramBlockComponent,
 		},
 	);
 

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -146,6 +146,10 @@ export const document = ({ data }: Props): string => {
 			chunkName: 'elements-VineBlockComponent',
 			addWhen: 'model.dotcomrendering.pageElements.VineBlockElement',
 		},
+		{
+			chunkName: 'elements-InstagramBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+		},
 	];
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -130,14 +130,6 @@ export const document = ({ data }: Props): string => {
 			addWhen: 'model.dotcomrendering.pageElements.DocumentBlockElement',
 		},
 		{
-			chunkName: 'elements-EmbedBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		},
-		{
-			chunkName: 'elements-InstagramBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
-		},
-		{
 			chunkName: 'elements-MapEmbedBlockComponent',
 			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
 		},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?
Loadable components created a race condition for UnsafeEmbed type embeds on Dotcom, that was causing the height adjustment of the first 'loaded' embed to fail, so we rolled back this change for this type of component only. Would like to investigate further during health week.

### Before
<img width="654" alt="before" src="https://user-images.githubusercontent.com/3300789/127504351-83e22b27-8c04-4314-bcbe-15158db7d2bb.png">

### After
<img width="668" alt="AFTER" src="https://user-images.githubusercontent.com/3300789/127504371-4033d8cf-7bfb-47bd-8cc1-592058494114.png">

