### PR TITLE
Run DCR locally with more memory

### DIFF
--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ run: stop build start
 
 dev: clear clean-dist install
 	$(call log, "starting frontend DEV server")
-	@NODE_ENV=development nodemon scripts/frontend/dev-server -- --max-old-space-size=7000
+	@NODE_ENV=development nodemon scripts/frontend/dev-server -- --max-old-space-size=7168
 
 # tests #####################################
 

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ run: stop build start
 
 dev: clear clean-dist install
 	$(call log, "starting frontend DEV server")
-	@NODE_ENV=development nodemon scripts/frontend/dev-server -- --max-old-space-size=8192
+	@NODE_ENV=development nodemon scripts/frontend/dev-server -- --max-old-space-size=7000
 
 # tests #####################################
 

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ run: stop build start
 
 dev: clear clean-dist install
 	$(call log, "starting frontend DEV server")
-	@NODE_ENV=development nodemon scripts/frontend/dev-server
+	@NODE_ENV=development nodemon scripts/frontend/dev-server -- --max-old-space-size=8192
 
 # tests #####################################
 


### PR DESCRIPTION
## What?
Tells `make dev` to run `node` with 8GB of memory

## Why?
Because I keep getting out of memory errors when running locally