### PR TITLE
Add Identifier enum for `id` attributes

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -7,6 +7,7 @@ import { LiveBlogRenderer } from '@root/src/web/lib/LiveBlogRenderer';
 import { Design, Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
 import { space } from '@guardian/src-foundations';
+import { Identifier } from './SkipTo';
 
 type Props = {
 	format: Format;
@@ -93,7 +94,7 @@ export const ArticleBody = ({
 		<div
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
 			tabIndex={0}
-			id="maincontent"
+			id={Identifier.MainContent}
 			css={[
 				isInteractive ? null : bodyPadding,
 				globalH2Styles(format.display),

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -6,6 +6,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { Display, Design } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { navInputCheckboxId } from './Nav/config';
+import { Identifier } from './SkipTo';
 
 // CSS Vars
 
@@ -263,7 +264,11 @@ export const Pillars: React.FC<{
 							isSelected && forceUnderline,
 							showDivider && pillarDivider,
 						]}
-						id={isTopNav && i === 0 ? 'navigation' : undefined}
+						id={
+							isTopNav && i === 0
+								? Identifier.Navigation
+								: undefined
+						}
 						aria-label={i === 0 ? 'Navigation' : undefined}
 						href={p.url}
 						data-link-name={`${dataLinkName} : primary : ${p.title}`}

--- a/src/web/components/SkipTo.tsx
+++ b/src/web/components/SkipTo.tsx
@@ -2,15 +2,20 @@ import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, border } from '@guardian/src-foundations/palette';
 
+export enum Identifier {
+	Navigation = 'navigation',
+	MainContent = 'maincontent',
+}
+
 type Props = {
-	id: string;
+	id: Identifier;
 	label: string;
 };
 
 export const SkipTo = ({ id, label }: Props) => {
 	return (
 		<a
-			href={id}
+			href={`#${id}`}
 			css={css`
 				${textSans.medium()}
 				height: 40px;

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -21,7 +21,7 @@ import { Pillar } from '@guardian/types';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { htmlTemplate } from './htmlTemplate';
 import { decideTheme } from '../lib/decideTheme';
-import { SkipTo } from '../components/SkipTo';
+import { Identifier, SkipTo } from '../components/SkipTo';
 
 interface RenderToStringResult {
 	html: string;
@@ -328,10 +328,10 @@ export const document = ({ data }: Props): string => {
 			: CAPI.config.keywords;
 
 	const skipToMainContent = renderToString(
-		<SkipTo id="#maincontent" label="Skip to main content" />,
+		<SkipTo id={Identifier.MainContent} label="Skip to main content" />,
 	);
 	const skipToNavigation = renderToString(
-		<SkipTo id="#navigation" label="Skip to navigation" />,
+		<SkipTo id={Identifier.Navigation} label="Skip to navigation" />,
 	);
 
 	return htmlTemplate({


### PR DESCRIPTION
## What does this change?

Convert the `id` attributes to using an enum. The [IDs should be globally unique on a page][id], so mapping them in an enum  provides type safety and semantically links them all together.

[id]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id

## Why?

I saw #3210 and thought it was brilliant!
