### PR TITLE
Simplify SkipTo props

### DIFF
--- a/src/web/components/SkipTo.tsx
+++ b/src/web/components/SkipTo.tsx
@@ -2,15 +2,17 @@ import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, border } from '@guardian/src-foundations/palette';
 
+type Identifier = 'maincontent' | 'navigation';
+
 type Props = {
-	id: string;
+	id: Identifier;
 	label: string;
 };
 
 export const SkipTo = ({ id, label }: Props) => {
 	return (
 		<a
-			href={id}
+			href={`#${id}`}
 			css={css`
 				${textSans.medium()}
 				height: 40px;

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -328,10 +328,10 @@ export const document = ({ data }: Props): string => {
 			: CAPI.config.keywords;
 
 	const skipToMainContent = renderToString(
-		<SkipTo id="#maincontent" label="Skip to main content" />,
+		<SkipTo id="maincontent" label="Skip to main content" />,
 	);
 	const skipToNavigation = renderToString(
-		<SkipTo id="#navigation" label="Skip to navigation" />,
+		<SkipTo id="navigation" label="Skip to navigation" />,
 	);
 
 	return htmlTemplate({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Clarify identifiers and auto-complete them. Automatically add “#“ in `href`.

## Why?

There’s a potential confusion between `id` and `href`, so this fixes that. Enums have been explored, but rejected in #3219.
