### PR TITLE
Move webPublicationDate to free up space for new format

### DIFF
--- a/fixtures/generated/articles/Analysis.ts
+++ b/fixtures/generated/articles/Analysis.ts
@@ -1796,7 +1796,7 @@ export const Analysis: CAPIType = {
 			elementId: '2e19fdc4-4c9a-4826-bc94-3cceb9f583cb',
 		},
 	],
-	webPublicationDate: '2020-02-10T12:31:25.000Z',
+	webPublicationDateDeprecated: '2020-02-10T12:31:25.000Z',
 	blocks: [
 		{
 			id: '5e413c398f0811db2faf4cdd',

--- a/fixtures/generated/articles/Article.ts
+++ b/fixtures/generated/articles/Article.ts
@@ -1769,7 +1769,7 @@ export const Article: CAPIType = {
 			elementId: '61ed6463-adc6-4583-9f3c-a6d53a470f6c',
 		},
 	],
-	webPublicationDate: '2020-02-10T06:00:27.000Z',
+	webPublicationDateDeprecated: '2020-02-10T06:00:27.000Z',
 	blocks: [
 		{
 			id: '5e3d3b488f086a28115a74be',

--- a/fixtures/generated/articles/Comment.ts
+++ b/fixtures/generated/articles/Comment.ts
@@ -1844,7 +1844,7 @@ export const Comment: CAPIType = {
 			elementId: 'c59f08ad-f84d-4996-bdb5-a14d0116bd6e',
 		},
 	],
-	webPublicationDate: '2020-02-10T06:00:27.000Z',
+	webPublicationDateDeprecated: '2020-02-10T06:00:27.000Z',
 	blocks: [
 		{
 			id: '6bc6fa8c-a504-4e81-9828-3a7a0a78b052',

--- a/fixtures/generated/articles/Dead.ts
+++ b/fixtures/generated/articles/Dead.ts
@@ -1983,7 +1983,7 @@ export const Dead: CAPIType = {
 			elementId: '368b9dc2-e5f3-41b7-99ec-87d6ac92a886',
 		},
 	],
-	webPublicationDate: '2021-02-19T19:41:53.000Z',
+	webPublicationDateDeprecated: '2021-02-19T19:41:53.000Z',
 	blocks: [
 		{
 			id: '60300f5f8f08ad21ea60071e',

--- a/fixtures/generated/articles/Editorial.ts
+++ b/fixtures/generated/articles/Editorial.ts
@@ -1793,7 +1793,7 @@ export const Editorial: CAPIType = {
 			elementId: 'aa132cb0-c65c-4e44-b078-cbaccee39944',
 		},
 	],
-	webPublicationDate: '2021-02-03T18:54:37.000Z',
+	webPublicationDateDeprecated: '2021-02-03T18:54:37.000Z',
 	blocks: [
 		{
 			id: '5e74ae948f088d75755971e4',

--- a/fixtures/generated/articles/Feature.ts
+++ b/fixtures/generated/articles/Feature.ts
@@ -1419,7 +1419,7 @@ export const Feature: CAPIType = {
 			elementId: '99c8f3db-b5d8-4b07-acf4-6c3754c4a16f',
 		},
 	],
-	webPublicationDate: '2020-02-10T06:59:35.000Z',
+	webPublicationDateDeprecated: '2020-02-10T06:59:35.000Z',
 	blocks: [
 		{
 			id: '5e40df888f08e133247404c6',

--- a/fixtures/generated/articles/Interview.ts
+++ b/fixtures/generated/articles/Interview.ts
@@ -1950,7 +1950,7 @@ export const Interview: CAPIType = {
 			elementId: '5d9d2994-b98c-4488-9054-3ad6efd78b51',
 		},
 	],
-	webPublicationDate: '2020-02-09T11:00:04.000Z',
+	webPublicationDateDeprecated: '2020-02-09T11:00:04.000Z',
 	blocks: [
 		{
 			id: '8c447c98-b1ab-43fc-9570-a401998486d3',

--- a/fixtures/generated/articles/Labs.ts
+++ b/fixtures/generated/articles/Labs.ts
@@ -1661,7 +1661,7 @@ export const Labs: CAPIType = {
 			elementId: '6818c6d3-0c81-4e93-a66f-295ee3c0cd70',
 		},
 	],
-	webPublicationDate: '2018-10-11T13:30:08.000Z',
+	webPublicationDateDeprecated: '2018-10-11T13:30:08.000Z',
 	blocks: [
 		{
 			id: '5ba15482e4b0f675819f3d0d',

--- a/fixtures/generated/articles/Letter.ts
+++ b/fixtures/generated/articles/Letter.ts
@@ -1684,7 +1684,7 @@ export const Letter: CAPIType = {
 			elementId: '0f04e547-c9d7-4252-a82d-1bb2779ed413',
 		},
 	],
-	webPublicationDate: '2021-04-05T16:04:21.000Z',
+	webPublicationDateDeprecated: '2021-04-05T16:04:21.000Z',
 	blocks: [
 		{
 			id: '5e74b1928f089367b3d0b644',

--- a/fixtures/generated/articles/Live.ts
+++ b/fixtures/generated/articles/Live.ts
@@ -1983,7 +1983,7 @@ export const Live: CAPIType = {
 			elementId: '368b9dc2-e5f3-41b7-99ec-87d6ac92a886',
 		},
 	],
-	webPublicationDate: '2021-02-19T19:41:53.000Z',
+	webPublicationDateDeprecated: '2021-02-19T19:41:53.000Z',
 	blocks: [
 		{
 			id: '60300f5f8f08ad21ea60071e',

--- a/fixtures/generated/articles/MatchReport.ts
+++ b/fixtures/generated/articles/MatchReport.ts
@@ -1751,7 +1751,7 @@ export const MatchReport: CAPIType = {
 			elementId: '77549f03-7853-46ef-92ba-0ae397b89135',
 		},
 	],
-	webPublicationDate: '2021-02-05T22:16:43.000Z',
+	webPublicationDateDeprecated: '2021-02-05T22:16:43.000Z',
 	blocks: [
 		{
 			id: '601d96ef8f0862592e4b23ca',

--- a/fixtures/generated/articles/NumberedList.ts
+++ b/fixtures/generated/articles/NumberedList.ts
@@ -2055,7 +2055,7 @@ export const NumberedList: CAPIType = {
 			elementId: 'c7d7e097-2c87-407e-bdef-ad54731ecc4d',
 		},
 	],
-	webPublicationDate: '2019-12-17T07:00:44.000Z',
+	webPublicationDateDeprecated: '2019-12-17T07:00:44.000Z',
 	blocks: [
 		{
 			id: '5df7a00b8f087e8308e5f0ea',

--- a/fixtures/generated/articles/PhotoEssay.ts
+++ b/fixtures/generated/articles/PhotoEssay.ts
@@ -1712,7 +1712,7 @@ export const PhotoEssay: CAPIType = {
 			elementId: '8c318ebc-3550-416d-a4ff-4448be097aa6',
 		},
 	],
-	webPublicationDate: '2020-12-09T06:30:30.000Z',
+	webPublicationDateDeprecated: '2020-12-09T06:30:30.000Z',
 	blocks: [
 		{
 			id: '5fc4ed128f08959b167732bd',

--- a/fixtures/generated/articles/PrintShop.ts
+++ b/fixtures/generated/articles/PrintShop.ts
@@ -1314,7 +1314,7 @@ export const PrintShop: CAPIType = {
 	headline: 'Buy a classic sport photograph: the immortal Bobby Moore',
 	guardianBaseURL: 'https://www.theguardian.com',
 	mainMediaElements: [],
-	webPublicationDate: '2020-12-17T09:07:18.000Z',
+	webPublicationDateDeprecated: '2020-12-17T09:07:18.000Z',
 	blocks: [
 		{
 			id: '5dc05a8c8f0809525b6f5f10',

--- a/fixtures/generated/articles/Quiz.ts
+++ b/fixtures/generated/articles/Quiz.ts
@@ -1742,7 +1742,7 @@ export const Quiz: CAPIType = {
 			elementId: 'af46fef8-e15c-44c6-a36b-291497ac3ec8',
 		},
 	],
-	webPublicationDate: '2020-06-12T09:09:24.000Z',
+	webPublicationDateDeprecated: '2020-06-12T09:09:24.000Z',
 	blocks: [
 		{
 			id: '5ee1f3138f0875833522a23a',

--- a/fixtures/generated/articles/Recipe.ts
+++ b/fixtures/generated/articles/Recipe.ts
@@ -1833,7 +1833,7 @@ export const Recipe: CAPIType = {
 			elementId: 'b814107e-e394-4291-bd8d-989e8c1f5190',
 		},
 	],
-	webPublicationDate: '2021-02-06T10:30:38.000Z',
+	webPublicationDateDeprecated: '2021-02-06T10:30:38.000Z',
 	blocks: [
 		{
 			id: '5ee89b118f089a4ae3aff6e7',

--- a/fixtures/generated/articles/Review.ts
+++ b/fixtures/generated/articles/Review.ts
@@ -1813,7 +1813,7 @@ export const Review: CAPIType = {
 			elementId: '42f731cb-5341-49f3-ad17-15eee1e74e0e',
 		},
 	],
-	webPublicationDate: '2020-01-17T12:00:05.000Z',
+	webPublicationDateDeprecated: '2020-01-17T12:00:05.000Z',
 	blocks: [
 		{
 			id: '5e1df3f28f08d66fcfaa3e49',

--- a/fixtures/generated/articles/SpecialReport.ts
+++ b/fixtures/generated/articles/SpecialReport.ts
@@ -1870,7 +1870,7 @@ export const SpecialReport: CAPIType = {
 			elementId: 'bcff359a-2441-43c5-804a-672b64ca368a',
 		},
 	],
-	webPublicationDate: '2019-10-14T15:23:44.000Z',
+	webPublicationDateDeprecated: '2019-10-14T15:23:44.000Z',
 	blocks: [
 		{
 			id: '5d97218b8f08fbb0c1720cfa',

--- a/index.d.ts
+++ b/index.d.ts
@@ -400,7 +400,7 @@ interface CAPIType {
 	/**
 	 * @TJS-format date-time
 	 */
-	webPublicationDate: string;
+	webPublicationDateDeprecated: string;
 
 	webPublicationDateDisplay: string;
 	webPublicationSecondaryDateDisplay: string;

--- a/src/amp/components/topMeta/TopMetaAnalysis.tsx
+++ b/src/amp/components/topMeta/TopMetaAnalysis.tsx
@@ -145,7 +145,7 @@ export const TopMetaAnalysis: React.FC<{
 				pillar={pillar}
 				ageWarning={getAgeWarning(
 					articleData.tags,
-					articleData.webPublicationDate,
+					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
 				twitterHandle={articleData.author.twitterHandle}

--- a/src/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/src/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -133,7 +133,7 @@ export const TopMetaLiveblog: React.FC<{
 			pillar={pillar}
 			ageWarning={getAgeWarning(
 				articleData.tags,
-				articleData.webPublicationDate,
+				articleData.webPublicationDateDeprecated,
 			)}
 			webPublicationDate={articleData.webPublicationDateDisplay}
 			twitterHandle={articleData.author.twitterHandle}

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -118,7 +118,7 @@ export const TopMetaNews: React.FC<{
 				pillar={pillar}
 				ageWarning={getAgeWarning(
 					articleData.tags,
-					articleData.webPublicationDate,
+					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
 				twitterHandle={articleData.author.twitterHandle}

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -140,7 +140,7 @@ export const TopMetaOpinion: React.FC<{
 				pillar={pillar}
 				ageWarning={getAgeWarning(
 					articleData.tags,
-					articleData.webPublicationDate,
+					articleData.webPublicationDateDeprecated,
 				)}
 				webPublicationDate={articleData.webPublicationDateDisplay}
 				twitterHandle={articleData.author.twitterHandle}

--- a/src/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/src/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -119,7 +119,7 @@ export const TopMetaPaidContent: React.FC<{
 			pillar={pillar}
 			ageWarning={getAgeWarning(
 				articleData.tags,
-				articleData.webPublicationDate,
+				articleData.webPublicationDateDeprecated,
 			)}
 			webPublicationDate={articleData.webPublicationDateDisplay}
 			twitterHandle={articleData.author.twitterHandle}

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -8,7 +8,7 @@ export interface ArticleModel {
 	pagination?: Pagination;
 	blocks: Block[];
 	author: AuthorType;
-	webPublicationDate: string;
+	webPublicationDateDeprecated: string;
 	webPublicationDateDisplay: string;
 	pageId: string;
 	format: CAPIFormat;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -182,7 +182,7 @@
         "author": {
             "$ref": "#/definitions/AuthorType"
         },
-        "webPublicationDate": {
+        "webPublicationDateDeprecated": {
             "format": "date-time",
             "type": "string"
         },
@@ -429,7 +429,7 @@
         "trailText",
         "twitterData",
         "version",
-        "webPublicationDate",
+        "webPublicationDateDeprecated",
         "webPublicationDateDisplay",
         "webPublicationSecondaryDateDisplay",
         "webTitle",

--- a/src/model/validate.test.ts
+++ b/src/model/validate.test.ts
@@ -19,7 +19,7 @@ describe('validate', () => {
 
 	urlsToTest.forEach((url) => {
 		it('confirm valid data', () => {
-			return fetch(url)
+			return fetch(`${url}&purge=${Date.now()}`)
 				.then((response) => response.json())
 				.then((myJson) => {
 					expect(validateAsCAPIType(myJson)).toBe(myJson);

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -310,7 +310,7 @@ export const CommentLayout = ({
 
 	const showAvatar = avatarUrl && onlyOneContributor;
 
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -234,7 +234,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 	const showComments = CAPI.isCommentable;
 
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 	return (

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -207,7 +207,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 	const showComments = CAPI.isCommentable;
 
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 	return (

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -249,7 +249,7 @@ export const ShowcaseLayout = ({
 
 	const showComments = CAPI.isCommentable;
 
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -330,7 +330,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 	const showComments = CAPI.isCommentable;
 
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 


### PR DESCRIPTION
**Note: Frontend PR needs to go live first. (And the build will break until it does.)**

## What + why?

Replaces `webPublicationDate` with `webPublicationDateDeprecated` so that we can reformat the original field as part of wider DCR date refactor.

See: https://docs.google.com/document/d/1Emc0OivrVhH5-svVOiE2QLBER_wREdIxpe9G1XqMy9g/edit#. 

And part-1 here: https://github.com/guardian/frontend/pull/24054.
