### PR TITLE
Ad targeting should respect adfree for youtube

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -178,10 +178,12 @@ interface AdTargetParam {
 	value: string | string[];
 }
 
-interface AdTargeting {
+type AdTargeting = {
 	adUnit: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	customParams: { [key: string]: any };
+	customParams: Record<string, unknown>;
+	disableAds?: false;
+} | {
+	disableAds: true;
 }
 
 interface SectionNielsenAPI {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^17.0.1",
+    "@guardian/atoms-rendering": "^18.0.0",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/braze-components": "^3.3.0",
     "@guardian/commercial-core": "^0.19.2",

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -96,7 +96,10 @@ export const Body: React.FC<{
 	config: ConfigType;
 }> = ({ data, config }) => {
 	const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
-	const adTargeting = buildAdTargeting(config);
+	const adTargeting = buildAdTargeting({
+		isAdFreeUser: data.isAdFreeUser,
+		config,
+	});
 	const design = decideDesign(data.format);
 	const pillar = decideTheme(data.format);
 	const elementsWithoutAds = Elements(

--- a/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -3,26 +3,41 @@ import React from 'react';
 import { Caption } from '@root/src/amp/components/Caption';
 import { constructQuery } from '@root/src/lib/querystring';
 
-interface EmbedConfig {
-	adsConfig: {
-		adTagParameters: {
-			iu: string;
-			cust_params: string;
-		};
-	};
-}
+type EmbedConfig = {
+	adsConfig:
+		| {
+				adTagParameters: {
+					iu: string;
+					cust_params: string;
+				};
+				disableAds?: false;
+		  }
+		| {
+				disableAds: true;
+		  };
+};
 
 const buildEmbedConfig = (adTargeting: AdTargeting): EmbedConfig => {
-	return {
-		adsConfig: {
-			adTagParameters: {
-				iu: `${adTargeting.adUnit || ''}`,
-				cust_params: encodeURIComponent(
-					constructQuery(adTargeting.customParams),
-				),
-			},
-		},
-	};
+	switch (adTargeting.disableAds) {
+		case true:
+			return {
+				adsConfig: {
+					disableAds: true,
+				},
+			};
+		case false:
+		case undefined:
+			return {
+				adsConfig: {
+					adTagParameters: {
+						iu: `${adTargeting.adUnit || ''}`,
+						cust_params: encodeURIComponent(
+							constructQuery(adTargeting.customParams || {}),
+						),
+					},
+				},
+			};
+	}
 };
 
 export const YoutubeBlockComponent: React.FC<{

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -38,4 +38,5 @@ export interface ArticleModel {
 	commercialProperties: CommercialProperties;
 	isImmersive: boolean;
 	starRating?: number;
+	isAdFreeUser: boolean;
 }

--- a/src/lib/ad-targeting.test.ts
+++ b/src/lib/ad-targeting.test.ts
@@ -60,6 +60,6 @@ describe('buildAdTargeting', () => {
 	};
 
 	it('builds adTargeting correctly', () => {
-		expect(buildAdTargeting(CAPI.config)).toEqual(expectedAdTargeting);
+		expect(buildAdTargeting(CAPI)).toEqual(expectedAdTargeting);
 	});
 });

--- a/src/lib/ad-targeting.ts
+++ b/src/lib/ad-targeting.ts
@@ -1,6 +1,15 @@
 export const buildAdTargeting = (
-	config: ConfigType | ConfigTypeBrowser,
+	CAPI:
+		| CAPIType
+		| CAPIBrowserType
+		| Pick<CAPIType, 'isAdFreeUser' | 'config'>,
 ): AdTargeting => {
+	if (CAPI.isAdFreeUser) {
+		return {
+			disableAds: true,
+		};
+	}
+	const { config } = CAPI;
 	const customParams = {
 		sens: config.isSensitive ? 't' : 'f',
 		si: 'f',

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -372,7 +372,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	};
 	const palette = decidePalette(format);
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	// There are docs on loadable in ./docs/loadable-components.md
 	const YoutubeBlockComponent = loadable(

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -286,7 +286,7 @@ export const CommentLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -255,7 +255,7 @@ export const ImmersiveLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/src/web/layouts/InteractiveLayout.tsx
+++ b/src/web/layouts/InteractiveLayout.tsx
@@ -224,7 +224,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const seriesTag = CAPI.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -189,7 +189,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -232,7 +232,7 @@ export const ShowcaseLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -309,7 +309,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,10 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-17.0.1.tgz#4dae3632c553ea9e5c4f152d0c158e5713866ba4"
-  integrity sha512-emksLEndMIJiu5Igw5zCyYYELmFfapfyqKa29NN775oPdtTlLNfH0ptzpbYiYbepTlPKoaNcaaJAP4Qp6OEFlQ==
+"@guardian/atoms-rendering@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.0.tgz#b2035deebdac8a2de372bd42e87d6828d5e85ca9"
+  integrity sha512-lRKlt1utgxzUlOGiOwbpYR6c6R+quUCtZr3bMDIwzsi83f8L++uwI7ncH4BT1uuWbrTs/BVGZP/7xFHB7DMlUQ==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
## What does this change?

Update DCR to disable YouTube ads if the user is an ad free user.

Amended `ad-targeting` to check `CAPI.isAdFreeUser` and if so propagate ` { disableAds: true }` to the YouTubeAtom and the AMP YouTube player.

Follows method in Frontend [youtube-player](https://github.com/guardian/frontend/blob/df31b4deeb7f72303ebfa766f6a2699e2be1a293/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts#L171)

Example pages:

https://www.theguardian.com/science/2021/jul/20/jeff-bezos-rocket-design-an-inquiry
https://www.theguardian.com/politics/2021/jul/21/uk-substantially-rewrite-northern-ireland-brexit-protocol

## Why?

Subscribed users should not see YouTube ads.

## Dependencies

Dependent on release of: https://github.com/guardian/atoms-rendering/pull/274  (released as v18.0.0)