### PR TITLE
Fix carousel immersive cards

### DIFF
--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
 
-import { Design, Display } from '@guardian/types';
-import { neutral } from '@guardian/src-foundations/palette';
+import { Design } from '@guardian/types';
 import { textSans } from '@guardian/src-foundations/typography';
 import { timeAgo } from '@guardian/libs';
 
 import ClockIcon from '@frontend/static/icons/clock.svg';
 
-import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
@@ -46,18 +44,6 @@ const ageStyles = (format: Format, palette: Palette) => {
 	`;
 };
 
-const fullCardImageTextStyles = css`
-	color: ${neutral[100]};
-	background-color: rgba(0, 0, 0, 0.75);
-	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
-	/* Box decoration is required to push the box shadow out on Firefox */
-	box-decoration-break: clone;
-	line-height: 1;
-	white-space: pre-wrap;
-	padding-left: ${space[1]}px;
-	padding-right: ${space[1]}px;
-`;
-
 export const CardAge = ({
 	format,
 	palette,
@@ -72,12 +58,7 @@ export const CardAge = ({
 
 	return (
 		<span css={ageStyles(format, palette)}>
-			<span
-				css={
-					format.display === Display.Immersive &&
-					fullCardImageTextStyles
-				}
-			>
+			<span			>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate}>{displayString}</time>
 			</span>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -58,7 +58,7 @@ export const CardAge = ({
 
 	return (
 		<span css={ageStyles(format, palette)}>
-			<span			>
+			<span>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate}>{displayString}</time>
 			</span>

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -280,7 +280,7 @@ export const OnwardsUpper = ({
 				<ElementContainer showTopBorder={true}>
 					<OnwardsData
 						url={curatedDataUrl}
-						limit={8}
+						limit={20}
 						ophanComponentName="curated-content"
 						Container={Carousel}
 						isCuratedContent={true}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -226,7 +226,7 @@ const textArticleLinkHover = (format: Format): string => {
 };
 
 const textCardHeadline = (format: Format): string => {
-	if (format.display === Display.Immersive) return WHITE;
+	if (format.display === Display.Immersive) return BLACK;
 	if (format.theme === Special.SpecialReport) return WHITE;
 	switch (format.design) {
 		case Design.Feature:
@@ -262,8 +262,6 @@ const textCardKicker = (format: Format): string => {
 		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
 		return '#ff9941';
 	if (format.theme === Special.SpecialReport) return brandAlt[400];
-	if (format.display === Display.Immersive)
-		return pillarPalette[format.theme].bright;
 	switch (format.design) {
 		case Design.LiveBlog:
 			switch (format.theme) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes the display of immersive carousels, as they were broken on prod. Includes bonus card limit increase on curated containers for @paperboyo

### Before
![Screen Shot 2021-08-04 at 00 31 16](https://user-images.githubusercontent.com/2051501/128099535-eceaffcb-44d3-40ce-b0f5-d0aa210c6fa1.png)

### After
![Screen Shot 2021-08-04 at 00 37 28](https://user-images.githubusercontent.com/2051501/128099545-7679e70b-bd60-45a3-a72b-b7caf2102524.png)