### PR TITLE
Revert "Revert "Carousel template for onwards upper""

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -1179,6 +1179,8 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							contentType={CAPI.contentType}
 							tags={CAPI.tags}
 							format={format}
+							pillar={pillar}
+							edition={CAPI.editionId}
 						/>
 					</Suspense>
 				</Lazy>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
 
-import { Design, Display } from '@guardian/types';
-import { neutral } from '@guardian/src-foundations/palette';
+import { Design } from '@guardian/types';
 import { textSans } from '@guardian/src-foundations/typography';
 import { timeAgo } from '@guardian/libs';
 
 import ClockIcon from '@frontend/static/icons/clock.svg';
 
-import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
@@ -46,18 +44,6 @@ const ageStyles = (format: Format, palette: Palette) => {
 	`;
 };
 
-const fullCardImageTextStyles = css`
-	color: ${neutral[100]};
-	background-color: rgba(0, 0, 0, 0.75);
-	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
-	/* Box decoration is required to push the box shadow out on Firefox */
-	box-decoration-break: clone;
-	line-height: 1;
-	white-space: pre-wrap;
-	padding-left: ${space[1]}px;
-	padding-right: ${space[1]}px;
-`;
-
 export const CardAge = ({
 	format,
 	palette,
@@ -72,12 +58,7 @@ export const CardAge = ({
 
 	return (
 		<span css={ageStyles(format, palette)}>
-			<span
-				css={
-					format.display === Display.Immersive &&
-					fullCardImageTextStyles
-				}
-			>
+			<span>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate}>{displayString}</time>
 			</span>

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -56,7 +56,7 @@ const wrapperStyle = css`
 	display: flex;
 	justify-content: space-between;
 	overflow: hidden;
-	${from.tablet} {
+	${from.desktop} {
 		padding-right: 40px;
 	}
 `;
@@ -236,6 +236,16 @@ const buttonStyle = css`
 
 const prevButtonStyle = (index: number) => css`
 	background-color: ${index !== 0 ? neutral[0] : neutral[60]};
+	cursor: ${index !== 0 ? 'pointer' : 'default'};
+
+	&:hover,
+	&:focus {
+		background-color: ${index !== 0 ? brandAlt[400] : neutral[60]};
+
+		svg {
+			fill: ${neutral[100]};
+		}
+	}
 `;
 
 const nextButtonStyle = (index: number, totalStories: number) => css`
@@ -244,6 +254,18 @@ const nextButtonStyle = (index: number, totalStories: number) => css`
 	background-color: ${!isLastCardShowing(index, totalStories)
 		? neutral[0]
 		: neutral[60]};
+	cursor: ${!isLastCardShowing(index, totalStories) ? 'pointer' : 'default'};
+
+	&:hover,
+	&:focus {
+		background-color: ${!isLastCardShowing(index, totalStories)
+			? brandAlt[400]
+			: neutral[60]};
+
+		svg {
+			fill: ${neutral[100]};
+		}
+	}
 `;
 
 const headerRowStyles = css`
@@ -606,7 +628,6 @@ export const Carousel: React.FC<OnwardsType> = ({
 						const {
 							url: linkTo,
 							headline: headlineText,
-							format: trailFormat,
 							webPublicationDate,
 							image: fallbackImageUrl,
 							carouselImages,
@@ -620,7 +641,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<CarouselCard
 								key={`${trail.url}${i}`}
 								isFirst={i === 0}
-								format={trailFormat}
+								format={format}
 								linkTo={linkTo}
 								headlineText={headlineText}
 								webPublicationDate={webPublicationDate}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -629,6 +629,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							url: linkTo,
 							headline: headlineText,
 							webPublicationDate,
+							format: trailFormat,
 							image: fallbackImageUrl,
 							carouselImages,
 							kickerText,
@@ -641,7 +642,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 							<CarouselCard
 								key={`${trail.url}${i}`}
 								isFirst={i === 0}
-								format={format}
+								format={trailFormat}
 								linkTo={linkTo}
 								headlineText={headlineText}
 								webPublicationDate={webPublicationDate}

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -280,7 +280,7 @@ export const OnwardsUpper = ({
 				<ElementContainer showTopBorder={true}>
 					<OnwardsData
 						url={curatedDataUrl}
-						limit={8}
+						limit={20}
 						ophanComponentName="curated-content"
 						Container={Carousel}
 						isCuratedContent={true}

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -2,9 +2,18 @@ import { css } from '@emotion/react';
 
 import { joinUrl } from '@root/src/lib/joinUrl';
 import { ElementContainer } from '@root/src/web/components/ElementContainer';
+import { Pillar } from '@guardian/types';
 
 import { OnwardsData } from './OnwardsData';
+import { Carousel } from './Carousel/Carousel';
 import { OnwardsLayout } from './OnwardsLayout';
+
+type PillarForContainer =
+	| 'headlines'
+	| 'sport'
+	| 'opinion'
+	| 'culture'
+	| 'lifestyle';
 
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
 // If you change this list then you should also update ^
@@ -70,6 +79,88 @@ const onwardsWrapper = css`
 	width: 100%;
 `;
 
+const containerUrls = {
+	headlines: {
+		UK: 'uk-alpha/news/regular-stories',
+		US: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026',
+		AU: 'au-alpha/news/regular-stories',
+		INT: '10f21d96-18f6-426f-821b-19df55dfb831',
+	},
+	sport: {
+		UK: '754c-8e8c-fad9-a927',
+		US: 'f6dd-d7b1-0e85-4650',
+		AU: 'c45d-318f-896c-3a85',
+		INT: 'd1ad8ec3-5ee2-4673-94c8-cc3f8d261e52',
+	},
+	opinion: {
+		UK: '3ff78b30-52f5-4d30-ace8-c887113cbe0d',
+		US: '98df412d-b0e7-4d9a-98c2-062642823e94',
+		AU: 'au-alpha/contributors/feature-stories',
+		INT: 'ee3386bb-9430-4a6d-8bca-b99d65790f3b',
+	},
+	culture: {
+		UK: 'ae511a89-ef38-4ec9-aab1-3a5ebc96d118',
+		US: 'fb59c1f8-72a7-41d5-8365-a4d574809bed',
+		AU: '22262088-4bce-4290-9810-cb50bbead8db',
+		INT: 'c7154e22-7292-4d93-a14d-22fd4b6b693d',
+	},
+	lifestyle: {
+		UK: 'uk-alpha/features/feature-stories',
+		US: 'us-alpha/features/feature-stories',
+		AU: '13636104-51ce-4264-bb6b-556c80227331',
+		INT: '7b297ef5-a3f9-45e5-b915-b54951d7f6ec',
+	},
+};
+
+const getContainer = (pillar: PillarForContainer, edition: Edition) => {
+	return containerUrls[pillar][edition];
+};
+
+const getContainerDataUrl = (
+	pillar: Theme,
+	edition: Edition,
+	ajaxUrl: string,
+) => {
+	switch (pillar) {
+		case Pillar.Sport:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('sport', edition)}.json`,
+			]);
+		case Pillar.News:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('headlines', edition)}.json`,
+			]);
+		case Pillar.Culture:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('culture', edition)}.json`,
+			]);
+		case Pillar.Lifestyle:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('lifestyle', edition)}.json`,
+			]);
+		case Pillar.Opinion:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('opinion', edition)}.json`,
+			]);
+		default:
+			return joinUrl([
+				ajaxUrl,
+				'container/data',
+				`${getContainer('headlines', edition)}.json`,
+			]);
+	}
+};
+
 type Props = {
 	ajaxUrl: string;
 	hasRelated: boolean;
@@ -82,6 +173,8 @@ type Props = {
 	contentType: string;
 	tags: TagType[];
 	format: Format;
+	edition: Edition;
+	pillar: Theme;
 };
 
 export const OnwardsUpper = ({
@@ -96,6 +189,8 @@ export const OnwardsUpper = ({
 	contentType,
 	tags,
 	format,
+	pillar,
+	edition,
 }: Props) => {
 	const dontShowRelatedContent = !showRelatedContent || !hasRelated;
 
@@ -166,6 +261,8 @@ export const OnwardsUpper = ({
 		ophanComponentName = 'related-stories';
 	}
 
+	const curatedDataUrl = getContainerDataUrl(pillar, edition, ajaxUrl);
+
 	return (
 		<div css={onwardsWrapper}>
 			{url && (
@@ -174,7 +271,19 @@ export const OnwardsUpper = ({
 						url={url}
 						limit={8}
 						ophanComponentName={ophanComponentName}
-						Container={OnwardsLayout}
+						Container={isPaidContent ? OnwardsLayout : Carousel}
+						format={format}
+					/>
+				</ElementContainer>
+			)}
+			{!isPaidContent && (
+				<ElementContainer showTopBorder={true}>
+					<OnwardsData
+						url={curatedDataUrl}
+						limit={8}
+						ophanComponentName="curated-content"
+						Container={Carousel}
+						isCuratedContent={true}
 						format={format}
 					/>
 				</ElementContainer>

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -262,8 +262,6 @@ const textCardKicker = (format: Format): string => {
 		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
 		return '#ff9941';
 	if (format.theme === Special.SpecialReport) return brandAlt[400];
-	if (format.display === Display.Immersive)
-		return pillarPalette[format.theme].bright;
 	switch (format.design) {
 		case Design.LiveBlog:
 			switch (format.theme) {

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -226,7 +226,7 @@ const textArticleLinkHover = (format: Format): string => {
 };
 
 const textCardHeadline = (format: Format): string => {
-	if (format.display === Display.Immersive) return WHITE;
+	if (format.display === Display.Immersive) return BLACK;
 	if (format.theme === Special.SpecialReport) return WHITE;
 	switch (format.design) {
 		case Design.Feature:

--- a/src/web/lib/decideTrail.ts
+++ b/src/web/lib/decideTrail.ts
@@ -1,20 +1,24 @@
+import { Design, Display, Pillar } from '@guardian/types';
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
 import { decideDisplay } from './decideDisplay';
 import { decidePalette } from './decidePalette';
 
 export const decideTrail = (trail: CAPITrailType): TrailType => {
-	// We don't have tags here so we send an empty array
-	const display = decideDisplay(trail.format);
-	const design = decideDesign(trail.format);
-	const theme = decideTheme(trail.format);
+	const format: Format = trail.format
+		? {
+				display: decideDisplay(trail.format),
+				theme: decideTheme(trail.format),
+				design: decideDesign(trail.format),
+		  }
+		: {
+				display: Display.Standard,
+				theme: Pillar.News,
+				design: Design.Article,
+		  };
 
-	const format: Format = {
-		display,
-		theme,
-		design,
-	};
 	const palette = decidePalette(format);
+
 	return {
 		...trail,
 		format,


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3234

This should work better now that card formats are coming through correctly: https://github.com/guardian/frontend/pull/24075.

Also, with some fixes from https://github.com/guardian/dotcom-rendering/pull/3235. thanks to @rcrphillips .