### PR TITLE
Update Ophan Tracker for removed `kruxId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lodash.get": "^4.4.2",
     "log4js": "6.3.0",
     "minify-css-string": "^1.0.0",
-    "ophan-tracker-js": "^1.3.25",
+    "ophan-tracker-js": "^1.3.27",
     "pm2": "5.0.0",
     "preact": "^10.5.12",
     "preact-render-to-string": "^5.1.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15097,10 +15097,10 @@ openurl@^1.1.1:
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-ophan-tracker-js@^1.3.25:
-  version "1.3.25"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.25.tgz#7a43b4a232d940cd68f74a82a712bd2a1ddb4b6f"
-  integrity sha512-jufAOME9FLSuzEMgWhDd6O6xoMJTv2I/GJISiOuaT0W1YVs9upP7zTeXVEPQi12NMe1ZliqFBWnqCea8gVx+2g==
+ophan-tracker-js@^1.3.27:
+  version "1.3.27"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.27.tgz#a9913e3cc49ba39b712578659150acf202b6b8c1"
+  integrity sha512-0UXITRMb5tNJhYQzu6tDFsBLFqltYVAbbAqe4m9iVNyX8pV1xCTx+z6rA4MeM4vZEmf1yV+ERUzfEYfrCGyCOQ==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
Upgrading Ophan Tracker-JS as part of followup for the following PRs:

- https://github.com/guardian/ophan/pull/4216
- https://github.com/guardian/ophan/pull/4221

This will ensure dotcom rendering uses the latest, KruxId-free version of the script. Removing Krux Ids has been part of a broader effort by @shtukas and the rest of the Transparency and Consent team to ensure Krux Ids are no longer collected and passed downstream - especially to the data lake. 

A corresponding PR for frontend is pending at https://github.com/guardian/frontend/pull/24063.

**Further reading and context:**

- https://github.com/guardian/ophan/issues/3628
- https://github.com/guardian/android-news-app/pull/6942