### PR TITLE
More Nav, less Sticky

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -348,51 +348,49 @@ export const CommentLayout = ({
 							/>
 						</ElementContainer>
 					)}
-
-					<ElementContainer
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
-						/>
-					</ElementContainer>
-
-					{NAV.subNavSections && (
-						<ElementContainer
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-								format={format}
-							/>
-						</ElementContainer>
-					)}
-
-					<ElementContainer
-						backgroundColour={palette.background.article}
-						padded={false}
-						showTopBorder={false}
-					>
-						<Lines count={4} effect="straight" />
-					</ElementContainer>
 				</SendToBack>
 			</div>
+
+			<ElementContainer
+				showSideBorders={true}
+				borderColour={brandLine.primary}
+				showTopBorder={false}
+				padded={false}
+				backgroundColour={brandBackground.primary}
+			>
+				<Nav
+					nav={NAV}
+					format={{
+						...format,
+						theme: getCurrentPillar(CAPI),
+					}}
+					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+					edition={CAPI.editionId}
+				/>
+			</ElementContainer>
+
+			{NAV.subNavSections && (
+				<ElementContainer
+					backgroundColour={palette.background.article}
+					padded={false}
+					sectionId="sub-nav-root"
+				>
+					<SubNav
+						subNavSections={NAV.subNavSections}
+						currentNavLink={NAV.currentNavLink}
+						palette={palette}
+						format={format}
+					/>
+				</ElementContainer>
+			)}
+
+			<ElementContainer
+				backgroundColour={palette.background.article}
+				padded={false}
+				showTopBorder={false}
+			>
+				<Lines count={4} effect="straight" />
+			</ElementContainer>
 
 			<ElementContainer
 				showTopBorder={false}

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -246,54 +246,53 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							}
 						/>
 					</ElementContainer>
-
-					<ElementContainer
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
-						/>
-					</ElementContainer>
-
-					{NAV.subNavSections && (
-						<ElementContainer
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-							borderColour={palette.border.article}
-							element="nav"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-								format={format}
-							/>
-						</ElementContainer>
-					)}
-
-					<ElementContainer
-						backgroundColour={palette.background.article}
-						padded={false}
-						showTopBorder={false}
-						borderColour={palette.border.article}
-					>
-						<Lines count={4} effect="straight" />
-					</ElementContainer>
 				</SendToBack>
 			</div>
+
+			<ElementContainer
+				showSideBorders={true}
+				borderColour={brandLine.primary}
+				showTopBorder={false}
+				padded={false}
+				backgroundColour={brandBackground.primary}
+			>
+				<Nav
+					nav={NAV}
+					format={{
+						...format,
+						theme: getCurrentPillar(CAPI),
+					}}
+					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+					edition={CAPI.editionId}
+				/>
+			</ElementContainer>
+
+			{NAV.subNavSections && (
+				<ElementContainer
+					backgroundColour={palette.background.article}
+					padded={false}
+					sectionId="sub-nav-root"
+					borderColour={palette.border.article}
+					element="nav"
+				>
+					<SubNav
+						subNavSections={NAV.subNavSections}
+						currentNavLink={NAV.currentNavLink}
+						palette={palette}
+						format={format}
+					/>
+				</ElementContainer>
+			)}
+
+			<ElementContainer
+				backgroundColour={palette.background.article}
+				padded={false}
+				showTopBorder={false}
+				borderColour={palette.border.article}
+			>
+				<Lines count={4} effect="straight" />
+			</ElementContainer>
+
 			<ContainerLayout
 				showTopBorder={false}
 				backgroundColour={palette.background.header}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -256,81 +256,84 @@ export const ShowcaseLayout = ({
 	return (
 		<>
 			{format.theme !== Special.Labs ? (
-				<div>
-					<Stuck>
-						<ElementContainer
-							showTopBorder={false}
-							showSideBorders={false}
-							padded={false}
-						>
-							<HeaderAdSlot
-								isAdFreeUser={CAPI.isAdFreeUser}
-								shouldHideAds={CAPI.shouldHideAds}
-								display={format.display}
-							/>
-						</ElementContainer>
-					</Stuck>
-					<SendToBack>
-						<ElementContainer
-							showTopBorder={false}
-							showSideBorders={false}
-							padded={false}
-							backgroundColour={brandBackground.primary}
-						>
-							<Header
-								edition={CAPI.editionId}
-								idUrl={CAPI.config.idUrl}
-								mmaUrl={CAPI.config.mmaUrl}
-								isAnniversary={
-									CAPI.config.switches.anniversaryHeaderSvg
-								}
-							/>
-						</ElementContainer>
-
-						<ElementContainer
-							showSideBorders={true}
-							borderColour={brandLine.primary}
-							showTopBorder={false}
-							padded={false}
-							backgroundColour={brandBackground.primary}
-						>
-							<Nav
-								nav={NAV}
-								format={{
-									...format,
-									theme: getCurrentPillar(CAPI),
-								}}
-								subscribeUrl={
-									CAPI.nav.readerRevenueLinks.header.subscribe
-								}
-								edition={CAPI.editionId}
-							/>
-						</ElementContainer>
-
-						{NAV.subNavSections && (
+				<>
+					<div>
+						<Stuck>
 							<ElementContainer
-								backgroundColour={palette.background.article}
+								showTopBorder={false}
+								showSideBorders={false}
 								padded={false}
-								sectionId="sub-nav-root"
 							>
-								<SubNav
-									subNavSections={NAV.subNavSections}
-									currentNavLink={NAV.currentNavLink}
-									palette={palette}
-									format={format}
+								<HeaderAdSlot
+									isAdFreeUser={CAPI.isAdFreeUser}
+									shouldHideAds={CAPI.shouldHideAds}
+									display={format.display}
 								/>
 							</ElementContainer>
-						)}
+						</Stuck>
+						<SendToBack>
+							<ElementContainer
+								showTopBorder={false}
+								showSideBorders={false}
+								padded={false}
+								backgroundColour={brandBackground.primary}
+							>
+								<Header
+									edition={CAPI.editionId}
+									idUrl={CAPI.config.idUrl}
+									mmaUrl={CAPI.config.mmaUrl}
+									isAnniversary={
+										CAPI.config.switches
+											.anniversaryHeaderSvg
+									}
+								/>
+							</ElementContainer>
+						</SendToBack>
+					</div>
 
+					<ElementContainer
+						showSideBorders={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padded={false}
+						backgroundColour={brandBackground.primary}
+					>
+						<Nav
+							nav={NAV}
+							format={{
+								...format,
+								theme: getCurrentPillar(CAPI),
+							}}
+							subscribeUrl={
+								CAPI.nav.readerRevenueLinks.header.subscribe
+							}
+							edition={CAPI.editionId}
+						/>
+					</ElementContainer>
+
+					{NAV.subNavSections && (
 						<ElementContainer
 							backgroundColour={palette.background.article}
 							padded={false}
-							showTopBorder={false}
+							sectionId="sub-nav-root"
 						>
-							<Lines count={4} effect="straight" />
+							<SubNav
+								subNavSections={NAV.subNavSections}
+								currentNavLink={NAV.currentNavLink}
+								palette={palette}
+								format={format}
+							/>
 						</ElementContainer>
-					</SendToBack>
-				</div>
+					)}
+
+					<ElementContainer
+						backgroundColour={palette.background.article}
+						padded={false}
+						showTopBorder={false}
+					>
+						<Lines count={4} effect="straight" />
+					</ElementContainer>
+				</>
 			) : (
 				// Else, this is a labs article so just show Nav and the Labs header
 				<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
In some layouts we were keeping the `Nav` visible when sticking the top ad slot, in others we were hiding it behind the slot. This PR brings consistency bu always showing the `Nav`

## Why?
For consistency

## Why decide on showing the `Nav` more instead of sticking more?
Because this is the primary site navigation and by giving it more weight we encourage readers to browse the site more

### Before
![2021-08-04 15 55 31](https://user-images.githubusercontent.com/1336821/128203791-8ce2e258-2851-4628-ad28-a578f3aebfe3.gif)


### After
![2021-08-04 15 54 33](https://user-images.githubusercontent.com/1336821/128203588-db1fa76c-e8eb-4522-81b4-144fe0faa986.gif)

