### PR TITLE
Remove the open Load Balancer Security Group

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -281,7 +281,7 @@ Resources:
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:
-      - Ref: InternalLoadBalancerSecurityGroup
+      - Ref: InternalLoadBalancer
       Tags:
       - Key: Stage
         Value:
@@ -318,7 +318,7 @@ Resources:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
       Dimensions:
-      - Name: LoadBalancerName
+      - Name: InternalLoadBalancer
         Value: !Ref InternalLoadBalancerSecurityGroup
       EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
       MetricName: Latency

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -124,12 +124,6 @@ Resources:
         FromPort: 9000
         ToPort: 9000
         SourceSecurityGroupId:
-          Ref: LoadBalancerSecurityGroup
-        # allow ELB to talk to instance
-      - IpProtocol: tcp
-        FromPort: 9000
-        ToPort: 9000
-        SourceSecurityGroupId:
           Ref: InternalLoadBalancerSecurityGroup
       Tags:
       - Key: Stage
@@ -210,7 +204,7 @@ Resources:
       Subnets:
         Ref: Subnets
       SecurityGroups:
-      - Ref: LoadBalancerSecurityGroup
+      - Ref: InternalLoadBalancerSecurityGroup
       AccessLoggingPolicy:
         EmitInterval: 5
         Enabled: true

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -318,8 +318,8 @@ Resources:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
       Dimensions:
-      - Name: InternalLoadBalancer
-        Value: !Ref InternalLoadBalancerSecurityGroup
+      - Name: InternalLoadBalancerName
+        Value: !Ref InternalLoadBalancer
       EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
       MetricName: Latency
       Namespace: AWS/ELB

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -386,8 +386,8 @@ Resources:
         Alarm if 5XX backend errors are greater than ${Backend5XXAlarmThreshold} over last ${Backend5XXAlarmPeriod} seconds
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-      - Name: LoadBalancerName
-        Value: !Ref LoadBalancer
+      - Name: InternalLoadBalancerSecurityGroupName
+        Value: !Ref InternalLoadBalancerSecurityGroup
       MetricName: HTTPCode_Backend_5XX
       Namespace: AWS/ELB
       EvaluationPeriods: !Ref Backend5XXConsecutivePeriod

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -341,8 +341,8 @@ Resources:
         Alarm if 5XX backend errors are greater than ${Backend5XXAlarmThreshold} over last ${Backend5XXAlarmPeriod} seconds
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-      - Name: InternalLoadBalancerSecurityGroupName
-        Value: !Ref InternalLoadBalancerSecurityGroup
+      - Name: InternalLoadBalancerName
+        Value: !Ref InternalLoadBalancer
       MetricName: HTTPCode_Backend_5XX
       Namespace: AWS/ELB
       EvaluationPeriods: !Ref Backend5XXConsecutivePeriod

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -86,28 +86,6 @@ Mappings:
       MaxCapacity: 4
 
 Resources:
-  LoadBalancerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: HTTP access to the load balancer from within the Guardian (for now)
-      VpcId:
-        Ref: VpcId
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 80
-        ToPort: 80
-        CidrIp: 0.0.0.0/0
-      Tags:
-      - Key: Stage
-        Value:
-          Ref: Stage
-      - Key: Stack
-        Value:
-          Fn::FindInMap: [ Constants, Stack, Value ]
-      - Key: App
-        Value:
-          Fn::FindInMap: [ Constants, App, Value ]
-
   InternalLoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -356,5 +356,5 @@ Outputs:
   LoadBalancerUrl:
     Value:
       'Fn::GetAtt':
-      - LoadBalancer
+      - InternalLoadBalancer
       - DNSName

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -189,44 +189,6 @@ Resources:
       Roles:
       - Ref: InstanceRole
 
-  LoadBalancer:
-    Type: AWS::ElasticLoadBalancing::LoadBalancer
-    Properties:
-      Listeners:
-      - { LoadBalancerPort: 80, InstancePort: 9000, Protocol: HTTP }
-      CrossZone: true
-      HealthCheck:
-        Target: HTTP:9000/_healthcheck
-        HealthyThreshold: 2
-        UnhealthyThreshold: 10
-        Interval: 30
-        Timeout: 10
-      Subnets:
-        Ref: Subnets
-      SecurityGroups:
-      - Ref: InternalLoadBalancerSecurityGroup
-      AccessLoggingPolicy:
-        EmitInterval: 5
-        Enabled: true
-        S3BucketName: gu-elb-logs
-        S3BucketPrefix:
-          Fn::Join:
-          - "/"
-          - - ELBLogs
-            - Fn::FindInMap: [ Constants, Stack, Value ]
-            - Fn::FindInMap: [ Constants, App, Value ]
-            - Ref: Stage
-      Tags:
-      - Key: Stage
-        Value:
-          Ref: Stage
-      - Key: Stack
-        Value:
-          Fn::FindInMap: [ Constants, Stack, Value ]
-      - Key: App
-        Value:
-          Fn::FindInMap: [ Constants, App, Value ]
-
   InternalLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -319,8 +281,7 @@ Resources:
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:
-      - Ref: LoadBalancer
-      - Ref: InternalLoadBalancer
+      - Ref: InternalLoadBalancerSecurityGroup
       Tags:
       - Key: Stage
         Value:
@@ -358,7 +319,7 @@ Resources:
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
       Dimensions:
       - Name: LoadBalancerName
-        Value: !Ref LoadBalancer
+        Value: !Ref InternalLoadBalancerSecurityGroup
       EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
       MetricName: Latency
       Namespace: AWS/ELB

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -318,7 +318,7 @@ Resources:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
       Dimensions:
-      - Name: InternalLoadBalancerName
+      - Name: LoadBalancerName
         Value: !Ref InternalLoadBalancer
       EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
       MetricName: Latency
@@ -341,7 +341,7 @@ Resources:
         Alarm if 5XX backend errors are greater than ${Backend5XXAlarmThreshold} over last ${Backend5XXAlarmPeriod} seconds
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-      - Name: InternalLoadBalancerName
+      - Name: LoadBalancerName
         Value: !Ref InternalLoadBalancer
       MetricName: HTTPCode_Backend_5XX
       Namespace: AWS/ELB


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

As per the title it removes the old LoadBalancerSecurityGroup which was open and posed a security risk. The new configuration configures frontend with an internal IP address.

## Why?

🔒 
