### PR TITLE
Stuck sans borders

### DIFF
--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -6,7 +6,8 @@ type Props = {
 	children?: React.ReactNode;
 };
 
-type StuckProps = Props & {
+type StuckProps = {
+	children?: React.ReactNode;
 	zIndex?: string;
 };
 

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -10,16 +10,17 @@ type StuckProps = Props & {
 	zIndex?: string;
 };
 
-// The advert is stuck to the top of the container as we scroll
-// until we hit the bottom of the wrapper that contains
-// the top banner and the header/navigation
-// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
-// classes are tightly coupled.
-const stickyAdWrapper = (zIndex = 'stickyAdWrapper') => css`
-	background-color: white;
+const stickyStyles = css`
 	position: sticky;
 	top: 0;
+`;
+
+const addZindex = (zIndex = 'stickyAdWrapper') => css`
 	${getZIndex(zIndex)}
+`;
+
+const whiteBackground = css`
+	background-color: white;
 `;
 
 const headerWrapper = css`
@@ -41,7 +42,9 @@ const bannerWrapper = css`
 `;
 
 export const Stuck = ({ children, zIndex }: StuckProps) => (
-	<div css={stickyAdWrapper(zIndex)}>{children}</div>
+	<div css={[stickyStyles, addZindex(zIndex), whiteBackground]}>
+		{children}
+	</div>
 );
 
 export const SendToBack = ({ children }: Props) => (

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
 
-import { border } from '@guardian/src-foundations/palette';
-
 import { getZIndex, getZIndexImportant } from '@frontend/web/lib/getZIndex';
 
 type Props = {
@@ -19,7 +17,6 @@ type StuckProps = Props & {
 // classes are tightly coupled.
 const stickyAdWrapper = (zIndex = 'stickyAdWrapper') => css`
 	background-color: white;
-	border-bottom: 0.0625rem solid ${border.secondary};
 	position: sticky;
 	top: 0;
 	${getZIndex(zIndex)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
On every article page we're showing a 1 pixel grey border under any content that we 'stick' - like the `Header`. Sometimes this slides through without being obvious and other times it's a motorway running across the page

## Why is it there?
It was originally added to the code (for perfectly good reasons) over 2 years ago in [this PR here](https://github.com/guardian/dotcom-rendering/pull/754). But those reasons have - I believe - long passed . Yet this line of css has persisted through a series of refactors and copy pastes (lots of them by me!) - each one faithfully preserving the original code but some point along the way the need for this border was lost and it ended up an extra line of grey pixels taking up space

### Before
<img width="295" alt="Screenshot 2021-08-06 at 09 18 02" src="https://user-images.githubusercontent.com/1336821/128479966-d035f6b0-1405-4ec1-9e2f-a06c1b3656b7.png">

### After
<img width="295" alt="Screenshot 2021-08-06 at 09 18 13" src="https://user-images.githubusercontent.com/1336821/128479970-43e21597-40c3-43e2-b48c-29f5f90025a2.png">
