### PR TITLE
Standalone Commercial Bundle

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -665,9 +665,10 @@ interface ConfigType extends CommercialConfigType {
 	sentryHost: string;
 	dcrSentryDsn: string;
 	switches: { [key: string]: boolean };
-	abTests: { [key: string]: string };
+	abTests: Record<string, "control" | "variant">;
 	dfpAccountId: string;
 	commercialBundleUrl: string;
+	standaloneCommercialBundleUrl: string;
 	revisionNumber: string;
 	shortUrlId: string;
 	isDev?: boolean;

--- a/scripts/test-data/gen-fixtures.js
+++ b/scripts/test-data/gen-fixtures.js
@@ -17,13 +17,13 @@ const root = resolve(__dirname, '..', '..');
  *
  * A script to automatically download the latest json data for a production article and
  * insert it into a fixture file to use for testing. In particular, we use these fixtures
- * for our layoout stories
+ * for our layout stories
  *
  * Edit the articles array below to add or amend the urls that we use. The script will fetch
  * ${article.url}.json?dcr and save the response in ${article.name}.ts in the fixtures folder
  *
  * Usage
- * $ node scripts/test-data/gen-schema.js
+ * $ node scripts/test-data/gen-fixtures.js
  */
 
 const articles = [

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -3788,6 +3788,7 @@
                 "shortUrlId",
                 "showRelatedContent",
                 "stage",
+				"standaloneCommercialBundleUrl",
                 "switches"
             ]
         },

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -207,7 +207,7 @@ NumberedListStory.story = {
 
 // Anniversary stuff (Delete once event is over)
 
-const convertToAnniversary = (CAPI: CAPIType) => {
+const convertToAnniversary = (CAPI: CAPIType): CAPIType => {
 	return {
 		...CAPI,
 		config: {

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -256,7 +256,7 @@ NumberedListStory.story = {
 
 // Anniversary stuff (Delete once event is over)
 
-const convertToAnniversary = (CAPI: CAPIType) => {
+const convertToAnniversary = (CAPI: CAPIType): CAPIType => {
 	return {
 		...CAPI,
 		config: {

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -256,8 +256,7 @@ export const document = ({ data }: Props): string => {
 	}
 
 	const commercialBundle =
-		CAPI.config &&
-		CAPI.config.abTests.standaloneCommercialBundleVariant === 'variant'
+		CAPI.config?.abTests.standaloneCommercialBundleVariant === 'variant'
 			? { src: CAPI.config.standaloneCommercialBundleUrl }
 			: { src: CAPI.config.commercialBundleUrl };
 	/**

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -254,6 +254,12 @@ export const document = ({ data }: Props): string => {
 	function isDefined<T>(argument: T | boolean): argument is T {
 		return argument !== false;
 	}
+
+	const commercialBundle =
+		CAPI.config &&
+		CAPI.config.abTests.standaloneCommercialBundleVariant === 'variant'
+			? { src: CAPI.config.standaloneCommercialBundleUrl }
+			: { src: CAPI.config.commercialBundleUrl };
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -265,7 +271,7 @@ export const document = ({ data }: Props): string => {
 		[
 			{ src: polyfillIO },
 			...getScriptArrayFromChunkName('ophan'),
-			CAPI.config && { src: CAPI.config.commercialBundleUrl },
+			commercialBundle,
 			...getScriptArrayFromChunkName('sentryLoader'),
 			...getScriptArrayFromChunkName('coreVitals'),
 			...getScriptArrayFromChunkName('dynamicImport'),


### PR DESCRIPTION
## What does this change?

Conditionally load a standalone commercial bundle which is identical between `frontend` and `dcr`. 

Required steps before this can go live:
- merge https://github.com/guardian/frontend/pull/24058
- regenerate fixtures

Also narrows `abTests` type and fix two typos.

## Why?

This could be the future.

### Before

### After
