### PR TITLE
remove list and listtype from youtube block component

### DIFF
--- a/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -51,8 +51,6 @@ export const YoutubeBlockComponent: React.FC<{
 	if (element.channelId) {
 		// related videos metadata
 		attributes['data-param-rel'] = '0';
-		attributes['data-param-listType'] = 'playlist';
-		attributes['data-param-list'] = element.channelId;
 	}
 
 	return (


### PR DESCRIPTION
## What does this change?
Youtube videos in amp were not playing because of invalid values set against query params in the youtube iframe src. The list and listtype params were incorrect, and are only needed to identify the video if we don't have the
videoId. We believe it's safe to remove the data attributes as we have the videoId (data-videoId).

Refs:
https://developers.google.com/youtube/player_parameters#list
https://amp.dev/documentation/components/amp-youtube/

## Why?
To enable youtube videos to be played in amp.

### Before
<img width="573" alt="Screenshot 2021-08-06 at 10 01 14" src="https://user-images.githubusercontent.com/45561419/128486583-75b595b8-9017-46dd-971b-300ee7f68b5e.png">

### After
<img width="584" alt="Screenshot 2021-08-06 at 10 01 06" src="https://user-images.githubusercontent.com/45561419/128486605-53229ba0-7a46-4ebc-a2f3-fbf1730cd2b9.png">
