### PR TITLE
Add GHGuardianHeadline-BoldItalic font for standfirsts, H2s etc.

### DIFF
--- a/src/lib/fonts-css.ts
+++ b/src/lib/fonts-css.ts
@@ -131,6 +131,28 @@ const fontList: FontDisplay[] = [
 		weight: 700,
 		style: 'normal',
 	},
+	{
+		family: 'GH Guardian Headline',
+		woff2:
+			'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
+	{
+		family: 'Guardian Egyptian Web',
+		woff2:
+			'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
 	// GuardianTextEgyptian, with legacy family name of Guardian Text Egyptian Web
 	{
 		family: 'GuardianTextEgyptian',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This is similar to https://github.com/guardian/dotcom-rendering/pull/2636 and the rationale is the same: if fonts are loaded **only** when they are needed, we should always be providing all the fonts page design may use. As GHGuardianHeadline-Bold is used in eg. standfirsts and H2s, and those can contain italic, not defining GHGuardianHeadline-BoldItalic leads to ugly faux rendering. Death to faux.

## Why?
We cannot have pages using fonts we do not provide!

## Before (font missing, faux style)

![image](https://user-images.githubusercontent.com/6032869/128484534-d4dc62d4-3689-46ed-8024-17d96012c98d.png)

## After (font loaded)

![image](https://user-images.githubusercontent.com/6032869/128484576-b1270613-be1e-41dd-bc24-7a6e96588560.png)



cc @sndrs @jamie-lynch 