### PR TITLE
Use automat v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^17.0.1",
-    "@guardian/automat-client": "^0.2.17",
+    "@guardian/automat-contributions": "^0.3.6",
     "@guardian/braze-components": "^3.2.0",
     "@guardian/commercial-core": "^0.19.2",
     "@guardian/consent-management-platform": "~6.11.5",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -15,7 +15,7 @@ import { Discussion } from '@frontend/web/components/Discussion';
 import { StickyBottomBanner } from '@root/src/web/components/StickyBottomBanner/StickyBottomBanner';
 import { SignInGateSelector } from '@root/src/web/components/SignInGate/SignInGateSelector';
 
-import { incrementWeeklyArticleCount } from '@guardian/automat-client';
+import { incrementWeeklyArticleCount } from '@guardian/automat-contributions';
 import {
 	QandaAtom,
 	GuideAtom,

--- a/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 
 import {
-	getBodyEnd,
+	getEpicMeta,
 	getViewLog,
 	logView,
 	getWeeklyArticleHistory,
-} from '@guardian/automat-client';
+} from '@guardian/automat-contributions';
 import {
 	isRecurringContributor,
 	getLastOneOffContributionTimestamp,
@@ -25,7 +25,7 @@ import {
 	submitComponentEvent,
 	SdcTestMeta,
 } from '@root/src/web/browser/ophan/ophan';
-import { Metadata } from '@guardian/automat-client/dist/types';
+import { Metadata } from '@guardian/automat-contributions/dist/lib/types';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { cmp } from '@guardian/consent-management-platform';
 import { getCookie } from '../../browser/cookie';
@@ -142,7 +142,7 @@ export const canShow = async (
 
 	const contributionsPayload = await buildPayload(data);
 
-	const response = await getBodyEnd(
+	const response = await getEpicMeta(
 		contributionsPayload,
 		`${contributionsServiceUrl}/epic${queryString}`,
 	);

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -5,7 +5,7 @@ import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
 import {
 	getWeeklyArticleHistory,
 	logView,
-} from '@root/node_modules/@guardian/automat-client';
+} from '@guardian/automat-contributions';
 import {
 	shouldHideSupportMessaging,
 	withinLocalNoBannerCachePeriod,
@@ -21,7 +21,7 @@ import {
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { trackNonClickInteraction } from '@root/src/web/browser/ga/ga';
-import { WeeklyArticleHistory } from '@root/node_modules/@guardian/automat-client/dist/types';
+import { WeeklyArticleHistory } from '@root/node_modules/@guardian/automat-contributions/dist/lib/types';
 import { getForcedVariant } from '@root/src/web/lib/readerRevenueDevUtils';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { setAutomat } from '@root/src/web/lib/setAutomat';

--- a/src/web/components/package.json
+++ b/src/web/components/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "components",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/src/web/components/package.json
+++ b/src/web/components/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "components",
-  "version": "1.0.0",
-  "dependencies": {}
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,10 +1726,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/automat-client@^0.2.17":
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.17.tgz#253724307312f4d5bc01b5749179193b8a29ae8b"
-  integrity sha512-SbNeBjoc1iqt/EZ+zQTy7EbbXbdEHOuKObcseLKWyy/LF+4FQtHNuYxLGQ3zjl6fR7s/nvcnIEBAPrnFv0gcqQ==
+"@guardian/automat-contributions@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.3.6.tgz#eeb47307522f88a8cb41ccfb34b7ecae36b363b0"
+  integrity sha512-v6LkzMQaE8MaR1aNBA+9QGBSt7ICjvsPOB3iNudhnKft1LP+99TZohOyroJKc1HPYL5fbR0Oe+5CVbpkfABgrg==
 
 "@guardian/braze-components@^3.2.0":
   version "3.2.0"


### PR DESCRIPTION
The old automat-client library will be archived.
Frontend uses automat v2 for Supporter Revenue messages. DCR should do too.