### PR TITLE
Make opinion articles accessible (and update font size)

### DIFF
--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -78,7 +78,7 @@ export const pillarPalette_DO_NOT_USE: Record<
 	},
 	[Pillar.Opinion]: {
 		dark: opinion[300],
-		main: opinion[400],
+		main: opinion[300],
 		bright: opinion[500],
 		pastel: opinion[600],
 		faded: opinion[800],
@@ -163,9 +163,9 @@ export const pillarMap: <T>(f: (name: Theme) => T) => { [K in Theme]: T } = (
 });
 /*
 Further notes on this function:
-    - It maps by hand because it's easy to lose track of types when you use Object.assign()
-    - Where the function parameter f returns type T, pillarMap will return an object with
-      a key for each pillar and values of type T.
+	- It maps by hand because it's easy to lose track of types when you use Object.assign()
+	- Where the function parameter f returns type T, pillarMap will return an object with
+	  a key for each pillar and values of type T.
  */
 
 export const neutralBorder = (pillar: Theme): ColourType => {

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -6,6 +6,7 @@ import { space } from '@guardian/src-foundations';
 import { BylineLink } from '@root/src/web/components/BylineLink';
 import { Display, Design, Format, Special } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
+import { until } from '@guardian/src-foundations/mq';
 
 const wrapperStyles = css`
 	margin-left: 6px;
@@ -53,6 +54,12 @@ const opinionStyles = (palette: Palette, format: Format) => css`
 	font-style: italic;
 	color: ${palette.text.headlineByline};
 	background: ${palette.background.headlineByline};
+
+	${until.mobileMedium} {
+		${headline.small({
+			fontWeight: 'light',
+		})}
+	}
 
 	a {
 		color: inherit;

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -701,7 +701,7 @@ const textDropCap = (format: Format): string => {
 		case Design.Letter:
 		case Design.Comment:
 			return format.theme === Pillar.Opinion
-				? opinion[400]
+				? pillarPalette[format.theme].main
 				: pillarPalette[format.theme].dark;
 		default:
 			return pillarPalette[format.theme].dark;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the opinion.main from .400 to .300 so it is now accessible
Changes the font size of the byline until mobileMedium to match the headline size

## Why?
Wasn't accessible & font size was wrong

### Before
![image](https://user-images.githubusercontent.com/20658471/128723665-e907e9be-425a-499e-9ce5-4ed444743e84.png)

### After
![image](https://user-images.githubusercontent.com/20658471/128723613-dc7915b6-b1c7-44c6-9117-6dd344bab7f9.png)
