### PR TITLE
Use caption field in email embed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
     "files.watcherExclude": {
         "**/target": true
     },
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#648FFF",
+        "titleBar.activeForeground": "#000000"
+	},
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,6 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#648FFF",
-        "titleBar.activeForeground": "#000000"
-	},
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/fixtures/generated/articles/MatchReport.ts
+++ b/fixtures/generated/articles/MatchReport.ts
@@ -1842,6 +1842,7 @@ export const MatchReport: CAPIType = {
 					_type:
 						'model.dotcomrendering.pageElements.EmbedBlockElement',
 					elementId: '2957b548-62b0-42ad-bdbc-ee69ec1562e3',
+					caption: 'Fiver email embed',
 				},
 				{
 					html:

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -142,6 +142,7 @@ interface EmbedBlockElement extends ThirdPartyEmbeddedContent {
 	width?: number;
 	html: string;
 	isMandatory: boolean;
+	caption?: string;
 }
 
 interface ExplainerAtomBlockElement {

--- a/src/model/enhance-embeds.test.ts
+++ b/src/model/enhance-embeds.test.ts
@@ -33,6 +33,7 @@ describe('Enhance Embeds', () => {
 							_type:
 								'model.dotcomrendering.pageElements.EmbedBlockElement',
 							elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+							caption: 'Sign up to the Fiver',
 						},
 					],
 				},
@@ -57,6 +58,7 @@ describe('Enhance Embeds', () => {
 							_type:
 								'model.dotcomrendering.pageElements.EmbedBlockElement',
 							elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+							caption: 'Sign up to the Fiver',
 						},
 					],
 				},

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1351,6 +1351,9 @@
                 "isMandatory": {
                     "type": "boolean"
                 },
+                "caption": {
+                    "type": "string"
+                },
                 "isThirdPartyTracking": {
                     "type": "boolean"
                 },

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -1025,7 +1025,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						>
 							<EmbedBlockComponent
 								html={embed.html}
-								alt={embed.alt}
+								caption={embed.caption}
 							/>
 						</ClickToView>
 					) : (

--- a/src/web/components/ClickToView.stories.tsx
+++ b/src/web/components/ClickToView.stories.tsx
@@ -480,7 +480,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={facebookEmbed.html}
-							alt={facebookEmbed.alt}
+							caption={facebookEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>
@@ -501,7 +501,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={vimeoEmbedEmbed.html}
-							alt={vimeoEmbedEmbed.alt}
+							caption={vimeoEmbedEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>
@@ -522,7 +522,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={youtubeEmbedEmbed.html}
-							alt={youtubeEmbedEmbed.alt}
+							caption={youtubeEmbedEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>
@@ -543,7 +543,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={spotifyEmbedEmbed.html}
-							alt={spotifyEmbedEmbed.alt}
+							caption={spotifyEmbedEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>
@@ -564,7 +564,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bandcampEmbedEmbed.html}
-							alt={bandcampEmbedEmbed.alt}
+							caption={bandcampEmbedEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>
@@ -585,7 +585,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={ourworldindataEmbedEmbed.html}
-							alt={ourworldindataEmbedEmbed.alt}
+							caption={ourworldindataEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -606,7 +606,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bbcEmbedEmbed.html}
-							alt={bbcEmbedEmbed.alt}
+							caption={bbcEmbedEmbed.caption}
 						/>
 					</ClickToView>
 				</Figure>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -5,7 +5,7 @@ import { text } from '@guardian/src-foundations/palette';
 
 type Props = {
 	html: string;
-	alt?: string;
+	caption?: string;
 };
 
 const emailCaptionStyle = css`
@@ -21,13 +21,13 @@ const embedContainer = css`
 	}
 `;
 
-export const EmbedBlockComponent = ({ html, alt }: Props) => {
+export const EmbedBlockComponent = ({ html, caption }: Props) => {
 	// TODO: Email embeds are being turned into atoms, so we can remove this hack when that happens
 	const isEmailEmbed = html.includes('email/form');
 	return (
 		<div data-cy="embed-block" css={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
-			{isEmailEmbed && alt && <div css={emailCaptionStyle}>{alt}</div>}
+			{isEmailEmbed && caption && <div css={emailCaptionStyle}>{caption}</div>}
 		</div>
 	);
 };

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -27,7 +27,9 @@ export const EmbedBlockComponent = ({ html, caption }: Props) => {
 	return (
 		<div data-cy="embed-block" css={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
-			{isEmailEmbed && caption && <div css={emailCaptionStyle}>{caption}</div>}
+			{isEmailEmbed && caption && (
+				<div css={emailCaptionStyle}>{caption}</div>
+			)}
 		</div>
 	);
 };

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -256,7 +256,7 @@ export const renderElement = ({
 					<EmbedBlockComponent
 						key={index}
 						html={element.html}
-						alt={element.alt}
+						caption={element.caption}
 					/>
 				</ClickToView>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Uses the caption field from CAPI instead of the alt field 
## Why?
The caption field is the one that we should really use, instead of alt.
### Before
![Screen Shot 2021-08-10 at 10 53 30](https://user-images.githubusercontent.com/2051501/128846878-b50b593d-5617-4329-a784-7965f47ebc57.png)

### After
![Screen Shot 2021-08-10 at 10 51 31](https://user-images.githubusercontent.com/2051501/128846755-119957a3-105c-4605-81a0-8c8e47ff989b.png)

