### PR TITLE
Update automat client for smarter article count

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^18.0.0",
-    "@guardian/automat-contributions": "^0.3.6",
+    "@guardian/automat-contributions": "^0.4.0",
     "@guardian/braze-components": "^3.3.0",
     "@guardian/commercial-core": "^0.19.2",
     "@guardian/consent-management-platform": "~6.11.5",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -68,6 +68,7 @@ import { UnsafeEmbedBlockComponent } from '@root/src/web/components/elements/Uns
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { storage } from '@guardian/libs';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,
@@ -232,7 +233,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			const hasOptedOut = await hasOptedOutOfArticleCount();
 			if (!hasOptedOut) {
 				incrementDailyArticleCount();
-				incrementWeeklyArticleCount();
+				incrementWeeklyArticleCount(storage.local, CAPI.pageId);
 			}
 		};
 		incrementArticleCountsIfConsented().catch((e) =>

--- a/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -28,6 +28,7 @@ import {
 import { Metadata } from '@guardian/automat-contributions/dist/lib/types';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { cmp } from '@guardian/consent-management-platform';
+import { storage } from '@guardian/libs';
 import { getCookie } from '../../browser/cookie';
 import { useHasBeenSeen } from '../../lib/useHasBeenSeen';
 
@@ -107,8 +108,8 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 				data.isSignedIn || false,
 			),
 			lastOneOffContributionDate: getLastOneOffContributionTimestamp(),
-			epicViewLog: getViewLog(),
-			weeklyArticleHistory: getWeeklyArticleHistory(),
+			epicViewLog: getViewLog(storage.local),
+			weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
 			hasOptedOutOfArticleCount: await hasOptedOutOfArticleCount(),
 			mvtId: Number(getCookie('GU_mvt_id')),
 			countryCode: data.countryCode,
@@ -220,7 +221,7 @@ export const ReaderRevenueEpic = ({
 			// Should only run once
 			const { abTestName } = meta;
 
-			logView(abTestName);
+			logView(storage.local, abTestName);
 
 			sendOphanComponentEvent('VIEW', meta);
 		}

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -26,6 +26,7 @@ import { getForcedVariant } from '@root/src/web/lib/readerRevenueDevUtils';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { useOnce } from '@root/src/web/lib/useOnce';
+import { storage } from '@guardian/libs';
 
 type BaseProps = {
 	isSignedIn: boolean;
@@ -92,7 +93,7 @@ const buildPayload = ({
 			subscriptionBannerLastClosedAt,
 			mvtId: Number(getCookie('GU_mvt_id')),
 			countryCode,
-			weeklyArticleHistory: getWeeklyArticleHistory(),
+			weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
 			optedOutOfArticleCount,
 			modulesVersion: MODULES_VERSION,
 		},
@@ -311,7 +312,7 @@ const RemoteBanner = ({
 	useOnce(() => {
 		const { abTestName, componentType } = meta;
 
-		logView(abTestName);
+		logView(storage.local, abTestName);
 
 		sendOphanComponentEvent('VIEW', meta);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,10 +1726,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/automat-contributions@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.3.6.tgz#eeb47307522f88a8cb41ccfb34b7ecae36b363b0"
-  integrity sha512-v6LkzMQaE8MaR1aNBA+9QGBSt7ICjvsPOB3iNudhnKft1LP+99TZohOyroJKc1HPYL5fbR0Oe+5CVbpkfABgrg==
+"@guardian/automat-contributions@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.0.tgz#bc710031601dd3eb90f3e6555a8fed9d69d0b93d"
+  integrity sha512-ooyeNl4lFOCTi376GipsdV6IHnxY7MGHfM7c/iFbAatElYbH4Lr2Y0kIOBg6yR5XGDMhQ8PWyDQ/YgMIL5BKRw==
 
 "@guardian/braze-components@^3.3.0":
   version "3.3.0"


### PR DESCRIPTION
- Doesn't count repeat views of the same url
- Takes local storage as a parameter

For details see automat PR: https://github.com/guardian/automat-client-v2/pull/5