### PR TITLE
Onwards: Fix carousel, don't display & repeated article bugs

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -1202,6 +1202,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							format={format}
 							pillar={pillar}
 							edition={CAPI.editionId}
+							shortUrlId={CAPI.config.shortUrlId}
 						/>
 					</Suspense>
 				</Lazy>

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -5,7 +5,6 @@ interface Props {
 	children: React.ReactNode;
 	when: 'above' | 'below';
 	breakpoint: Breakpoint;
-	force?: boolean;
 }
 
 interface PropsSpan extends Props {
@@ -19,7 +18,6 @@ export const Hide = ({
 	children,
 	when,
 	breakpoint,
-	force,
 	el,
 }: PropsSpan | PropsLi) => {
 	let whenToHide;
@@ -36,13 +34,6 @@ export const Hide = ({
 			}
 		`;
 	}
-
-	if (force) {
-		whenToHide = css`
-			display: none;
-		`;
-	}
-
 	return el === 'li' ? (
 		<li css={whenToHide}>{children}</li>
 	) : (

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -5,6 +5,7 @@ interface Props {
 	children: React.ReactNode;
 	when: 'above' | 'below';
 	breakpoint: Breakpoint;
+	force?: boolean;
 }
 
 interface PropsSpan extends Props {
@@ -18,6 +19,7 @@ export const Hide = ({
 	children,
 	when,
 	breakpoint,
+	force,
 	el,
 }: PropsSpan | PropsLi) => {
 	let whenToHide;
@@ -34,6 +36,13 @@ export const Hide = ({
 			}
 		`;
 	}
+
+	if (force) {
+		whenToHide = css`
+			display: none;
+		`;
+	}
+
 	return el === 'li' ? (
 		<li css={whenToHide}>{children}</li>
 	) : (

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -304,6 +304,25 @@ export const Headlines = () => (
 
 Headlines.story = 'Headlines carousel';
 
+export const SingleItemCarousel = () => (
+	<>
+		<ElementContainer showTopBorder={true}>
+			<Carousel
+				heading="More on this story"
+				trails={trails.slice(1, 2)}
+				ophanComponentName="curated-content"
+				format={{
+					theme: Pillar.News,
+					design: Design.Article,
+					display: Display.Standard,
+				}}
+			/>
+		</ElementContainer>
+	</>
+);
+
+Headlines.story = 'Carousel with single item';
+
 export const Immersive = () => (
 	<>
 		<ElementContainer showTopBorder={true}>

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -54,6 +54,7 @@ const SvgChevronRightSingle = () => {
 
 const wrapperStyle = (length: number) => css`
 	display: flex;
+	/* Remove space-between where there is a single item, so that it is left-aligned */
 	${length > 1 && 'justify-content: space-between'}
 	overflow: hidden;
 	${from.desktop} {

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -52,8 +52,9 @@ const SvgChevronRightSingle = () => {
 	);
 };
 
-const wrapperStyle = css`
+const wrapperStyle = (length: number) => css`
 	display: flex;
+	${length > 1 && 'justify-content: space-between'}
 	overflow: hidden;
 	${from.desktop} {
 		padding-right: 40px;
@@ -545,7 +546,10 @@ export const Carousel: React.FC<OnwardsType> = ({
 	if (isFullCardImage) trails = convertToImmersive(trails);
 
 	return (
-		<div css={wrapperStyle} data-link-name={formatAttrString(heading)}>
+		<div
+			css={wrapperStyle(trails.length)}
+			data-link-name={formatAttrString(heading)}
+		>
 			<LeftColumn showRightBorder={false} showPartialRightBorder={true}>
 				<HeaderAndNav
 					heading={heading}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -54,7 +54,6 @@ const SvgChevronRightSingle = () => {
 
 const wrapperStyle = css`
 	display: flex;
-	justify-content: space-between;
 	overflow: hidden;
 	${from.desktop} {
 		padding-right: 40px;

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -161,5 +161,3 @@ export const MaybeBrazeEpic = ({ meta, countryCode, idApiUrl }: EpicConfig) => {
 		</>
 	);
 };
-
-


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Respect `showRelatedContent` being disabled above all other related content options
- Fix styling - single item carousels are no longer centred
- Prevent current article being shown in series by sending short URL to series API as part of request

## Why?

Bugs related to this article: https://www.theguardian.com/global-development/2021/aug/10/please-pray-for-me-female-reporter-being-hunted-by-the-taliban-tells-her-story

1. Series carousel has only 1 item and its the article we're already viewing
2. Carousels with only 1 item center the card
3. When disabling showRelatedContent this is not respected for all onwards containers

### Before

Screenshots unavailable due to current outage

### After


