### PR TITLE
Add bash script for team city build

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source ~/.nvm/nvm.sh
+nvm install
+nvm use
+#Code Validation
+echo bundlesize token $BUNDLESIZE_GITHUB_TOKEN
+make validate-ci
+
+#Cypress Tests
+# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
+# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+make cypress
+
+#RiffRaff publish
+make riffraff-publish

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+
 source ~/.nvm/nvm.sh
 nvm install
 nvm use
+
 #Code Validation
 echo bundlesize token $BUNDLESIZE_GITHUB_TOKEN
 make validate-ci

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -161,5 +161,3 @@ export const MaybeBrazeEpic = ({ meta, countryCode, idApiUrl }: EpicConfig) => {
 		</>
 	);
 };
-
-


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds a CI bash script for TeamCity for DCR builds. It contains all of the TeamCity steps in a single script.

This has been tested in teamcity. Existing teamcity steps will be ignored if this script exists and instead a new created step `Run CI Bash Script` would run. TeamCity is setup so it can run with or without this script meaning there will be no down time by switching from existing setup to use the new bash script, however, after a grace period of a week the old TeamCity steps will be disabled.

## Why?

Allows build configuration to be version controlled.

## After

The second step doesn't run because the ci script exists:

<img width="738" alt="Screenshot 2021-08-11 at 11 28 31" src="https://user-images.githubusercontent.com/35331926/129013979-d913959b-5593-4972-a53b-f8812cf57af4.png">

Paired on this: @OllysCoding @marjisound @nitro-marky 