### PR TITLE
Disable validation on PROD for perf reasons

### DIFF
--- a/src/model/validate.ts
+++ b/src/model/validate.ts
@@ -16,6 +16,11 @@ addFormats(ajv);
 const validate = ajv.compile(schema);
 
 export const validateAsCAPIType = (data: { [key: string]: any }): CAPIType => {
+	// validation is slow so don't perform on PROD.
+	if (process.env.NODE_ENV === 'production') {
+		return data as CAPIType;
+	}
+
 	const isValid = validate(data);
 
 	if (!isValid) {


### PR DESCRIPTION
(Will deploy and see perf impact before any merge.)

## What does this change?

Disables validation of CAPI model on PROD.

## Why?

Validation is expensive, especially for larger JS objects.

### Before

### After
