### PR TITLE
render text block elements directly as children of the element container

### DIFF
--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -63,17 +63,34 @@ const Renderer: React.FC<{
 			webTitle,
 		});
 
-		return ok ? (
-			<figure
-				id={'elementId' in element ? element.elementId : undefined}
-				key={index}
-				className={
-					interactiveLegacyFigureClasses.get(element._type) || ''
-				}
-			>
-				{el}
-			</figure>
-		) : null;
+		if (ok) {
+			switch (element._type) {
+				// Here we think it makes sense not to wrap every `p` inside a `figure`
+				case 'model.dotcomrendering.pageElements.TextBlockElement':
+					return el;
+
+				default:
+					return (
+						<figure
+							id={
+								'elementId' in element
+									? element.elementId
+									: undefined
+							}
+							key={index}
+							className={
+								interactiveLegacyFigureClasses.get(
+									element._type,
+								) || ''
+							}
+						>
+							{el}
+						</figure>
+					);
+			}
+		}
+
+		return null;
 	});
 
 	return <div>{output}</div>;


### PR DESCRIPTION
## Why?
For legacy immersive interactives there was incompatible styling when rendering via DCR. Through this investigation we found that we wrapped every text block component in a figure, which didn't feel right. This change renders text block components as direct children on the element container, instead of nesting inside figures.

NB: this doesn't completely resolve all the styling issues seen for these legacy immersive interactives.

### Before
<img width="943" alt="Screenshot 2021-08-12 at 18 03 50" src="https://user-images.githubusercontent.com/45561419/129238431-cf5dfcb6-8ae4-4dcc-97d4-ce079fecdb18.png">


### After
<img width="937" alt="Screenshot 2021-08-12 at 18 04 51" src="https://user-images.githubusercontent.com/45561419/129238454-3cbe5d54-2cd8-4cd1-8afb-2cbb7729f91e.png">
