### PR TITLE
Prioritise showing Braze Epic in end of article slot

### DIFF
--- a/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -88,7 +88,7 @@ const buildBrazeEpicConfig = (
 				/>
 			),
 		},
-		timeoutMillis: 5000,
+		timeoutMillis: 2000,
 	};
 };
 
@@ -127,7 +127,7 @@ export const SlotBodyEnd = ({
 			idApiUrl,
 		);
 		const epicConfig: SlotConfig = {
-			candidates: [readerRevenueEpic, brazeEpic],
+			candidates: [brazeEpic, readerRevenueEpic],
 			name: 'slotBodyEnd',
 		};
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
https://trello.com/c/W3Iqd0Xq/1148-change-priority-of-braze-epic-messages
Changes prioritisation to attempt to show braze epic before attempting to show reader revenue epic in end of body slot (SlotBodyEnd).

This change also reduces the timeout to wait for a valid Braze message to show in the end of article slot down to 2 seconds. This is based on data analysis by @tjmw showing that a reduction from 5 seconds to 2 seconds only reduced impressions by 3%, but helps keep web performance metrics good.

## Why?
This is because of the introduction of new types of end of article components powered by Braze, notable newsletter suggestion epics.

### Before
Braze end of article components would only show if reader revenue epic did not qualify for that page view.

### After
Now Braze end of article components will show if a message triggering one is received within a 2 second timeout after loading the page. If no braze message for an end of article component is received after 2 seconds, then the reader revenue epic is shown if desired by RRCP logic.