### PR TITLE
Add position to atom - required for certain legacy interactives

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -139,4 +139,8 @@ export const interactiveGlobalStyles = css`
 			display: none;
 		}
 	}
+
+	.interactive-atom {
+		position: relative;
+	}
 `;


### PR DESCRIPTION
## Why

Some legacy interactives require this to style their main image. e.g. https://www.theguardian.com/environment/ng-interactive/2019/jul/01/its-getting-warmer-wetter-wilder-the-arctic-town-heating-faster-than-anywhere

### Before

![Screenshot 2021-08-13 at 10 20 37](https://user-images.githubusercontent.com/858402/129338780-f30f1f71-c982-4edf-854c-7d117b71e204.png)

### After

![Screenshot 2021-08-13 at 10 20 29](https://user-images.githubusercontent.com/858402/129338813-9bb57125-8feb-421c-8ca2-2c81d32cb108.png)
