### PR TITLE
Add z-index to header for immersive interactives

### DIFF
--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -119,7 +119,13 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 	}
 
 	return (
-		<div>
+		<header
+			/* Note, some interactives require this - e.g. https://www.theguardian.com/environment/ng-interactive/2015/jun/05/carbon-bomb-the-coal-boom-choking-china. */
+			css={css`
+				${getZIndex('headerWrapper')};
+				position: relative;
+			`}
+		>
 			<div data-print-layout="hide">
 				<Stuck>
 					<ElementContainer
@@ -188,7 +194,7 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 					/>
 				</ElementContainer>
 			)}
-		</div>
+		</header>
 	);
 };
 


### PR DESCRIPTION
Some interactives require this to work. E.g.

https://www.theguardian.com/environment/ng-interactive/2015/jun/05/carbon-bomb-the-coal-boom-choking-china
https://www.theguardian.com/environment/ng-interactive/2015/may/15/carbon-bomb-australia-the-new-coal-frontier

### Before
![Screenshot 2021-08-13 at 11 31 21](https://user-images.githubusercontent.com/858402/129348660-0597ebd8-3878-4ecf-8cef-cc171493a21d.png)

### After
![Screenshot 2021-08-13 at 11 31 27](https://user-images.githubusercontent.com/858402/129348686-de464159-2217-47e1-88c3-51199c878cf7.png)
