### PR TITLE
updating box sizing for legacy interactive immersives

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -24,6 +24,12 @@ export const interactiveLegacyClasses = {
 // Styles expected by interactives from the Frontend days. These shouldn't be
 // used for new interactives though.
 export const interactiveGlobalStyles = css`
+	*,
+	*:before,
+	*:after {
+		box-sizing: content-box;
+	}
+
 	.fc-container__inner,
 	.gs-container {
 		${center}
@@ -42,11 +48,6 @@ export const interactiveGlobalStyles = css`
 		font-size: 1.0625rem;
 		line-height: 1.5;
 		font-weight: 400;
-
-		::before,
-		::after {
-			box-sizing: content-box;
-		}
 	}
 
 	button,


### PR DESCRIPTION
## What does this change?
It was found that some legacy interactive immersives did not display correctly because of the default box-sizing. This change overrides the default.

Example: https://www.theguardian.com/us-news/ng-interactive/2017/dec/08/donald-trump-russia-investigation-key-questions-latest-news-collusion-timeline?dcr

## Why?
To support migration of all interactive immersives to DCR.

### Before
<img width="1630" alt="Screenshot 2021-08-13 at 14 09 41" src="https://user-images.githubusercontent.com/45561419/129361843-3f6f495b-3a3f-498a-94e7-65a817ad6ed7.png">

### After
<img width="1242" alt="Screenshot 2021-08-13 at 14 09 56" src="https://user-images.githubusercontent.com/45561419/129361878-561c9d9f-25ae-4dbd-9e5e-a8d404311b22.png">

