### PR TITLE
Support single quote dropcaps

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -37,7 +37,7 @@ const isLongEnough = (html: string): boolean => {
 
 const decideDropCapLetter = (html: string): string => {
 	const first = html.substr(0, 1);
-	if (first === '“') {
+	if (first === '“' || first === "'") {
 		const second = html.substr(1, 1);
 
 		if (!isLetter(second)) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Allow the two-character dropcaps to start with a single quote

## Why?

Parity with frontend

### Before

### After
