### PR TITLE
Add interactive alt attr to top-level figure

### DIFF
--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -17,6 +17,7 @@ type Props = {
 	caption?: string;
 	format: Format;
 	palette: Palette;
+	elementId?: string;
 };
 
 /*
@@ -231,6 +232,7 @@ export const InteractiveBlockComponent = ({
 	caption,
 	format,
 	palette,
+	elementId = '',
 }: Props) => {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
@@ -281,14 +283,14 @@ export const InteractiveBlockComponent = ({
 	}, [loaded]);
 
 	return (
-		<figure
-			className={interactiveLegacyFigureClasses}
-			data-alt={alt} /* for compatibility with custom boot scripts */
-			data-cypress={`interactive-element-${encodeURI(alt || '')}`}
-		>
-			<div
+		<>
+			<figure
+				id={elementId} // required for hydration
 				ref={wrapperRef}
 				css={wrapperStyle({ format, role, loaded, palette })}
+				className={interactiveLegacyFigureClasses}
+				data-alt={alt} // for compatibility with custom boot scripts
+				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 			>
 				{!loaded && (
 					<>
@@ -306,7 +308,7 @@ export const InteractiveBlockComponent = ({
 						</a>
 					</>
 				)}
-			</div>
+			</figure>
 			{caption && (
 				<Caption
 					captionText={caption}
@@ -314,6 +316,6 @@ export const InteractiveBlockComponent = ({
 					palette={palette}
 				/>
 			)}
-		</figure>
+		</>
 	);
 };

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -7,6 +7,7 @@ import { space } from '@guardian/src-foundations';
 import { Placeholder } from '@root/src/web/components/Placeholder';
 import { Caption } from '@root/src/web/components/Caption';
 import libDebounce from 'lodash.debounce';
+import { interactiveLegacyFigureClasses } from '@root/src/web/layouts/lib/interactiveLegacyStyling';
 
 type Props = {
 	url?: string;
@@ -280,12 +281,14 @@ export const InteractiveBlockComponent = ({
 	}, [loaded]);
 
 	return (
-		<>
+		<figure
+			className={interactiveLegacyFigureClasses}
+			data-alt={alt} /* for compatibility with custom boot scripts */
+			data-cypress={`interactive-element-${encodeURI(alt || '')}`}
+		>
 			<div
-				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 				ref={wrapperRef}
 				css={wrapperStyle({ format, role, loaded, palette })}
-				data-alt={alt} // for compatibility with custom boot scripts
 			>
 				{!loaded && (
 					<>
@@ -311,6 +314,6 @@ export const InteractiveBlockComponent = ({
 					palette={palette}
 				/>
 			)}
-		</>
+		</figure>
 	);
 };

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -25,10 +25,7 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { renderElement } from '../lib/renderElement';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
-import {
-	interactiveGlobalStyles,
-	interactiveLegacyFigureClasses,
-} from './lib/interactiveLegacyStyling';
+import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 
 interface Props {
 	CAPI: CAPIType;
@@ -66,6 +63,7 @@ const Renderer: React.FC<{
 		if (ok) {
 			switch (element._type) {
 				// Here we think it makes sense not to wrap every `p` inside a `figure`
+				case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 				case 'model.dotcomrendering.pageElements.TextBlockElement':
 					return el;
 
@@ -78,11 +76,6 @@ const Renderer: React.FC<{
 									: undefined
 							}
 							key={index}
-							className={
-								interactiveLegacyFigureClasses.get(
-									element._type,
-								) || ''
-							}
 						>
 							{el}
 						</figure>

--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -4,12 +4,8 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { center } from '@root/src/web/lib/center';
 
 // Classes present in Frontend on figure wrapping elements for certain element types.
-export const interactiveLegacyFigureClasses = new Map([
-	[
-		'model.dotcomrendering.pageElements.InteractiveBlockElement',
-		'element-interactive element interactive',
-	],
-]);
+export const interactiveLegacyFigureClasses =
+	'element-interactive element interactive';
 
 // Classes present in Frontend that we add for legacy interactives.
 export const interactiveLegacyClasses = {

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -721,7 +721,8 @@ export const renderElement = ({
 };
 
 // bareElements is the set of element types that don't get wrapped in a Figure
-// for most article types.
+// for most article types, either because they don't need it or because they
+// add the figure themselves.
 const bareElements = new Set([
 	'model.dotcomrendering.pageElements.BlockquoteBlockElement',
 	'model.dotcomrendering.pageElements.CaptionBlockElement',

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -365,6 +365,7 @@ export const renderElement = ({
 					role={element.role}
 					format={format}
 					palette={palette}
+					elementId={element.elementId}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.ItemLinkBlockElement':
@@ -734,7 +735,6 @@ const bareElements = new Set([
 	'model.dotcomrendering.pageElements.SubheadingBlockElement',
 	'model.dotcomrendering.pageElements.TextBlockElement',
 	'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-	'model.dotcomrendering.pageElements.InteractiveBlockElement',
 ]);
 
 // renderArticleElement is a wrapper for renderElement that wraps elements in a

--- a/src/web/lib/renderElement.tsx
+++ b/src/web/lib/renderElement.tsx
@@ -733,6 +733,7 @@ const bareElements = new Set([
 	'model.dotcomrendering.pageElements.SubheadingBlockElement',
 	'model.dotcomrendering.pageElements.TextBlockElement',
 	'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+	'model.dotcomrendering.pageElements.InteractiveBlockElement',
 ]);
 
 // renderArticleElement is a wrapper for renderElement that wraps elements in a


### PR DESCRIPTION
It needs to be on the same element as has the legacy classes for
some interactives to work. E.g.

https://www.theguardian.com/film/ng-interactive/2015/dec/04/best-films-of-2015-us-america

Note, these interactives (like documentaries) still don't work on DCR locally for some reason. Though they should work on PROD.