### PR TITLE
Add missing styling for interactive immersives

### DIFF
--- a/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -37,6 +37,7 @@ export const interactiveGlobalStyles = css`
 
 	/* There is room for better solution where we don't have to load global styles onto the body.
 		For now this works, but we shouldn't support for it for newly made interactives. */
+	p,
 	.${interactiveLegacyClasses.contentInteractive} {
 		margin-bottom: 1rem;
 


### PR DESCRIPTION
## Why?
Some interactive immersives assume default styling exists (primarily font family for `p` elements). We should add the default styling as part of the interactive immersive migration to DCR.

Example: https://www.theguardian.com/environment/ng-interactive/2019/oct/17/stripped-bare-australias-hidden-climate-crisis?dcr

The missing default `p` styling was noted during conversations with Visuals - it's something they mentioned having to add.

### Before
<img width="883" alt="Screenshot 2021-08-13 at 17 37 34" src="https://user-images.githubusercontent.com/45561419/129391481-f1a4e4d9-82b7-4514-9e14-b0b29fd87454.png">

### After
<img width="815" alt="Screenshot 2021-08-13 at 17 37 38" src="https://user-images.githubusercontent.com/45561419/129391595-acc37b2d-12f7-4cbd-b614-ea00caeab678.png">

