### PR TITLE
Exhaustive quote matching for drop caps

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -23,6 +23,15 @@ const isLetter = (letter: string) => {
 	return letter.toLowerCase() !== letter.toUpperCase();
 };
 
+const isOpenQuote = (t: string) => {
+	[
+		'\'' /* apostrophe  */,
+		'"'/* quotation mark */,
+		'\u2018'/* open single quote */,
+		'\u201c' /* open double quote */
+	].includes(t)
+}
+
 const isLongEnough = (html: string): boolean => {
 	// Only show a dropcap if the block of text is 200 characters or
 	// longer. But we first need to strip any markup from our html string so
@@ -37,7 +46,7 @@ const isLongEnough = (html: string): boolean => {
 
 const decideDropCapLetter = (html: string): string => {
 	const first = html.substr(0, 1);
-	if (first === '“' || first === "'") {
+	if (isOpenQuote(first)) {
 		const second = html.substr(1, 1);
 
 		if (!isLetter(second)) {
@@ -171,7 +180,7 @@ export const TextBlockComponent = ({
 					width: 15.2px;
 					margin-right: 0.2px;
 					background-color: ${decidePalette(format).background
-						.bullet};
+					.bullet};
 				}
 
 				${until.tablet} {

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -23,8 +23,8 @@ const isLetter = (letter: string) => {
 	return letter.toLowerCase() !== letter.toUpperCase();
 };
 
-const isOpenQuote = (t: string) => {
-	[
+const isOpenQuote = (t: string): boolean => {
+	return [
 		'\'' /* apostrophe  */,
 		'"'/* quotation mark */,
 		'\u2018'/* open single quote */,


### PR DESCRIPTION
Having some issues with DropCaps not picking up quotes. I think the open single and open double are the only ones needed to match, but thought it would probably be useful to be exhaustive.

(I also made this all in codespaces so maybe none of the plugins etc have run against this branch)