### PR TITLE
Don't Stick when `isSignedIn`

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1151,7 +1151,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			<Portal rootId="most-viewed-right">
 				<Lazy margin={100}>
 					<Suspense fallback={<></>}>
-						<MostViewedRightWrapper isSignedIn={isSignedIn} />
+						<MostViewedRightWrapper />
 					</Suspense>
 				</Lazy>
 			</Portal>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1151,7 +1151,9 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			<Portal rootId="most-viewed-right">
 				<Lazy margin={100}>
 					<Suspense fallback={<></>}>
-						<MostViewedRightWrapper />
+						<MostViewedRightWrapper
+							isAdFreeUser={CAPI.isAdFreeUser}
+						/>
 					</Suspense>
 				</Lazy>
 			</Portal>

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
@@ -41,7 +41,7 @@ export const defaultStory = () => {
 						showTopBorder={false}
 						padded={false}
 					>
-						<MostViewedRight />
+						<MostViewedRight isAdFreeUser={false} />
 					</ElementContainer>
 				</RightColumn>
 			</Flex>
@@ -71,7 +71,7 @@ export const limitItemsStory = () => {
 						showTopBorder={false}
 						padded={false}
 					>
-						<MostViewedRight limitItems={3} />
+						<MostViewedRight limitItems={3} isAdFreeUser={false} />
 					</ElementContainer>
 				</RightColumn>
 			</Flex>
@@ -88,7 +88,7 @@ export const outsideContextStory = () => {
 
 	return (
 		<ElementContainer>
-			<MostViewedRight />
+			<MostViewedRight isAdFreeUser={false} />
 		</ElementContainer>
 	);
 };

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.test.tsx
@@ -19,7 +19,9 @@ describe('MostViewedList', () => {
 	it('should call the api and render the response as expected', () => {
 		useApi.mockReturnValue(response);
 
-		const { asFragment, getAllByText } = render(<MostViewedRight />);
+		const { asFragment, getAllByText } = render(
+			<MostViewedRight isAdFreeUser={false} />,
+		);
 
 		// Calls api once only
 		expect(useApi).toHaveBeenCalledTimes(1);
@@ -58,7 +60,9 @@ describe('MostViewedList', () => {
 	it('should implement a limit on the number of items', () => {
 		useApi.mockReturnValue(response);
 
-		const { getAllByText } = render(<MostViewedRight limitItems={3} />);
+		const { getAllByText } = render(
+			<MostViewedRight limitItems={3} isAdFreeUser={false} />,
+		);
 
 		// Calls api once only
 		expect(useApi).toHaveBeenCalledTimes(1);
@@ -76,7 +80,7 @@ describe('MostViewedList', () => {
 	it('should show a byline when this property is set to true', async () => {
 		useApi.mockReturnValue(response);
 
-		const { getByText } = render(<MostViewedRight />);
+		const { getByText } = render(<MostViewedRight isAdFreeUser={false} />);
 
 		expect(
 			getByText('Jennifer Rankin and Daniel Boffey'),

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -28,10 +28,9 @@ const headingStyles = css`
 
 interface Props {
 	limitItems?: number;
-	isSignedIn?: boolean;
 }
 
-export const MostViewedRight = ({ limitItems = 5, isSignedIn }: Props) => {
+export const MostViewedRight = ({ limitItems = 5 }: Props) => {
 	const adBlockerDetected = useAdBlockInUse();
 
 	const endpointUrl: string =
@@ -47,11 +46,10 @@ export const MostViewedRight = ({ limitItems = 5, isSignedIn }: Props) => {
 		const trails: TrailType[] = data.trails
 			.map(decideTrail)
 			.slice(0, limitItems);
-		const stickToTop = adBlockerDetected || isSignedIn;
 		// Look I don't know why data-component is geo-most-popular either, but it is, ok? Ok.
 		return (
 			<div
-				css={[wrapperStyles, stickToTop && stickyStyles]}
+				css={[wrapperStyles, adBlockerDetected && stickyStyles]}
 				data-component="geo-most-popular"
 			>
 				<Lines count={4} effect="straight" />

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -28,9 +28,10 @@ const headingStyles = css`
 
 interface Props {
 	limitItems?: number;
+	isAdFreeUser: boolean;
 }
 
-export const MostViewedRight = ({ limitItems = 5 }: Props) => {
+export const MostViewedRight = ({ limitItems = 5, isAdFreeUser }: Props) => {
 	const adBlockerDetected = useAdBlockInUse();
 
 	const endpointUrl: string =
@@ -46,10 +47,11 @@ export const MostViewedRight = ({ limitItems = 5 }: Props) => {
 		const trails: TrailType[] = data.trails
 			.map(decideTrail)
 			.slice(0, limitItems);
+		const stickToTop = adBlockerDetected || isAdFreeUser;
 		// Look I don't know why data-component is geo-most-popular either, but it is, ok? Ok.
 		return (
 			<div
-				css={[wrapperStyles, adBlockerDetected && stickyStyles]}
+				css={[wrapperStyles, stickToTop && stickyStyles]}
 				data-component="geo-most-popular"
 			>
 				<Lines count={4} effect="straight" />

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -5,6 +5,7 @@ import { MostViewedRight } from './MostViewedRight';
 
 type Props = {
 	limitItems?: number;
+	isAdFreeUser: boolean;
 };
 
 // Minimum height needed to render MostViewedRight is its own outer height.
@@ -15,7 +16,7 @@ const flexGrow = css`
 `;
 
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
-export const MostViewedRightWrapper = ({ limitItems }: Props) => {
+export const MostViewedRightWrapper = ({ limitItems, isAdFreeUser }: Props) => {
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const [heightIsAvailable, setHeightIsAvailable] = useState<boolean>(false);
 
@@ -44,7 +45,10 @@ export const MostViewedRightWrapper = ({ limitItems }: Props) => {
 	return (
 		<div ref={bodyRef} css={flexGrow}>
 			{heightIsAvailable ? (
-				<MostViewedRight limitItems={limitItems} />
+				<MostViewedRight
+					limitItems={limitItems}
+					isAdFreeUser={isAdFreeUser}
+				/>
 			) : null}
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -5,7 +5,6 @@ import { MostViewedRight } from './MostViewedRight';
 
 type Props = {
 	limitItems?: number;
-	isSignedIn?: boolean;
 };
 
 // Minimum height needed to render MostViewedRight is its own outer height.
@@ -16,7 +15,7 @@ const flexGrow = css`
 `;
 
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
-export const MostViewedRightWrapper = ({ limitItems, isSignedIn }: Props) => {
+export const MostViewedRightWrapper = ({ limitItems }: Props) => {
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const [heightIsAvailable, setHeightIsAvailable] = useState<boolean>(false);
 
@@ -45,10 +44,7 @@ export const MostViewedRightWrapper = ({ limitItems, isSignedIn }: Props) => {
 	return (
 		<div ref={bodyRef} css={flexGrow}>
 			{heightIsAvailable ? (
-				<MostViewedRight
-					limitItems={limitItems}
-					isSignedIn={isSignedIn}
-				/>
+				<MostViewedRight limitItems={limitItems} />
 			) : null}
 		</div>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes an issue where the `MostViewed` list was being stuck for signed in users that are still being shown ads. Instead we now use `isAdFreeUser` to know when ads are not being shown.

## Why?
Because `isSignedIn` does not mean you won't be shown adverts