### PR TITLE
Use `dotcom-rendering` Subdirectory For Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ version: 2
 updates:
   # NPM packages
   - package-ecosystem: "npm" 
-    directory: "/"
+    directory: "/dotcom-rendering"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this change?

This change will be made as part of the AR migration anyway, but until then this should allow dependabot to find the `yarn.lock`.
