### PR TITLE
ensure text sans in comments for interactives

### DIFF
--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -15,6 +15,10 @@ export const interactiveLegacyClasses = {
 	contentMainColumn: 'content__main-column--interactive',
 	headline: 'content__headline',
 	labelLink: 'content__label__link',
+
+	// some legacy interactives do not use the content--interactive container
+	// to ensure all editorial content has correct font, we need to target this too
+	interactiveWrapper: 'interactive-wrapper',
 };
 
 // Styles expected by interactives from the Frontend days. These shouldn't be
@@ -33,8 +37,8 @@ export const interactiveGlobalStyles = css`
 
 	/* There is room for better solution where we don't have to load global styles onto the body.
 		For now this works, but we shouldn't support for it for newly made interactives. */
-	p,
-	.${interactiveLegacyClasses.contentInteractive} {
+	.${interactiveLegacyClasses.contentInteractive},
+	.${interactiveLegacyClasses.interactiveWrapper} {
 		margin-bottom: 1rem;
 
 		/* stylelint-disable */


### PR DESCRIPTION
## What does this change?
Increase specificity of egyptian font family for interactives. Some interactives don't use the contentInteractive class so we've
expanded the legacy classes to also target interactive-wrapper when specifying the main content font family.

## Why?
To ensure correct font-family in content as well as in the comments.


2 example interactives:
https://www.theguardian.com/environment/ng-interactive/2019/oct/17/stripped-bare-australias-hidden-climate-crisis
https://www.theguardian.com/football/ng-interactive/2021/aug/17/david-squires-on-premier-league-opening-weekend

### Before
climate crisis (main body content has expected font family egyptian):
<img width="690" alt="Screenshot 2021-08-17 at 13 14 14" src="https://user-images.githubusercontent.com/45561419/129723751-0c98a8fa-9f40-4d93-85d1-8f2ae6d2bac7.png">


squires (has incorrect font family egyptian):
<img width="354" alt="Screenshot 2021-08-17 at 13 13 01" src="https://user-images.githubusercontent.com/45561419/129723612-1bdc564c-75f5-4e3e-b583-28bc9d95c544.png">


### After
climate crisis (content still has expected font family egyptian):
<img width="658" alt="Screenshot 2021-08-17 at 13 14 58" src="https://user-images.githubusercontent.com/45561419/129723869-0138b359-68e2-46b0-86e6-c78c6dcc748a.png">


squires (now has expected font family text sans):
<img width="345" alt="Screenshot 2021-08-17 at 13 12 33" src="https://user-images.githubusercontent.com/45561419/129723524-fc20649b-f956-4075-9ce3-2e5f75252f37.png">
