### PR TITLE
Specify header background colour

### DIFF
--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -4,12 +4,14 @@ import { EditionDropdown } from '@frontend/web/components/EditionDropdown';
 import { Hide } from '@root/src/web/components/Hide';
 import { Logo } from '@frontend/web/components/Logo';
 import { Links } from '@frontend/web/components/Links';
+import { palette } from '@guardian/src-foundations';
 
 const headerStyles = css`
 	/* Ensure header height contains it's children */
 	overflow: auto;
 	/* Prevent a scrollbar appearing here on IE/Edge */
 	-ms-overflow-style: none;
+	background-color: ${palette.brand[400]};
 `;
 
 type Props = {


### PR DESCRIPTION
### What/why

Not needed mostly but some interactives target header (which didn't
exist in Frontend's markup) and cause issues here.

E.g. for https://www.theguardian.com/us-news/ng-interactive/2016/jan/14/the-injustice-system-us-prisons-tyra-patterson-michelle-lai-dayton-ohio-montgomery-county.

### Before
![Screenshot 2021-08-18 at 14 22 24](https://user-images.githubusercontent.com/858402/129906001-646b5de6-636f-432f-bba4-b9e99e35f74a.png)

### After
![Screenshot 2021-08-18 at 14 22 41](https://user-images.githubusercontent.com/858402/129906026-e3d77fc6-3792-421d-a9a1-f111d6056ce0.png)
