### PR TITLE
Limit legacy interactive styling

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -472,6 +472,11 @@ interface CAPIType {
 	matchUrl?: string;
 	isSpecialReport: boolean;
 
+	// Interactives made on Frontend rather than DCR require special handling.
+	// The logic is date-driven. See:
+	// https://github.com/guardian/frontend/blob/main/common/app/model/dotcomrendering/InteractiveSwitchOver.scala#L7.
+	isLegacyInteractive?: boolean;
+
 	anniversaryInteractiveAtom?: InteractiveAtomBlockElement; // TEMPORARY, to be removed following 200th anniversary
 }
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -2,7 +2,6 @@
 // CAPIType and its subtypes //
 // ------------------------- //
 
-
 // Pillars are used for styling
 // RealPillars have pillar palette colours
 // FakePillars allow us to make modifications to style based on rules outside of the pillar of an article
@@ -15,7 +14,12 @@ type LegacyPillar = RealPillars | FakePillars;
 // RealPillars have pillar palette colours and have a `Pillar` type in Scala
 // FakePillars allow us to make modifications to style based on rules outside of the pillar of an article and have a `Special` type in Scala
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
-type ThemePillar = 'NewsPillar' | 'OpinionPillar' | 'SportPillar' | 'CulturePillar' | 'LifestylePillar';
+type ThemePillar =
+	| 'NewsPillar'
+	| 'OpinionPillar'
+	| 'SportPillar'
+	| 'CulturePillar'
+	| 'LifestylePillar';
 type ThemeSpecial = 'SpecialReportTheme' | 'Labs';
 type CAPITheme = ThemePillar | ThemeSpecial;
 
@@ -43,7 +47,11 @@ type CAPIDesign =
 
 // CAPIDisplay is the display information passed through from CAPI and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
-type CAPIDisplay = 'StandardDisplay' | 'ImmersiveDisplay' | 'ShowcaseDisplay' | 'NumberedListDisplay';
+type CAPIDisplay =
+	| 'StandardDisplay'
+	| 'ImmersiveDisplay'
+	| 'ShowcaseDisplay'
+	| 'NumberedListDisplay';
 
 // CAPIFormat is the stringified version of Format passed through from CAPI.
 // It gets converted to the @guardian/types format on platform
@@ -52,7 +60,7 @@ type CAPIFormat = {
 	design: CAPIDesign;
 	theme: CAPITheme;
 	display: CAPIDisplay;
-}
+};
 
 type Display = import('@guardian/types').Display;
 type Design = import('@guardian/types').Design;
@@ -106,7 +114,7 @@ type Palette = {
 		blockquote: Colour;
 		numberedTitle: Colour;
 		numberedPosition: Colour;
-	},
+	};
 	background: {
 		article: Colour;
 		seriesTitle: Colour;
@@ -125,7 +133,7 @@ type Palette = {
 		carouselDotFocus: Colour;
 		headlineTag: Colour;
 		mostViewedTab: Colour;
-	},
+	};
 	fill: {
 		commentCount: Colour;
 		shareIcon: Colour;
@@ -134,7 +142,7 @@ type Palette = {
 		richLink: Colour;
 		quoteIcon: Colour;
 		blockquoteIcon: Colour;
-	},
+	};
 	border: {
 		syndicationButton: Colour;
 		subNav: Colour;
@@ -148,13 +156,13 @@ type Palette = {
 		navPillar: Colour;
 		article: Colour;
 		lines: Colour;
-	},
+	};
 	topBar: {
 		card: Colour;
-	},
+	};
 	hover: {
 		headlineByline: Colour;
-	}
+	};
 };
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
@@ -178,13 +186,15 @@ interface AdTargetParam {
 	value: string | string[];
 }
 
-type AdTargeting = {
-	adUnit: string;
-	customParams: Record<string, unknown>;
-	disableAds?: false;
-} | {
-	disableAds: true;
-}
+type AdTargeting =
+	| {
+			adUnit: string;
+			customParams: Record<string, unknown>;
+			disableAds?: false;
+	  }
+	| {
+			disableAds: true;
+	  };
 
 interface SectionNielsenAPI {
 	name: string;
@@ -203,7 +213,7 @@ type BrandingLogo = {
 	link: string;
 	label: string;
 	dimensions: { width: number; height: number };
-}
+};
 
 interface Branding {
 	brandingType?: { name: string };
@@ -361,29 +371,29 @@ type PageTypeType = {
 // misleading - the model is *not* the same as the Content API content models.
 
 interface CAPILinkType {
-    url: string;
-    title: string;
-    longTitle?: string;
-    iconName?: string;
-    children?: CAPILinkType[];
-    pillar?: LegacyPillar;
-    more?: boolean;
-    classList?: string[];
+	url: string;
+	title: string;
+	longTitle?: string;
+	iconName?: string;
+	children?: CAPILinkType[];
+	pillar?: LegacyPillar;
+	more?: boolean;
+	classList?: string[];
 }
 
 interface CAPINavType {
-    currentUrl: string;
-    pillars: CAPILinkType[];
-    otherLinks: CAPILinkType[];
-    brandExtensions: CAPILinkType[];
-    currentNavLink?: CAPILinkType;
-    currentNavLinkTitle?: string;
-    currentPillarTitle?: string;
-    subNavSections?: {
-        parent?: CAPILinkType;
-        links: CAPILinkType[];
-    };
-    readerRevenueLinks: ReaderRevenuePositions;
+	currentUrl: string;
+	pillars: CAPILinkType[];
+	otherLinks: CAPILinkType[];
+	brandExtensions: CAPILinkType[];
+	currentNavLink?: CAPILinkType;
+	currentNavLinkTitle?: string;
+	currentPillarTitle?: string;
+	subNavSections?: {
+		parent?: CAPILinkType;
+		links: CAPILinkType[];
+	};
+	readerRevenueLinks: ReaderRevenuePositions;
 }
 
 // WARNING: run `gen-schema` task if changing this to update the associated JSON
@@ -536,7 +546,7 @@ type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
 type ShareIconSize = 'small' | 'medium';
 
-type LeftColSize = 'compact'|'wide';
+type LeftColSize = 'compact' | 'wide';
 
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
 
@@ -614,7 +624,7 @@ type MatchReportType = {
 	venue: string;
 	comments: string;
 	minByMinUrl: string;
-}
+};
 
 /**
  * Onwards
@@ -625,9 +635,9 @@ type OnwardsType = {
 	description?: string;
 	url?: string;
 	ophanComponentName: OphanComponentName;
-    format: Format;
+	format: Format;
 	isCuratedContent?: boolean;
-    isFullCardImage?: boolean;
+	isFullCardImage?: boolean;
 };
 
 type OphanComponentName =
@@ -667,7 +677,7 @@ interface ConfigType extends CommercialConfigType {
 	sentryHost: string;
 	dcrSentryDsn: string;
 	switches: { [key: string]: boolean };
-	abTests: Record<string, "control" | "variant">;
+	abTests: Record<string, 'control' | 'variant'>;
 	dfpAccountId: string;
 	commercialBundleUrl: string;
 	revisionNumber: string;
@@ -767,7 +777,7 @@ interface DCRServerDocumentData {
 	CAPI: CAPIType;
 	NAV: NavType;
 	GA: GADataType;
-	linkedData: { [key: string]: any; };
+	linkedData: { [key: string]: any };
 }
 
 interface BrowserNavType {
@@ -781,7 +791,7 @@ interface DCRBrowserDocumentData {
 	CAPI: CAPIBrowserType;
 	NAV: BrowserNavType;
 	GA: GADataType;
-	linkedData: { [key: string]: any; };
+	linkedData: { [key: string]: any };
 }
 
 // All Components that are loaded with loadable
@@ -789,65 +799,65 @@ interface DCRBrowserDocumentData {
 // defined in loadable-manifest-browser.json
 type BlockElementType = string;
 interface ComponentNameChunkMap {
-    chunkName: string;
-    addWhen: BlockElementType | 'always';
+	chunkName: string;
+	addWhen: BlockElementType | 'always';
 }
-interface EditionDropdownLoadable extends ComponentNameChunkMap{
-    chunkName: 'EditionDropdown';
-    addWhen: 'always';
+interface EditionDropdownLoadable extends ComponentNameChunkMap {
+	chunkName: 'EditionDropdown';
+	addWhen: 'always';
 }
 interface YoutubeBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-YoutubeBlockComponent';
-    addWhen: YoutubeBlockElement['_type'];
+	chunkName: 'elements-YoutubeBlockComponent';
+	addWhen: YoutubeBlockElement['_type'];
 }
 
 interface RichLinkBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-RichLinkComponent';
-    addWhen: RichLinkBlockElement['_type'];
+	chunkName: 'elements-RichLinkComponent';
+	addWhen: RichLinkBlockElement['_type'];
 }
 
 interface InteractiveBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-InteractiveBlockComponent';
-    addWhen: InteractiveBlockElement['_type'];
+	chunkName: 'elements-InteractiveBlockComponent';
+	addWhen: InteractiveBlockElement['_type'];
 }
 
 interface InteractiveContentsBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-InteractiveContentsBlockComponent';
-    addWhen: InteractiveContentsBlockElement['_type'];
+	chunkName: 'elements-InteractiveContentsBlockComponent';
+	addWhen: InteractiveContentsBlockElement['_type'];
 }
 
 interface CalloutBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-CalloutBlockComponent';
-    addWhen: CalloutBlockElement['_type'];
+	chunkName: 'elements-CalloutBlockComponent';
+	addWhen: CalloutBlockElement['_type'];
 }
 
 interface DocumentBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-DocumentBlockComponent';
-    addWhen: DocumentBlockElement['_type'];
+	chunkName: 'elements-DocumentBlockComponent';
+	addWhen: DocumentBlockElement['_type'];
 }
 
 interface MapBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-MapEmbedBlockComponent';
-    addWhen: MapBlockElement['_type'];
+	chunkName: 'elements-MapEmbedBlockComponent';
+	addWhen: MapBlockElement['_type'];
 }
 
 interface SpotifyBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-SpotifyBlockComponent';
-    addWhen: SpotifyBlockElement['_type'];
+	chunkName: 'elements-SpotifyBlockComponent';
+	addWhen: SpotifyBlockElement['_type'];
 }
 
 interface FacebookVideoBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-VideoFacebookBlockComponent';
-    addWhen: VideoFacebookBlockElement['_type'];
+	chunkName: 'elements-VideoFacebookBlockComponent';
+	addWhen: VideoFacebookBlockElement['_type'];
 }
 interface VineBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-VineBlockComponent';
-    addWhen: VineBlockElement['_type'];
+	chunkName: 'elements-VineBlockComponent';
+	addWhen: VineBlockElement['_type'];
 }
 
 interface InstagramBlockLoadable extends ComponentNameChunkMap {
-    chunkName: 'elements-InstagramBlockComponent';
-    addWhen: InstagramBlockElement['_type'];
+	chunkName: 'elements-InstagramBlockComponent';
+	addWhen: InstagramBlockElement['_type'];
 }
 
 // There are docs on loadable in ./docs/loadable-components.md
@@ -864,31 +874,31 @@ type LoadableComponents = [
 	FacebookVideoBlockLoadable,
 	VineBlockLoadable,
 	InstagramBlockLoadable,
-]
+];
 
 interface CarouselImagesMap {
 	'300'?: string;
 	'460'?: string;
 }
 interface BaseTrailType {
-    url: string;
-    headline: string;
-    isLiveBlog: boolean;
-    webPublicationDate: string;
-    image?: string;
+	url: string;
+	headline: string;
+	isLiveBlog: boolean;
+	webPublicationDate: string;
+	image?: string;
 	carouselImages?: CarouselImagesMap;
-    avatarUrl?: string;
-    mediaType?: MediaType;
-    mediaDuration?: number;
-    ageWarning?: string;
-    byline?: string;
-    showByline?: boolean;
-    kickerText?: string;
-    shortUrl?: string;
-    commentCount?: number;
-    starRating?: number;
-    linkText?: string;
-	branding?: Branding
+	avatarUrl?: string;
+	mediaType?: MediaType;
+	mediaDuration?: number;
+	ageWarning?: string;
+	byline?: string;
+	showByline?: boolean;
+	kickerText?: string;
+	shortUrl?: string;
+	commentCount?: number;
+	starRating?: number;
+	linkText?: string;
+	branding?: Branding;
 }
 interface TrailType extends BaseTrailType {
 	palette: Palette;

--- a/dotcom-rendering/src/model/json-schema.json
+++ b/dotcom-rendering/src/model/json-schema.json
@@ -382,6 +382,9 @@
         "isSpecialReport": {
             "type": "boolean"
         },
+        "isLegacyInteractive": {
+            "type": "boolean"
+        },
         "anniversaryInteractiveAtom": {
             "$ref": "#/definitions/InteractiveAtomBlockElement"
         }
@@ -3628,10 +3631,7 @@
                     }
                 },
                 "abTests": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "$ref": "#/definitions/Record<string,\"control\"|\"variant\">"
                 },
                 "dfpAccountId": {
                     "type": "string"
@@ -3793,6 +3793,9 @@
                 "stage",
                 "switches"
             ]
+        },
+        "Record<string,\"control\"|\"variant\">": {
+            "type": "object"
         },
         "CommercialProperties": {
             "type": "object",

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -220,7 +220,9 @@ export const InteractiveImmersiveLayout = ({
 
 	return (
 		<>
-			<Global styles={interactiveGlobalStyles} />
+			{CAPI.isLegacyInteractive && (
+				<Global styles={interactiveGlobalStyles} />
+			)}
 			<div
 				css={css`
 					background-color: ${palette.background.article};

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -240,7 +240,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	return (
 		<>
 			<div data-print-layout="hide">
-				<Global styles={interactiveGlobalStyles} />
+				{CAPI.isLegacyInteractive && (
+					<Global styles={interactiveGlobalStyles} />
+				)}
 				<>
 					<Stuck>
 						<ElementContainer

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -28,131 +28,135 @@ export const interactiveLegacyClasses = {
 // Styles expected by interactives from the Frontend days. These shouldn't be
 // used for new interactives though.
 export const interactiveGlobalStyles = css`
-	*,
-	*:before,
-	*:after {
-		box-sizing: content-box;
-	}
-
-	.fc-container__inner,
-	.gs-container {
-		${center}
-	}
-
-	/* There is room for better solution where we don't have to load global styles onto the body.
-		For now this works, but we shouldn't support for it for newly made interactives. */
-	.${interactiveLegacyClasses.contentInteractive},
-	.${interactiveLegacyClasses.interactiveWrapper} {
-		margin-bottom: 1rem;
-
-		/* stylelint-disable */
-		font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia,
-			serif;
-		/* stylelint-enable */
-
-		font-size: 1.0625rem;
-		line-height: 1.5;
-		font-weight: 400;
-	}
-
-	button,
-	input,
-	optgroup,
-	select,
-	textarea {
-		color: inherit;
-	}
-
-	button,
-	html input[type='button'],
-	input[type='reset'],
-	input[type='submit'] {
-		cursor: pointer;
-	}
-
-	/* Start social icon support */
-	.meta__social {
-		padding-top: 0.375rem;
-	}
-
-	.social__item {
-		float: left;
-		min-width: 2rem;
-		padding: 0 0.1875rem 0.375rem 0;
-		cursor: pointer;
-
-		.inline-icon__fallback {
-			display: none;
+	/* Scope this as tightly as possible. Otherwise, e.g. box-model will break
+	footer. */
+	body article {
+		*,
+		*:before,
+		*:after {
+			box-sizing: content-box;
 		}
 
-		.inline-icon {
-			background-color: transparent;
-			border: 1px solid #dcdcdc; /* stylelint-disable-line */
-			transition: fill 0.3s ease, background-color 0.3s ease;
+		.fc-container__inner,
+		.gs-container {
+			${center}
 		}
 
-		.social-icon {
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			border: 0;
+		/* There is room for better solution where we don't have to load global styles onto the body.
+			For now this works, but we shouldn't support for it for newly made interactives. */
+		.${interactiveLegacyClasses.contentInteractive},
+			.${interactiveLegacyClasses.interactiveWrapper} {
+			margin-bottom: 1rem;
+
+			/* stylelint-disable */
+			font-family: GuardianTextEgyptian, Guardian Text Egyptian Web,
+				Georgia, serif;
+			/* stylelint-enable */
+
+			font-size: 1.0625rem;
+			line-height: 1.5;
+			font-weight: 400;
+		}
+
+		button,
+		input,
+		optgroup,
+		select,
+		textarea {
+			color: inherit;
+		}
+
+		button,
+		html input[type='button'],
+		input[type='reset'],
+		input[type='submit'] {
+			cursor: pointer;
+		}
+
+		/* Start social icon support */
+		.meta__social {
+			padding-top: 0.375rem;
+		}
+
+		.social__item {
+			float: left;
 			min-width: 2rem;
-			max-width: 100%;
-			width: auto;
-			height: 2rem;
-			svg {
-				height: 88%;
-				width: 88%;
+			padding: 0 0.1875rem 0.375rem 0;
+			cursor: pointer;
+
+			.inline-icon__fallback {
+				display: none;
+			}
+
+			.inline-icon {
+				background-color: transparent;
+				border: 1px solid #dcdcdc; /* stylelint-disable-line */
+				transition: fill 0.3s ease, background-color 0.3s ease;
+			}
+
+			.social-icon {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				border: 0;
+				min-width: 2rem;
+				max-width: 100%;
+				width: auto;
+				height: 2rem;
+				svg {
+					height: 88%;
+					width: 88%;
+				}
+			}
+
+			.rounded-icon {
+				border-radius: 62.5rem;
+				display: inline-block;
+				vertical-align: middle;
+				position: relative;
+			}
+
+			.centered-icon svg {
+				top: 0;
+				bottom: 0;
+				right: 0;
+				left: 0;
+				margin: auto;
+				position: absolute;
 			}
 		}
 
-		.rounded-icon {
-			border-radius: 62.5rem;
-			display: inline-block;
-			vertical-align: middle;
+		.content__dateline {
+			font-size: 0.75rem;
+			line-height: 1rem;
+			position: relative;
+			box-sizing: border-box;
+			padding-top: 0.125rem;
+			margin-bottom: 0.375rem;
+		}
+		/* End social icon support */
+
+		/* Typically required for ad display. */
+		${until.tablet} {
+			.hide-until-tablet {
+				display: none;
+			}
+		}
+
+		${from.tablet} {
+			.mobile-only {
+				display: none;
+			}
+		}
+
+		.interactive-atom {
 			position: relative;
 		}
 
-		.centered-icon svg {
-			top: 0;
-			bottom: 0;
-			right: 0;
-			left: 0;
-			margin: auto;
-			position: absolute;
+		ol,
+		ul {
+			padding: 0;
+			margin-left: 1.5625rem;
 		}
-	}
-
-	.content__dateline {
-		font-size: 0.75rem;
-		line-height: 1rem;
-		position: relative;
-		box-sizing: border-box;
-		padding-top: 0.125rem;
-		margin-bottom: 0.375rem;
-	}
-	/* End social icon support */
-
-	/* Typically required for ad display. */
-	${until.tablet} {
-		.hide-until-tablet {
-			display: none;
-		}
-	}
-
-	${from.tablet} {
-		.mobile-only {
-			display: none;
-		}
-	}
-
-	.interactive-atom {
-		position: relative;
-	}
-
-	ol,
-	ul {
-		padding: 0;
-		margin-left: 1.5625rem;
 	}
 `;


### PR DESCRIPTION
## What does this change?

Limts the global legacy styles:

* to scope to `body article`
* and only for 'legacy' interactives

## Why?

To avoid unfortunate side effects like introducing side scrolling on the footer (due to the change in box-model). E.g.

![Screenshot 2021-08-18 at 14 35 49](https://user-images.githubusercontent.com/858402/129909662-c31bb84e-eedb-4bd9-93e7-810e694113df.png)

