### PR TITLE
Fix label and double rendering of ads in interactive articles

### DIFF
--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -1,11 +1,12 @@
 import { ClassNames, css as emoCss } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { center } from '@root/src/web/lib/center';
 // @ts-ignore-start
 import { jsx as _jsx } from 'react/jsx-runtime';
 // @ts-ignore-end
+import { labelStyles as adLabelStyles } from './AdSlot';
 
 const padding = emoCss`
 	padding: 0 10px;
@@ -15,10 +16,24 @@ const padding = emoCss`
 	}
 `;
 
-const adStyles = emoCss`
+const adStylesDynamic = emoCss`
 	& .ad-slot.ad-slot--collapse {
 		display: none;
 	}
+
+	${from.tablet} {
+		.mobile-only .ad-slot {
+			display: none;
+		}
+	}
+
+	${until.tablet} {
+		.hide-until-tablet .ad-slot {
+			display: none;
+		}
+
+	}
+
 `;
 
 const sideBorders = (colour: string) => emoCss`
@@ -74,8 +89,11 @@ export const ElementContainer = ({
 					{children && children}
 				</div>
 			);
+			// Apply ad styles to dynamic ad slots (i.e. slots that are not fixed), e.g. ads inserted
+			// by spacefinder and ads in interactive articles
 			const style = css`
-				${adStyles}
+				${adStylesDynamic}
+				${adLabelStyles}
 				${backgroundColour && setBackgroundColour(backgroundColour)}
 			`;
 			// Create a react element from the tagName passed in OR


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

## Why?
Interactives are now rendered by DCR, but the ad styles were referencing classes that only exist in `frontend`. 
This caused two issues:

1) Ad labels were incorrectly styled and showing a cross button. This PR addresses this by importing `labelStyles` from the `AdSlot` component for fixed ads that already exists in DCR.

2) The `.mobile-only` and `.hide-until-tablet` classes were not present in DCR, resulting in two ads being displayed. These classes have now been added to the ad styles CSS.

Example: https://www.theguardian.com/tv-and-radio/ng-interactive/2021/aug/04/whats-on-netflix-and-amazon-this-month-august

### Before
![image](https://user-images.githubusercontent.com/57295823/130067891-4563744c-9c95-4881-a2d8-5dc3aa7d197d.png)

### After
![image](https://user-images.githubusercontent.com/57295823/130068111-ad645475-1f8e-42fc-8daf-eab4bbecacf5.png)