### PR TITLE
Support variables for interactive atoms on interactive pages

### DIFF
--- a/dotcom-rendering/src/model/enhance-placeholders.test.ts
+++ b/dotcom-rendering/src/model/enhance-placeholders.test.ts
@@ -1,0 +1,57 @@
+import { replacePlaceholders } from './enhance-placeholders';
+
+describe('Enhance Placeholders', () => {
+	it('replaces supported placeholder', () => {
+		const el: InteractiveAtomBlockElement = {
+			_type:
+				'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+			id: 'foo',
+			url: 'example.com/foo',
+			elementId: 'foo1',
+			html: '<div>Written by: {{ byline }}</div>',
+		};
+
+		const variables = new Map();
+		variables.set('byline', 'Joda');
+		const got = replacePlaceholders(el, variables).html;
+		const want = '<div>Written by: Joda</div>';
+
+		expect(got).toEqual(want);
+	});
+
+	it('replaces supported placeholder ignoring surrounding whitespace', () => {
+		const el: InteractiveAtomBlockElement = {
+			_type:
+				'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+			id: 'foo',
+			url: 'example.com/foo',
+			elementId: 'foo1',
+			html: '<div>Written by: {{byline    }}</div>',
+		};
+
+		const variables = new Map();
+		variables.set('byline', 'Joda');
+		const got = replacePlaceholders(el, variables).html;
+		const want = '<div>Written by: Joda</div>';
+
+		expect(got).toEqual(want);
+	});
+
+	it('preserves unsupported placeholder', () => {
+		const el: InteractiveAtomBlockElement = {
+			_type:
+				'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+			id: 'foo',
+			url: 'example.com/foo',
+			elementId: 'foo1',
+			html: '<div>Written by: {{ unsupported }}</div>',
+		};
+
+		const variables = new Map();
+		variables.set('byline', 'Joda');
+		const got = replacePlaceholders(el, variables).html;
+		const want = el.html;
+
+		expect(got).toEqual(want);
+	});
+});

--- a/dotcom-rendering/src/model/enhance-placeholders.ts
+++ b/dotcom-rendering/src/model/enhance-placeholders.ts
@@ -1,0 +1,83 @@
+import { Design } from '@guardian/types';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+
+export const replacePlaceholders = (
+	elem: InteractiveAtomBlockElement,
+	variables: Map<string, string>,
+): InteractiveAtomBlockElement => {
+	if (!elem.html) {
+		return elem;
+	}
+
+	const replacer = (substring: string, name: string): string => {
+		return variables.get(name) || substring;
+	};
+
+	// Note: use str.replace with 'g' (global) flag as str.replaceAll not
+	// supported in current node version (14.6).
+	const re = /{{\s*(\w+)\s*}}/g;
+	elem.html = elem.html.replace(re, replacer);
+
+	return elem;
+};
+
+/**
+ * generateVariables defines the templated variables we replace. As such, it
+ * represents an ongoing contract with interactive atoms; fields should not be
+ * removed from it once added so be cautious when thinking about adding new
+ * ones.
+ */
+const buildPlaceholders = (data: CAPIType): Map<string, string> => {
+	return new Map(
+		Object.entries({
+			webPublicationDate: data.webPublicationDateDisplay || '',
+			byline: data.author.byline || '',
+			webTitle: data.webTitle,
+			trailText: data.trailText,
+			sectionLabel: data.sectionLabel,
+			// shareLinks: TODO,
+		}),
+	);
+};
+
+/**
+ * enhancePlaceholders replaces templated fields in interactive atom elements
+ * for interactive pages (format.design === Design.Interactive) only.
+ *
+ * Supported variables will be replaced within the HTML of any interactive atom
+ * elements. Note, this will therefore not work on dynamically loaded or
+ * generated markup.
+ *
+ * Variables are wrapped in curlies, e.g. {{ webPublicationDate }}. Surrounding
+ * whitespace is ignored. E.g. {{webPublicationDate    }} is fine.
+ */
+export const enhancePlaceholders = (data: CAPIType): CAPIType => {
+	const design: Design = decideDesign(data.format);
+
+	// Only immersive interactives are modified.
+	if (design !== Design.Interactive) {
+		return data;
+	}
+
+	const enhancedBlocks = data.blocks.map((block: Block) => {
+		return {
+			...block,
+			elements: block.elements.map((el) => {
+				if (
+					el._type ===
+					'model.dotcomrendering.pageElements.InteractiveAtomBlockElement'
+				) {
+					const variables = buildPlaceholders(data);
+					return replacePlaceholders(el, variables);
+				}
+
+				return el;
+			}),
+		};
+	});
+
+	return {
+		...data,
+		blocks: enhancedBlocks,
+	} as CAPIType;
+};

--- a/dotcom-rendering/src/model/enhanceCAPI.ts
+++ b/dotcom-rendering/src/model/enhanceCAPI.ts
@@ -7,6 +7,7 @@ import { enhanceInteractiveContentsElements } from '@root/src/model/enhance-inte
 import { enhanceNumberedLists } from '@root/src/model/enhance-numbered-lists';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';
 import { enhanceEmbeds } from '@root/src/model/enhance-embeds';
+import { enhancePlaceholders } from '@root/src/model/enhance-placeholders';
 
 class CAPIEnhancer {
 	capi: CAPIType;
@@ -57,6 +58,11 @@ class CAPIEnhancer {
 
 	setIsDev() {
 		this.capi = setIsDev(this.capi);
+		return this;
+	}
+
+	enhancePlaceholders() {
+		this.capi = enhancePlaceholders(this.capi);
 		return this;
 	}
 }


### PR DESCRIPTION
Syntax is, e.g.:

{{ byline }}

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Introduce support for some basic placeholders in interactive atoms. (Limited to interactive pages only for now.)

E.g. include  byline by adding this to the HTML part of your atom  definition:

    <div>My byline: {{ byline }}</div>

## Why?

To enable easier creation of interactives by making it easy to include key metadata. This is particularly relevant to immersive interactives (which provide no meta/header section but require the  interactive to do this). By using placeholders, we can leverage Composer data/changes without requiring changes to the core interactive  code.

cc @HarryFischer 
