### PR TITLE
update ci script to skip build if only AR files were changed

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,7 +7,7 @@ files="$(git diff --name-only origin/main)"
 echo "files: $files"
 
 # files that are not within apps-rendering sub directory
-filteredFiles="$(echo "$files" | grep -v 'apps-rendering' | grep -v 'scripts')"
+filteredFiles="$(echo "$files" | grep -v 'apps-rendering')"
 echo "filteredFiles: $filteredFiles"
 
 # run the ci steps if either of the followings is true

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,19 +1,40 @@
 #!/bin/bash
 
-source ~/.nvm/nvm.sh
-nvm install
-nvm use
+currentBranch="$(git branch --show-current)"
 
-cd dotcom-rendering
+# files that were changed between current branch and main
+files="$(git diff --name-only origin/main)"
+echo "files: $files"
 
-#Code Validation
-echo bundlesize token $BUNDLESIZE_GITHUB_TOKEN
-make validate-ci
+# files that are not within apps-rendering sub directory
+filteredFiles="$(echo "$files" | grep -v 'apps-rendering' | grep -v 'scripts')"
+echo "filteredFiles: $filteredFiles"
 
-#Cypress Tests
-# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
-# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
-make cypress
+# run the ci steps if either of the followings is true
+# - filteredFiles is empty (all changes were in apps-rendering)
+# - we are in the main branch
+if [[ $currentBranch != "main" ]] && [ -z "$filteredFiles" ] 
+then
+    printf "Skipping DCR ci build because \nDCR file changes is empty \nand branch is $currentBranch"
+else
+    printf "Running DCR ci build because \nDCR file changes contains $filteredFiles \nand branch is $currentBranch"
 
-#RiffRaff publish
-make riffraff-publish
+    source ~/.nvm/nvm.sh
+    nvm install
+    nvm use
+
+    cd dotcom-rendering
+
+    #Code Validation
+    echo bundlesize token $BUNDLESIZE_GITHUB_TOKEN
+    make validate-ci
+
+    #Cypress Tests
+    # see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
+    # apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+    make cypress
+
+    #RiffRaff publish
+    make riffraff-publish
+fi
+

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-gitVersion="$(git --version)"
-echo "git version: $gitVersion"
+git fetch origin main
 
-currentBranch="$(git branch --show-current)"
+gitBranches="$(git branch -r)"
+echo "git branches: $gitBranches"
+
+currentBranch="$(git rev-parse --abbrev-ref HEAD)"
 echo "current branch: $currentBranch"
 
 # files that were changed between current branch and main
-files="$(git diff --name-only origin/main)"
+files="$(git diff --name-only $currentBranch origin/main)"
 echo "files: $files"
 
 # files that are not within apps-rendering sub directory
@@ -19,9 +21,9 @@ echo "filteredFiles: $filteredFiles"
 # - we are in the main branch
 if [[ $currentBranch != "main" ]] && [ -z "$filteredFiles" ] 
 then
-    printf "Skipping DCR ci build because \nDCR file changes is empty \nand branch is $currentBranch"
+    printf "Skipping DCR ci build because DCR file changes is empty and branch is $currentBranch\n\n"
 else
-    printf "Running DCR ci build because \nDCR file changes contains $filteredFiles \nand branch is $currentBranch"
+    printf "Running DCR ci build because DCR file changes contains $filteredFiles and branch is $currentBranch\n\n"
 
     source ~/.nvm/nvm.sh
     nvm install

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+gitVersion="$(git --version)"
+echo "git version: $gitVersion"
+
 currentBranch="$(git branch --show-current)"
 echo "current branch: $currentBranch"
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 currentBranch="$(git branch --show-current)"
+echo "current branch: $currentBranch"
 
 # files that were changed between current branch and main
 files="$(git diff --name-only origin/main)"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR updates ci script by adding checks for branch name and file changes. 

- If branch name is main, it always runs the build steps.
- If branch name is not main, it would also skip the build step if all file changes were from apps-rendering sub directory.  
- Otherwise, it would run the build step.

## Why?
This change is a pre-migration enabler. With this, we can remove the filters on teamcity trigger and the teamcity build always runs no matter if changes were in DCR or AR. As a result the DCR build status check in github would always get an update from teamcity (even when the file changes were only for AR)

### Before

### After
