### PR TITLE
Migration - Prepare storybook for AR

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,91 +1,161 @@
-const path = require('path');
-const webpack = require('webpack');
+const path = require("path");
+const webpack = require("webpack");
 
 module.exports = {
 	core: {
-		builder: 'webpack5',
+		builder: "webpack5",
 	},
-	stories: [ '../dotcom-rendering/src/**/*.stories.@(tsx)' ],
+	stories: [
+		// TODO: This must be commented back in for apps-rendering to work
+		// "../apps-rendering/src/**/*.stories.@(js|mdx|ts|tsx)",
+		"../dotcom-rendering/src/**/*.stories.@(tsx)",
+	],
 	addons: [
-		'@storybook/addon-essentials',
-		'storybook-addon-turbo-build',
+		"@storybook/addon-essentials",
+		"storybook-addon-turbo-build",
+		"@storybook/addon-knobs",
 		{
-			name: 'storybook-addon-turbo-build',
+			name: "storybook-addon-turbo-build",
 			options: {
 				optimizationLevel: 1,
 			},
 		},
 	],
 	webpackFinal: async (config) => {
-		const rules = config.module.rules;
-		const { extensions } = config.resolve;
+		// Get project specific webpack options
+		config = dcrWebpack(config);
 
-		// Mock JSDOM for storybook - it relies on native node.js packages
-		// Allows us to use enhancers in stories for better testing of compoenents & full articles
-		config.resolve.alias.jsdom$ = path.resolve(
-			__dirname,
-			'./mocks/jsdom.js',
-		);
+		// TODO: This is commented out as some sections of the config are
+		// reliant on the apps-rendering directory existing.
+		// This should be updated during the migration
+		// config = arWebpack(config);
 
-		// Support typescript in Storybook
-		// https://storybook.js.org/docs/configurations/typescript-config/
-		rules.push({
-			test: /\.[jt]sx?|mjs$/,
-			exclude: require('../dotcom-rendering/scripts/webpack/browser').babelExclude,
-			use: [
-				{
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-react',
-							[
-								'@babel/preset-env',
-								{
-									bugfixes: true,
-									targets: {
-										esmodules: true,
-									},
-								},
-							],
-						],
-					},
-				},
-				{
-					loader: 'ts-loader',
-					options: {
-						configFile: 'dotcom-rendering/tsconfig.build.json',
-						transpileOnly: true,
-					},
-				},
-			],
-		});
-		extensions.push('.ts', '.tsx');
-
-		// modify storybook's file-loader rule to avoid conflicts with our svg
-		// https://stackoverflow.com/questions/54292667/react-storybook-svg-failed-to-execute-createelement-on-document
-		const fileLoaderRule = rules.find((rule) => rule.test.test('.svg'));
-		fileLoaderRule.exclude = /\.svg$/;
-		rules.push({
-			test: /\.svg$/,
-			use: [ 'desvg-loader/react', 'svg-loader' ],
-		});
-
-		// Add the @frontend and @root aliases to prevent imports using it from failing
-		// Nb. __dirname is the current working directory, so .storybook in this case
-		config.resolve.alias = {
-			...config.resolve.alias,
-			'@root': path.resolve(__dirname, '../dotcom-rendering'),
-			'@frontend': path.resolve(__dirname, '../dotcom-rendering/src'),
-		};
+		// Global options for webpack
+		config.resolve.extensions.push(".ts", ".tsx");
 
 		// Required as otherwise 'process' will not be defined when included on its own (without .env)
 		// e.g process?.env?.SOME_VAR
 		config.plugins.push(
 			new webpack.DefinePlugin({
-				process: '{}',
-			}),
+				process: "{}",
+			})
 		);
 
 		return config;
 	},
+};
+
+const dcrWebpack = (config) => {
+	const rules = config.module.rules;
+
+	// Mock JSDOM for storybook - it relies on native node.js packages
+	// Allows us to use enhancers in stories for better testing of compoenents & full articles
+	config.resolve.alias.jsdom$ = path.resolve(__dirname, "./mocks/jsdom.js");
+
+	// Support typescript in Storybook
+	// https://storybook.js.org/docs/configurations/typescript-config/
+	rules.push({
+		test: /\.[jt]sx?|mjs$/,
+		include: path.resolve(__dirname, "../dotcom-rendering"),
+		exclude: require("../dotcom-rendering/scripts/webpack/browser")
+			.babelExclude,
+		use: [
+			{
+				loader: "babel-loader",
+				options: {
+					presets: [
+						"@babel/preset-react",
+						[
+							"@babel/preset-env",
+							{
+								bugfixes: true,
+								targets: {
+									esmodules: true,
+								},
+							},
+						],
+					],
+				},
+			},
+			{
+				loader: "ts-loader",
+				options: {
+					configFile: "dotcom-rendering/tsconfig.build.json",
+					transpileOnly: true,
+				},
+			},
+		],
+	});
+
+	// modify storybook's file-loader rule to avoid conflicts with our svg
+	// https://stackoverflow.com/questions/54292667/react-storybook-svg-failed-to-execute-createelement-on-document
+	const fileLoaderRule = rules.find((rule) => rule.test.test(".svg"));
+	fileLoaderRule.exclude = /\.svg$/;
+	rules.push({
+		test: /\.svg$/,
+		use: ["desvg-loader/react", "svg-loader"],
+	});
+
+	config.resolve.alias = {
+		...config.resolve.alias,
+		"@root": path.resolve(__dirname, "../dotcom-rendering"),
+		"@frontend": path.resolve(__dirname, "../dotcom-rendering/src"),
+	};
+
+	return config;
+};
+
+const arWebpack = (config) => {
+	const rules = config.module.rules;
+
+	rules.push({
+		test: /\.tsx?$/,
+		include: path.resolve(__dirname, "../apps-rendering"),
+		use: [
+			{
+				loader: "babel-loader",
+				options: {
+					presets: [
+						[
+							"@babel/preset-env",
+							{
+								// Babel recommends installing corejs as a peer dependency
+								// and specifying the version used here
+								// https://babeljs.io/docs/en/babel-preset-env#usebuiltins
+								// This should automatically inject polyfills as needed,
+								// based on our code and the browserslist in package.json
+								useBuiltIns: "usage",
+								corejs: 3,
+								modules: false,
+								targets: { esmodules: true },
+							},
+						],
+					],
+				},
+			},
+			{
+				loader: "ts-loader",
+				options: {
+					configFile: "apps-rendering/config/tsconfig.client.json",
+				},
+			},
+		],
+	});
+
+	config.resolve.modules = [
+		...(config?.resolve?.modules || []),
+		path.resolve(__dirname, "../apps-rendering/src"),
+	];
+
+	config.resolve.alias = {
+		...config.resolve.alias,
+		logger: path.resolve(
+			__dirname,
+			`../apps-rendering/src/logger/clientDev`
+		),
+		"preact-render-to-string": "react-dom/server",
+		Buffer: "buffer",
+	};
+
+	return config;
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This multi-project repo includes dotcom-rendering, annd shortly will include apps-rendering, which will live side by side as separate applications. The purpose of the monorepo is to make it easier for the two projects to share code and reduce duplication. The projects are swimlaned for fault isolation, and share the same node version.
 
-The codebase of dotcom rendering is moved in a ‘dotcom-rendering’ subdirectory. To run dotcom-rendering scripts, e.g `make dev` `yarn storybook`, etc - You can do so by first `cd`’ing into the dotcom-rendering subdirectory.
+The codebase of dotcom rendering is moved in a ‘dotcom-rendering’ subdirectory. To run dotcom-rendering scripts, e.g `make dev`, etc - You can do so by first `cd`’ing into the dotcom-rendering subdirectory.
 
 <!-- TEMPORARY : This section is just here as an initial guide for the first few days post-migration -->
 
@@ -15,6 +15,9 @@ If you're using this project, not too much has changed! Follow the steps below t
 ```bash
 # (Optional) Delete your existing node_modules folder
 dotcom-rendering $ rm -rf ./node_modules
+
+# Install root dependencies
+dotcom-rendering $ yarn install
 
 # (IMPORTANT) Move into the dotcom-rendering subdirectory
 dotcom-rendering $ cd dotcom-rendering
@@ -30,6 +33,10 @@ dotcom-rendering/dotcom-rendering $ make dev
 ```
 
 The biggest change to the repository is simply that the contents of dotcom-rendering has now moved into a `dotcom-rendering` subdirectory, and you should always cd into that directory before running your familiar DCR commands. Everything you're used to (linting, imports, builds, github actions) should work as before, so no need to worry!
+
+## Storybook
+
+While most DCR scripts should be run from within the `dotcom-rendering` subdirectory, storybook remains at the root of the project. So make sure you're _not_ in a subdirectory before running `yarn storybook` or `yarn build-storybook` as before.
 
 ## Quick start
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the necessary components to storybook comfig for AR to run when added.

Unfortunately storybook won't run unless we comment them out for the time being, so it might be useful to move this updated version to [dcr-ar-migration repo](https://github.com/guardian/dcr-ar-migration) and run it as part of the apps-rendering migration script instead.

It may be worthwhile ensuring that the storybook config is stable (e.g not going to be changed) before moving it over to the migration repo however.

## Why?

Supporting storybook in AR is an important step to preventing visual regression with chromatic 

### Before

### After
