### PR TITLE
Update article count timing

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -178,6 +178,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		submitComponentEvent(componentEvent, ophanRecord);
 	};
 
+	const [articleCountIsReady, setArticleCountIsReady] = useState<boolean>(
+		false,
+	);
+
 	// *******************************
 	// ** Setup AB Test Tracking *****
 	// *******************************
@@ -235,6 +239,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				incrementDailyArticleCount();
 				incrementWeeklyArticleCount(storage.local, CAPI.pageId);
 			}
+			setArticleCountIsReady(true);
 		};
 		incrementArticleCountsIfConsented().catch((e) =>
 			console.error(`incrementArticleCountsIfConsented - error: ${e}`),
@@ -1166,22 +1171,24 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					</Lazy>
 				</Portal>
 			)}
-			<Portal rootId="slot-body-end">
-				<SlotBodyEnd
-					isSignedIn={isSignedIn}
-					countryCode={countryCode}
-					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName}
-					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-					isMinuteArticle={CAPI.pageType.isMinuteArticle}
-					isPaidContent={CAPI.pageType.isPaidContent}
-					tags={CAPI.tags}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
-					brazeMessages={brazeMessages}
-					idApiUrl={CAPI.config.idApiUrl}
-					stage={CAPI.stage}
-				/>
-			</Portal>
+			{articleCountIsReady && (
+				<Portal rootId="slot-body-end">
+					<SlotBodyEnd
+						isSignedIn={isSignedIn}
+						countryCode={countryCode}
+						contentType={CAPI.contentType}
+						sectionName={CAPI.sectionName}
+						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+						isMinuteArticle={CAPI.pageType.isMinuteArticle}
+						isPaidContent={CAPI.pageType.isPaidContent}
+						tags={CAPI.tags}
+						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						brazeMessages={brazeMessages}
+						idApiUrl={CAPI.config.idApiUrl}
+						stage={CAPI.stage}
+					/>
+				</Portal>
+			)}
 			<Portal
 				rootId={
 					isSignedIn
@@ -1273,15 +1280,17 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					/>
 				</Lazy>
 			</Portal>
-			<Portal rootId="bottom-banner">
-				<StickyBottomBanner
-					isSignedIn={isSignedIn}
-					asyncCountryCode={asyncCountryCode}
-					CAPI={CAPI}
-					brazeMessages={brazeMessages}
-					isPreview={!!CAPI.isPreview}
-				/>
-			</Portal>
+			{articleCountIsReady && (
+				<Portal rootId="bottom-banner">
+					<StickyBottomBanner
+						isSignedIn={isSignedIn}
+						asyncCountryCode={asyncCountryCode}
+						CAPI={CAPI}
+						brazeMessages={brazeMessages}
+						isPreview={!!CAPI.isPreview}
+					/>
+				</Portal>
+			)}
 		</React.StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -178,9 +178,9 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		submitComponentEvent(componentEvent, ophanRecord);
 	};
 
-	const [articleCountIsReady, setArticleCountIsReady] = useState<boolean>(
-		false,
-	);
+	const [articleCountIsReady, setArticleCountIsReady] = useState<
+		Promise<true>
+	>();
 
 	// *******************************
 	// ** Setup AB Test Tracking *****
@@ -239,10 +239,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				incrementDailyArticleCount();
 				incrementWeeklyArticleCount(storage.local, CAPI.pageId);
 			}
-			setArticleCountIsReady(true);
 		};
-		incrementArticleCountsIfConsented().catch((e) =>
-			console.error(`incrementArticleCountsIfConsented - error: ${e}`),
+
+		setArticleCountIsReady(
+			incrementArticleCountsIfConsented().then(() => true),
 		);
 	}, [CAPI.pageId]);
 
@@ -1171,24 +1171,23 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					</Lazy>
 				</Portal>
 			)}
-			{articleCountIsReady && (
-				<Portal rootId="slot-body-end">
-					<SlotBodyEnd
-						isSignedIn={isSignedIn}
-						countryCode={countryCode}
-						contentType={CAPI.contentType}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						tags={CAPI.tags}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
-						brazeMessages={brazeMessages}
-						idApiUrl={CAPI.config.idApiUrl}
-						stage={CAPI.stage}
-					/>
-				</Portal>
-			)}
+			<Portal rootId="slot-body-end">
+				<SlotBodyEnd
+					isSignedIn={isSignedIn}
+					countryCode={countryCode}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					brazeMessages={brazeMessages}
+					idApiUrl={CAPI.config.idApiUrl}
+					stage={CAPI.stage}
+					articleCountIsReady={articleCountIsReady}
+				/>
+			</Portal>
 			<Portal
 				rootId={
 					isSignedIn
@@ -1280,17 +1279,16 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					/>
 				</Lazy>
 			</Portal>
-			{articleCountIsReady && (
-				<Portal rootId="bottom-banner">
-					<StickyBottomBanner
-						isSignedIn={isSignedIn}
-						asyncCountryCode={asyncCountryCode}
-						CAPI={CAPI}
-						brazeMessages={brazeMessages}
-						isPreview={!!CAPI.isPreview}
-					/>
-				</Portal>
-			)}
+			<Portal rootId="bottom-banner">
+				<StickyBottomBanner
+					isSignedIn={isSignedIn}
+					asyncCountryCode={asyncCountryCode}
+					CAPI={CAPI}
+					brazeMessages={brazeMessages}
+					isPreview={!!CAPI.isPreview}
+					articleCountIsReady={articleCountIsReady}
+				/>
+			</Portal>
 		</React.StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -15,7 +15,10 @@ import { Discussion } from '@frontend/web/components/Discussion';
 import { StickyBottomBanner } from '@root/src/web/components/StickyBottomBanner/StickyBottomBanner';
 import { SignInGateSelector } from '@root/src/web/components/SignInGate/SignInGateSelector';
 
-import { incrementWeeklyArticleCount } from '@guardian/automat-contributions';
+import {
+	getWeeklyArticleHistory,
+	incrementWeeklyArticleCount,
+} from '@guardian/automat-contributions';
 import {
 	QandaAtom,
 	GuideAtom,
@@ -69,6 +72,7 @@ import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { storage } from '@guardian/libs';
+import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,
@@ -178,8 +182,8 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		submitComponentEvent(componentEvent, ophanRecord);
 	};
 
-	const [articleCountIsReady, setArticleCountIsReady] = useState<
-		Promise<true>
+	const [asyncArticleCount, setAsyncArticleCount] = useState<
+		Promise<WeeklyArticleHistory | undefined>
 	>();
 
 	// *******************************
@@ -241,8 +245,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			}
 		};
 
-		setArticleCountIsReady(
-			incrementArticleCountsIfConsented().then(() => true),
+		setAsyncArticleCount(
+			incrementArticleCountsIfConsented().then(() =>
+				getWeeklyArticleHistory(storage.local),
+			),
 		);
 	}, [CAPI.pageId]);
 
@@ -1185,7 +1191,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					brazeMessages={brazeMessages}
 					idApiUrl={CAPI.config.idApiUrl}
 					stage={CAPI.stage}
-					articleCountIsReady={articleCountIsReady}
+					asyncArticleCount={asyncArticleCount}
 				/>
 			</Portal>
 			<Portal
@@ -1286,7 +1292,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					CAPI={CAPI}
 					brazeMessages={brazeMessages}
 					isPreview={!!CAPI.isPreview}
-					articleCountIsReady={articleCountIsReady}
+					asyncArticleCount={asyncArticleCount}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -5,7 +5,6 @@ import {
 	getEpicMeta,
 	getViewLog,
 	logView,
-	getWeeklyArticleHistory,
 } from '@guardian/automat-contributions';
 import {
 	isRecurringContributor,
@@ -25,7 +24,10 @@ import {
 	submitComponentEvent,
 	SdcTestMeta,
 } from '@root/src/web/browser/ophan/ophan';
-import { Metadata } from '@guardian/automat-contributions/dist/lib/types';
+import {
+	Metadata,
+	WeeklyArticleHistory,
+} from '@guardian/automat-contributions/dist/lib/types';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { cmp } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
@@ -83,7 +85,7 @@ export type CanShowData = {
 	contributionsServiceUrl: string;
 	idApiUrl: string;
 	stage: string;
-	articleCountIsReady: Promise<true>;
+	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
 };
 
 const buildPayload = async (data: CanShowData): Promise<Metadata> => {
@@ -110,7 +112,7 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 			),
 			lastOneOffContributionDate: getLastOneOffContributionTimestamp(),
 			epicViewLog: getViewLog(storage.local),
-			weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+			weeklyArticleHistory: await data.asyncArticleCount,
 			hasOptedOutOfArticleCount: await hasOptedOutOfArticleCount(),
 			mvtId: Number(getCookie('GU_mvt_id')),
 			countryCode: data.countryCode,
@@ -130,7 +132,6 @@ export const canShow = async (
 		contributionsServiceUrl,
 		idApiUrl,
 		stage,
-		articleCountIsReady,
 	} = data;
 
 	if (shouldHideReaderRevenue || isPaidContent) {
@@ -143,7 +144,6 @@ export const canShow = async (
 	const forcedVariant = getForcedVariant('epic');
 	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
 
-	await articleCountIsReady;
 	const contributionsPayload = await buildPayload(data);
 
 	const response = await getEpicMeta(

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -83,6 +83,7 @@ export type CanShowData = {
 	contributionsServiceUrl: string;
 	idApiUrl: string;
 	stage: string;
+	articleCountIsReady: Promise<true>;
 };
 
 const buildPayload = async (data: CanShowData): Promise<Metadata> => {
@@ -129,6 +130,7 @@ export const canShow = async (
 		contributionsServiceUrl,
 		idApiUrl,
 		stage,
+		articleCountIsReady,
 	} = data;
 
 	if (shouldHideReaderRevenue || isPaidContent) {
@@ -141,6 +143,7 @@ export const canShow = async (
 	const forcedVariant = getForcedVariant('epic');
 	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
 
+	await articleCountIsReady;
 	const contributionsPayload = await buildPayload(data);
 
 	const response = await getEpicMeta(

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -9,6 +9,7 @@ import {
 } from '@root/src/web/lib/messagePicker';
 
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
+import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
 import {
 	ReaderRevenueEpic,
 	canShow as canShowReaderRevenueEpic,
@@ -30,7 +31,7 @@ type Props = {
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	idApiUrl: string;
 	stage: string;
-	articleCountIsReady?: Promise<true>;
+	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 };
 
 const buildReaderRevenueEpicConfig = ({
@@ -45,7 +46,7 @@ const buildReaderRevenueEpicConfig = ({
 	contributionsServiceUrl,
 	idApiUrl,
 	stage,
-	articleCountIsReady,
+	asyncArticleCount,
 }: RRCanShowData): CandidateConfig<RREpicConfig> => {
 	return {
 		candidate: {
@@ -63,7 +64,7 @@ const buildReaderRevenueEpicConfig = ({
 					contributionsServiceUrl,
 					idApiUrl,
 					stage,
-					articleCountIsReady,
+					asyncArticleCount,
 				}),
 			show: (meta: RREpicConfig) => () => {
 				/* eslint-disable-next-line react/jsx-props-no-spreading */
@@ -108,7 +109,7 @@ export const SlotBodyEnd = ({
 	brazeMessages,
 	idApiUrl,
 	stage,
-	articleCountIsReady,
+	asyncArticleCount,
 }: Props) => {
 	const [SelectedEpic, setSelectedEpic] = useState<React.FC | null>(null);
 	useOnce(() => {
@@ -124,7 +125,9 @@ export const SlotBodyEnd = ({
 			contributionsServiceUrl,
 			idApiUrl,
 			stage,
-			articleCountIsReady: articleCountIsReady as Promise<true>,
+			asyncArticleCount: asyncArticleCount as Promise<
+				WeeklyArticleHistory | undefined
+			>,
 		});
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as Promise<BrazeMessagesInterface>,
@@ -141,7 +144,7 @@ export const SlotBodyEnd = ({
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${e}`),
 			);
-	}, [isSignedIn, countryCode, brazeMessages, articleCountIsReady]);
+	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount]);
 
 	if (SelectedEpic) {
 		return <SelectedEpic />;

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -30,6 +30,7 @@ type Props = {
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	idApiUrl: string;
 	stage: string;
+	articleCountIsReady?: Promise<true>;
 };
 
 const buildReaderRevenueEpicConfig = ({
@@ -44,6 +45,7 @@ const buildReaderRevenueEpicConfig = ({
 	contributionsServiceUrl,
 	idApiUrl,
 	stage,
+	articleCountIsReady,
 }: RRCanShowData): CandidateConfig<RREpicConfig> => {
 	return {
 		candidate: {
@@ -61,6 +63,7 @@ const buildReaderRevenueEpicConfig = ({
 					contributionsServiceUrl,
 					idApiUrl,
 					stage,
+					articleCountIsReady,
 				}),
 			show: (meta: RREpicConfig) => () => {
 				/* eslint-disable-next-line react/jsx-props-no-spreading */
@@ -105,6 +108,7 @@ export const SlotBodyEnd = ({
 	brazeMessages,
 	idApiUrl,
 	stage,
+	articleCountIsReady,
 }: Props) => {
 	const [SelectedEpic, setSelectedEpic] = useState<React.FC | null>(null);
 	useOnce(() => {
@@ -120,6 +124,7 @@ export const SlotBodyEnd = ({
 			contributionsServiceUrl,
 			idApiUrl,
 			stage,
+			articleCountIsReady: articleCountIsReady as Promise<true>,
 		});
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as Promise<BrazeMessagesInterface>,
@@ -136,7 +141,7 @@ export const SlotBodyEnd = ({
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${e}`),
 			);
-	}, [isSignedIn, countryCode, brazeMessages]);
+	}, [isSignedIn, countryCode, brazeMessages, articleCountIsReady]);
 
 	if (SelectedEpic) {
 		return <SelectedEpic />;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -2,10 +2,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
-import {
-	getWeeklyArticleHistory,
-	logView,
-} from '@guardian/automat-contributions';
+import { logView } from '@guardian/automat-contributions';
 import {
 	shouldHideSupportMessaging,
 	withinLocalNoBannerCachePeriod,
@@ -47,6 +44,7 @@ type BaseProps = {
 type BuildPayloadProps = BaseProps & {
 	countryCode: string;
 	optedOutOfArticleCount: boolean;
+	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
 };
 
 type CanShowProps = BaseProps & {
@@ -56,7 +54,7 @@ type CanShowProps = BaseProps & {
 	isPreview: boolean;
 	idApiUrl: string;
 	signInGateWillShow: boolean;
-	articleCountIsReady: Promise<true>;
+	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
 };
 
 type ReaderRevenueComponentType =
@@ -68,7 +66,7 @@ export type CanShowFunctionType<T> = (
 ) => Promise<CanShowResult<T>>;
 
 // TODO specify return type (need to update client to provide this first)
-const buildPayload = ({
+const buildPayload = async ({
 	isSignedIn,
 	shouldHideReaderRevenue,
 	isPaidContent,
@@ -77,6 +75,7 @@ const buildPayload = ({
 	subscriptionBannerLastClosedAt,
 	countryCode,
 	optedOutOfArticleCount,
+	asyncArticleCount,
 }: BuildPayloadProps) => {
 	return {
 		tracking: {
@@ -94,7 +93,7 @@ const buildPayload = ({
 			subscriptionBannerLastClosedAt,
 			mvtId: Number(getCookie('GU_mvt_id')),
 			countryCode,
-			weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+			weeklyArticleHistory: await asyncArticleCount,
 			optedOutOfArticleCount,
 			modulesVersion: MODULES_VERSION,
 		},
@@ -139,7 +138,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	isPreview,
 	idApiUrl,
 	signInGateWillShow,
-	articleCountIsReady,
+	asyncArticleCount,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
 
@@ -163,8 +162,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 
 	const countryCode = await asyncCountryCode;
 	const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
-	await articleCountIsReady;
-	const bannerPayload = buildPayload({
+	const bannerPayload = await buildPayload({
 		isSignedIn,
 		countryCode,
 		contentType,
@@ -179,6 +177,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		engagementBannerLastClosedAt,
 		subscriptionBannerLastClosedAt,
 		optedOutOfArticleCount,
+		asyncArticleCount,
 	});
 	const forcedVariant = getForcedVariant('banner');
 	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
@@ -217,6 +216,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	section,
+	asyncArticleCount,
 }) => {
 	const isPuzzlesPage =
 		section === 'crosswords' ||
@@ -230,7 +230,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	if (isPuzzlesPage && remoteBannerConfig) {
 		const countryCode = await asyncCountryCode;
 		const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
-		const bannerPayload = buildPayload({
+		const bannerPayload = await buildPayload({
 			isSignedIn,
 			countryCode,
 			contentType,
@@ -245,6 +245,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
 			optedOutOfArticleCount,
+			asyncArticleCount,
 		});
 		return getBanner(
 			bannerPayload,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -56,6 +56,7 @@ type CanShowProps = BaseProps & {
 	isPreview: boolean;
 	idApiUrl: string;
 	signInGateWillShow: boolean;
+	articleCountIsReady: Promise<true>;
 };
 
 type ReaderRevenueComponentType =
@@ -138,6 +139,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	isPreview,
 	idApiUrl,
 	signInGateWillShow,
+	articleCountIsReady,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
 
@@ -161,6 +163,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 
 	const countryCode = await asyncCountryCode;
 	const optedOutOfArticleCount = await hasOptedOutOfArticleCount();
+	await articleCountIsReady;
 	const bannerPayload = buildPayload({
 		isSignedIn,
 		countryCode,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -27,6 +27,7 @@ type Props = {
 	CAPI: CAPIBrowserType;
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	isPreview: boolean;
+	articleCountIsReady?: Promise<true>;
 };
 
 type RRBannerConfig = {
@@ -77,6 +78,7 @@ const buildRRBannerConfigWith = ({
 		isSignedIn: boolean,
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
+		articleCountIsReady: Promise<true>,
 		signInGateWillShow: boolean = false,
 	): CandidateConfig<BannerProps> => {
 		return {
@@ -106,6 +108,7 @@ const buildRRBannerConfigWith = ({
 						isPreview,
 						idApiUrl: CAPI.config.idApiUrl,
 						signInGateWillShow,
+						articleCountIsReady,
 					}),
 				show: ({ meta, module, email }: BannerProps) => () => (
 					<BannerComponent
@@ -151,6 +154,7 @@ export const StickyBottomBanner = ({
 	CAPI,
 	brazeMessages,
 	isPreview,
+	articleCountIsReady,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({ isSignedIn, CAPI });
@@ -161,12 +165,14 @@ export const StickyBottomBanner = ({
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<string>,
 			isPreview,
+			articleCountIsReady as Promise<true>,
 		);
 		const readerRevenue = buildReaderRevenueBannerConfig(
 			CAPI,
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<CountryCode>,
 			isPreview,
+			articleCountIsReady as Promise<true>,
 			signInGateWillShow,
 		);
 		const brazeBanner = buildBrazeBanner(
@@ -184,7 +190,13 @@ export const StickyBottomBanner = ({
 			.catch((e) =>
 				console.error(`StickyBottomBanner pickMessage - error: ${e}`),
 			);
-	}, [isSignedIn, asyncCountryCode, CAPI, brazeMessages]);
+	}, [
+		isSignedIn,
+		asyncCountryCode,
+		CAPI,
+		brazeMessages,
+		articleCountIsReady,
+	]);
 
 	if (SelectedBanner) {
 		return <SelectedBanner />;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -19,6 +19,7 @@ import {
 import { CountryCode } from '@guardian/types';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { useSignInGateWillShow } from '@root/src/web/lib/useSignInGateWillShow';
+import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
 import { BrazeBanner, canShow as canShowBrazeBanner } from './BrazeBanner';
 
 type Props = {
@@ -27,7 +28,7 @@ type Props = {
 	CAPI: CAPIBrowserType;
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	isPreview: boolean;
-	articleCountIsReady?: Promise<true>;
+	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 };
 
 type RRBannerConfig = {
@@ -78,7 +79,7 @@ const buildRRBannerConfigWith = ({
 		isSignedIn: boolean,
 		asyncCountryCode: Promise<string>,
 		isPreview: boolean,
-		articleCountIsReady: Promise<true>,
+		asyncArticleCount: Promise<WeeklyArticleHistory | undefined>,
 		signInGateWillShow: boolean = false,
 	): CandidateConfig<BannerProps> => {
 		return {
@@ -108,7 +109,7 @@ const buildRRBannerConfigWith = ({
 						isPreview,
 						idApiUrl: CAPI.config.idApiUrl,
 						signInGateWillShow,
-						articleCountIsReady,
+						asyncArticleCount,
 					}),
 				show: ({ meta, module, email }: BannerProps) => () => (
 					<BannerComponent
@@ -154,7 +155,7 @@ export const StickyBottomBanner = ({
 	CAPI,
 	brazeMessages,
 	isPreview,
-	articleCountIsReady,
+	asyncArticleCount,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({ isSignedIn, CAPI });
@@ -165,14 +166,14 @@ export const StickyBottomBanner = ({
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<string>,
 			isPreview,
-			articleCountIsReady as Promise<true>,
+			asyncArticleCount as Promise<WeeklyArticleHistory | undefined>,
 		);
 		const readerRevenue = buildReaderRevenueBannerConfig(
 			CAPI,
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<CountryCode>,
 			isPreview,
-			articleCountIsReady as Promise<true>,
+			asyncArticleCount as Promise<WeeklyArticleHistory | undefined>,
 			signInGateWillShow,
 		);
 		const brazeBanner = buildBrazeBanner(
@@ -190,13 +191,7 @@ export const StickyBottomBanner = ({
 			.catch((e) =>
 				console.error(`StickyBottomBanner pickMessage - error: ${e}`),
 			);
-	}, [
-		isSignedIn,
-		asyncCountryCode,
-		CAPI,
-		brazeMessages,
-		articleCountIsReady,
-	]);
+	}, [isSignedIn, asyncCountryCode, CAPI, brazeMessages, asyncArticleCount]);
 
 	if (SelectedBanner) {
 		return <SelectedBanner />;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Update article count timing to wait for the article count to be incremented before requesting epics & banners. This ensures the article count that is displayed is correct, and also ensures that it is the same in both epics & banners (It was reliably showing me the updated count in the banner and the old count in the epic when running locally).

[**Trello card**](https://trello.com/c/4BeEimqf/2765-dcr-increment-article-count-before-fetching-epic-banner)
