### PR TITLE
Change `top-above-nav` to 250px high minimum

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -359,11 +359,12 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			);
 		}
 		case 'top-above-nav': {
+			const padding = space[4] + 2; // 18px - currently being reviewed
 			const adSlotAboveNav = css`
 				position: relative;
 				margin: 0 auto;
-				min-height: 108px;
-				padding-bottom: 18px;
+				min-height: ${250 + padding}px;
+				padding-bottom: ${padding}px;
 				text-align: left;
 				display: table;
 				width: 728px;


### PR DESCRIPTION
## What does this change?

Most of the `top-above-nav` ads are 250px high, resulting in a lot of cumulative layout shift (CLS).

Related to https://github.com/guardian/frontend/pull/24095

## Why?

We ran some tests in `frontend` that showed a marked improvement in layout shift. Thus, we are looking to now roll this change out to all users and continue monitoring.

### Before

![image](https://user-images.githubusercontent.com/76776/130966451-e1c85bb5-906c-4d89-8632-b7ad8ff90a95.png)


### After

![image](https://user-images.githubusercontent.com/76776/130966378-749abc6e-47a1-4ab3-8612-fb81a00edea7.png)



