### PR TITLE
move styles for top-above-nav

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -45,10 +45,12 @@ enum Size {
 	empty = '2,2',
 }
 
+export const labelHeight = 24;
+
 const adSlotLabelStyles = css`
 	${textSans.xxsmall()};
 	position: relative;
-	height: 24px;
+	height: ${labelHeight}px;
 	background-color: ${neutral[97]};
 	padding: 0 8px;
 	border-top: 1px solid ${border.secondary};
@@ -359,14 +361,12 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 			);
 		}
 		case 'top-above-nav': {
-			const padding = space[4] + 2; // 18px - currently being reviewed
 			const adSlotAboveNav = css`
 				position: relative;
 				margin: 0 auto;
-				min-height: ${250 + padding}px;
-				padding-bottom: ${padding}px;
+				min-height: 90px;
 				text-align: left;
-				display: table;
+				display: block;
 				width: 728px;
 			`;
 			return (

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -1,17 +1,26 @@
 import { css } from '@emotion/react';
+import { space } from '@guardian/src-foundations';
 import { Display } from '@guardian/types';
 
-import { AdSlot } from '@root/src/web/components/AdSlot';
+import { AdSlot, labelHeight } from '@root/src/web/components/AdSlot';
 import { Hide } from '@root/src/web/components/Hide';
 
 const headerWrapper = css`
 	position: static;
 `;
 
+const padding = space[4] + 2; // 18px - currently being reviewed
+
 const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
 	background-color: white;
+	min-height: ${250 + padding + labelHeight}px;
+	padding-bottom: ${padding}px;
+
+	display: flex;
+	flex-wrap: wrap;
+	align-content: center;
 
 	position: sticky;
 	top: 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

In `frontend` &rarr; #24133

## Why?

In #3340 we introduced the `250px` height, but ads were not centred.

### Before


### After
