### PR TITLE
LIVE-2953: add football score parsing

### DIFF
--- a/apps-rendering/src/__snapshots__/storyshots.test.ts.snap
+++ b/apps-rendering/src/__snapshots__/storyshots.test.ts.snap
@@ -8375,12 +8375,12 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   width: 1.5em;
   height: 1.5em;
   position: relative;
+  text-align: center;
 }
 
 .emotion-16 {
-  position: absolute;
+  position: relative;
   top: 7%;
-  left: 29%;
 }
 
 .emotion-18 {
@@ -12069,12 +12069,12 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
   width: 1.5em;
   height: 1.5em;
   position: relative;
+  text-align: center;
 }
 
 .emotion-9 {
-  position: absolute;
+  position: relative;
   top: 7%;
-  left: 29%;
 }
 
 .emotion-11 {
@@ -12086,6 +12086,22 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
 }
 
 .emotion-12 {
+  font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 740px) {
+  .emotion-12 {
+    grid-column: 1;
+  }
+}
+
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12103,7 +12119,7 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-12 {
+  .emotion-13 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -12123,12 +12139,12 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
 }
 
 @media (min-width: 740px) {
-  .emotion-12 {
+  .emotion-13 {
     border-right: 1px dotted #000000;
   }
 }
 
-.emotion-13 {
+.emotion-14 {
   font-family: GH Guardian Headline,Guardian Egyptian Web,Georgia,serif;
   font-size: 2.625rem;
   line-height: 1.15;
@@ -12137,18 +12153,18 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
 }
 
 @media (min-width: 660px) {
-  .emotion-13 {
+  .emotion-14 {
     margin-left: 0.75rem;
   }
 }
 
 @media (min-width: 660px) {
-  .emotion-16 {
+  .emotion-17 {
     margin-left: 0.75rem;
   }
 }
 
-.emotion-18 {
+.emotion-19 {
   font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
   font-size: 0.9375rem;
   line-height: 1.5;
@@ -12206,13 +12222,16 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
         >
           Arsenal
         </h3>
+        <ul
+          className="emotion-12"
+        />
       </div>
     </section>
     <section
-      className="emotion-12"
+      className="emotion-13"
     >
       <div
-        className="emotion-13"
+        className="emotion-14"
       >
         <div
           className="emotion-8"
@@ -12225,7 +12244,7 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
         </div>
       </div>
       <div
-        className="emotion-16"
+        className="emotion-17"
       >
         <h3
           className="emotion-11"
@@ -12233,7 +12252,7 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
           Man City
         </h3>
         <ul
-          className="emotion-18"
+          className="emotion-19"
         >
           <li>
             Sterling

--- a/apps-rendering/src/components/editions/teamScore/index.tsx
+++ b/apps-rendering/src/components/editions/teamScore/index.tsx
@@ -1,11 +1,14 @@
 import type { SerializedStyles } from '@emotion/core';
 import { css } from '@emotion/core';
 import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballTeam';
+import type { Scorer } from '@guardian/apps-rendering-api-models/scorer';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+import { fromNullable } from '@guardian/types';
 import { TeamLocation } from 'football';
+import { maybeRender } from 'lib';
 import type { FC } from 'react';
 
 interface Props {
@@ -61,12 +64,12 @@ const scoreNumberStyles = css`
 	width: 1.5em;
 	height: 1.5em;
 	position: relative;
+	text-align: center;
 `;
 
 const scoreInlineStyles = css`
-	position: absolute;
+	position: relative;
 	top: 7%;
-	left: 29%;
 `;
 
 const infoStyles = (location: TeamLocation): SerializedStyles => css`
@@ -86,27 +89,30 @@ const scorerStyles = (location: TeamLocation): SerializedStyles => css`
 	}
 `;
 
-const TeamScore: FC<Props> = ({ team, location }) => (
-	<section css={styles(location)}>
-		<div css={scoreStyles(location)}>
-			<div css={scoreNumberStyles}>
-				<span css={scoreInlineStyles}>{team.score}</span>
+const TeamScore: FC<Props> = ({ team, location }) => {
+	const scorers = fromNullable(team.scorers);
+	return (
+		<section css={styles(location)}>
+			<div css={scoreStyles(location)}>
+				<div css={scoreNumberStyles}>
+					<span css={scoreInlineStyles}>{team.score}</span>
+				</div>
 			</div>
-		</div>
-		<div css={infoStyles(location)}>
-			<h3 css={teamNameStyles}>{team.name}</h3>
-			{team.scorers.length > 0 && (
-				<ul css={scorerStyles(location)}>
-					{team.scorers.map((scorer) => (
-						<li key={`${scorer.player}`}>
-							{scorer.player} {scorer.timeInMinutes}&apos;{' '}
-							{scorer.additionalInfo}
-						</li>
-					))}
-				</ul>
-			)}
-		</div>
-	</section>
-);
+			<div css={infoStyles(location)}>
+				<h3 css={teamNameStyles}>{team.name}</h3>
+				{maybeRender(scorers, (s: Scorer[]) => (
+					<ul css={scorerStyles(location)}>
+						{s.map((scorer: Scorer) => (
+							<li key={`${scorer.player}`}>
+								{scorer.player} {scorer.timeInMinutes}&apos;{' '}
+								{scorer.additionalInfo}
+							</li>
+						))}
+					</ul>
+				))}
+			</div>
+		</section>
+	);
+};
 
 export { TeamScore };

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -7,6 +7,7 @@ import {
 	map,
 	none,
 	ok,
+	OptionKind,
 	ResultKind,
 	some,
 	withDefault,
@@ -116,6 +117,24 @@ const resultMap3 = <A, B, C, D>(f: (a: A, b: B, c: C) => D) => <E>(
 	return ok(f(resultA.value, resultB.value, resultC.value));
 };
 
+const optionMap3 = <A, B, C, D>(f: (a: A, b: B, c: C) => D) => (
+	optA: Option<A>,
+	optB: Option<B>,
+	optC: Option<C>,
+): Option<D> => {
+	if (
+		optA.kind === OptionKind.Some &&
+		optB.kind === OptionKind.Some &&
+		optC.kind === OptionKind.Some
+	) {
+		return some(f(optA.value, optB.value, optC.value));
+	}
+	return none;
+};
+
+const resultToNullable = <E, A>(result: Result<E, A>): A | undefined =>
+	result.kind === ResultKind.Ok ? result.value : undefined;
+
 const resultMap2 = <A, B, C>(f: (a: A, b: B) => C) => <E>(
 	resultA: Result<E, A>,
 ) => (resultB: Result<E, B>): Result<E, C> => {
@@ -148,8 +167,10 @@ export {
 	handleErrors,
 	index,
 	resultFromNullable,
+	optionMap3,
 	parseIntOpt,
 	resultMap2,
 	resultMap3,
+	resultToNullable,
 	fold,
 };

--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -1,66 +1,162 @@
 import type { FootballContent } from '@guardian/apps-rendering-api-models/footballContent';
+import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballTeam';
+import type { Scorer } from '@guardian/apps-rendering-api-models/scorer';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { err, none, ok, OptionKind, ResultKind, some } from '@guardian/types';
+import {
+	err,
+	fromNullable,
+	map2,
+	none,
+	OptionKind,
+	map as optMap,
+	resultAndThen,
+	some,
+	withDefault,
+} from '@guardian/types';
 import type { Option, Result } from '@guardian/types';
 import { padZero } from 'date';
+import { pipe } from 'lib';
 import fetch from 'node-fetch';
 import type { Response } from 'node-fetch';
+import type { Parser } from 'parser';
+import {
+	arrayParser,
+	fieldParser,
+	map,
+	map3,
+	map6,
+	map7,
+	maybe,
+	numberParser,
+	oneOf,
+	parse,
+	stringParser,
+	succeed,
+} from 'parser';
 
 type Teams = [string, string];
 
-const getFootballSelector = (
-	date: Option<Date>,
-	teamA: Option<string>,
-	teamB: Option<string>,
-): Option<string> => {
-	if (
-		date.kind === OptionKind.Some &&
-		teamA.kind === OptionKind.Some &&
-		teamB.kind === OptionKind.Some
-	) {
-		// MAPI sorts these by string value
-		const teams =
-			teamA.value < teamB.value
-				? [teamA.value, teamB.value]
-				: [teamB.value, teamA.value];
+const getFootballSelector = (date: Date, [teamA, teamB]: Teams): string => {
+	// MAPI sorts these by string value
+	const teams = teamA < teamB ? [teamA, teamB] : [teamB, teamA];
 
-		const d = date.value;
-		const year = d.getUTCFullYear();
-		const month = padZero(d.getUTCMonth() + 1);
-		const day = padZero(d.getUTCDate());
+	const d = date;
+	const year = d.getUTCFullYear();
+	const month = padZero(d.getUTCMonth() + 1);
+	const day = padZero(d.getUTCDate());
 
-		return some(`${year}-${month}-${day}_${teams[0]}_${teams[1]}`);
-	}
-
-	return none;
+	return `${year}-${month}-${day}_${teams[0]}_${teams[1]}`;
 };
 
-const getFootballEndpoint = (selectorId: Option<string>): Option<string> => {
-	if (selectorId.kind === OptionKind.Some) {
-		return some(
-			`https://mobile.guardianapis.com/sport/football/matches?selector=${selectorId.value}`,
-		);
-	}
-	return none;
-};
+const getFootballEndpoint = (selectorId: string): string =>
+	`https://mobile.guardianapis.com/sport/football/matches?selector=${selectorId}`;
 
-type FootballResponse = Record<string, FootballContent>;
+const optionToUndefined = <A>(optA: Option<A>): A | undefined =>
+	withDefault<A | undefined>(undefined)(optA);
 
-interface FootballError {
-	errorMessage: string;
-}
+const stringOrUndefinedParser: Parser<string | undefined> = pipe(
+	stringParser,
+	maybe,
+	map(optionToUndefined),
+);
+
+const makeScorer = (
+	player: string,
+	timeInMinutes: number,
+	additionalInfo: undefined | string,
+): Scorer => ({
+	player,
+	timeInMinutes,
+	additionalInfo,
+});
+
+const makeFootballTeam = (
+	id: string,
+	name: string,
+	shortCode: string,
+	crestUri: string,
+	score: number,
+	scorers: Scorer[],
+): FootballTeam => ({
+	id,
+	name,
+	shortCode,
+	crestUri,
+	score,
+	scorers,
+});
+
+const makeFootballContent = (
+	id: string,
+	status: string,
+	kickOff: string,
+	competitionDisplayName: string,
+	homeTeam: FootballTeam,
+	awayTeam: FootballTeam,
+	venue: string | undefined,
+): FootballContent => ({
+	id,
+	status,
+	kickOff,
+	competitionDisplayName,
+	homeTeam,
+	awayTeam,
+	venue,
+});
+
+const scorerParser: Parser<Scorer> = map3(makeScorer)(
+	fieldParser('player', stringParser),
+	fieldParser('timeInMinutes', numberParser),
+	oneOf([
+		fieldParser('additionalInfo', stringOrUndefinedParser),
+		succeed(''),
+	]),
+);
+
+const footballTeamParser: Parser<FootballTeam> = map6(makeFootballTeam)(
+	fieldParser('id', stringParser),
+	fieldParser('name', stringParser),
+	fieldParser('shortCode', stringParser),
+	fieldParser('crestUri', stringParser),
+	fieldParser('score', numberParser),
+	oneOf([fieldParser('scorers', arrayParser(scorerParser)), succeed([])]),
+);
+
+const footballContentParser: Parser<FootballContent> = map7(
+	makeFootballContent,
+)(
+	fieldParser('id', stringParser),
+	fieldParser('status', stringParser),
+	fieldParser('kickOff', stringParser),
+	fieldParser('competitionDisplayName', stringParser),
+	fieldParser('homeTeam', footballTeamParser),
+	fieldParser('awayTeam', footballTeamParser),
+	oneOf([fieldParser('venue', stringParser), succeed(undefined)]),
+);
+
+const footballContentParserFor = (
+	selectorId: string,
+): Parser<FootballContent> => fieldParser(selectorId, footballContentParser);
+
+const footballErrorParser: Parser<string> = fieldParser(
+	'errorMessage',
+	stringParser,
+);
 
 const parseFootballResponse = async (
 	response: Response,
 	selectorId: string,
 ): Promise<Result<string, FootballContent>> => {
 	if (response.status === 200) {
-		const json = (await response.json()) as FootballResponse;
-		return ok(json[selectorId]);
+		const parser = footballContentParserFor(selectorId);
+		return pipe(await response.json(), parse(parser));
 	} else if (response.status === 400) {
-		const json = (await response.json()) as FootballError;
-		return err(json.errorMessage);
+		return pipe(
+			await response.json(),
+			parse(footballErrorParser),
+			resultAndThen<string, string, FootballContent>(err),
+		);
 	} else {
 		return err('Problem accessing PA API');
 	}
@@ -90,44 +186,32 @@ const teamsFromTags = (tags: Tag[]): Option<Teams> => {
 
 const getFootballContent = async (
 	content: Content,
-): Promise<FootballContent | undefined> => {
+): Promise<Result<string, FootballContent>> => {
 	const teams = teamsFromTags(content.tags);
 
-	if (teams.kind === OptionKind.Some) {
-		const currentTeams = teams.value;
-		const teamA = some(currentTeams[0]);
-		const teamB = some(currentTeams[1]);
+	const makeDate = (s: string): Date => new Date(s);
 
-		const webPublicationDate = content.webPublicationDate?.iso8601;
+	const date = pipe(
+		content.webPublicationDate?.iso8601,
+		fromNullable,
+		optMap(makeDate),
+	);
 
-		if (webPublicationDate) {
-			const date = some(new Date(webPublicationDate));
+	const selectorId = map2(getFootballSelector)(date)(teams);
 
-			const selectorId = getFootballSelector(date, teamA, teamB);
+	if (selectorId.kind === OptionKind.Some) {
+		const footballEndpoint = getFootballEndpoint(selectorId.value);
 
-			if (selectorId.kind === OptionKind.Some) {
-				const footballEndpoint = getFootballEndpoint(selectorId);
+		const response = await fetch(footballEndpoint);
 
-				if (footballEndpoint.kind === OptionKind.Some) {
-					const response = await fetch(footballEndpoint.value);
+		const footballContent = await parseFootballResponse(
+			response,
+			selectorId.value,
+		);
 
-					const footballContent = await parseFootballResponse(
-						response,
-						selectorId.value,
-					);
-
-					if (footballContent.kind === ResultKind.Ok) {
-						return footballContent.value;
-					}
-					return undefined;
-				}
-				return undefined;
-			}
-			return undefined;
-		}
-		return undefined;
+		return footballContent;
 	}
-	return undefined;
+	return err('Could not get selectorId');
 };
 
 export { getFootballContent };

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -29,7 +29,7 @@ import express from 'express';
 import { MainMediaKind } from 'headerMedia';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
-import { pipe, toArray } from 'lib';
+import { pipe, resultToNullable, toArray } from 'lib';
 import { logger } from 'logger';
 import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
@@ -273,8 +273,10 @@ async function serveEditionsArticlePost(
 		// The "req.body" should contain a 'Content' object which fetched by the
 		// Edition backend from the capi
 		const content = await capiContentDecoder(req.body);
+		const footballContent = await getFootballContent(content);
 		const renderingRequest: RenderingRequest = {
 			content,
+			footballContent: resultToNullable(footballContent),
 		};
 		const themeOverride = themeFromUnknown(req.query.theme);
 
@@ -310,7 +312,7 @@ async function serveArticleGet(
 					},
 					commentCount: 30,
 					relatedContent,
-					footballContent,
+					footballContent: resultToNullable(footballContent),
 				};
 
 				const richLinkDetails = req.query.richlink === '';


### PR DESCRIPTION
## Why are you doing this?

We're missing football scores in Editions currently. This PR adds PA based automated football scorers for Editions match reports, bringing it into line with Apps-Rendering and Dotcom.

Paired with @JamieB-gu & @marjisound on the parsing section.

## Changes

- Add football scores to Editions-Rendering endpoint
- fix score number positioning
- add `fromNullable` to `teamScorers` component
- add `optionMap3` and `resultToNullable` to `lib`
- refactor `footballContent.ts` to use `fieldParser` based approach

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/130443719-4028bc71-83ad-4e6d-8c1d-feebb4089d52.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/130443778-e480695d-07a0-4cb9-9f77-c96170b8aa8f.png" width="300px" /> |

