### PR TITLE
LIVE-3015: update letter headline styles

### DIFF
--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -202,6 +202,11 @@ const getHeadlineStyles = (
 	}
 
 	// this needs to come before Display.Showcase
+	if (format.design === Design.Letter) {
+		return css(sharedStyles, getFontStyles('tight', 'light'));
+	}
+
+	// this needs to come before Display.Showcase
 	if (format.design === Design.Interview) {
 		return css(
 			sharedStyles,
@@ -217,8 +222,6 @@ const getHeadlineStyles = (
 	switch (format.design) {
 		case Design.Review:
 			return css(sharedStyles, getFontStyles('tight', 'bold'));
-		case Design.Letter:
-			return css(sharedStyles, getFontStyles('tight', 'light'));
 		case Design.Analysis:
 			return css(
 				sharedStyles,


### PR DESCRIPTION
## Why are you doing this?
The Editions `headline` component wrongly had `Display.Showcase` above `Design.Letter` in the styling hierarchy. 


## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/131546920-b490d1ba-6019-44ba-b3ed-ab2675f6e89c.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131547003-c81771f0-3f9f-456e-8fa4-8b6c1439cf7b.png" width="300px" /> |


