### PR TITLE
FIX: `top-above-nav` flex styling

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -367,7 +367,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 				min-height: 90px;
 				text-align: left;
 				display: block;
-				width: 728px;
+				min-width: 728px;
 			`;
 			return (
 				<>

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -19,8 +19,8 @@ const headerAdWrapper = css`
 	padding-bottom: ${padding}px;
 
 	display: flex;
-	flex-wrap: wrap;
-	align-content: center;
+	flex-direction: column;
+	justify-content: center;
 
 	position: sticky;
 	top: 0;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the flex direction and width of the `top-above-nav` ad.

## Why?

- Ads wider than 728 weren’t centred with their labels.
- Screens wider than 1456 would see the label beside the ad.

### Before

![before](https://user-images.githubusercontent.com/76776/131637212-c525a21f-b550-45fb-a57c-e056a9e95aeb.png)


### After

![after](https://user-images.githubusercontent.com/76776/131637245-52553462-0e62-4ab0-b94c-e48eadc9bce1.png)
