### PR TITLE
LIVE-2953: add football scores when video header media

### DIFF
--- a/apps-rendering/src/__snapshots__/storyshots.test.ts.snap
+++ b/apps-rendering/src/__snapshots__/storyshots.test.ts.snap
@@ -8435,14 +8435,14 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
 
 @media (min-width: 740px) {
   .emotion-7 {
-    width: 531px;
+    width: 527px;
     padding-right: 0;
   }
 }
 
 @media (min-width: 980px) {
   .emotion-7 {
-    width: 550px;
+    width: 546px;
   }
 }
 
@@ -8549,6 +8549,13 @@ exports[`Storyshots Editions/Article Match Report 1`] = `
   height: 1.5em;
   position: relative;
   text-align: center;
+  margin-top: 0.25rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-15 {
+    margin-top: 0.5rem;
+  }
 }
 
 .emotion-16 {
@@ -12170,14 +12177,14 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
 
 @media (min-width: 740px) {
   .emotion-0 {
-    width: 531px;
+    width: 527px;
     padding-right: 0;
   }
 }
 
 @media (min-width: 980px) {
   .emotion-0 {
-    width: 550px;
+    width: 546px;
   }
 }
 
@@ -12284,6 +12291,13 @@ exports[`Storyshots Editions/FootballScores Default 1`] = `
   height: 1.5em;
   position: relative;
   text-align: center;
+  margin-top: 0.25rem;
+}
+
+@media (min-width: 660px) {
+  .emotion-8 {
+    margin-top: 0.5rem;
+  }
 }
 
 .emotion-9 {

--- a/apps-rendering/src/components/editions/footballScores/index.tsx
+++ b/apps-rendering/src/components/editions/footballScores/index.tsx
@@ -24,12 +24,12 @@ const styles = css`
 	padding: ${remSpace[3]};
 
 	${from.tablet} {
-		width: ${tabletContentWidth + 5}px;
+		width: ${tabletContentWidth + 1}px;
 		padding-right: 0;
 	}
 
 	${from.desktop} {
-		width: ${wideContentWidth + 5}px;
+		width: ${wideContentWidth + 1}px;
 	}
 `;
 

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -58,14 +58,13 @@ const fullWidthCaptionStyles = css`
 	height: 100%;
 `;
 
-const footballWrapperStyles: SerializedStyles = css`
+const footballWrapperStyles = (isVideo: boolean): SerializedStyles => css`
 	${from.tablet} {
-		width: calc(100vw - 3.75rem);
+		width: ${isVideo ? `750px` : `calc(100vw - 3.75rem)`};
 		background-color: ${brandAltBackground.primary};
 	}
-
 	${from.desktop} {
-		width: inherit;
+		width: ${isVideo ? `750px` : `inherit`};
 	}
 `;
 
@@ -166,6 +165,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 		cameraIcon: iconColor,
 		cameraIconBackground: iconBackgroundColor,
 	} = getThemeStyles(format.theme);
+	const matchScores = 'football' in item ? item.football : none;
 
 	return maybeRender(item.mainMedia, (media) => {
 		if (media.kind === MainMediaKind.Image) {
@@ -174,8 +174,6 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				image: { caption, credit },
 			} = media;
 
-			const matchScores = 'football' in item ? item.football : none;
-
 			return (
 				<figure
 					css={[getStyles(format, isPicture)]}
@@ -183,7 +181,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				>
 					{maybeRender(matchScores, (scores) => {
 						return (
-							<div css={footballWrapperStyles}>
+							<div css={footballWrapperStyles(false)}>
 								<FootballScores
 									league={scores.league}
 									homeTeam={scores.homeTeam}
@@ -222,7 +220,22 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 				video: { title, atomId },
 			} = media;
 
-			return <Video atomId={atomId} title={title} />;
+			return (
+				<>
+					{maybeRender(matchScores, (scores) => {
+						return (
+							<div css={footballWrapperStyles(true)}>
+								<FootballScores
+									league={scores.league}
+									homeTeam={scores.homeTeam}
+									awayTeam={scores.awayTeam}
+								/>
+							</div>
+						);
+					})}
+					<Video atomId={atomId} title={title} />
+				</>
+			);
 		}
 	});
 };

--- a/apps-rendering/src/components/editions/teamScore/index.tsx
+++ b/apps-rendering/src/components/editions/teamScore/index.tsx
@@ -65,6 +65,11 @@ const scoreNumberStyles = css`
 	height: 1.5em;
 	position: relative;
 	text-align: center;
+	margin-top: ${remSpace[1]};
+
+	${from.phablet} {
+		margin-top: ${remSpace[2]};
+	}
 `;
 
 const scoreInlineStyles = css`


### PR DESCRIPTION
## Why are you doing this?

The earlier football scores PR did not render the scores component if the header media was a video.

## Changes
- add football scores component to header media video
- minor styling fixes

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/131678132-2d5b6aaf-cf0a-4c0f-9c23-b3cf9b80ded5.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131678224-ff9ee291-8cb3-4d08-b887-63e43fdc4811.png" width="300px" /> |


