### PR TITLE
Bump @guardian/braze-components to v3.5.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -42,7 +42,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^18.0.0",
     "@guardian/automat-contributions": "^0.4.0",
-    "@guardian/braze-components": "^3.4.0",
+    "@guardian/braze-components": "^3.5.0",
     "@guardian/commercial-core": "^0.19.2",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^7.0.0",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1731,10 +1731,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.0.tgz#bc710031601dd3eb90f3e6555a8fed9d69d0b93d"
   integrity sha512-ooyeNl4lFOCTi376GipsdV6IHnxY7MGHfM7c/iFbAatElYbH4Lr2Y0kIOBg6yR5XGDMhQ8PWyDQ/YgMIL5BKRw==
 
-"@guardian/braze-components@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.4.0.tgz#55930a56b75a645bd4e3f45aafe52d1352a65458"
-  integrity sha512-I6Yr0AwPAvdCwd4YblQX5NUjpbNz2hTgo/XbkQbLRFzSQiPKv3DWx2JbbvUJHXGvaoFMfwdefdBx9sAN8o5Yyg==
+"@guardian/braze-components@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.5.0.tgz#cb2b28e06d0ede0b967a21fcb1c33f3de29585f2"
+  integrity sha512-FnRh53rTJZfgg1eqSnAf8T0RBVdDEbC2PrK0OZ0d54/Exy/uUislOPEfA667QyLuB4jN5mThM98vNIlmfP2wVw==
 
 "@guardian/commercial-core@^0.19.2":
   version "0.19.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates the version of `@guardian/braze-components` used on DCR.

## Why?

Release 3.5.0 includes some changes for the in progress and error states of the newsletter epics.
