### PR TITLE
LIVE-3021: move interview kicker to headerMedia component

### DIFF
--- a/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { Display, Pillar } from '@guardian/types';
-import { article, review } from 'fixtures/item';
+import { article, interview, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import HeaderMedia from './index';
@@ -64,6 +64,16 @@ const Video = (): ReactElement => (
 	/>
 );
 
+const InterviewVideo = (): ReactElement => (
+	<HeaderMedia
+		item={{
+			...interview,
+			mainMedia: video,
+			theme: selectPillar(Pillar.News),
+		}}
+	/>
+);
+
 // ----- Exports ----- //
 
 export default {
@@ -71,4 +81,4 @@ export default {
 	title: 'Editions/HeaderMedia',
 };
 
-export { Image, FullScreen, WithStarRating, Video };
+export { Image, FullScreen, WithStarRating, Video, InterviewVideo };

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -21,7 +21,7 @@ import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import FootballScores from '../footballScores';
 import Series from '../series';
-import { articleMarginStyles, wideImageWidth } from '../styles';
+import { wideImageWidth } from '../styles';
 import Video from '../video';
 
 // ----- Styles ----- //
@@ -59,20 +59,15 @@ const fullWidthCaptionStyles = css`
 	height: 100%;
 `;
 
-const imageSeriesStyles = css`
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	${articleMarginStyles}
-`;
+const getVideoSeriesStyles = (format: Format): SerializedStyles => {
+	if (format.design === Design.Interview) {
+		return interviewStyles;
+	}
+	return css``;
+};
 
-const videoSeriesStyles = css`
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	z-index: 2;
+const interviewStyles = css`
 	display: none;
-	${articleMarginStyles}
 
 	${from.desktop} {
 		display: block;
@@ -242,11 +237,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						isFullWidthImage={isFullWidthImage(format)}
 					/>
 					<StarRating item={item} />
-					{hasSeriesKicker(format) && (
-						<div css={imageSeriesStyles}>
-							<Series item={item} />
-						</div>
-					)}
+					{hasSeriesKicker(format) && <Series item={item} />}
 				</figure>
 			);
 		} else {
@@ -269,7 +260,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						);
 					})}
 					{hasSeriesKicker(format) && (
-						<div css={videoSeriesStyles}>
+						<div css={getVideoSeriesStyles(format)}>
 							<Series item={item} />
 						</div>
 					)}

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -20,7 +20,8 @@ import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import FootballScores from '../footballScores';
-import { wideImageWidth } from '../styles';
+import Series from '../series';
+import { articleMarginStyles, wideImageWidth } from '../styles';
 import Video from '../video';
 
 // ----- Styles ----- //
@@ -56,6 +57,30 @@ const captionStyles = css`
 const fullWidthCaptionStyles = css`
 	width: 100%;
 	height: 100%;
+`;
+
+const imageSeriesStyles = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	${articleMarginStyles}
+`;
+
+const videoSeriesStyles = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	z-index: 2;
+	display: none;
+	${articleMarginStyles}
+
+	${from.desktop} {
+		display: block;
+	}
+`;
+
+const videoWrapperStyles = css`
+	position: relative;
 `;
 
 const footballWrapperStyles = (isVideo: boolean): SerializedStyles => css`
@@ -133,6 +158,9 @@ const getStyles = (format: Format, isPicture: boolean): SerializedStyles => {
 const getCaptionStyles = (format: Format): SerializedStyles => {
 	return isFullWidthImage(format) ? fullWidthCaptionStyles : captionStyles;
 };
+
+const hasSeriesKicker = (format: Format): boolean =>
+	format.display === Display.Immersive || format.design === Design.Interview;
 
 const getImageSizes = (
 	format: Format,
@@ -214,6 +242,11 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						isFullWidthImage={isFullWidthImage(format)}
 					/>
 					<StarRating item={item} />
+					{hasSeriesKicker(format) && (
+						<div css={imageSeriesStyles}>
+							<Series item={item} />
+						</div>
+					)}
 				</figure>
 			);
 		} else {
@@ -222,7 +255,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 			} = media;
 
 			return (
-				<>
+				<div css={videoWrapperStyles}>
 					{maybeRender(matchScores, (scores) => {
 						return (
 							<div css={footballWrapperStyles(true)}>
@@ -235,8 +268,13 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 							</div>
 						);
 					})}
+					{hasSeriesKicker(format) && (
+						<div css={videoSeriesStyles}>
+							<Series item={item} />
+						</div>
+					)}
 					<Video atomId={atomId} title={title} />
-				</>
+				</div>
 			);
 		}
 	});

--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -19,7 +19,6 @@ import { getFormat } from 'item';
 import { index } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
-import Series from '../series';
 import {
 	articleWidthStyles,
 	tabletContentWidth,
@@ -103,13 +102,6 @@ const interviewFontStyles = css`
 	box-shadow: -${remSpace[3]} 0 0 ${neutral[7]},
 		${remSpace[3]} 0 0 ${neutral[7]};
 	display: inline;
-`;
-
-const seriesStyles = css`
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
 `;
 
 // ----- Headline Component Styles ----- //
@@ -235,9 +227,6 @@ const getHeadlineStyles = (
 	return css(sharedStyles, getFontStyles('tight', 'medium'));
 };
 
-const hasSeriesKicker = (format: Format): boolean =>
-	format.display === Display.Immersive || format.design === Design.Interview;
-
 // ----- Component ----- //
 
 interface Props {
@@ -255,11 +244,6 @@ const Headline: FC<Props> = ({ item }) => {
 
 	return (
 		<div css={headlineWrapperStyles}>
-			{hasSeriesKicker(format) && (
-				<div css={seriesStyles}>
-					<Series item={item} />
-				</div>
-			)}
 			<h1 css={getHeadlineStyles(format, kickerColor, hasImage)}>
 				{getDecorativeStyles(item)}
 			</h1>

--- a/apps-rendering/src/components/editions/series/index.tsx
+++ b/apps-rendering/src/components/editions/series/index.tsx
@@ -12,6 +12,7 @@ import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import { kickerPicker } from '../kickerPicker';
+import { articleMarginStyles } from '../styles';
 
 // ----- Component ----- //
 
@@ -27,14 +28,27 @@ const styles = (kicker: string): SerializedStyles => css`
 	}
 `;
 
-const interviewStyles = (kicker: string): SerializedStyles => css`
+const interviewStyles = css`
+	bottom: 0;
+`;
+
+const immersiveStyles = css`
+	bottom: 52px;
+
+	${from.tablet} {
+		bottom: 74px;
+	}
+`;
+
+const sharedFullwidthStyles = (kicker: string): SerializedStyles => css`
 	position: absolute;
 	left: 0;
-	bottom: 0;
 	border: 0;
 	color: ${neutral[100]};
 	background-color: ${kicker};
 	padding: ${remSpace[3]} ${remSpace[3]};
+	${articleMarginStyles}
+	z-index: 2;
 `;
 
 interface Props {
@@ -44,11 +58,20 @@ interface Props {
 const getStyles = (item: Item): SerializedStyles => {
 	const format = getFormat(item);
 	const { kicker } = getThemeStyles(format.theme);
-	if (
-		item.design === Design.Interview ||
-		item.display === Display.Immersive
-	) {
-		return css(styles(kicker), interviewStyles(kicker));
+
+	if (item.design === Design.Interview) {
+		return css(
+			styles(kicker),
+			sharedFullwidthStyles(kicker),
+			interviewStyles,
+		);
+	}
+	if (item.display === Display.Immersive) {
+		return css(
+			styles(kicker),
+			sharedFullwidthStyles(kicker),
+			immersiveStyles,
+		);
 	}
 	return styles(kicker);
 };


### PR DESCRIPTION
## Why are you doing this?

On interviews with video headers there was a clash between the kicker and the play button.

@abeddow91 @JamieB-gu  everything seems to be working for me in the browser, but for some reason the `position: relative` i've added hides the video in storybook. I'm away next week but would one of you be able to pick this up and get it finished? Thanks.

## Changes
- moves kicker from headline component to headerMedia component
- hides if video on smaller breakpoints



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/131878917-143765d1-a31a-4017-aa28-4f94fcbe7063.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131878981-fc1c4cb8-9c38-4a85-b105-ae5885a2dd84.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/77005274/131878769-083b4c63-dc84-4acb-8217-33a8cd9d0d35.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131878835-12a35a50-d3e8-431e-84e5-d2a7a31d3a39.png" width="300px" /> |






