### PR TITLE
LIVE-3021: hide kicker on small breakpoints

### DIFF
--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -14,6 +14,7 @@ import { SvgQuote } from '@guardian/src-icons';
 import type { Format } from '@guardian/types';
 import { Design, Display, OptionKind } from '@guardian/types';
 import { editionsHeadlineTextColour } from 'editorialStyles';
+import { MainMediaKind } from 'headerMedia';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { index } from 'lib';
@@ -105,11 +106,16 @@ const interviewFontStyles = css`
 	display: inline;
 `;
 
-const seriesStyles = css`
+const seriesStyles = (isInterviewVideoHeader: boolean): SerializedStyles => css`
 	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;
+	display: ${isInterviewVideoHeader ? 'none' : 'block'};
+
+	${from.desktop} {
+		display: block;
+	}
 `;
 
 // ----- Headline Component Styles ----- //
@@ -238,6 +244,9 @@ const getHeadlineStyles = (
 const hasSeriesKicker = (format: Format): boolean =>
 	format.display === Display.Immersive || format.design === Design.Interview;
 
+const isInterviewHeadline = (format: Format): boolean =>
+	format.design === Design.Interview;
+
 // ----- Component ----- //
 
 interface Props {
@@ -253,10 +262,17 @@ const Headline: FC<Props> = ({ item }) => {
 		contributor.kind === OptionKind.Some &&
 		contributor.value.image.kind === OptionKind.Some;
 
+	const isVideo =
+		item.mainMedia.kind === OptionKind.Some &&
+		item.mainMedia.value.kind === MainMediaKind.Video;
+
+	const isInterview = isInterviewHeadline(format);
+	const isInterviewVideoHeader = isInterview && isVideo;
+
 	return (
 		<div css={headlineWrapperStyles}>
 			{hasSeriesKicker(format) && (
-				<div css={seriesStyles}>
+				<div css={seriesStyles(isInterviewVideoHeader)}>
 					<Series item={item} />
 				</div>
 			)}


### PR DESCRIPTION
## Why are you doing this?

On interviews with video headers there was a clash between the kicker and the play button.

@abeddow91 got this finished at 7pm on Thursday - could you give it a bit of a double check and make sure it hasn't broken anything before merging please?

## Changes
- hides kicker if video header on smaller breakpoints



## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/131878917-143765d1-a31a-4017-aa28-4f94fcbe7063.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131878981-fc1c4cb8-9c38-4a85-b105-ae5885a2dd84.png" width="300px" /> |







