### PR TITLE
LIVE-2953: swap undefined for empty string

### DIFF
--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -95,7 +95,7 @@ const makeFootballContent = (
 const scorerParser: Parser<Scorer> = map3(makeScorer)(
 	fieldParser('player', stringParser),
 	fieldParser('timeInMinutes', numberParser),
-	oneOf([fieldParser('additionalInfo', stringParser), succeed(undefined)]),
+	oneOf([fieldParser('additionalInfo', stringParser), succeed('')]),
 );
 
 const footballTeamParser: Parser<FootballTeam> = map6(makeFootballTeam)(
@@ -116,7 +116,7 @@ const footballContentParser: Parser<FootballContent> = map7(
 	fieldParser('competitionDisplayName', stringParser),
 	fieldParser('homeTeam', footballTeamParser),
 	fieldParser('awayTeam', footballTeamParser),
-	oneOf([fieldParser('venue', stringParser), succeed(undefined)]),
+	oneOf([fieldParser('venue', stringParser), succeed('')]),
 );
 
 const footballContentParserFor = (


### PR DESCRIPTION
## Why are you doing this?


If we return `succeed(undefined)` in the case of an empty `venue` field the component does not  render, switching it for `''` means the `footballScores` component still renders.
```
oneOf([fieldParser('venue', stringParser), succeed('')]),
```

## Changes
- swap `undefined` for `''` if no `venue` or `additionalInfo` field

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/77005274/131980418-cc97b23e-5688-4223-8732-2a585cccb3eb.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/77005274/131980332-44f0707e-0820-4307-8fdc-393d004aad09.png" width="300px" /> |
