### PR TITLE
Submit consent events to Ophan

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -324,6 +324,17 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				}
 			});
 
+			onConsentChange((consentState) => {
+				const consentUUID = getCookie('consentUUID')
+				console.log("browserId", browserId);
+				console.log("consentUUID", consentUUID);
+				if (consentState.tcfv2) {
+					console.log("[tcfv2] consent string", consentState?.tcfv2?.tcString);
+				} else {
+					console.log("Not tcfv2")
+				}
+			});
+
 			cmp.init({
 				country: countryCode,
 				pubData,

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -330,7 +330,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					if (consentState.tcfv2) {
 						return consentState.tcfv2?.tcString;
 					}
-					return "undefined";
+					return "";
 				}
 				const consentUUID = getCookie('consentUUID')
 				const consentString = decideConsentString();

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -70,6 +70,7 @@ import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { storage } from '@guardian/libs';
 import {
+	getOphanRecordFunction,
 	submitComponentEvent,
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
@@ -325,14 +326,24 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			});
 
 			onConsentChange((consentState) => {
-				const consentUUID = getCookie('consentUUID')
-				console.log("browserId", browserId);
-				console.log("consentUUID", consentUUID);
-				if (consentState.tcfv2) {
-					console.log("[tcfv2] consent string", consentState?.tcfv2?.tcString);
-				} else {
-					console.log("Not tcfv2")
+				const decideConsentString = () => {
+					if (consentState.tcfv2) {
+						return consentState?.tcfv2?.tcString;
+					}
+					return "undefined";
 				}
+				const consentUUID = getCookie('consentUUID')
+				const consentString = decideConsentString();
+				const event = {
+					component: {
+					  componentType: 'CONSENT',
+					  products: [],
+					  labels:  [consentUUID, consentString],
+					},
+					action: 'CONSENT',
+				}
+				const ophanEventSubmit = getOphanRecordFunction()
+				ophanEventSubmit(event);
 			});
 
 			cmp.init({

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -328,7 +328,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			onConsentChange((consentState) => {
 				const decideConsentString = () => {
 					if (consentState.tcfv2) {
-						return consentState?.tcfv2?.tcString;
+						return consentState.tcfv2?.tcString;
 					}
 					return "undefined";
 				}
@@ -336,11 +336,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				const consentString = decideConsentString();
 				const event = {
 					component: {
-					  componentType: 'CONSENT',
-					  products: [],
-					  labels:  [consentUUID, consentString],
+						componentType: 'CONSENT',
+						products: [],
+						labels: [consentUUID, consentString],
 					},
-					action: 'CONSENT',
+					action: 'MANAGE_CONSENT', // I am using MANAGE_CONSENT as the default action while we develop this code.
 				}
 				const ophanEventSubmit = getOphanRecordFunction()
 				ophanEventSubmit(event);
@@ -721,11 +721,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				CAPI.config.switches.commercialMetrics,
 				window.guardian.config?.ophan !== undefined,
 			].every(Boolean) && (
-				<CommercialMetrics
-					browserId={browserId}
-					pageViewId={pageViewId}
-				/>
-			)}
+			<CommercialMetrics
+				browserId={browserId}
+				pageViewId={pageViewId}
+					/>
+				)}
 			<Portal rootId="reader-revenue-links-header">
 				<ReaderRevenueLinks
 					urls={CAPI.nav.readerRevenueLinks.header}


### PR DESCRIPTION
This is the first of few PRs all aimed at submitting consent related events to Ophan, notably the initial capture (if any) and user driven update of user consent.  At the moment we are only registering the consentState.tcfv2 case. The other cases will be introduced shortly. 

This PR comes after the Ophan PR to update the component event model with a new action and a new component type: https://github.com/guardian/ophan/pull/4257

 