### PR TITLE
Fix Bonzai TrueSkin page skin

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -55,6 +55,7 @@ export const HeaderAdSlot: React.FC<{
 					headerAdWrapper,
 					(isAdFreeUser || shouldHideAds) && headerAdWrapperHidden,
 				]}
+				className="top-banner-ad-container"
 			>
 				<AdSlot position="top-above-nav" display={display} />
 			</div>

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -41,6 +41,7 @@ export const HeaderAdSlot: React.FC<{
 				/**
 				* Hides the top-above-nav ad-slot container when a
 				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
+				* Temporary fix - introduced 06-Sep-2021
 				*/
 				.bz-custom-container
 					~ #bannerandheader

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Display } from '@guardian/types';
 
@@ -36,6 +36,19 @@ export const HeaderAdSlot: React.FC<{
 	display: Display;
 }> = ({ isAdFreeUser, shouldHideAds, display }) => (
 	<div css={headerWrapper}>
+		<Global
+			styles={css`
+				/**
+				* Hides the top-above-nav ad-slot container when a
+				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
+				*/
+				.bz-custom-container
+					~ #bannerandheader
+					> .top-banner-ad-container {
+					display: none;
+				}
+			`}
+		/>
 		<Hide when="below" breakpoint="tablet">
 			<div
 				css={[

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -344,7 +344,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 	return (
 		<>
-			<div data-print-layout="hide">
+			<div data-print-layout="hide" id="bannerandheader">
 				<>
 					<Stuck>
 						<ElementContainer


### PR DESCRIPTION
## Why?

Hides the top-above-nav ad-slot container when a Bonzai TruSkin (Australian 3rd Party page skin) is shown.

The commercial team appreciates this fix is a blunt instrument but we are losing revenue until the vendor applies a fix on their side.

This is a **temporary fix** and we will revert asap.

Frontend PR: https://github.com/guardian/frontend/pull/24146

## Before

![image](https://user-images.githubusercontent.com/7014230/132022723-63d0e560-6410-42dc-9999-33a38b99bbbb.png)
