### PR TITLE
Storybook Tidy: Prefix AR storybook

### DIFF
--- a/apps-rendering/src/components/anchor.stories.tsx
+++ b/apps-rendering/src/components/anchor.stories.tsx
@@ -32,7 +32,7 @@ const Default: FC = () => (
 
 export default {
 	component: Anchor,
-	title: 'Anchor',
+	title: 'AR/Anchor',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/bullet.stories.tsx
+++ b/apps-rendering/src/components/bullet.stories.tsx
@@ -23,7 +23,7 @@ const Default: FC = () => (
 
 export default {
 	component: Bullet,
-	title: 'Bullet',
+	title: 'AR/Bullet',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/byline.stories.tsx
+++ b/apps-rendering/src/components/byline.stories.tsx
@@ -61,7 +61,7 @@ const Labs: FC = () => (
 
 export default {
 	component: Byline,
-	title: 'Byline',
+	title: 'AR/Byline',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/commentCount.stories.tsx
+++ b/apps-rendering/src/components/commentCount.stories.tsx
@@ -22,7 +22,7 @@ const Default: FC = () => (
 
 export default {
 	component: CommentCount,
-	title: 'CommentCount',
+	title: 'AR/CommentCount',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/dateline.stories.tsx
+++ b/apps-rendering/src/components/dateline.stories.tsx
@@ -21,7 +21,7 @@ const Default: FC = () => (
 
 export default {
 	component: Dateline,
-	title: 'Dateline',
+	title: 'AR/Dateline',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/article/article.stories.tsx
+++ b/apps-rendering/src/components/editions/article/article.stories.tsx
@@ -247,7 +247,7 @@ Gallery.parameters = {
 
 export default {
 	component: Article,
-	title: 'Editions/Article',
+	title: 'AR/Editions/Article',
 	decorators: [withKnobs],
 	parameters: {
 		layout: 'fullscreen',

--- a/apps-rendering/src/components/editions/avatar/avatar.stories.tsx
+++ b/apps-rendering/src/components/editions/avatar/avatar.stories.tsx
@@ -51,7 +51,7 @@ const Default = (): ReactElement => (
 
 export default {
 	component: Avatar,
-	title: 'Editions/Avatar',
+	title: 'AR/Editions/Avatar',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/byline/byline.stories.tsx
+++ b/apps-rendering/src/components/editions/byline/byline.stories.tsx
@@ -161,7 +161,7 @@ const Comment = (): ReactElement => (
 
 export default {
 	component: Byline,
-	title: 'Editions/Byline',
+	title: 'AR/Editions/Byline',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/footballScores/footballScores.stories.tsx
+++ b/apps-rendering/src/components/editions/footballScores/footballScores.stories.tsx
@@ -47,7 +47,7 @@ const Default: FC = () => (
 
 export default {
 	component: FootballScores,
-	title: 'Editions/FootballScores',
+	title: 'AR/Editions/FootballScores',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
@@ -26,7 +26,7 @@ const Default = (): ReactElement => (
 
 export default {
 	component: GalleryImage,
-	title: 'Editions/GalleryImage',
+	title: 'AR/Editions/GalleryImage',
 	parameters: {
 		backgrounds: {
 			default: 'gallery-template-bg',

--- a/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
@@ -68,7 +68,7 @@ const Video = (): ReactElement => (
 
 export default {
 	component: HeaderMedia,
-	title: 'Editions/HeaderMedia',
+	title: 'AR/Editions/HeaderMedia',
 };
 
 export { Image, FullScreen, WithStarRating, Video };

--- a/apps-rendering/src/components/editions/headline/headline.stories.tsx
+++ b/apps-rendering/src/components/editions/headline/headline.stories.tsx
@@ -145,7 +145,7 @@ const Media = (): ReactElement => (
 
 export default {
 	component: Headline,
-	title: 'Editions/Headline',
+	title: 'AR/Editions/Headline',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/pullquote/pullquote.stories.tsx
+++ b/apps-rendering/src/components/editions/pullquote/pullquote.stories.tsx
@@ -34,7 +34,7 @@ const Default = (): ReactElement => <Pullquote {...getInputProps()} />;
 
 export default {
 	component: Pullquote,
-	title: 'Editions/PullQuote',
+	title: 'AR/Editions/PullQuote',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/series/series.stories.tsx
+++ b/apps-rendering/src/components/editions/series/series.stories.tsx
@@ -60,7 +60,7 @@ const Immersive = (): ReactElement => (
 
 export default {
 	component: Series,
-	title: 'Editions/Series',
+	title: 'AR/Editions/Series',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
+++ b/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
@@ -47,7 +47,7 @@ const Default = (): ReactElement => {
 
 export default {
 	component: ShareIcon,
-	title: 'Editions/ShareIcon',
+	title: 'AR/Editions/ShareIcon',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
@@ -89,7 +89,7 @@ const Media = (): ReactElement => (
 
 export default {
 	component: Standfirst,
-	title: 'Editions/Standfirst',
+	title: 'AR/Editions/Standfirst',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
+++ b/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
@@ -26,7 +26,7 @@ const NotReview = (): ReactElement => <StarRating item={article} />;
 
 export default {
 	component: StarRating,
-	title: 'Editions/Star Rating',
+	title: 'AR/Editions/Star Rating',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/editions/video/video.stories.tsx
+++ b/apps-rendering/src/components/editions/video/video.stories.tsx
@@ -23,7 +23,7 @@ const Default = (): ReactElement => <Video {...video} />;
 
 export default {
 	component: Video,
-	title: 'Editions/Video',
+	title: 'AR/Editions/Video',
 };
 
 export { Default };

--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -152,7 +152,7 @@ const Instagram: FC = () => (
 
 export default {
 	component: EmbedComponentWrapper,
-	title: 'EmbedComponentWrapper',
+	title: 'AR/EmbedComponentWrapper',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/follow.stories.tsx
+++ b/apps-rendering/src/components/follow.stories.tsx
@@ -28,7 +28,7 @@ const Default: FC = () => (
 
 export default {
 	component: Follow,
-	title: 'Follow',
+	title: 'AR/Follow',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/footballScores.stories.tsx
+++ b/apps-rendering/src/components/footballScores.stories.tsx
@@ -62,7 +62,7 @@ const Default: FC = () => (
 
 export default {
 	component: FootballScores,
-	title: 'FootballScores',
+	title: 'AR/FootballScores',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/footer.stories.tsx
+++ b/apps-rendering/src/components/footer.stories.tsx
@@ -14,7 +14,7 @@ const Default: FC = () => <Footer isCcpa={false} />;
 
 export default {
 	component: Footer,
-	title: 'Footer',
+	title: 'AR/Footer',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/headline.stories.tsx
+++ b/apps-rendering/src/components/headline.stories.tsx
@@ -73,7 +73,7 @@ const Labs = (): ReactElement => (
 
 export default {
 	component: Headline,
-	title: 'Headline',
+	title: 'AR/Headline',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/horizontalRule.stories.tsx
+++ b/apps-rendering/src/components/horizontalRule.stories.tsx
@@ -11,7 +11,7 @@ const Default: FC = () => <HorizontalRule />;
 
 export default {
 	component: HorizontalRule,
-	title: 'HorizontalRule',
+	title: 'AR/HorizontalRule',
 };
 
 export { Default };

--- a/apps-rendering/src/components/list.stories.tsx
+++ b/apps-rendering/src/components/list.stories.tsx
@@ -27,7 +27,7 @@ const Default: FC = () => <List>{[listItem, listItem, listItem]}</List>;
 
 export default {
 	component: List,
-	title: 'List',
+	title: 'AR/List',
 };
 
 export { Default };

--- a/apps-rendering/src/components/listItem.stories.tsx
+++ b/apps-rendering/src/components/listItem.stories.tsx
@@ -23,7 +23,7 @@ const Default: FC = () => (
 
 export default {
 	component: ListItem,
-	title: 'ListItem',
+	title: 'AR/ListItem',
 };
 
 export { Default };

--- a/apps-rendering/src/components/paragraph.stories.tsx
+++ b/apps-rendering/src/components/paragraph.stories.tsx
@@ -38,7 +38,7 @@ const Labs: FC = () => (
 
 export default {
 	component: Paragraph,
-	title: 'Paragraph',
+	title: 'AR/Paragraph',
 };
 
 export { Default, Labs };

--- a/apps-rendering/src/components/richLink.stories.tsx
+++ b/apps-rendering/src/components/richLink.stories.tsx
@@ -37,7 +37,7 @@ const Default: FC = () => (
 
 export default {
 	component: RichLink,
-	title: 'Rich Link',
+	title: 'AR/Rich Link',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/standfirst.stories.tsx
+++ b/apps-rendering/src/components/standfirst.stories.tsx
@@ -61,7 +61,7 @@ const Comment = (): ReactElement => (
 
 export default {
 	component: Standfirst,
-	title: 'Standfirst',
+	title: 'AR/Standfirst',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/starRating.stories.tsx
+++ b/apps-rendering/src/components/starRating.stories.tsx
@@ -26,7 +26,7 @@ const NotReview = (): ReactElement => <StarRating item={article} />;
 
 export default {
 	component: StarRating,
-	title: 'Star Rating',
+	title: 'AR/Star Rating',
 	decorators: [withKnobs],
 };
 

--- a/apps-rendering/src/components/tags.stories.tsx
+++ b/apps-rendering/src/components/tags.stories.tsx
@@ -21,7 +21,7 @@ const Default = (format: Format): JSX.Element => (
 
 export default {
 	component: Tags,
-	title: 'Tags',
+	title: 'AR/Tags',
 	decorators: [withKnobs],
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Prefix all AR stories with `AR/` to move them into their own subfolder

A second PR could be raised to move all of the DCR stories into a `DCR/` subdirectory - this would be a much larger process

## Why?

There was no way to distinguish between AR and DCR stories

### Before

![image](https://user-images.githubusercontent.com/9575458/132038758-05568f6b-4bee-41ef-8805-3c1d533d89ef.png)

### After

![image](https://user-images.githubusercontent.com/9575458/132038681-fbc1e9df-41cc-49da-bc17-f8c48568fbb1.png)

