### PR TITLE
Remove `editor.formatOnSave`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "editor.formatOnSave": true,
     "eslint.validate": ["typescript", "typescriptreact"],
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true


### PR DESCRIPTION
## Why?

Two reasons:

1. It's currently formatting AR files in a way that conflicts with the ESLint config, which prevents validation from passing
2. I don't think this should be something specified at the project level - I think it should be up to each developer to decide whether this setting is something they want as part of their workflow

## Changes

- Remove `editor.formatOnSave`
