### PR TITLE
Enable TCF API on AMP

### DIFF
--- a/dotcom-rendering/src/amp/components/AdConsent.tsx
+++ b/dotcom-rendering/src/amp/components/AdConsent.tsx
@@ -104,6 +104,7 @@ export const AdConsent: React.FC = ({}) => {
 								clientConfig: clientConfigAus,
 							},
 						},
+						exposesTcfApi: true,
 					}}
 				/>
 			</amp-consent>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Enable access to the TCF API on AMP pages.

## Why?

This will allow Teads to access the TCF API and TC string on the page (being in a SafeFrame).
