### PR TITLE
Update Atoms to 18.0.1 For Temporary Quiz Fix

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -40,7 +40,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^18.0.0",
+    "@guardian/atoms-rendering": "^18.0.1",
     "@guardian/automat-contributions": "^0.4.0",
     "@guardian/braze-components": "^3.4.0",
     "@guardian/commercial-core": "^0.19.2",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1719,10 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.0.tgz#b2035deebdac8a2de372bd42e87d6828d5e85ca9"
-  integrity sha512-lRKlt1utgxzUlOGiOwbpYR6c6R+quUCtZr3bMDIwzsi83f8L++uwI7ncH4BT1uuWbrTs/BVGZP/7xFHB7DMlUQ==
+"@guardian/atoms-rendering@^18.0.1":
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.1.tgz#3c05b514f5ea3883f64c37fe29973db813ff1301"
+  integrity sha512-UqWsEC3KUETwRM8sbhZQTLXWvlWcFg09EpdPGhMxLXKvtnoqMALWjOkp7mH4hu8n/AwaihLQjiiAXbrw/m787w==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps atoms rendering to provide a temporary fix to knowledge quizzes as they are showing the incorrect message.

This is a temporary fix.

### Before
![Screenshot 2021-09-06 at 12 21 23](https://user-images.githubusercontent.com/35331926/132229220-c99e303d-e158-427d-84b1-0a43c0428894.png)


### After
![Screenshot 2021-09-06 at 12 22 00](https://user-images.githubusercontent.com/35331926/132229155-8dc69aa1-efad-4c42-8b87-3d6a53a53a6b.png)
