### PR TITLE
Ravi/fix bonzai skin 2

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -45,7 +45,7 @@ export const HeaderAdSlot: React.FC<{
 				*/
 				.bz-custom-container
 					~ #bannerandheader
-					> .top-banner-ad-container {
+					.top-banner-ad-container {
 					display: none;
 				}
 			`}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -316,7 +316,7 @@ export const CommentLayout = ({
 
 	return (
 		<>
-			<div>
+			<div id="bannerandheader">
 				<Stuck>
 					<ElementContainer
 						showTopBorder={false}


### PR DESCRIPTION
## What does this change?

Hide the top-above-nav ad-slot container when a Bonzai TruSkin (Australian 3rd Party page skin) is shown.

This PR extends the [previous PR](https://github.com/guardian/dotcom-rendering/pull/3372) to:

1) amend the CSS selector to target descendants for `#bannerandheader`.
1) add the fix to page types of 'comment' 

This is a **temporary fix** and we will revert asap.

### Before

![image](https://user-images.githubusercontent.com/7014230/132022723-63d0e560-6410-42dc-9999-33a38b99bbbb.png)

