### PR TITLE
Enable prebid on mobile sticky ads

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -26,9 +26,24 @@ const ampData = (section: string, contentType: string): string => {
 	return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
+/**
+ * Determine the Placement ID that is used to look up a given stored bid request
+ *
+ * Stored bid requests are stored by the prebid server instance and each is
+ * keyed by a placement ID. This placement ID corresponds to the tag id parameter
+ * provided on the client
+ *
+ * @param isSticky Whether the ad is sticky - sticky ads have stored bid requests
+ * containing different SSP ids to non-sticky ads
+ * @param adRegion The advertising region - different regions are covered by different
+ * stored bid requests
+ * @returns The placement id for an ad, depending on its ad region and whether
+ * it is sticky
+ */
 const getPlacementId = (isSticky: boolean, adRegion: AdRegion): number => {
 	switch (adRegion) {
 		case 'US': {
+			// In the US use different placement IDs depending on whether ad is sticky
 			return isSticky ? 22138171 : 7;
 		}
 		case 'AU':
@@ -48,8 +63,10 @@ const realTimeConfig = (
 	const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
-
 	const prebidURL = [
+		// The tag_id in the URL is used to look up the bulk of the request
+		// In this case it corresponds to the placement ID of the bid requests
+		// on the prebid server
 		`${preBidServerPrefix}?tag_id=${placementID}`,
 		'w=ATTR(width)',
 		'h=ATTR(height)',

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -26,10 +26,11 @@ const ampData = (section: string, contentType: string): string => {
 	return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
-const getPlacementId = (adRegion: AdRegion): number => {
+const getPlacementId = (isSticky: boolean, adRegion: AdRegion): number => {
 	switch (adRegion) {
-		case 'US':
-			return 7;
+		case 'US': {
+			return isSticky ? 22138171 : 7;
+		}
 		case 'AU':
 			return 6;
 		default:
@@ -38,11 +39,12 @@ const getPlacementId = (adRegion: AdRegion): number => {
 };
 
 const realTimeConfig = (
+	isSticky: boolean,
 	adRegion: AdRegion,
 	usePrebid: boolean,
 	usePermutive: boolean,
 ): any => {
-	const placementID = getPlacementId(adRegion);
+	const placementID = getPlacementId(isSticky, adRegion);
 	const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
@@ -89,7 +91,7 @@ export interface AdProps {
 }
 
 export const Ad = ({
-	isSticky,
+	isSticky = false,
 	adRegion,
 	edition,
 	section,
@@ -123,6 +125,7 @@ export const Ad = ({
 					)}
 					data-slot={ampData(section, contentType)}
 					rtc-config={realTimeConfig(
+						isSticky,
 						adRegion,
 						config.usePrebid,
 						config.usePermutive,


### PR DESCRIPTION
## What does this change?

Enable prebid on mobile sticky ads.

## Why?

Allow SSPs to bid on mobile sticky slots on AMP, hopefully leading to a revenue uplift.
