### PR TITLE
Refactor ad region logic

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.test.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.test.tsx
@@ -33,32 +33,13 @@ describe('AdComponent', () => {
 
 	it('rtc-config returns correctly formed Permutive and PreBid URLs when usePermutive and usePrebid flags are set to true', () => {
 		const { container } = render(
-			<>
-				<Ad
-					adRegion="US"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="AU"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="ROW"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-			</>,
+			<Ad
+				edition={edition}
+				section={section || ''}
+				contentType={contentType}
+				config={commercialConfig}
+				commercialProperties={commercialProperties}
+			/>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
@@ -105,32 +86,13 @@ describe('AdComponent', () => {
 		commercialConfig.usePermutive = false;
 
 		const { container } = render(
-			<>
-				<Ad
-					adRegion="US"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="AU"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="ROW"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-			</>,
+			<Ad
+				edition={edition}
+				section={section || ''}
+				contentType={contentType}
+				config={commercialConfig}
+				commercialProperties={commercialProperties}
+			/>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
@@ -168,32 +130,13 @@ describe('AdComponent', () => {
 		commercialConfig.usePrebid = false;
 
 		const { container } = render(
-			<>
-				<Ad
-					adRegion="US"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="AU"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="ROW"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-			</>,
+			<Ad
+				edition={edition}
+				section={section || ''}
+				contentType={contentType}
+				config={commercialConfig}
+				commercialProperties={commercialProperties}
+			/>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
@@ -232,32 +175,13 @@ describe('AdComponent', () => {
 		commercialConfig.usePermutive = false;
 
 		const { container } = render(
-			<>
-				<Ad
-					adRegion="US"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="AU"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-				<Ad
-					adRegion="ROW"
-					edition={edition}
-					section={section || ''}
-					contentType={contentType}
-					config={commercialConfig}
-					commercialProperties={commercialProperties}
-				/>
-			</>,
+			<Ad
+				edition={edition}
+				section={section || ''}
+				contentType={contentType}
+				config={commercialConfig}
+				commercialProperties={commercialProperties}
+			/>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -15,6 +15,9 @@ const stickySizes = [{ width: 320, height: 50 }]; // Mobile Leaderboard
 
 type AdRegion = 'US' | 'AU' | 'ROW';
 
+// Array of possible ad regions
+const adRegions: AdRegion[] = ['US', 'AU', 'ROW'];
+
 const dfpAdUnitRoot = 'theguardian.com';
 
 const ampData = (section: string, contentType: string): string => {
@@ -81,7 +84,6 @@ interface CommercialConfig {
 
 export interface AdProps {
 	isSticky?: boolean;
-	adRegion: AdRegion;
 	edition: Edition;
 	section: string;
 	contentType: string;
@@ -89,7 +91,11 @@ export interface AdProps {
 	commercialProperties: CommercialProperties;
 }
 
-export const Ad = ({
+export interface RegionalAdProps extends AdProps {
+	adRegion: AdRegion;
+}
+
+export const RegionalAd = ({
 	isSticky,
 	adRegion,
 	edition,
@@ -97,7 +103,7 @@ export const Ad = ({
 	contentType,
 	config,
 	commercialProperties,
-}: AdProps) => {
+}: RegionalAdProps) => {
 	const adSizes = isSticky ? stickySizes : inlineSizes;
 	// Set Primary ad size as first element (should be the largest)
 	const [{ width, height }] = adSizes;
@@ -141,3 +147,26 @@ export const Ad = ({
 		</ClassNames>
 	);
 };
+
+export const Ad = ({
+	isSticky,
+	edition,
+	section,
+	contentType,
+	config,
+	commercialProperties,
+}: AdProps) => (
+	<>
+		{adRegions.map((adRegion) => (
+			<RegionalAd
+				adRegion={adRegion}
+				isSticky={isSticky}
+				edition={edition}
+				section={section}
+				contentType={contentType}
+				config={config}
+				commercialProperties={commercialProperties}
+			/>
+		))}
+	</>
+);

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -147,23 +147,6 @@ export const Blocks: React.FunctionComponent<{
 								css={adStyle}
 							>
 								<Ad
-									adRegion="US"
-									edition={edition}
-									section={section || ''}
-									contentType={contentType}
-									config={adConfig}
-									commercialProperties={commercialProperties}
-								/>
-								<Ad
-									adRegion="AU"
-									edition={edition}
-									section={section || ''}
-									contentType={contentType}
-									config={adConfig}
-									commercialProperties={commercialProperties}
-								/>
-								<Ad
-									adRegion="ROW"
 									edition={edition}
 									section={section || ''}
 									contentType={contentType}

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -140,27 +140,6 @@ export const Body: React.FC<{
 								css={adStyle}
 							>
 								<Ad
-									adRegion="US"
-									edition={data.editionId}
-									section={data.sectionName || ''}
-									contentType={adInfo.contentType}
-									config={adConfig}
-									commercialProperties={
-										adInfo.commercialProperties
-									}
-								/>
-								<Ad
-									adRegion="AU"
-									edition={data.editionId}
-									section={data.sectionName || ''}
-									contentType={adInfo.contentType}
-									config={adConfig}
-									commercialProperties={
-										adInfo.commercialProperties
-									}
-								/>
-								<Ad
-									adRegion="ROW"
 									edition={data.editionId}
 									section={data.sectionName || ''}
 									contentType={adInfo.contentType}

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -1,7 +1,6 @@
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { AdProps } from './Ad';
-import { Ad } from './Ad';
+import { RegionalAd, RegionalAdProps } from './Ad';
 
 // This CSS should be imported and added to global styles in amp/server/document.tsx to add the Advertisment label to the sticky
 export const stickyAdLabelCss = `
@@ -24,10 +23,10 @@ export const StickyAd = ({
 	contentType,
 	config,
 	commercialProperties,
-}: AdProps) => {
+}: RegionalAdProps) => {
 	return (
 		<amp-sticky-ad layout="nodisplay">
-			<Ad
+			<RegionalAd
 				isSticky={true}
 				adRegion={adRegion}
 				edition={edition}


### PR DESCRIPTION
## What does this change?

Move the logic that renders ads based on regions into the `<Ad />` component. This component renders a `<RegionalAd />` component for each ad region (currently US, AU and ROW) which has the amp-geo classes applied to ensure only the component in the user's region is displayed.

## Why?

Previously the responsibility for ensuring that ads for each region were included fell upon the component that rendered them. This change means the renderer is required to simply include one component regardless of region and leaves the responsibility of rendering the correct regional ad to `<Ad />`. This should also make it simpler to add/modify regions.

