### PR TITLE
`Page`

### DIFF
--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -1,0 +1,36 @@
+import React, { StrictMode } from 'react';
+import { EmotionCache } from '@emotion/cache';
+import { CacheProvider, Global, css } from '@emotion/react';
+import { focusHalo } from '@guardian/src-foundations/accessibility';
+
+type Props = {
+	children: React.ReactNode;
+	cache: EmotionCache;
+};
+
+/**
+ * @description
+ * Page is a high level wrapper for pages on Dotcom. Sets strict mode, some globals
+ * and the Emotion cache
+ *
+ * @param {ReactNode} children - What gets rendered on the page
+ * @param {EmotionCache} cache - Provides the Emotion cache
+ * */
+export const Page = ({ children, cache }: Props) => {
+	return (
+		<CacheProvider value={cache}>
+			<StrictMode>
+				<Global
+					styles={css`
+						/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+						/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+						*:focus {
+							${focusHalo}
+						}
+					`}
+				/>
+				{children}
+			</StrictMode>
+		</CacheProvider>
+	);
+};

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -1,11 +1,9 @@
-import { StrictMode } from 'react';
 import { renderToString } from 'react-dom/server';
 
 import createEmotionServer from '@emotion/server/create-instance';
 import createCache from '@emotion/cache';
-import { CacheProvider, Global, css } from '@emotion/react';
 
-import { focusHalo } from '@guardian/src-foundations/accessibility';
+import { Page } from '@root/src/web/components/Page';
 
 import { escapeData } from '@root/src/lib/escapeData';
 import {
@@ -70,20 +68,9 @@ export const document = ({ data }: Props): string => {
 		ids: cssIDs,
 	}: RenderToStringResult = extractCritical(
 		renderToString(
-			<CacheProvider value={cache}>
-				<StrictMode>
-					<Global
-						styles={css`
-							/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-							/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-							*:focus {
-								${focusHalo}
-							}
-						`}
-					/>
-					<DecideLayout CAPI={CAPI} NAV={NAV} />
-				</StrictMode>
-			</CacheProvider>,
+			<Page cache={cache}>
+				<DecideLayout CAPI={CAPI} NAV={NAV} />
+			</Page>,
 		),
 	);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `Page` component. An abstraction broken out from `document.tsx`.

```ts
/**
 * @description
 * Page is a high level wrapper for pages on Dotcom. Sets strict mode, some globals
 * and the Emotion cache
 *
 * @param {ReactNode} children - What gets rendered on the page
 * @param {EmotionCache} cache - Provides the Emotion cache
 * */
```

## Why?
By breaking out the logic for what defines a page in DCR we have the ability to consider other use cases in the future. We will probably always want strict mode on, centralised global css and an emotion cache set but perhaps we want to pass in other content, such as a Newsletters page? This supports that use case.