### PR TITLE
Dependabot For Root Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@
 version: 2
 updates:
     - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+    - package-ecosystem: 'npm'
       directory: '/apps-rendering'
       schedule:
           interval: 'daily'


### PR DESCRIPTION
## Why?

We want dependabot to pick up changes to the root dependency tree.

## Changes

- Adds dependabot to the root dependency tree
