### PR TITLE
Cypress Workflow - Ubuntu 20.04

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     cypress:
         name: DCR Cypress
-        runs-on: ubuntu-16.04
+        runs-on: ubuntu-20.04
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
## Why?

Ubuntu 20.04 is the most recent LTS version. List of available GH Action virtual environments here: https://github.com/actions/virtual-environments#available-environments

## Changes

- Update cypress workflow to use Ubuntu 20.04
