### PR TITLE
Migrate `image-rendering` Into `common-rendering`

### DIFF
--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -8,14 +8,20 @@
     "dependencies": {
         "@emotion/react": "^11.4.1",
         "@guardian/src-foundations": "^3.9.0",
-        "react": "^17.0.2"
+        "react": "^17.0.2",
+        "@guardian/types": "^8.0.0"
     },
     "devDependencies": {
+        "@emotion/jest": "^11.3.0",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
+        "react-test-renderer": "^17.0.1",
         "ts-jest": "^26.5.3"
     },
     "jest": {
-        "preset": "ts-jest/presets/js-with-ts"
+        "preset": "ts-jest/presets/js-with-ts",
+        "transformIgnorePatterns": [
+            "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
+        ]
     }
 }

--- a/common-rendering/src/__snapshots__/sizes.test.tsx.snap
+++ b/common-rendering/src/__snapshots__/sizes.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sizesAttribute returns a list of media queries 1`] = `"(min-width: 980px) 20px, (min-width: 740px) 20%, 30vw"`;
+
+exports[`styles returns dimensions for each media query 1`] = `
+<div
+  className="css-9i4kf7"
+/>
+`;
+
+exports[`styles returns the default dimensions when there are no media queries 1`] = `
+<div
+  className="css-1xhyoy7"
+/>
+`;

--- a/common-rendering/src/components/bodyImage.stories.tsx
+++ b/common-rendering/src/components/bodyImage.stories.tsx
@@ -1,0 +1,104 @@
+/* eslint-disable import/no-default-export -- exclude stories for this rule */
+
+// ----- Imports ----- //
+
+import { Design, Display, none, Pillar, Role, some } from "@guardian/types";
+import type { FC } from "react";
+import { image } from "../fixtures/image";
+import { BodyImage } from "./bodyImage";
+
+// ----- Setup ----- //
+
+const format = {
+  design: Design.Article,
+  display: Display.Standard,
+  theme: Pillar.News,
+};
+const caption = some(
+  "Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images"
+);
+const copy = (
+  <>
+    <p>
+      Ever since Mexico City was founded on an island in the lake of Texcoco its
+      inhabitants have dreamed of water: containing it, draining it and now
+      retaining it.
+    </p>
+    <p>
+      Nezahualcoyotl, the illustrious lord of Texcoco, made his name
+      constructing a dyke shielding Mexico City’s Aztec predecessor city of
+      Tenochtitlan from flooding. The gravest threat to Mexico City’s existence
+      came from a five-year flood starting in 1629, almost causing the city to
+      be abandoned. Ironically now its surrounding lake system has been drained,
+      the greatest threat to the city’s existence is probably the rapid decline
+      of its overstressed aquifers.
+    </p>
+  </>
+);
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+  <BodyImage
+    image={image}
+    format={format}
+    supportsDarkMode={true}
+    lightbox={none}
+    caption={caption}
+    leftColumnBreakpoint={none}
+  />
+);
+
+const NoCaption: FC = () => (
+  <BodyImage
+    image={image}
+    format={format}
+    supportsDarkMode={true}
+    lightbox={none}
+    caption={none}
+    leftColumnBreakpoint={none}
+  />
+);
+
+const Thumbnail: FC = () => (
+  <>
+    <BodyImage
+      image={{
+        ...image,
+        role: Role.Thumbnail,
+      }}
+      format={format}
+      supportsDarkMode={true}
+      lightbox={none}
+      caption={caption}
+      leftColumnBreakpoint={none}
+    />
+    {copy}
+  </>
+);
+
+const ThumbnailNoCaption: FC = () => (
+  <>
+    <BodyImage
+      image={{
+        ...image,
+        role: Role.Thumbnail,
+      }}
+      format={format}
+      supportsDarkMode={true}
+      lightbox={none}
+      caption={none}
+      leftColumnBreakpoint={none}
+    />
+    {copy}
+  </>
+);
+
+// ----- Exports ----- //
+
+export default {
+  component: BodyImage,
+  title: "Common/Components/BodyImage",
+};
+
+export { Default, NoCaption, Thumbnail, ThumbnailNoCaption };

--- a/common-rendering/src/components/bodyImage.tsx
+++ b/common-rendering/src/components/bodyImage.tsx
@@ -1,0 +1,127 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
+import { remSpace } from "@guardian/src-foundations";
+import type { Breakpoint } from "@guardian/src-foundations/mq";
+import { from } from "@guardian/src-foundations/mq";
+import type { Format, Option } from "@guardian/types";
+import { none, Role, some, withDefault } from "@guardian/types";
+import type { FC, ReactNode } from "react";
+import type { Image } from "../image";
+import { darkModeCss } from "../lib";
+import type { Lightbox } from "../lightbox";
+import type { Sizes } from "../sizes";
+import { FigCaption } from "./figCaption";
+import { Img } from "./img";
+
+// ----- Setup ----- //
+
+const width = "100%";
+const phabletWidth = "620px";
+const thumbnailWidth = "8.75rem";
+
+// ----- Functions ----- //
+
+const getSizes = (role: Role): Sizes => {
+  switch (role) {
+    case Role.Thumbnail:
+      return {
+        mediaQueries: [],
+        default: thumbnailWidth,
+      };
+    default:
+      return {
+        mediaQueries: [{ breakpoint: "phablet", size: phabletWidth }],
+        default: width,
+      };
+  }
+};
+
+// ----- Component ----- //
+
+type Props = {
+  image: Image;
+  format: Format;
+  supportsDarkMode: boolean;
+  lightbox: Option<Lightbox>;
+  caption: Option<ReactNode>;
+  leftColumnBreakpoint: Option<Breakpoint>;
+};
+
+const styles = css`
+  margin: ${remSpace[4]} 0;
+  width: ${width};
+
+  ${from.phablet} {
+    width: ${phabletWidth};
+  }
+`;
+
+const thumbnailStyles = (
+  leftColumnBreakpoint: Breakpoint
+): SerializedStyles => css`
+  float: left;
+  width: ${thumbnailWidth};
+  margin: 0 ${remSpace[3]} 0 0;
+
+  ${from[leftColumnBreakpoint]} {
+    position: absolute;
+    transform: translateX(calc(-100% - ${remSpace[4]}));
+  }
+`;
+
+const imgStyles = (
+  role: Role,
+  supportsDarkMode: boolean
+): Option<SerializedStyles> => {
+  switch (role) {
+    case Role.Thumbnail:
+      return some(css`
+        background-color: transparent;
+
+        ${darkModeCss(supportsDarkMode)`
+                    background-color: transparent;
+                `}
+      `);
+    default:
+      return none;
+  }
+};
+
+const getStyles = (
+  role: Role,
+  leftColumnBreakpoint: Option<Breakpoint>
+): SerializedStyles => {
+  switch (role) {
+    case Role.Thumbnail:
+      return thumbnailStyles(
+        withDefault<Breakpoint>("leftCol")(leftColumnBreakpoint)
+      );
+    default:
+      return styles;
+  }
+};
+
+export const BodyImage: FC<Props> = ({
+  image,
+  format,
+  supportsDarkMode,
+  lightbox,
+  caption,
+  leftColumnBreakpoint,
+}) => (
+  <figure css={getStyles(image.role, leftColumnBreakpoint)}>
+    <Img
+      image={image}
+      sizes={getSizes(image.role)}
+      className={imgStyles(image.role, supportsDarkMode)}
+      format={format}
+      supportsDarkMode={supportsDarkMode}
+      lightbox={lightbox}
+    />
+    <FigCaption format={format} supportsDarkMode={supportsDarkMode}>
+      {caption}
+    </FigCaption>
+  </figure>
+);

--- a/common-rendering/src/components/figCaption.stories.tsx
+++ b/common-rendering/src/components/figCaption.stories.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable import/no-default-export -- exclude stories for this rule */
+
+// ----- Imports ----- //
+
+import { Design, Display, Pillar, some } from "@guardian/types";
+import type { FC } from "react";
+import { FigCaption } from "./figCaption";
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+  <FigCaption
+    format={{
+      design: Design.Article,
+      display: Display.Standard,
+      theme: Pillar.News,
+    }}
+    supportsDarkMode={true}
+  >
+    {some(
+      "Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images"
+    )}
+  </FigCaption>
+);
+
+// ----- Exports ----- //
+
+export default {
+  component: FigCaption,
+  title: "Common/Components/FigCaption",
+};
+
+export { Default };

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -1,0 +1,106 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
+import { remSpace } from "@guardian/src-foundations";
+import { brandAltText, neutral, text } from "@guardian/src-foundations/palette";
+import { textSans } from "@guardian/src-foundations/typography";
+import type { Format, Option } from "@guardian/types";
+import { Design, OptionKind } from "@guardian/types";
+import type { FC, ReactNode } from "react";
+import { fill } from "../editorialPalette";
+import { darkModeCss } from "../lib";
+
+// ----- Sub-Components ----- //
+
+interface TriangleProps {
+  format: Format;
+  supportsDarkMode: boolean;
+}
+
+const triangleStyles = (
+  format: Format,
+  supportsDarkMode: boolean
+): SerializedStyles => css`
+  fill: ${fill.iconPrimary(format)};
+  height: 0.8em;
+  padding-right: ${remSpace[1]};
+
+  ${darkModeCss(supportsDarkMode)`
+        fill: ${fill.iconPrimaryInverse(format)};
+    `}
+`;
+
+const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
+  switch (format.design) {
+    case Design.Media:
+      return null;
+    default:
+      return (
+        <svg
+          css={triangleStyles(format, supportsDarkMode)}
+          viewBox="0 0 10 9"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon points="0,9 5,0 10,9" />
+        </svg>
+      );
+  }
+};
+
+// ----- Component ----- //
+
+type Props = {
+  format: Format;
+  supportsDarkMode: boolean;
+  children: Option<ReactNode>;
+};
+
+const styles = (supportsDarkMode: boolean) => css`
+  ${textSans.xxsmall({ lineHeight: "regular" })}
+  padding-top: ${remSpace[2]};
+  color: ${text.supporting};
+
+  ${darkModeCss(supportsDarkMode)`
+    color: ${brandAltText.supporting};
+  `}
+`;
+
+const mediaStyles = (supportsDarkMode: boolean) => css`
+  color: ${neutral[86]};
+
+  ${darkModeCss(supportsDarkMode)`
+    color: ${neutral[86]};
+  `}
+`;
+
+const getStyles = (
+  format: Format,
+  supportsDarkMode: boolean
+): SerializedStyles => {
+  switch (format.design) {
+    case Design.Media:
+      return css(styles(supportsDarkMode), mediaStyles(supportsDarkMode));
+    default:
+      return styles(supportsDarkMode);
+  }
+};
+
+export const FigCaption: FC<Props> = ({
+  format,
+  supportsDarkMode,
+  children,
+}) => {
+  switch (children.kind) {
+    case OptionKind.Some:
+      return (
+        <figcaption css={getStyles(format, supportsDarkMode)}>
+          <Triangle format={format} supportsDarkMode={supportsDarkMode} />
+          {children.value}
+        </figcaption>
+      );
+
+    default:
+      return null;
+  }
+};

--- a/common-rendering/src/components/img.stories.tsx
+++ b/common-rendering/src/components/img.stories.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable import/no-default-export -- exclude stories for this rule */
+
+// ----- Imports ----- //
+
+import { Design, Display, none, Pillar } from "@guardian/types";
+import type { FC } from "react";
+import { image } from "../fixtures/image";
+import { Img } from "./img";
+
+// ----- Setup ----- //
+
+const sizes = { mediaQueries: [], default: "40vw" };
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+  <Img
+    image={image}
+    sizes={sizes}
+    className={none}
+    format={{
+      design: Design.Article,
+      display: Display.Standard,
+      theme: Pillar.News,
+    }}
+    supportsDarkMode={true}
+    lightbox={none}
+  />
+);
+
+const Placeholder: FC = () => (
+  <Img
+    image={{
+      ...image,
+      src: "",
+      srcset: "",
+      dpr2Srcset: "",
+    }}
+    sizes={sizes}
+    className={none}
+    format={{
+      design: Design.Article,
+      display: Display.Standard,
+      theme: Pillar.News,
+    }}
+    supportsDarkMode={true}
+    lightbox={none}
+  />
+);
+
+// ----- Exports ----- //
+
+export default {
+  component: Img,
+  title: "Common/Components/Img",
+  parameters: {
+    chromatic: { diffThreshold: 0.25 },
+  },
+};
+
+export { Default, Placeholder };

--- a/common-rendering/src/components/img.tsx
+++ b/common-rendering/src/components/img.tsx
@@ -1,0 +1,83 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
+import { neutral } from "@guardian/src-foundations/palette";
+import type { Format, Option } from "@guardian/types";
+import { Design, withDefault } from "@guardian/types";
+import type { FC } from "react";
+import type { Image } from "../image";
+import { darkModeCss } from "../lib";
+import type { Lightbox } from "../lightbox";
+import { getCaption, getClassName, getCredit } from "../lightbox";
+import { sizesAttribute, styles as sizeStyles } from "../sizes";
+import type { Sizes } from "../sizes";
+
+// ----- Functions ----- //
+
+const backgroundColour = (format: Format): string => {
+  switch (format.design) {
+    case Design.Media:
+      return neutral[20];
+    case Design.Comment:
+    case Design.Letter:
+      return neutral[86];
+    default:
+      return neutral[97];
+  }
+};
+
+// ----- Component ----- //
+
+type Props = {
+  image: Image;
+  sizes: Sizes;
+  className: Option<SerializedStyles>;
+  format: Format;
+  supportsDarkMode: boolean;
+  lightbox: Option<Lightbox>;
+};
+
+const styles = (
+  format: Format,
+  supportsDarkMode: boolean
+): SerializedStyles => css`
+  background-color: ${backgroundColour(format)};
+  color: ${neutral[60]};
+  display: block;
+
+  ${darkModeCss(supportsDarkMode)`
+        background-color: ${neutral[20]};
+    `}
+`;
+
+export const Img: FC<Props> = ({
+  image,
+  sizes,
+  className,
+  format,
+  supportsDarkMode,
+  lightbox,
+}) => (
+  <picture>
+    <source
+      sizes={sizesAttribute(sizes)}
+      srcSet={image.dpr2Srcset}
+      media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+    />
+    <source sizes={sizesAttribute(sizes)} srcSet={image.srcset} />
+    <img
+      src={image.src}
+      alt={withDefault("")(image.alt)}
+      className={getClassName(image.width, lightbox)}
+      css={[
+        sizeStyles(sizes, image.width, image.height),
+        styles(format, supportsDarkMode),
+        withDefault<SerializedStyles | undefined>(undefined)(className),
+      ]}
+      data-ratio={image.height / image.width}
+      data-caption={getCaption(lightbox)}
+      data-credit={getCredit(lightbox)}
+    />
+  </picture>
+);

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -1,0 +1,65 @@
+// ----- Imports ----- //
+
+import {
+  culture,
+  lifestyle,
+  news,
+  opinion,
+  specialReport,
+  sport,
+} from "@guardian/src-foundations/palette";
+import type { Format } from "@guardian/types";
+import { Pillar, Special } from "@guardian/types";
+
+// ----- Types ----- //
+
+type Colour = string;
+
+// ----- Functions ----- //
+
+const fillIconPrimary = (format: Format): Colour => {
+  switch (format.theme) {
+    case Pillar.Opinion:
+      return opinion[400];
+    case Pillar.Sport:
+      return sport[400];
+    case Pillar.Culture:
+      return culture[400];
+    case Pillar.Lifestyle:
+      return lifestyle[400];
+    case Special.SpecialReport:
+      return specialReport[500];
+    case Pillar.News:
+    default:
+      return news[400];
+  }
+};
+
+const fillIconPrimaryInverse = (format: Format): Colour => {
+  switch (format.theme) {
+    case Pillar.Opinion:
+      return opinion[500];
+    case Pillar.Sport:
+      return sport[500];
+    case Pillar.Culture:
+      return culture[500];
+    case Pillar.Lifestyle:
+      return lifestyle[500];
+    case Special.SpecialReport:
+      return specialReport[500];
+    case Pillar.News:
+    default:
+      return news[500];
+  }
+};
+
+// ----- API ----- //
+
+const fill = {
+  iconPrimary: fillIconPrimary,
+  iconPrimaryInverse: fillIconPrimaryInverse,
+};
+
+// ----- Exports ----- //
+
+export { fill };

--- a/common-rendering/src/fixtures/image.ts
+++ b/common-rendering/src/fixtures/image.ts
@@ -1,0 +1,23 @@
+// ----- Imports ----- //
+
+import { Role, some } from "@guardian/types";
+import type { Image } from "../image";
+
+// ----- Fixtures ----- //
+
+const image: Image = {
+  src:
+    "https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=85&fit=bounds&s=f1467e8be532692f4aaa9597adc07306",
+  srcset:
+    "https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=140&quality=85&fit=bounds&s=822845d0639c4b4deb572c7e6f72baea 140w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=85&fit=bounds&s=f1467e8be532692f4aaa9597adc07306 500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1000&quality=85&fit=bounds&s=ccf2535722cc3f3034495dae0e761e0c 1000w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1500&quality=85&fit=bounds&s=7764655d28b562fbbcc184c3bd46e7b2 1500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=2000&quality=85&fit=bounds&s=78425cffd6524942947d5177a5713bdd 2000w",
+  dpr2Srcset:
+    "https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=140&quality=45&fit=bounds&s=ad06e480e9a2cbd3f59c77f6b1f06454 140w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=45&fit=bounds&s=1fe31b8d41295aba16065512712d59c9 500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1000&quality=45&fit=bounds&s=35194881b5e1c282daf291a59cafba65 1000w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1500&quality=45&fit=bounds&s=37a96bc69746a31f7cd982b21d63ef13 1500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=2000&quality=45&fit=bounds&s=07fa87119df669fb396b8f81732b7674 2000w",
+  alt: some("Demo image"),
+  width: 5644,
+  height: 3387,
+  role: Role.Standard,
+};
+
+// ----- Exports ----- //
+
+export { image };

--- a/common-rendering/src/image.ts
+++ b/common-rendering/src/image.ts
@@ -1,0 +1,19 @@
+// ----- Imports ----- //
+
+import type { Option, Role } from "@guardian/types";
+
+// ----- Types ----- //
+
+interface Image {
+  src: string;
+  srcset: string;
+  dpr2Srcset: string;
+  alt: Option<string>;
+  width: number;
+  height: number;
+  role: Role;
+}
+
+// ----- Exports ----- //
+
+export type { Image };

--- a/common-rendering/src/lib.ts
+++ b/common-rendering/src/lib.ts
@@ -1,0 +1,26 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
+
+// ----- Functions ----- //
+
+const darkModeCss = (supportsDarkMode: boolean) => (
+  styles: TemplateStringsArray,
+  ...placeholders: string[]
+): SerializedStyles =>
+  supportsDarkMode
+    ? css`
+        @media (prefers-color-scheme: dark) {
+          ${styles
+            .map(
+              (style, i) => `${style}${placeholders[i] ? placeholders[i] : ""}`
+            )
+            .join("")}
+        }
+      `
+    : css``;
+
+// ----- Exports ----- //
+
+export { darkModeCss };

--- a/common-rendering/src/lightbox.ts
+++ b/common-rendering/src/lightbox.ts
@@ -1,0 +1,59 @@
+// ----- Imports ----- //
+
+import type { Option } from "@guardian/types";
+import { OptionKind } from "@guardian/types";
+
+// ----- Types ----- //
+
+interface Lightbox {
+  className: string;
+  caption: Option<string>;
+  credit: Option<string>;
+}
+
+// ----- Functions ----- //
+
+/**
+ * Lightbox is only available for images above a certain size,
+ * we don't enable it for small images (e.g. thumbnails). Therefore
+ * this will only return a lightbox className if one is provided *and*
+ * the image is above a certain width.
+ */
+const getClassName = (
+  imageWidth: number,
+  lightbox: Option<Lightbox>
+): string | undefined => {
+  if (imageWidth > 620 && lightbox.kind === OptionKind.Some) {
+    return lightbox.value.className;
+  }
+
+  return undefined;
+};
+
+const getCaption = (lightbox: Option<Lightbox>): string | undefined => {
+  if (
+    lightbox.kind === OptionKind.Some &&
+    lightbox.value.caption.kind === OptionKind.Some
+  ) {
+    return lightbox.value.caption.value;
+  }
+
+  return undefined;
+};
+
+const getCredit = (lightbox: Option<Lightbox>): string | undefined => {
+  if (
+    lightbox.kind === OptionKind.Some &&
+    lightbox.value.credit.kind === OptionKind.Some
+  ) {
+    return lightbox.value.credit.value;
+  }
+
+  return undefined;
+};
+
+// ----- Exports ----- //
+
+export type { Lightbox };
+
+export { getClassName, getCaption, getCredit };

--- a/common-rendering/src/sizes.test.tsx
+++ b/common-rendering/src/sizes.test.tsx
@@ -1,0 +1,64 @@
+// ----- Imports ----- //
+
+import { matchers } from "@emotion/jest";
+import { breakpoints } from "@guardian/src-foundations/mq";
+import renderer from "react-test-renderer";
+import type { Sizes } from "./sizes";
+import { sizesAttribute, styles } from "./sizes";
+
+// ----- Setup ----- //
+
+expect.extend(matchers);
+
+const noQueries = { mediaQueries: [], default: "30vw" };
+const sizes: Sizes = {
+  mediaQueries: [
+    { breakpoint: "desktop", size: "20px" },
+    { breakpoint: "tablet", size: "20%" },
+  ],
+  default: "30vw",
+};
+
+// ----- Tests ----- //
+
+describe("sizesAttribute", () => {
+  it("returns the default when there are no media queries", () => {
+    expect(sizesAttribute(noQueries)).toBe(noQueries.default);
+  });
+
+  it("returns a list of media queries", () => {
+    expect(sizesAttribute(sizes)).toMatchSnapshot();
+  });
+});
+
+describe("styles", () => {
+  it("returns the default dimensions when there are no media queries", () => {
+    const component = renderer
+      .create(<div css={styles(noQueries, 2000, 1500)} />)
+      .toJSON();
+
+    expect(component).toMatchSnapshot();
+    expect(component).toHaveStyleRule("width", noQueries.default);
+    expect(component).toHaveStyleRule(
+      "height",
+      `calc(${noQueries.default} * 0.75)`
+    );
+  });
+
+  it("returns dimensions for each media query", () => {
+    const component = renderer
+      .create(<div css={styles(sizes, 600, 300)} />)
+      .toJSON();
+
+    expect(component).toMatchSnapshot();
+    expect(component).toHaveStyleRule("width", "30vw");
+    expect(component).toHaveStyleRule("width", "20%", {
+      media: `(min-width: ${breakpoints.tablet}px)`,
+    });
+    expect(component).toHaveStyleRule(
+      "height",
+      `calc(${sizes.mediaQueries[0].size} * 0.5)`,
+      { media: `(min-width: ${breakpoints.desktop}px)` }
+    );
+  });
+});

--- a/common-rendering/src/sizes.ts
+++ b/common-rendering/src/sizes.ts
@@ -1,0 +1,63 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
+import type { Breakpoint } from "@guardian/src-foundations/mq";
+import { breakpoints, from } from "@guardian/src-foundations/mq";
+
+// ----- Types ----- //
+
+type Size = {
+  breakpoint: Breakpoint;
+  size: string;
+};
+
+type Sizes = {
+  mediaQueries: Size[];
+  default: string;
+};
+
+// ----- Functions ----- //
+
+const sizesAttribute = (sizes: Sizes): string => {
+  if (sizes.mediaQueries.length === 0) {
+    return sizes.default;
+  }
+
+  const queries = sizes.mediaQueries
+    .map(
+      (query) => `(min-width: ${breakpoints[query.breakpoint]}px) ${query.size}`
+    )
+    .join(", ");
+
+  return `${queries}, ${sizes.default}`;
+};
+
+const dimensions = (size: string, ratio: number): SerializedStyles => css`
+  width: ${size};
+  height: calc(${size} * ${ratio});
+`;
+
+const styles = (
+  sizes: Sizes,
+  width: number,
+  height: number
+): SerializedStyles => {
+  const ratio = height / width;
+
+  return css`
+    ${dimensions(sizes.default, ratio)}
+
+    ${sizes.mediaQueries.map(
+      (query) => css`
+        ${from[query.breakpoint]} {
+          ${dimensions(query.size, ratio)}
+        }
+      `
+    )}
+  `;
+};
+
+// ----- Exports ----- //
+
+export { Sizes, styles, sizesAttribute };

--- a/common-rendering/src/srcsets.test.ts
+++ b/common-rendering/src/srcsets.test.ts
@@ -1,0 +1,25 @@
+// ----- Imports ----- //
+
+import { Dpr, srcset } from "./srcsets";
+
+// ----- Tests ----- //
+
+describe("srcsets", () => {
+  test("show lower quality when DPR is 2", () => {
+    const src = srcset(
+      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
+      "",
+      Dpr.Two
+    );
+    expect(src).toContain("quality=45");
+  });
+
+  test("show higher quality when DPR is 1", () => {
+    const src = srcset(
+      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
+      "",
+      Dpr.One
+    );
+    expect(src).toContain("quality=85");
+  });
+});

--- a/common-rendering/src/srcsets.ts
+++ b/common-rendering/src/srcsets.ts
@@ -1,0 +1,90 @@
+// ----- Imports ----- //
+
+import { createHash } from "crypto";
+import type { Result } from "@guardian/types";
+import { fromUnsafe, ResultKind } from "@guardian/types";
+
+// ----- Setup ----- //
+
+const imageResizer = "https://i.guim.co.uk/img";
+
+const defaultWidths = [140, 500, 1000, 1500, 2000, 2500, 3000];
+
+// Percentage.
+const defaultQuality = 85;
+const lowerQuality = 45;
+
+// ----- Types ----- //
+
+const enum Dpr {
+  One,
+  Two,
+}
+
+interface Srcsets {
+  srcset: string;
+  dpr2Srcset: string;
+}
+
+// ----- Functions ----- //
+
+const getSubdomain = (domain: string): string => domain.split(".")[0];
+
+const sign = (salt: string, path: string): string =>
+  createHash("md5")
+    .update(salt + path)
+    .digest("hex");
+
+function src(salt: string, input: string, width: number, dpr: Dpr): string {
+  const maybeUrl: Result<string, URL> = fromUnsafe(
+    () => new URL(input),
+    "invalid url"
+  );
+
+  switch (maybeUrl.kind) {
+    case ResultKind.Ok: {
+      const url = maybeUrl.value;
+      const service = getSubdomain(url.hostname);
+
+      const params = new URLSearchParams({
+        width: width.toString(),
+        quality:
+          dpr === Dpr.Two ? lowerQuality.toString() : defaultQuality.toString(),
+        fit: "bounds",
+      });
+
+      const path = `${url.pathname}?${params.toString()}`;
+      const sig = sign(salt, path);
+
+      return `${imageResizer}/${service}${path}&s=${sig}`;
+    }
+    case ResultKind.Err:
+    default: {
+      return input;
+    }
+  }
+}
+
+const srcsetWithWidths = (widths: number[]) => (
+  url: string,
+  salt: string,
+  dpr: Dpr
+): string =>
+  widths.map((width) => `${src(salt, url, width, dpr)} ${width}w`).join(", ");
+
+const srcset: (
+  url: string,
+  salt: string,
+  dpr: Dpr
+) => string = srcsetWithWidths(defaultWidths);
+
+const srcsets = (url: string, salt: string): Srcsets => ({
+  srcset: srcset(url, salt, Dpr.One),
+  dpr2Srcset: srcset(url, salt, Dpr.Two),
+});
+
+// ----- Exports ----- //
+
+export type { Srcsets };
+
+export { Dpr, src, srcset, srcsets, srcsetWithWidths };

--- a/common-rendering/tsconfig.json
+++ b/common-rendering/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "jsx": "react-jsx",
-        "jsxImportSource": "@emotion/react"
+        "jsxImportSource": "@emotion/react",
+        "allowJs": true,
+        "esModuleInterop": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,14 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
+"@emotion/css-prettifier@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz#3ed4240d93c9798c001cedf27dd0aa960bdddd1a"
+  integrity sha512-efxSrRTiTqHTQVKW15Gz5H4pNAw8OqcG8NaiwkJIkqIdNXTD4Qr1zC1Ou6r2acd1oJJ2s56nb1ClnXMiWoj6gQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    stylis "^4.0.3"
+
 "@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
@@ -1268,6 +1276,17 @@
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
     "@emotion/memoize" "0.7.4"
+
+"@emotion/jest@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.3.0.tgz#43bed6dcb47c8691b346cee231861ebc8f9b0016"
+  integrity sha512-LZqYc3yerhic1IvAcEwBLRs1DsUt3oY7Oz6n+e+HU32iYOK/vpfzlhgmQURE94BHfv6eCOj6DV38f3jSnIkBkQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/css-prettifier" "^1.0.0"
+    chalk "^4.1.0"
+    specificity "^0.4.1"
+    stylis "^4.0.3"
 
 "@emotion/memoize@0.7.4":
   version "0.7.4"
@@ -1371,6 +1390,11 @@
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.9.0.tgz#573cc294ff607698941f90e544826f598fd66fad"
   integrity sha512-jc0tA10MFeJ/mXKFSQngF9CAQIpZVvUD3GI/qWlMyRUttjEBsYlEbvFddqsTz2GdFZxrzyERSfIVunNQ8jTQgA==
+
+"@guardian/types@^8.0.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-8.1.0.tgz#520e16d93c1a8f2bf36c8f4faff5bea81fb9346d"
+  integrity sha512-6qpQxHW+DwvJqc4aPrWIN0GoErTN8R+WlQ4Cq/NJKiIWROvgOytC4P/2hiLNxoEpla93cT56293Fd1cYRUhnPA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -9890,15 +9914,15 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
+"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^17.0.1, react-is@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -9927,6 +9951,14 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-shallow-renderer@^16.13.1:
+  version "16.14.1"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
+  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0"
+
 react-sizeme@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.2.tgz#4a2f167905ba8f8b8d932a9e35164e459f9020e4"
@@ -9947,6 +9979,16 @@ react-syntax-highlighter@^13.5.3:
     lowlight "^1.14.0"
     prismjs "^1.21.0"
     refractor "^3.1.0"
+
+react-test-renderer@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
 
 react-textarea-autosize@^8.3.0:
   version "8.3.3"
@@ -10749,6 +10791,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
   integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+
+specificity@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
+  integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
 speedometer@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Why?

There are a few reasons behind this:

1. This project was only a package because we planned to share it between AR and DCR. Now that they're in the same repo it can exist here too.
2. We're looking to migrate this entire repo over to Yarn, and Yarn has some issues with the `prepare` script `image-rendering` relies on.
3. We like to share the way images are rendered on liveblogs, and `image-rendering` will need updating to handle this. That will be easier to do now it's in the same repo.

FYI @paperboyo 

## Changes

- Added testing dependencies and `@guardian/types`
- Allowed Jest transformation of guardian packages
- Tweaked `tsconfig` for import of guardian packages JS and test deps
- Added the `image-rendering` files, components, stories and tests
