### PR TITLE
Use Local Image-Rendering

### DIFF
--- a/.github/workflows/ar-nodejs.yml
+++ b/.github/workflows/ar-nodejs.yml
@@ -21,6 +21,10 @@ jobs:
             - uses: actions/checkout@v1
             - uses: guardian/actions-setup-node@main
 
+            # Cache npm dependencies using https://github.com/bahmutov/npm-install
+            # Root dependencies
+            - uses: bahmutov/npm-install@v1
+
             - uses: actions/cache@v2
               with:
                   path: ~/.npm

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -6026,10 +6026,6 @@
         }
       }
     },
-    "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#1167f8bc1f1b7f65ba883e4678e10190abbabb05",
-      "from": "github:guardian/image-rendering#1167f8bc"
-    },
     "@guardian/node-riffraff-artifact": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@guardian/node-riffraff-artifact/-/node-riffraff-artifact-0.2.0.tgz",

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -30221,15 +30221,6 @@
         }
       }
     },
-    "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "react-app-rewired": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
@@ -30418,16 +30409,6 @@
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.0.0.tgz",
       "integrity": "sha512-lPf+KJKAo6a9klKyK4y8WwgaX+6t5/HkVjHOpJDMbmaXfXcV7zP0QgWtnEOc3ccEUXKvlHMGUMIS9f6Zgo1BSw==",
       "dev": true
-    },
-    "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      }
     },
     "react-draggable": {
       "version": "4.4.3",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -71,8 +71,6 @@
     "jsdom": "^16.5.3",
     "node-fetch": "^2.6.1",
     "node-int64": "^0.4.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-test-renderer": "^17.0.2",
     "regenerator-runtime": "^0.13.5",
     "source-map-support": "^0.5.19",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -42,7 +42,6 @@
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^4.6.1",
-    "@guardian/image-rendering": "github:guardian/image-rendering#1167f8bc",
     "@guardian/node-riffraff-artifact": "^0.2.0",
     "@guardian/renditions": "^0.2.0",
     "@guardian/src-brand": "^3.3.0",

--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import Img from '@guardian/common-rendering/src/components/img';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';

--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import Img from '@guardian/common-rendering/src/components/img';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { brandAltBackground } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import Img from '@guardian/common-rendering/src/components/img';
 import { brandAltBackground } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/headerImage.tsx
+++ b/apps-rendering/src/components/headerImage.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import Img from '@guardian/common-rendering/src/components/img';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/headerImage.tsx
+++ b/apps-rendering/src/components/headerImage.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import {

--- a/apps-rendering/src/contributor.ts
+++ b/apps-rendering/src/contributor.ts
@@ -2,7 +2,7 @@
 
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { Dpr, src, srcsetWithWidths } from '@guardian/image-rendering';
+import { Dpr, src, srcsetWithWidths } from '@guardian/common-rendering/src/srcsets';
 import type { Option } from '@guardian/types';
 import { fromNullable, map, none, Role } from '@guardian/types';
 import { articleContributors } from 'capi';

--- a/apps-rendering/src/contributor.ts
+++ b/apps-rendering/src/contributor.ts
@@ -1,8 +1,12 @@
 // ----- Imports ----- //
 
+import {
+	Dpr,
+	src,
+	srcsetWithWidths,
+} from '@guardian/common-rendering/src/srcsets';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { Dpr, src, srcsetWithWidths } from '@guardian/common-rendering/src/srcsets';
 import type { Option } from '@guardian/types';
 import { fromNullable, map, none, Role } from '@guardian/types';
 import { articleContributors } from 'capi';

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -1,9 +1,9 @@
 // ----- Imports ----- //
 
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
-import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import type { Image as ImageData } from '@guardian/common-rendering/src/image';
 import { Dpr, src, srcsets } from '@guardian/common-rendering/src/srcsets';
+import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import type { Format, Option } from '@guardian/types';
 import { andThen, fromNullable, map, none, Role, some } from '@guardian/types';
 import { pipe } from 'lib';

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -2,8 +2,8 @@
 
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
-import type { Image as ImageData } from '@guardian/image-rendering';
-import { Dpr, src, srcsets } from '@guardian/image-rendering';
+import type { Image as ImageData } from '@guardian/common-rendering/src/image';
+import { Dpr, src, srcsets } from '@guardian/common-rendering/src/srcsets';
 import type { Format, Option } from '@guardian/types';
 import { andThen, fromNullable, map, none, Role, some } from '@guardian/types';
 import { pipe } from 'lib';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -13,7 +13,8 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import { BodyImage, FigCaption } from '@guardian/image-rendering';
+import BodyImage from '@guardian/common-rendering/src/components/bodyImage';
+import FigCaption from '@guardian/common-rendering/src/components/figCaption';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import type { Breakpoint } from '@guardian/src-foundations/mq';

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -43,7 +43,6 @@ function resolve(
 		modules: [path.resolve(__dirname, 'src'), 'node_modules'],
 		alias: {
 			logger: path.resolve(__dirname, `src/logger/${loggerName}`),
-			react: path.resolve('./node_modules/react'),
 			// This line exists because atoms-rendering imports `preact-render-to-string`
 			// https://github.com/guardian/atoms-rendering/blob/24b166fc40d125b33ae9ac56d3535c27b0ff5304/src/lib/unifyPageContent.tsx#L2
 			//

--- a/common-rendering/src/components/bodyImage.stories.tsx
+++ b/common-rendering/src/components/bodyImage.stories.tsx
@@ -5,7 +5,7 @@
 import { Design, Display, none, Pillar, Role, some } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
-import { BodyImage } from "./bodyImage";
+import BodyImage from "./bodyImage";
 
 // ----- Setup ----- //
 

--- a/common-rendering/src/components/bodyImage.tsx
+++ b/common-rendering/src/components/bodyImage.tsx
@@ -12,8 +12,8 @@ import type { Image } from "../image";
 import { darkModeCss } from "../lib";
 import type { Lightbox } from "../lightbox";
 import type { Sizes } from "../sizes";
-import { FigCaption } from "./figCaption";
-import { Img } from "./img";
+import FigCaption from "./figCaption";
+import Img from "./img";
 
 // ----- Setup ----- //
 
@@ -103,7 +103,7 @@ const getStyles = (
   }
 };
 
-export const BodyImage: FC<Props> = ({
+const BodyImage: FC<Props> = ({
   image,
   format,
   supportsDarkMode,
@@ -125,3 +125,7 @@ export const BodyImage: FC<Props> = ({
     </FigCaption>
   </figure>
 );
+
+// ----- Exports ----- //
+
+export default BodyImage;

--- a/common-rendering/src/components/figCaption.stories.tsx
+++ b/common-rendering/src/components/figCaption.stories.tsx
@@ -4,7 +4,7 @@
 
 import { Design, Display, Pillar, some } from "@guardian/types";
 import type { FC } from "react";
-import { FigCaption } from "./figCaption";
+import FigCaption from "./figCaption";
 
 // ----- Stories ----- //
 

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -86,7 +86,7 @@ const getStyles = (
   }
 };
 
-export const FigCaption: FC<Props> = ({
+const FigCaption: FC<Props> = ({
   format,
   supportsDarkMode,
   children,
@@ -104,3 +104,7 @@ export const FigCaption: FC<Props> = ({
       return null;
   }
 };
+
+// ----- Exports ----- //
+
+export default FigCaption;

--- a/common-rendering/src/components/img.stories.tsx
+++ b/common-rendering/src/components/img.stories.tsx
@@ -5,7 +5,7 @@
 import { Design, Display, none, Pillar } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
-import { Img } from "./img";
+import Img from "./img";
 
 // ----- Setup ----- //
 

--- a/common-rendering/src/components/img.tsx
+++ b/common-rendering/src/components/img.tsx
@@ -51,7 +51,7 @@ const styles = (
     `}
 `;
 
-export const Img: FC<Props> = ({
+const Img: FC<Props> = ({
   image,
   sizes,
   className,
@@ -81,3 +81,7 @@ export const Img: FC<Props> = ({
     />
   </picture>
 );
+
+// ----- Exports ----- //
+
+export default Img;

--- a/common-rendering/src/srcsets.ts
+++ b/common-rendering/src/srcsets.ts
@@ -16,7 +16,7 @@ const lowerQuality = 45;
 
 // ----- Types ----- //
 
-const enum Dpr {
+enum Dpr {
   One,
   Two,
 }

--- a/scripts/ci-ar.sh
+++ b/scripts/ci-ar.sh
@@ -29,6 +29,8 @@ else
     nvm install
     nvm use
 
+    yarn --silent
+
     cd apps-rendering
 
     npm ci


### PR DESCRIPTION
## Why?

Following up on #3391, now we have `image-rendering` in the mono-repo we can start using the local files instead of the package.

**Note:** There's currently an issue with the tests. I _think_ it might be because there are two instances of `React` (one from `common-rendering` and one from AR) and that's confusing one of the hooks implementations.

## Changes

- Removed `@guardian/image-rendering` dep
- Migrated AR imports over to local image files
- Switched image components over to default exports
- Made `Dpr` a normal `enum` because DCR doesn't support `const enum`s
