### PR TITLE
increase h3 sizing on numbered lists

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -30,7 +30,7 @@ const globalH3Styles = (display: Display) => {
 	if (display !== Display.NumberedList) return null;
 	return css`
 		h3 {
-			${headline.xxsmall({ fontWeight: 'bold' })};
+			${headline.small({ fontWeight: 'bold' })};
 			margin-bottom: ${space[2]}px;
 		}
 	`;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Increases size of H3 in Numbered List articles

## Why?
Was too small

### Before
![Screenshot 2021-09-09 at 12 42 02](https://user-images.githubusercontent.com/20658471/132679576-f37d9162-1cbf-4274-a2d9-78c1573bdd83.png)

### After
![image](https://user-images.githubusercontent.com/20658471/132679673-72e7eaa0-b821-477e-b65f-fee8154fcf6d.png)

