### PR TITLE
Bump Atoms to 18.0.2

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -40,7 +40,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^18.0.1",
+    "@guardian/atoms-rendering": "^18.0.2",
     "@guardian/automat-contributions": "^0.4.0",
     "@guardian/braze-components": "^3.5.0",
     "@guardian/commercial-core": "^0.19.2",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1719,10 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^18.0.1":
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.1.tgz#3c05b514f5ea3883f64c37fe29973db813ff1301"
-  integrity sha512-UqWsEC3KUETwRM8sbhZQTLXWvlWcFg09EpdPGhMxLXKvtnoqMALWjOkp7mH4hu8n/AwaihLQjiiAXbrw/m787w==
+"@guardian/atoms-rendering@^18.0.2":
+  version "18.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.2.tgz#ea91278b9f07202db587a9c1e21cd6fe89df9c0f"
+  integrity sha512-DRFwShOCF1qQNRxxDWeQmmD1R22gHP3g+tk+CjJKxJ5/xsjJV34cfWP57G+0HSfOghQjDhetiVBKDgmDg4AG5w==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the comment back after the score, the hypothesis now is that it could have been a user related issue rather than a bug.
