### PR TITLE
make h3 a little smaller

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -30,7 +30,7 @@ const globalH3Styles = (display: Display) => {
 	if (display !== Display.NumberedList) return null;
 	return css`
 		h3 {
-			${headline.small({ fontWeight: 'bold' })};
+			${headline.xsmall({ fontWeight: 'bold' })};
 			margin-bottom: ${space[2]}px;
 		}
 	`;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes h3 use xsmall font size rather than small
## Why?
Change it but was a bit too big in some situations
### Before
![image](https://user-images.githubusercontent.com/20658471/132688381-e826b759-6576-4119-9ba0-c84938c320c3.png)

### After
![image](https://user-images.githubusercontent.com/20658471/132688428-ddc50778-649d-43e0-98a1-58e0d0a2404b.png)
