### PR TITLE
No global h2 styles when `Design.NumberedList`

### DIFF
--- a/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.test.ts
@@ -572,7 +572,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.TextBlockElement',
 							elementId: 'mockId',
-							html: '<h2>★★★★☆</h2>',
+							html: '<h2 data-ignore="global-h2-styling">★★★★☆</h2>',
 						},
 					],
 				},
@@ -773,7 +773,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.SubheadingBlockElement',
 							elementId: 'mockId',
-							html: '<h2>Some text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 						},
 					],
 				},
@@ -797,7 +797,7 @@ describe('Enhance Numbered Lists', () => {
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId',
 							position: 1,
-							html: '<h2>Some text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 							format: NumberedList.format,
 						},
 					],
@@ -819,7 +819,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.SubheadingBlockElement',
 							elementId: 'mockId1',
-							html: '<h2>Some text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 						},
 						{
 							_type:
@@ -832,13 +832,13 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.SubheadingBlockElement',
 							elementId: 'mockId2',
-							html: '<h2>Other text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
 						},
 						{
 							_type:
 								'model.dotcomrendering.pageElements.SubheadingBlockElement',
 							elementId: 'mockId3',
-							html: '<h2>More text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">More text</h2>',
 						},
 					],
 				},
@@ -862,7 +862,7 @@ describe('Enhance Numbered Lists', () => {
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId1',
 							position: 1,
-							html: '<h2>Some text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Some text</h2>',
 							format: NumberedList.format,
 						},
 						{
@@ -880,7 +880,7 @@ describe('Enhance Numbered Lists', () => {
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId2',
 							position: 2,
-							html: '<h2>Other text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">Other text</h2>',
 							format: NumberedList.format,
 						},
 						{
@@ -895,7 +895,7 @@ describe('Enhance Numbered Lists', () => {
 
 							elementId: 'mockId3',
 							position: 3,
-							html: '<h2>More text</h2>',
+							html: '<h2 data-ignore="global-h2-styling">More text</h2>',
 							format: NumberedList.format,
 						},
 					],


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Ensures that the global h2 css rules that are defined in `ArticleBody` do not get applied for Numbered Lists

## How?
We're employing the `data-ignore="global-h2-styling"` contract which was established to allow use cases such as this one where we might want to opt out of the global css rules.

## Why?
Because these article types have an established contract using `h2` tags that should result in unique styles but this was being affected by the global h2 styles that tried to do different things.

### Before
<img width="1433" alt="Screenshot 2021-09-09 at 13 57 21" src="https://user-images.githubusercontent.com/1336821/132690379-01276c6d-a544-4c38-b433-163707bafd5b.png">


### After
<img width="1433" alt="Screenshot 2021-09-09 at 13 54 48" src="https://user-images.githubusercontent.com/1336821/132690399-14959442-3b1b-4607-803b-7c0bb6f94ad4.png">

