### PR TITLE
Update Atoms Rendering to 18.0.3

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -40,7 +40,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^18.0.1",
+    "@guardian/atoms-rendering": "^18.0.3",
     "@guardian/automat-contributions": "^0.4.0",
     "@guardian/braze-components": "^3.5.0",
     "@guardian/commercial-core": "^0.19.2",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1719,10 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^18.0.1":
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.1.tgz#3c05b514f5ea3883f64c37fe29973db813ff1301"
-  integrity sha512-UqWsEC3KUETwRM8sbhZQTLXWvlWcFg09EpdPGhMxLXKvtnoqMALWjOkp7mH4hu8n/AwaihLQjiiAXbrw/m787w==
+"@guardian/atoms-rendering@^18.0.3":
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.3.tgz#de63cb6af5fbfe030edbdebe499a46c3f3907e29"
+  integrity sha512-KG0PKiob3P3/6pWSb3FqQVvWxK/Ru8HQcjvN6vLbvKoUZFz5FVJYJ0V8EZipKalh4PaT9pbQg8UAvMg8oMg7fw==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
## What does this change?

This reworks the logic for knowledge quizzes. Previously batched scores had not been accounted for i.e. scoring between 1 and 5. This will account for a response to every question and batched questions.

## Images

<img width="311" alt="Screenshot 2021-09-09 at 16 57 56" src="https://user-images.githubusercontent.com/35331926/132721503-41db4152-19fb-49da-906e-d47a7610dd55.png">

<img width="311" alt="Screenshot 2021-09-09 at 16 58 42" src="https://user-images.githubusercontent.com/35331926/132721531-61833f3f-ee4d-4dc6-b3d8-4711f5fc9e72.png">

<img width="311" alt="Screenshot 2021-09-09 at 16 59 24" src="https://user-images.githubusercontent.com/35331926/132721556-3fa7a32c-6762-4528-9909-7b73fec1701e.png">
