### PR TITLE
Copy the root .gitignore the into the dotcom-rendering sub-directory

### DIFF
--- a/dotcom-rendering/.gitignore
+++ b/dotcom-rendering/.gitignore
@@ -1,0 +1,48 @@
+### Node template
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules
+
+# Yarn Integrity file
+.yarn-integrity
+
+# IDE files
+.idea
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/dcr.code-snippets
+.metals/
+
+# System files
+.DS_Store
+
+# Built files
+dist
+jsconfig.json
+target
+
+# Test coverage reports
+coverage
+
+# .git-hooks
+# Ignore auto generate husky hooks
+scripts/git-hooks/*
+!scripts/git-hooks/post-merge
+!scripts/git-hooks/install.js
+
+# Cypress result files
+/cypress/screenshots/*
+/cypress/videos/*
+
+# Storybook static folder (used if taking snapshots locally)
+/storybook-static/*
+
+# Architecture Diagram
+webArchitecture.svg


### PR DESCRIPTION
This will prevent *lots* of files to show up in a PR when running Cypress tests on local 😬