### PR TITLE
Refactor CMP Initialisation

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,6 +10,7 @@ import 'reset-css';
 import { Lazy } from '@root/src/web/components/Lazy';
 import { Picture } from '@root/src/web/components/Picture';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
+import { addCookie } from '@root/src/web/browser/cookie';
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
@@ -29,6 +30,22 @@ let style = document.createElement('style');
 head.appendChild(style);
 style.type = 'text/css';
 style.appendChild(document.createTextNode(css));
+
+// Mock certain page properties to ensure client side hydration completes as expected
+// in our page/layout stories. These properties were specifically added after we refactored
+// how the CMP loads in App.tsx but they are also used in other areas and can be taken
+// as an example for a quick way to mock cookies or the window object.
+// Could this be better? Sure, we could investigate ways to really, truly server side
+// render in Storybook but for now this (and some of the other steps we take around
+// hydration) achieve what we need
+window.guardian = {
+	config: {
+		ophan: {
+			pageViewId: 'mockPageViewId',
+		}
+	},
+}
+addCookie('bwid', 'mockBrowserId');
 
 const guardianViewports = {
 	mobileMedium: {

--- a/dotcom-rendering/cypress/integration/parallel-2/braze.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-2/braze.spec.js
@@ -82,6 +82,8 @@ describe('Braze messaging', function () {
 		enableBraze();
 		becomeLoggedIn();
 
+		cy.setCookie('bwid', 'myBrowserId');
+
 		setCountry();
 		acceptConsents()
 			.then(visitArticle)
@@ -95,6 +97,8 @@ describe('Braze messaging', function () {
 	it('clears Braze data when a user logs out', function () {
 		enableBraze();
 		becomeLoggedIn();
+
+		cy.setCookie('bwid', 'myBrowserId');
 
 		setCountry();
 		acceptConsents()

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -721,11 +721,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				CAPI.config.switches.commercialMetrics,
 				window.guardian.config?.ophan !== undefined,
 			].every(Boolean) && (
-			<CommercialMetrics
-				browserId={browserId}
-				pageViewId={pageViewId}
-					/>
-				)}
+				<CommercialMetrics
+					browserId={browserId}
+					pageViewId={pageViewId}
+				/>
+			)}
 			<Portal rootId="reader-revenue-links-header">
 				<ReaderRevenueLinks
 					urls={CAPI.nav.readerRevenueLinks.header}

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -378,15 +378,15 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		});
 	}, []);
 
-	const display: Display = decideDisplay(CAPI.format);
-	const design: Design = decideDesign(CAPI.format);
-	const pillar: Theme = decideTheme(CAPI.format);
-
 	useOnce(() => {
 		setBrazeMessages(
 			buildBrazeMessages(isSignedIn as boolean, CAPI.config.idApiUrl),
 		);
 	}, [isSignedIn, CAPI.config.idApiUrl]);
+
+	const display: Display = decideDisplay(CAPI.format);
+	const design: Design = decideDesign(CAPI.format);
+	const pillar: Theme = decideTheme(CAPI.format);
 
 	const format: Format = {
 		display,

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -298,6 +298,20 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	useOnce(() => {
 		if (!CAPI.config.switches.consentManagement) return; // CMP turned off!
 
+		// keep this in sync with CONSENT_TIMING in static/src/javascripts/boot.js in frontend
+		// mark: CONSENT_TIMING
+		cmp.willShowPrivacyMessage()
+			.then((willShow) => {
+				trackPerformance(
+					'consent',
+					'acquired',
+					willShow ? 'new' : 'existing',
+				);
+			})
+			.catch((e) =>
+				console.error(`CMP willShowPrivacyMessage - error: ${e}`),
+			);
+
 		// Run each time consent is submitted
 		onConsentChange((newConsent) => {
 			setConsentState(newConsent);
@@ -322,26 +336,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	// This code is executed at first render and then again each time consentState is set
 	useEffect(() => {
 		if (!consentState) return;
-		// keep this in sync with CONSENT_TIMING in static/src/javascripts/boot.js in frontend
-		// mark: CONSENT_TIMING
-		let recordedConsentTime = false;
-
-		// Track performance once
-		if (!recordedConsentTime) {
-			recordedConsentTime = true;
-			cmp.willShowPrivacyMessage()
-				.then((willShow) => {
-					trackPerformance(
-						'consent',
-						'acquired',
-						willShow ? 'new' : 'existing',
-					);
-				})
-				.catch((e) =>
-					console.error(`CMP willShowPrivacyMessage - error: ${e}`),
-				);
-		}
-
 		// Register changes in consent state
 		const decideConsentString = () => {
 			if (consentState.tcfv2) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Refactors how we initialise CMP to be a bit more react-y (eg. More declarative)

I also added the `bwid` cookie to some Cypress tests around CMP that were managing to pass before but only because of a quirk, one which is now removed by this PR. The `browserId` state wasn't a strict dependency for `cmp.init` beforehand so not having it (you get it from the `bwid` cookie) was working. But now that we have refactored things to ensure we only initialise cmp once, and have added a strict dependency on this cookie, it had to be added to Cypress.