### PR TITLE
Add `navigator.sendBeacon` polyfill

### DIFF
--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -228,7 +228,7 @@ export const document = ({ data }: Props): string => {
 	];
 
 	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasNonBootInteractiveElements = CAPIElements.some(
 		(element) =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a polyfill for [navigator.sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon).

## Why?

As stated in https://github.com/guardian/frontend/pull/24164

> We’re using it to capture metrics. As of today, [support is only 96%][caniuse]. We currently use this API in:
>
> - [`sentinel` ](https://github.com/guardian/frontend/blob/8212b2a393b99503159b97fd3e1eded60e06c8c1/static/src/javascripts/projects/commercial/sentinel.ts#L64)
> - `commercial-metrics` via **`@guardian/commercial-core`**’s [`sendCommercialMetrics`](https://github.com/guardian/commercial-core/blob/2d736b61956f2aba978e35190e20cd72e6ac2028/src/sendCommercialMetrics.ts#L58)

[caniuse]: https://caniuse.com/beacon