### PR TITLE
Quick rota fix to remove Journalists Avatar When Author has no byline

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -272,7 +272,7 @@ export const ArticleMeta = ({
 	console.log('byline' in author);
 
 	const showAvatarFromAuthor = () => {
-		if ('byline' in author) {
+		if ('byline' in author && format.design !== Design.Comment) {
 			return true;
 		}
 		return false;

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -23,6 +23,7 @@ type Props = {
 	primaryDateline: string;
 	secondaryDateline: string;
 	branding?: Branding;
+	hasByline?: boolean;
 };
 
 const meta = css`
@@ -263,7 +264,8 @@ export const ArticleMeta = ({
 	const onlyOneContributor: boolean =
 		tags.filter((tag) => tag.type === 'Contributor').length === 1;
 
-	const showAvatar = onlyOneContributor && shouldShowAvatar(format);
+	const showAvatar =
+		onlyOneContributor && hasByline && shouldShowAvatar(format);
 	const isInteractive = format.design === Design.Interactive;
 	return (
 		<div

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -23,7 +23,7 @@ type Props = {
 	primaryDateline: string;
 	secondaryDateline: string;
 	branding?: Branding;
-	hasByline?: boolean;
+	hasByline?: string;
 };
 
 const meta = css`
@@ -247,6 +247,13 @@ const RowBelowLeftCol = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
+const ShowAvatar = (hasByline: string | undefined) => {
+	if (hasByline === undefined || hasByline === '') {
+		return false;
+	}
+	return true;
+};
+
 export const ArticleMeta = ({
 	branding,
 	format,
@@ -262,11 +269,13 @@ export const ArticleMeta = ({
 	const bylineImageUrl = getBylineImageUrl(tags);
 	const authorName = getAuthorName(tags);
 
+	const bylineAvatar = ShowAvatar(hasByline);
+
 	const onlyOneContributor: boolean =
 		tags.filter((tag) => tag.type === 'Contributor').length === 1;
 
 	const showAvatar =
-		onlyOneContributor && hasByline && shouldShowAvatar(format);
+		onlyOneContributor && bylineAvatar && shouldShowAvatar(format);
 	const isInteractive = format.design === Design.Interactive;
 	return (
 		<div

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -261,10 +261,7 @@ export const ArticleMeta = ({
 	const authorName = getAuthorName(tags);
 
 	const showAvatarFromAuthor = () => {
-		if (
-			(!('byline' in author) || author.byline === '') &&
-			format.design === Design.Comment
-		) {
+		if (!('byline' in author) || author.byline === '') {
 			return false;
 		}
 		return true;

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -272,10 +272,13 @@ export const ArticleMeta = ({
 	console.log('byline' in author);
 
 	const showAvatarFromAuthor = () => {
-		if ('byline' in author && format.design !== Design.Comment) {
-			return true;
+		if (
+			!('byline' in author) ||
+			(author.byline === '' && format.design === Design.Comment)
+		) {
+			return false;
 		}
-		return false;
+		return true;
 	};
 
 	const onlyOneContributor: boolean =

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -257,6 +257,7 @@ export const ArticleMeta = ({
 	tags,
 	primaryDateline,
 	secondaryDateline,
+	hasByline,
 }: Props) => {
 	const bylineImageUrl = getBylineImageUrl(tags);
 	const authorName = getAuthorName(tags);

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -246,13 +246,6 @@ const RowBelowLeftCol = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-/* const ShowAvatar = (hasByline: string | undefined) => {
-	if (hasByline === undefined || hasByline === '') {
-		return false;
-	}
-	return true;
-}; */
-
 export const ArticleMeta = ({
 	branding,
 	format,
@@ -266,10 +259,6 @@ export const ArticleMeta = ({
 }: Props) => {
 	const bylineImageUrl = getBylineImageUrl(tags);
 	const authorName = getAuthorName(tags);
-
-	// const bylineAvatar = ShowAvatar(hasByline);
-
-	console.log('byline' in author);
 
 	const showAvatarFromAuthor = () => {
 		if (

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -23,7 +23,6 @@ type Props = {
 	primaryDateline: string;
 	secondaryDateline: string;
 	branding?: Branding;
-	hasByline?: string;
 };
 
 const meta = css`
@@ -247,12 +246,12 @@ const RowBelowLeftCol = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-const ShowAvatar = (hasByline: string | undefined) => {
+/* const ShowAvatar = (hasByline: string | undefined) => {
 	if (hasByline === undefined || hasByline === '') {
 		return false;
 	}
 	return true;
-};
+}; */
 
 export const ArticleMeta = ({
 	branding,
@@ -264,18 +263,26 @@ export const ArticleMeta = ({
 	tags,
 	primaryDateline,
 	secondaryDateline,
-	hasByline,
 }: Props) => {
 	const bylineImageUrl = getBylineImageUrl(tags);
 	const authorName = getAuthorName(tags);
 
-	const bylineAvatar = ShowAvatar(hasByline);
+	// const bylineAvatar = ShowAvatar(hasByline);
+
+	console.log('byline' in author);
+
+	const showAvatarFromAuthor = () => {
+		if ('byline' in author) {
+			return true;
+		}
+		return false;
+	};
 
 	const onlyOneContributor: boolean =
 		tags.filter((tag) => tag.type === 'Contributor').length === 1;
 
 	const showAvatar =
-		onlyOneContributor && bylineAvatar && shouldShowAvatar(format);
+		onlyOneContributor && showAvatarFromAuthor && shouldShowAvatar(format);
 	const isInteractive = format.design === Design.Interactive;
 	return (
 		<div

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -262,8 +262,8 @@ export const ArticleMeta = ({
 
 	const showAvatarFromAuthor = () => {
 		if (
-			!('byline' in author) ||
-			(author.byline === '' && format.design === Design.Comment)
+			(!('byline' in author) || author.byline === '') &&
+			format.design === Design.Comment
 		) {
 			return false;
 		}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -562,7 +562,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								secondaryDateline={
 									CAPI.webPublicationSecondaryDateDisplay
 								}
-								hasByline={!!CAPI.author.byline}
 							/>
 						</div>
 					</GridItem>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -562,6 +562,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								secondaryDateline={
 									CAPI.webPublicationSecondaryDateDisplay
 								}
+								hasByline={!!CAPI.author.byline}
 							/>
 						</div>
 					</GridItem>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds a bool check which tells the ArticleMeta whether it should show an avatar or not. It's mainly meant for times where there is no byline in the author data but still has a contributor listed. [See Here](https://www.theguardian.com/music/2021/sep/10/rewrite-rule-britannia-what-would-you-do-with-the-last-night-of-the-proms)

## Before
![Screenshot 2021-09-14 at 10 11 14](https://user-images.githubusercontent.com/35331926/133230275-40b4c214-b91e-493d-b6d5-34407e4aa25f.png)

## After
![Screenshot 2021-09-14 at 10 11 49](https://user-images.githubusercontent.com/35331926/133230301-657698a6-8069-474b-8192-334a36dff8a0.png)


