### PR TITLE
Revert `remove-sticky-nav` server-side A/B test

### DIFF
--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -47,10 +47,6 @@ const topBorder = (colour: string) => emoCss`
 	border-top: 1px solid ${colour};
 `;
 
-const bottomBorder = (colour: string) => emoCss`
-	border-bottom: 1px solid ${colour};
-`;
-
 const setBackgroundColour = (colour: string) => emoCss`
 	background-color: ${colour};
 `;
@@ -59,7 +55,6 @@ type Props = {
 	sectionId?: string;
 	showSideBorders?: boolean;
 	showTopBorder?: boolean;
-	showBottomBorder?: boolean;
 	padded?: boolean;
 	backgroundColour?: string;
 	borderColour?: string;
@@ -72,7 +67,6 @@ export const ElementContainer = ({
 	sectionId,
 	showSideBorders = true,
 	showTopBorder = true,
-	showBottomBorder = false,
 	padded = true,
 	borderColour = border.secondary,
 	backgroundColour,
@@ -89,7 +83,6 @@ export const ElementContainer = ({
 						shouldCenter && center,
 						showSideBorders && sideBorders(borderColour),
 						showTopBorder && topBorder(borderColour),
-						showBottomBorder && bottomBorder(borderColour),
 						padded && padding,
 					]}
 				>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { css } from '@emotion/react';
 
 import {
@@ -343,25 +342,14 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					theme: getCurrentPillar(CAPI),
 			  };
 
-
-	// The following two lines refer to a server-side experiment ("remove-sticky-nav")
-	// that removes the sticky behaviour of the navigation and subnavigation bars
-	// in order to measure ad viewability when these components are not sticky.
-	// TODO: Remove this code after the experiment is complete.
-	const isInRemoveStickyNavVariant = CAPI.config.abTests.removeStickyNavVariant === 'variant';
-	const componentName = isInRemoveStickyNavVariant ? "non-sticky-nav" : "sticky-nav";
-
 	return (
 		<>
-			{/* The data-component attribute within this div is needed to run analytics on the experiment.
-			Remove after A/B testing is over. */}
-			<div data-print-layout="hide" id="bannerandheader" data-component={componentName}>
+			<div data-print-layout="hide" id="bannerandheader">
 				<>
 					<Stuck>
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							showBottomBorder={isInRemoveStickyNavVariant}
 							padded={false}
 							shouldCenter={false}
 						>
@@ -389,55 +377,9 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							/>
 						</ElementContainer>
 					)}
-
-					{/* For the purpose of this A/B test, the nav bar, the subnav and the four lines have been moved up
-					into this div to get rid of stickiness.
-					Remove this block of code after A/B testing is complete to restore original behaviour */}
-					{isInRemoveStickyNavVariant && (<ElementContainer
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={formatForNav}
-							subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
-							edition={CAPI.editionId}
-					/>
-					</ElementContainer>)}
-
-					{isInRemoveStickyNavVariant && NAV.subNavSections && format.theme !== Special.Labs && (
-						<>
-							<ElementContainer
-								backgroundColour={palette.background.article}
-								padded={false}
-								sectionId="sub-nav-root"
-				>
-								<SubNav
-									subNavSections={NAV.subNavSections}
-									currentNavLink={NAV.currentNavLink}
-									palette={palette}
-									format={format}
-					/>
-							</ElementContainer>
-							<ElementContainer
-								backgroundColour={palette.background.article}
-								padded={false}
-								showTopBorder={false}
-								>
-								<Lines count={4} effect="straight" />
-							</ElementContainer>
-						</>
-
-			)}
-					{/* Remove block of code above after A/B testing is complete */}
 				</>
 			</div>
 
-			{/* Remove isInRemoveStickyNavVariant conditional rendering after A/B testing is complete */}
-			{!isInRemoveStickyNavVariant && (
 			<ElementContainer
 				showSideBorders={true}
 				borderColour={brandLine.primary}
@@ -451,10 +393,9 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
 					edition={CAPI.editionId}
 				/>
-			</ElementContainer> )}
+			</ElementContainer>
 
-			{/* Remove !isInRemoveStickyNavVariant conditional rendering after A/B testing is complete */}
-			{!isInRemoveStickyNavVariant && NAV.subNavSections && format.theme !== Special.Labs && (
+			{NAV.subNavSections && format.theme !== Special.Labs && (
 				<ElementContainer
 					backgroundColour={palette.background.article}
 					padded={false}
@@ -469,11 +410,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				</ElementContainer>
 			)}
 
-			{/* If the user is in the experiment bucket and the page is not a Guardian Labs article, don't display the four lines,
-			as they've already been rendered in the sticky div above.
-			TODO: Get rid of nested ternary after the experiment is over */}
-			{format.theme !== Special.Labs ?
-			(!isInRemoveStickyNavVariant ? (
+			{format.theme !== Special.Labs ? (
 				<ElementContainer
 					backgroundColour={palette.background.article}
 					padded={false}
@@ -481,17 +418,19 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				>
 					<Lines count={4} effect="straight" />
 				</ElementContainer>
-			) : null) : (<Stuck>
-				<ElementContainer
-					showSideBorders={true}
-					showTopBorder={false}
-					backgroundColour={labs[400]}
-					borderColour={border.primary}
-					sectionId="labs-header"
-			>
-					<LabsHeader />
-				</ElementContainer>
-			</Stuck>)}
+			) : (
+				<Stuck>
+					<ElementContainer
+						showSideBorders={true}
+						showTopBorder={false}
+						backgroundColour={labs[400]}
+						borderColour={border.primary}
+						sectionId="labs-header"
+					>
+						<LabsHeader />
+					</ElementContainer>
+				</Stuck>
+			)}
 
 			{CAPI.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />


### PR DESCRIPTION
## What does this change?
This PR reverts the changes introduced by https://github.com/guardian/dotcom-rendering/pull/3418.
Please merge this once the `remove-sticky-nav` server-side experiment is complete.

## Why?
`StandardLayout` and `ElementContainer` should go back to the way they were before the A/B test. 