### PR TITLE
Select Pillar is now its own importable function

### DIFF
--- a/common-rendering/src/fixtures/SelectPillar.ts
+++ b/common-rendering/src/fixtures/SelectPillar.ts
@@ -1,0 +1,16 @@
+import { Pillar, Theme, Special } from "@guardian/types";
+import { select } from "@storybook/addon-knobs";
+
+const pillarOptions = {
+	News: Pillar.News,
+	Opinion: Pillar.Opinion,
+	Sport: Pillar.Sport,
+	Culture: Pillar.Culture,
+	Lifestyle: Pillar.Lifestyle,
+	Labs: Special.Labs,
+	SpecialReport: Special.SpecialReport,
+};
+
+export const SelectPillar = (initial: Pillar): Theme => {
+	return select("Pillar", pillarOptions, initial);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extracts `selectPillar` from stories to an importable function.

Include this `import { SelectPillar } from "../Fixtures/SelectStoryPillar";` and `SelectPillar(Pillar.News)` can be used as normal.

## Why?

Suggestion from @joecowton1 