### PR TITLE
DCR as a page rendering service, not an _article_ rendering service

### DIFF
--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -1,297 +1,49 @@
 import { renderToString } from 'react-dom/server';
 
-import createEmotionServer from '@emotion/server/create-instance';
-import createCache from '@emotion/cache';
-
-import { Page } from '@root/src/web/components/Page';
-
-import { escapeData } from '@root/src/lib/escapeData';
-import {
-	CDN,
-	getScriptArrayFromFilename,
-	getScriptArrayFromChunkName,
-	loadableManifestJson,
-} from '@root/src/lib/assets';
-
-import { makeWindowGuardian } from '@root/src/model/window-guardian';
-import { ChunkExtractor } from '@loadable/server';
-import { Pillar } from '@guardian/types';
-import { DecideLayout } from '../layouts/DecideLayout';
 import { htmlTemplate } from './htmlTemplate';
-import { decideTheme } from '../lib/decideTheme';
 import { SkipTo } from '../components/SkipTo';
 
-interface RenderToStringResult {
-	html: string;
-	css: string;
-	ids: string[];
-}
-
-const generateScriptTags = (
-	scripts: Array<{ src: string; legacy?: boolean }>,
-) =>
-	scripts.reduce((scriptTags, script) => {
-		let attrs = 'defer';
-
-		if (Object.prototype.hasOwnProperty.call(script, 'legacy')) {
-			attrs = script.legacy ? 'defer nomodule' : 'type="module"';
-		}
-
-		return [
-			...scriptTags,
-			`<script ${attrs} src="${script.src}"></script>`,
-		];
-	}, [] as string[]);
-
 interface Props {
-	data: DCRServerDocumentData;
+	title?: string;
+	CAPI?: CAPIType;
+	linkedData?: { [key: string]: any };
+	description: string;
+	priorityScriptTags?: string[];
+	lowPriorityScriptTags?: string[];
+	gaPath?: { modern: string; legacy: string };
+	loadableConfigScripts?: string[];
+	windowGuardian?: string;
+	extractedCss: string;
+	html: string;
 }
 
-const decideTitle = (CAPI: CAPIType): string => {
-	if (decideTheme(CAPI.format) === Pillar.Opinion && CAPI.author.byline) {
-		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
-	}
-	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
-};
-
-export const document = ({ data }: Props): string => {
-	const { CAPI, NAV, linkedData } = data;
-	const title = decideTitle(CAPI);
-	const key = 'dcr';
-	const cache = createCache({ key });
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	const { extractCritical } = createEmotionServer(cache);
-
-	const {
-		html,
-		css: extractedCss,
-		ids: cssIDs,
-	}: RenderToStringResult = extractCritical(
-		renderToString(
-			<Page cache={cache}>
-				<DecideLayout CAPI={CAPI} NAV={NAV} />
-			</Page>,
-		),
-	);
-
-	// There are docs on loadable in ./docs/loadable-components.md
-	const loadableExtractor = new ChunkExtractor({
-		stats: loadableManifestJson,
-		entrypoints: ['react'],
-	});
-
-	// The lodable-components docs want us to use extractor.collectChunks() but
-	// we don't have the traditional same <App /> rendered on server and client.
-	// Our data structure is vastly different (CAPIType vs CAPIBrowserType) and
-	// our architecture expects src/web/App to be client-side only, therefore
-	// it is difficult for us to use collectChunks to automatically extract the
-	// component splits that we want.
-	// However, this does actually suit our architecture as we can use the CAPI
-	// component reference.
-	const allChunks: LoadableComponents = [
-		{ chunkName: 'EditionDropdown', addWhen: 'always' },
-		{
-			chunkName: 'elements-YoutubeBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
-		},
-		{
-			chunkName: 'elements-RichLinkComponent',
-			addWhen: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
-		},
-		{
-			chunkName: 'elements-InteractiveBlockComponent',
-			addWhen:
-				'model.dotcomrendering.pageElements.InteractiveBlockElement',
-		},
-		{
-			chunkName: 'elements-InteractiveContentsBlockComponent',
-			addWhen:
-				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-		},
-		{
-			chunkName: 'elements-CalloutBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
-		},
-		{
-			chunkName: 'elements-DocumentBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.DocumentBlockElement',
-		},
-		{
-			chunkName: 'elements-MapEmbedBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
-		},
-		{
-			chunkName: 'elements-SpotifyBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
-		},
-		{
-			chunkName: 'elements-VideoFacebookBlockComponent',
-			addWhen:
-				'model.dotcomrendering.pageElements.VideoFacebookBlockElement',
-		},
-		{
-			chunkName: 'elements-VineBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.VineBlockElement',
-		},
-		{
-			chunkName: 'elements-InstagramBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
-		},
-	];
-	// We want to only insert script tags for the elements or main media elements on this page view
-	// so we need to check what elements we have and use the mapping to the the chunk name
-	const CAPIElements: CAPIElement[] = CAPI.blocks
-		.map((block) => block.elements)
-		.flat();
-	const { mainMediaElements } = CAPI;
-	// Filter the chunks defined above by whether
-	// the 'addWhen' value is 'always' or matches
-	// any elements in the body or main media element
-	// arrays for the page request.
-	const chunksForPage = allChunks.filter((chunk) =>
-		[...CAPIElements, ...mainMediaElements].some(
-			(block) =>
-				chunk.addWhen === 'always' || block._type === chunk.addWhen,
-		),
-	);
-	// Once we have the chunks for the page, we can add them directly to the loadableExtractor
-	chunksForPage.forEach((chunk) => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		loadableExtractor.addChunk(chunk.chunkName); // addChunk is *undocumented* and not in TS types. It allows manually adding chunks to extractor.
-	});
-
-	let arrayOfLoadableScriptObjects: {
-		src: string;
-		legacy: boolean;
-	}[] = [];
-
-	// Pre assets returns an array of objects structured as:
-	// {
-	//     filename: 'elements-RichLinkComponent.js',
-	//     scriptType: 'script',
-	//     chunk: 'elements-RichLinkComponent',
-	//     url: '/elements-RichLinkComponent.js',
-	//     path: '/Users/gareth_trufitt/code/dotcom-rendering/dist/elements-RichLinkComponent.js',
-	//     type: 'mainAsset',
-	//     linkType: 'preload'
-	// }
-	//
-
-	const preAssets: {
-		filename: string;
-		scriptType: string;
-		chunk: string;
-		url: string;
-		path: string;
-		type: string;
-		linkType: string;
-	}[] =
-		// PreAssets is *undocumented* and not in TS types. It returns the webpack asset for each script.
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		loadableExtractor.getPreAssets();
-
-	preAssets.forEach((script) => {
-		arrayOfLoadableScriptObjects = [
-			...arrayOfLoadableScriptObjects,
-			...getScriptArrayFromFilename(script.filename),
-		];
-	});
-
-	// Loadable generates configuration script elements as the first two items
-	// of the script element array. We need to generate the react component version
-	// and then build an array of them, rendering them to string and grabbing
-	// the first two items. The alternative getScriptTags just returns a string
-	// of scripts tags already concatenated, so is not useful in this scenario.
-	const loadableConfigScripts = loadableExtractor
-		.getScriptElements()
-		.map((script) => renderToString(script))
-		.slice(0, 2);
-
-	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
-
-	const pageHasNonBootInteractiveElements = CAPIElements.some(
-		(element) =>
-			element._type ===
-				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
-			element.scriptUrl !==
-				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
-	);
-
-	function isDefined<T>(argument: T | boolean): argument is T {
-		return argument !== false;
-	}
-	/**
-	 * The highest priority scripts.
-	 * These scripts have a considerable impact on site performance.
-	 * Only scripts critical to application execution may go in here.
-	 * Please talk to the dotcom platform team before adding more.
-	 * Scripts will be executed in the order they appear in this array
-	 */
-	const priorityScriptTags = generateScriptTags(
-		[
-			{ src: polyfillIO },
-			...getScriptArrayFromChunkName('ophan'),
-			CAPI.config && { src: CAPI.config.commercialBundleUrl },
-			...getScriptArrayFromChunkName('sentryLoader'),
-			...getScriptArrayFromChunkName('coreVitals'),
-			...getScriptArrayFromChunkName('dynamicImport'),
-			pageHasNonBootInteractiveElements && {
-				src: `${CDN}static/frontend/js/curl-with-js-and-domReady.js`,
-			},
-			...arrayOfLoadableScriptObjects, // This includes the 'react' entry point
-		].filter(isDefined), // We use the TypeGuard to keep TS happy
-	);
-
-	/**
-	 * Low priority scripts. These scripts will be requested
-	 * asynchronously after the main HTML has been parsed. Execution
-	 * order is not guaranteed. It is even possible that these execute
-	 * *before* the high priority scripts, although this is very
-	 * unlikely.
-	 */
-	const lowPriorityScriptTags = generateScriptTags([
-		...getScriptArrayFromChunkName('atomIframe'),
-		...getScriptArrayFromChunkName('embedIframe'),
-		...getScriptArrayFromChunkName('newsletterEmbedIframe'),
-	]);
-
-	const gaChunk = getScriptArrayFromChunkName('ga');
-	const modernScript = gaChunk.filter(
-		(script) => script && script.legacy === false,
-	)[0];
-	const legacyScript = gaChunk.filter(
-		(script) => script && script.legacy === true,
-	)[0];
-	const gaPath = {
-		modern: modernScript.src,
-		legacy: legacyScript.src,
-	};
-
-	/**
-	 * We escape windowGuardian here to prevent errors when the data
-	 * is placed in a script tag on the page
-	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(makeWindowGuardian(data, cssIDs)),
-	);
-
-	const hasAmpInteractiveTag = CAPI.tags.some(
+export const document = ({
+	title = 'The Guardian',
+	CAPI,
+	linkedData,
+	description,
+	priorityScriptTags = [],
+	lowPriorityScriptTags = [],
+	gaPath,
+	loadableConfigScripts = [],
+	windowGuardian,
+	extractedCss,
+	html,
+}: Props): string => {
+	const hasAmpInteractiveTag = CAPI?.tags.some(
 		(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',
 	);
 
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
 	const ampLink =
-		CAPI.format.design !== 'InteractiveDesign' || hasAmpInteractiveTag
-			? `https://amp.theguardian.com/${data.CAPI.pageId}`
+		CAPI?.format.design !== 'InteractiveDesign' || hasAmpInteractiveTag
+			? `https://amp.theguardian.com/${CAPI?.pageId}`
 			: undefined;
 
-	const { openGraphData } = CAPI;
-	const { twitterData } = CAPI;
+	const openGraphData = CAPI?.openGraphData;
+	const twitterData = CAPI?.twitterData;
 	const keywords =
-		typeof CAPI.config.keywords === 'undefined' ||
+		typeof CAPI?.config.keywords === 'undefined' ||
 		CAPI.config.keywords === 'Network Front'
 			? ''
 			: CAPI.config.keywords;
@@ -311,7 +63,7 @@ export const document = ({ data }: Props): string => {
 		css: extractedCss,
 		html,
 		title,
-		description: CAPI.trailText,
+		description,
 		windowGuardian,
 		gaPath,
 		ampLink,

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -209,24 +209,6 @@ export const document = ({ data }: Props): string => {
 		.map((script) => renderToString(script))
 		.slice(0, 2);
 
-	/**
-	 * Preload the following woff2 font files
-	 * TODO: Identify critical fonts to preload
-	 */
-	const fontFiles = [
-		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2',
-		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
-		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
-		// 'http://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2',
-		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
-	];
-
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
@@ -328,7 +310,6 @@ export const document = ({ data }: Props): string => {
 		lowPriorityScriptTags,
 		css: extractedCss,
 		html,
-		fontFiles,
 		title,
 		description: CAPI.trailText,
 		windowGuardian,

--- a/dotcom-rendering/src/web/server/generateArticleHtml.tsx
+++ b/dotcom-rendering/src/web/server/generateArticleHtml.tsx
@@ -1,0 +1,284 @@
+import { renderToString } from 'react-dom/server';
+import { document } from '@root/src/web/server/document';
+import { Pillar } from '@guardian/types';
+import { ChunkExtractor } from '@loadable/server';
+import {
+	CDN,
+	getScriptArrayFromFilename,
+	getScriptArrayFromChunkName,
+	loadableManifestJson,
+} from '@root/src/lib/assets';
+import createEmotionServer from '@emotion/server/create-instance';
+import createCache from '@emotion/cache';
+
+import { Page } from '@root/src/web/components/Page';
+
+import { escapeData } from '@root/src/lib/escapeData';
+
+import { makeWindowGuardian } from '@root/src/model/window-guardian';
+import { DecideLayout } from '../layouts/DecideLayout';
+import { decideTheme } from '../lib/decideTheme';
+
+interface Props {
+	data: DCRServerDocumentData;
+}
+
+const decideTitle = (CAPI: CAPIType): string => {
+	if (decideTheme(CAPI.format) === Pillar.Opinion && CAPI.author.byline) {
+		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
+	}
+	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
+};
+
+const generateScriptTags = (
+	scripts: Array<{ src: string; legacy?: boolean }>,
+) =>
+	scripts.reduce((scriptTags, script) => {
+		let attrs = 'defer';
+
+		if (Object.prototype.hasOwnProperty.call(script, 'legacy')) {
+			attrs = script.legacy ? 'defer nomodule' : 'type="module"';
+		}
+
+		return [
+			...scriptTags,
+			`<script ${attrs} src="${script.src}"></script>`,
+		];
+	}, [] as string[]);
+
+export const generateArticleHtml = ({ data }: Props): string => {
+	const { CAPI, NAV, linkedData } = data;
+	const description = CAPI.trailText;
+	const title = decideTitle(CAPI);
+	const key = 'dcr';
+	const cache = createCache({ key });
+	// eslint-disable-next-line @typescript-eslint/unbound-method
+	const { extractCritical } = createEmotionServer(cache);
+
+	const { html, css: extractedCss, ids: cssIDs } = extractCritical(
+		renderToString(
+			<Page cache={cache}>
+				<DecideLayout CAPI={CAPI} NAV={NAV} />
+			</Page>,
+		),
+	);
+
+	/**
+	 * We escape windowGuardian here to prevent errors when the data
+	 * is placed in a script tag on the page
+	 */
+	const windowGuardian = escapeData(
+		JSON.stringify(makeWindowGuardian(data, cssIDs)),
+	);
+
+	// There are docs on loadable in ./docs/loadable-components.md
+	const loadableExtractor = new ChunkExtractor({
+		stats: loadableManifestJson,
+		entrypoints: ['react'],
+	});
+
+	// The lodable-components docs want us to use extractor.collectChunks() but
+	// we don't have the traditional same <App /> rendered on server and client.
+	// Our data structure is vastly different (CAPIType vs CAPIBrowserType) and
+	// our architecture expects src/web/App to be client-side only, therefore
+	// it is difficult for us to use collectChunks to automatically extract the
+	// component splits that we want.
+	// However, this does actually suit our architecture as we can use the CAPI
+	// component reference.
+	const allChunks: LoadableComponents = [
+		{ chunkName: 'EditionDropdown', addWhen: 'always' },
+		{
+			chunkName: 'elements-YoutubeBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
+		},
+		{
+			chunkName: 'elements-RichLinkComponent',
+			addWhen: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
+		},
+		{
+			chunkName: 'elements-InteractiveBlockComponent',
+			addWhen:
+				'model.dotcomrendering.pageElements.InteractiveBlockElement',
+		},
+		{
+			chunkName: 'elements-InteractiveContentsBlockComponent',
+			addWhen:
+				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+		},
+		{
+			chunkName: 'elements-CalloutBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
+		},
+		{
+			chunkName: 'elements-DocumentBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.DocumentBlockElement',
+		},
+		{
+			chunkName: 'elements-MapEmbedBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
+		},
+		{
+			chunkName: 'elements-SpotifyBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
+		},
+		{
+			chunkName: 'elements-VideoFacebookBlockComponent',
+			addWhen:
+				'model.dotcomrendering.pageElements.VideoFacebookBlockElement',
+		},
+		{
+			chunkName: 'elements-VineBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.VineBlockElement',
+		},
+		{
+			chunkName: 'elements-InstagramBlockComponent',
+			addWhen: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+		},
+	];
+
+	let arrayOfLoadableScriptObjects: {
+		src: string;
+		legacy: boolean;
+	}[] = [];
+
+	// We want to only insert script tags for the elements or main media elements on this page view
+	// so we need to check what elements we have and use the mapping to the the chunk name
+	const CAPIElements: CAPIElement[] = CAPI.blocks
+		.map((block) => block.elements)
+		.flat();
+	const { mainMediaElements } = CAPI;
+	// Filter the chunks defined above by whether
+	// the 'addWhen' value is 'always' or matches
+	// any elements in the body or main media element
+	// arrays for the page request.
+	const chunksForPage = allChunks.filter((chunk) =>
+		[...CAPIElements, ...mainMediaElements].some(
+			(block) =>
+				chunk.addWhen === 'always' || block._type === chunk.addWhen,
+		),
+	);
+	// Once we have the chunks for the page, we can add them directly to the loadableExtractor
+	chunksForPage.forEach((chunk) => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		loadableExtractor.addChunk(chunk.chunkName); // addChunk is *undocumented* and not in TS types. It allows manually adding chunks to extractor.
+	});
+
+	const polyfillIO =
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+
+	const pageHasNonBootInteractiveElements = CAPIElements.some(
+		(element) =>
+			element._type ===
+				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
+			element.scriptUrl !==
+				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
+	);
+
+	// Pre assets returns an array of objects structured as:
+	// {
+	//     filename: 'elements-RichLinkComponent.js',
+	//     scriptType: 'script',
+	//     chunk: 'elements-RichLinkComponent',
+	//     url: '/elements-RichLinkComponent.js',
+	//     path: '/Users/gareth_trufitt/code/dotcom-rendering/dist/elements-RichLinkComponent.js',
+	//     type: 'mainAsset',
+	//     linkType: 'preload'
+	// }
+	//
+
+	const preAssets: {
+		filename: string;
+		scriptType: string;
+		chunk: string;
+		url: string;
+		path: string;
+		type: string;
+		linkType: string;
+	}[] =
+		// PreAssets is *undocumented* and not in TS types. It returns the webpack asset for each script.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		loadableExtractor.getPreAssets();
+
+	preAssets.forEach((script) => {
+		arrayOfLoadableScriptObjects = [
+			...arrayOfLoadableScriptObjects,
+			...getScriptArrayFromFilename(script.filename),
+		];
+	});
+
+	// Loadable generates configuration script elements as the first two items
+	// of the script element array. We need to generate the react component version
+	// and then build an array of them, rendering them to string and grabbing
+	// the first two items. The alternative getScriptTags just returns a string
+	// of scripts tags already concatenated, so is not useful in this scenario.
+	const loadableConfigScripts = loadableExtractor
+		.getScriptElements()
+		.map((script) => renderToString(script))
+		.slice(0, 2);
+
+	const gaChunk = getScriptArrayFromChunkName('ga');
+	const modernScript = gaChunk.filter(
+		(script) => script && script.legacy === false,
+	)[0];
+	const legacyScript = gaChunk.filter(
+		(script) => script && script.legacy === true,
+	)[0];
+	const gaPath = {
+		modern: modernScript.src,
+		legacy: legacyScript.src,
+	};
+
+	function isDefined<T>(argument: T | boolean): argument is T {
+		return argument !== false;
+	}
+	/**
+	 * The highest priority scripts.
+	 * These scripts have a considerable impact on site performance.
+	 * Only scripts critical to application execution may go in here.
+	 * Please talk to the dotcom platform team before adding more.
+	 * Scripts will be executed in the order they appear in this array
+	 */
+	const priorityScriptTags = generateScriptTags(
+		[
+			{ src: polyfillIO },
+			...getScriptArrayFromChunkName('ophan'),
+			CAPI.config && { src: CAPI.config.commercialBundleUrl },
+			...getScriptArrayFromChunkName('sentryLoader'),
+			...getScriptArrayFromChunkName('coreVitals'),
+			...getScriptArrayFromChunkName('dynamicImport'),
+			pageHasNonBootInteractiveElements && {
+				src: `${CDN}static/frontend/js/curl-with-js-and-domReady.js`,
+			},
+			...arrayOfLoadableScriptObjects, // This includes the 'react' entry point
+		].filter(isDefined), // We use the TypeGuard to keep TS happy
+	);
+
+	/**
+	 * Low priority scripts. These scripts will be requested
+	 * asynchronously after the main HTML has been parsed. Execution
+	 * order is not guaranteed. It is even possible that these execute
+	 * *before* the high priority scripts, although this is very
+	 * unlikely.
+	 */
+	const lowPriorityScriptTags = generateScriptTags([
+		...getScriptArrayFromChunkName('atomIframe'),
+		...getScriptArrayFromChunkName('embedIframe'),
+		...getScriptArrayFromChunkName('newsletterEmbedIframe'),
+	]);
+
+	return document({
+		title,
+		CAPI,
+		linkedData,
+		description,
+		priorityScriptTags,
+		lowPriorityScriptTags,
+		gaPath,
+		loadableConfigScripts,
+		windowGuardian,
+		html,
+		extractedCss,
+	});
+};

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -15,7 +15,6 @@ export const htmlTemplate = ({
 	html,
 	windowGuardian,
 	gaPath,
-	fontFiles = [],
 	ampLink,
 	openGraphData,
 	twitterData,
@@ -31,7 +30,6 @@ export const htmlTemplate = ({
 	lowPriorityScriptTags: string[];
 	css: string;
 	html: string;
-	fontFiles?: string[];
 	windowGuardian: string;
 	gaPath: { modern: string; legacy: string };
 	ampLink?: string;
@@ -46,10 +44,29 @@ export const htmlTemplate = ({
 			? 'favicon-32x32.ico'
 			: 'favicon-32x32-dev-yellow.ico';
 
+	/**
+	 * Preload the following woff2 font files
+	 * TODO: Identify critical fonts to preload
+	 */
+	const fontFiles = [
+		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2',
+		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
+		// 'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
+		// 'http://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2',
+		'https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
+	];
+
 	const fontPreloadTags = fontFiles.map(
 		(fontFile) =>
 			`<link rel="preload" href="${fontFile}" as="font" crossorigin>`,
 	);
+
 
 	const generateMetaTags = (
 		dataObject: { [key: string]: string },

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -24,17 +24,17 @@ export const htmlTemplate = ({
 }: {
 	title?: string;
 	description: string;
-	linkedData: { [key: string]: any };
+	linkedData?: { [key: string]: any };
 	loadableConfigScripts: string[];
 	priorityScriptTags: string[];
 	lowPriorityScriptTags: string[];
 	css: string;
 	html: string;
-	windowGuardian: string;
-	gaPath: { modern: string; legacy: string };
+	windowGuardian?: string;
+	gaPath?: { modern: string; legacy: string };
 	ampLink?: string;
-	openGraphData: { [key: string]: string };
-	twitterData: { [key: string]: string };
+	openGraphData?: { [key: string]: string };
+	twitterData?: { [key: string]: string };
 	keywords: string;
 	skipToMainContent: string;
 	skipToNavigation: string;
@@ -83,13 +83,13 @@ export const htmlTemplate = ({
 		return '';
 	};
 
-	const openGraphMetaTags = generateMetaTags(openGraphData, 'property');
+	const openGraphMetaTags = openGraphData && generateMetaTags(openGraphData, 'property');
 
 	// Opt out of having information from our website used for personalization of content and suggestions for Twitter users, including ads
 	// See https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties/overview
 	const twitterSecAndPrivacyMetaTags = `<meta name="twitter:dnt" content="on">`;
 
-	const twitterMetaTags = generateMetaTags(twitterData, 'name');
+	const twitterMetaTags = twitterData && generateMetaTags(twitterData, 'name');
 
 	// Duplicated prefetch and preconnect tags from DCP:
 	// Documented here: https://github.com/guardian/frontend/pull/12935
@@ -192,9 +192,11 @@ export const htmlTemplate = ({
                 ${preconnectTags.join('\n')}
                 ${prefetchTags.join('\n')}
 
-                <script type="application/ld+json">
-                    ${JSON.stringify(linkedData)}
-                </script>
+				${linkedData && `
+					<script type="application/ld+json">
+						${JSON.stringify(linkedData)}
+					</script>`
+				}
 
                 <!-- TODO make this conditional when we support more content types -->
                 ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
@@ -212,19 +214,19 @@ export const htmlTemplate = ({
                 <meta name="robots" content="max-image-preview:large">
 
                 <script>
-                    window.guardian = ${windowGuardian};
+                    ${windowGuardian && `window.guardian = ${windowGuardian};`}
                     window.guardian.queue = []; // Queue for functions to be fired by polyfill.io callback
                 </script>
 
                 <script type="module">
                     window.guardian.mustardCut = true;
-                    window.guardian.gaPath = "${gaPath.modern}";
+                    ${gaPath && `window.guardian.gaPath = "${gaPath.modern}";`}
                 </script>
 
                 <script nomodule>
                     // Browser fails mustard check
                     window.guardian.mustardCut = false;
-                    window.guardian.gaPath = "${gaPath.legacy}";
+                    ${gaPath && `window.guardian.gaPath = "${gaPath.legacy}";`}
                 </script>
 
                 <script>

--- a/dotcom-rendering/src/web/server/render.ts
+++ b/dotcom-rendering/src/web/server/render.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { extractNAV } from '@root/src/model/extract-nav';
 
-import { document } from '@root/src/web/server/document';
+import { generateArticleHtml } from '@root/src/web/server/generateArticleHtml';
 import { enhanceCAPI } from '@root/src/model/enhanceCAPI';
 import { extract as extractGA } from '@root/src/model/extract-ga';
 import { Article as ExampleArticle } from '@root/fixtures/generated/articles/Article';
@@ -12,7 +12,7 @@ export const renderArticle = (
 ): void => {
 	try {
 		const CAPI = enhanceCAPI(body);
-		const resp = document({
+		const html = generateArticleHtml({
 			data: {
 				CAPI,
 				site: 'frontend',
@@ -23,8 +23,8 @@ export const renderArticle = (
 			},
 		});
 
-		res.status(200).send(resp);
-	} catch (e) {
+		res.status(200).send(html);
+	} catch (e: any) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		res.status(500).send(`<pre>${e.stack}</pre>`);
 	}
@@ -48,7 +48,7 @@ export const renderArticleJson = (
 		};
 
 		res.status(200).send(resp);
-	} catch (e) {
+	} catch (e: any) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		res.status(500).send(`<pre>${e.stack}</pre>`);
 	}
@@ -68,7 +68,7 @@ export const renderInteractive = (
 ): void => {
 	try {
 		const CAPI = enhanceCAPI(body);
-		const resp = document({
+		const html = generateArticleHtml({
 			data: {
 				CAPI,
 				site: 'frontend',
@@ -79,8 +79,8 @@ export const renderInteractive = (
 			},
 		});
 
-		res.status(200).send(resp);
-	} catch (e) {
+		res.status(200).send(html);
+	} catch (e: any) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		res.status(500).send(`<pre>${e.stack}</pre>`);
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This refactors how DCR builds the html for a page to remove the dependency on the `CAPI` object. Now both `document` and `htmlTemplate` will work for rendering simpler, non article pages.

### Before
```ts
// document.tsx
interface Props {
	data: DCRServerDocumentData;
}
```

```ts
// htmlTemplate.ts
type Props = {
	title?: string;
	description: string;
	linkedData: { [key: string]: any };
	loadableConfigScripts: string[];
	priorityScriptTags: string[];
	lowPriorityScriptTags: string[];
	css: string;
	html: string;
	fontFiles?: string[];
	windowGuardian: string;
	gaPath: { modern: string; legacy: string };
	ampLink?: string;
	openGraphData: { [key: string]: string };
	twitterData: { [key: string]: string };
	keywords: string;
	skipToMainContent: string;
	skipToNavigation: string;
}
```

### After
```ts
// document.tsx
interface Props {
	extractedCss: string;
	html: string;
	description: string;
	title?: string;
	CAPI?: CAPIType;
	linkedData?: { [key: string]: any };
	priorityScriptTags?: string[];
	lowPriorityScriptTags?: string[];
	gaPath?: { modern: string; legacy: string };
	loadableConfigScripts?: string[];
	windowGuardian?: string;
}
```

```ts
// htmlTemplate.ts
type Props = {
	title?: string;
	description: string;
	linkedData?: { [key: string]: any };
	loadableConfigScripts: string[];
	priorityScriptTags: string[];
	lowPriorityScriptTags: string[];
	css: string;
	html: string;
	windowGuardian?: string;
	gaPath?: { modern: string; legacy: string };
	ampLink?: string;
	openGraphData?: { [key: string]: string };
	twitterData?: { [key: string]: string };
	keywords: string;
	skipToMainContent: string;
	skipToNavigation: string;
}
```

## Why?
Because we want DCR to serve other pages, not just articles

## Do we?
Well, I think so. I want to add pages such as https://www.theguardian.com/email-newsletters but if I want to do that at the moment I need to build a whole react app from scratch, which isn't great 😐 

## Why is this a draft PR?
Personally, I think this PR is a good idea. We should be aligning this kind of high level page structure (and all the build and test logic as well) for all pages on dotcom. But rather than try to push it through I wanted to canvas opinion on this and maybe this PR is a good place to do that?

**I am not going to merge this PR** If there's agreement that this approach is something that we all want then I will go back and make these changes bit by bit in separate PRs so that we can check them more thoroughly.

