### PR TITLE
LIVE-3071: add min height to headlines

### DIFF
--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -75,17 +75,23 @@ const immersiveStyles = css`
 	padding-top: 0.0625rem;
 	padding-bottom: ${remSpace[6]};
 	background-color: ${neutral[7]};
+	min-height: 3.5rem;
 
 	${from.tablet} {
 		padding-left: 0;
+		min-height: 4.625rem;
 	}
 `;
 
 const interviewStyles = css`
 	margin-left: ${remSpace[3]};
 	border: 0;
-
+	min-height: 3.5rem;
 	${articleWidthStyles}
+
+	${from.tablet} {
+		min-height: 4.625rem;
+	}
 `;
 
 const interviewFontStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `min-height` to `interview` and `immersive` article template `headline` components.

## Why?
Previously we were seeing gaps when we had a one line headline.

### Before
![Screenshot 2021-09-20 at 12 08 22](https://user-images.githubusercontent.com/77005274/133994219-114b8499-eed1-40a3-8e8c-c3e6ae882813.png)

### After

![Screenshot 2021-09-20 at 12 08 01](https://user-images.githubusercontent.com/77005274/133994256-fde4ea45-3032-4385-84b3-c79010f4dd7d.png)


