### PR TITLE
Fix yarn linking and remove webpack workarounds

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -153,7 +153,6 @@ const arWebpack = (config) => {
 			__dirname,
 			`../apps-rendering/src/logger/clientDev`
 		),
-		"preact-render-to-string": "react-dom/server",
 		Buffer: "buffer",
 	};
 

--- a/apps-rendering/config/jest.config.js
+++ b/apps-rendering/config/jest.config.js
@@ -50,7 +50,4 @@ module.exports = {
 	moduleDirectories: ['node_modules', 'src'],
 	snapshotSerializers: ['@emotion/jest/serializer'],
 	transformIgnorePatterns: ['node_modules/(?!@guardian)'],
-	moduleNameMapper: {
-		'preact-render-to-string': 'react-dom/server',
-	},
 };

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3439,9 +3439,9 @@
       }
     },
     "@guardian/atoms-rendering": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-17.0.0.tgz",
-      "integrity": "sha512-PWG5liw94s+wPND7pMr0vE7CmTB/VIdg8GmNs89JDtk9enh0hPszew8mk11g/gPxPRe93k0jg0kV/YWvmDEDBg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-19.0.0.tgz",
+      "integrity": "sha512-Kxd4l4LO7j1bqCpvgmGaZO9E6b+Q2eUJWKLSrZG7vdp1MGACrUAgJBl3qztI10nAqt3KNJrbpOFgWMEU7OuYcA==",
       "requires": {
         "youtube-player": "^5.5.2"
       }

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -35,7 +35,7 @@
     "@emotion/react": "^11.4.0",
     "@emotion/server": "^11.0.0",
     "@guardian/apps-rendering-api-models": "^0.11.2",
-    "@guardian/atoms-rendering": "^17.0.0",
+    "@guardian/atoms-rendering": "^19.0.0",
     "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -44,19 +44,6 @@ function resolve(
 		alias: {
 			logger: path.resolve(__dirname, `src/logger/${loggerName}`),
 			react: path.resolve('./node_modules/react'),
-			// This line exists because atoms-rendering imports `preact-render-to-string`
-			// https://github.com/guardian/atoms-rendering/blob/24b166fc40d125b33ae9ac56d3535c27b0ff5304/src/lib/unifyPageContent.tsx#L2
-			//
-			// It works to keep the compiler happy, but it will crash at runtime
-			// because it's imported as default, whereas ReactDOM exports
-			// as a named method. This isn't a problem for now because it
-			// only affects Interactive Atoms, and we don't use atoms-rendering
-			// for those yet.
-			//
-			// I think a better solution would be for atoms-rendering to import
-			// `react-dom/server`, and for DCR to alias that to `preact-render-to-string`.
-			// Then we can get rid of this line.
-			'preact-render-to-string': 'react-dom/server',
 		},
 	};
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -40,7 +40,7 @@
     "@emotion/server": "^11.4.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^18.0.3",
+    "@guardian/atoms-rendering": "^19.0.0",
     "@guardian/braze-components": "^3.5.0",
     "@guardian/automat-contributions": "^0.4.1",
     "@guardian/commercial-core": "^0.19.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -105,7 +105,7 @@
     "minify-css-string": "^1.0.0",
     "ophan-tracker-js": "^1.3.27",
     "pm2": "5.0.0",
-    "preact": "^10.5.12",
+    "preact": "^10.5.14",
     "preact-render-to-string": "^5.1.19",
     "prettier-eslint": "^11.0.0",
     "pretty-bytes": "^5.6.0",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -16035,10 +16035,10 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.5.12:
-  version "10.5.12"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.12.tgz#6a8ee8bf40a695c505df9abebacd924e4dd37704"
-  integrity sha512-r6siDkuD36oszwlCkcqDJCAKBQxGoeEGytw2DGMD5A/GGdu5Tymw+N2OBXwvOLxg6d1FeY8MgMV3cc5aVQo4Cg==
+preact@^10.5.14:
+  version "10.5.14"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.14.tgz#0b14a2eefba3c10a57116b90d1a65f5f00cd2701"
+  integrity sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==
 
 prebuild-install@^5.3.0:
   version "5.3.0"

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1719,10 +1719,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^18.0.3":
-  version "18.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-18.0.3.tgz#de63cb6af5fbfe030edbdebe499a46c3f3907e29"
-  integrity sha512-KG0PKiob3P3/6pWSb3FqQVvWxK/Ru8HQcjvN6vLbvKoUZFz5FVJYJ0V8EZipKalh4PaT9pbQg8UAvMg8oMg7fw==
+"@guardian/atoms-rendering@^19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-19.0.0.tgz#5bfcb779acecc541b26d2985cba43c4d2d325263"
+  integrity sha512-Kxd4l4LO7j1bqCpvgmGaZO9E6b+Q2eUJWKLSrZG7vdp1MGACrUAgJBl3qztI10nAqt3KNJrbpOFgWMEU7OuYcA==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
## What does this change?

Fixes yarn linking and removes `preact-render-to-string` aliasing.

Builds on: https://github.com/guardian/atoms-rendering/pull/286

## TL;DR

1. This previous [workaround](https://github.com/guardian/atoms-rendering/pull/143) meant `preact-render-to-string` was introduced to `atoms-rendering`
1. Because `preact-render-to-string` was introduced to `atoms-rendering` any React app that transpiled `atoms-rendering` had to implement a (reverse) webpack alias:
    `'preact-render-to-string': 'react-dom/server'`
1. Because `preact` was added to `atoms-rendering` when yarn/npm linking to a consuming app that also had `preact` (e.g. DCR) runtime exceptions would be thrown because of known artifacts with yarn/npm linking.

Given there is a fix for 1. and `preact` has now been removed from `atoms-rendering`, we can (in DCR) remove the workarounds, aliasing and fix yarn linking.

## Before and After

https://user-images.githubusercontent.com/7014230/134013543-e2426069-343d-413a-b076-d850daf0da71.mp4

## Detail

### Issues

We have the following related issues:

1. **Module not found Error**
Back in Nov 2020 compiling DCR would result in the following error:
`Module not found: Error: Package path ./compat/server is not exported`
A workaround resulted in adding `preact-render-to-string` to `atoms-rendering` as explained in [this PR](https://github.com/guardian/atoms-rendering/pull/143).
1. **Webpack aliasing**
Due to 1. any React app consumer of `atoms-rendering` had to implement a webpack alias:
    `'preact-render-to-string': 'react-dom/server'` such as ([link](https://github.com/guardian/dotcom-rendering/blob/33b89cfcf321fb999880f38419f6353a55a2e05b/apps-rendering/webpack.config.ts#L59), [link](https://github.com/guardian/dotcom-rendering/blob/d69152d08f86d7a22aa12b9df8a417588c520438/apps-rendering/config/jest.config.js#L54), [link](https://github.com/guardian/dotcom-rendering/blob/98486a70fbe147e9c51577f11a48a64d202adf6a/.storybook/main.js#L156))
1. **Yarn linking x-rendering projects**
Due to 1. and **known artifacts of yarn/npm symlinking** ([link](https://blog.maximeheckel.com/posts/duplicate-dependencies-npm-link), [link](https://github.com/yarnpkg/yarn/issues/8105)) when locally linking `atoms-rendering` to `dotcom-rendering` (for example) linked **components hooks** would throw the runtime exception:
`Uncaught (in promise) TypeError: Cannot read property '__H' of undefined` 

    What is happening is that the symlinked repo would resolve dependencies to its own dependencies (either actual or dev) rather than those of the consuming app, creating multiple instances.

    Packages such as React, Preact and emotion however require a single context i.e. all 'react' dependencies should resolve to the same module ([link](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react), [link](https://github.com/facebook/react/issues/13991)).

    The result was when linking repositories locally, linked components (e.g. `YoutubeAtom`) did not work.
An adhoc fix (not applied but fyi) would be to force the consuming app to make React, Preact etc to resolve to its _own_ `node_modules` e.g. : 
    ```js
    // ... App Webpack config ...
    resolve: {
      alias: {
        react: path.resolve('./node_modules/react'),
        @emotion/core: path.resolve('./node_modules/@emotion/core')
    }
    ```

### Fixes

1. **Module not found Error**

    The root cause of this is a bug in the exported files of the Preact project :
     https://github.com/preactjs/preact/issues/1329 
    
    This first stable release to include this was preact@10.0.0 :
    https://github.com/preactjs/preact/pull/1332
    It was fixed _again_ for Webpack 5 in preact@10.5.8 :
    https://github.com/preactjs/preact/pull/2873
    
    DCR has got this Preact fix via its semver but upgrading will make this explicit.

2. **Webpack aliasing**

    A recent `atoms-rendering` [PR](https://github.com/guardian/atoms-rendering/pull/270) removed `preact-render-to-string` and instead forces the consuming application to alias `react-dom/server` if required.

    Because of fixes 1. and 2. we can now remove all webpack aliases.

3. **Yarn linking x-rendering projects**
Because of fixes 1. and 2. we can simply remove Preact from `atoms-rendering` so there is no duplicate module resolution when linking locally and linked components function as expected.



