### PR TITLE
LIVE-3075: render links as text in overlay

### DIFF
--- a/apps-rendering/src/components/editions/headerImageCaption.tsx
+++ b/apps-rendering/src/components/editions/headerImageCaption.tsx
@@ -86,7 +86,7 @@ const toReact = (node: Node, key: number): ReactNode => {
 		case 'EM':
 			return <em>{node.textContent}</em>;
 		case 'A':
-			return <span>{node.textContent ?? ''}</span>;
+			return <span>{node.textContent}</span>;
 		case '#text':
 			return node.textContent;
 	}

--- a/apps-rendering/src/components/editions/headerImageCaption.tsx
+++ b/apps-rendering/src/components/editions/headerImageCaption.tsx
@@ -85,6 +85,8 @@ const toReact = (node: Node, key: number): ReactNode => {
 	switch (node.nodeName) {
 		case 'EM':
 			return <em>{node.textContent}</em>;
+		case 'A':
+			return <span>{node.textContent ?? ''}</span>;
 		case '#text':
 			return node.textContent;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Handles `a` tags in header image overlay.

## Why?
Previously we weren't rendering these so any links were rendered as an empty string.

### Before
![Screenshot 2021-09-20 at 12 39 20](https://user-images.githubusercontent.com/77005274/134011984-4bf2e522-ff66-4973-adf7-65881f042c74.png)

### Afte
![Screenshot 2021-09-20 at 14 38 35](https://user-images.githubusercontent.com/77005274/134011996-37156be2-18af-4e47-bea2-3fe991e2c7f4.png)
r
