### PR TITLE
Style inline merchandising ad slot

### DIFF
--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -1,12 +1,11 @@
 import { ClassNames, css as emoCss } from '@emotion/react';
 
 import { border } from '@guardian/src-foundations/palette';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { center } from '@root/src/web/lib/center';
 // @ts-ignore-start
 import { jsx as _jsx } from 'react/jsx-runtime';
 // @ts-ignore-end
-import { labelStyles as adLabelStyles } from './AdSlot';
 
 const padding = emoCss`
 	padding: 0 10px;
@@ -14,26 +13,6 @@ const padding = emoCss`
 	${from.mobileLandscape} {
 		padding: 0 20px;
 	}
-`;
-
-const adStylesDynamic = emoCss`
-	& .ad-slot.ad-slot--collapse {
-		display: none;
-	}
-
-	${from.tablet} {
-		.mobile-only .ad-slot {
-			display: none;
-		}
-	}
-
-	${until.tablet} {
-		.hide-until-tablet .ad-slot {
-			display: none;
-		}
-
-	}
-
 `;
 
 const sideBorders = (colour: string) => emoCss`
@@ -96,11 +75,7 @@ export const ElementContainer = ({
 					{children && children}
 				</div>
 			);
-			// Apply ad styles to dynamic ad slots (i.e. slots that are not fixed), e.g. ads inserted
-			// by spacefinder and ads in interactive articles
 			const style = css`
-				${adStylesDynamic}
-				${adLabelStyles}
 				${backgroundColour && setBackgroundColour(backgroundColour)}
 			`;
 			// Create a react element from the tagName passed in OR

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -3,11 +3,38 @@ import { css } from '@emotion/react';
 import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+import { from, until } from '@guardian/src-foundations/mq';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
+import { labelStyles as adLabelStyles } from '../components/AdSlot';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
 	position: relative;
+`;
+
+// These styles are applied to dynamic ad slots (i.e. slots that are not fixed), e.g. ads inserted
+// by spacefinder across all layout types (articles, comments, etc)
+//
+// spacefinder is scoped to placing elements in spaces within the .article-body-commercial-selector
+// hence we scope the styles at the same level
+const adStylesDynamic = css`
+	${adLabelStyles}
+
+	& .ad-slot.ad-slot--collapse {
+		display: none;
+	}
+
+	${from.tablet} {
+		.mobile-only .ad-slot {
+			display: none;
+		}
+	}
+
+	${until.tablet} {
+		.hide-until-tablet .ad-slot {
+			display: none;
+		}
+	}
 `;
 
 export const ArticleRenderer: React.FC<{
@@ -50,7 +77,7 @@ export const ArticleRenderer: React.FC<{
 					? interactiveLegacyClasses.contentMainColumn
 					: '',
 			].join(' ')}
-			css={commercialPosition}
+			css={[adStylesDynamic, commercialPosition]}
 		>
 			{/* Insert the placeholder for the sign in gate on the 2nd article element */}
 			{withSignInGateSlot(output)}

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -35,6 +35,27 @@ const adStylesDynamic = css`
 			display: none;
 		}
 	}
+
+	.ad-slot--im {
+		float: left;
+		width: 130px;
+		${from.mobileLandscape} {
+			width: 220px;
+		}
+
+		&:not(.ad-slot--rendered) {
+			width: 0;
+			height: 0;
+		}
+
+		&.ad-slot--rendered {
+			margin: 5px 10px 6px 0;
+			${from.mobileLandscape} {
+				margin-bottom: 12px;
+				margin-right: 20px;
+			}
+		}
+	}
 `;
 
 export const ArticleRenderer: React.FC<{


### PR DESCRIPTION
## What does this change?

- Move dynamic ad styles from the `ElementContainer` component level to the `ArticleRenderer` component level. 
- Add styling to DCR for the `ad-slot--im` inline merchandising class so that the styles match those of frontend. These are a transformation of the [frontend styles](https://github.com/guardian/frontend/blob/07305ca708926ef75db9b4489644c1174585cd84/static/src/stylesheets/module/_adslot.scss#L379-L400) such that node-sass syntax is removed and measurements are set in pixels to match the rest of the styling in `ArticleContainer`.

## Why?

- The styling of dynamic ads is moved up to the `ArticleRenderer` level so that these styles are not replicated across each individual `ElementContainer`. `ArticleRenderer` is the component to which a class is added that scopes where dynamic ads can be placed in the article by spacefinder.
- So the styling between frontend and DCR for inline merchandising ads matches and specifically that the DCR variant doesn't take up the full width of the article container.

### Before

![Screenshot 2021-09-21 at 15 05 55](https://user-images.githubusercontent.com/8000415/134185768-638dcb18-5e8e-4160-9b1e-b90b640eb317.png)

### After

![Screenshot 2021-09-21 at 15 05 35](https://user-images.githubusercontent.com/8000415/134185793-f2d6bea7-9790-4cb3-b93c-046592dbd2a3.png)

