### PR TITLE
Use ad sizes defined in `commercial-core`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
     "@guardian/atoms-rendering": "^19.0.0",
     "@guardian/automat-contributions": "^0.4.1",
     "@guardian/braze-components": "^3.6.0",
-    "@guardian/commercial-core": "0.19.2",
+    "@guardian/commercial-core": "0.21.0",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^7.0.0",
     "@guardian/libs": "^3.0.0",

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -5,45 +5,12 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Display } from '@guardian/types';
 import { space } from '@guardian/src-foundations';
+import { adSizes } from '@guardian/commercial-core';
 
 type Props = {
 	display: Display;
 	position: AdSlotType;
 };
-
-/*
-    This file's values are meant to mirror the values used by frontend.
-    Look for marks:
-        432b3a46-90c1-4573-90d3-2400b51af8d0
-        1b109a4a-791c-4214-acd2-2720d7d9f96f
-    ... in the frontend code
- */
-
-enum Size {
-	// standard ad sizes
-	billboard = '970,250',
-	leaderboard = '728,90',
-	mpu = '300,250',
-	halfPage = '300,600',
-	portrait = '300,1050',
-	skyscraper = '160,600',
-	mobilesticky = '320,50',
-	// dfp proprietary ad sizes
-	fluid = 'fluid',
-	outOfPage = '1,1',
-	googleCard = '300,274',
-	// guardian proprietary ad sizes
-	video = '620,1',
-	outstreamDesktop = '620,350',
-	outstreamGoogleDesktop = '550,310',
-	outstreamMobile = '300,197',
-	merchandisingHighAdFeature = '88,89',
-	merchandisingHigh = '88,87',
-	merchandising = '88,88',
-	inlineMerchandising = '88,85',
-	fabric = '88,71',
-	empty = '2,2',
-}
 
 export const labelHeight = 24;
 
@@ -240,13 +207,15 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							data-name="right"
 							// mark: 01303e88-ef1f-462d-9b6e-242419435cec
 							data-mobile={[
-								`${Size.outOfPage}`,
-								`${Size.empty}`,
-								`${Size.mpu}`,
-								`${Size.googleCard}`,
-								`${Size.halfPage}`,
-								`${Size.fluid}`,
-							].join('|')}
+								adSizes.outOfPage,
+								adSizes.empty,
+								adSizes.mpu,
+								adSizes.googleCard,
+								adSizes.halfPage,
+								adSizes.fluid,
+							]
+								.map((size) => size.toString())
+								.join('|')}
 							aria-hidden="true"
 						/>
 					);
@@ -282,13 +251,15 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 								data-name="right"
 								// mark: 01303e88-ef1f-462d-9b6e-242419435cec
 								data-mobile={[
-									`${Size.outOfPage}`,
-									`${Size.empty}`,
-									`${Size.mpu}`,
-									`${Size.googleCard}`,
-									`${Size.halfPage}`,
-									`${Size.fluid}`,
-								].join('|')}
+									adSizes.outOfPage,
+									adSizes.empty,
+									adSizes.mpu,
+									adSizes.googleCard,
+									adSizes.halfPage,
+									adSizes.fluid,
+								]
+									.map((size) => size.toString())
+									.join('|')}
 								aria-hidden="true"
 							/>
 						</div>
@@ -325,36 +296,42 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						data-link-name="ad slot comments"
 						data-name="comments"
 						data-mobile={[
-							`${Size.outOfPage}`,
-							`${Size.empty}`,
-							`${Size.halfPage}`,
-							`${Size.outstreamMobile}`,
-							`${Size.mpu}`,
-							`${Size.googleCard}`,
-							`${Size.fluid}`,
-						].join('|')}
+							adSizes.outOfPage,
+							adSizes.empty,
+							adSizes.halfPage,
+							adSizes.outstreamMobile,
+							adSizes.mpu,
+							adSizes.googleCard,
+							adSizes.fluid,
+						]
+							.map((size) => size.toString())
+							.join('|')}
 						data-desktop={[
-							`${Size.outOfPage}`,
-							`${Size.empty}`,
-							`${Size.mpu}`,
-							`${Size.googleCard}`,
-							`${Size.video}`,
-							`${Size.outstreamDesktop}`,
-							`${Size.outstreamGoogleDesktop}`,
-							`${Size.fluid}`,
-							`${Size.halfPage}`,
-							`${Size.skyscraper}`,
-						].join('|')}
+							adSizes.outOfPage,
+							adSizes.empty,
+							adSizes.mpu,
+							adSizes.googleCard,
+							adSizes.video,
+							adSizes.outstreamDesktop,
+							adSizes.outstreamGoogleDesktop,
+							adSizes.fluid,
+							adSizes.halfPage,
+							adSizes.skyscraper,
+						]
+							.map((size) => size.toString())
+							.join('|')}
 						data-phablet={[
-							`${Size.outOfPage}`,
-							`${Size.empty}`,
-							`${Size.outstreamMobile}`,
-							`${Size.mpu}`,
-							`${Size.googleCard}`,
-							`${Size.outstreamDesktop}`,
-							`${Size.outstreamGoogleDesktop}`,
-							`${Size.fluid}`,
-						].join('|')}
+							adSizes.outOfPage,
+							adSizes.empty,
+							adSizes.outstreamMobile,
+							adSizes.mpu,
+							adSizes.googleCard,
+							adSizes.outstreamDesktop,
+							adSizes.outstreamGoogleDesktop,
+							adSizes.fluid,
+						]
+							.map((size) => size.toString())
+							.join('|')}
 						aria-hidden="true"
 					/>
 				</div>
@@ -388,22 +365,26 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						// 1. file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
 						// 2. file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
 						data-tablet={[
-							`${Size.outOfPage}`,
-							`${Size.empty}`,
-							`${Size.fabric}`,
-							`${Size.fluid}`,
-							`${Size.leaderboard}`,
-						].join('|')}
+							adSizes.outOfPage,
+							adSizes.empty,
+							adSizes.fabric,
+							adSizes.fluid,
+							adSizes.leaderboard,
+						]
+							.map((size) => size.toString())
+							.join('|')}
 						data-desktop={[
-							`${Size.outOfPage}`,
-							`${Size.empty}`,
-							`${Size.leaderboard}`,
+							adSizes.outOfPage,
+							adSizes.empty,
+							adSizes.leaderboard,
 							`940,230`,
 							`900,250`,
-							`${Size.billboard}`,
-							`${Size.fabric}`,
-							`${Size.fluid}`,
-						].join('|')}
+							adSizes.billboard,
+							adSizes.fabric,
+							adSizes.fluid,
+						]
+							.map((size) => size.toString())
+							.join('|')}
 						// Values from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
 						aria-hidden="true"
 					/>
@@ -431,39 +412,47 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					data-name="mostpop"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
 					data-mobile={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.mpu}`,
-						`${Size.googleCard}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.mpu,
+						adSizes.googleCard,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					data-tablet={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.mpu}`,
-						`${Size.googleCard}`,
-						`${Size.halfPage}`,
-						`${Size.leaderboard}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.mpu,
+						adSizes.googleCard,
+						adSizes.halfPage,
+						adSizes.leaderboard,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					data-phablet={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.outstreamMobile}`,
-						`${Size.mpu}`,
-						`${Size.googleCard}`,
-						`${Size.halfPage}`,
-						`${Size.outstreamGoogleDesktop}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.outstreamMobile,
+						adSizes.mpu,
+						adSizes.googleCard,
+						adSizes.halfPage,
+						adSizes.outstreamGoogleDesktop,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					data-desktop={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.mpu}`,
-						`${Size.googleCard}`,
-						`${Size.halfPage}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.mpu,
+						adSizes.googleCard,
+						adSizes.halfPage,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -488,11 +477,13 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					data-name="merchandising-high"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
 					data-mobile={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.merchandisingHigh}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.merchandisingHigh,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -517,11 +508,13 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					data-name="merchandising"
 					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
 					data-mobile={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.merchandising}`,
-						`${Size.fluid}`,
-					].join('|')}
+						adSizes.outOfPage,
+						adSizes.empty,
+						adSizes.merchandising,
+						adSizes.fluid,
+					]
+						.map((size) => size.toString())
+						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -541,7 +534,9 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					data-label="false"
 					data-refresh="false"
 					data-out-of-page="true"
-					data-desktop={[`${Size.outOfPage}`].join('|')}
+					data-desktop={[adSizes.outOfPage]
+						.map((size) => size.toString())
+						.join('|')}
 					aria-hidden="true"
 				/>
 			);

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1536,10 +1536,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.6.0.tgz#51ba3cfd067e075859b1234a3799b53855a87620"
   integrity sha512-qIeESQ+RLV6ta8OBh3VBxNu3FSA6ekg9N+wdUzj4aDzKwycHaomHrs98CQWWzWCRkLiG+7PJBm8L5k0hspHvPQ==
 
-"@guardian/commercial-core@0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.19.2.tgz#8965a502f6a3c6ed7373f324f4180d41f1c1ed87"
-  integrity sha512-039V6kicXnwI3Xug2kwzOcpLRWvOITBbj69il//kvSSPNu65C0K4QiTewO0oozL1pDVoYH20BC9j1C+oAFok4g==
+"@guardian/commercial-core@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.21.0.tgz#a876dee100e2d341efa176edfccdbe71f40620ca"
+  integrity sha512-GLI97c2pJGnH350DNmYypIF433BZzeWHG46JzfwcnaSK/6d+3h/fzD1j7cAeN59T1nRb3ehibmYDXoDaxGUpOA==
 
 "@guardian/consent-management-platform@~6.11.5":
   version "6.11.5"


### PR DESCRIPTION
Co-Authored-By: Chris Jones <chrislomaxjones96@gmail.com>

## What does this change?

This change pulls `adSizes` from `@guardian/commercial-core` which is the new owner of this information.

## Why?

Part of a change to centralise where we store information about ad sizes. Previously, they were stored separately in `frontend` and `dotcom-rendering` which risked the ad size definitions diverging over time if not managed carefully.

Related PRs:

https://github.com/guardian/commercial-core/pull/353
https://github.com/guardian/frontend/pull/24184
