### PR TITLE
Allow `null` browserId

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -340,7 +340,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			country: countryCode,
 			pubData: {
 				platform: 'next-gen',
-				browserId: browserId ?? undefined,
+				browserId: browserId ?? undefined, // if `undefined`, the resulting consent signal cannot be joined to a page view.
 				pageViewId,
 			},
 		});

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -337,7 +337,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			country: countryCode,
 			pubData: {
 				platform: 'next-gen',
-				browserId,
+				browserId: browserId ?? undefined,
 				pageViewId,
 			},
 		});
@@ -731,7 +731,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				window.guardian.config?.ophan !== undefined,
 			].every(Boolean) && (
 				<CommercialMetrics
-					browserId={browserId}
+					browserId={browserId ?? undefined}
 					pageViewId={pageViewId}
 				/>
 			)}

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -164,10 +164,9 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	>();
 
 	const pageViewId = window.guardian?.config?.ophan?.pageViewId;
-	const [browserId, setBrowserId] = useState<string | undefined>(undefined);
+	const [browserId, setBrowserId] = useState<string | null | undefined>(undefined);
 	useOnce(() => {
-		// TODO: can the browserId actually be null?
-		setBrowserId(getCookie('bwid') ?? undefined);
+		setBrowserId(getCookie('bwid'));
 	}, []);
 
 	const componentEventHandler = (

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -164,6 +164,9 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	>();
 
 	const pageViewId = window.guardian?.config?.ophan?.pageViewId;
+	// [string] for the actual id;
+	// [null] for when the cookie does not exist;
+	// [undefined] for when the cookie has not been read yet
 	const [browserId, setBrowserId] = useState<string | null | undefined>(undefined);
 	useOnce(() => {
 		setBrowserId(getCookie('bwid'));


### PR DESCRIPTION
## What does this change?

Allows the `browserId` to be `null`, if there’s no `bwid` cookie set.

## Why?

This allows for the CMP to run in local and CODE environments.
