### PR TITLE
Change `HeaderAdSlot` background colour from white to light grey

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from '@emotion/react';
-import { space } from '@guardian/src-foundations';
+import { neutral, space} from '@guardian/src-foundations';
 import { Display } from '@guardian/types';
 
 import { AdSlot, labelHeight } from '@root/src/web/components/AdSlot';
@@ -14,7 +14,7 @@ const padding = space[4] + 2; // 18px - currently being reviewed
 const headerAdWrapper = css`
 	z-index: 1080;
 	width: 100%;
-	background-color: white;
+	background-color: ${neutral[97]};
 	min-height: ${250 + padding + labelHeight}px;
 	padding-bottom: ${padding}px;
 


### PR DESCRIPTION
## Why?
Since we recently rolled out a change to increase the space reserved for the top-above-nav advertising slot to 250px, the large white space looks a bit jarring.
This PR changes the background colour to a light shade of grey to make it clear that the slot is separate from any editorial content (this may or may not have been influenced by the New York Times!)
The change has been discussed with @zeek01 and @HarryFischer 

Frontend PR: https://github.com/guardian/frontend/pull/24192

### Before
![image](https://user-images.githubusercontent.com/57295823/134339224-50a75fd7-091f-48ab-a31e-a083a94acb76.png)

### After
![image](https://user-images.githubusercontent.com/57295823/134339157-49e2799e-66af-45fd-8bbe-b29945275e17.png)
