### PR TITLE
Migrate Ophan types from @guardian/types to @guardian/libs and bump version

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@guardian/commercial-core": "^0.19.2",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^7.0.0",
-    "@guardian/libs": "^2.0.0",
+    "@guardian/libs": "^3.0.0",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^3.8.0",
     "@guardian/src-checkbox": "^3.8.0",

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -1,4 +1,8 @@
 import type {
+	TestMeta,
+} from '@guardian/types';
+
+import type {
 	OphanABEvent,
 	OphanABPayload,
 	OphanAction,
@@ -6,8 +10,7 @@ import type {
 	OphanComponentEvent,
 	OphanComponentType,
 	OphanProduct,
-	TestMeta,
-} from '@guardian/types';
+} from '@guardian/libs';
 
 export type OphanRecordFunction = (event: { [key: string]: any }) => void;
 

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1763,10 +1763,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
   integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
 
-"@guardian/libs@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-2.0.0.tgz#8582703eb510df2e1c29b4b57aa81213dd63fd6f"
-  integrity sha512-rcl6BnePEh/ecp1Vgd8lA2ZANLjLSiHyG4F7RnlLNsr+G0U756/YJpLZRZ5HevALLLrU+g02c51yiSEqpDXFZw==
+"@guardian/libs@^3.0.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.2.1.tgz#96368fcd76f63b842708ea1489275bd3200f5e4b"
+  integrity sha512-/o84jYYlodIfKs+aRj1QoluHnQ/OdgJN/v1FONwGCf7eGn6RYn9BCh5QvHRujpoSqzgq435tzx5Ug3EF1wWvfQ==
 
 "@guardian/prettier@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION

Migrate Ophan types from @guardian/types to @guardian/libs and bump version. This is in preparation to solving an ongoing consent submission problem.