### PR TITLE
Do not constrain container width of `HeaderAdSlot` in Showcase and Comment layouts

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from '@emotion/react';
-import { neutral, space} from '@guardian/src-foundations';
+import { neutral, space } from '@guardian/src-foundations';
 import { Display } from '@guardian/types';
 
 import { AdSlot, labelHeight } from '@root/src/web/components/AdSlot';

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -322,6 +322,7 @@ export const CommentLayout = ({
 						showTopBorder={false}
 						showSideBorders={false}
 						padded={false}
+						shouldCenter={false}
 					>
 						<HeaderAdSlot
 							isAdFreeUser={CAPI.isAdFreeUser}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -263,6 +263,7 @@ export const ShowcaseLayout = ({
 								showTopBorder={false}
 								showSideBorders={false}
 								padded={false}
+								shouldCenter={false}
 							>
 								<HeaderAdSlot
 									isAdFreeUser={CAPI.isAdFreeUser}


### PR DESCRIPTION
## Why?
There are a few advertising campaigns coming up in October that will use the fabric video template.

Fabric videos take up a max width of 1920px, but the div containing those ads has the `shouldCenter` prop set to `true` by default in certain layouts, which constrains the max width to 1300px on desktop (and lower breakpoints for users on smaller devices). 

This is a problem because advertisers are paying for a 1920px ad that is effectively cropped to 1300px on desktop.

This PR brings consistency with the other layouts so `shouldCenter` is always set to `false` for the div containing the header ad slot. It also has the added benefit of showing the light grey background introduced in https://github.com/guardian/dotcom-rendering/pull/3452 

### Before
![image](https://user-images.githubusercontent.com/57295823/134378280-d0a626ee-d353-4be8-a5de-00a3dcd834d0.png)

### After
![image](https://user-images.githubusercontent.com/57295823/134381067-064fa29c-349c-4fe8-9ad1-8f3f3d00b030.png)
