### PR TITLE
Storybook : Add AR Live Prototype story

### DIFF
--- a/apps-rendering/src/components/layout/live.stories.tsx
+++ b/apps-rendering/src/components/layout/live.stories.tsx
@@ -1,0 +1,28 @@
+// ----- Imports ----- //
+import { breakpoints } from '@guardian/src-foundations';
+import { withKnobs } from '@storybook/addon-knobs';
+import Live from 'components/layout/live';
+
+import type { ReactElement } from 'react';
+import { live } from 'fixtures/live';
+
+// ----- Stories ----- //
+
+const Default = (): ReactElement => <Live item={{ ...live }} />;
+
+// ----- Exports ----- //
+
+export default {
+	component: Live,
+	title: 'AR/LiveBlog Prototype',
+	decorators: [withKnobs],
+	parameters: {
+		layout: 'fullscreen',
+		chromatic: {
+			diffThreshold: 0.4,
+			viewports: [breakpoints.mobile, breakpoints.tablet],
+		},
+	},
+};
+
+export { Default };

--- a/apps-rendering/src/components/layout/live.stories.tsx
+++ b/apps-rendering/src/components/layout/live.stories.tsx
@@ -2,9 +2,8 @@
 import { breakpoints } from '@guardian/src-foundations';
 import { withKnobs } from '@storybook/addon-knobs';
 import Live from 'components/layout/live';
-
-import type { ReactElement } from 'react';
 import { live } from 'fixtures/live';
+import type { ReactElement } from 'react';
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -5,9 +5,14 @@ import { Lines } from '@guardian/src-ed-lines';
 import { background, neutral } from '@guardian/src-foundations';
 import { breakpoints, from } from '@guardian/src-foundations/mq';
 import Footer from 'components/footer';
-import type { FC } from 'react';
-import type { Liveblog } from 'item';
+import Headline from 'components/headline';
+import Metadata from 'components/metadata';
 import RelatedContent from 'components/shared/relatedContent';
+import Standfirst from 'components/standfirst';
+import Tags from 'components/tags';
+import HeaderMedia from 'headerMedia';
+import type { Liveblog } from 'item';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -15,11 +20,6 @@ import {
 	onwardStyles,
 } from 'styles';
 import Series from '../series';
-import Headline from 'components/headline';
-import Standfirst from 'components/standfirst';
-import HeaderMedia from 'headerMedia';
-import Metadata from 'components/metadata';
-import Tags from 'components/tags';
 
 // // ----- Styles ----- //
 

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -1,0 +1,74 @@
+// // ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { Lines } from '@guardian/src-ed-lines';
+import { background, neutral } from '@guardian/src-foundations';
+import { breakpoints, from } from '@guardian/src-foundations/mq';
+import Footer from 'components/footer';
+import type { FC } from 'react';
+import type { Liveblog } from 'item';
+import RelatedContent from 'components/shared/relatedContent';
+import {
+	articleWidthStyles,
+	darkModeCss,
+	lineStyles,
+	onwardStyles,
+} from 'styles';
+import Series from '../series';
+import Headline from 'components/headline';
+import Standfirst from 'components/standfirst';
+import HeaderMedia from 'headerMedia';
+import Metadata from 'components/metadata';
+import Tags from 'components/tags';
+
+// // ----- Styles ----- //
+
+const BorderStyles = css`
+	background: ${neutral[100]};
+	${darkModeCss`background: ${background.inverse};`}
+
+	${from.wide} {
+		width: ${breakpoints.wide}px;
+		margin: 0 auto;
+	}
+`;
+
+interface Props {
+	item: Liveblog;
+}
+
+const Live: FC<Props> = ({ item }) => {
+	return (
+		<main>
+			<article className="js-article" css={BorderStyles}>
+				<header>
+					<Series item={item} />
+					<Headline item={item} />
+					<div css={articleWidthStyles}>
+						<Standfirst item={item} />
+					</div>
+					<div css={lineStyles}>
+						<Lines count={4} />
+					</div>
+					<div css={articleWidthStyles}>
+						<Metadata item={item} />
+						<HeaderMedia item={item} />
+					</div>
+				</header>
+			</article>
+			<section css={articleWidthStyles}>
+				<Tags tags={item.tags} format={item} />
+			</section>
+			<section css={onwardStyles}>
+				<RelatedContent content={item.relatedContent} />
+			</section>
+			<section css={articleWidthStyles}>
+				<Footer isCcpa={false} />
+			</section>
+		</main>
+	);
+};
+
+// // ----- Exports ----- //
+
+export default Live;

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -12,9 +12,10 @@ import {
 } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { parse } from 'client/parser';
+import type { MainMedia } from 'headerMedia';
+import { MainMediaKind } from 'headerMedia';
+import type { Liveblog } from 'item';
 import { pipe } from 'lib';
-import { Liveblog } from 'item';
-import { MainMedia, MainMediaKind } from 'headerMedia';
 
 const parser = new DOMParser();
 const parseHtml = parse(parser);
@@ -23,7 +24,7 @@ const headline =
 	'Covid live: Brazil health minister who shook hands with maskless Boris Johnson at UN tests positive';
 
 const standfirst: Option<DocumentFragment> = pipe(
-	'<p><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ae7e58f08b228c9498279#block-614ae7e58f08b228c9498279\">Marcelo Quiroga tests positive</a> at UN general assembly in New York; <a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ad64b8f087b5c6fb4a8dc#block-614ad64b8f087b5c6fb4a8dc\">Australia tourism minister says</a> on track to reopen borders ‘by Christmas’</p>\n<ul>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/2021/sep/22/calculated-risk-ardern-gambles-as-new-zealand-covid-restrictions-eased\">Ardern gambles as New Zealand Covid restrictions eased</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/australia-news/2021/sep/22/riot-police-on-melbourne-streets-to-prevent-third-day-of-protests\">Riot police on Melbourne streets to prevent third day of protests</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/global-development/2021/sep/21/argentina-to-lift-almost-all-covid-restrictions-as-cases-and-deaths-fall\">Argentina to lift almost all Covid restrictions as cases and deaths fall</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/education/2021/sep/21/more-than-100000-pupils-off-school-in-england-last-week-amid-covid-surge\">‘High alert’ warning as more than 100,000 pupils in England miss school</a></li>\n</ul>',
+	'<p><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ae7e58f08b228c9498279#block-614ae7e58f08b228c9498279">Marcelo Quiroga tests positive</a> at UN general assembly in New York; <a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ad64b8f087b5c6fb4a8dc#block-614ad64b8f087b5c6fb4a8dc">Australia tourism minister says</a> on track to reopen borders ‘by Christmas’</p>\n<ul>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/2021/sep/22/calculated-risk-ardern-gambles-as-new-zealand-covid-restrictions-eased">Ardern gambles as New Zealand Covid restrictions eased</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/australia-news/2021/sep/22/riot-police-on-melbourne-streets-to-prevent-third-day-of-protests">Riot police on Melbourne streets to prevent third day of protests</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/global-development/2021/sep/21/argentina-to-lift-almost-all-covid-restrictions-as-cases-and-deaths-fall">Argentina to lift almost all Covid restrictions as cases and deaths fall</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/education/2021/sep/21/more-than-100000-pupils-off-school-in-england-last-week-amid-covid-surge">‘High alert’ warning as more than 100,000 pupils in England miss school</a></li>\n</ul>',
 	parseHtml,
 	toOption,
 );
@@ -38,7 +39,6 @@ const captionDocFragment: Option<DocumentFragment> = pipe(
 	parseHtml,
 	toOption,
 );
-
 
 const mainMedia: Option<MainMedia> = {
 	kind: OptionKind.Some,
@@ -77,10 +77,11 @@ const tags = [
 		sectionName: 'World news',
 		webTitle: 'Coronavirus live',
 		webUrl: 'https://www.theguardian.com/world/series/coronavirus-live',
-		apiUrl: 'https://content.guardianapis.com/world/series/coronavirus-live',
+		apiUrl:
+			'https://content.guardianapis.com/world/series/coronavirus-live',
 		references: [],
 		description: `<p>Follow the Guardian's live coverage of the <a href="https://www.theguardian.com/world/coronavirus-outbreak">coronavirus pandemic</a><br></p>`,
-		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)'
+		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)',
 	},
 	{
 		id: 'world/coronavirus-outbreak',
@@ -91,7 +92,7 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/world/coronavirus-outbreak',
 		apiUrl: 'https://content.guardianapis.com/world/coronavirus-outbreak',
 		references: [],
-		internalName: 'Coronavirus (main tag)'
+		internalName: 'Coronavirus (main tag)',
 	},
 	{
 		id: 'world/world',
@@ -102,7 +103,7 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/world/world',
 		apiUrl: 'https://content.guardianapis.com/world/world',
 		references: [],
-		internalName: 'World news'
+		internalName: 'World news',
 	},
 	{
 		id: 'type/article',
@@ -111,7 +112,7 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/articles',
 		apiUrl: 'https://content.guardianapis.com/type/article',
 		references: [],
-		internalName: 'Article (Content type)'
+		internalName: 'Article (Content type)',
 	},
 	{
 		id: 'tone/minutebyminute',
@@ -120,7 +121,7 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/tone/minutebyminute',
 		apiUrl: 'https://content.guardianapis.com/tone/minutebyminute',
 		references: [],
-		internalName: 'Minute by minute (Tone)'
+		internalName: 'Minute by minute (Tone)',
 	},
 	{
 		id: 'tone/news',
@@ -129,7 +130,7 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/tone/news',
 		apiUrl: 'https://content.guardianapis.com/tone/news',
 		references: [],
-		internalName: 'News (Tone)'
+		internalName: 'News (Tone)',
 	},
 	{
 		id: 'profile/helen-sullivan',
@@ -139,13 +140,15 @@ const tags = [
 		apiUrl: 'https://content.guardianapis.com/profile/helen-sullivan',
 		references: [],
 		bio: `<p>Helen Sullivan is the world news liveblogger and reporter on the Guardian's foreign desk in Sydney. She also writes a fortnightly column about animals. Twitter <a href="https://twitter.com/helenrsullivan">@helenrsullivan</a></p>`,
-		bylineImageUrl: 'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.jpg',
-		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.png',
+		bylineImageUrl:
+			'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.jpg',
+		bylineLargeImageUrl:
+			'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.png',
 		firstName: 'Helen',
 		lastName: 'Sullivan',
 		twitterHandle: 'helenrsullivan',
 		r2ContributorId: '83691',
-		internalName: 'Helen Sullivan'
+		internalName: 'Helen Sullivan',
 	},
 	{
 		id: 'profile/miranda-bryant',
@@ -158,7 +161,7 @@ const tags = [
 		firstName: 'Miranda',
 		lastName: 'Bryant',
 		r2ContributorId: '85415',
-		internalName: 'Miranda Bryant'
+		internalName: 'Miranda Bryant',
 	},
 	{
 		id: 'profile/tom-ambrose',
@@ -170,7 +173,7 @@ const tags = [
 		firstName: 'Tom',
 		lastName: 'Ambrose',
 		r2ContributorId: '90702',
-		internalName: 'Tom Ambrose'
+		internalName: 'Tom Ambrose',
 	},
 	{
 		id: 'profile/oliver-milman',
@@ -179,15 +182,18 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/profile/oliver-milman',
 		apiUrl: 'https://content.guardianapis.com/profile/oliver-milman',
 		references: [],
-		bio: '<p>Oliver Milman is an environment reporter for Guardian US. Twitter&nbsp;<a href="https://twitter.com/olliemilman">@olliemilman</a></p>',
-		bylineImageUrl: 'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/9/30/1412084830432/Oliver-Milman.jpg',
-		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2017/10/09/Oliver-Milman,-L.png',
+		bio:
+			'<p>Oliver Milman is an environment reporter for Guardian US. Twitter&nbsp;<a href="https://twitter.com/olliemilman">@olliemilman</a></p>',
+		bylineImageUrl:
+			'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/9/30/1412084830432/Oliver-Milman.jpg',
+		bylineLargeImageUrl:
+			'https://uploads.guim.co.uk/2017/10/09/Oliver-Milman,-L.png',
 		firstName: 'Milman',
 		lastName: 'Oliver',
 		twitterHandle: 'olliemilman',
 		rcsId: 'Oliver Mi',
 		r2ContributorId: '47089',
-		internalName: 'Oliver Milman'
+		internalName: 'Oliver Milman',
 	},
 	{
 		id: 'profile/peterwalker',
@@ -196,13 +202,15 @@ const tags = [
 		webUrl: 'https://www.theguardian.com/profile/peterwalker',
 		apiUrl: 'https://content.guardianapis.com/profile/peterwalker',
 		references: [],
-		bio: '<p>Peter Walker is a political correspondent for the Guardian. <br></p><p>He is the author of The Miracle Pill: Why A Sedentary World Is Getting It All Wrong</p>',
-		bylineImageUrl: 'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/peter_walker_140x140.jpg',
+		bio:
+			'<p>Peter Walker is a political correspondent for the Guardian. <br></p><p>He is the author of The Miracle Pill: Why A Sedentary World Is Getting It All Wrong</p>',
+		bylineImageUrl:
+			'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/peter_walker_140x140.jpg',
 		firstName: 'Peter',
 		lastName: 'Walker',
 		twitterHandle: 'peterwalker99',
 		r2ContributorId: '19159',
-		internalName: 'Peter Walker'
+		internalName: 'Peter Walker',
 	},
 	{
 		id: 'profile/ben-doherty',
@@ -213,14 +221,15 @@ const tags = [
 		references: [],
 		bio: `<p>Ben Doherty is a reporter for Guardian Australia, and a former foreign correspondent covering south-east Asia. He has won three Walkley awards for his foreign and immigration reporting. Email: ben.doherty@theguardian.com. Click <a href="https://www.theguardian.com/pgp/PublicKeys/Ben%20Doherty.pub.txt">here</a> for Ben's public key</p>`,
 		bylineImageUrl: 'https://uploads.guim.co.uk/2020/06/29/Ben_Doherty.png',
-		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2017/11/27/Ben_Doherty_720x600_final.png',
+		bylineLargeImageUrl:
+			'https://uploads.guim.co.uk/2017/11/27/Ben_Doherty_720x600_final.png',
 		firstName: 'Ben ',
 		lastName: 'Doherty',
 		twitterHandle: 'bendohertycorro',
 		r2ContributorId: '37536',
-		internalName: 'Ben Doherty'
-	}
-]
+		internalName: 'Ben Doherty',
+	},
+];
 
 const fields = {
 	theme: Pillar.News,
@@ -240,10 +249,11 @@ const fields = {
 		sectionName: 'World news',
 		webTitle: 'Coronavirus live',
 		webUrl: 'https://www.theguardian.com/world/series/coronavirus-live',
-		apiUrl: 'https://content.guardianapis.com/world/series/coronavirus-live',
+		apiUrl:
+			'https://content.guardianapis.com/world/series/coronavirus-live',
 		references: [],
 		description: `<p>Follow the Guardian's live coverage of the <a href="https://www.theguardian.com/world/coronavirus-outbreak">coronavirus pandemic</a><br></p>`,
-		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)'
+		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)',
 	}),
 	commentable: false,
 	tags: tags,
@@ -264,8 +274,4 @@ const live: Liveblog = {
 	totalBodyBlocks: 12,
 };
 
-
-export {
-	live
-};
-
+export { live };

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -1,0 +1,271 @@
+// ----- Imports ----- //
+
+import {
+	Design,
+	Display,
+	none,
+	OptionKind,
+	Pillar,
+	Role,
+	some,
+	toOption,
+} from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { parse } from 'client/parser';
+import { pipe } from 'lib';
+import { Liveblog } from 'item';
+import { MainMedia, MainMediaKind } from 'headerMedia';
+
+const parser = new DOMParser();
+const parseHtml = parse(parser);
+
+const headline =
+	'Covid live: Brazil health minister who shook hands with maskless Boris Johnson at UN tests positive';
+
+const standfirst: Option<DocumentFragment> = pipe(
+	'<p><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ae7e58f08b228c9498279#block-614ae7e58f08b228c9498279\">Marcelo Quiroga tests positive</a> at UN general assembly in New York; <a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ad64b8f087b5c6fb4a8dc#block-614ad64b8f087b5c6fb4a8dc\">Australia tourism minister says</a> on track to reopen borders ‘by Christmas’</p>\n<ul>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/world/2021/sep/22/calculated-risk-ardern-gambles-as-new-zealand-covid-restrictions-eased\">Ardern gambles as New Zealand Covid restrictions eased</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/australia-news/2021/sep/22/riot-police-on-melbourne-streets-to-prevent-third-day-of-protests\">Riot police on Melbourne streets to prevent third day of protests</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/global-development/2021/sep/21/argentina-to-lift-almost-all-covid-restrictions-as-cases-and-deaths-fall\">Argentina to lift almost all Covid restrictions as cases and deaths fall</a></li>\n <li><a href=\"x-gu://item/mobile.guardianapis.com/uk/items/education/2021/sep/21/more-than-100000-pupils-off-school-in-england-last-week-amid-covid-surge\">‘High alert’ warning as more than 100,000 pupils in England miss school</a></li>\n</ul>',
+	parseHtml,
+	toOption,
+);
+
+const bylineHtml: Option<DocumentFragment> = pipe(
+	'<a href="https://theguardian.com">Tom Ambrose</a> (now); <a href="https://theguardian.com">Miranda Bryant</a> and <a href="https://theguardian.com">Helen Sullivan</a> (earlier)',
+	parseHtml,
+	toOption,
+);
+const captionDocFragment: Option<DocumentFragment> = pipe(
+	'<em>Jane Smith</em> Editor of things',
+	parseHtml,
+	toOption,
+);
+
+
+const mainMedia: Option<MainMedia> = {
+	kind: OptionKind.Some,
+	value: {
+		kind: MainMediaKind.Image,
+		image: {
+			src:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f',
+			srcset:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=85&fit=bounds&s=d0c466d24ac750ce4b1c9fe8a40fbdd3 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=85&fit=bounds&s=6d0b66dcc9233754f89c07e74c44158f 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=85&fit=bounds&s=8f38bcd742d1ae10a3f01508e31c7f5f 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=85&fit=bounds&s=45e33e51a33abe2b327882eb9de69d04 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=85&fit=bounds&s=5bc078a6facde21b41d2c649ac36e01b 2000w',
+			dpr2Srcset:
+				'https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=140&quality=45&fit=bounds&s=5b4d13a66861d58dff15b371d11043ae 140w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=500&quality=45&fit=bounds&s=e043c3329b11500e9b907ac2c93275ff 500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1000&quality=45&fit=bounds&s=bb69b200c27229f685132af3eddd10b3 1000w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=1500&quality=45&fit=bounds&s=5ea519b33cadfdca59a7d7b1ce570631 1500w, https://i.guim.co.uk/img/media/305593466a8bbd045d233b207b368a5dbcfd08f4/0_101_3000_1800/master/3000.jpg?width=2000&quality=45&fit=bounds&s=fe2810561ff271c2a97583ca67cd97e8 2000w',
+			alt: some('image'),
+			width: 3000,
+			height: 1800,
+			caption: captionDocFragment,
+			credit: {
+				kind: OptionKind.Some,
+				value: 'Photograph: Philip Keith/The Guardian',
+			},
+			nativeCaption: {
+				kind: OptionKind.Some,
+				value:
+					'‘They could kill me any day; that’s all right with me. I am going down swinging, brother’ … West.',
+			},
+			role: Role.Standard,
+		},
+	},
+};
+
+const tags = [
+	{
+		id: 'world/series/coronavirus-live',
+		type: 2,
+		sectionId: 'world',
+		sectionName: 'World news',
+		webTitle: 'Coronavirus live',
+		webUrl: 'https://www.theguardian.com/world/series/coronavirus-live',
+		apiUrl: 'https://content.guardianapis.com/world/series/coronavirus-live',
+		references: [],
+		description: `<p>Follow the Guardian's live coverage of the <a href="https://www.theguardian.com/world/coronavirus-outbreak">coronavirus pandemic</a><br></p>`,
+		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)'
+	},
+	{
+		id: 'world/coronavirus-outbreak',
+		type: 1,
+		sectionId: 'world',
+		sectionName: 'World news',
+		webTitle: 'Coronavirus',
+		webUrl: 'https://www.theguardian.com/world/coronavirus-outbreak',
+		apiUrl: 'https://content.guardianapis.com/world/coronavirus-outbreak',
+		references: [],
+		internalName: 'Coronavirus (main tag)'
+	},
+	{
+		id: 'world/world',
+		type: 1,
+		sectionId: 'world',
+		sectionName: 'World news',
+		webTitle: 'World news',
+		webUrl: 'https://www.theguardian.com/world/world',
+		apiUrl: 'https://content.guardianapis.com/world/world',
+		references: [],
+		internalName: 'World news'
+	},
+	{
+		id: 'type/article',
+		type: 7,
+		webTitle: 'Article',
+		webUrl: 'https://www.theguardian.com/articles',
+		apiUrl: 'https://content.guardianapis.com/type/article',
+		references: [],
+		internalName: 'Article (Content type)'
+	},
+	{
+		id: 'tone/minutebyminute',
+		type: 6,
+		webTitle: 'Minute by minute',
+		webUrl: 'https://www.theguardian.com/tone/minutebyminute',
+		apiUrl: 'https://content.guardianapis.com/tone/minutebyminute',
+		references: [],
+		internalName: 'Minute by minute (Tone)'
+	},
+	{
+		id: 'tone/news',
+		type: 6,
+		webTitle: 'News',
+		webUrl: 'https://www.theguardian.com/tone/news',
+		apiUrl: 'https://content.guardianapis.com/tone/news',
+		references: [],
+		internalName: 'News (Tone)'
+	},
+	{
+		id: 'profile/helen-sullivan',
+		type: 0,
+		webTitle: 'Helen Sullivan',
+		webUrl: 'https://www.theguardian.com/profile/helen-sullivan',
+		apiUrl: 'https://content.guardianapis.com/profile/helen-sullivan',
+		references: [],
+		bio: `<p>Helen Sullivan is the world news liveblogger and reporter on the Guardian's foreign desk in Sydney. She also writes a fortnightly column about animals. Twitter <a href="https://twitter.com/helenrsullivan">@helenrsullivan</a></p>`,
+		bylineImageUrl: 'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.jpg',
+		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2020/04/08/Helen_Sullivan.png',
+		firstName: 'Helen',
+		lastName: 'Sullivan',
+		twitterHandle: 'helenrsullivan',
+		r2ContributorId: '83691',
+		internalName: 'Helen Sullivan'
+	},
+	{
+		id: 'profile/miranda-bryant',
+		type: 0,
+		webTitle: 'Miranda Bryant',
+		webUrl: 'https://www.theguardian.com/profile/miranda-bryant',
+		apiUrl: 'https://content.guardianapis.com/profile/miranda-bryant',
+		references: [],
+		bio: '<p>Miranda Bryant is a freelance journalist</p>',
+		firstName: 'Miranda',
+		lastName: 'Bryant',
+		r2ContributorId: '85415',
+		internalName: 'Miranda Bryant'
+	},
+	{
+		id: 'profile/tom-ambrose',
+		type: 0,
+		webTitle: 'Tom Ambrose',
+		webUrl: 'https://www.theguardian.com/profile/tom-ambrose',
+		apiUrl: 'https://content.guardianapis.com/profile/tom-ambrose',
+		references: [],
+		firstName: 'Tom',
+		lastName: 'Ambrose',
+		r2ContributorId: '90702',
+		internalName: 'Tom Ambrose'
+	},
+	{
+		id: 'profile/oliver-milman',
+		type: 0,
+		webTitle: 'Oliver Milman',
+		webUrl: 'https://www.theguardian.com/profile/oliver-milman',
+		apiUrl: 'https://content.guardianapis.com/profile/oliver-milman',
+		references: [],
+		bio: '<p>Oliver Milman is an environment reporter for Guardian US. Twitter&nbsp;<a href="https://twitter.com/olliemilman">@olliemilman</a></p>',
+		bylineImageUrl: 'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/9/30/1412084830432/Oliver-Milman.jpg',
+		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2017/10/09/Oliver-Milman,-L.png',
+		firstName: 'Milman',
+		lastName: 'Oliver',
+		twitterHandle: 'olliemilman',
+		rcsId: 'Oliver Mi',
+		r2ContributorId: '47089',
+		internalName: 'Oliver Milman'
+	},
+	{
+		id: 'profile/peterwalker',
+		type: 0,
+		webTitle: 'Peter Walker',
+		webUrl: 'https://www.theguardian.com/profile/peterwalker',
+		apiUrl: 'https://content.guardianapis.com/profile/peterwalker',
+		references: [],
+		bio: '<p>Peter Walker is a political correspondent for the Guardian. <br></p><p>He is the author of The Miracle Pill: Why A Sedentary World Is Getting It All Wrong</p>',
+		bylineImageUrl: 'https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/peter_walker_140x140.jpg',
+		firstName: 'Peter',
+		lastName: 'Walker',
+		twitterHandle: 'peterwalker99',
+		r2ContributorId: '19159',
+		internalName: 'Peter Walker'
+	},
+	{
+		id: 'profile/ben-doherty',
+		type: 0,
+		webTitle: 'Ben Doherty',
+		webUrl: 'https://www.theguardian.com/profile/ben-doherty',
+		apiUrl: 'https://content.guardianapis.com/profile/ben-doherty',
+		references: [],
+		bio: `<p>Ben Doherty is a reporter for Guardian Australia, and a former foreign correspondent covering south-east Asia. He has won three Walkley awards for his foreign and immigration reporting. Email: ben.doherty@theguardian.com. Click <a href="https://www.theguardian.com/pgp/PublicKeys/Ben%20Doherty.pub.txt">here</a> for Ben's public key</p>`,
+		bylineImageUrl: 'https://uploads.guim.co.uk/2020/06/29/Ben_Doherty.png',
+		bylineLargeImageUrl: 'https://uploads.guim.co.uk/2017/11/27/Ben_Doherty_720x600_final.png',
+		firstName: 'Ben ',
+		lastName: 'Doherty',
+		twitterHandle: 'bendohertycorro',
+		r2ContributorId: '37536',
+		internalName: 'Ben Doherty'
+	}
+]
+
+const fields = {
+	theme: Pillar.News,
+	display: Display.Standard,
+	body: [],
+	headline: headline,
+	standfirst: standfirst,
+	byline: '',
+	bylineHtml: bylineHtml,
+	publishDate: none,
+	contributors: [],
+	mainMedia: mainMedia,
+	series: some({
+		id: 'world/series/coronavirus-live',
+		type: 2,
+		sectionId: 'world',
+		sectionName: 'World news',
+		webTitle: 'Coronavirus live',
+		webUrl: 'https://www.theguardian.com/world/series/coronavirus-live',
+		apiUrl: 'https://content.guardianapis.com/world/series/coronavirus-live',
+		references: [],
+		description: `<p>Follow the Guardian's live coverage of the <a href="https://www.theguardian.com/world/coronavirus-outbreak">coronavirus pandemic</a><br></p>`,
+		internalName: 'Coronavirus live (LIVE BLOG ONLY series tag)'
+	}),
+	commentable: false,
+	tags: tags,
+	shouldHideReaderRevenue: false,
+	branding: none,
+	internalShortId: none,
+	commentCount: none,
+	relatedContent: none,
+	footballContent: none,
+	logo: none,
+	webUrl: '',
+};
+
+const live: Liveblog = {
+	design: Design.LiveBlog,
+	...fields,
+	blocks: [],
+	totalBodyBlocks: 12,
+};
+
+
+export {
+	live
+};
+


### PR DESCRIPTION
## What does this change?
Adds a story for an AR live layout component.

## Why?
Provides a visual example of how far we can currently build a live layout with existing AR platform components.

