### PR TITLE
Add `performance.now` to `polyfill.io` bundle

### DIFF
--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -228,7 +228,7 @@ export const document = ({ data }: Props): string => {
 	];
 
 	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasNonBootInteractiveElements = CAPIElements.some(
 		(element) =>


### PR DESCRIPTION
## What does this change?

Adds `performance.now` to the `polyfill.io` bundle.

## Why?

[Some older browsers don't support the User Timing API](https://caniuse.com/user-timing). Mostly we guard against this case by checking if `window.performance` is `undefined` before calling methods on it, but we discovered one instance where this wasn't happening and we believe this to be the cause of a number of Sentry errors. Adding a polyfill for older browsers feels like the right approach so we don't always need to worry about guards.

Related PR: https://github.com/guardian/frontend/pull/24210
