### PR TITLE
Remove `emotion/core` Dependency

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3113,11 +3113,6 @@
         }
       }
     },
-    "@emotion/core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-w4sE3AmHmyG6RDKf6mIbtHpgJUSJ2uGvPQb8VXFL7hFjMPibE8IiehG8cMX3Ztm4svfCQV6KqusQbeIOkurBcA=="
-    },
     "@emotion/css": {
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3496,13 +3496,12 @@
       }
     },
     "@guardian/discussion-rendering": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@guardian/discussion-rendering/-/discussion-rendering-4.6.1.tgz",
-      "integrity": "sha512-0SK6TKfFwWDTf1Mky6DmnsgT31PRfXBWpIJFvXDt524neVotphkjsOs5FA7Ub3jq+ICuD566mEHYCVSWBcWoMg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/discussion-rendering/-/discussion-rendering-7.0.0.tgz",
+      "integrity": "sha512-R8HK1dMM8H60aasne4v2QaPgnMBQf4Q1QUFjeHz4BvPQAPLLFnPAtWOaoHAoUyy460oKFpwkZ2jFv+dahzRkpQ==",
       "requires": {
         "babel-plugin-emotion": "^10.0.33",
         "customize-cra": "^1.0.0",
-        "react-app-rewired": "^2.1.6",
         "react-focus-lock": "^2.2.1",
         "timeago.js": "^4.0.2"
       }
@@ -7517,9 +7516,9 @@
       "dev": true
     },
     "detect-node-es": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
-      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "diff": {
       "version": "4.0.2",
@@ -9231,11 +9230,18 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.8.1.tgz",
-      "integrity": "sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
+      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "follow-redirects": {
@@ -13242,14 +13248,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "react-app-rewired": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
-      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
-      "requires": {
-        "semver": "^5.6.0"
-      }
-    },
     "react-clientside-effect": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz",
@@ -13259,9 +13257,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -13279,16 +13277,16 @@
       }
     },
     "react-focus-lock": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",
-      "integrity": "sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.8.1",
+        "focus-lock": "^0.9.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       }
     },
     "react-is": {
@@ -15378,11 +15376,11 @@
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
     },
     "use-sidecar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.4.tgz",
-      "integrity": "sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
       "requires": {
-        "detect-node-es": "^1.0.0",
+        "detect-node-es": "^1.1.0",
         "tslib": "^1.9.3"
       }
     },

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@creditkarma/thrift-server-core": "^0.16.1",
     "@emotion/cache": "^11.1.3",
-    "@emotion/core": "^11.0.0",
     "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.4.0",
     "@emotion/server": "^11.0.0",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -38,7 +38,7 @@
     "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.0.0",
     "@guardian/content-atom-model": "^3.2.4",
-    "@guardian/discussion-rendering": "^4.6.1",
+    "@guardian/discussion-rendering": "^7.0.0",
     "@guardian/image-rendering": "github:guardian/image-rendering#1167f8bc",
     "@guardian/node-riffraff-artifact": "^0.2.0",
     "@guardian/renditions": "^0.2.0",


### PR DESCRIPTION
## Why?

This dependency isn't used explicitly, but somehow it's being included in the AR client-side script and causing errors. Just removing the existence of the dependency seems to fix this, which is odd.

## Changes

- Removed `@emotion/core` dependency
- Update `discussion-rendering` to latest (to stop it relying on `emotion/core`)
