### PR TITLE
Repair the submission of consent component events

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@guardian/commercial-core": "0.19.2",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^7.0.0",
-    "@guardian/libs": "^3.0.0",
+    "@guardian/libs": "^3.3.0",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^3.9.0",
     "@guardian/src-checkbox": "^3.9.0",

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -47,7 +47,7 @@ import { getLocaleCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
 
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
-import { Display, Design } from '@guardian/types';
+import { Display, Design} from '@guardian/types';
 import type { Format, CountryCode } from '@guardian/types';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
@@ -73,8 +73,10 @@ import { OphanRecordFunction } from '@guardian/ab-core/dist/types';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { storage } from '@guardian/libs';
 import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
+
 import {
-	getOphanRecordFunction,
+	OphanComponentType,
+	OphanAction,
 	submitComponentEvent,
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
@@ -356,18 +358,19 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			}
 			return '';
 		};
-		const consentUUID = getCookie('consentUUID');
+		const componentType: OphanComponentType = "CONSENT";
+		const consentUUID = getCookie('consentUUID') || "";
 		const consentString = decideConsentString();
+		const action: OphanAction = 'MANAGE_CONSENT'; // I am using MANAGE_CONSENT as the default action while we develop this code.
 		const event = {
 			component: {
-				componentType: 'CONSENT',
+				componentType,
 				products: [],
 				labels: [consentUUID, consentString],
 			},
-			action: 'MANAGE_CONSENT', // I am using MANAGE_CONSENT as the default action while we develop this code.
+			action,
 		};
-		const ophanEventSubmit = getOphanRecordFunction();
-		ophanEventSubmit(event);
+		submitComponentEvent(event);
 	}, [consentState]);
 
 	// ************************

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1563,10 +1563,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
   integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
 
-"@guardian/libs@^3.0.0":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.2.1.tgz#96368fcd76f63b842708ea1489275bd3200f5e4b"
-  integrity sha512-/o84jYYlodIfKs+aRj1QoluHnQ/OdgJN/v1FONwGCf7eGn6RYn9BCh5QvHRujpoSqzgq435tzx5Ug3EF1wWvfQ==
+"@guardian/libs@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
+  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
 "@guardian/prettier@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
The (currently experimental) consent related component events that are sent from DCR are not reaching their destination in the lake. Careful investigation revealed that it might be caused by an incorrect query parameters (see below)

![Before](https://user-images.githubusercontent.com/6035518/134692566-6fc3df52-5de2-48b5-951e-415e0a40b044.png)

... which doesn't match the expected name in Ophan ( https://github.com/guardian/ophan/blob/0c1181bb273655af8ae523cc903ca17baeea7a08/the-slab/app/extractors/ComponentEventExtractor.scala#L73 ). This change essentially fix that bug by calling the right Ophan Tracker-JS submission function

Correct URL: 

![After](https://user-images.githubusercontent.com/6035518/134692847-8508a74d-02dc-43b9-bb77-fd8eed744031.png)

Two previous PRs were needed to make this happen
1. https://github.com/guardian/dotcom-rendering/pull/3461 
2. https://github.com/guardian/libs/pull/286
