### PR TITLE
Change labs standfirst link colour

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -277,3 +277,19 @@ export const PhotoEssay = () => {
 	);
 };
 PhotoEssay.story = { name: 'PhotoEssay' };
+
+export const LabsWithLink = () => {
+	return (
+		<ElementContainer>
+			<Standfirst
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+				standfirst='<p>Whether your holiday priorities are sampling gastronomic delights, visiting cultural landmarks, adventuring in the great outdoors or just having an easy time with the kids, this quiz will help you plan your itinerary for Brittany, Normandy and the Atlantic Loire Valley</p> <ul> <li>National restrictions may apply, please consult <a href="https://www.gov.uk/guidance/travel-advice-novel-coronavirus" rel="nofollow">government advice</a> before planning travel</li> </ul>'
+			/>
+		</ElementContainer>
+	);
+};
+LabsWithLink.story = { name: 'LabsWithLink' };

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -152,6 +152,13 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 								margin-bottom: ${space[3]}px;
 								max-width: 540px;
 								color: ${palette.text.standfirst};
+								a {
+									color: ${neutral[7]};
+									border-bottom: 1px solid ${neutral[60]};
+								}
+								a:hover {
+									border-bottom: 1px solid ${neutral[7]};
+								}
 							`;
 						default:
 							return css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This removes the teal colour from links in the standfirst on lab articles and replaces it with the same colour as the old site.

## Why?

Parity.

### Before

![Screenshot 2021-09-27 at 10 06 42](https://user-images.githubusercontent.com/35331926/134878931-fe6a1213-dd77-4fc6-b167-7e08d4d99c7e.png)

### After

<img width="631" alt="Screenshot 2021-09-27 at 10 07 05" src="https://user-images.githubusercontent.com/35331926/134878967-4cfe76e0-8083-412e-ad77-796032590618.png">

