### PR TITLE
Show contributor badges in comments

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
     "@guardian/braze-components": "^3.6.0",
     "@guardian/commercial-core": "0.21.0",
     "@guardian/consent-management-platform": "~6.11.5",
-    "@guardian/discussion-rendering": "^7.0.0",
+    "@guardian/discussion-rendering": "^7.2.0",
     "@guardian/libs": "^3.3.0",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^3.9.0",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1548,10 +1548,10 @@
   dependencies:
     "@guardian/libs" "^1"
 
-"@guardian/discussion-rendering@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-7.0.0.tgz#2cc39a04eaa03d5d26ef4cb08a88583d9c82d8d3"
-  integrity sha512-R8HK1dMM8H60aasne4v2QaPgnMBQf4Q1QUFjeHz4BvPQAPLLFnPAtWOaoHAoUyy460oKFpwkZ2jFv+dahzRkpQ==
+"@guardian/discussion-rendering@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-7.2.0.tgz#b2d10ac2b7f7c2117d3963899591f4244b6e1efc"
+  integrity sha512-Ui5RyPdhbrbAfi4G+6JP7LiI+8D/2K5Bh5SG/rwlHYRmHM3gGOzm2Koqj42V+v9bHm3A8g+qS9A0khG5QfgEcw==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
## What does this change?
Bump the version of discussion-rendering to ensure comments from contributors have the expected badge.

## Why?
For articles rendered via DCR, Central Production reported that comments from Contributors did not have the expected badges.

In frontend we marked comments from contributors with an associated badge. https://github.com/guardian/frontend/blob/main/discussion/app/views/fragments/commentBadges.scala.html#L8

This change adds the equivalent functionality into DCR. Note that the badge is added as part of discussion-rendering, https://github.com/guardian/discussion-rendering/pull/524

### Before
Currently, for articles rendered via DCR, contributors did not have a badge:
<img width="1174" alt="Screenshot 2021-09-24 at 17 13 38" src="https://user-images.githubusercontent.com/45561419/134709611-c4a05c0e-8219-4b2f-9230-f22d87d0ebc8.png">


### After
After this change, comments from contributors have a badge:
<img width="1478" alt="Screenshot 2021-09-24 at 17 14 26" src="https://user-images.githubusercontent.com/45561419/134709646-f7cafa7c-5504-40ed-a041-398de7fb055d.png">
