### PR TITLE
Fix JS assets path issues in `frontend`

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/article.metaAndOphan.e2e.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.metaAndOphan.e2e.spec.js
@@ -106,9 +106,9 @@ describe('The web document renders with the correct meta and analytics elements 
 	});
 
 	it('Sample of script tags have the correct attributes', function () {
-		getExists(`script[type="module"][src="/assets/react.js"]`);
-		getExists(`script[defer][nomodule][src="/assets/react.legacy.js"]`);
-		getExists(`script[type="module"][src="/assets/ophan.js"]`);
-		getExists(`script[defer][nomodule][src="/assets/ophan.legacy.js"]`);
+		getExists(`script[type="module"][src$="/assets/react.js"]`);
+		getExists(`script[defer][nomodule][src$="/assets/react.legacy.js"]`);
+		getExists(`script[type="module"][src$="/assets/ophan.js"]`);
+		getExists(`script[defer][nomodule][src$="/assets/ophan.legacy.js"]`);
 	});
 });

--- a/dotcom-rendering/scripts/frontend/dev-server.js
+++ b/dotcom-rendering/scripts/frontend/dev-server.js
@@ -47,6 +47,11 @@ const go = () => {
 		webpackDevMiddleware(compiler, {
 			serverSideRender: true,
 			publicPath: '/assets/',
+			headers: (req, res) => {
+				// Allow any localhost request from accessing the assets
+				if(req.hostname === "localhost" && req.headers.origin)
+					res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+			  },
 		}),
 	);
 

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -15,7 +15,7 @@ try {
 	// do nothing
 }
 
-// TODO: this should be removed in favor of `frontendAssetsFullURL` defined in CAPI
+// TODO: this should be removed in favour of `frontendAssetsFullURL` defined in CAPI
 // GU_STAGE is set in cloudformation.yml, so will be undefined locally
 const stage =
 	typeof process.env.GU_STAGE === 'string'

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -20,11 +20,11 @@ try {
 const stage =
 	typeof process.env.GU_STAGE === 'string'
 		? process.env.GU_STAGE.toUpperCase()
-		: process.env.GU_STAGE;
+		: undefined;
 
 export const CDN = stage
 	? `//assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/`
-	: '/';
+	: 'http://localhost:3030/';
 export const loadableManifestJson = loadableManifest;
 
 export const getScriptArrayFromFilename = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Explicitly serve assets from `localhost:3030/` instead of the root path `/`. Send a CORS header to any request from `localhost`.

Also fix a small typo in British spelling of “favour”.

## Why?

Currently, when an article is loaded by `frontend` locally, the static assets are pointing to `/`, which is incorrect, as the assets are actually served by `dotcom-rendering`’s `:3030` server, not `frontend`’s `:9000`.

The CORS request is needed for the cross-origin request, as different ports count as different origins.

This allows developers working between the two projects to easily navigate between fronts and articles, such as @guardian/commercial-dev.

### Before

![failing assets requests](https://user-images.githubusercontent.com/76776/134927214-d79bbdc9-a131-4831-8c76-082c4435c9d2.png)


### After

![fixed assets requests](https://user-images.githubusercontent.com/76776/134927100-32995d91-6929-4fba-88c7-f9fe28d4c448.png)
