### PR TITLE
Show Contributor badges in top picks

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
     "@guardian/braze-components": "^4.0.0",
     "@guardian/commercial-core": "0.21.0",
     "@guardian/consent-management-platform": "~6.11.5",
-    "@guardian/discussion-rendering": "^8.0.0",
+    "@guardian/discussion-rendering": "^8.1.0",
     "@guardian/libs": "^3.3.0",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^3.9.0",

--- a/dotcom-rendering/yarn.lock
+++ b/dotcom-rendering/yarn.lock
@@ -1548,10 +1548,10 @@
   dependencies:
     "@guardian/libs" "^1"
 
-"@guardian/discussion-rendering@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-8.0.0.tgz#2d969612f9ab32b0ea02342bfd4470d45f9e2ae6"
-  integrity sha512-JeCxiW33nK45M8kVYr81weJnVleV2Fel4/3jhiG+ziuSA1ww6nWxWgjoNTMj1hiIFquG3LD75rTkGy0HB9LOvQ==
+"@guardian/discussion-rendering@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-8.1.0.tgz#5bc0a93fdda6507826aa07661af88d7982b4536c"
+  integrity sha512-Lw6pdpjG9GKp7pVo/bLb129qbY+SBqYwkV3AKOzCxcDRRAsbifV2Toxo9ZyoPFhwyuSTs8qCQPwbaBQh6gHHBw==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
## What does this change?
Update discussion-rendering version to show Contributor badges in highlighted comments.

## Why?
Moderators can pick comments to highlight at the top of the comments list. If the picked/highlighted comment is from a Contributor, they would also like the highlighted comment to have a Contributor badge. 

### Before
Top picks/ highlighted comments do not show Contributor badges:
<img width="1496" alt="Screenshot 2021-09-27 at 16 14 17" src="https://user-images.githubusercontent.com/45561419/134942116-c9691870-c7f8-41af-b378-86ed4a6937f5.png">


### After
Contributor badges are shown in highlighted comments:
<img width="1512" alt="Screenshot 2021-09-27 at 16 14 03" src="https://user-images.githubusercontent.com/45561419/134942185-3b4ce594-d7aa-4f2c-b39a-5c2386bd7dce.png">

