### PR TITLE
Local Image Rendering - Alias React

### DIFF
--- a/apps-rendering/config/jest.config.js
+++ b/apps-rendering/config/jest.config.js
@@ -50,4 +50,7 @@ module.exports = {
 	moduleDirectories: ['node_modules', 'src'],
 	snapshotSerializers: ['@emotion/jest/serializer'],
 	transformIgnorePatterns: ['node_modules/(?!@guardian)'],
+	moduleNameMapper: {
+		'^react$': '<rootDir>/node_modules/react'
+	}
 };

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3708,10 +3708,6 @@
         }
       }
     },
-    "@guardian/image-rendering": {
-      "version": "github:guardian/image-rendering#1167f8bc1f1b7f65ba883e4678e10190abbabb05",
-      "from": "github:guardian/image-rendering#1167f8bc"
-    },
     "@guardian/node-riffraff-artifact": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@guardian/node-riffraff-artifact/-/node-riffraff-artifact-0.2.2.tgz",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -39,7 +39,6 @@
     "@guardian/content-api-models": "^17.1.1",
     "@guardian/content-atom-model": "^3.2.4",
     "@guardian/discussion-rendering": "^7.0.0",
-    "@guardian/image-rendering": "github:guardian/image-rendering#1167f8bc",
     "@guardian/node-riffraff-artifact": "^0.2.2",
     "@guardian/renditions": "^0.2.0",
     "@guardian/src-brand": "^3.9.0",

--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { brandAltBackground } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/headerImage.tsx
+++ b/apps-rendering/src/components/headerImage.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Sizes } from '@guardian/image-rendering';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { Format } from '@guardian/types';

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { Img } from '@guardian/image-rendering';
+import Img from '@guardian/common-rendering/src/components/img';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import {

--- a/apps-rendering/src/contributor.ts
+++ b/apps-rendering/src/contributor.ts
@@ -1,8 +1,12 @@
 // ----- Imports ----- //
 
+import {
+	Dpr,
+	src,
+	srcsetWithWidths,
+} from '@guardian/common-rendering/src/srcsets';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { Dpr, src, srcsetWithWidths } from '@guardian/image-rendering';
 import type { Option } from '@guardian/types';
 import { fromNullable, map, none, Role } from '@guardian/types';
 import { articleContributors } from 'capi';

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -1,9 +1,9 @@
 // ----- Imports ----- //
 
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
+import type { Image as ImageData } from '@guardian/common-rendering/src/image';
+import { Dpr, src, srcsets } from '@guardian/common-rendering/src/srcsets';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
-import type { Image as ImageData } from '@guardian/image-rendering';
-import { Dpr, src, srcsets } from '@guardian/image-rendering';
 import type { Format, Option } from '@guardian/types';
 import { andThen, fromNullable, map, none, Role, some } from '@guardian/types';
 import { pipe } from 'lib';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -13,7 +13,8 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import { BodyImage, FigCaption } from '@guardian/image-rendering';
+import BodyImage from '@guardian/common-rendering/src/components/bodyImage';
+import FigCaption from '@guardian/common-rendering/src/components/figCaption';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import type { Breakpoint } from '@guardian/src-foundations/mq';

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -43,6 +43,7 @@ function resolve(
 		modules: [path.resolve(__dirname, 'src'), 'node_modules'],
 		alias: {
 			logger: path.resolve(__dirname, `src/logger/${loggerName}`),
+			react: path.resolve(__dirname, './node_modules/react'),
 		},
 	};
 

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -43,7 +43,6 @@ function resolve(
 		modules: [path.resolve(__dirname, 'src'), 'node_modules'],
 		alias: {
 			logger: path.resolve(__dirname, `src/logger/${loggerName}`),
-			react: path.resolve('./node_modules/react'),
 		},
 	};
 

--- a/common-rendering/src/components/bodyImage.stories.tsx
+++ b/common-rendering/src/components/bodyImage.stories.tsx
@@ -5,7 +5,7 @@
 import { Design, Display, none, Pillar, Role, some } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
-import { BodyImage } from "./bodyImage";
+import BodyImage from "./bodyImage";
 
 // ----- Setup ----- //
 

--- a/common-rendering/src/components/bodyImage.tsx
+++ b/common-rendering/src/components/bodyImage.tsx
@@ -12,8 +12,8 @@ import type { Image } from "../image";
 import { darkModeCss } from "../lib";
 import type { Lightbox } from "../lightbox";
 import type { Sizes } from "../sizes";
-import { FigCaption } from "./figCaption";
-import { Img } from "./img";
+import FigCaption from "./figCaption";
+import Img from "./img";
 
 // ----- Setup ----- //
 
@@ -103,7 +103,7 @@ const getStyles = (
   }
 };
 
-export const BodyImage: FC<Props> = ({
+const BodyImage: FC<Props> = ({
   image,
   format,
   supportsDarkMode,
@@ -125,3 +125,7 @@ export const BodyImage: FC<Props> = ({
     </FigCaption>
   </figure>
 );
+
+// ----- Exports ----- //
+
+export default BodyImage;

--- a/common-rendering/src/components/figCaption.stories.tsx
+++ b/common-rendering/src/components/figCaption.stories.tsx
@@ -4,7 +4,7 @@
 
 import { Design, Display, Pillar, some } from "@guardian/types";
 import type { FC } from "react";
-import { FigCaption } from "./figCaption";
+import FigCaption from "./figCaption";
 
 // ----- Stories ----- //
 

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -57,7 +57,7 @@ type Props = {
 };
 
 const styles = (supportsDarkMode: boolean) => css`
-  ${textSans.xxsmall({ lineHeight: "regular" })}
+  ${textSans.xsmall()}
   padding-top: ${remSpace[2]};
   color: ${text.supporting};
 
@@ -86,7 +86,7 @@ const getStyles = (
   }
 };
 
-export const FigCaption: FC<Props> = ({
+const FigCaption: FC<Props> = ({
   format,
   supportsDarkMode,
   children,
@@ -104,3 +104,7 @@ export const FigCaption: FC<Props> = ({
       return null;
   }
 };
+
+// ----- Exports ----- //
+
+export default FigCaption;

--- a/common-rendering/src/components/img.stories.tsx
+++ b/common-rendering/src/components/img.stories.tsx
@@ -5,7 +5,7 @@
 import { Design, Display, none, Pillar } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
-import { Img } from "./img";
+import Img from "./img";
 
 // ----- Setup ----- //
 

--- a/common-rendering/src/components/img.tsx
+++ b/common-rendering/src/components/img.tsx
@@ -51,7 +51,7 @@ const styles = (
     `}
 `;
 
-export const Img: FC<Props> = ({
+const Img: FC<Props> = ({
   image,
   sizes,
   className,
@@ -81,3 +81,7 @@ export const Img: FC<Props> = ({
     />
   </picture>
 );
+
+// ----- Exports ----- //
+
+export default Img;

--- a/common-rendering/src/srcsets.ts
+++ b/common-rendering/src/srcsets.ts
@@ -16,7 +16,7 @@ const lowerQuality = 45;
 
 // ----- Types ----- //
 
-const enum Dpr {
+enum Dpr {
   One,
   Two,
 }

--- a/scripts/ci-ar.sh
+++ b/scripts/ci-ar.sh
@@ -29,6 +29,9 @@ else
     nvm install
     nvm use
 
+    npm i -g yarn@1.x
+    yarn --silent
+
     cd apps-rendering
 
     npm ci


### PR DESCRIPTION
## Why?

As seen in #3482, using code from `common-rendering` came with a problem. Somewhere along the way two different instances of react were being resolved and loaded, most likely because `apps-rendering` and `common-rendering` both directly depend on it. This is a common enough problem that React has [some documentation](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) on it.

I don't _believe_ two copies of the code were being included in the bundle, but the issue still occurred and caused a runtime crash.

There are two solutions to this that I can think of:

1. Explicitly tell all bundlers how to resolve references to React. In practice that means adding entries to Jest's `moduleNameMapper` and Webpack's `alias`es. This is the approach taken in this PR.
2. Stop depending on `react` directly in AR, `common-rendering` and DCR. Instead depend on it only in the project's root `package.json`. This is a step on the road towards having a single dependency tree for all parts of this project. This is the approach taken in #3485.

I've opened both PRs as drafts to get feedback, and will close one and promote the other once we settle on a preference.

## Changes

- All the `image-rendering` changes from #3472
- Add an alias to AR's `react` in the webpack config
