### PR TITLE
liveblogs: move header to separate component

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -1,31 +1,15 @@
 // // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import type { SerializedStyles } from '@emotion/react';
-import { Lines } from '@guardian/src-ed-lines';
 import { background, neutral } from '@guardian/src-foundations';
 import { breakpoints, from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
 import Footer from 'components/footer';
-import Headline from 'components/headline';
-import Metadata from 'components/metadata';
+import LiveblogHeader from 'components/liveblogHeader';
 import RelatedContent from 'components/shared/relatedContent';
-import Standfirst from 'components/standfirst';
 import Tags from 'components/tags';
-import { headlineBackgroundColour } from 'editorialStyles';
-import HeaderMedia from 'headerMedia';
 import type { Liveblog } from 'item';
-import { getFormat } from 'item';
 import type { FC } from 'react';
-import {
-	articleWidthStyles,
-	darkModeCss,
-	lineStyles,
-	onwardStyles,
-} from 'styles';
-import type { ThemeStyles } from 'themeStyles';
-import { getThemeStyles } from 'themeStyles';
-import Series from '../series';
+import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
 
 // // ----- Styles ----- //
 
@@ -38,66 +22,26 @@ const BorderStyles = css`
 		margin: 0 auto;
 	}
 `;
-
-const headlineBackgroundStyles = (format: Format): SerializedStyles => css`
-	${headlineBackgroundColour(format)};
-`;
-
-const liveblogsBackgroundStyles = ({
-	liveblogBackground,
-	liveblogDarkBackground,
-}: ThemeStyles): SerializedStyles => css`
-	background-color: ${liveblogBackground};
-
-	@media (prefers-color-scheme: dark) {
-		background-color: ${liveblogDarkBackground};
-	}
-`;
-
 interface Props {
 	item: Liveblog;
 }
 
-const Live: FC<Props> = ({ item }) => {
-	const format = getFormat(item);
-	const themeStyles = getThemeStyles(format.theme);
-
-	return (
-		<main>
-			<article className="js-article" css={BorderStyles}>
-				<header>
-					<div css={headlineBackgroundStyles(format)}>
-						<Series item={item} />
-						<Headline item={item} />
-					</div>
-					<div css={liveblogsBackgroundStyles(themeStyles)}>
-						<div css={articleWidthStyles}>
-							<Standfirst item={item} />
-						</div>
-						<div css={lineStyles}>
-							<Lines count={4} />
-						</div>
-						<div css={articleWidthStyles}>
-							<Metadata item={item} />
-						</div>
-					</div>
-					<div css={articleWidthStyles}>
-						<HeaderMedia item={item} />
-					</div>
-				</header>
-			</article>
-			<section css={articleWidthStyles}>
-				<Tags tags={item.tags} format={item} />
-			</section>
-			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
-			</section>
-			<section css={articleWidthStyles}>
-				<Footer isCcpa={false} />
-			</section>
-		</main>
-	);
-};
+const Live: FC<Props> = ({ item }) => (
+	<main>
+		<article className="js-article" css={BorderStyles}>
+			<LiveblogHeader item={item} />
+		</article>
+		<section css={articleWidthStyles}>
+			<Tags tags={item.tags} format={item} />
+		</section>
+		<section css={onwardStyles}>
+			<RelatedContent content={item.relatedContent} />
+		</section>
+		<section css={articleWidthStyles}>
+			<Footer isCcpa={false} />
+		</section>
+	</main>
+);
 
 // // ----- Exports ----- //
 

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -1,0 +1,71 @@
+// // ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { Lines } from '@guardian/src-ed-lines';
+import type { Format } from '@guardian/types';
+import Headline from 'components/headline';
+import Metadata from 'components/metadata';
+import Standfirst from 'components/standfirst';
+import { headlineBackgroundColour } from 'editorialStyles';
+import HeaderMedia from 'headerMedia';
+import type { Liveblog } from 'item';
+import { getFormat } from 'item';
+import type { FC } from 'react';
+import { articleWidthStyles, lineStyles } from 'styles';
+import type { ThemeStyles } from 'themeStyles';
+import { getThemeStyles } from 'themeStyles';
+import Series from './series';
+
+// // ----- Styles ----- //
+
+const headlineBackgroundStyles = (format: Format): SerializedStyles => css`
+	${headlineBackgroundColour(format)};
+`;
+
+const headerBackgroundStyles = ({
+	liveblogBackground,
+	liveblogDarkBackground,
+}: ThemeStyles): SerializedStyles => css`
+	background-color: ${liveblogBackground};
+
+	@media (prefers-color-scheme: dark) {
+		background-color: ${liveblogDarkBackground};
+	}
+`;
+
+interface Props {
+	item: Liveblog;
+}
+
+const LiveblogHeader: FC<Props> = ({ item }) => {
+	const format = getFormat(item);
+	const themeStyles = getThemeStyles(format.theme);
+
+	return (
+		<header>
+			<div css={headlineBackgroundStyles(format)}>
+				<Series item={item} />
+				<Headline item={item} />
+			</div>
+			<div css={headerBackgroundStyles(themeStyles)}>
+				<div css={articleWidthStyles}>
+					<Standfirst item={item} />
+				</div>
+				<div css={lineStyles}>
+					<Lines count={4} />
+				</div>
+				<div css={articleWidthStyles}>
+					<Metadata item={item} />
+				</div>
+			</div>
+			<div css={articleWidthStyles}>
+				<HeaderMedia item={item} />
+			</div>
+		</header>
+	);
+};
+
+// // ----- Exports ----- //
+
+export default LiveblogHeader;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

Before starting work on the overall layout it makes sense to pull out the liveblogs header to it's own component

No UI changes.
