### PR TITLE
Fix bugs raised by Visuals team

### DIFF
--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -45,6 +45,7 @@ type Props = {
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
 	element?: 'div' | 'article' | 'aside' | 'nav'; // ElementContainer is generally a top-level wrapper
+	className?: string | null;
 };
 
 export const ElementContainer = ({
@@ -58,6 +59,7 @@ export const ElementContainer = ({
 	shouldCenter = true,
 	children,
 	element = 'div',
+	className = null,
 }: Props) => (
 	<ClassNames>
 		{({ css }) => {
@@ -81,7 +83,7 @@ export const ElementContainer = ({
 			// Create a react element from the tagName passed in OR
 			// default to <div>
 			return _jsx(`${element}`, {
-				className: style,
+				className: className ? `${style} ${className}` : style,
 				children: child,
 			});
 		}}

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -45,7 +45,7 @@ type Props = {
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
 	element?: 'div' | 'article' | 'aside' | 'nav'; // ElementContainer is generally a top-level wrapper
-	className?: string | null;
+	className?: string;
 };
 
 export const ElementContainer = ({
@@ -59,7 +59,7 @@ export const ElementContainer = ({
 	shouldCenter = true,
 	children,
 	element = 'div',
-	className = null,
+	className,
 }: Props) => (
 	<ClassNames>
 		{({ css }) => {

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -358,6 +358,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
 				element="article"
+				className={interactiveLegacyClasses.contentInteractive}
 			>
 				<div className={interactiveLegacyClasses.contentInteractive}>
 					<InteractiveGrid>

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -31,7 +31,6 @@ export const interactiveGlobalStyles = css`
 	/* Scope this as tightly as possible. Otherwise, e.g. box-model will break
 	footer. */
 	body article {
-		*,
 		*:before,
 		*:after {
 			box-sizing: content-box;


### PR DESCRIPTION
## What does this change?
The Visuals team highlighted some errors that were blocking the migration of legacy interactives, which included an error making the background colour extend the full width and misalignment of the article margins. The background colour can be fixed by applying styling to the <article> tag. To resolve the margin alignment I had to undo some of the styling previously added to fix legacy interactives (see https://github.com/guardian/dotcom-rendering/pull/3284). This means some legacy articles will regress if rendering via DCR.

Note there will still be some regression between DCR and Frontend for these articles, this PR just tackles the primary issues raised by the Visuals team.

Interactives reported to have issues with background colour not extending full width of page:
https://www.theguardian.com/environment/ng-interactive/2021/feb/19/how-fires-have-spread-to-previously-untouched-parts-of-the-world?dcr
https://www.theguardian.com/us-news/ng-interactive/2020/nov/07/how-did-joe-biden-win-presidency-visual-guide?dcr

Interactives reported to have issues with margins:
https://www.theguardian.com/environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive?dcr
https://www.theguardian.com/environment/ng-interactive/2021/feb/19/how-fires-have-spread-to-previously-untouched-parts-of-the-world?dcr
https://www.theguardian.com/world/ng-interactive/2021/apr/21/how-vaccines-are-affecting-covid-19-outbreaks-globally?dcr
https://www.theguardian.com/world/ng-interactive/2020/sep/29/one-million-coronavirus-deaths-how-did-we-get-here-covid?dcr
https://www.theguardian.com/world/ng-interactive/2021/mar/19/revealed-the-data-that-shows-how-covid-bounced-back-after-the-uks-lockdowns?dcr
https://www.theguardian.com/media/ng-interactive/2021/may/05/guardian-200-first-ever-edition-annotated?dcr
https://www.theguardian.com/business/ng-interactive/2021/mar/31/uk-housing-crisis-how-did-owning-a-home-become-unaffordable?dcr
https://www.theguardian.com/world/ng-interactive/2021/jan/08/which-countries-have-reported-new-uk-covid-variant?dcr

## Why?
To support the interactive migration and fix issues with some interactives the Visuals team would like to migrate.

### Before
Via DCR:
![Screenshot 2021-09-30 at 14 28 57](https://user-images.githubusercontent.com/45561419/135464225-18e7ed51-e7de-45a3-8f0c-6a4a491cfc7a.png)

Via Frontend:
![Screenshot 2021-09-30 at 14 30 28](https://user-images.githubusercontent.com/45561419/135464502-3a292b56-8d08-416e-8251-0629ee0b49d1.png)


### After
<img width="1774" alt="Screenshot 2021-09-30 at 14 29 31" src="https://user-images.githubusercontent.com/45561419/135464343-1e824bbe-1b46-41d4-bb25-16a5abf65d56.png">

