### PR TITLE
Add legacy element-[role] class to elements in interactive articles

### DIFF
--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -149,6 +149,7 @@ type Props = {
 	role?: RoleType | 'richLink';
 	id?: string;
 	isNumberedListTitle?: boolean;
+	className?: string;
 };
 
 const mainMediaFigureStyles = css`
@@ -161,6 +162,7 @@ export const Figure = ({
 	id,
 	isMainMedia,
 	isNumberedListTitle = false,
+	className = '',
 }: Props) => {
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
@@ -181,6 +183,7 @@ export const Figure = ({
 			data-spacefinder-ignore={
 				isNumberedListTitle ? 'numbered-list-title' : null
 			}
+			className={className}
 		>
 			{children}
 		</figure>

--- a/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -289,7 +289,10 @@ export const InteractiveBlockComponent = ({
 				id={elementId} // required for hydration
 				ref={wrapperRef}
 				css={wrapperStyle({ format, role, loaded, palette })}
-				className={interactiveLegacyFigureClasses}
+				className={interactiveLegacyFigureClasses(
+					'model.dotcomrendering.pageElements.InteractiveBlockElement',
+					role,
+				)}
 				data-alt={alt} // for compatibility with custom boot scripts
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 			>

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.test.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.test.ts
@@ -1,0 +1,23 @@
+import { interactiveLegacyFigureClasses } from './interactiveLegacyStyling';
+
+describe('interactiveLegacyStyling', () => {
+	it('should add correct legacy classes for immersive interactive block element', () => {
+		const got = interactiveLegacyFigureClasses(
+			'model.dotcomrendering.pageElements.InteractiveBlockElement',
+			'immersive',
+		);
+		const want = 'element element-interactive element-immersive';
+
+		expect(got).toBe(want);
+	});
+
+	it('should add correct legacy classes for showcase interactive atom element', () => {
+		const got = interactiveLegacyFigureClasses(
+			'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+			'showcase',
+		);
+		const want = 'element element-atom element-showcase';
+
+		expect(got).toBe(want);
+	});
+});

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -1,11 +1,27 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { center } from '@root/src/web/lib/center';
 
-// Classes present in Frontend on figure wrapping elements for certain element types.
-export const interactiveLegacyFigureClasses =
-	'element-interactive element interactive';
+export const isInteractive = (design: ArticleDesign): boolean =>
+	design === ArticleDesign.Interactive;
+
+export const interactiveLegacyFigureClasses = (
+	elementType: string,
+	role?: RoleType,
+): string => {
+	const elementClasses: { [key: string]: string } = {
+		'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
+			'element-atom',
+		'model.dotcomrendering.pageElements.InteractiveBlockElement':
+			'element-interactive',
+	};
+
+	const roleClass = role ? `element-${role}` : '';
+	const elementClass = elementClasses[elementType] || '';
+	return `element ${elementClass} ${roleClass}`;
+};
 
 // Classes present in Frontend that we add for legacy interactives.
 export const interactiveLegacyClasses = {

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -652,7 +652,6 @@ export const renderElement = ({
 			const witnessType = element.witnessTypeData._type;
 			switch (witnessType) {
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataImage':
-					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataImage = element.witnessTypeData;
 					return [
 						true,
@@ -667,7 +666,6 @@ export const renderElement = ({
 						/>,
 					];
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataVideo':
-					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataVideo = element.witnessTypeData;
 					return [
 						true,
@@ -681,7 +679,6 @@ export const renderElement = ({
 						/>,
 					];
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataText':
-					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataText = element.witnessTypeData;
 					return [
 						true,

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -56,6 +56,10 @@ import {
 } from '@guardian/atoms-rendering';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import { Figure } from '../components/Figure';
+import {
+	isInteractive,
+	interactiveLegacyFigureClasses,
+} from '../layouts/lib/interactiveLegacyStyling';
 
 type Props = {
 	format: ArticleFormat;
@@ -649,7 +653,7 @@ export const renderElement = ({
 			switch (witnessType) {
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataImage':
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-					const witnessTypeDataImage = element.witnessTypeData as WitnessTypeDataImage;
+					const witnessTypeDataImage = element.witnessTypeData;
 					return [
 						true,
 						<WitnessImageBlockComponent
@@ -664,7 +668,7 @@ export const renderElement = ({
 					];
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataVideo':
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-					const witnessTypeDataVideo = element.witnessTypeData as WitnessTypeDataVideo;
+					const witnessTypeDataVideo = element.witnessTypeData;
 					return [
 						true,
 						<WitnessVideoBlockComponent
@@ -678,7 +682,7 @@ export const renderElement = ({
 					];
 				case 'model.dotcomrendering.pageElements.WitnessTypeDataText':
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-					const witnessTypeDataText = element.witnessTypeData as WitnessTypeDataText;
+					const witnessTypeDataText = element.witnessTypeData;
 					return [
 						true,
 						<WitnessTextBlockComponent
@@ -778,12 +782,18 @@ export const renderArticleElement = ({
 	}
 
 	const needsFigure = !bareElements.has(element._type);
+	const role = 'role' in element ? (element.role as RoleType) : undefined;
 
 	return needsFigure ? (
 		<Figure
 			isMainMedia={isMainMedia}
 			id={'elementId' in element ? element.elementId : undefined}
-			role={'role' in element ? (element.role as RoleType) : undefined}
+			role={role}
+			className={
+				isInteractive(format.design)
+					? interactiveLegacyFigureClasses(element._type, role)
+					: ''
+			}
 		>
 			{el}
 		</Figure>


### PR DESCRIPTION
## What

Adds role-specific classes to elements (when role is set) for interactives.

Note, this improves things for some articles but doesn't entirely fix image and atom layout as DCRs surround markup/CSS is still quite different. It does seem to remove the horiztonal scrollbar in many cases and also ensure the left-padding is present.

## Why?

Many legacy interactives style elements using this.

### Before

![Screenshot 2021-09-30 at 17 37 28](https://user-images.githubusercontent.com/858402/135496258-e9470e3d-82a2-44cb-b710-6912cb4f6f43.png)

### After

![Screenshot 2021-09-30 at 17 37 00](https://user-images.githubusercontent.com/858402/135496308-7f94b446-dd12-42f0-86cc-d02680973bca.png)

### Before

![Screenshot 2021-09-30 at 17 39 11](https://user-images.githubusercontent.com/858402/135496486-a5490d45-30ee-40f4-baf2-5eeef0b17e8f.png)

### After

![Screenshot 2021-09-30 at 17 38 39](https://user-images.githubusercontent.com/858402/135496410-d80400e1-1a1e-4ce5-9dc2-6fbd0e39ca00.png)