### PR TITLE
Braze article context filtering (section only)

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -42,7 +42,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^20.0.0",
     "@guardian/automat-contributions": "^0.4.2",
-    "@guardian/braze-components": "^4.0.0",
+    "@guardian/braze-components": "^4.1.0-0",
     "@guardian/commercial-core": "0.21.0",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^8.1.0",

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 
-import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
+import type { BrazeArticleContext, BrazeMessagesInterface } from '@guardian/braze-components/logic';
 
 import { getBrazeMetaFromUrlFragment } from '@root/src/web/lib/braze/forceBrazeMessage';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
@@ -29,6 +29,7 @@ type EpicConfig = {
 
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
+	brazeArticleContext: BrazeArticleContext
 ): Promise<CanShowResult<any>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
@@ -40,7 +41,7 @@ export const canShow = async (
 
 	try {
 		const brazeMessages = await brazeMessagesPromise;
-		const message = await brazeMessages.getMessageForEndOfArticle();
+		const message = await brazeMessages.getMessageForEndOfArticle(brazeArticleContext);
 
 		return {
 			show: true,

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -8,7 +8,7 @@ import {
 	CandidateConfig,
 } from '@root/src/web/lib/messagePicker';
 
-import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
+import type { BrazeMessagesInterface, BrazeArticleContext } from '@guardian/braze-components/logic';
 import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
 import {
 	ReaderRevenueEpic,
@@ -79,11 +79,12 @@ const buildBrazeEpicConfig = (
 	brazeMessages: Promise<BrazeMessagesInterface>,
 	countryCode: string,
 	idApiUrl: string,
+	brazeArticleContext: BrazeArticleContext
 ): CandidateConfig<any> => {
 	return {
 		candidate: {
 			id: 'braze-epic',
-			canShow: () => canShowBrazeEpic(brazeMessages),
+			canShow: () => canShowBrazeEpic(brazeMessages, brazeArticleContext),
 			show: (meta: any) => () => (
 				<MaybeBrazeEpic
 					meta={meta}
@@ -129,10 +130,14 @@ export const SlotBodyEnd = ({
 				WeeklyArticleHistory | undefined
 			>,
 		});
+		const brazeArticleContext: BrazeArticleContext = {
+			section: sectionName
+		};
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as Promise<BrazeMessagesInterface>,
 			countryCode as string,
 			idApiUrl,
+			brazeArticleContext
 		);
 		const epicConfig: SlotConfig = {
 			candidates: [brazeEpic, readerRevenueEpic],


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
https://trello.com/c/d5NYSNVi/1250-update-guardian-braze-components-to-filter-by-section
Adds article context filtering (worked on by Tom Wey as part of team hack day) to the braze components message cache. When we receive a message from Braze that should trigger a component being displayed on the page we store in in a local storage cache. With this change we only show messages from the cache if they match the article context (otherwise they stay in the cache).


## Why?
This enables Braze messages (end of article epics, or banners) to tailored to the article context. e.g show an Olympics related banner only on sports article, or a Green light epic only on environment articles.

### Before
Braze messages are shown on all pages regardless of article section.

### After
Braze messages can be filtered to show only on certain sections.

Depends on Braze components PR: https://github.com/guardian/braze-components/pull/237