### PR TITLE
Stop onwards carousel buttons obscuring banner

### DIFF
--- a/dotcom-rendering/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -13,6 +13,7 @@ import { Hide } from '@frontend/web/components/Hide';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';
 import { Card } from '@frontend/web/components/Card/Card';
 import { LI } from '@frontend/web/components/Card/components/LI';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
@@ -184,7 +185,7 @@ const buttonContainerStyle = css`
 	flex-direction: column;
 	justify-content: center;
 	position: absolute;
-	z-index: 20;
+	${getZIndex('onwardsCarousel')}
 	height: 100%;
 	padding-bottom: 36px; /* Align buttons centrally with cards */
 

--- a/dotcom-rendering/src/web/lib/getZIndex.test.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.test.tsx
@@ -2,15 +2,16 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 17;');
-		expect(getZIndex('dropdown')).toBe('z-index: 16;');
-		expect(getZIndex('burger')).toBe('z-index: 15;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 14;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 13;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 12;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 11;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 10;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 9;');
+		expect(getZIndex('banner')).toBe('z-index: 18;');
+		expect(getZIndex('dropdown')).toBe('z-index: 17;');
+		expect(getZIndex('burger')).toBe('z-index: 16;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 15;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 14;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 13;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 12;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 11;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 10;');
+		expect(getZIndex('onwardsCarousel')).toBe('z-index: 9;');
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');
 		expect(getZIndex('headerWrapper')).toBe('z-index: 6;');

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -38,6 +38,9 @@ const indices = [
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 
+	// Onwards Carousel (Related content etc)
+	'onwardsCarousel',
+
 	// Search link should be above The Guardian svg
 	'searchHeaderLink',
 	'TheGuardian',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Before this the carousel buttons had a higher z-index so they were sitting on top of banners in the sticky bottom banner slot.

## Why?

The buttons are the only part of the carousel which sit above the banner, so it looks confusing.

### Before

![Screenshot 2021-10-05 at 10 58 26](https://user-images.githubusercontent.com/379839/136002802-7339883b-b9ae-47a9-9fed-db197fe3b8ea.png)

### After

![Screenshot 2021-10-05 at 10 57 34](https://user-images.githubusercontent.com/379839/136002912-9afed39b-eaac-4f0b-9834-f5eeb21bf728.png)
