### PR TITLE
LIVE-3157: add extra line to parsing

### DIFF
--- a/apps-rendering/src/embed.ts
+++ b/apps-rendering/src/embed.ts
@@ -317,7 +317,10 @@ const parseGenericEmbedKind =
 		if (element.embedTypeData?.source === 'TikTok') {
 			return EmbedKind.TikTok;
 		}
-		if (isEmailSignUp(parser)(html)) {
+		if (
+			isEmailSignUp(parser)(html) ||
+			element.embedTypeData?.alt === 'Email signup'
+		) {
 			return EmbedKind.EmailSignup;
 		}
 		return EmbedKind.Generic;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Parses generic embeds with `alt="Signup form"` as `EmbedKind.SignupForm`

## Why?

Signup forms are not meant to render in Editions.

### Before
<img width="667" alt="Screenshot 2021-10-07 at 15 44 38" src="https://user-images.githubusercontent.com/77005274/136408325-65dca845-7a0f-4c6c-9525-f7a845a3529f.png">

### After
<img width="667" alt="Screenshot 2021-10-07 at 15 44 22" src="https://user-images.githubusercontent.com/77005274/136408378-cc936a17-dd07-40bf-bd4d-b70dee788c09.png">

