### PR TITLE
AR: `node-fetch` v3

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -4611,29 +4611,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.19.tgz",
       "integrity": "sha512-jjYI6NkyfXykucU6ELEoT64QyKOdvaA6enOqKtP4xUsGY0X0ZUZz29fUmrTRo+7v7c6TgDu82q3GHHaCEkqZwA=="
     },
-    "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/node-int64": {
       "version": "0.4.29",
       "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -83,7 +83,6 @@
     "@types/html-webpack-plugin": "^3.2.6",
     "@types/jest": "^26.0.24",
     "@types/node": "^14.17.19",
-    "@types/node-fetch": "^2.5.12",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@types/react-test-renderer": "^17.0.1",


### PR DESCRIPTION
## Why?

Brings `node-fetch` to latest version.

## Changes

- Updated `node-fetch` to v3
- Removed `@types/node-fetch` as the main library includes type definitions

