### PR TITLE
Move hiring message above ascii art for a11y

### DIFF
--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -119,6 +119,10 @@ export const htmlTemplate = ({
 	const weAreHiringMessage = `
 <!--
 
+We are hiring, ever thought about joining us?
+https://workforus.theguardian.com/careers/product-engineering/
+
+
                                     GGGGGGGGG
                            GGGGGGGGGGGGGGGGGGGGGGGGGG
                        GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
@@ -144,10 +148,6 @@ export const htmlTemplate = ({
                        GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
                             GGGGGGGGGGGGGGGGGGGGGGGGG
                                     GGGGGGGGG
-
-
-        We are hiring, ever thought about joining us?
-        https://workforus.theguardian.com/careers/product-engineering/
 
 
          GGGGG    GGG     GGG


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Moves the hiring message above the ascii art

## Why?

The hiring message in the HTML is not super-accessible to screen reader users. Moving the hiring message above the ascii art means the user doesn't have to listen to a lot of "G's" before discovering what the purpose of the message is.
