### PR TITLE
Use `format` in `getSizes`

### DIFF
--- a/dotcom-rendering/src/web/components/elements/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/ImageComponent.tsx
@@ -259,6 +259,7 @@ export const ImageComponent = ({
 			>
 				<Picture
 					role={role}
+					format={format}
 					imageSources={element.imageSources}
 					alt={element.data.alt || ''}
 					width={imageWidth}
@@ -290,6 +291,7 @@ export const ImageComponent = ({
 			>
 				<Picture
 					role={role}
+					format={format}
 					imageSources={element.imageSources}
 					alt={element.data.alt || ''}
 					width={imageWidth}
@@ -321,6 +323,7 @@ export const ImageComponent = ({
 			>
 				<Picture
 					role={role}
+					format={format}
 					imageSources={element.imageSources}
 					alt={element.data.alt || ''}
 					width={imageWidth}


### PR DESCRIPTION
## What?
This PR refactors how we decide the `sizes` array for image source elements. In particular, it adds the `format` value to `getSizes` and uses `format.display` to decide when to use larger image sizes on immersive articles

## Why?
Previously, we had a bug where we were always using the image `role` to decide which sizes array to use but for main media this value is not always accurate. In particular, for Immersive articles it was only possible to set the image weighting to `showcase` or `inline` meaning that smaller images were being used incorrectly

Before                                |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1336821/137023351-21365648-e5cd-4d80-a2ab-59fe59812269.png)  |  ![](https://user-images.githubusercontent.com/1336821/137023347-3e9826d6-36cc-4445-a84f-99bb7040fcb6.png)



 Ref: https://www.theguardian.com/news/2018/dec/07/china-plan-for-global-media-dominance-propaganda-xi-jinping