### PR TITLE
Fix ads on interactive immersive pages

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -59,6 +59,12 @@ export const labelStyles = css`
 	}
 `;
 
+export const adCollapseStyles = css`
+	& .ad-slot.ad-slot--collapse {
+		display: none;
+	}
+`;
+
 /**
  * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
  * These styles come mostly from RichLink in DCR.

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -17,6 +17,7 @@ import { Nav } from '@root/src/web/components/Nav/Nav';
 import {
 	MobileStickyContainer,
 	labelStyles as adLabelStyles,
+	adCollapseStyles,
 } from '@root/src/web/components/AdSlot';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
@@ -92,6 +93,7 @@ const Renderer: React.FC<{
 
 	const adStyles = css`
 		${adLabelStyles}
+		${adCollapseStyles}
 
 		${from.tablet} {
 			.mobile-only .ad-slot {

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -5,7 +5,10 @@ import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/src-foundations/mq';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
-import { labelStyles as adLabelStyles } from '../components/AdSlot';
+import {
+	labelStyles as adLabelStyles,
+	adCollapseStyles,
+} from '../components/AdSlot';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -19,10 +22,7 @@ const commercialPosition = css`
 // hence we scope the styles at the same level
 const adStylesDynamic = css`
 	${adLabelStyles}
-
-	& .ad-slot.ad-slot--collapse {
-		display: none;
-	}
+	${adCollapseStyles}
 
 	.ad-slot--im {
 		float: left;


### PR DESCRIPTION
Co-Authored-By: Chris Jones <chrislomaxjones96@gmail.com>

## What does this change?

Fixes two issues with the rendering of ads on interactive immersive pages:

- ad labels were being styled incorrectly
- ads were being double rendered

## Why?

When we moved some styles from `ElementContainer` to `ArticleRenderer` in [this PR](https://github.com/guardian/dotcom-rendering/pull/3439), we unintentionally broke some styling on interactive immersive pages. 

This is because, unlike all other layout types, `InteractiveImmersiveLayout` does not rely on `ArticleBody` (which itself relies on `ArticleRenderer`, where the styles were moved) for rendering article content. It instead uses a [custom renderer](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx#L37-L90).

The fix was to apply the missing styles in the custom renderer.

Because `InteractiveImmersiveLayout` is the only layout which works like this, we can be reasonably confident it's the only one which was broken.

### Before

![Screenshot 2021-10-14 at 15 03 33](https://user-images.githubusercontent.com/7423751/137333577-76690d4a-f104-4f52-a47b-c2e00dd20c43.png)

### After

![Screenshot 2021-10-14 at 15 04 16](https://user-images.githubusercontent.com/7423751/137333599-62f05bbb-cea8-4d40-9049-52e3aed51a11.png)


