### PR TITLE
Auto-label `*-rendering` PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# https://github.com/marketplace/actions/labeler
+
+dotcom-rendering: dotcom-rendering/**/*
+apps-rendering: apps-rendering/**/*
+common-rendering: common-rendering/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true # remove redundant labels after a change


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

automatically labels PRs `dotcom-rendering`/`apps-rendering`/`common-rendering` according to the changes they contain

## Why?

it's easier to see where changes are being proposed in a consistent way