### PR TITLE
More Visible Camera Icon In Dark Mode

### DIFF
--- a/common-rendering/src/components/imageDetails.tsx
+++ b/common-rendering/src/components/imageDetails.tsx
@@ -56,8 +56,7 @@ const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	}
 
 	${darkModeCss(supportsDarkMode)`
-		background-color: ${neutral[60]};
-		opacity: .7;
+		background-color: ${neutral[93]};
 	`}
 `;
 


### PR DESCRIPTION
## Why?

Tweaking the colour and opacity of the caption camera icon to make it more visible on some images.

## Changes

- Tweaked the colour and opacity of the dark mode camera icon

## Screenshots

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/53781962/137508317-966eaf62-d315-4def-9ef2-4c258dd7136a.jpg) | ![after](https://user-images.githubusercontent.com/53781962/137508334-3ae1b677-dec4-446a-82e6-16c150928a8d.jpg) |
