### PR TITLE
Block AMP Youtube player until consent is obtained

### DIFF
--- a/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -53,6 +53,7 @@ export const YoutubeBlockComponent: React.FC<{
 		layout: 'responsive',
 		width: '16',
 		height: '9',
+		'data-block-on-consent': true, // Block player until consent is obtained
 		'data-param-modestbranding': true, // Remove YouTube logo
 		credentials: 'omit',
 	};


### PR DESCRIPTION
Co-authored-by: Simon Byford <simon.byford@guardian.co.uk>
Co-authored-by: Frederick O'brien <frederick.obrien@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add the `data-block-on-consent` attribute to the AMP youtube player element.

## Why?

This will block the loading of the Youtube Player on AMP until after consent has been obtained.
