### PR TITLE
Use browserId for epic if consented

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1227,6 +1227,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					idApiUrl={CAPI.config.idApiUrl}
 					stage={CAPI.stage}
 					asyncArticleCount={asyncArticleCount}
+					browserId={browserId || undefined}
 				/>
 			</Portal>
 			<Portal

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -14,6 +14,7 @@ import {
 	getEmail,
 	MODULES_VERSION,
 	hasOptedOutOfArticleCount,
+	hasCmpConsentForBrowserId,
 } from '@root/src/web/lib/contributions';
 import { getForcedVariant } from '@root/src/web/lib/readerRevenueDevUtils';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
@@ -86,6 +87,7 @@ export type CanShowData = {
 	idApiUrl: string;
 	stage: string;
 	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
+	browserId?: string;
 };
 
 const buildPayload = async (data: CanShowData): Promise<Metadata> => {
@@ -118,6 +120,7 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 			countryCode: data.countryCode,
 			modulesVersion: MODULES_VERSION,
 			url: window.location.origin + window.location.pathname,
+			browserId: await hasCmpConsentForBrowserId() ? data.browserId : undefined,
 		},
 	} as Metadata; // Metadata type incorrectly does not include required hasOptedOutOfArticleCount property
 };

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -32,40 +32,15 @@ type Props = {
 	idApiUrl: string;
 	stage: string;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
+	browserId?: string,
 };
 
-const buildReaderRevenueEpicConfig = ({
-	isSignedIn,
-	countryCode,
-	contentType,
-	sectionName,
-	shouldHideReaderRevenue,
-	isMinuteArticle,
-	isPaidContent,
-	tags,
-	contributionsServiceUrl,
-	idApiUrl,
-	stage,
-	asyncArticleCount,
-}: RRCanShowData): CandidateConfig<RREpicConfig> => {
+const buildReaderRevenueEpicConfig = (canShowData: RRCanShowData): CandidateConfig<RREpicConfig> => {
 	return {
 		candidate: {
 			id: 'reader-revenue-banner',
 			canShow: () =>
-				canShowReaderRevenueEpic({
-					isSignedIn,
-					countryCode,
-					contentType,
-					sectionName,
-					shouldHideReaderRevenue,
-					isMinuteArticle,
-					isPaidContent,
-					tags,
-					contributionsServiceUrl,
-					idApiUrl,
-					stage,
-					asyncArticleCount,
-				}),
+				canShowReaderRevenueEpic(canShowData),
 			show: (meta: RREpicConfig) => () => {
 				/* eslint-disable-next-line react/jsx-props-no-spreading */
 				return <ReaderRevenueEpic {...meta} />;
@@ -111,6 +86,7 @@ export const SlotBodyEnd = ({
 	idApiUrl,
 	stage,
 	asyncArticleCount,
+	browserId,
 }: Props) => {
 	const [SelectedEpic, setSelectedEpic] = useState<React.FC | null>(null);
 	useOnce(() => {
@@ -129,6 +105,7 @@ export const SlotBodyEnd = ({
 			asyncArticleCount: asyncArticleCount as Promise<
 				WeeklyArticleHistory | undefined
 			>,
+			browserId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionName

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -141,6 +141,7 @@ export const shouldHideSupportMessaging = (
 	isRecentOneOffContributor();
 
 const REQUIRED_CONSENTS_FOR_ARTICLE_COUNT = [1, 3, 7];
+const REQUIRED_CONSENTS_FOR_BROWSER_ID = [1, 3, 5, 7];
 
 export const hasArticleCountOptOutCookie = (): boolean =>
 	getCookie(OPT_OUT_OF_ARTICLE_COUNT_COOKIE) !== null;
@@ -176,6 +177,23 @@ export const hasOptedOutOfArticleCount = async (): Promise<boolean> => {
 	const hasCmpConsent = await hasCmpConsentForArticleCount();
 	return !hasCmpConsent || hasArticleCountOptOutCookie();
 };
+
+export const hasCmpConsentForBrowserId = (): Promise<boolean> =>
+	new Promise((resolve) => {
+		if (getCookie('gu-cmp-disabled')) {
+			resolve(true);
+		}
+		onConsentChange(({ ccpa, tcfv2, aus }) => {
+			if (ccpa || aus) {
+				resolve(true);
+			} else if (tcfv2) {
+				const hasRequiredConsents = REQUIRED_CONSENTS_FOR_BROWSER_ID.every(
+					(consent) => tcfv2.consents[consent],
+				);
+				resolve(hasRequiredConsents);
+			}
+		});
+	});
 
 const twentyMins = 20 * 60000;
 export const withinLocalNoBannerCachePeriod = (): boolean => {


### PR DESCRIPTION
We're testing browserId-based targeting. This means the client (dcr) needs to send the browserId to the targeting service (support-dotcom-components). We must only use browserId if the user has consented.