### PR TITLE
Shared `MainMediaImage` Component

### DIFF
--- a/common-rendering/src/components/imageDetails.tsx
+++ b/common-rendering/src/components/imageDetails.tsx
@@ -9,7 +9,7 @@ import { SvgCamera } from '@guardian/src-icons';
 import { Option, OptionKind } from '@guardian/types';
 import { withDefault } from '@guardian/types';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 
 // ----- Component ----- //
 
@@ -76,7 +76,7 @@ const svgStyles: SerializedStyles = css`
 `;
 
 interface Props {
-	caption: Option<string>;
+	caption: Option<ReactNode>;
 	credit: Option<string>;
 	supportsDarkMode: boolean;
 	id: string;
@@ -102,7 +102,7 @@ const ImageDetails: FC<Props> = ({
 					</span>
 				</summary>
 				<span id={id}>
-					{withDefault('')(caption)} {withDefault('')(credit)}
+					{withDefault<ReactNode>(null)(caption)} {withDefault('')(credit)}
 				</span>
 			</details>
 		</figcaption>

--- a/common-rendering/src/components/mainMediaImage.stories.tsx
+++ b/common-rendering/src/components/mainMediaImage.stories.tsx
@@ -1,0 +1,33 @@
+// ----- Imports ----- //
+
+import type { FC } from 'react';
+import MainMediaImage from './mainMediaImage';
+import { image } from '@guardian/common-rendering/src/fixtures/image';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+
+// ----- Stories ----- //
+
+const Default: FC = () =>
+    <MainMediaImage
+        caption="This is a main media image"
+        credit="A photographer"
+        supportsDarkMode
+        lightbox={null}
+        format={{
+            design: ArticleDesign.Standard,
+            display: ArticleDisplay.Standard,
+            theme: ArticlePillar.News,
+        }}
+        image={image}
+    />
+
+// ----- Exports ----- //
+
+export default {
+    component: Image,
+    title: 'Common/Components/MainMediaImage',
+}
+
+export {
+    Default,
+}

--- a/common-rendering/src/components/mainMediaImage.tsx
+++ b/common-rendering/src/components/mainMediaImage.tsx
@@ -1,0 +1,82 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import type { FC, ReactNode } from 'react';
+import ImageDetails from '@guardian/common-rendering/src/components/imageDetails';
+import { fromNullable, none } from '@guardian/types';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Lightbox } from '@guardian/common-rendering/src/lightbox';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { Image } from '@guardian/common-rendering/src/image';
+import { from } from '@guardian/src-foundations/mq';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+
+// ----- Setup ----- //
+
+const captionId = 'main-media-caption';
+const desktopWidth = 43.75;
+
+// ----- Component ----- //
+
+const sizes = (format: ArticleFormat): Sizes => {
+    switch (format.design) {
+        case ArticleDesign.LiveBlog:
+        case ArticleDesign.DeadBlog:            
+        default:
+            return {
+                mediaQueries: [
+                    // Centre column from here up, which is 700px wide
+                    { breakpoint: "desktop", size: `${desktopWidth}rem` }
+                ],
+                // Image is full width of the screen at narrower breakpoints
+                default: '100vw',
+            };
+    }
+}
+
+const styles: SerializedStyles = css`
+    position: relative;
+
+    ${from.desktop} {
+        width: ${desktopWidth}rem;
+    }
+`;
+
+interface Props {
+    caption: ReactNode | null;
+    credit: string | null;
+    supportsDarkMode: boolean;
+    lightbox: Lightbox | null;
+    format: ArticleFormat;
+    image: Image;
+}
+
+const MainMediaImage: FC<Props> = ({
+    caption,
+    credit,
+    supportsDarkMode,
+    lightbox,
+    format,
+    image,
+}) =>
+    <figure css={styles} aria-labelledby={captionId}>
+        <Img
+            format={format}
+            supportsDarkMode={supportsDarkMode}
+            lightbox={fromNullable(lightbox)}
+            sizes={sizes(format)}
+            className={none}
+            image={image}
+        />
+        <ImageDetails
+            caption={fromNullable(caption)}
+            credit={fromNullable(credit)}
+            supportsDarkMode={supportsDarkMode}
+            id={captionId}
+        />
+    </figure>
+
+// ----- Exports ----- //
+
+export default MainMediaImage;


### PR DESCRIPTION
## Why?

The image variant of main media, for use in liveblogs. It uses the shared image-rendering code under the hood.

It's also un-opinionated about how captions should be rendered, allowing AR to render via `DocumentFragment` and DCR to render via `dangerouslySetInnerHTML`.

This also uses the updated `ArticleFormat` from `guardian/libs` - thanks @jamie-lynch!

**Note:** We're currently reviewing the pros and cons of allowing `Option` and `Result` to propagate into the overall DCAR codebase, so I've kept them out of the API for this component. cc @sndrs @SiAdcock 

## Changes

- Added component
- Added stories
- Tweaked `ImageDetails` to accept already rendered caption
