### PR TITLE
Fix compress workflow

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -18,6 +18,5 @@ jobs:
 
             - uses: preactjs/compressed-size-action@v2
               with:
-                  cwd: ./dotcom-rendering
                   repo-token: "${{ secrets.GITHUB_TOKEN }}"
-                  build-script: makeBuild
+                  build-script: build:dcr


### PR DESCRIPTION
## What does this change?

* Remove the `cwd`  option from the compress workflow
* Update the `build-script` option in the compress workflow config to use the new `build:dcr` command added in #3549 

## Why?

This check was failing due to an error installing dependencies for the base branch. This change fixes that problem. 

Since yarn workspaces have been adopted for dotcom-rendering, there is no longer a `yarn.lock` in the `./dotcom-rendering` directory. Because of this, when the [preactjs/compressed-size-action](https://github.com/preactjs/compressed-size-action) runs on the target branch, it runs `npm install` to install the dependencies which also creates a lock file. When the base branch is then checked out `npm ci` is run to install the dependencies, using the `package-lock.json` file that was previously created. 

This is generally undesired as it means that status checks are not running in a representative environment. It is also causing failures for changes that update dependencies to previously unsupported versions as the `npm ci` call on the base branch cannot complete.