### PR TITLE
Make every day our 200 year anniversary!

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,7 +18,9 @@ Picture.disableLazyLoading = isChromatic();
 
 if (isChromatic()) {
 	// Fix the date to prevent false negatives
-	MockDate.set('Fri Oct 22 2021 11:28:15 GMT+0100 (British Summer Time)');
+	// And not just any date... 200 years! 🎉
+	// https://www.theguardian.com/gnm-press-office/2021/apr/30/the-guardian-celebrates-200-extraordinary-years
+	MockDate.set('Wed May 5 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
 }
 
 mockRESTCalls();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the date that we mock inside Chromatic to a more recent, and extraordinary, one.

## Why?
Because we saw an issue where when we were using `timeAgo` it was returning `false` because the relative difference was negative. By moving the date forward we remove most of these issues.

It's not a perfect solution because adding more stories that use future dates will continue to cause this problem

## Why this date?
Because [it was requested](https://github.com/guardian/dotcom-rendering/pull/2358#pullrequestreview-576510156) by @mxdvl - [200 Years!](https://www.theguardian.com/gnm-press-office/2021/apr/30/the-guardian-celebrates-200-extraordinary-years)

