### PR TITLE
Fix ordered lists styling for ArticleBody

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -6,7 +6,7 @@ import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { LiveBlogRenderer } from '@root/src/web/lib/LiveBlogRenderer';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { space, remSpace } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
 	format: ArticleFormat;
@@ -33,7 +33,7 @@ const globalOlStyles = () => css`
 			${body.medium({lineHeight : 'tight'})};
 			content: counter(li);
 			counter-increment: li;
-			margin-right: ${remSpace[1]}
+			margin-right: ${space[1]}px;
 		}
 	}
 `;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add global styling for ordered list

## Why?
Currently the numbers do not show

### Before
![image](https://user-images.githubusercontent.com/19683595/138448506-b5f29b72-5e92-415f-a8d7-ef477dff387d.png)


### After
![image](https://user-images.githubusercontent.com/19683595/138471608-4d7c8576-e065-494c-8c72-eb8f9f4a623a.png)


