### PR TITLE
Remove `skipOn` CI for `consent.spec` cypress test

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-6/consent.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/consent.spec.js
@@ -2,7 +2,7 @@
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
-import { skipOn } from '@cypress/skip-test';
+import { storage } from '@guardian/libs';
 
 const firstPage =
 	'https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife';
@@ -21,64 +21,57 @@ describe('Consent tests', function () {
 
 	beforeEach(function () {
 		setLocalBaseUrl();
+		storage.local.set('gu.geo.override', 'GB');
 	});
 
-	// Skipping only on CI because, these tests work fine locally but can fail on CI is the server
-	// being used is in the US
-	skipOn(
-		Cypress.env('TEAMCITY') === 'true' ||
-			Cypress.env('GITHUB_ACTIONS') === 'true',
-		() => {
-			it('should make calls to Google Analytics after the reader consents', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Accept tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Accept all']").click();
-				// Make a second page load now that we have the CMP cookies set to accept tracking
-				cy.visit(`Article?url=${secondPage}`);
-				// Wait for a call to Google Analytics to be made - we expect this to happen
-				cy.intercept('POST', 'https://www.google-analytics.com/**');
-			});
+	it('should make calls to Google Analytics after the reader consents', function () {
+		cy.visit(`Article?url=${firstPage}`);
+		waitForAnalyticsToInit();
+		cy.window().its('ga').should('not.exist');
+		// Open the Privacy setting dialogue
+		cmpIframe().contains("It's your choice");
+		cmpIframe().find("[title='Manage my cookies']").click();
+		// Accept tracking cookies
+		privacySettingsIframe().contains('Privacy settings');
+		privacySettingsIframe().find("[title='Accept all']").click();
+		// Make a second page load now that we have the CMP cookies set to accept tracking
+		cy.visit(`Article?url=${secondPage}`);
+		// Wait for a call to Google Analytics to be made - we expect this to happen
+		cy.intercept('POST', 'https://www.google-analytics.com/**');
+	});
 
-			it('should not add GA tracking scripts onto the window object after the reader rejects consent', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Reject tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Reject all']").click();
-				// Make a second page load now that we have the CMP cookies set to reject tracking and check
-				// to see if the ga property was set by Google on the window object
-				cy.visit(`Article?url=${secondPage}`);
-				waitForAnalyticsToInit();
-				// We force window.ga to be null on consent rejection to prevent subsequent requests
-				cy.window().its('ga').should('equal', null);
-			});
+	it('should not add GA tracking scripts onto the window object after the reader rejects consent', function () {
+		cy.visit(`Article?url=${firstPage}`);
+		waitForAnalyticsToInit();
+		cy.window().its('ga').should('not.exist');
+		// Open the Privacy setting dialogue
+		cmpIframe().contains("It's your choice");
+		cmpIframe().find("[title='Manage my cookies']").click();
+		// Reject tracking cookies
+		privacySettingsIframe().contains('Privacy settings');
+		privacySettingsIframe().find("[title='Reject all']").click();
+		// Make a second page load now that we have the CMP cookies set to reject tracking and check
+		// to see if the ga property was set by Google on the window object
+		cy.visit(`Article?url=${secondPage}`);
+		waitForAnalyticsToInit();
+		// We force window.ga to be null on consent rejection to prevent subsequent requests
+		cy.window().its('ga').should('equal', null);
+	});
 
-			it('should add GA tracking scripts onto the window object after the reader accepts consent', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Reject tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Accept all']").click();
-				// Make a second page load now that we have the CMP cookies set to reject tracking and check
-				// to see if the ga property was set by Google on the window object
-				cy.visit(`Article?url=${secondPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('exist');
-			});
-		},
-	);
+	it('should add GA tracking scripts onto the window object after the reader accepts consent', function () {
+		cy.visit(`Article?url=${firstPage}`);
+		waitForAnalyticsToInit();
+		cy.window().its('ga').should('not.exist');
+		// Open the Privacy setting dialogue
+		cmpIframe().contains("It's your choice");
+		cmpIframe().find("[title='Manage my cookies']").click();
+		// Reject tracking cookies
+		privacySettingsIframe().contains('Privacy settings');
+		privacySettingsIframe().find("[title='Accept all']").click();
+		// Make a second page load now that we have the CMP cookies set to reject tracking and check
+		// to see if the ga property was set by Google on the window object
+		cy.visit(`Article?url=${secondPage}`);
+		waitForAnalyticsToInit();
+		cy.window().its('ga').should('exist');
+	});
 });


### PR DESCRIPTION
## What does this change?

Remove the `skipOn` CI for the `consent.spec` cypress test now that we can override the geo location for consent.

