### PR TITLE
return 415 http status code when amp component not renderable in DCR

### DIFF
--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -20,6 +20,7 @@ import { VideoYoutubeBlockComponent } from '@root/src/amp/components/elements/Vi
 import { YoutubeBlockComponent } from '@root/src/amp/components/elements/YoutubeBlockComponent';
 
 import { enhance } from '@root/src/amp/lib/enhance';
+import { NotRenderableInDCR } from '@root/src/lib/errors/not-renderable-in-dcr';
 
 export const Elements = (
 	elements: CAPIElement[],
@@ -221,9 +222,7 @@ export const Elements = (
 				// eslint-disable-next-line no-console
 				console.log('Unsupported Element', JSON.stringify(element));
 				if ((element as { isMandatory?: boolean }).isMandatory) {
-					throw new Error(
-						'This page cannot be rendered due to incompatible content that is marked as mandatory.',
-					);
+					throw new NotRenderableInDCR();
 				}
 				return null;
 		}

--- a/dotcom-rendering/src/amp/components/elements/EmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/EmbedBlockComponent.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
+import { NotRenderableInDCR } from '@root/src/lib/errors/not-renderable-in-dcr';
 
 export const EmbedBlockComponent: React.FC<{
 	element: EmbedBlockElement;
 }> = ({ element }) => {
 	if (element.isMandatory) {
-		throw new Error(
-			'This page cannot be rendered due to incompatible content that is marked as mandatory.',
-		);
+		throw new NotRenderableInDCR();
 	}
 	return null;
 };

--- a/dotcom-rendering/src/amp/components/elements/InteractiveBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/InteractiveBlockComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ClassNames } from '@emotion/react';
 
 import { ShowMoreButton } from '@root/src/amp/components/ShowMoreButton';
+import { NotRenderableInDCR } from '@root/src/lib/errors/not-renderable-in-dcr';
 
 export const InteractiveBlockComponent: React.FunctionComponent<{
 	url?: string;
@@ -10,9 +11,7 @@ export const InteractiveBlockComponent: React.FunctionComponent<{
 	// If this element is mandatory, we don't know if we can render it properly, so we have to
 	// throw an error and chuck the whole page out of AMP. You're barred son.
 	if (isMandatory) {
-		throw new Error(
-			'This page cannot be rendered due to incompatible content that is marked as mandatory.',
-		);
+		throw new NotRenderableInDCR();
 	}
 
 	if (!url) {

--- a/dotcom-rendering/src/amp/server/render.tsx
+++ b/dotcom-rendering/src/amp/server/render.tsx
@@ -10,6 +10,7 @@ import { findBySubsection } from '@root/src/model/article-sections';
 import { Article as ExampleArticle } from '@root/fixtures/generated/articles/Article';
 import { generatePermutivePayload } from '@root/src/amp/lib/permutive';
 import { getAmpExperimentCache } from '@root/src/amp/server/ampExperimentCache';
+import { NotRenderableInDCR } from '@root/src/lib/errors/not-renderable-in-dcr';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
 	try {
@@ -72,6 +73,8 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 		// a validation error
 		if (e instanceof TypeError) {
 			res.status(400).send(`<pre>${e.message}</pre>`);
+		} else if (e instanceof NotRenderableInDCR) {
+			res.status(415).send(`<pre>${e.message}</pre>`);
 		} else {
 			// @ts-expect-error
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/dotcom-rendering/src/lib/errors/not-renderable-in-dcr.ts
+++ b/dotcom-rendering/src/lib/errors/not-renderable-in-dcr.ts
@@ -1,0 +1,5 @@
+export class NotRenderableInDCR extends Error {
+	constructor() {
+		super('This page cannot be rendered due to incompatible content that is marked as mandatory.')
+	}
+}


### PR DESCRIPTION
## What does this change?
If an AMP component is not supported then we threw a 500 server error. We have ongoing pager duty alarms because of this which could mask genuine failures.

If an AMP component is not supported in DCR we now throw a 415 status code (unsupported media type) which is more descriptive of the situation. This will help reduce false positive alarms in pager duty.

## Why?
To eliminate false positive alarms being raised when unsupported media is attempted to render via AMP.

### Before
If an element was not supported in AMP we returned a 500:
<img width="790" alt="Screenshot 2021-10-26 at 11 52 42" src="https://user-images.githubusercontent.com/45561419/138864075-9aa15dbb-cec2-418d-9b05-aa832146acb9.png">


### After
If an element is not supported in AMP we return a 415:
<img width="792" alt="Screenshot 2021-10-26 at 11 54 10" src="https://user-images.githubusercontent.com/45561419/138864134-016b68a0-9774-41e1-bcc1-6a11ea59f137.png">
