### PR TITLE
Add prebid timeout AB test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.tsx
@@ -3,6 +3,7 @@ import { tests } from '@frontend/web/experiments/ab-tests';
 import { sendCommercialMetrics } from '@guardian/commercial-core';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { useAB } from '@guardian/ab-react';
+import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-test';
 import { useDocumentVisibilityState } from '../lib/useDocumentHidden';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 
@@ -20,7 +21,7 @@ export const CommercialMetrics: React.FC<{
 	const isHidden = visibilityState === 'hidden' || undefined
 
 	useOnce(() => {
-		const testsToForceMetrics: ABTest[] = [];
+		const testsToForceMetrics: ABTest[] = [prebidTimeout];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),
 		);

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -6,6 +6,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
+import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-test';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -15,4 +16,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
+	prebidTimeout,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidTimeout: ABTest = {
+	id: 'PrebidTimeout',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2021-10-6',
+	expiry: '2021-10-29',
+	audience: 3 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'All users',
+	description:
+		'Vary the length of the prebid timeout beyond which we stop accepting bids. See if varying this timeout leads to any changes in commercial timing metrics',
+	successMeasure:
+		'Varying the length of the prebid timeout has an effect on commercial timing metrics',
+	variants: [
+		{ id: 'variant500', test: (): void => {} },
+		{ id: 'variant1500', test: (): void => {} },
+		{ id: 'variant4000', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
Co-authored-by: Simon Byford <simon.byford@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the Prebid Timeout AB test to DCR. This test is a duplicate of the [test defined in frontend](https://github.com/guardian/frontend/blob/6d340478c65e20cd6f4301e0df04c810735188e0/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts). We also force sending commercial metrics when a visitor is assigned to a variant group.

## Why?

In order to collect data for content types rendered by DCR.