### PR TITLE
Block AMP Youtube block until consent obtained

### DIFF
--- a/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -15,6 +15,7 @@ export const VideoYoutubeBlockComponent: React.FC<{
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
 			<amp-youtube
+				data-block-on-consent={true} // Block player until consent is obtained
 				data-videoid={youtubeId}
 				layout="responsive"
 				width={element.width}


### PR DESCRIPTION
## What does this change?

Block AMP Youtube block until consent obtained

## Why?

We need to wait for consent to be obtained before loading and passing consent data to the Youtube player.