### PR TITLE
Update VideoYoutubeBlockElement example

### DIFF
--- a/dotcom-rendering/scripts/frontend/landing/index.html
+++ b/dotcom-rendering/scripts/frontend/landing/index.html
@@ -239,7 +239,7 @@
                 {
                     name: 'VideoYoutubeBlockElement',
                     article:
-                        '/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests',
+                        '/music/2021/oct/23/buffalo-nichols-buffalo-nichols-review-carl-nichols',
                 },
                 {
                     name: 'VineBlockElement',


### PR DESCRIPTION
## Why?

The current `VideoYoutubeBlockElement` example is age-restricted and does not play inline so swapped for a more useful example.
