### PR TITLE
Wire Up The Live Layout In AR

### DIFF
--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -15,6 +15,7 @@ import Standard from 'components/layout/standard';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 import { renderAll, renderAllWithoutStyles } from 'renderer';
+import Live from './live';
 
 // ----- Functions ----- //
 
@@ -41,8 +42,8 @@ const notImplemented = (
 );
 
 const Layout: FC<Props> = ({ item, shouldHideAds }) => {
-	if (item.design === Design.LiveBlog) {
-		return notImplemented;
+	if (item.design === Design.LiveBlog || item.design === Design.DeadBlog) {
+		return <Live item={item} />;
 	}
 
 	const body = partition(item.body).oks;

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -1,4 +1,4 @@
-// // ----- Imports ----- //
+// ----- Imports ----- //
 
 import { css } from '@emotion/react';
 import { background, neutral } from '@guardian/src-foundations';
@@ -7,11 +7,26 @@ import Footer from 'components/footer';
 import LiveblogHeader from 'components/liveblogHeader';
 import RelatedContent from 'components/shared/relatedContent';
 import Tags from 'components/tags';
-import type { Liveblog } from 'item';
+import type { DeadBlog, LiveBlog } from 'item';
 import type { FC } from 'react';
 import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
+import KeyEvents, { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
+import { convertThemeToArticleTheme } from 'lib';
+import { OptionKind } from '@guardian/types';
+import { LiveBlock } from 'liveBlock';
 
-// // ----- Styles ----- //
+// ----- Component ----- //
+
+const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
+	blocks.reduce<KeyEvent[]>((events, block) =>
+		block.isKeyEvent && block.firstPublished.kind !== OptionKind.None
+			? [ ...events, {
+				time: block.firstPublished.value.toUTCString(),
+				text: block.title,
+				url: `#block-${block.id}`,
+			}]
+			: events
+	, []);
 
 const BorderStyles = css`
 	background: ${neutral[100]};
@@ -22,8 +37,9 @@ const BorderStyles = css`
 		margin: 0 auto;
 	}
 `;
+
 interface Props {
-	item: Liveblog;
+	item: LiveBlog | DeadBlog;
 }
 
 const Live: FC<Props> = ({ item }) => (
@@ -31,6 +47,11 @@ const Live: FC<Props> = ({ item }) => (
 		<article className="js-article" css={BorderStyles}>
 			<LiveblogHeader item={item} />
 		</article>
+		<KeyEvents
+			keyEvents={keyEvents(item.blocks)}
+			theme={convertThemeToArticleTheme(item.theme)}
+			supportsDarkMode
+		/>
 		<section css={articleWidthStyles}>
 			<Tags tags={item.tags} format={item} />
 		</section>
@@ -43,6 +64,6 @@ const Live: FC<Props> = ({ item }) => (
 	</main>
 );
 
-// // ----- Exports ----- //
+// ----- Exports ----- //
 
 export default Live;

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -1,32 +1,38 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import type { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
+import KeyEvents from '@guardian/common-rendering/src/components/keyEvents';
 import { background, neutral } from '@guardian/src-foundations';
 import { breakpoints, from } from '@guardian/src-foundations/mq';
+import { OptionKind } from '@guardian/types';
 import Footer from 'components/footer';
 import LiveblogHeader from 'components/liveblogHeader';
 import RelatedContent from 'components/shared/relatedContent';
 import Tags from 'components/tags';
 import type { DeadBlog, LiveBlog } from 'item';
+import { convertThemeToArticleTheme } from 'lib';
+import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
-import KeyEvents, { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
-import { convertThemeToArticleTheme } from 'lib';
-import { OptionKind } from '@guardian/types';
-import { LiveBlock } from 'liveBlock';
 
 // ----- Component ----- //
 
 const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
-	blocks.reduce<KeyEvent[]>((events, block) =>
-		block.isKeyEvent && block.firstPublished.kind !== OptionKind.None
-			? [ ...events, {
-				time: block.firstPublished.value.toUTCString(),
-				text: block.title,
-				url: `#block-${block.id}`,
-			}]
-			: events
-	, []);
+	blocks.reduce<KeyEvent[]>(
+		(events, block) =>
+			block.isKeyEvent && block.firstPublished.kind !== OptionKind.None
+				? [
+						...events,
+						{
+							time: block.firstPublished.value.toUTCString(),
+							text: block.title,
+							url: `#block-${block.id}`,
+						},
+				  ]
+				: events,
+		[],
+	);
 
 const BorderStyles = css`
 	background: ${neutral[100]};

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -12,7 +12,7 @@ import Metadata from 'components/metadata';
 import Standfirst from 'components/standfirst';
 import { headlineBackgroundColour } from 'editorialStyles';
 import HeaderMedia from 'headerMedia';
-import type { Liveblog } from 'item';
+import type { DeadBlog, LiveBlog } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
 import { articleWidthStyles, darkModeCss, wideContentWidth } from 'styles';
@@ -64,7 +64,7 @@ const lineStyles = (format: Format): SerializedStyles => {
 };
 
 interface Props {
-	item: Liveblog;
+	item: LiveBlog | DeadBlog;
 }
 
 const LiveblogHeader: FC<Props> = ({ item }) => {

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -14,7 +14,7 @@ import type { Option } from '@guardian/types';
 import { parse } from 'client/parser';
 import type { MainMedia } from 'headerMedia';
 import { MainMediaKind } from 'headerMedia';
-import type { Liveblog } from 'item';
+import type { LiveBlog } from 'item';
 import { pipe } from 'lib';
 
 const parser = new DOMParser();
@@ -260,7 +260,7 @@ const fields = {
 	webUrl: '',
 };
 
-const live: Liveblog = {
+const live: LiveBlog = {
 	design: Design.LiveBlog,
 	...fields,
 	blocks: [],

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -61,6 +61,14 @@ const reviewContent = {
 	},
 };
 
+const liveblogContent = {
+	...contentWithTag('tone/minutebyminute'),
+	type: ContentType.LIVEBLOG,
+	fields: {
+		liveBloggingNow: true,
+	}
+}
+
 const immersive = {
 	id: '',
 	type: ContentType.ARTICLE,
@@ -224,8 +232,13 @@ describe('fromCapi returns correct Item', () => {
 		expect(item.design).toBe(Design.Feature);
 	});
 
-	test('live blog', () => {
+	test('deadblog', () => {
 		const item = f(contentWithTag('tone/minutebyminute'));
+		expect(item.design).toBe(Design.DeadBlog);
+	});
+
+	test('liveblog', () => {
+		const item = f(liveblogContent);
 		expect(item.design).toBe(Design.LiveBlog);
 	});
 

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -75,8 +75,14 @@ interface ResizedRelatedContent extends RelatedContent {
 	resizedImages: Array<Option<Image>>;
 }
 
-interface Liveblog extends Fields {
+interface LiveBlog extends Fields {
 	design: Design.LiveBlog;
+	blocks: LiveBlock[];
+	totalBodyBlocks: number;
+}
+
+interface DeadBlog extends Fields {
+	design: Design.DeadBlog;
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 }
@@ -123,6 +129,7 @@ interface Standard extends Fields {
 	design: Exclude<
 		Design,
 		| Design.LiveBlog
+		| Design.DeadBlog
 		| Design.Review
 		| Design.Comment
 		| Design.Letter
@@ -132,7 +139,8 @@ interface Standard extends Fields {
 }
 
 type Item =
-	| Liveblog
+	| LiveBlog
+	| DeadBlog
 	| Review
 	| Comment
 	| Standard
@@ -315,12 +323,12 @@ const isPicture = hasTag('type/picture');
 
 const fromCapiLiveBlog =
 	(context: Context) =>
-	(request: RenderingRequest): Liveblog => {
+	(request: RenderingRequest): LiveBlog | DeadBlog => {
 		const { content } = request;
-		const body = content.blocks?.body?.slice(0, 7) ?? [];
+		const body = content.blocks?.body ?? [];
 
 		return {
-			design: Design.LiveBlog,
+			design: content.fields?.liveBloggingNow === true ? Design.LiveBlog : Design.DeadBlog,
 			blocks: parseLiveBlocks(body)(context),
 			totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
 			...itemFields(context, request),
@@ -432,7 +440,8 @@ const fromCapi =
 export {
 	Item,
 	Comment,
-	Liveblog,
+	LiveBlog,
+	DeadBlog,
 	Review,
 	Standard,
 	MatchReport,

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -328,7 +328,10 @@ const fromCapiLiveBlog =
 		const body = content.blocks?.body ?? [];
 
 		return {
-			design: content.fields?.liveBloggingNow === true ? Design.LiveBlog : Design.DeadBlog,
+			design:
+				content.fields?.liveBloggingNow === true
+					? Design.LiveBlog
+					: Design.DeadBlog,
 			blocks: parseLiveBlocks(body)(context),
 			totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
 			...itemFields(context, request),

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -254,4 +254,5 @@ export {
 	resultToNullable,
 	fold,
 	convertFormatToArticleFormat,
+	convertThemeToArticleTheme,
 };

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -48,7 +48,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 	);
 
 const getElements = (item: Item): Array<Result<string, BodyElement>> =>
-	item.design === Design.LiveBlog
+	item.design === Design.LiveBlog || item.design === Design.DeadBlog
 		? item.blocks.flatMap((block) => block.body)
 		: item.body;
 


### PR DESCRIPTION
## Why?

We'd like to begin displaying liveblog/deadblog layouts in AR, using the components we've built so far. This PR wires up the `Live` layout and adds the shared `KeyEvents` component to that layout.

**Note:** Liveblogs and deadblogs are still filtered out for production users, this is only visible for us.

## Changes

- Make casing on `LiveBlog` consistent
- Added `DeadBlog` item
- Stopped limiting number of blocks parsed for liveblogs
- Added support for deadblogs in `LiveblogHeader`
- Wired up `Live` layout
- Added `KeyEvents` to `Live` layout
