### PR TITLE
Send section and tag ids to banner service

### DIFF
--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -25,7 +25,7 @@ import { useOnce } from '@root/src/web/lib/useOnce';
 type BaseProps = {
 	isSignedIn: boolean;
 	contentType: string;
-	sectionName?: string;
+	sectionId?: string;
 	shouldHideReaderRevenue: boolean;
 	isMinuteArticle: boolean;
 	isPaidContent: boolean;
@@ -73,6 +73,8 @@ const buildPayload = async ({
 	countryCode,
 	optedOutOfArticleCount,
 	asyncArticleCount,
+	sectionId,
+	tags,
 }: BuildPayloadProps) => {
 	return {
 		tracking: {
@@ -93,6 +95,8 @@ const buildPayload = async ({
 			weeklyArticleHistory: await asyncArticleCount,
 			optedOutOfArticleCount,
 			modulesVersion: MODULES_VERSION,
+			sectionId,
+			tags: tags.map(tag => tag.id),
 		},
 	};
 };
@@ -122,7 +126,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	isSignedIn,
 	asyncCountryCode,
 	contentType,
-	sectionName,
+	sectionId,
 	shouldHideReaderRevenue,
 	isMinuteArticle,
 	isPaidContent,
@@ -163,7 +167,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		isSignedIn,
 		countryCode,
 		contentType,
-		sectionName,
+		sectionId,
 		shouldHideReaderRevenue,
 		isMinuteArticle,
 		isPaidContent,
@@ -202,7 +206,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 	isSignedIn,
 	asyncCountryCode,
 	contentType,
-	sectionName,
+	sectionId,
 	shouldHideReaderRevenue,
 	isMinuteArticle,
 	isPaidContent,
@@ -231,7 +235,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 			isSignedIn,
 			countryCode,
 			contentType,
-			sectionName,
+			sectionId,
 			shouldHideReaderRevenue,
 			isMinuteArticle,
 			isPaidContent,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -96,7 +96,7 @@ const buildPayload = async ({
 			optedOutOfArticleCount,
 			modulesVersion: MODULES_VERSION,
 			sectionId,
-			tags: tags.map(tag => tag.id),
+			tagIds: tags.map(tag => tag.id),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -91,7 +91,7 @@ const buildRRBannerConfigWith = ({
 						isSignedIn,
 						asyncCountryCode,
 						contentType: CAPI.contentType,
-						sectionName: CAPI.sectionName,
+						sectionId: CAPI.config.section,
 						shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,
 						isMinuteArticle: CAPI.pageType.isMinuteArticle,
 						isPaidContent: CAPI.pageType.isPaidContent,


### PR DESCRIPTION
We're testing targeting banners by content/tag, see https://github.com/guardian/support-dotcom-components/pull/548
`sectionName` was previously being passed into `ReaderRevenueBanner` but wasn't actually used. I've replaced it with `sectionId` which is preferable.

Request now includes `sectionId` and `tagIds`:
![Screen Shot 2021-10-28 at 16 13 25](https://user-images.githubusercontent.com/1513454/139285057-5da20397-7c44-4358-a90c-30d93b3ab0fd.png)

