### PR TITLE
Apply 80% max-width in all articles and add Letter story for Standfirst

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -50,6 +50,22 @@ export const Comment = () => {
 };
 Comment.story = { name: 'Comment' };
 
+export const Letter = () => {
+	return (
+		<ElementContainer>
+			<Standfirst
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Letter,
+					theme: ArticlePillar.News,
+				}}
+				standfirst="This is how Letter standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+			/>
+		</ElementContainer>
+	);
+};
+Letter.story = { name: 'Letter' };
+
 export const Feature = () => {
 	return (
 		<ElementContainer>

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -121,6 +121,9 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 				case ArticleDesign.Comment:
+				case ArticleDesign.Feature:
+				case ArticleDesign.Recipe:
+				case ArticleDesign.Review:
 					return css`
 						${headline.xxxsmall({
 							fontWeight: 'light',
@@ -134,17 +137,6 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 							})};
 							max-width:540px;
 						}
-					`;
-				case ArticleDesign.Feature:
-				case ArticleDesign.Recipe:
-				case ArticleDesign.Review:
-					return css`
-						${headline.xxsmall({
-							fontWeight: 'light',
-						})};
-						margin-bottom: ${space[3]}px;
-						max-width: 540px;
-						color: ${palette.text.standfirst};
 					`;
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
@@ -181,8 +173,11 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 								})};
 								line-height: 20px;
 								margin-bottom: ${space[3]}px;
-								max-width: 540px;
+								max-width: 80%;
 								color: ${palette.text.standfirst};
+								${from.tablet} {
+									max-width:540px;
+								}
 							`;
 					}
 			}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Following this pr: https://github.com/guardian/dotcom-rendering/pull/3565

* Makes max-width 80% and reduces font-size for screens less than tablet. Change applied to:

Article
Feature
Review
Interview
Analysis
Media
Recipe
MatchReport
Quiz
SpecialReport
PhotoEssay

* Adds Letter story in Standfirst component

## Why?

Currently it is different in DCR and frontend

### Before
![image](https://user-images.githubusercontent.com/19683595/139406342-0ca22131-f52b-4aa6-a218-6cc8af78d6c1.png)


### After
![image](https://user-images.githubusercontent.com/19683595/139406406-0eec454a-f353-4ba1-ba0d-3f8d96a6a463.png)


