### PR TITLE
Apply AMP regional classes to containers instead of `amp-` elements

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -130,41 +130,30 @@ export const RegionalAd = ({
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
 	return (
-		<ClassNames>
-			{({ css, cx }) => (
-				<amp-ad
-					class={cx(
-						css`
-							${regionClasses[adRegion].styles}
-						`,
-					)}
-					data-block-on-consent=""
-					// Primary ad size width and height
-					width={width}
-					height={height}
-					// Secondary ad sizes
-					data-multi-size={multiSizes}
-					// Setting data-multi-size-validation to false allows
-					// secondary ad sizes that are less than 2/3rds of the
-					// corresponding primary size.
-					data-multi-size-validation="false"
-					data-npa-on-unknown-consent={true}
-					data-loading-strategy="prefer-viewability-over-views"
-					layout="fixed"
-					type="doubleclick"
-					json={stringify(
-						adJson(commercialProperties[edition].adTargeting),
-					)}
-					data-slot={ampData(section, contentType)}
-					rtc-config={realTimeConfig(
-						isSticky,
-						adRegion,
-						config.usePrebid,
-						config.usePermutive,
-					)}
-				/>
+		<amp-ad
+			data-block-on-consent=""
+			// Primary ad size width and height
+			width={width}
+			height={height}
+			// Secondary ad sizes
+			data-multi-size={multiSizes}
+			// Setting data-multi-size-validation to false allows
+			// secondary ad sizes that are less than 2/3rds of the
+			// corresponding primary size.
+			data-multi-size-validation="false"
+			data-npa-on-unknown-consent={true}
+			data-loading-strategy="prefer-viewability-over-views"
+			layout="fixed"
+			type="doubleclick"
+			json={stringify(adJson(commercialProperties[edition].adTargeting))}
+			data-slot={ampData(section, contentType)}
+			rtc-config={realTimeConfig(
+				isSticky,
+				adRegion,
+				config.usePrebid,
+				config.usePermutive,
 			)}
-		</ClassNames>
+		/>
 	);
 };
 
@@ -178,15 +167,27 @@ export const Ad = ({
 }: AdProps) => (
 	<>
 		{adRegions.map((adRegion) => (
-			<RegionalAd
-				adRegion={adRegion}
-				isSticky={isSticky}
-				edition={edition}
-				section={section}
-				contentType={contentType}
-				config={config}
-				commercialProperties={commercialProperties}
-			/>
+			<ClassNames>
+				{({ css, cx }) => (
+					<div
+						className={cx(
+							css`
+								${regionClasses[adRegion].styles}
+							`,
+						)}
+					>
+						<RegionalAd
+							adRegion={adRegion}
+							isSticky={isSticky}
+							edition={edition}
+							section={section}
+							contentType={contentType}
+							config={config}
+							commercialProperties={commercialProperties}
+						/>
+					</div>
+				)}
+			</ClassNames>
 		))}
 	</>
 );

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -1,6 +1,8 @@
+import { ClassNames } from '@emotion/react';
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import { RegionalAd, RegionalAdProps } from './Ad';
+import { regionClasses } from '../lib/region-classes';
+import { RegionalAdProps, RegionalAd } from './Ad';
 
 // This CSS should be imported and added to global styles in amp/server/document.tsx to add the Advertisment label to the sticky
 export const stickyAdLabelCss = `
@@ -25,16 +27,28 @@ export const StickyAd = ({
 	commercialProperties,
 }: RegionalAdProps) => {
 	return (
-		<amp-sticky-ad layout="nodisplay">
-			<RegionalAd
-				isSticky={true}
-				adRegion={adRegion}
-				edition={edition}
-				section={section}
-				contentType={contentType}
-				config={config}
-				commercialProperties={commercialProperties}
-			/>
-		</amp-sticky-ad>
+		<ClassNames>
+			{({ css, cx }) => (
+				<div
+					className={cx(
+						css`
+							${regionClasses[adRegion].styles}
+						`,
+					)}
+				>
+					<amp-sticky-ad layout="nodisplay">
+						<RegionalAd
+							isSticky={true}
+							adRegion={adRegion}
+							edition={edition}
+							section={section}
+							contentType={contentType}
+							config={config}
+							commercialProperties={commercialProperties}
+						/>
+					</amp-sticky-ad>
+				</div>
+			)}
+		</ClassNames>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Move the application of regional classes to div containers that surround the AMP element they were previously applied to.

## Why?

This fixes an issue with the mobile sticky ad. The AMP runtime applies some additional styling when a sticky ad is filled that cannot be overridden, which caused the sticky ad to be made visible regardless of the regional classes implied. This had the effect of delivering an impression for an ad regardless of region.

With this fix the styling is not overridden as it applies to the container.
