### PR TITLE
Rename `canShow` functions

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -114,7 +114,7 @@ export const hasRequiredConsents = (): Promise<boolean> => {
 	});
 };
 
-export const canShow = (
+export const canShowSignInGate = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
 	currentTest: CurrentSignInGateABTest,
@@ -147,6 +147,6 @@ export const canShowMandatoryUs: (
 	return (
 		(await getLocale()) === 'US' &&
 		(await hasRequiredConsents()) &&
-		(await canShow(CAPI, isSignedIn, currentTest))
+		(await canShowSignInGate(CAPI, isSignedIn, currentTest))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Lazy } from '@root/src/web/components/Lazy';
 
 import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
-import { canShow } from '@frontend/web/components/SignInGate/displayRule';
+import { canShowSignInGate } from '@frontend/web/components/SignInGate/displayRule';
 import { initPerf } from '@root/src/web/browser/initPerf';
 
 const SignInGateFakeSocial = React.lazy(() => {
@@ -38,5 +38,5 @@ export const signInGateComponent: SignInGateComponent = {
 			</Suspense>
 		</Lazy>
 	),
-	canShow,
+	canShow: canShowSignInGate,
 };

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Lazy } from '@root/src/web/components/Lazy';
 
 import { SignInGateComponent } from '@frontend/web/components/SignInGate/types';
-import { canShow } from '@frontend/web/components/SignInGate/displayRule';
+import { canShowSignInGate } from '@frontend/web/components/SignInGate/displayRule';
 import { initPerf } from '@root/src/web/browser/initPerf';
 
 const SignInGateMain = React.lazy(() => {
@@ -38,5 +38,5 @@ export const signInGateComponent: SignInGateComponent = {
 			</Suspense>
 		</Lazy>
 	),
-	canShow,
+	canShow: canShowSignInGate,
 };

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -27,7 +27,7 @@ type EpicConfig = {
 	idApiUrl: string;
 };
 
-export const canShow = async (
+export const canShowBrazeEpic = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 	brazeArticleContext: BrazeArticleContext
 ): Promise<CanShowResult<any>> => {

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -115,7 +115,7 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 	} as Metadata; // Metadata type incorrectly does not include required hasOptedOutOfArticleCount property
 };
 
-export const canShow = async (
+export const canShowReaderRevenueEpic = async (
 	data: CanShowData,
 ): Promise<CanShowResult<EpicConfig>> => {
 	const {

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -12,11 +12,11 @@ import type { BrazeMessagesInterface, BrazeArticleContext } from '@guardian/braz
 import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
 import {
 	ReaderRevenueEpic,
-	canShow as canShowReaderRevenueEpic,
+	canShowReaderRevenueEpic,
 	CanShowData as RRCanShowData,
 	EpicConfig as RREpicConfig,
 } from './ReaderRevenueEpic';
-import { MaybeBrazeEpic, canShow as canShowBrazeEpic } from './BrazeEpic';
+import { MaybeBrazeEpic, canShowBrazeEpic } from './BrazeEpic';
 
 type Props = {
 	isSignedIn?: boolean;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -38,7 +38,7 @@ const containerStyles = css`
 // - The Braze app Boy subscription to in app message returns meta info
 // OR
 // - The force-braze-message query string arg is passed
-export const canShow = async (
+export const canShowBrazeBanner = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 	brazeArticleContext: BrazeArticleContext
 ): Promise<CanShowResult<any>> => {

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -20,7 +20,7 @@ import { CountryCode } from '@guardian/libs';
 import type { BrazeArticleContext, BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import { useSignInGateWillShow } from '@root/src/web/lib/useSignInGateWillShow';
 import { WeeklyArticleHistory } from '@guardian/automat-contributions/dist/lib/types';
-import { BrazeBanner, canShow as canShowBrazeBanner } from './BrazeBanner';
+import { BrazeBanner, canShowBrazeBanner } from './BrazeBanner';
 
 type Props = {
 	isSignedIn?: boolean;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR gives the various `canShow` functions more explicit names, indicating what they are relating to.

```
SignInGate/displayRule/canShow > canShowSignInGate
BrazeEpic/canShow > canShowBrazeEpic
ReaderRevenueEpic/canShow > canShowReaderRevenueEpic
BrazeBanner/canShow > canShowBrazeBanner
```

## Why?
Because it will make it easier to refactor the props for some of these functions later on. We we would like to remove use of the `CAPI` object as a prop and this is an easier task when each function has its own name that we can search the codebase for.
