### PR TITLE
Extend Prebid timeout AB test until 2021-11-08

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
@@ -4,7 +4,7 @@ export const prebidTimeout: ABTest = {
 	id: 'PrebidTimeout',
 	author: 'Chris Jones (@chrislomaxjones)',
 	start: '2021-10-6',
-	expiry: '2021-10-29',
+	expiry: '2021-11-08',
 	audience: 3 / 100,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extend the Prebid timeout AB test to 8th November 2021.

Related frontend PR: [#24333](https://github.com/guardian/frontend/pull/24333)

## Why?

Enable further data collection.