### PR TITLE
Stop calling IDAPI GET /user/me on every article page

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-2/braze.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-2/braze.spec.js
@@ -1,7 +1,8 @@
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 import { overrideGeo } from '../../lib/overrideGeo';
 import { hasCurrentBrazeUser } from '../../lib/hasCurrentBrazeUser';
-const idapiResponse = `{ "status": "ok", "user": { "primaryEmailAddress": "user@example.com", "id": "000000000", "publicFields": { "displayName": "user" }, "privateFields": { "brazeUuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "puzzleUuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "legacyPackages": "CRE,RCO", "legacyProducts": "CRE,RCO" }, "statusFields": { "userEmailValidated": true }, "dates": { "accountCreatedDate": "2021-01-01T00:00:00Z" }, "userGroups": [ { "path": "/sys/policies/basic-identity", "packageCode": "CRE" }, { "path": "/sys/policies/basic-community", "packageCode": "RCO" } ], "socialLinks": [ { "socialId": "111111111111111111111", "network": "google" } ], "adData": {}, "consents": [ { "actor": "user", "id": "sms", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "post_optout", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "phone_optout", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "market_research_optout", "version": 0, "consented": true, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "supporter", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "jobs", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "holidays", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "events", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "offers", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 }, { "actor": "user", "id": "profiling_optout", "version": 0, "consented": false, "timestamp": "2021-01-01T00:00:00Z", "privacyPolicyVersion": 1 } ], "hasPassword": false } }`;
+
+const idapiIdentifiersResponse = `{ "id": "000000000", "brazeUuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "puzzleUuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }`;
 
 const handleGuCookieError = () => {
 	cy.on('uncaught:exception', (err, runnable) => {
@@ -64,13 +65,13 @@ describe('Braze messaging', function () {
 		cy.setCookie('gu_hide_support_messaging', 'true', {
 			log: true,
 		});
-		cy.intercept('GET', '**/user/me', idapiResponse);
+		cy.intercept('GET', '**/user/me/identifiers', idapiIdentifiersResponse);
 	};
 
 	const becomeLoggedOut = () => {
 		// User no longer logged in
 		cy.clearCookie('GU_U');
-		cy.intercept('GET', '**/user/me', { statusCode: 403 });
+		cy.intercept('GET', '**/user/me/identifiers', { statusCode: 403 });
 	};
 
 	const setCountry = () => {

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -148,7 +148,7 @@ type Props = {
 
 let renderCount = 0;
 export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
-	log('dotcom', `App.tsx render #${renderCount += 1}`);
+	log('dotcom', `App.tsx render #${(renderCount += 1)}`);
 	const [isSignedIn, setIsSignedIn] = useState<boolean>();
 	const [user, setUser] = useState<UserProfile | null>();
 	const [countryCode, setCountryCode] = useState<string>();
@@ -237,7 +237,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			setAsyncCountryCode(countryCodePromise);
 			countryCodePromise
 				.then((cc) => {
-					setCountryCode(cc || '')
+					setCountryCode(cc || '');
 					log('dotcom', 'State: countryCode set');
 				})
 				.catch((e) =>
@@ -402,9 +402,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				Promise.all([
 					loadScript('https://www.google-analytics.com/analytics.js'),
 					loadScript(window.guardian.gaPath),
-				]).then(()=>{
-					log('dotcom', 'GA script loaded');
-				}).catch((e) => console.error(`GA - error: ${e}`));
+				])
+					.then(() => {
+						log('dotcom', 'GA script loaded');
+					})
+					.catch((e) => console.error(`GA - error: ${e}`));
 			} else {
 				// We should never be able to directly set things to the global window object.
 				// But in this case we want to stub things for testing, so it's ok to ignore this rule

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -7,9 +7,9 @@ import {
 	getLastOneOffContributionTimestamp,
 	shouldHideSupportMessaging,
 	hasCmpConsentForArticleCount,
-	getEmail,
 	MODULES_VERSION,
 	hasOptedOutOfArticleCount,
+	lazyFetchEmailWithTimeout,
 } from '@root/src/web/lib/contributions';
 import { getForcedVariant } from '@root/src/web/lib/readerRevenueDevUtils';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
@@ -35,13 +35,13 @@ type PreEpicConfig = {
 };
 
 export type EpicConfig = PreEpicConfig & {
-	email?: string;
+	fetchEmail?: () => Promise<string | null>;
 	hasConsentForArticleCount: boolean;
 	stage: string;
 };
 
 type EpicProps = {
-	email?: string;
+	fetchEmail?: () => Promise<string | null>;
 	submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
 	openCmp: () => void;
 	hasConsentForArticleCount: boolean;
@@ -149,7 +149,9 @@ export const canShowReaderRevenueEpic = async (
 		return { show: false };
 	}
 
-	const email = isSignedIn ? await getEmail(idApiUrl) : undefined;
+	const fetchEmail: (() => Promise<string | null>) | undefined = isSignedIn
+		? lazyFetchEmailWithTimeout(idApiUrl)
+		: undefined;
 
 	const hasConsentForArticleCount = await hasCmpConsentForArticleCount();
 
@@ -158,7 +160,7 @@ export const canShowReaderRevenueEpic = async (
 		show: true,
 		meta: {
 			module,
-			email,
+			fetchEmail,
 			hasConsentForArticleCount,
 			stage,
 		},
@@ -167,7 +169,7 @@ export const canShowReaderRevenueEpic = async (
 
 export const ReaderRevenueEpic = ({
 	module,
-	email,
+	fetchEmail,
 	hasConsentForArticleCount,
 	stage,
 }: EpicConfig) => {
@@ -207,7 +209,7 @@ export const ReaderRevenueEpic = ({
 				{/* eslint-disable react/jsx-props-no-spreading */}
 				<Epic
 					{...module.props}
-					email={email}
+					fetchEmail={fetchEmail}
 					submitComponentEvent={submitComponentEvent}
 					openCmp={openCmp}
 					hasConsentForArticleCount={hasConsentForArticleCount}

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -110,7 +110,9 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 			countryCode: data.countryCode,
 			modulesVersion: MODULES_VERSION,
 			url: window.location.origin + window.location.pathname,
-			browserId: await hasCmpConsentForBrowserId() ? data.browserId : undefined,
+			browserId: (await hasCmpConsentForBrowserId())
+				? data.browserId
+				: undefined,
 		},
 	} as Metadata; // Metadata type incorrectly does not include required hasOptedOutOfArticleCount property
 };

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -35,15 +35,16 @@ type Props = {
 	idApiUrl: string;
 	stage: string;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
-	browserId?: string,
+	browserId?: string;
 };
 
-const buildReaderRevenueEpicConfig = (canShowData: RRCanShowData): CandidateConfig<RREpicConfig> => {
+const buildReaderRevenueEpicConfig = (
+	canShowData: RRCanShowData,
+): CandidateConfig<RREpicConfig> => {
 	return {
 		candidate: {
 			id: 'reader-revenue-banner',
-			canShow: () =>
-				canShowReaderRevenueEpic(canShowData),
+			canShow: () => canShowReaderRevenueEpic(canShowData),
 			show: (meta: RREpicConfig) => () => {
 				/* eslint-disable-next-line react/jsx-props-no-spreading */
 				return <ReaderRevenueEpic {...meta} />;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -8,7 +8,7 @@ import {
 	setLocalNoBannerCachePeriod,
 	MODULES_VERSION,
 	hasOptedOutOfArticleCount,
-	getEmail,
+	lazyFetchEmailWithTimeout,
 } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
@@ -190,9 +190,11 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 
 	const { module, meta } = json.data;
 
-	const email = isSignedIn ? await getEmail(idApiUrl) : undefined;
+	const fetchEmail = isSignedIn
+		? lazyFetchEmailWithTimeout(idApiUrl)
+		: undefined;
 
-	return { show: true, meta: { module, meta, email } };
+	return { show: true, meta: { module, meta, fetchEmail } };
 };
 
 export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
@@ -262,7 +264,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType<BannerProps> = async ({
 export type BannerProps = {
 	meta: any;
 	module: { url: string; name: string; props: any[] };
-	email?: string;
+	fetchEmail?: () => Promise<string | null>;
 };
 
 type RemoteBannerProps = BannerProps & {
@@ -275,7 +277,7 @@ const RemoteBanner = ({
 	displayEvent,
 	meta,
 	module,
-	email,
+	fetchEmail,
 }: RemoteBannerProps) => {
 	const [Banner, setBanner] = useState<React.FC>();
 
@@ -331,7 +333,7 @@ const RemoteBanner = ({
 					{...module.props}
 					// @ts-ignore
 					submitComponentEvent={submitComponentEvent}
-					email={email}
+					fetchEmail={fetchEmail}
 				/>
 				{/* eslint-enable react/jsx-props-no-spreading */}
 			</div>
@@ -341,13 +343,17 @@ const RemoteBanner = ({
 	return null;
 };
 
-export const ReaderRevenueBanner = ({ meta, module, email }: BannerProps) => (
+export const ReaderRevenueBanner = ({
+	meta,
+	module,
+	fetchEmail,
+}: BannerProps) => (
 	<RemoteBanner
 		componentTypeName="ACQUISITIONS_SUBSCRIPTIONS_BANNER"
 		displayEvent="subscription-banner : display"
 		meta={meta}
 		module={module}
-		email={email}
+		fetchEmail={fetchEmail}
 	/>
 );
 

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -115,13 +115,13 @@ const buildRRBannerConfigWith = ({
 						asyncArticleCount,
 					}),
 				show:
-					({ meta, module, email }: BannerProps) =>
+					({ meta, module, fetchEmail }: BannerProps) =>
 					() =>
 						(
 							<BannerComponent
 								meta={meta}
 								module={module}
-								email={email}
+								fetchEmail={fetchEmail}
 							/>
 						),
 			},

--- a/dotcom-rendering/src/web/lib/contributions.test.ts
+++ b/dotcom-rendering/src/web/lib/contributions.test.ts
@@ -1,4 +1,4 @@
-import {addCookie} from '../browser/cookie';
+import { addCookie } from '../browser/cookie';
 import {
 	getLastOneOffContributionTimestamp,
 	isRecentOneOffContributor,
@@ -6,7 +6,7 @@ import {
 	ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
-import {getIdApiUserData} from "@root/src/web/lib/getIdapiUserData";
+import { getIdApiUserData } from '@root/src/web/lib/getIdapiUserData';
 
 const clearAllCookies = () => {
 	const cookies = document.cookie.split(';');
@@ -21,18 +21,20 @@ const clearAllCookies = () => {
 };
 
 const userResponse = {
-	status: "ok",
+	status: 'ok',
 	user: {
-		"primaryEmailAddress": "test@guardian.co.uk",
-	}
+		primaryEmailAddress: 'test@guardian.co.uk',
+	},
 };
 
 jest.mock('@root/src/web/lib/getIdapiUserData', () => {
-	const originalModule = jest.requireActual('@root/src/web/lib/getIdapiUserData');
+	const originalModule = jest.requireActual(
+		'@root/src/web/lib/getIdapiUserData',
+	);
 	return {
 		...originalModule,
 		getIdApiUserData: jest.fn(() => Promise.resolve(userResponse)),
-	}
+	};
 });
 
 describe('getLastOneOffContributionDate', () => {
@@ -110,11 +112,11 @@ describe('isRecentOneOffContributor', () => {
 
 describe('lazyFetchEmailWithTimeout', () => {
 	it('returns a function to get the email address', async () => {
-		const fetchEmail = lazyFetchEmailWithTimeout("https://idapi-url.com");
+		const fetchEmail = lazyFetchEmailWithTimeout('https://idapi-url.com');
 		expect(getIdApiUserData).not.toHaveBeenCalled();
 
 		const result = await fetchEmail();
 		expect(result).toBe(userResponse.user.primaryEmailAddress);
-		expect(getIdApiUserData).toHaveBeenCalledWith("https://idapi-url.com");
+		expect(getIdApiUserData).toHaveBeenCalledWith('https://idapi-url.com');
 	});
 });

--- a/dotcom-rendering/src/web/lib/contributions.test.ts
+++ b/dotcom-rendering/src/web/lib/contributions.test.ts
@@ -1,3 +1,4 @@
+import { getIdApiUserData } from '@root/src/web/lib/getIdapiUserData';
 import { addCookie } from '../browser/cookie';
 import {
 	getLastOneOffContributionTimestamp,
@@ -6,7 +7,6 @@ import {
 	ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
-import { getIdApiUserData } from '@root/src/web/lib/getIdapiUserData';
 
 const clearAllCookies = () => {
 	const cookies = document.cookie.split(';');

--- a/dotcom-rendering/src/web/lib/contributions.test.ts
+++ b/dotcom-rendering/src/web/lib/contributions.test.ts
@@ -1,10 +1,12 @@
-import { addCookie } from '../browser/cookie';
+import {addCookie} from '../browser/cookie';
 import {
 	getLastOneOffContributionTimestamp,
 	isRecentOneOffContributor,
+	lazyFetchEmailWithTimeout,
 	ONE_OFF_CONTRIBUTION_DATE_COOKIE,
 	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
+import {getIdApiUserData} from "@root/src/web/lib/getIdapiUserData";
 
 const clearAllCookies = () => {
 	const cookies = document.cookie.split(';');
@@ -17,6 +19,21 @@ const clearAllCookies = () => {
 		document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 	}
 };
+
+const userResponse = {
+	status: "ok",
+	user: {
+		"primaryEmailAddress": "test@guardian.co.uk",
+	}
+};
+
+jest.mock('@root/src/web/lib/getIdapiUserData', () => {
+	const originalModule = jest.requireActual('@root/src/web/lib/getIdapiUserData');
+	return {
+		...originalModule,
+		getIdApiUserData: jest.fn(() => Promise.resolve(userResponse)),
+	}
+});
 
 describe('getLastOneOffContributionDate', () => {
 	beforeEach(clearAllCookies);
@@ -90,3 +107,14 @@ describe('isRecentOneOffContributor', () => {
 	});
 });
 /* eslint-enable @typescript-eslint/unbound-method  */
+
+describe('lazyFetchEmailWithTimeout', () => {
+	it('returns a function to get the email address', async () => {
+		const fetchEmail = lazyFetchEmailWithTimeout("https://idapi-url.com");
+		expect(getIdApiUserData).not.toHaveBeenCalled();
+
+		const result = await fetchEmail();
+		expect(result).toBe(userResponse.user.primaryEmailAddress);
+		expect(getIdApiUserData).toHaveBeenCalledWith("https://idapi-url.com");
+	});
+});

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -204,18 +204,18 @@ const getEmail = (ajaxUrl: string): Promise<string | undefined> => {
 		});
 };
 
-export const lazyFetchEmailWithTimeout = (
-	idapiUrl: string,
-): (() => Promise<string | null>) => () => {
-	return new Promise((resolve) => {
-		setTimeout(() => resolve(null), 1000);
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		getEmail(idapiUrl).then((email) => {
-			if (email) {
-				resolve(email);
-			} else {
-				resolve(null);
-			}
+export const lazyFetchEmailWithTimeout =
+	(idapiUrl: string): (() => Promise<string | null>) =>
+	() => {
+		return new Promise((resolve) => {
+			setTimeout(() => resolve(null), 1000);
+			// eslint-disable-next-line @typescript-eslint/no-floating-promises
+			getEmail(idapiUrl).then((email) => {
+				if (email) {
+					resolve(email);
+				} else {
+					resolve(null);
+				}
+			});
 		});
-	});
-};
+	};

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -195,11 +195,27 @@ export const withinLocalNoBannerCachePeriod = (): boolean => {
 export const setLocalNoBannerCachePeriod = (): void =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
-export const getEmail = (ajaxUrl: string): Promise<string | undefined> => {
+const getEmail = (ajaxUrl: string): Promise<string | undefined> => {
 	return getIdApiUserData(ajaxUrl)
 		.then((data: IdApiUserData) => data.user?.primaryEmailAddress)
 		.catch((error) => {
 			window.guardian.modules.sentry.reportError(error, 'getEmail');
 			return undefined;
 		});
+};
+
+export const lazyFetchEmailWithTimeout = (
+	idapiUrl: string,
+): (() => Promise<string | null>) => () => {
+	return new Promise((resolve) => {
+		setTimeout(() => resolve(null), 1000);
+		// eslint-disable-next-line @typescript-eslint/no-floating-promises
+		getEmail(idapiUrl).then((email) => {
+			if (email) {
+				resolve(email);
+			} else {
+				resolve(null);
+			}
+		});
+	});
 };

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -188,9 +188,10 @@ export const hasCmpConsentForBrowserId = (): Promise<boolean> =>
 			if (ccpa || aus) {
 				resolve(true);
 			} else if (tcfv2) {
-				const hasRequiredConsents = REQUIRED_CONSENTS_FOR_BROWSER_ID.every(
-					(consent) => tcfv2.consents[consent],
-				);
+				const hasRequiredConsents =
+					REQUIRED_CONSENTS_FOR_BROWSER_ID.every(
+						(consent) => tcfv2.consents[consent],
+					);
 				resolve(hasRequiredConsents);
 			}
 		});

--- a/dotcom-rendering/src/web/lib/getBrazeUuid.test.ts
+++ b/dotcom-rendering/src/web/lib/getBrazeUuid.test.ts
@@ -1,0 +1,21 @@
+import {getBrazeUuid} from "@root/src/web/lib/getBrazeUuid";
+import {getIdapiUserIdentifiers} from "@root/src/web/lib/getIdapiUserData";
+
+const userIdentifiers = {
+	id: "idValue",
+	brazeUuid: "brazeUuidValue",
+	puzzleId: "puzzleIdValue",
+	googleTagId: "googleTagIdValue"
+};
+
+jest.mock('@root/src/web/lib/getIdapiUserData', () => ({
+	getIdapiUserIdentifiers: jest.fn(() => Promise.resolve(userIdentifiers)),
+}));
+
+describe("getBrazeUuid", () => {
+	it("gets the braze uuid using Identity user identifiers api", async () => {
+		const result = await getBrazeUuid("https://idapi-url.com");
+		expect(result).toBe(userIdentifiers.brazeUuid);
+		expect(getIdapiUserIdentifiers).toHaveBeenCalledWith("https://idapi-url.com");
+	});
+});

--- a/dotcom-rendering/src/web/lib/getBrazeUuid.test.ts
+++ b/dotcom-rendering/src/web/lib/getBrazeUuid.test.ts
@@ -1,21 +1,23 @@
-import {getBrazeUuid} from "@root/src/web/lib/getBrazeUuid";
-import {getIdapiUserIdentifiers} from "@root/src/web/lib/getIdapiUserData";
+import { getBrazeUuid } from '@root/src/web/lib/getBrazeUuid';
+import { getIdapiUserIdentifiers } from '@root/src/web/lib/getIdapiUserData';
 
 const userIdentifiers = {
-	id: "idValue",
-	brazeUuid: "brazeUuidValue",
-	puzzleId: "puzzleIdValue",
-	googleTagId: "googleTagIdValue"
+	id: 'idValue',
+	brazeUuid: 'brazeUuidValue',
+	puzzleId: 'puzzleIdValue',
+	googleTagId: 'googleTagIdValue',
 };
 
 jest.mock('@root/src/web/lib/getIdapiUserData', () => ({
 	getIdapiUserIdentifiers: jest.fn(() => Promise.resolve(userIdentifiers)),
 }));
 
-describe("getBrazeUuid", () => {
-	it("gets the braze uuid using Identity user identifiers api", async () => {
-		const result = await getBrazeUuid("https://idapi-url.com");
+describe('getBrazeUuid', () => {
+	it('gets the braze uuid using Identity user identifiers api', async () => {
+		const result = await getBrazeUuid('https://idapi-url.com');
 		expect(result).toBe(userIdentifiers.brazeUuid);
-		expect(getIdapiUserIdentifiers).toHaveBeenCalledWith("https://idapi-url.com");
+		expect(getIdapiUserIdentifiers).toHaveBeenCalledWith(
+			'https://idapi-url.com',
+		);
 	});
 });

--- a/dotcom-rendering/src/web/lib/getBrazeUuid.ts
+++ b/dotcom-rendering/src/web/lib/getBrazeUuid.ts
@@ -1,11 +1,11 @@
 import {
-	getIdApiUserData,
-	IdApiUserData,
+	getIdapiUserIdentifiers,
+	IdApiUserIdentifiers,
 } from '@root/src/web/lib/getIdapiUserData';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string | void> => {
-	return getIdApiUserData(ajaxUrl)
-		.then((data: IdApiUserData) => data.user?.privateFields?.brazeUuid)
+	return getIdapiUserIdentifiers(ajaxUrl)
+		.then((data: IdApiUserIdentifiers) => data.brazeUuid)
 		.catch((error) => {
 			window.guardian.modules.sentry.reportError(error, 'getBrazeUuid');
 		});

--- a/dotcom-rendering/src/web/lib/getIdapiUserData.ts
+++ b/dotcom-rendering/src/web/lib/getIdapiUserData.ts
@@ -9,6 +9,13 @@ export interface IdApiUserData {
 	};
 }
 
+export interface IdApiUserIdentifiers {
+	id: string;
+	brazeUuid: string;
+	puzzleId: string;
+	googleTagId: string;
+}
+
 function checkForErrors(response: Response) {
 	if (!response.ok) {
 		throw Error(
@@ -27,13 +34,25 @@ const callApi = (url: string) => {
 		.then((response) => response.json());
 };
 
-const cache: { [url: string]: Promise<IdApiUserData> } = {};
+const cache: {
+	idapiUserMeResponse?: Promise<IdApiUserData>;
+	idapiUserIdentifiersResponse?: Promise<IdApiUserIdentifiers>;
+} = {};
 
 export const getIdApiUserData = (ajaxUrl: string): Promise<IdApiUserData> => {
-	if (!(ajaxUrl in cache)) {
+	if (!cache.idapiUserMeResponse) {
 		const url = joinUrl([ajaxUrl, 'user/me']);
-		const response = callApi(url);
-		cache[ajaxUrl] = response;
+		cache.idapiUserMeResponse = callApi(url);
 	}
-	return cache[ajaxUrl];
+	return cache.idapiUserMeResponse;
+};
+
+export const getIdapiUserIdentifiers = (
+	ajaxUrl: string,
+): Promise<IdApiUserIdentifiers> => {
+	if (!cache.idapiUserIdentifiersResponse) {
+		const url = joinUrl([ajaxUrl, 'user/me/identifiers']);
+		cache.idapiUserIdentifiersResponse = callApi(url);
+	}
+	return cache.idapiUserIdentifiersResponse;
 };


### PR DESCRIPTION
## What does this change?

Stop calling IDAPI GET /user/me on every article page

- The Braze ID is retrieved from a new optimised endpoint on IDAPI.
- The email address required for Reader Revenue epic and banner reminder service is provided lazily. It is returned with a timeout because the result is used to autofill the email address in the reminder form. If the result is not returned in one second, the user will be shown the form to fill the email address manually

## Why?

We want to reduce requests to IDAPI GET /user/me in preparation to migrating Identity user data to OKTA. OKTA's API has rate limit thresholds.


https://github.com/guardian/support-dotcom-components/pull/551 needs to be released first
This has been merged ^