### PR TITLE
Support youtube short-urls in AMP

### DIFF
--- a/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -9,7 +9,7 @@ export const VideoYoutubeBlockComponent: React.FC<{
 	const youtubeId = getIdFromUrl(
 		element.originalUrl || element.url,
 		'^[a-zA-Z0-9_-]{11}$', // Alpha numeric, underscores and hyphens, exactly 11 numbers long
-		false,
+		true,
 		'v',
 	);
 	return (

--- a/dotcom-rendering/src/amp/lib/get-video-id.test.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.test.ts
@@ -17,10 +17,23 @@ describe('getIdFromUrl', () => {
 				url: 'http://www.youtube.com/ytscreeningroom?v=NRH-IGHTx8I',
 				id: 'NRH-IGHTx8I',
 			},
+			{
+				url: 'https://youtu.be/NRHEIGHTx8I',
+				id: 'NRHEIGHTx8I'
+			},
+			{
+				url: 'https://youtu.be/NRH_IGHTx8I',
+				id: 'NRH_IGHTx8I'
+			},
+			{
+				url: 'https://youtu.be/NRH-IGHTx8I',
+				id: 'NRH-IGHTx8I'
+			}
 		];
 
 		formats.forEach((_) => {
-			expect(getIdFromUrl(_.url, youtubeRegEx, false, 'v')).toBe(_.id);
+			// Search for both in path & query param
+			expect(getIdFromUrl(_.url, youtubeRegEx, true, 'v')).toBe(_.id);
 		});
 	});
 
@@ -47,6 +60,15 @@ describe('getIdFromUrl', () => {
 		});
 	});
 
+	it('Finds ID if both options are allowed', () => {
+		const formats = [ 'https://theguardian.com/test', 'https://theguardian.com?a=test', 'https://theguardian.com/test?a=test']
+
+		formats.forEach((_) => {
+			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
+		});
+
+	})
+
 	it('Throws an error if it cannot find an ID', () => {
 		expect(() => {
 			getIdFromUrl('https://theguardian.com', '', false, 'v');
@@ -71,6 +93,15 @@ describe('getIdFromUrl', () => {
 				'https://theguardian.com?p=test',
 				'nottest',
 				false,
+				'p',
+			);
+		}).toThrow();
+
+		expect(() => {
+			getIdFromUrl(
+				'https://theguardian.com/test?p=test',
+				'nottest',
+				true,
 				'p',
 			);
 		}).toThrow();

--- a/dotcom-rendering/src/amp/lib/get-video-id.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.ts
@@ -3,8 +3,8 @@ import { parse, URLSearchParams } from 'url';
 export const getIdFromUrl = (
 	urlString: string,
 	regexFormat: string,
-	inPath?: boolean,
-	queryParam?: string,
+	tryInPath?: boolean,
+	tryQueryParam?: string,
 ) => {
 	const logErr = (actual: string, message: string) => {
 		throw new Error(
@@ -14,20 +14,24 @@ export const getIdFromUrl = (
 
 	const url = parse(urlString);
 
-	const id =
-		(inPath && url.pathname && url.pathname.split('/').pop()) ||
-		(queryParam &&
-			url.query &&
-			new URLSearchParams(url.query).get(queryParam)) ||
-		logErr(
-			'an undefined ID',
-			'Could not get ID from pathname or searchParams.',
-		);
+	// Looks for ID in both formats if provided
+	const ids: string[] = [
+		tryInPath && url.pathname && url.pathname.split('/').pop(),
+		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam)
+	].filter((tryId): tryId is string => !!tryId)
 
-	if (!new RegExp(regexFormat).test(id)) {
+	if (!ids.length) logErr(
+		'an undefined ID',
+		'Could not get ID from pathname or searchParams.',
+	);
+
+	// Allows for a matching ID to be selected from either (or both) formats
+	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId))
+
+	if (!id) {
 		return logErr(
-			id,
-			`Popped value didn't match regexFormat ${regexFormat}`,
+			id || ids.join(', '),
+			`Value(s) didn't match regexFormat ${regexFormat}`,
 		);
 	}
 

--- a/dotcom-rendering/src/amp/lib/get-video-id.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.ts
@@ -16,8 +16,8 @@ export const getIdFromUrl = (
 
 	// Looks for ID in both formats if provided
 	const ids: string[] = [
+		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam),
 		tryInPath && url.pathname && url.pathname.split('/').pop(),
-		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam)
 	].filter((tryId): tryId is string => !!tryId)
 
 	if (!ids.length) logErr(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
AMP page will completely fail to render if a youtube short-url e.g (`https://youtu.be/some-youtube-id`) was passed to the `VideoYoutubeBlockComponent`

Example broken url: https://amp.theguardian.com/football/blog/2021/may/29/golden-goal-bryan-robson-for-manchester-united-v-wimbledon-1993

This could be solved by allowing the `getIdFromUrl` function to search for both the url path & query param at once. While in theory this was already supported by the function (perhaps not intentionally), the implementation favoured finding the url path & only checked the first found 'match' against the provided regex. Meaning that a regular youtube url (`http://www.youtube.com/watch?v=some-id`) would find the id `watch` first, fail the regex check, and bail out of rendering.

Refactoring the `getIdFromUrl` allows us to pick matches from both formats if available (and the caller asks for both) - and then find one (if any) which matches the regex. This allows us to look for the ID in both locations, while still keeping concise error handling.

The functionality of the function remains identical to consumers who aren't matching for both formats. This function is only consumed by the `VideoYoutubeBlockComponent` and `VideoVimeoBlockComponent`. The tests have been updated to ensure the new functionality works as expected

## Why?

Solves render failing as detailed above


