### PR TITLE
Remove workaround for `commercial.spec` now that the article rich-link tag has been fixed

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-6/commercial.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/commercial.spec.js
@@ -41,15 +41,6 @@ describe('Commercial E2E tests', function () {
 		});
 
 		it(`It should check slots for a long article in Frontend`, function () {
-			// TODO: temporary workaround for uncaught exception from rich-link json request
-			cy.on('uncaught:exception', (err, runnable, promise) => {
-				// return false to prevent the error from failing this test
-				if (promise) {
-					console.log(err);
-					return false;
-				}
-			});
-
 			Cypress.config('baseUrl', '');
 			runLongReadTestFor(`${longReadURL}?dcr=false`);
 		});

--- a/dotcom-rendering/src/amp/lib/get-video-id.test.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.test.ts
@@ -19,16 +19,16 @@ describe('getIdFromUrl', () => {
 			},
 			{
 				url: 'https://youtu.be/NRHEIGHTx8I',
-				id: 'NRHEIGHTx8I'
+				id: 'NRHEIGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH_IGHTx8I',
-				id: 'NRH_IGHTx8I'
+				id: 'NRH_IGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH-IGHTx8I',
-				id: 'NRH-IGHTx8I'
-			}
+				id: 'NRH-IGHTx8I',
+			},
 		];
 
 		formats.forEach((_) => {
@@ -61,13 +61,16 @@ describe('getIdFromUrl', () => {
 	});
 
 	it('Finds ID if both options are allowed', () => {
-		const formats = [ 'https://theguardian.com/test', 'https://theguardian.com?a=test', 'https://theguardian.com/test?a=test']
+		const formats = [
+			'https://theguardian.com/test',
+			'https://theguardian.com?a=test',
+			'https://theguardian.com/test?a=test',
+		];
 
 		formats.forEach((_) => {
 			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
 		});
-
-	})
+	});
 
 	it('Throws an error if it cannot find an ID', () => {
 		expect(() => {

--- a/dotcom-rendering/src/amp/lib/get-video-id.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.ts
@@ -16,17 +16,20 @@ export const getIdFromUrl = (
 
 	// Looks for ID in both formats if provided
 	const ids: string[] = [
-		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam),
+		tryQueryParam &&
+			url.query &&
+			new URLSearchParams(url.query).get(tryQueryParam),
 		tryInPath && url.pathname && url.pathname.split('/').pop(),
-	].filter((tryId): tryId is string => !!tryId)
+	].filter((tryId): tryId is string => !!tryId);
 
-	if (!ids.length) logErr(
-		'an undefined ID',
-		'Could not get ID from pathname or searchParams.',
-	);
+	if (!ids.length)
+		logErr(
+			'an undefined ID',
+			'Could not get ID from pathname or searchParams.',
+		);
 
 	// Allows for a matching ID to be selected from either (or both) formats
-	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId))
+	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId));
 
 	if (!id) {
 		return logErr(

--- a/yarn.lock
+++ b/yarn.lock
@@ -14699,7 +14699,7 @@ prettier-eslint@^11.0.0:
     typescript "^3.9.3"
     vue-eslint-parser "~7.1.0"
 
-prettier@^2.0.0:
+prettier@^2.0.0, prettier@^2.2.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
## What does this change?

Remove the workaround for the unhandled promise rejection in the `commercial.spec` cypress test.

Also prettier errors had somehow crept into main which I've also fixed as I couldn't push otherwise.

**Problem**

`commercial.spec` compares the number of adverts rendered on a long read article between DCR and Frontend i.e.:

The Frontend article:

https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife?dcr=false

vs DCR:

https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife

The article had a rich-link tag of:

https://www.theguardian.com/environment/2015/oct/19/sign-up-to-the-green-light-email

However this is no longer valid and redirects to:

https://www.theguardian.com/info/ng-interactive/2021/oct/20/sign-up-for-down-to-earth-the-best-way-to-make-sense-of-the-biggest-environment-stories

In order to render the rich-link Frontend was making a request to:

https://api.nextgen.guardianapps.co.uk/embed/card/environment/2015/oct/19/sign-up-to-the-green-light-email.json

Which was no longer valid and returned a 404 http status.

Central production have changed the tag to its redirect which now resolves without error i.e.:

https://www.theguardian.com/info/ng-interactive/2021/oct/20/sign-up-for-down-to-earth-the-best-way-to-make-sense-of-the-biggest-environment-stories
