### PR TITLE
Fix Instagram Chromatic diffs

### DIFF
--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -113,6 +113,11 @@ const Spotify: FC = () => (
 	</div>
 );
 
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Instagram = () => (
 	<div>
 		<p>

--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -113,7 +113,7 @@ const Spotify: FC = () => (
 	</div>
 );
 
-const Instagram: FC = () => (
+const Instagram = () => (
 	<div>
 		<p>
 			This is an example of the embed wrapper rendering a instagram
@@ -143,6 +143,11 @@ const Instagram: FC = () => (
 		/>
 	</div>
 );
+Instagram.story = {
+	parameters: {
+		chromatic: { disable: true },
+	},
+};
 
 // ----- Exports ----- //
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14699,7 +14699,7 @@ prettier-eslint@^11.0.0:
     typescript "^3.9.3"
     vue-eslint-parser "~7.1.0"
 
-prettier@^2.0.0:
+prettier@^2.0.0, prettier@^2.2.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Disables the Chromatic story for the AR Instagram ClickToView story

## Why?
Because every time the Guardian got a new follower on Instagram it meant we got false negatives on our PRs
