### PR TITLE
Revert standfirst max width 80%

### DIFF
--- a/dotcom-rendering/src/amp/lib/get-video-id.test.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.test.ts
@@ -19,16 +19,16 @@ describe('getIdFromUrl', () => {
 			},
 			{
 				url: 'https://youtu.be/NRHEIGHTx8I',
-				id: 'NRHEIGHTx8I'
+				id: 'NRHEIGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH_IGHTx8I',
-				id: 'NRH_IGHTx8I'
+				id: 'NRH_IGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH-IGHTx8I',
-				id: 'NRH-IGHTx8I'
-			}
+				id: 'NRH-IGHTx8I',
+			},
 		];
 
 		formats.forEach((_) => {
@@ -61,13 +61,16 @@ describe('getIdFromUrl', () => {
 	});
 
 	it('Finds ID if both options are allowed', () => {
-		const formats = [ 'https://theguardian.com/test', 'https://theguardian.com?a=test', 'https://theguardian.com/test?a=test']
+		const formats = [
+			'https://theguardian.com/test',
+			'https://theguardian.com?a=test',
+			'https://theguardian.com/test?a=test',
+		];
 
 		formats.forEach((_) => {
 			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
 		});
-
-	})
+	});
 
 	it('Throws an error if it cannot find an ID', () => {
 		expect(() => {

--- a/dotcom-rendering/src/amp/lib/get-video-id.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.ts
@@ -16,17 +16,20 @@ export const getIdFromUrl = (
 
 	// Looks for ID in both formats if provided
 	const ids: string[] = [
-		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam),
+		tryQueryParam &&
+			url.query &&
+			new URLSearchParams(url.query).get(tryQueryParam),
 		tryInPath && url.pathname && url.pathname.split('/').pop(),
-	].filter((tryId): tryId is string => !!tryId)
+	].filter((tryId): tryId is string => !!tryId);
 
-	if (!ids.length) logErr(
-		'an undefined ID',
-		'Could not get ID from pathname or searchParams.',
-	);
+	if (!ids.length)
+		logErr(
+			'an undefined ID',
+			'Could not get ID from pathname or searchParams.',
+		);
 
 	// Allows for a matching ID to be selected from either (or both) formats
-	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId))
+	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId));
 
 	if (!id) {
 		return logErr(

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -1,4 +1,4 @@
-import { breakpoints, news } from '@guardian/src-foundations';
+import { news } from '@guardian/src-foundations';
 import {
 	ArticleDisplay,
 	ArticleDesign,
@@ -12,11 +12,6 @@ import { Standfirst } from './Standfirst';
 export default {
 	component: Standfirst,
 	title: 'Components/Standfirst',
-	parameters: {
-		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
-		},
-	},
 };
 
 export const Article = () => {

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -125,18 +125,12 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Review:
 					return css`
-						${headline.xxxsmall({
+						${headline.xxsmall({
 							fontWeight: 'light',
 						})};
 						margin-bottom: ${space[3]}px;
-						max-width: 80%;
+						max-width: 540px;
 						color: ${palette.text.standfirst};
-						${from.tablet} {
-							${headline.xxsmall({
-								fontWeight: 'light',
-							})};
-							max-width: 540px;
-						}
 					`;
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
@@ -173,11 +167,8 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 								})};
 								line-height: 20px;
 								margin-bottom: ${space[3]}px;
-								max-width: 80%;
+								max-width: 540px;
 								color: ${palette.text.standfirst};
-								${from.tablet} {
-									max-width: 540px;
-								}
 							`;
 					}
 			}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
* Reverts change that applied max-width 80% to all Articles standfirst
* Fixes some prettier issues

## Why?
It was causing problems to journalists using Composer

### Before

![image](https://user-images.githubusercontent.com/19683595/139853477-f566dcae-a909-4452-85cb-b18fda217313.png)


### After
![image](https://user-images.githubusercontent.com/19683595/139853553-2105a99e-95d9-4d27-afa3-ac928235ed45.png)

