### PR TITLE
Add Blocks To Live Fixtures

### DIFF
--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -270,7 +270,7 @@ const live: LiveBlog = {
 			title: 'Block One',
 			firstPublished: some(new Date('2021-11-02T12:00:00Z')),
 			lastModified: some(new Date('2021-11-02T13:13:13Z')),
-			body: []
+			body: [],
 		},
 		{
 			id: '2',
@@ -278,7 +278,7 @@ const live: LiveBlog = {
 			title: 'Block Two',
 			firstPublished: some(new Date('2021-11-02T11:20:00Z')),
 			lastModified: some(new Date('2021-11-02T13:03:13Z')),
-			body: []
+			body: [],
 		},
 		{
 			id: '3',
@@ -286,7 +286,7 @@ const live: LiveBlog = {
 			title: 'Block Three',
 			firstPublished: some(new Date('2021-11-02T11:05:12Z')),
 			lastModified: some(new Date('2021-11-02T12:13:13Z')),
-			body: []
+			body: [],
 		},
 		{
 			id: '4',
@@ -294,7 +294,7 @@ const live: LiveBlog = {
 			title: 'Block Four',
 			firstPublished: some(new Date('2021-11-02T10:55:03Z')),
 			lastModified: some(new Date('2021-11-02T11:13:13Z')),
-			body: []
+			body: [],
 		},
 		{
 			id: '5',
@@ -302,8 +302,8 @@ const live: LiveBlog = {
 			title: 'Block Five',
 			firstPublished: some(new Date('2021-11-02T10:20:20Z')),
 			lastModified: some(new Date('2021-11-02T11:13:13Z')),
-			body: []
-		}
+			body: [],
+		},
 	],
 	totalBodyBlocks: 5,
 };

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -263,8 +263,49 @@ const fields = {
 const live: LiveBlog = {
 	design: Design.LiveBlog,
 	...fields,
-	blocks: [],
-	totalBodyBlocks: 12,
+	blocks: [
+		{
+			id: '1',
+			isKeyEvent: true,
+			title: 'Block One',
+			firstPublished: some(new Date('2021-11-02T12:00:00Z')),
+			lastModified: some(new Date('2021-11-02T13:13:13Z')),
+			body: []
+		},
+		{
+			id: '2',
+			isKeyEvent: false,
+			title: 'Block Two',
+			firstPublished: some(new Date('2021-11-02T11:20:00Z')),
+			lastModified: some(new Date('2021-11-02T13:03:13Z')),
+			body: []
+		},
+		{
+			id: '3',
+			isKeyEvent: true,
+			title: 'Block Three',
+			firstPublished: some(new Date('2021-11-02T11:05:12Z')),
+			lastModified: some(new Date('2021-11-02T12:13:13Z')),
+			body: []
+		},
+		{
+			id: '4',
+			isKeyEvent: true,
+			title: 'Block Four',
+			firstPublished: some(new Date('2021-11-02T10:55:03Z')),
+			lastModified: some(new Date('2021-11-02T11:13:13Z')),
+			body: []
+		},
+		{
+			id: '5',
+			isKeyEvent: false,
+			title: 'Block Five',
+			firstPublished: some(new Date('2021-11-02T10:20:20Z')),
+			lastModified: some(new Date('2021-11-02T11:13:13Z')),
+			body: []
+		}
+	],
+	totalBodyBlocks: 5,
 };
 
 export { live };


### PR DESCRIPTION
## Why?

Gives us a better representation of a liveblog layout in storybook. Suggestion from @marjisound here: https://github.com/guardian/dotcom-rendering/pull/3573#discussion_r740229783

You should be able to see the difference in storybook/chromatic.

## Changes

- Added some blocks to the live fixtures