### PR TITLE
Remove Onward Styles

### DIFF
--- a/apps-rendering/src/components/layout/comment.tsx
+++ b/apps-rendering/src/components/layout/comment.tsx
@@ -23,11 +23,7 @@ import Tags from 'components/tags';
 import HeaderMedia from 'headerMedia';
 import type { Comment as CommentItem, Editorial, Letter } from 'item';
 import type { FC, ReactNode } from 'react';
-import {
-	articleWidthStyles,
-	darkModeCss,
-	lineStyles,
-} from 'styles';
+import { articleWidthStyles, darkModeCss, lineStyles } from 'styles';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/layout/comment.tsx
+++ b/apps-rendering/src/components/layout/comment.tsx
@@ -27,7 +27,6 @@ import {
 	articleWidthStyles,
 	darkModeCss,
 	lineStyles,
-	onwardStyles,
 } from 'styles';
 
 // ----- Styles ----- //
@@ -108,9 +107,7 @@ const Comment: FC<Props> = ({ item, children }) => (
 				<Tags tags={item.tags} format={item} />
 			</section>
 		</article>
-		<section css={onwardStyles}>
-			<RelatedContent content={item.relatedContent} />
-		</section>
+		<RelatedContent content={item.relatedContent} />
 		<Footer isCcpa={false} />
 	</main>
 );

--- a/apps-rendering/src/components/layout/labs.tsx
+++ b/apps-rendering/src/components/layout/labs.tsx
@@ -17,11 +17,7 @@ import HeaderMedia from 'headerMedia';
 import type { Item } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
-import {
-	articleWidthStyles,
-	darkModeCss,
-	lineStyles,
-} from 'styles';
+import { articleWidthStyles, darkModeCss, lineStyles } from 'styles';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/layout/labs.tsx
+++ b/apps-rendering/src/components/layout/labs.tsx
@@ -21,7 +21,6 @@ import {
 	articleWidthStyles,
 	darkModeCss,
 	lineStyles,
-	onwardStyles,
 } from 'styles';
 
 // ----- Styles ----- //
@@ -80,9 +79,7 @@ const Labs: FC<Props> = ({ item, children }) => {
 					{children}
 				</Body>
 			</article>
-			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
-			</section>
+			<RelatedContent content={item.relatedContent} />
 			<Footer isCcpa={false} />
 		</main>
 	);

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -14,7 +14,7 @@ import type { DeadBlog, LiveBlog } from 'item';
 import { convertThemeToArticleTheme } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
-import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
+import { articleWidthStyles, darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -61,9 +61,7 @@ const Live: FC<Props> = ({ item }) => (
 		<section css={articleWidthStyles}>
 			<Tags tags={item.tags} format={item} />
 		</section>
-		<section css={onwardStyles}>
-			<RelatedContent content={item.relatedContent} />
-		</section>
+		<RelatedContent content={item.relatedContent} />
 		<section css={articleWidthStyles}>
 			<Footer isCcpa={false} />
 		</section>

--- a/apps-rendering/src/components/layout/media.tsx
+++ b/apps-rendering/src/components/layout/media.tsx
@@ -14,7 +14,7 @@ import Standfirst from 'components/standfirst';
 import HeaderMedia from 'headerMedia';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
-import { articleWidthStyles, onwardStyles } from 'styles';
+import { articleWidthStyles } from 'styles';
 
 // ----- Styles ----- //
 
@@ -68,9 +68,7 @@ const Media: FC<Props> = ({ item, children }) => (
 				<Tags tags={item.tags} />
 			</section>
 		</article>
-		<section css={onwardStyles}>
-			<RelatedContent content={item.relatedContent} />
-		</section>
+		<RelatedContent content={item.relatedContent} />
 		<Footer isCcpa={false} />
 	</main>
 );

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -28,11 +28,7 @@ import type {
 } from 'item';
 import { maybeRender, pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
-import {
-	articleWidthStyles,
-	darkModeCss,
-	lineStyles,
-} from 'styles';
+import { articleWidthStyles, darkModeCss, lineStyles } from 'styles';
 import { getThemeStyles, themeToPillarString } from 'themeStyles';
 
 // ----- Styles ----- //

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -32,7 +32,6 @@ import {
 	articleWidthStyles,
 	darkModeCss,
 	lineStyles,
-	onwardStyles,
 } from 'styles';
 import { getThemeStyles, themeToPillarString } from 'themeStyles';
 
@@ -103,7 +102,6 @@ const Standard: FC<Props> = ({ item, children }) => {
 				item.internalShortId,
 				map((id) => (
 					<section
-						css={onwardStyles}
 						id="comments"
 						data-closed={false}
 						data-pillar={themeToPillarString(item.theme)}
@@ -157,9 +155,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 					<Tags tags={item.tags} format={item} />
 				</section>
 			</article>
-			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
-			</section>
+			<RelatedContent content={item.relatedContent} />
 			{commentContainer}
 			<Footer isCcpa={false} />
 		</main>

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -1,6 +1,11 @@
 import { css } from '@emotion/react';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { background, breakpoints, neutral, remSpace } from '@guardian/src-foundations';
+import {
+	background,
+	breakpoints,
+	neutral,
+	remSpace,
+} from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Option } from '@guardian/types';

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import { neutral, remSpace } from '@guardian/src-foundations';
+import { background, breakpoints, neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import type { Option } from '@guardian/types';
@@ -15,6 +15,22 @@ import { darkModeCss } from 'styles';
 interface Props {
 	content: Option<ResizedRelatedContent>;
 }
+
+const styles = css`
+	background: ${neutral[97]};
+	margin: 0 ${remSpace[3]};
+
+	${darkModeCss`
+        background: ${background.inverse};
+    `};
+
+	padding: ${remSpace[1]} 0 0;
+	${from.wide} {
+		width: ${breakpoints.wide}px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
 
 const headingStyles = css`
 	${headline.xsmall({ fontWeight: 'bold' })}
@@ -92,7 +108,7 @@ const RelatedContent: FC<Props> = ({ content }) => {
 			}
 
 			return (
-				<section>
+				<section css={styles}>
 					<h2 css={headingStyles}>{title}</h2>
 					<ul css={listStyles}>
 						{relatedItems.map((relatedItem, key) => {

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -2,10 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
-import {
-	brandAltBackground,
-	neutral,
-} from '@guardian/src-foundations/palette';
+import { brandAltBackground, neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import type { Format, Option } from '@guardian/types';
 import { Design, map, none, some, withDefault } from '@guardian/types';

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 import {
-	background,
 	brandAltBackground,
 	neutral,
 } from '@guardian/src-foundations/palette';
@@ -83,22 +82,6 @@ export const lineStyles = css`
             transparent 3px
             );
     `}
-	}
-`;
-
-export const onwardStyles: SerializedStyles = css`
-	background: ${neutral[97]};
-	margin: 0 ${remSpace[3]};
-
-	${darkModeCss`
-        background: ${background.inverse};
-    `};
-
-	padding: 0.125rem 0 0;
-	${from.wide} {
-		width: 1300px;
-		margin-left: auto;
-		margin-right: auto;
 	}
 `;
 


### PR DESCRIPTION
## Why?

A few reasons:

1. All related content sections had a double-nested `<section>` tag
2. Almost every usage of these was related content
3. We'd like to have styles live alongside components as much as possible

**Note:** This does change the styles of the comments section, but the styles of that section are already majorly broken and need an overhaul at some point.

## Changes

- Removed `onwardStyles`
- Removed nested `<section>` tags
