### PR TITLE
Revert "Bump `consent-management-platform` to v9"

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
     "@guardian/automat-contributions": "^0.4.2",
     "@guardian/braze-components": "^4.1.0",
     "@guardian/commercial-core": "^0.26.0",
-    "@guardian/consent-management-platform": "^9.0.1",
+    "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^8.1.0",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,12 +1497,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.26.1.tgz#e93d900dc31b80678c5d12af3d2811c4563de02f"
   integrity sha512-VpwN7I/2uZ5TsxJWMQHZ5buT/dkHdCA7RtwGnaoPy6YyjlipR1SjNAUxEeBbZ4+Sz8YPBDmAFAL8+3m/9gnokw==
 
-"@guardian/consent-management-platform@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-9.0.1.tgz#bfcfca3eb32a65faa0f60ff723a294ba840d9953"
-  integrity sha512-ZN4tf7VpGxQu1CcqRsHNzWK61Q3KlaLGf8HKEX2oGotKzWZdoCx22tEA/v5Stdlv1ZkcMSqnfmtF1fJ5STgWGg==
+"@guardian/consent-management-platform@~6.11.5":
+  version "6.11.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.5.tgz#93681cbf61de0fadb4b65d835d7fc445cb847b31"
+  integrity sha512-ap7b09qk8I/EfoWB3NR8kT63hBpm4ATFGpRicCQ61DLMw2PgCWunMvizdbSmo5wNCQKPFgmX9cfRT5IGfPneKw==
   dependencies:
-    "@guardian/libs" "1.6.1 - 3.3.0"
+    "@guardian/libs" "^1"
 
 "@guardian/discussion-rendering@^8.1.0":
   version "8.1.0"
@@ -1514,7 +1514,12 @@
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"
 
-"@guardian/libs@1.6.1 - 3.3.0", "@guardian/libs@^3.2.1":
+"@guardian/libs@^1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
+  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
+
+"@guardian/libs@^3.2.1":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
@@ -14694,7 +14699,7 @@ prettier-eslint@^11.0.0:
     typescript "^3.9.3"
     vue-eslint-parser "~7.1.0"
 
-prettier@^2.0.0, prettier@^2.2.1:
+prettier@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3561
This change broke advertising in Canada