### PR TITLE
Liveblog Pagination

### DIFF
--- a/dotcom-rendering/src/amp/lib/get-video-id.test.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.test.ts
@@ -19,16 +19,16 @@ describe('getIdFromUrl', () => {
 			},
 			{
 				url: 'https://youtu.be/NRHEIGHTx8I',
-				id: 'NRHEIGHTx8I'
+				id: 'NRHEIGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH_IGHTx8I',
-				id: 'NRH_IGHTx8I'
+				id: 'NRH_IGHTx8I',
 			},
 			{
 				url: 'https://youtu.be/NRH-IGHTx8I',
-				id: 'NRH-IGHTx8I'
-			}
+				id: 'NRH-IGHTx8I',
+			},
 		];
 
 		formats.forEach((_) => {
@@ -61,13 +61,16 @@ describe('getIdFromUrl', () => {
 	});
 
 	it('Finds ID if both options are allowed', () => {
-		const formats = [ 'https://theguardian.com/test', 'https://theguardian.com?a=test', 'https://theguardian.com/test?a=test']
+		const formats = [
+			'https://theguardian.com/test',
+			'https://theguardian.com?a=test',
+			'https://theguardian.com/test?a=test',
+		];
 
 		formats.forEach((_) => {
 			expect(getIdFromUrl(_, 'test', true, 'a')).toBe('test');
 		});
-
-	})
+	});
 
 	it('Throws an error if it cannot find an ID', () => {
 		expect(() => {

--- a/dotcom-rendering/src/amp/lib/get-video-id.ts
+++ b/dotcom-rendering/src/amp/lib/get-video-id.ts
@@ -16,17 +16,20 @@ export const getIdFromUrl = (
 
 	// Looks for ID in both formats if provided
 	const ids: string[] = [
-		tryQueryParam && url.query && new URLSearchParams(url.query).get(tryQueryParam),
+		tryQueryParam &&
+			url.query &&
+			new URLSearchParams(url.query).get(tryQueryParam),
 		tryInPath && url.pathname && url.pathname.split('/').pop(),
-	].filter((tryId): tryId is string => !!tryId)
+	].filter((tryId): tryId is string => !!tryId);
 
-	if (!ids.length) logErr(
-		'an undefined ID',
-		'Could not get ID from pathname or searchParams.',
-	);
+	if (!ids.length)
+		logErr(
+			'an undefined ID',
+			'Could not get ID from pathname or searchParams.',
+		);
 
 	// Allows for a matching ID to be selected from either (or both) formats
-	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId))
+	const id = ids.find((tryId) => new RegExp(regexFormat).test(tryId));
 
 	if (!id) {
 		return logErr(

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -32,6 +32,7 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
+import { Pagination } from '@frontend/web/components/Pagination';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -418,6 +419,22 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<GridItem area="body">
 						<ArticleContainer>
 							<main css={articleWidth}>
+								{CAPI.pagination &&
+									CAPI.pagination.currentPage !== 1 && (
+										<Pagination
+											currentPage={
+												CAPI.pagination?.currentPage ||
+												1
+											}
+											totalPages={
+												CAPI.pagination?.totalPages || 1
+											}
+											newest={CAPI.pagination?.newest}
+											oldest={CAPI.pagination?.oldest}
+											newer={CAPI.pagination?.newer}
+											older={CAPI.pagination?.older}
+										/>
+									)}
 								<ArticleBody
 									format={format}
 									palette={palette}
@@ -427,6 +444,22 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 								/>
+								{CAPI.pagination &&
+									CAPI.pagination.totalPages > 1 && (
+										<Pagination
+											currentPage={
+												CAPI.pagination?.currentPage ||
+												1
+											}
+											totalPages={
+												CAPI.pagination?.totalPages || 1
+											}
+											newest={CAPI.pagination?.newest}
+											oldest={CAPI.pagination?.oldest}
+											newer={CAPI.pagination?.newer}
+											older={CAPI.pagination?.older}
+										/>
+									)}
 								{showBodyEndSlot && <div id="slot-body-end" />}
 								<Lines
 									data-print-layout="hide"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds the `Pagination` component to the `LiveLayout` file, plugging in the `pagination` data and deciding when to show the component or not

<img width="669" alt="Screenshot 2021-11-03 at 15 08 37" src="https://user-images.githubusercontent.com/1336821/140087194-1cf8b7e9-1417-4b51-9d37-c2600feae2b4.png">


## Things that are pending design input
- It looks a bit blue at the moment
- We could perhaps add some padding below
- Decide how to manage when buttons won't work (can't go back or forward because you're at the end)
