### PR TITLE
Remove obsolete tracking

### DIFF
--- a/dotcom-rendering/src/amp/components/Analytics.tsx
+++ b/dotcom-rendering/src/amp/components/Analytics.tsx
@@ -9,7 +9,6 @@ export interface AnalyticsModel {
 	section?: string;
 	contentType: string;
 	id: string;
-	beacon: string;
 	neilsenAPIID: string;
 	domain: string;
 	permutive: {
@@ -31,7 +30,6 @@ export const Analytics: React.FC<{
 		section,
 		contentType,
 		id,
-		beacon,
 		neilsenAPIID,
 		domain,
 		permutive,
@@ -39,7 +37,6 @@ export const Analytics: React.FC<{
 	},
 }) => {
 	const scripts: string[] = [
-		`<amp-pixel data-block-on-consent src="${beacon}"></amp-pixel>`,
 		`<amp-pixel data-block-on-consent src="//www.facebook.com/tr?id=${fbPixelaccount}&ev=PageView&noscript=1"></amp-pixel>`,
 		`<amp-analytics config="https://ophan.theguardian.com/amp.json" data-credentials="include" ></amp-analytics>`,
 		`<amp-analytics data-block-on-consent type="googleanalytics" id="google-analytics">

--- a/dotcom-rendering/src/amp/server/document.test.tsx
+++ b/dotcom-rendering/src/amp/server/document.test.tsx
@@ -43,7 +43,6 @@ test('produces valid AMP doc', async () => {
 		section: CAPI.sectionName,
 		contentType: CAPI.contentType,
 		id: CAPI.pageId,
-		beacon: `${CAPI.beaconURL}/count/pv.gif`,
 		neilsenAPIID: 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXX',
 		domain: 'amp.theguardian.com',
 		permutive: {

--- a/dotcom-rendering/src/amp/server/render.tsx
+++ b/dotcom-rendering/src/amp/server/render.tsx
@@ -36,7 +36,6 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 			section: sectionName,
 			contentType: CAPI.contentType,
 			id: CAPI.pageId,
-			beacon: `${CAPI.beaconURL}/count/pv.gif`,
 			neilsenAPIID,
 			domain: 'amp.theguardian.com',
 			permutive: {

--- a/dotcom-rendering/src/web/browser/ga/ga.ts
+++ b/dotcom-rendering/src/web/browser/ga/ga.ts
@@ -149,13 +149,6 @@ export const sendPageView = (): void => {
 		// do nothing
 	}
 
-	ga(send, 'pageview', {
-		hitCallback() {
-			const image = new Image();
-			image.src = `${GA.beaconUrl}/count/pvg.gif`;
-		},
-	});
-
 	// //////////////////////
 	// Core Vitals Reporting
 	// Supported only in Chromium but npm module tested in all our supported browsers


### PR DESCRIPTION
## What does this change?

Removes obsolete tracking code from web and AMP articles. This is a continuation of https://github.com/guardian/frontend/pull/24326.

## Why?

These requests are failing on every page load and cluttering the console.

### Before

When visiting a [web article](https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software):

![Screenshot 2021-11-04 at 11 08 32](https://user-images.githubusercontent.com/7423751/140303673-018f29a2-aa5d-4620-868f-3f1c88f17463.png)

When visiting an [AMP article](https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance):

![Screenshot 2021-11-04 at 11 08 54](https://user-images.githubusercontent.com/7423751/140303668-e454f754-16df-4749-9741-7bf2c042273d.png)

### After

The errors are gone 🪄