### PR TITLE
Remove Padding To Stop Captions Being Too Far Left On Immersives

### DIFF
--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -25,10 +25,6 @@ const captionStyle = (palette: Palette) => css`
 	padding-top: 6px;
 	word-wrap: break-all;
 	color: ${palette.text.caption};
-	${until.tablet} {
-		padding-left: ${space[2]}px;
-		padding-right: ${space[2]}px;
-	}
 `;
 
 const bottomMargin = css`

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -94,7 +94,7 @@ const buildPayload = async ({
 			optedOutOfArticleCount,
 			modulesVersion: MODULES_VERSION,
 			sectionId,
-			tagIds: tags.map(tag => tag.id),
+			tagIds: tags.map((tag) => tag.id),
 		},
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

It removes padding which affects captions in Immersive articles that were being pushing over by 8px, now they are aligned with the title. It's been checked against standard articles and seems to have left those as they should be.

## Why?

To make it look better.

### Before
Mobile Medium
<img width="530" alt="Screenshot 2021-11-05 at 12 38 57" src="https://user-images.githubusercontent.com/35331926/140511804-5a3a97d8-28bd-4ad5-9573-8788712ec7cc.png">

Phablet
<img width="730" alt="Screenshot 2021-11-05 at 12 39 14" src="https://user-images.githubusercontent.com/35331926/140511862-59dbf752-2fd8-45ab-9d88-348e12a6f792.png">

### After
Mobile Medium
<img width="530" alt="Screenshot 2021-11-05 at 12 38 33" src="https://user-images.githubusercontent.com/35331926/140511952-fbcd5686-b1fd-4820-9da8-7d047f3e40c5.png">

Phablet
<img width="730" alt="Screenshot 2021-11-05 at 12 39 35" src="https://user-images.githubusercontent.com/35331926/140512008-3f863686-6fed-4cdb-a1b2-a5c382623181.png">


