### PR TITLE
LIVE-3028: Renders Ordered Lists in AR

### DIFF
--- a/apps-rendering/src/components/listItem.tsx
+++ b/apps-rendering/src/components/listItem.tsx
@@ -16,18 +16,6 @@ const baseStyles = css`
 	padding-left: ${remSpace[6]};
 	padding-bottom: 0.375rem;
 
-	&::before {
-		display: inline-block;
-		content: '';
-		border-radius: 0.5rem;
-		height: 1rem;
-		width: 1rem;
-		margin-right: ${remSpace[2]};
-		background-color: ${neutral[86]};
-		margin-left: -${remSpace[6]};
-		vertical-align: middle;
-	}
-
 	> p:first-of-type {
 		display: inline;
 		padding: 0;

--- a/apps-rendering/src/components/orderedList.stories.tsx
+++ b/apps-rendering/src/components/orderedList.stories.tsx
@@ -1,0 +1,35 @@
+// ----- Imports ----- //
+
+import { Design, Display, Pillar } from '@guardian/types';
+import type { FC } from 'react';
+import ListItem from './listItem';
+import OrderedList from './orderedList';
+
+// ----- Setup ----- //
+
+const listItem = (
+	<ListItem
+		format={{
+			design: Design.Article,
+			display: Display.Standard,
+			theme: Pillar.News,
+		}}
+	>
+		A bullet point
+	</ListItem>
+);
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+	<OrderedList>{[listItem, listItem, listItem]}</OrderedList>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: OrderedList,
+	title: 'AR/OrderedList',
+};
+
+export { Default };

--- a/apps-rendering/src/components/orderedList.tsx
+++ b/apps-rendering/src/components/orderedList.tsx
@@ -3,7 +3,6 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import { remSpace } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
 import type { FC, ReactNode } from 'react';
 
 // ----- Component ----- //
@@ -14,16 +13,19 @@ const styles: SerializedStyles = css`
 	padding-left: 0;
 	clear: both;
 
+	counter-reset: li;
 	> li::before {
-		display: inline-block;
-		content: '';
-		border-radius: 0.5rem;
-		height: 1rem;
-		width: 1rem;
-		margin-right: ${remSpace[2]};
-		background-color: ${neutral[86]};
-		margin-left: -${remSpace[6]};
-		vertical-align: middle;
+		content: counter(li);
+		counter-increment: li;
+		display: block;
+	}
+
+	> li {
+		padding-left: 0;
+	}
+
+	> li p:first-of-type {
+		display: block;
 	}
 `;
 
@@ -31,8 +33,10 @@ interface Props {
 	children: ReactNode;
 }
 
-const List: FC<Props> = ({ children }) => <ul css={styles}>{children}</ul>;
+const OrderedList: FC<Props> = ({ children }) => (
+	<ol css={styles}>{children}</ol>
+);
 
 // ----- Exports ----- //
 
-export default List;
+export default OrderedList;

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -63,6 +63,7 @@ import InteractiveAtom, {
 import List from 'components/list';
 import ListItem from 'components/listItem';
 import LiveEventLink from 'components/liveEventLink';
+import OrderedList from 'components/orderedList';
 import Paragraph from 'components/paragraph';
 import Pullquote from 'components/pullquote';
 import RichLink from 'components/richLink';
@@ -181,6 +182,8 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 			return h('br', { key }, null);
 		case 'UL':
 			return h('ul', { key }, children);
+		case 'OL':
+			return h('ol', { key }, children);
 		case 'LI':
 			return h('li', { key }, children);
 		case 'MARK':
@@ -241,6 +244,8 @@ const textElement =
 				return h('br', { key }, null);
 			case 'UL':
 				return h(List, { children });
+			case 'OL':
+				return h(OrderedList, { children });
 			case 'LI':
 				return h(ListItem, { format, children });
 			case 'MARK':


### PR DESCRIPTION

## What does this change?
Adds the ability for AR to render ordered list `<ol>` elements.

## Why?
Currently, only unordered list `<ul>` elements are renderable in AR. The implementation for rendering `<ol>` elements is missing in AR, which this pull request addresses.

### Before


![LIVE-3028_before_change](https://user-images.githubusercontent.com/91967886/140643236-a27bce73-0723-4e9f-8564-5a6f6d969838.png)

### After

![LIVE-3028_after_change](https://user-images.githubusercontent.com/91967886/140643088-d999b5ad-ee35-407a-90d9-a2151dfd3557.png)

