### PR TITLE
Revert call to google analytics

### DIFF
--- a/dotcom-rendering/src/web/browser/ga/ga.ts
+++ b/dotcom-rendering/src/web/browser/ga/ga.ts
@@ -149,6 +149,8 @@ export const sendPageView = (): void => {
 		// do nothing
 	}
 
+	ga(send, 'pageview');
+
 	// //////////////////////
 	// Core Vitals Reporting
 	// Supported only in Chromium but npm module tested in all our supported browsers


### PR DESCRIPTION
Revert call to google analytics

This was removed in error in this PR: https://github.com/guardian/dotcom-rendering/pull/3592
