### PR TITLE
Extend Prebid timeout AB test until 2021-11-15

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/prebid-timeout-test.ts
@@ -4,7 +4,7 @@ export const prebidTimeout: ABTest = {
 	id: 'PrebidTimeout',
 	author: 'Chris Jones (@chrislomaxjones)',
 	start: '2021-10-6',
-	expiry: '2021-11-08',
+	expiry: '2021-11-15',
 	audience: 3 / 100,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extend The Prebid timeout AB test until 15th November 2021.

## Why?

To ensure we collect sufficient volumes of data.