### PR TITLE
Adding break-word property in order to avoid page display issues

### DIFF
--- a/dotcom-rendering/src/web/components/elements/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/TextBlockComponent.tsx
@@ -126,6 +126,7 @@ export const TextBlockComponent = ({
 		{({ css }) => {
 			const paraStyles = css`
 				margin-bottom: 16px;
+				word-break: break-word;
 				${format.theme === ArticleSpecial.Labs
 					? textSans.medium()
 					: body.medium()};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Brings in a new property for paragraphs in order to avoid long words breaking the layout on mobile.

https://trello.com/c/gZ7P7psh/374-page-overrun-on-ios-safari

### Before

![Screen Shot 2021-11-08 at 17 21 52](https://user-images.githubusercontent.com/2051501/140789902-6cd27108-980d-4d9a-93c0-b29a9bdff536.png)

### After
![Screen Shot 2021-11-08 at 17 25 44](https://user-images.githubusercontent.com/2051501/140789888-6b763e91-13c6-4621-80c3-cfdb0d164b80.png)

