### PR TITLE
Revert "Fix bash scripts not bailing out when build step fails"

### DIFF
--- a/scripts/ci-ar.sh
+++ b/scripts/ci-ar.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
-
 git fetch origin main
 
 gitBranches="$(git branch -r)"
@@ -22,7 +19,7 @@ echo "files that are not in dotcom-rendering: $filteredFiles"
 # run the ci steps if either of the followings is true
 # - filteredFiles is empty (all changes were in dotcom-rendering)
 # - we are in the main branch
-if [[ $currentBranch != "main" ]] && [ -z "$filteredFiles" ]
+if [[ $currentBranch != "main" ]] && [ -z "$filteredFiles" ] 
 then
     printf "Skipping AR ci build because AR file changes is empty and branch is $currentBranch\n\n"
 else

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
-
 git fetch origin main
 
 gitBranches="$(git branch -r)"


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3506

This fails if `filteredFiles` would be empty because `grep` returns a non-zero exit code.

`filteredFiles="$(echo "$files" | { grep -v 'dotcom-rendering' || true; })"` would probably fix, but I'd rather just revert for now given the time.