### PR TITLE
Fix epic when there is a floating element above

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -61,6 +61,7 @@ const checkForErrors = (response: Response) => {
 
 const wrapperMargins = css`
 	margin: 18px 0;
+	clear: both;
 `;
 
 export type CanShowData = {


### PR DESCRIPTION
Before:
<img width="676" alt="Screen Shot 2021-11-09 at 08 29 12" src="https://user-images.githubusercontent.com/1513454/140889120-5368c807-0f84-4831-9ff9-15d1955c2078.png">

After:
<img width="676" alt="Screen Shot 2021-11-09 at 08 29 18" src="https://user-images.githubusercontent.com/1513454/140889145-cc5fae60-9df8-40e2-82e4-10164fcdb2e7.png">
