### PR TITLE
AR: Fix Content Scaling On Android

### DIFF
--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -109,9 +109,9 @@ function renderHead(
 
 	return `
         ${renderToString(meta)}
-        <link rel="stylesheet" type="text/css" href="/fontSize.css">
         <style>${generalStyles}</style>
         <style data-emotion-css="${emotionIds.join(' ')}">${itemStyles}</style>
+        <link rel="stylesheet" type="text/css" href="/fontSize.css">
         <script id="targeting-params" type="application/json">
             ${JSON.stringify(request.targetingParams)}
         </script>


### PR DESCRIPTION
## Why?

### TL;DR

Content scaling is broken on Android. This change re-orders the stylesheets so that the Android styles that manage scaling appear later and take precedence.

### Details

The apps offer the ability for users to resize the content of articles using a slider in the toolbar. On Android this is implemented via a `fontSize` stylesheet, which is loaded from the native app. This stylesheet sets a `font-size` attribute on the root HTML element. Because AR uses `rem`s throughout, changing this root font size scales everything on the page.

I think the reset introduced in #3392 may have overridden the `font-size` rule used to resize content on Android. Source's "reset" styles include `font-size: 100%` applied to the `html` element. The main style tag that includes this reset occurs after the stylesheet loaded from Android, which means it takes precedence.

This PR simply shifts the Android stylesheet to load _after_ the main stylesheet, which should switch the order of precedence.

## Changes

- Move font resize stylesheet after main styles
