### PR TITLE
Move `lint-staged` to `pre-commit`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn workspace @guardian/dotcom-rendering lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,4 +3,3 @@
 
 yarn workspace @guardian/dotcom-rendering prettier:check
 yarn workspace @guardian/dotcom-rendering tsc
-yarn workspace @guardian/dotcom-rendering lint-staged


### PR DESCRIPTION
## What?
Move the `lint-staged` linting action out of the `pre-push` Husky action and into `pre-commit`.

## Why?
The `lint-staged` action only runs against files that have been staged by git (reducing the time taken to lint drastically) but when pushing there won't be any staged files to lint because they're already committed.

Thanks to @sndrs for [pointing this out](https://github.com/guardian/dotcom-rendering/pull/3569#pullrequestreview-801235309)!