### PR TITLE
Update braze components for down to earth epic

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^21.0.0",
     "@guardian/automat-contributions": "^0.4.2",
-    "@guardian/braze-components": "^4.1.0",
+    "@guardian/braze-components": "^4.2.0",
     "@guardian/commercial-core": "^0.26.0",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,10 +1487,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.2.tgz#38eff2111ee032a1a25dc6bc32798cbf62a9db7e"
   integrity sha512-6aSGaIHgkcVYLW5tgmiWYdv3N5k7I4NOCwv+YIz8HPWOq/QBHR43nx1tliF8+7LX9bKBVPuEEvPkND1i44tQbA==
 
-"@guardian/braze-components@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-4.1.0.tgz#09cc2546d521790382256c2ed431194a4c8a3761"
-  integrity sha512-Q1MPpV6GKJjpuRqzBqn8s7B5sSh3wt9eF72K1DeOY0NoEtV60GnX7gCFnR6SeRMKV8TsEpKT+f1am8SU98S33Q==
+"@guardian/braze-components@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-4.2.0.tgz#dea9f6fc81cf0235dd3d6f7255b5b199cef013e3"
+  integrity sha512-IO/1bYCSI3rKowlA6T/VEnbTW+/6ZjOmRad3T3h1S6YguEUmkEJG1hOxZEYS6driiD6fO12PcKIZuWIlPoJJnA==
 
 "@guardian/commercial-core@^0.26.0":
   version "0.26.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This updates the version of Braze components used by dotcom-rendering.

## Why?
This version of braze components introduces the new Down to Earth Newsletter epic

![image](https://user-images.githubusercontent.com/3285072/140946100-5e582af7-d236-474a-be9d-cf4dc6588591.png)

### Before
Braze messages that wanted to show the DownToEarthNewletterEpic would show nothing in the Braze epic slot.

### After
Braze messages that want to show the DownToEarthNewletterEpic now display the epic component.
