### PR TITLE
Interactive contents block element fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,10 +9,6 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#648FFF",
-        "titleBar.activeForeground": "#000000"
-	},
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,10 @@
     "files.watcherExclude": {
         "**/target": true
     },
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#648FFF",
+        "titleBar.activeForeground": "#000000"
+	},
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -506,14 +506,14 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				).length > 0
 			) {
 				return import(
-					'@frontend/web/components/elements/InteractiveContentsBlockElement'
+					'@frontend/web/components/elements/InteractiveContentsBlockComponent'
 				);
 			}
 			return Promise.reject();
 		},
 		{
 			resolveComponent: (module) =>
-				module.InteractiveContentsBlockElement,
+				module.InteractiveContentsBlockComponent,
 		},
 	);
 

--- a/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.stories.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { NumberedList } from '@root/fixtures/generated/articles/NumberedList';
 import { enhanceInteractiveContentsElements } from '@root/src/model/enhance-interactive-contents-elements';
 
-import { InteractiveContentsBlockElement } from './InteractiveContentsBlockElement';
+import { InteractiveContentsBlockComponent } from './InteractiveContentsBlockComponent';
 
 // @ts-ignore: we know that NumberedList fixture has an interactive content block
 const interactiveContentsBlock: InteractiveContentsBlockElement =
@@ -14,7 +14,7 @@ const interactiveContentsBlock: InteractiveContentsBlockElement =
 	);
 
 export default {
-	component: InteractiveContentsBlockElement,
+	component: InteractiveContentsBlockComponent,
 	title: 'Components/InteractiveContentsBlockElement',
 };
 
@@ -24,7 +24,7 @@ export const Default = () => (
 			margin: 20px;
 		`}
 	>
-		<InteractiveContentsBlockElement
+		<InteractiveContentsBlockComponent
 			subheadingLinks={interactiveContentsBlock.subheadingLinks}
 			endDocumentElementId={interactiveContentsBlock.endDocumentElementId}
 		/>

--- a/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
@@ -135,7 +135,7 @@ interface EnhancedSubheadingType extends SubheadingBlockElement {
 	ref?: HTMLElement | null;
 }
 
-export const InteractiveContentsBlockElement = ({
+export const InteractiveContentsBlockComponent = ({
 	subheadingLinks,
 	endDocumentElementId,
 }: Props) => {

--- a/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
@@ -284,6 +284,7 @@ export const InteractiveContentsBlockComponent = ({
 				</button>
 			)}
 			<ol
+				data-ignore="global-ol-styling"
 				css={[
 					olStyles,
 					// we detach `ol` from the container when `stickyNavCurrentHeader` is defined

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -15,7 +15,7 @@ import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBloc
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { InteractiveBlockComponent } from '@root/src/web/components/elements/InteractiveBlockComponent';
 import { ItemLinkBlockElement } from '@root/src/web/components/elements/ItemLinkBlockElement';
-import { InteractiveContentsBlockElement } from '@root/src/web/components/elements/InteractiveContentsBlockElement';
+import { InteractiveContentsBlockComponent } from '@root/src/web/components/elements/InteractiveContentsBlockComponent';
 import { MainMediaEmbedBlockComponent } from '@root/src/web/components/elements/MainMediaEmbedBlockComponent';
 import { NumberedTitleBlockComponent } from '@root/src/web/components/elements/NumberedTitleBlockComponent';
 import { MapEmbedBlockComponent } from '@root/src/web/components/elements/MapEmbedBlockComponent';
@@ -382,7 +382,7 @@ export const renderElement = ({
 			return [
 				true,
 				<div id={element.elementId}>
-					<InteractiveContentsBlockElement
+					<InteractiveContentsBlockComponent
 						subheadingLinks={element.subheadingLinks}
 						endDocumentElementId={element.endDocumentElementId}
 					/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Some articles contain interactive embeds which insert a contents block at the top of the article and create anchors out of the h2 elements on the body, in order for the reader to be able to navigate around the page. This PR fixes the display of the interactive contents block as well as makes them work correctly, as DCR versions of these pages were throwing 500 errors - e.g. https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked

This is also one of the tasks required in order to get DCR articles over the line.

https://trello.com/c/bkchcvG6/373-fixing-the-contents-block-in-dcr-articles

### Before
<img width="457" alt="Screen Shot 2021-11-09 at 21 38 19" src="https://user-images.githubusercontent.com/2051501/141009638-29bbb487-33a8-44ab-aa19-f108b9cdb7f6.png">

### After
<img width="457" alt="Screen Shot 2021-11-09 at 21 36 11" src="https://user-images.githubusercontent.com/2051501/141009571-c6542c11-30bd-47f0-9b08-26ebd7146d5a.png">

