### PR TITLE
Remove Husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn workspace @guardian/dotcom-rendering lint-staged


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the `pre-commit` file that was being used to run `lint-staged`

## Why?
Because it is throwing errors (ones with no message) when I try to commit. Even when I am confident my staged files have no linting issues and when linting everything is not a problem.

I suspect there is a config issue here and I don't want to block main
