### PR TITLE
Convert apps-rendering from @guardian/types to @guardian/libs

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2874,9 +2874,9 @@
       }
     },
     "@guardian/atoms-rendering": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-19.0.0.tgz",
-      "integrity": "sha512-Kxd4l4LO7j1bqCpvgmGaZO9E6b+Q2eUJWKLSrZG7vdp1MGACrUAgJBl3qztI10nAqt3KNJrbpOFgWMEU7OuYcA==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-21.0.0.tgz",
+      "integrity": "sha512-iYKNihtSYzqhETRIr+8T2Y2zdjD8+8YPAHFrkLTBPVYnxZTRJ9LfKSYnr5YNm4w2P2t9xaEG6O8JKQtFvMoIyQ==",
       "requires": {
         "youtube-player": "^5.5.2"
       }
@@ -3428,9 +3428,9 @@
       }
     },
     "@guardian/types": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-8.1.0.tgz",
-      "integrity": "sha512-6qpQxHW+DwvJqc4aPrWIN0GoErTN8R+WlQ4Cq/NJKiIWROvgOytC4P/2hiLNxoEpla93cT56293Fd1cYRUhnPA=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/types/-/types-9.0.1.tgz",
+      "integrity": "sha512-JTQe4giki1QYqE5bRkCbYWvelF2DtaQVlGmIbVwO8XWNc62TOQcBOUmqFb2EWpszWqkzBLEBB4rKKArgBZHTeA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@creditkarma/thrift-server-core": "^0.16.1",
     "@guardian/apps-rendering-api-models": "^0.11.2",
-    "@guardian/atoms-rendering": "^19.0.0",
+    "@guardian/atoms-rendering": "^21.0.0",
     "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.1.1",
     "@guardian/content-atom-model": "^3.2.4",
@@ -38,7 +38,7 @@
     "@guardian/libs": "^3.3.0",
     "@guardian/node-riffraff-artifact": "^0.2.2",
     "@guardian/renditions": "^0.2.0",
-    "@guardian/types": "^8.1.0",
+    "@guardian/types": "^9.0.1",
     "@types/jsdom": "^16.2.13",
     "@types/uuid": "^8.3.1",
     "@types/webpack-node-externals": "^2.5.2",

--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -2,16 +2,16 @@ import { getAdPlaceholderInserter } from './ads';
 import { ReactNode } from 'react';
 import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
-import { Pillar, Format, Design, Display } from '@guardian/types';
+import {ArticlePillar, ArticleFormat, ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { compose } from 'lib';
 import { ElementKind, BodyElement } from 'bodyElement';
 
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);
-const mockFormat: Format = {
-	theme: Pillar.News,
-	design: Design.Article,
-	display: Display.Standard,
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
 };
 
 const textElement = (nodes: string[]): BodyElement => ({

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -155,7 +155,12 @@ function insertEpic(): void {
 	}
 }
 
-declare type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
+declare type ArticlePillar =
+	| 'news'
+	| 'opinion'
+	| 'sport'
+	| 'culture'
+	| 'lifestyle';
 
 function isPillarString(pillar: string): boolean {
 	return ['news', 'opinion', 'sport', 'culture', 'lifestyle'].includes(
@@ -169,7 +174,7 @@ function renderComments(): void {
 	const isClosedForComments = !!commentContainer?.getAttribute('pillar');
 
 	if (pillarString && isPillarString(pillarString) && shortUrl) {
-		const pillar = pillarString as Pillar;
+		const pillar = pillarString as ArticlePillar;
 		const user = {
 			userId: 'abc123',
 			displayName: 'Jane Smith',

--- a/apps-rendering/src/client/atoms.tsx
+++ b/apps-rendering/src/client/atoms.tsx
@@ -6,14 +6,10 @@ import {
 	KnowledgeQuizAtom,
 	PersonalityQuizAtom,
 } from '@guardian/atoms-rendering';
-import type { Result, Theme } from '@guardian/types';
-import {
-	fromUnsafe,
-	Pillar,
-	resultAndThen,
-	ResultKind,
-	Special,
-} from '@guardian/types';
+import type { ArticleTheme } from '@guardian/libs';
+import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { Result } from '@guardian/types';
+import { fromUnsafe, resultAndThen, ResultKind } from '@guardian/types';
 import { ElementKind } from 'bodyElementKind';
 import { pipe, resultFromNullable } from 'lib';
 import type { Parser } from 'parser';
@@ -33,27 +29,27 @@ import ReactDOM from 'react-dom';
 
 interface QuizProps {
 	quiz: QuizAtom;
-	theme: Theme;
+	theme: ArticleTheme;
 }
 
 // ----- Functions ----- //
 
-const makeQuizProps = (quiz: QuizAtom, theme: Theme): QuizProps => ({
+const makeQuizProps = (quiz: QuizAtom, theme: ArticleTheme): QuizProps => ({
 	quiz,
 	theme,
 });
 
-const themeParser: Parser<Theme> = pipe(
+const themeParser: Parser<ArticleTheme> = pipe(
 	numberParser,
 	andThen((num) => {
 		switch (num) {
-			case Pillar.News:
-			case Pillar.Opinion:
-			case Pillar.Sport:
-			case Pillar.Culture:
-			case Pillar.Lifestyle:
-			case Special.SpecialReport:
-			case Special.Labs:
+			case ArticlePillar.News:
+			case ArticlePillar.Opinion:
+			case ArticlePillar.Sport:
+			case ArticlePillar.Culture:
+			case ArticlePillar.Lifestyle:
+			case ArticleSpecial.SpecialReport:
+			case ArticleSpecial.Labs:
 				return succeed(num);
 			default:
 				return fail(

--- a/apps-rendering/src/components/ClickToView.tsx
+++ b/apps-rendering/src/components/ClickToView.tsx
@@ -1,53 +1,54 @@
 import { css } from '@emotion/react';
+import { ArticleElementRole } from '@guardian/libs';
 import { Button } from '@guardian/src-button';
 import { remSpace } from '@guardian/src-foundations';
 import { background, border } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { SvgCheckmark } from '@guardian/src-icons';
 import type { Option } from '@guardian/types';
-import { OptionKind, Role, withDefault } from '@guardian/types';
+import { OptionKind, withDefault } from '@guardian/types';
 import { fold } from 'lib';
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
 export type ClickToViewProps = {
 	children: React.ReactNode;
-	role: Option<Role>;
+	role: Option<ArticleElementRole>;
 	onAccept: Option<() => void>;
 	source: Option<string>;
 	sourceDomain: Option<string>;
 };
 
-const roleTextSize = (role: Role): string => {
+const roleTextSize = (role: ArticleElementRole): string => {
 	switch (role) {
-		case Role.Standard:
-		case Role.Immersive:
-		case Role.Inline:
-		case Role.Showcase: {
+		case ArticleElementRole.Standard:
+		case ArticleElementRole.Immersive:
+		case ArticleElementRole.Inline:
+		case ArticleElementRole.Showcase: {
 			return textSans.medium({ lineHeight: 'regular' });
 		}
-		case Role.HalfWidth:
-		case Role.Supporting:
-		case Role.Thumbnail: {
+		case ArticleElementRole.HalfWidth:
+		case ArticleElementRole.Supporting:
+		case ArticleElementRole.Thumbnail: {
 			return textSans.small({ lineHeight: 'regular' });
 		}
 	}
 };
 
-const roleHeadlineSize = (role: Role): string => {
+const roleHeadlineSize = (role: ArticleElementRole): string => {
 	switch (role) {
-		case Role.Standard:
-		case Role.Immersive:
-		case Role.Inline:
-		case Role.Showcase: {
+		case ArticleElementRole.Standard:
+		case ArticleElementRole.Immersive:
+		case ArticleElementRole.Inline:
+		case ArticleElementRole.Showcase: {
 			return textSans.large({
 				fontWeight: 'bold',
 				lineHeight: 'regular',
 			});
 		}
-		case Role.HalfWidth:
-		case Role.Supporting:
-		case Role.Thumbnail: {
+		case ArticleElementRole.HalfWidth:
+		case ArticleElementRole.Supporting:
+		case ArticleElementRole.Thumbnail: {
 			return textSans.medium({
 				fontWeight: 'bold',
 				lineHeight: 'regular',
@@ -56,34 +57,36 @@ const roleHeadlineSize = (role: Role): string => {
 	}
 };
 
-const roleButtonSize = (role: Role): 'default' | 'small' | 'xsmall' => {
+const roleButtonSize = (
+	role: ArticleElementRole,
+): 'default' | 'small' | 'xsmall' => {
 	switch (role) {
-		case Role.Standard:
-		case Role.Immersive:
-		case Role.Inline:
-		case Role.Showcase: {
+		case ArticleElementRole.Standard:
+		case ArticleElementRole.Immersive:
+		case ArticleElementRole.Inline:
+		case ArticleElementRole.Showcase: {
 			return 'default';
 		}
-		case Role.HalfWidth:
-		case Role.Supporting:
+		case ArticleElementRole.HalfWidth:
+		case ArticleElementRole.Supporting:
 			return 'small';
-		case Role.Thumbnail: {
+		case ArticleElementRole.Thumbnail: {
 			return 'xsmall';
 		}
 	}
 };
 
-const roleButtonText = (role: Role): string => {
+const roleButtonText = (role: ArticleElementRole): string => {
 	switch (role) {
-		case Role.Standard:
-		case Role.Immersive:
-		case Role.Inline:
-		case Role.Showcase:
-		case Role.HalfWidth:
-		case Role.Supporting: {
+		case ArticleElementRole.Standard:
+		case ArticleElementRole.Immersive:
+		case ArticleElementRole.Inline:
+		case ArticleElementRole.Showcase:
+		case ArticleElementRole.HalfWidth:
+		case ArticleElementRole.Supporting: {
 			return 'Allow and continue';
 		}
-		case Role.Thumbnail: {
+		case ArticleElementRole.Thumbnail: {
 			return 'Allow';
 		}
 	}
@@ -105,7 +108,7 @@ export const ClickToView: FC<ClickToViewProps> = ({
 		}
 	};
 
-	const roleWithDefault = withDefault(Role.Inline)(role);
+	const roleWithDefault = withDefault(ArticleElementRole.Inline)(role);
 
 	const textSize = roleTextSize(roleWithDefault);
 

--- a/apps-rendering/src/components/anchor.stories.tsx
+++ b/apps-rendering/src/components/anchor.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from '../storybookHelpers';
@@ -18,9 +18,9 @@ const copy = (): string =>
 const Default: FC = () => (
 	<Anchor
 		format={{
-			design: Design.Article,
-			display: Display.Standard,
-			theme: selectPillar(Pillar.News),
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 		href={link()}
 	>

--- a/apps-rendering/src/components/anchor.tsx
+++ b/apps-rendering/src/components/anchor.tsx
@@ -2,10 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { palette } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, Special } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -15,7 +15,7 @@ import { getThemeStyles } from 'themeStyles';
 interface Props {
 	href: string;
 	children?: ReactNode;
-	format: Format;
+	format: ArticleFormat;
 	className?: SerializedStyles;
 	isEditions?: boolean;
 }
@@ -29,9 +29,9 @@ const styles = (isEditions: boolean): SerializedStyles => css`
     `}
 `;
 
-const colour = (format: Format): SerializedStyles => {
+const colour = (format: ArticleFormat): SerializedStyles => {
 	const { link, inverted } = getThemeStyles(format.theme);
-	if (format.theme === Special.Labs) {
+	if (format.theme === ArticleSpecial.Labs) {
 		return css`
 			color: ${palette.labs[300]};
 			border-bottom: 0.0625rem solid ${neutral[86]};
@@ -42,7 +42,7 @@ const colour = (format: Format): SerializedStyles => {
 		`;
 	}
 	switch (format.design) {
-		case Design.Media:
+		case ArticleDesign.Media:
 			return css`
 				color: ${inverted};
 				border-bottom: 0.0625rem solid ${neutral[20]};

--- a/apps-rendering/src/components/atoms/quiz.tsx
+++ b/apps-rendering/src/components/atoms/quiz.tsx
@@ -4,7 +4,7 @@ import {
 	KnowledgeQuizAtom,
 	PersonalityQuizAtom,
 } from '@guardian/atoms-rendering';
-import type { Format } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import { ElementKind } from 'bodyElementKind';
 import type { QuizAtom } from 'quizAtom';
 import type { FC } from 'react';
@@ -12,7 +12,7 @@ import type { FC } from 'react';
 // ----- Component ----- //
 
 interface Props {
-	format: Format;
+	format: ArticleFormat;
 	element: QuizAtom;
 }
 

--- a/apps-rendering/src/components/avatar.tsx
+++ b/apps-rendering/src/components/avatar.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
-import type { Format } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import Img from 'components/img';
 import { isSingleContributor } from 'contributor';
@@ -18,7 +18,7 @@ const dimensions = '4rem';
 
 // ----- Component ----- //
 
-interface Props extends Format {
+interface Props extends ArticleFormat {
 	contributors: Contributor[];
 }
 
@@ -32,7 +32,7 @@ const styles = (background: string): SerializedStyles => css`
 	margin-top: ${remSpace[1]};
 `;
 
-const getStyles = ({ theme }: Format): SerializedStyles => {
+const getStyles = ({ theme }: ArticleFormat): SerializedStyles => {
 	const colours = getThemeStyles(theme);
 	return styles(colours.inverted);
 };

--- a/apps-rendering/src/components/blockquote.tsx
+++ b/apps-rendering/src/components/blockquote.tsx
@@ -2,10 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { SvgQuote } from '@guardian/src-icons';
-import type { Format } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -14,10 +14,10 @@ import { getThemeStyles } from 'themeStyles';
 
 interface Props {
 	children?: ReactNode;
-	format: Format;
+	format: ArticleFormat;
 }
 
-const styles = (format: Format): SerializedStyles => {
+const styles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker } = getThemeStyles(format.theme);
 	return css`
 		font-style: italic;

--- a/apps-rendering/src/components/bullet.stories.tsx
+++ b/apps-rendering/src/components/bullet.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -11,9 +11,9 @@ import Bullet from './bullet';
 const Default: FC = () => (
 	<Bullet
 		format={{
-			design: Design.Article,
-			display: Display.Standard,
-			theme: selectPillar(Pillar.News),
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 		text="• Lorem ipsum"
 	/>

--- a/apps-rendering/src/components/bullet.tsx
+++ b/apps-rendering/src/components/bullet.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Format } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -10,11 +10,11 @@ import { getThemeStyles } from 'themeStyles';
 // ----- Component ----- //
 
 interface Props {
-	format: Format;
+	format: ArticleFormat;
 	text: string;
 }
 
-const styles = (format: Format): SerializedStyles => {
+const styles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(format.theme);
 
 	return css`

--- a/apps-rendering/src/components/byline.stories.tsx
+++ b/apps-rendering/src/components/byline.stories.tsx
@@ -1,6 +1,12 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar, Special, toOption } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
@@ -32,27 +38,27 @@ const mockBylineHtml = (): Option<DocumentFragment> =>
 
 const Default: FC = () => (
 	<Byline
-		theme={selectPillar(Pillar.News)}
-		design={Design.Article}
-		display={Display.Standard}
+		theme={selectPillar(ArticlePillar.News)}
+		design={ArticleDesign.Standard}
+		display={ArticleDisplay.Standard}
 		bylineHtml={mockBylineHtml()}
 	/>
 );
 
 const Comment: FC = () => (
 	<Byline
-		theme={selectPillar(Pillar.Opinion)}
-		design={Design.Comment}
-		display={Display.Standard}
+		theme={selectPillar(ArticlePillar.Opinion)}
+		design={ArticleDesign.Comment}
+		display={ArticleDisplay.Standard}
 		bylineHtml={mockBylineHtml()}
 	/>
 );
 
 const Labs: FC = () => (
 	<Byline
-		theme={Special.Labs}
-		design={Design.Article}
-		display={Display.Standard}
+		theme={ArticleSpecial.Labs}
+		design={ArticleDesign.Standard}
+		display={ArticleDisplay.Standard}
 		bylineHtml={mockBylineHtml()}
 	/>
 );

--- a/apps-rendering/src/components/byline.tsx
+++ b/apps-rendering/src/components/byline.tsx
@@ -2,11 +2,13 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { neutral, palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { Design, map, Special, withDefault } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactElement, ReactNode } from 'react';
 import { getHref } from 'renderer';
@@ -15,7 +17,7 @@ import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
-interface Props extends Format {
+interface Props extends ArticleFormat {
 	bylineHtml: Option<DocumentFragment>;
 }
 
@@ -112,38 +114,38 @@ const labsAnchorStyles = css`
     `}
 `;
 
-const getStyles = (format: Format): SerializedStyles => {
+const getStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, link, inverted } = getThemeStyles(format.theme);
 
-	if (format.theme === Special.Labs) {
+	if (format.theme === ArticleSpecial.Labs) {
 		return labsStyles;
 	}
 
 	switch (format.design) {
-		case Design.LiveBlog:
-		case Design.DeadBlog:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
 			return liveblogStyles(link, inverted);
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return commentStyles(kicker);
 		default:
 			return styles(kicker);
 	}
 };
 
-const getAnchorStyles = (format: Format): SerializedStyles => {
+const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted, link } = getThemeStyles(format.theme);
-	if (format.theme === Special.Labs) {
+	if (format.theme === ArticleSpecial.Labs) {
 		return labsAnchorStyles;
 	}
 	switch (format.design) {
-		case Design.LiveBlog:
-		case Design.DeadBlog:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
 			return liveblogAnchorStyles(link, inverted);
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return commentAnchorStyles(kicker, inverted);
 
 		default:
@@ -151,7 +153,7 @@ const getAnchorStyles = (format: Format): SerializedStyles => {
 	}
 };
 
-const toReact = (format: Format) => {
+const toReact = (format: ArticleFormat) => {
 	return function getReactNode(node: Node, index: number): ReactNode {
 		switch (node.nodeName) {
 			case 'A':
@@ -172,7 +174,10 @@ const toReact = (format: Format) => {
 	};
 };
 
-const renderText = (format: Format, byline: DocumentFragment): ReactNode =>
+const renderText = (
+	format: ArticleFormat,
+	byline: DocumentFragment,
+): ReactNode =>
 	Array.from(byline.childNodes).map((node, i) => toReact(format)(node, i));
 
 const Byline: FC<Props> = ({ bylineHtml, ...format }) =>

--- a/apps-rendering/src/components/calloutForm.tsx
+++ b/apps-rendering/src/components/calloutForm.tsx
@@ -2,13 +2,13 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Campaign } from '@guardian/apps-rendering-api-models/campaign';
 import type { FormField } from '@guardian/apps-rendering-api-models/formField';
+import type { ArticleFormat } from '@guardian/libs';
 import { Button } from '@guardian/src-button';
 import { neutral, remSpace, text } from '@guardian/src-foundations';
 import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgMinus, SvgPlus } from '@guardian/src-icons';
 import { TextArea } from '@guardian/src-text-area';
 import { TextInput } from '@guardian/src-text-input';
-import type { Format } from '@guardian/types';
 import FileInput from 'components/FileInput';
 import RadioInput from 'components/RadioInput';
 import type { FC, ReactElement } from 'react';
@@ -18,7 +18,7 @@ import { getThemeStyles } from 'themeStyles';
 
 export interface CalloutProps {
 	campaign: Campaign;
-	format: Format;
+	format: ArticleFormat;
 	description: DocumentFragment;
 }
 

--- a/apps-rendering/src/components/commentCount.stories.tsx
+++ b/apps-rendering/src/components/commentCount.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar, some } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { some } from '@guardian/types';
 import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -11,9 +12,9 @@ import CommentCount from './commentCount';
 const Default: FC = () => (
 	<CommentCount
 		count={some(number('Count', 1234, { min: 0 }))}
-		theme={selectPillar(Pillar.News)}
-		design={Design.Article}
-		display={Display.Standard}
+		theme={selectPillar(ArticlePillar.News)}
+		design={ArticleDesign.Standard}
+		display={ArticleDisplay.Standard}
 		commentable={boolean('Commentable', true)}
 	/>
 );

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -2,12 +2,14 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { border, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { Format, Option } from '@guardian/types';
-import { Design, map, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
@@ -15,7 +17,7 @@ import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
-interface Props extends Format {
+interface Props extends ArticleFormat {
 	count: Option<number>;
 	commentable: boolean;
 }
@@ -43,10 +45,13 @@ const bubbleStyles = (colour: string): SerializedStyles => css`
 	fill: ${colour};
 `;
 
-const getStyles = ({ theme, design }: Format): SerializedStyles => {
+const getStyles = ({ theme, design }: ArticleFormat): SerializedStyles => {
 	const colours = getThemeStyles(theme);
 
-	if (design === Design.LiveBlog || design === Design.DeadBlog) {
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return css`
 			${styles(
 				neutral[93],
@@ -65,10 +70,16 @@ const getStyles = ({ theme, design }: Format): SerializedStyles => {
 	return styles(colours.kicker, border.secondary, neutral[20]);
 };
 
-const getBubbleStyles = ({ theme, design }: Format): SerializedStyles => {
+const getBubbleStyles = ({
+	theme,
+	design,
+}: ArticleFormat): SerializedStyles => {
 	const colours = getThemeStyles(theme);
 
-	if (design === Design.LiveBlog || design === Design.DeadBlog) {
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return css`
 			${bubbleStyles(neutral[93])}
 			${from.desktop} {

--- a/apps-rendering/src/components/credit.tsx
+++ b/apps-rendering/src/components/credit.tsx
@@ -1,10 +1,12 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { Format, Option } from '@guardian/types';
-import { Design, map, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
@@ -12,7 +14,7 @@ import type { FC, ReactElement } from 'react';
 
 interface Props {
 	credit: Option<string>;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const mediaStyles = css`
@@ -29,7 +31,7 @@ const Credit: FC<Props> = ({ format, credit }) =>
 		credit,
 		map((cred) => {
 			switch (format.design) {
-				case Design.Media:
+				case ArticleDesign.Media:
 					return <p css={mediaStyles}>{cred}</p>;
 				default:
 					return <span css={defaultStyles}> {cred}</span>;

--- a/apps-rendering/src/components/cutout.tsx
+++ b/apps-rendering/src/components/cutout.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Format } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import { map, withDefault } from '@guardian/types';
 import Img from 'components/img';
 import type { Contributor } from 'contributor';
@@ -35,7 +35,7 @@ const imageStyles = css`
 interface Props {
 	contributors: Contributor[];
 	className: SerializedStyles;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const Cutout: FC<Props> = ({ contributors, className, format }) => {

--- a/apps-rendering/src/components/dateline.stories.tsx
+++ b/apps-rendering/src/components/dateline.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar, some } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { some } from '@guardian/types';
 import { date, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -11,9 +12,9 @@ import Dateline from './dateline';
 const Default: FC = () => (
 	<Dateline
 		format={{
-			design: Design.Article,
-			display: Display.Standard,
-			theme: selectPillar(Pillar.Opinion),
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.Opinion),
 		}}
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),

--- a/apps-rendering/src/components/dateline.tsx
+++ b/apps-rendering/src/components/dateline.tsx
@@ -2,11 +2,13 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/src-foundations/mq';
 import { neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import { Design, map, Pillar, withDefault } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { formatDate } from 'date';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
@@ -16,7 +18,7 @@ import { darkModeCss as darkMode } from 'styles';
 
 interface Props {
 	date: Option<Date>;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const darkStyles = darkMode`
@@ -53,13 +55,13 @@ const liveblogDatelineStyles = css`
 	`}
 `;
 
-const getDatelineStyles = (format: Format): SerializedStyles => {
+const getDatelineStyles = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return liveblogDatelineStyles;
 		default:
 			switch (format.theme) {
-				case Pillar.Opinion:
+				case ArticlePillar.Opinion:
 					return commentDatelineStyles;
 				default:
 					return styles;

--- a/apps-rendering/src/components/editions/article/article.stories.tsx
+++ b/apps-rendering/src/components/editions/article/article.stories.tsx
@@ -1,8 +1,12 @@
 // ----- Imports ----- //
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { ArticleElementRole } from '@guardian/libs';
+import {
+	ArticleDisplay,
+	ArticleElementRole,
+	ArticlePillar,
+} from '@guardian/libs';
 import { breakpoints } from '@guardian/src-foundations';
-import { Display, none, Pillar, some } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import type { Contributor } from 'contributor';
 import {
@@ -57,11 +61,11 @@ const hasContributor = (): { contributors: Contributor[] } => {
 	};
 };
 
-const isImmersive = (): { display: Display } => {
+const isImmersive = (): { display: ArticleDisplay } => {
 	return {
 		display: boolean('Immersive', false)
-			? Display.Immersive
-			: Display.Standard,
+			? ArticleDisplay.Immersive
+			: ArticleDisplay.Standard,
 	};
 };
 
@@ -89,7 +93,7 @@ const Default = (): ReactElement => (
 			...article,
 			...isImmersive(),
 			...hasShareIcon(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -102,7 +106,7 @@ const Analysis = (): ReactElement => (
 			...hasShareIcon(),
 
 			tags: [getTag('tone/analysis', 'View from the Guardian ')],
-			theme: selectPillar(Pillar.Lifestyle),
+			theme: selectPillar(ArticlePillar.Lifestyle),
 		}}
 	/>
 );
@@ -115,7 +119,7 @@ const Editorial = (): ReactElement => (
 			...isImmersive(),
 			...hasShareIcon(),
 
-			theme: selectPillar(Pillar.Opinion),
+			theme: selectPillar(ArticlePillar.Opinion),
 		}}
 	/>
 );
@@ -127,7 +131,7 @@ const Feature = (): ReactElement => (
 			...isImmersive(),
 			...hasShareIcon(),
 
-			theme: selectPillar(Pillar.Sport),
+			theme: selectPillar(ArticlePillar.Sport),
 		}}
 	/>
 );
@@ -138,7 +142,7 @@ const Review = (): ReactElement => (
 			...review,
 			...hasShareIcon(),
 
-			theme: selectPillar(Pillar.Culture),
+			theme: selectPillar(ArticlePillar.Culture),
 		}}
 	/>
 );
@@ -149,8 +153,8 @@ const Showcase = (): ReactElement => (
 			...article,
 			...hasShareIcon(),
 
-			display: Display.Showcase,
-			theme: selectPillar(Pillar.News),
+			display: ArticleDisplay.Showcase,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -162,7 +166,7 @@ const Interview = (): ReactElement => (
 			...hasShareIcon(),
 
 			...isImmersive(),
-			theme: selectPillar(Pillar.Sport),
+			theme: selectPillar(ArticlePillar.Sport),
 		}}
 	/>
 );
@@ -174,7 +178,7 @@ const Comment = (): ReactElement => (
 			...hasShareIcon(),
 			...hasContributor(),
 			...isImmersive(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -185,7 +189,7 @@ const Letter = (): ReactElement => (
 			...letter,
 			...hasShareIcon(),
 			tags: [getTag('tone/letters', 'Letters ')],
-			theme: selectPillar(Pillar.Opinion),
+			theme: selectPillar(ArticlePillar.Opinion),
 		}}
 	/>
 );
@@ -200,7 +204,7 @@ const Correction = (): ReactElement => (
 					'Corrections and Clarifications ',
 				),
 			],
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -211,7 +215,7 @@ const MatchReport = (): ReactElement => (
 			...matchReport,
 			...hasShareIcon(),
 			tags: [getTag('tone/sport', 'Sport ')],
-			theme: selectPillar(Pillar.Sport),
+			theme: selectPillar(ArticlePillar.Sport),
 		}}
 	/>
 );
@@ -231,7 +235,7 @@ const Gallery = (): ReactElement => (
 		item={{
 			...media,
 			...hasShareIcon(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/editions/article/index.tsx
+++ b/apps-rendering/src/components/editions/article/index.tsx
@@ -2,11 +2,12 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { background, border, neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, Display, partition } from '@guardian/types';
+import { partition } from '@guardian/types';
 import type { Item } from 'item';
 import { isPicture } from 'item';
 import type { FC } from 'react';
@@ -35,9 +36,11 @@ const mainStyles = css`
 	height: 100%;
 `;
 
-const articleWrapperStyles = (item: Format): SerializedStyles => css`
+const articleWrapperStyles = (item: ArticleFormat): SerializedStyles => css`
 	min-height: 100%;
-	background-color: ${item.design === Design.Media ? neutral[7] : 'inherit'};
+	background-color: ${item.design === ArticleDesign.Media
+		? neutral[7]
+		: 'inherit'};
 `;
 
 const articleStyles = css`
@@ -112,7 +115,7 @@ export const galleryWrapperStyles = css`
 	}
 `;
 
-const headerBackgroundStyles = (format: Format): SerializedStyles => css`
+const headerBackgroundStyles = (format: ArticleFormat): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(format)};
 `;
 
@@ -120,7 +123,7 @@ const itemStyles = (item: Item): SerializedStyles => {
 	const { kicker } = getThemeStyles(item.theme);
 
 	switch (item.display) {
-		case Display.Immersive:
+		case ArticleDisplay.Immersive:
 			return css`
 				> p:first-of-type:first-letter,
 				> hr + p:first-letter {
@@ -141,11 +144,11 @@ const itemStyles = (item: Item): SerializedStyles => {
 	}
 };
 
-const getSectionStyles = (item: Format): SerializedStyles[] => {
+const getSectionStyles = (item: ArticleFormat): SerializedStyles[] => {
 	if (
-		item.design === Design.Interview ||
-		item.design === Design.Media ||
-		item.display === Display.Immersive
+		item.design === ArticleDesign.Interview ||
+		item.design === ArticleDesign.Media ||
+		item.display === ArticleDisplay.Immersive
 	) {
 		return [];
 	}
@@ -154,20 +157,20 @@ const getSectionStyles = (item: Format): SerializedStyles[] => {
 
 const Article: FC<Props> = ({ item }) => {
 	if (
-		item.design === Design.Analysis ||
-		item.design === Design.Article ||
-		item.design === Design.Comment ||
-		item.design === Design.Review ||
-		item.design === Design.Interview ||
-		item.design === Design.Feature ||
-		item.design === Design.Media ||
-		item.design === Design.Editorial ||
-		item.design === Design.Letter ||
-		item.design === Design.Quiz ||
-		item.design === Design.Recipe ||
-		item.design === Design.MatchReport ||
-		item.design === Design.Obituary ||
-		item.design === Design.Correction
+		item.design === ArticleDesign.Analysis ||
+		item.design === ArticleDesign.Standard ||
+		item.design === ArticleDesign.Comment ||
+		item.design === ArticleDesign.Review ||
+		item.design === ArticleDesign.Interview ||
+		item.design === ArticleDesign.Feature ||
+		item.design === ArticleDesign.Media ||
+		item.design === ArticleDesign.Editorial ||
+		item.design === ArticleDesign.Letter ||
+		item.design === ArticleDesign.Quiz ||
+		item.design === ArticleDesign.Recipe ||
+		item.design === ArticleDesign.MatchReport ||
+		item.design === ArticleDesign.Obituary ||
+		item.design === ArticleDesign.Correction
 	) {
 		return (
 			<main css={mainStyles}>
@@ -182,7 +185,7 @@ const Article: FC<Props> = ({ item }) => {
 							bodyWrapperStyles,
 							articleStyles,
 							isPicture(item.tags) && extendedBodyStyles,
-							item.design === Design.Media
+							item.design === ArticleDesign.Media
 								? galleryWrapperStyles
 								: null,
 						]}

--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -6,7 +6,7 @@ import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import { map, none, some, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { convertFormatToArticleFormat, pipe } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 
 // ----- Component ----- //
@@ -36,7 +36,7 @@ const Avatar: FC<Props> = ({ item }) => {
 				image={image}
 				sizes={sizes}
 				className={some(imgStyles)}
-				format={convertFormatToArticleFormat(format)}
+				format={format}
 				supportsDarkMode={false}
 				lightbox={none}
 			/>

--- a/apps-rendering/src/components/editions/byline/byline.stories.tsx
+++ b/apps-rendering/src/components/editions/byline/byline.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Display, none, Pillar, some, toOption } from '@guardian/types';
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { none, some, toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
@@ -63,11 +64,11 @@ const mockBylineHtml = (): Option<DocumentFragment> =>
 		toOption,
 	);
 
-const isImmersive = (): { display: Display } => {
+const isImmersive = (): { display: ArticleDisplay } => {
 	return {
 		display: boolean('Immersive', false)
-			? Display.Immersive
-			: Display.Standard,
+			? ArticleDisplay.Immersive
+			: ArticleDisplay.Standard,
 	};
 };
 
@@ -77,9 +78,9 @@ const Default = (): ReactElement => (
 	<Byline
 		item={{
 			...article,
-			display: Display.Standard,
+			display: ArticleDisplay.Standard,
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -90,7 +91,7 @@ const Analysis = (): ReactElement => (
 			...analysis,
 			...isImmersive(),
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -101,7 +102,7 @@ const Feature = (): ReactElement => (
 			...feature,
 			...isImmersive(),
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -111,7 +112,7 @@ const Review = (): ReactElement => (
 		item={{
 			...review,
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -120,9 +121,9 @@ const Showcase = (): ReactElement => (
 	<Byline
 		item={{
 			...article,
-			display: Display.Showcase,
+			display: ArticleDisplay.Showcase,
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -133,7 +134,7 @@ const Interview = (): ReactElement => (
 			...interview,
 			...isImmersive(),
 			bylineHtml: mockBylineHtml(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -149,7 +150,7 @@ const Comment = (): ReactElement => (
 				...comment,
 				...isImmersive(),
 				bylineHtml: mockBylineHtml(),
-				theme: selectPillar(Pillar.News),
+				theme: selectPillar(ArticlePillar.News),
 				contributors: contributors,
 			}}
 		/>

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -1,6 +1,8 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import type {
 	FontStyle,
@@ -10,8 +12,7 @@ import type {
 import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { body, headline } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
-import { Design, Display, OptionKind } from '@guardian/types';
+import { OptionKind } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { index, maybeRender } from 'lib';
@@ -134,11 +135,14 @@ const standardTextStyles = (
 	${body.medium({ fontStyle, fontWeight, lineHeight })}
 `;
 
-const bylinePrimaryStyles = (format: Format): SerializedStyles => {
+const bylinePrimaryStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 	const color = ignoreTextColour(format) ? neutral[100] : kickerColor;
 
-	if (format.design === Design.Analysis || format.design === Design.Comment) {
+	if (
+		format.design === ArticleDesign.Analysis ||
+		format.design === ArticleDesign.Comment
+	) {
 		return css`
 			color: ${color};
 			${largeTextStyles('normal', 'bold', 'regular')}
@@ -151,10 +155,13 @@ const bylinePrimaryStyles = (format: Format): SerializedStyles => {
 	`;
 };
 
-const bylineSecondaryStyles = (format: Format): SerializedStyles => {
+const bylineSecondaryStyles = (format: ArticleFormat): SerializedStyles => {
 	const color = ignoreTextColour(format) ? neutral[100] : neutral[7];
 
-	if (format.design === Design.Analysis || format.design === Design.Comment) {
+	if (
+		format.design === ArticleDesign.Analysis ||
+		format.design === ArticleDesign.Comment
+	) {
 		return css`
 			${largeTextStyles('italic', 'light')};
 			color: ${color};
@@ -167,24 +174,24 @@ const bylineSecondaryStyles = (format: Format): SerializedStyles => {
 };
 
 const getBylineStyles = (
-	format: Format,
+	format: ArticleFormat,
 	iconColor: string,
 	hasImage: boolean,
 ): SerializedStyles => {
-	// Display.Immersive needs to come before Design.Interview
-	if (format.display === Display.Immersive) {
+	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
+	if (format.display === ArticleDisplay.Immersive) {
 		return css(styles(iconColor), immersiveStyles);
 	}
-	if (format.design === Design.Interview) {
+	if (format.design === ArticleDesign.Interview) {
 		return css(styles(iconColor), interviewStyles);
 	}
-	if (format.design === Design.Comment) {
+	if (format.design === ArticleDesign.Comment) {
 		return css(styles(iconColor), commentStyles(hasImage));
 	}
-	if (format.display === Display.Showcase) {
+	if (format.display === ArticleDisplay.Showcase) {
 		return css(styles(iconColor), showcaseStyles);
 	}
-	if (format.design === Design.Media) {
+	if (format.design === ArticleDesign.Media) {
 		return css(styles(iconColor), galleryStyles);
 	}
 	return styles(iconColor);
@@ -196,7 +203,10 @@ interface Props {
 	item: Item;
 }
 
-const renderText = (byline: DocumentFragment, format: Format): ReactNode =>
+const renderText = (
+	byline: DocumentFragment,
+	format: ArticleFormat,
+): ReactNode =>
 	Array.from(byline.childNodes).map((node) => {
 		switch (node.nodeName) {
 			case 'A':
@@ -215,17 +225,23 @@ const renderText = (byline: DocumentFragment, format: Format): ReactNode =>
 		}
 	});
 
-const hasShareIcon = (format: Format): boolean =>
-	!(format.design === Design.Analysis || format.design === Design.Comment);
+const hasShareIcon = (format: ArticleFormat): boolean =>
+	!(
+		format.design === ArticleDesign.Analysis ||
+		format.design === ArticleDesign.Comment
+	);
 
 const hasAvatar = (item: Item): boolean => {
-	return item.design === Design.Comment && item.contributors.length > 0;
+	return (
+		item.design === ArticleDesign.Comment && item.contributors.length > 0
+	);
 };
-const ignoreIconColour = (format: Format): boolean =>
-	format.design === Design.Media;
+const ignoreIconColour = (format: ArticleFormat): boolean =>
+	format.design === ArticleDesign.Media;
 
-const ignoreTextColour = (format: Format): boolean =>
-	format.design === Design.Media || format.display === Display.Immersive;
+const ignoreTextColour = (format: ArticleFormat): boolean =>
+	format.design === ArticleDesign.Media ||
+	format.display === ArticleDisplay.Immersive;
 
 const Byline: FC<Props> = ({ item }) => {
 	const format = getFormat(item);

--- a/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 import imageFixture from 'fixtures/galleryImage';
 import { article } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -15,7 +15,7 @@ const Default = (): ReactElement => (
 		<GalleryImage
 			format={{
 				...article,
-				theme: selectPillar(Pillar.News),
+				theme: selectPillar(ArticlePillar.News),
 			}}
 			image={imageFixture}
 		/>

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -2,13 +2,14 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import Img from '@guardian/common-rendering/src/components/img';
 import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { Format, Option } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, none, OptionKind, some, withDefault } from '@guardian/types';
 import type { Image } from 'bodyElement';
-import { convertFormatToArticleFormat, maybeRender, pipe } from 'lib';
+import { maybeRender, pipe } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 
@@ -16,12 +17,12 @@ const width = '100%';
 
 type Props = {
 	image: Image;
-	format: Format;
+	format: ArticleFormat;
 };
 
 type CaptionProps = {
 	details: CaptionDetails;
-	format: Format;
+	format: ArticleFormat;
 };
 
 type CaptionDetails = {
@@ -173,7 +174,7 @@ const GalleryImage: FC<Props> = ({ image, format }) => {
 				image={image}
 				sizes={sizes}
 				className={none}
-				format={convertFormatToArticleFormat(format)}
+				format={format}
 				supportsDarkMode={false}
 				lightbox={some({
 					className: 'js-launch-slideshow',

--- a/apps-rendering/src/components/editions/header/index.tsx
+++ b/apps-rendering/src/components/editions/header/index.tsx
@@ -2,9 +2,9 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { border, neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { Design, Display } from '@guardian/types';
 import Byline from 'components/editions/byline';
 import HeaderMedia from 'components/editions/headerMedia';
 import Headline from 'components/editions/headline';
@@ -250,24 +250,24 @@ const CorrectionsHeader: FC<HeaderProps> = ({ item }) => (
 );
 
 const renderArticleHeader = (item: Item): ReactElement<HeaderProps> => {
-	// Display.Immersive needs to come before Design.Interview
-	if (item.display === Display.Immersive) {
+	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
+	if (item.display === ArticleDisplay.Immersive) {
 		return <ImmersiveHeader item={item} />;
-	} else if (item.design === Design.Editorial) {
+	} else if (item.design === ArticleDesign.Editorial) {
 		return <StandardHeader item={item} />;
-	} else if (item.design === Design.Letter) {
+	} else if (item.design === ArticleDesign.Letter) {
 		return <LetterHeader item={item} />;
-	} else if (item.design === Design.Interview) {
+	} else if (item.design === ArticleDesign.Interview) {
 		return <InterviewHeader item={item} />;
-	} else if (item.design === Design.Comment) {
+	} else if (item.design === ArticleDesign.Comment) {
 		return <CommentHeader item={item} />;
-	} else if (item.display === Display.Showcase) {
+	} else if (item.display === ArticleDisplay.Showcase) {
 		return <ShowcaseHeader item={item} />;
-	} else if (item.design === Design.Analysis) {
+	} else if (item.design === ArticleDesign.Analysis) {
 		return <AnalysisHeader item={item} />;
-	} else if (item.design === Design.Correction) {
+	} else if (item.design === ArticleDesign.Correction) {
 		return <CorrectionsHeader item={item} />;
-	} else if (item.design === Design.Media) {
+	} else if (item.design === ArticleDesign.Media) {
 		return isPicture(item.tags) ? (
 			<PictureHeader item={item} />
 		) : (

--- a/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/headerMedia.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Display, Pillar } from '@guardian/types';
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { article, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -29,7 +29,7 @@ const Image = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...article,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -38,8 +38,8 @@ const FullScreen = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...article,
-			display: Display.Immersive,
-			theme: selectPillar(Pillar.News),
+			display: ArticleDisplay.Immersive,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -48,7 +48,7 @@ const WithStarRating = (): ReactElement => (
 	<HeaderMedia
 		item={{
 			...review,
-			theme: selectPillar(Pillar.Culture),
+			theme: selectPillar(ArticlePillar.Culture),
 		}}
 	/>
 );
@@ -58,7 +58,7 @@ const Video = (): ReactElement => (
 		item={{
 			...article,
 			mainMedia: video,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -4,10 +4,11 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import Img from '@guardian/common-rendering/src/components/img';
 import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { brandAltBackground } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
-import { Design, Display, none, some } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import HeaderImageCaption, {
 	captionId,
 } from 'components/editions/headerImageCaption';
@@ -16,7 +17,7 @@ import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
 import type { Item } from 'item';
 import { isPicture as checkIfPicture, getFormat } from 'item';
-import { convertFormatToArticleFormat, maybeRender } from 'lib';
+import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import FootballScores from '../footballScores';
@@ -70,7 +71,7 @@ const footballWrapperStyles = (isVideo: boolean): SerializedStyles => css`
 
 const getImageStyle = (
 	{ width, height }: Image,
-	format: Format,
+	format: ArticleFormat,
 	isPicture: boolean,
 ): SerializedStyles => {
 	const aspectRatio = width / height;
@@ -121,21 +122,24 @@ const getImageStyle = (
 	`;
 };
 
-const isFullWidthImage = (format: Format): boolean =>
-	format.display === Display.Immersive ||
-	format.design === Design.Interview ||
-	format.design === Design.Media;
+const isFullWidthImage = (format: ArticleFormat): boolean =>
+	format.display === ArticleDisplay.Immersive ||
+	format.design === ArticleDesign.Interview ||
+	format.design === ArticleDesign.Media;
 
-const getStyles = (format: Format, isPicture: boolean): SerializedStyles => {
+const getStyles = (
+	format: ArticleFormat,
+	isPicture: boolean,
+): SerializedStyles => {
 	return isFullWidthImage(format) && !isPicture ? fullWidthStyles : styles;
 };
 
-const getCaptionStyles = (format: Format): SerializedStyles => {
+const getCaptionStyles = (format: ArticleFormat): SerializedStyles => {
 	return isFullWidthImage(format) ? fullWidthCaptionStyles : captionStyles;
 };
 
 const getImageSizes = (
-	format: Format,
+	format: ArticleFormat,
 	image: Image,
 	isPicture: boolean,
 ): Sizes => {
@@ -192,7 +196,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 					<Img
 						image={image}
 						sizes={getImageSizes(format, image, isPicture)}
-						format={convertFormatToArticleFormat(item)}
+						format={item}
 						className={some(
 							getImageStyle(image, format, isPicture),
 						)}

--- a/apps-rendering/src/components/editions/headline/headline.stories.tsx
+++ b/apps-rendering/src/components/editions/headline/headline.stories.tsx
@@ -1,7 +1,11 @@
 // ----- Imports ----- //
 
-import { ArticleElementRole } from '@guardian/libs';
-import { Display, none, Pillar, some } from '@guardian/types';
+import {
+	ArticleDisplay,
+	ArticleElementRole,
+	ArticlePillar,
+} from '@guardian/libs';
+import { none, some } from '@guardian/types';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import type { Contributor } from 'contributor';
 import {
@@ -51,11 +55,11 @@ const hasContributor = (): { contributors: Contributor[] } => {
 	};
 };
 
-const isImmersive = (): { display: Display } => {
+const isImmersive = (): { display: ArticleDisplay } => {
 	return {
 		display: boolean('Immersive', false)
-			? Display.Immersive
-			: Display.Standard,
+			? ArticleDisplay.Immersive
+			: ArticleDisplay.Standard,
 	};
 };
 
@@ -66,7 +70,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			...isImmersive(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -76,7 +80,7 @@ const Analysis = (): ReactElement => (
 		item={{
 			...analysis,
 			...isImmersive(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -86,7 +90,7 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			...isImmersive(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -95,7 +99,7 @@ const Review = (): ReactElement => (
 	<Headline
 		item={{
 			...review,
-			theme: selectPillar(Pillar.Culture),
+			theme: selectPillar(ArticlePillar.Culture),
 		}}
 	/>
 );
@@ -105,8 +109,8 @@ const Showcase = (): ReactElement => (
 		item={{
 			...review,
 			...isImmersive(),
-			display: Display.Showcase,
-			theme: selectPillar(Pillar.News),
+			display: ArticleDisplay.Showcase,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -116,7 +120,7 @@ const Interview = (): ReactElement => (
 		item={{
 			...interview,
 			...isImmersive(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -127,7 +131,7 @@ const Comment = (): ReactElement => (
 			...comment,
 			...isImmersive(),
 			...hasContributor(),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -136,7 +140,7 @@ const Media = (): ReactElement => (
 	<Headline
 		item={{
 			...media,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -2,6 +2,8 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import type {
 	FontWeight,
@@ -11,8 +13,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { border, neutral } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
-import type { Format } from '@guardian/types';
-import { Design, Display, OptionKind } from '@guardian/types';
+import { OptionKind } from '@guardian/types';
 import { editionsHeadlineTextColour } from 'editorialStyles';
 import { MainMediaKind } from 'headerMedia';
 import type { Item } from 'item';
@@ -30,7 +31,7 @@ import {
 const wide = wideContentWidth + 12;
 const tablet = tabletContentWidth + 12;
 
-// ----- Template Format Specific Styles ----- //
+// ----- Template ArticleFormat Specific Styles ----- //
 
 const analysisStyles = (kickerColor: string): SerializedStyles => css`
 	text-decoration: underline;
@@ -141,7 +142,7 @@ const getFontStyles = (
 	}
 `;
 
-const getSharedStyles = (format: Format): SerializedStyles => css`
+const getSharedStyles = (format: ArticleFormat): SerializedStyles => css`
 	${editionsHeadlineTextColour(format)}
 	box-sizing: border-box;
 	border-top: 1px solid ${border.secondary};
@@ -150,7 +151,7 @@ const getSharedStyles = (format: Format): SerializedStyles => css`
 	margin: 0;
 `;
 
-const getQuoteStyles = (format: Format): SerializedStyles => {
+const getQuoteStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker } = getThemeStyles(format.theme);
 
 	return css`
@@ -174,11 +175,11 @@ const getQuoteStyles = (format: Format): SerializedStyles => {
 const getDecorativeStyles = (item: Item): JSX.Element | string => {
 	const format = getFormat(item);
 
-	if (item.design === Design.Interview) {
+	if (item.design === ArticleDesign.Interview) {
 		return <span css={interviewFontStyles}>{item.headline}</span>;
 	}
 
-	if (item.design === Design.Comment) {
+	if (item.design === ArticleDesign.Comment) {
 		return (
 			<span css={getQuoteStyles(format)}>
 				<SvgQuote />
@@ -190,13 +191,13 @@ const getDecorativeStyles = (item: Item): JSX.Element | string => {
 };
 
 const getHeadlineStyles = (
-	format: Format,
+	format: ArticleFormat,
 	kickerColor: string,
 	hasImage: boolean,
 ): SerializedStyles => {
 	const sharedStyles = getSharedStyles(format);
 
-	if (format.display === Display.Immersive) {
+	if (format.display === ArticleDisplay.Immersive) {
 		return css(
 			sharedStyles,
 			getFontStyles('tight', 'bold'),
@@ -204,8 +205,8 @@ const getHeadlineStyles = (
 		);
 	}
 
-	// this needs to come before Display.Showcase
-	if (format.design === Design.Comment) {
+	// this needs to come before ArticleDisplay.Showcase
+	if (format.design === ArticleDesign.Comment) {
 		return css(
 			sharedStyles,
 			getFontStyles('tight', 'light'),
@@ -213,13 +214,13 @@ const getHeadlineStyles = (
 		);
 	}
 
-	// this needs to come before Display.Showcase
-	if (format.design === Design.Letter) {
+	// this needs to come before ArticleDisplay.Showcase
+	if (format.design === ArticleDesign.Letter) {
 		return css(sharedStyles, getFontStyles('tight', 'light'));
 	}
 
-	// this needs to come before Display.Showcase
-	if (format.design === Design.Interview) {
+	// this needs to come before ArticleDisplay.Showcase
+	if (format.design === ArticleDesign.Interview) {
 		return css(
 			sharedStyles,
 			getFontStyles('tight', 'bold'),
@@ -227,31 +228,32 @@ const getHeadlineStyles = (
 		);
 	}
 
-	if (format.display === Display.Showcase) {
+	if (format.display === ArticleDisplay.Showcase) {
 		return css(sharedStyles, getFontStyles('tight', 'bold'));
 	}
 
 	switch (format.design) {
-		case Design.Review:
+		case ArticleDesign.Review:
 			return css(sharedStyles, getFontStyles('tight', 'bold'));
-		case Design.Analysis:
+		case ArticleDesign.Analysis:
 			return css(
 				sharedStyles,
 				getFontStyles('regular', 'light'),
 				analysisStyles(kickerColor),
 			);
-		case Design.Media:
+		case ArticleDesign.Media:
 			return css(sharedStyles, galleryStyles);
 	}
 
 	return css(sharedStyles, getFontStyles('tight', 'medium'));
 };
 
-const hasSeriesKicker = (format: Format): boolean =>
-	format.display === Display.Immersive || format.design === Design.Interview;
+const hasSeriesKicker = (format: ArticleFormat): boolean =>
+	format.display === ArticleDisplay.Immersive ||
+	format.design === ArticleDesign.Interview;
 
-const isInterviewHeadline = (format: Format): boolean =>
-	format.design === Design.Interview;
+const isInterviewHeadline = (format: ArticleFormat): boolean =>
+	format.design === ArticleDesign.Interview;
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/editions/pullquote/index.tsx
+++ b/apps-rendering/src/components/editions/pullquote/index.tsx
@@ -1,9 +1,10 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
-import type { Format, Option } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
@@ -12,7 +13,7 @@ import { getThemeStyles } from 'themeStyles';
 export const pullquoteWidth = '10.875rem';
 const pullquoteTailSize = '1.5rem';
 
-const styles = (format: Format): SerializedStyles => {
+const styles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker } = getThemeStyles(format.theme);
 	return css`
 		width: ${pullquoteWidth};
@@ -59,7 +60,7 @@ const styles = (format: Format): SerializedStyles => {
 	`;
 };
 
-const quoteStyles = (format: Format): SerializedStyles => {
+const quoteStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker } = getThemeStyles(format.theme);
 
 	return css`
@@ -81,7 +82,7 @@ const citeStyles = css`
 
 type Props = {
 	quote: string;
-	format: Format;
+	format: ArticleFormat;
 	attribution: Option<string>;
 };
 

--- a/apps-rendering/src/components/editions/pullquote/pullquote.stories.tsx
+++ b/apps-rendering/src/components/editions/pullquote/pullquote.stories.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import type { Option } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -11,7 +12,7 @@ import Pullquote from './index';
 
 type Props = {
 	quote: string;
-	format: Format;
+	format: ArticleFormat;
 	attribution: Option<string>;
 };
 
@@ -19,9 +20,9 @@ const getInputProps = (): Props => ({
 	quote: 'The anti-slaughter movement is declining due to increased surveillance and repression that criminalises Tibetan identity',
 	attribution: { kind: 0, value: 'Katia Buffetrille, anthropologist' },
 	format: {
-		display: Display.Standard,
-		design: Design.Analysis,
-		theme: selectPillar(Pillar.News),
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Analysis,
+		theme: selectPillar(ArticlePillar.News),
 	},
 });
 

--- a/apps-rendering/src/components/editions/series/index.tsx
+++ b/apps-rendering/src/components/editions/series/index.tsx
@@ -2,10 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
-import { Design, Display } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
@@ -45,8 +45,8 @@ const getStyles = (item: Item): SerializedStyles => {
 	const format = getFormat(item);
 	const { kicker } = getThemeStyles(format.theme);
 	if (
-		item.design === Design.Interview ||
-		item.display === Display.Immersive
+		item.design === ArticleDesign.Interview ||
+		item.display === ArticleDisplay.Immersive
 	) {
 		return css(styles(kicker), interviewStyles(kicker));
 	}

--- a/apps-rendering/src/components/editions/series/series.stories.tsx
+++ b/apps-rendering/src/components/editions/series/series.stories.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { Display, Pillar } from '@guardian/types';
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
 import Series from 'components/series';
 import { article, interview } from 'fixtures/item';
@@ -30,7 +30,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			tags: getTags('lifeandstyle/running', 'Running'),
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -40,7 +40,7 @@ const Interview = (): ReactElement => (
 		item={{
 			...interview,
 			tags: getTags('tone/interview', 'Interview'),
-			theme: selectPillar(Pillar.Culture),
+			theme: selectPillar(ArticlePillar.Culture),
 		}}
 	/>
 );
@@ -50,8 +50,8 @@ const Immersive = (): ReactElement => (
 		item={{
 			...article,
 			tags: getTags('news/series/the-long-read', 'The long read'),
-			display: Display.Immersive,
-			theme: selectPillar(Pillar.News),
+			display: ArticleDisplay.Immersive,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
+++ b/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -33,7 +33,7 @@ const styles = (kickerColor: string): SerializedStyles => {
 // ----- Stories ----- //
 
 const Default = (): ReactElement => {
-	const theme = selectPillar(Pillar.News);
+	const theme = selectPillar(ArticlePillar.News);
 	const { kicker } = getThemeStyles(theme);
 
 	return (

--- a/apps-rendering/src/components/editions/standfirst/index.tsx
+++ b/apps-rendering/src/components/editions/standfirst/index.tsx
@@ -2,6 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { neutral, remSpace, text } from '@guardian/src-foundations';
 import type {
 	FontWeight,
@@ -9,8 +11,6 @@ import type {
 } from '@guardian/src-foundations/dist/types/typography/types';
 import { from } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
-import { Design, Display } from '@guardian/types';
 import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
@@ -19,7 +19,7 @@ import { getThemeStyles } from 'themeStyles';
 import ShareIcon from '../shareIcon';
 import { articleWidthStyles, sidePadding } from '../styles';
 
-// ----- Template Format Specific Styles ----- //
+// ----- Template ArticleFormat Specific Styles ----- //
 
 const interviewStyles = css`
 	${sidePadding}
@@ -87,33 +87,36 @@ const textContainerStyles = css`
 	flex-direction: column;
 `;
 
-const getStyles = (format: Format): SerializedStyles => {
+const getStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
-	// Display.Immersive needs to come before Design.Interview
-	if (format.display === Display.Immersive) {
+	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
+	if (format.display === ArticleDisplay.Immersive) {
 		return css(
 			styles(kickerColor),
 			getFontStyles(neutral[100], 'tight', 'bold'),
 		);
 	}
-	if (format.design === Design.Interview) {
+	if (format.design === ArticleDesign.Interview) {
 		return css(styles(kickerColor), interviewStyles);
 	}
-	if (format.design === Design.Analysis || format.design === Design.Letter) {
+	if (
+		format.design === ArticleDesign.Analysis ||
+		format.design === ArticleDesign.Letter
+	) {
 		return css(
 			styles(kickerColor),
 			getFontStyles(neutral[46], 'tight', 'bold'),
 		);
 	}
 	if (
-		format.design === Design.Comment ||
-		format.display === Display.Showcase
+		format.design === ArticleDesign.Comment ||
+		format.display === ArticleDisplay.Showcase
 	) {
 		return css(styles(kickerColor), getFontStyles(neutral[20], 'tight'));
 	}
 
-	if (format.design === Design.Media) {
+	if (format.design === ArticleDesign.Media) {
 		return css(styles(kickerColor), galleryStyles);
 	}
 	return styles(kickerColor);

--- a/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { neutral } from '@guardian/src-foundations/palette';
-import { Display, Pillar, toOption } from '@guardian/types';
+import { toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
@@ -29,7 +30,7 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			standfirst,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -40,8 +41,8 @@ const Showcase = (): ReactElement => (
 		item={{
 			...article,
 			standfirst,
-			display: Display.Showcase,
-			theme: selectPillar(Pillar.News),
+			display: ArticleDisplay.Showcase,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -52,7 +53,7 @@ const Comment = (): ReactElement => (
 		item={{
 			...comment,
 			standfirst,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -63,7 +64,7 @@ const Analysis = (): ReactElement => (
 		item={{
 			...analysis,
 			standfirst,
-			theme: selectPillar(Pillar.News),
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -79,7 +80,7 @@ const Media = (): ReactElement => (
 			item={{
 				...media,
 				standfirst,
-				theme: selectPillar(Pillar.News),
+				theme: selectPillar(ArticlePillar.News),
 			}}
 		/>
 	</div>

--- a/apps-rendering/src/components/editions/starRating/index.tsx
+++ b/apps-rendering/src/components/editions/starRating/index.tsx
@@ -1,12 +1,12 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	brandAltBackground,
 	brandAltLine,
 } from '@guardian/src-foundations/palette';
 import { SvgStar } from '@guardian/src-icons';
-import { Design } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 
@@ -57,7 +57,7 @@ const containerStyles = css`
 `;
 
 const StarRating: FC<Props> = ({ item }) =>
-	item.design === Design.Review ? (
+	item.design === ArticleDesign.Review ? (
 		<div css={containerStyles}>{stars(item.starRating)}</div>
 	) : null;
 

--- a/apps-rendering/src/components/editions/styles.ts
+++ b/apps-rendering/src/components/editions/styles.ts
@@ -1,10 +1,10 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import * as Palette from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, Display, Pillar } from '@guardian/types';
 import type { Colour } from 'editorialPalette';
 
 export const tabletContentWidth = 526;
@@ -83,39 +83,39 @@ export const articlePaddingStyles: SerializedStyles = css`
 	}
 `;
 
-export const headerBackgroundColour = (format: Format): Colour => {
-	if (format.display === Display.Immersive) {
+export const headerBackgroundColour = (format: ArticleFormat): Colour => {
+	if (format.display === ArticleDisplay.Immersive) {
 		return Palette.neutral[7];
 	}
 
-	if (format.design === Design.Analysis) {
+	if (format.design === ArticleDesign.Analysis) {
 		return Palette.neutral[97];
 	}
 
-	if (format.design === Design.Media) {
+	if (format.design === ArticleDesign.Media) {
 		return Palette.neutral[7];
 	}
 
-	if (format.design === Design.Comment) {
+	if (format.design === ArticleDesign.Comment) {
 		switch (format.theme) {
-			case Pillar.Culture:
+			case ArticlePillar.Culture:
 				return Palette.culture[800];
-			case Pillar.Sport:
+			case ArticlePillar.Sport:
 				return Palette.sport[800];
-			case Pillar.News:
+			case ArticlePillar.News:
 				return Palette.news[800];
-			case Pillar.Lifestyle:
+			case ArticlePillar.Lifestyle:
 				return Palette.lifestyle[800];
-			case Pillar.Opinion:
+			case ArticlePillar.Opinion:
 				return Palette.opinion[800];
 			default:
 				return Palette.neutral[100];
 		}
 	}
 
-	if (format.design === Design.Review) {
+	if (format.design === ArticleDesign.Review) {
 		switch (format.theme) {
-			case Pillar.Culture:
+			case ArticlePillar.Culture:
 				return Palette.culture[800];
 			default:
 				return Palette.neutral[100];
@@ -125,13 +125,13 @@ export const headerBackgroundColour = (format: Format): Colour => {
 	return Palette.neutral[100];
 };
 
-export const interviewBackgroundColour = (format: Format): Colour => {
+export const interviewBackgroundColour = (format: ArticleFormat): Colour => {
 	switch (format.theme) {
-		case Pillar.Sport:
+		case ArticlePillar.Sport:
 			return Palette.brandAlt[400];
-		case Pillar.Culture:
+		case ArticlePillar.Culture:
 			return Palette.culture[600];
-		case Pillar.Lifestyle:
+		case ArticlePillar.Lifestyle:
 			return Palette.lifestyle[800];
 		default:
 			return Palette.neutral[100];

--- a/apps-rendering/src/components/follow.stories.tsx
+++ b/apps-rendering/src/components/follow.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Design, Display, none, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { none } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
@@ -18,9 +19,9 @@ const Default: FC = () => (
 				image: none,
 			},
 		]}
-		theme={selectPillar(Pillar.News)}
-		design={Design.Article}
-		display={Display.Standard}
+		theme={selectPillar(ArticlePillar.News)}
+		design={ArticleDesign.Standard}
+		display={ArticleDisplay.Standard}
 	/>
 );
 

--- a/apps-rendering/src/components/follow.test.tsx
+++ b/apps-rendering/src/components/follow.test.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Design, Display, none, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { none } from '@guardian/types';
 import type { Contributor } from 'contributor';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
@@ -10,9 +11,9 @@ import Follow from './follow';
 // ----- Setup ----- //
 
 const followFormat = {
-	theme: Pillar.News,
-	design: Design.Article,
-	display: Display.Standard,
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
 };
 
 // ----- Tests ----- //

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -2,11 +2,11 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import { Special } from '@guardian/types';
-import type { Format } from '@guardian/types';
 import FollowStatus from 'components/followStatus';
 import type { Contributor } from 'contributor';
 import { isSingleContributor } from 'contributor';
@@ -16,11 +16,11 @@ import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
-interface Props extends Format {
+interface Props extends ArticleFormat {
 	contributors: Contributor[];
 }
 
-const styles = ({ theme }: Format): SerializedStyles => {
+const styles = ({ theme }: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(theme);
 
 	return css`
@@ -40,7 +40,7 @@ const styles = ({ theme }: Format): SerializedStyles => {
 	`;
 };
 
-const statusStyles = ({ theme }: Format): SerializedStyles => {
+const statusStyles = ({ theme }: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(theme);
 
 	return css`
@@ -86,7 +86,7 @@ const Follow: FC<Props> = ({ contributors, ...format }) => {
 	if (
 		isSingleContributor(contributors) &&
 		contributor.apiUrl !== '' &&
-		format.theme !== Special.Labs
+		format.theme !== ArticleSpecial.Labs
 	) {
 		return (
 			<button

--- a/apps-rendering/src/components/headerImage.tsx
+++ b/apps-rendering/src/components/headerImage.tsx
@@ -5,12 +5,12 @@ import { css } from '@emotion/react';
 import ImageDetails from '@guardian/common-rendering/src/components/imageDetails';
 import Img from '@guardian/common-rendering/src/components/img';
 import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
-import { Design, Display, some } from '@guardian/types';
+import { some } from '@guardian/types';
 import type { Image } from 'image';
-import { convertFormatToArticleFormat } from 'lib';
 import type { FC } from 'react';
 import { wideContentWidth } from 'styles';
 
@@ -21,13 +21,13 @@ const captionId = 'header-image-caption';
 // ----- Subcomponents ----- //
 
 interface CaptionProps {
-	format: Format;
+	format: ArticleFormat;
 	image: Image;
 }
 
 const Caption: FC<CaptionProps> = ({ format, image }: CaptionProps) => {
 	switch (format.display) {
-		case Display.Immersive:
+		case ArticleDisplay.Immersive:
 			return null;
 		default:
 			return (
@@ -99,12 +99,12 @@ const immersiveImgStyles = css`
 	width: 100vw;
 `;
 
-const getStyles = ({ design, display }: Format): SerializedStyles => {
+const getStyles = ({ design, display }: ArticleFormat): SerializedStyles => {
 	switch (design) {
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return css(styles, liveStyles);
 		default:
-			if (display === Display.Immersive) {
+			if (display === ArticleDisplay.Immersive) {
 				return immersiveStyles;
 			}
 
@@ -112,14 +112,17 @@ const getStyles = ({ design, display }: Format): SerializedStyles => {
 	}
 };
 
-const getImgStyles = (format: Format, image: Image): SerializedStyles => {
+const getImgStyles = (
+	format: ArticleFormat,
+	image: Image,
+): SerializedStyles => {
 	switch (format.design) {
-		case Design.LiveBlog:
-		case Design.DeadBlog:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
 			return liveblogImgStyles(image.width, image.height);
 		default:
 			switch (format.display) {
-				case Display.Immersive:
+				case ArticleDisplay.Immersive:
 					return immersiveImgStyles;
 				default:
 					return imgStyles(image.width, image.height);
@@ -127,9 +130,9 @@ const getImgStyles = (format: Format, image: Image): SerializedStyles => {
 	}
 };
 
-const getSizes = ({ display }: Format, image: Image): Sizes => {
+const getSizes = ({ display }: ArticleFormat, image: Image): Sizes => {
 	switch (display) {
-		case Display.Immersive:
+		case ArticleDisplay.Immersive:
 			return {
 				mediaQueries: [],
 				default: `${(100 * image.width) / image.height}vh `,
@@ -145,7 +148,7 @@ const getSizes = ({ display }: Format, image: Image): Sizes => {
 interface Props {
 	image: Image;
 	className?: SerializedStyles;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const HeaderImage: FC<Props> = ({ className, image, format }: Props) => (
@@ -154,7 +157,7 @@ const HeaderImage: FC<Props> = ({ className, image, format }: Props) => (
 			image={image}
 			sizes={getSizes(format, image)}
 			className={some(getImgStyles(format, image))}
-			format={convertFormatToArticleFormat(format)}
+			format={format}
 			supportsDarkMode
 			lightbox={some({
 				className: 'js-launch-slideshow',

--- a/apps-rendering/src/components/headerVideo.tsx
+++ b/apps-rendering/src/components/headerVideo.tsx
@@ -2,10 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
-import { Design } from '@guardian/types';
 import type { FC } from 'react';
 import { darkModeCss, wideContentWidth } from 'styles';
 import type { Video } from 'video';
@@ -19,20 +19,20 @@ const marginAuto = `
     margin-right: auto;
 `;
 
-const backgroundColour = (format: Format): string => {
+const backgroundColour = (format: ArticleFormat): string => {
 	switch (format.design) {
-		case Design.Media:
+		case ArticleDesign.Media:
 			return neutral[20];
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return neutral[86];
 		default:
 			return neutral[97];
 	}
 };
 
-const styles = (format: Format): SerializedStyles => css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	margin: 0 0 ${remSpace[3]} 0;
 	position: relative;
 	display: block;
@@ -47,13 +47,13 @@ const styles = (format: Format): SerializedStyles => css`
 	${from.wide} {
 		padding-bottom: ${videoHeight}px;
 		width: ${wideContentWidth}px;
-		${format.design !== Design.LiveBlog ? marginAuto : null}
+		${format.design !== ArticleDesign.LiveBlog ? marginAuto : null}
 	}
 `;
 
 interface Props {
 	video: Video;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const HeaderVideo: FC<Props> = ({ video, format }) => (

--- a/apps-rendering/src/components/headline.stories.tsx
+++ b/apps-rendering/src/components/headline.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Display, Pillar } from '@guardian/types';
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { boolean, radios, withKnobs } from '@storybook/addon-knobs';
 import { analysis, article, feature, labs, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -18,8 +18,8 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
 		}}
 	/>
 );
@@ -29,9 +29,9 @@ const Analysis = (): ReactElement => (
 		item={{
 			...analysis,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.News),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -41,9 +41,9 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.News),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -54,8 +54,8 @@ const Review = (): ReactElement => (
 			...review,
 			starRating: radios('Rating', starRating, 3),
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
 		}}
 	/>
 );
@@ -64,7 +64,7 @@ const Labs = (): ReactElement => (
 	<Headline
 		item={{
 			...labs,
-			display: Display.Standard,
+			display: ArticleDisplay.Standard,
 		}}
 	/>
 );

--- a/apps-rendering/src/components/headline.tsx
+++ b/apps-rendering/src/components/headline.tsx
@@ -2,11 +2,11 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { between, from } from '@guardian/src-foundations/mq';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
-import { Design, Display, Special } from '@guardian/types';
 import StarRating from 'components/starRating';
 import { border } from 'editorialPalette';
 import { headlineBackgroundColour, headlineTextColour } from 'editorialStyles';
@@ -20,7 +20,7 @@ interface Props {
 	item: Item;
 }
 
-const styles = (format: Format): SerializedStyles => css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium()}
 	${headlineTextColour(format)}
     ${headlineBackgroundColour(format)}
@@ -63,7 +63,7 @@ const immersiveStyles = css`
 	}
 `;
 
-const analysisStyles = (format: Format): SerializedStyles => css`
+const analysisStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ lineHeight: 'regular', fontWeight: 'light' })}
 
 	span {
@@ -112,34 +112,35 @@ const liveblogStyles = css`
 	padding: 0 0 ${remSpace[5]};
 `;
 
-const getStyles = (format: Format): SerializedStyles => {
-	if (format.display === Display.Immersive) {
-		const labs = format.theme === Special.Labs ? immersiveLabs : null;
+const getStyles = (format: ArticleFormat): SerializedStyles => {
+	if (format.display === ArticleDisplay.Immersive) {
+		const labs =
+			format.theme === ArticleSpecial.Labs ? immersiveLabs : null;
 		return css(styles(format), immersiveStyles, labs);
 	}
 
-	if (format.theme === Special.Labs) {
+	if (format.theme === ArticleSpecial.Labs) {
 		return css(styles(format), labsStyles, fontSizeRestriction);
 	}
 
 	switch (format.design) {
-		case Design.Analysis:
+		case ArticleDesign.Analysis:
 			return css(
 				styles(format),
 				analysisStyles(format),
 				fontSizeRestriction,
 			);
-		case Design.Feature:
+		case ArticleDesign.Feature:
 			return css(styles(format), featureStyles, fontSizeRestriction);
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return css(styles(format), commentStyles, fontSizeRestriction);
-		case Design.Media:
+		case ArticleDesign.Media:
 			return css(styles(format), mediaStyles, fontSizeRestriction);
 
-		case Design.LiveBlog:
-		case Design.DeadBlog:
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
 			return css(styles(format), fontSizeRestriction, liveblogStyles);
 
 		default:

--- a/apps-rendering/src/components/img.ts
+++ b/apps-rendering/src/components/img.ts
@@ -2,10 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
-import { ArticleElementRole } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleElementRole } from '@guardian/libs';
 import { neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, withDefault } from '@guardian/types';
+import { withDefault } from '@guardian/types';
 import type { Image } from 'image';
 import { createElement as h } from 'react';
 import type { FC } from 'react';
@@ -17,17 +17,20 @@ interface Props {
 	image: Image;
 	sizes: string;
 	className?: SerializedStyles;
-	format: Format;
+	format: ArticleFormat;
 }
 
-const styles = (role: ArticleElementRole, format: Format): SerializedStyles => {
-	const backgroundColour = (format: Format): string => {
+const styles = (
+	role: ArticleElementRole,
+	format: ArticleFormat,
+): SerializedStyles => {
+	const backgroundColour = (format: ArticleFormat): string => {
 		switch (format.design) {
-			case Design.Media:
+			case ArticleDesign.Media:
 				return neutral[20];
-			case Design.Editorial:
-			case Design.Letter:
-			case Design.Comment:
+			case ArticleDesign.Editorial:
+			case ArticleDesign.Letter:
+			case ArticleDesign.Comment:
 				return neutral[86];
 			default:
 				return neutral[97];

--- a/apps-rendering/src/components/immersiveCaption.tsx
+++ b/apps-rendering/src/components/immersiveCaption.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
+import { ArticleDisplay } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import { Display, OptionKind } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import { OptionKind } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { MainMediaKind } from 'headerMedia';
 import type { MainMedia } from 'headerMedia';
 import type { Item } from 'item';
@@ -24,7 +26,7 @@ const captionHeadingStyles = css`
 
 const buildCaption = (
 	cap: Option<DocumentFragment>,
-	format: Format,
+	format: ArticleFormat,
 	credit: Option<string>,
 ): ReactElement | null => {
 	if (cap.kind === OptionKind.Some && credit.kind === OptionKind.Some) {
@@ -50,7 +52,7 @@ const buildCaption = (
 };
 
 const caption =
-	(format: Format) =>
+	(format: ArticleFormat) =>
 	(mainmedia: MainMedia): ReactElement | null => {
 		switch (mainmedia.kind) {
 			case MainMediaKind.Image:
@@ -66,7 +68,7 @@ const caption =
 	};
 
 const ImmersiveCaption: FC<Props> = (props) => {
-	if (props.item.display === Display.Immersive) {
+	if (props.item.display === ArticleDisplay.Immersive) {
 		switch (props.item.mainMedia.kind) {
 			case OptionKind.Some:
 				return caption(props.item)(props.item.mainMedia.value);

--- a/apps-rendering/src/components/interactiveAtom.tsx
+++ b/apps-rendering/src/components/interactiveAtom.tsx
@@ -1,8 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
-import type { Format, Option } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
@@ -15,7 +16,7 @@ export interface InteractiveAtomProps {
 	html: string;
 	styles: string;
 	js: Option<string>;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const InteractiveAtomStyles = (
@@ -30,13 +31,13 @@ const InteractiveAtomStyles = (
 	}
 `;
 const atomCss = `
-    ${pageFonts} 
-    
+    ${pageFonts}
+
     @media (prefers-color-scheme: dark) {
         body {
             background: white;
             padding: ${remSpace[3]} !important;
-        } 
+        }
     }`;
 const atomScript = `
     function resize() {

--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -1,9 +1,10 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
-import { Design, Display, partition, Special } from '@guardian/types';
-import type { Format } from '@guardian/types';
+import { partition } from '@guardian/types';
 import { getAdPlaceholderInserter } from 'ads';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -21,7 +22,7 @@ import Live from './live';
 
 const renderWithAds =
 	(shouldHide: boolean) =>
-	(format: Format, elements: BodyElement[]): ReactNode[] =>
+	(format: ArticleFormat, elements: BodyElement[]): ReactNode[] =>
 		getAdPlaceholderInserter(shouldHide)(renderAll(format, elements));
 
 // ----- Component ----- //
@@ -42,33 +43,36 @@ const notImplemented = (
 );
 
 const Layout: FC<Props> = ({ item, shouldHideAds }) => {
-	if (item.design === Design.LiveBlog || item.design === Design.DeadBlog) {
+	if (
+		item.design === ArticleDesign.LiveBlog ||
+		item.design === ArticleDesign.DeadBlog
+	) {
 		return <Live item={item} />;
 	}
 
 	const body = partition(item.body).oks;
 	const render = renderWithAds(shouldHideAds);
 
-	if (item.theme === Special.Labs) {
+	if (item.theme === ArticleSpecial.Labs) {
 		return <Labs item={item}>{render(item, body)}</Labs>;
 	}
 
 	if (
-		item.design === Design.Interactive &&
-		item.display === Display.Immersive
+		item.design === ArticleDesign.Interactive &&
+		item.display === ArticleDisplay.Immersive
 	) {
 		return <Interactive>{renderAllWithoutStyles(item, body)}</Interactive>;
 	}
 
 	if (
-		item.design === Design.Comment ||
-		item.design === Design.Letter ||
-		item.design === Design.Editorial
+		item.design === ArticleDesign.Comment ||
+		item.design === ArticleDesign.Letter ||
+		item.design === ArticleDesign.Editorial
 	) {
 		return <Comment item={item}>{render(item, body)}</Comment>;
 	}
 
-	if (item.design === Design.Media) {
+	if (item.design === ArticleDesign.Media) {
 		return (
 			<Media item={item}>
 				{render(
@@ -80,15 +84,15 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 	}
 
 	if (
-		item.design === Design.Feature ||
-		item.design === Design.Analysis ||
-		item.design === Design.Review ||
-		item.design === Design.Article ||
-		item.design === Design.Interactive ||
-		item.design === Design.Quiz ||
-		item.design === Design.MatchReport ||
-		item.design === Design.Obituary ||
-		item.design === Design.Correction
+		item.design === ArticleDesign.Feature ||
+		item.design === ArticleDesign.Analysis ||
+		item.design === ArticleDesign.Review ||
+		item.design === ArticleDesign.Standard ||
+		item.design === ArticleDesign.Interactive ||
+		item.design === ArticleDesign.Quiz ||
+		item.design === ArticleDesign.MatchReport ||
+		item.design === ArticleDesign.Obituary ||
+		item.design === ArticleDesign.Correction
 	) {
 		return <Standard item={item}>{render(item, body)}</Standard>;
 	}

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -8,7 +8,6 @@ import LiveblogHeader from 'components/liveblogHeader';
 import RelatedContent from 'components/shared/relatedContent';
 import Tags from 'components/tags';
 import type { DeadBlog, LiveBlog } from 'item';
-import { convertThemeToArticleTheme } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { articleWidthStyles, onwardStyles } from 'styles';
@@ -40,7 +39,7 @@ const Live: FC<Props> = ({ item }) => (
 		<LiveblogHeader item={item} />
 		<KeyEvents
 			keyEvents={keyEvents(item.blocks)}
-			theme={convertThemeToArticleTheme(item.theme)}
+			theme={item.theme}
 			supportsDarkMode
 		/>
 		<section css={articleWidthStyles}>

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -2,11 +2,12 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { ArticleDisplay } from '@guardian/libs';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { remSpace } from '@guardian/src-foundations';
 import { breakpoints, from } from '@guardian/src-foundations/mq';
 import { background, neutral } from '@guardian/src-foundations/palette';
-import { Display, map, none, withDefault } from '@guardian/types';
+import { map, none, withDefault } from '@guardian/types';
 import FootballScores from 'components/footballScores';
 import Footer from 'components/footer';
 import Headline from 'components/headline';
@@ -60,7 +61,7 @@ const itemStyles = (item: Item): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(item.theme);
 
 	switch (item.display) {
-		case Display.Immersive:
+		case ArticleDisplay.Immersive:
 			return css`
 				> p:first-of-type:first-letter,
 				> hr + p:first-letter {

--- a/apps-rendering/src/components/list.stories.tsx
+++ b/apps-rendering/src/components/list.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
 import List from './list';
 import ListItem from './listItem';
@@ -10,9 +10,9 @@ import ListItem from './listItem';
 const listItem = (
 	<ListItem
 		format={{
-			design: Design.Article,
-			display: Display.Standard,
-			theme: Pillar.News,
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
 		}}
 	>
 		A bullet point

--- a/apps-rendering/src/components/listItem.stories.tsx
+++ b/apps-rendering/src/components/listItem.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
 import { selectDesign, selectPillar } from 'storybookHelpers';
 import ListItem from './listItem';
@@ -10,9 +10,9 @@ import ListItem from './listItem';
 const Default: FC = () => (
 	<ListItem
 		format={{
-			design: selectDesign(Design.Article),
-			display: Display.Standard,
-			theme: selectPillar(Pillar.News),
+			design: selectDesign(ArticleDesign.Standard),
+			display: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	>
 		A bullet point

--- a/apps-rendering/src/components/listItem.tsx
+++ b/apps-rendering/src/components/listItem.tsx
@@ -2,10 +2,10 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
@@ -34,7 +34,7 @@ const mediaStyles = css`
 	}
 `;
 
-const liveblogStyles = (format: Format): SerializedStyles => {
+const liveblogStyles = (format: ArticleFormat): SerializedStyles => {
 	const { liveblogKicker } = getThemeStyles(format.theme);
 
 	return css`
@@ -44,11 +44,11 @@ const liveblogStyles = (format: Format): SerializedStyles => {
 	`;
 };
 
-const styles = (format: Format): SerializedStyles => {
+const styles = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return css(baseStyles, liveblogStyles(format));
-		case Design.Media:
+		case ArticleDesign.Media:
 			return css(baseStyles, mediaStyles);
 		default:
 			return baseStyles;
@@ -56,7 +56,7 @@ const styles = (format: Format): SerializedStyles => {
 };
 
 interface Props {
-	format: Format;
+	format: ArticleFormat;
 	children: ReactNode;
 }
 

--- a/apps-rendering/src/components/media/articleBody.tsx
+++ b/apps-rendering/src/components/media/articleBody.tsx
@@ -1,14 +1,14 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { background, neutral } from '@guardian/src-foundations/palette';
-import type { Format, Theme } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 import type { ThemeStyles } from 'themeStyles';
 import { getThemeStyles } from 'themeStyles';
 
-const ArticleBodyStyles = (format: Format): SerializedStyles => css`
+const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	position: relative;
 	clear: both;
 	background: ${background.inverse};
@@ -30,10 +30,10 @@ const ArticleBodyDarkStyles = ({
 `;
 
 interface ArticleBodyProps {
-	theme: Theme;
+	theme: ArticleTheme;
 	className: SerializedStyles[];
 	children: ReactNode[];
-	format: Format;
+	format: ArticleFormat;
 }
 
 const ArticleBodyMedia: FC<ArticleBodyProps> = ({

--- a/apps-rendering/src/components/media/articleSeries.tsx
+++ b/apps-rendering/src/components/media/articleSeries.tsx
@@ -1,7 +1,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleTheme } from '@guardian/libs';
 import { headline } from '@guardian/src-foundations/typography';
-import type { Option, Theme } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import type { Series } from 'capi';
 import { pipe } from 'lib';
@@ -21,7 +22,7 @@ const ArticleSeriesStyles = ({
 
 interface ArticleSeriesProps {
 	series: Option<Series>;
-	theme: Theme;
+	theme: ArticleTheme;
 }
 
 const ArticleSeries: FC<ArticleSeriesProps> = (props) =>

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -1,13 +1,13 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import {
 	Lines,
 	ToggleSwitch,
 } from '@guardian/source-react-components-development-kitchen';
 import { neutral, remSpace } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
-import { Design, Display } from '@guardian/types';
 import Avatar from 'components/avatar';
 import Byline from 'components/byline';
 import CommentCount from 'components/commentCount';
@@ -186,13 +186,16 @@ const Metadata: FC<Props> = (props: Props) => {
 	const { display, design } = props.item;
 
 	if (
-		display === Display.Immersive ||
-		design === Design.Comment ||
-		design === Design.Letter ||
-		design === Design.Editorial
+		display === ArticleDisplay.Immersive ||
+		design === ArticleDesign.Comment ||
+		design === ArticleDesign.Letter ||
+		design === ArticleDesign.Editorial
 	) {
 		return <ShortMetadata {...props} />;
-	} else if (design === Design.LiveBlog || design === Design.DeadBlog) {
+	} else if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return <MetadataWithAlertSwitch {...props} />;
 	}
 

--- a/apps-rendering/src/components/orderedList.stories.tsx
+++ b/apps-rendering/src/components/orderedList.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
 import ListItem from './listItem';
 import OrderedList from './orderedList';
@@ -10,9 +10,9 @@ import OrderedList from './orderedList';
 const listItem = (
 	<ListItem
 		format={{
-			design: Design.Article,
-			display: Display.Standard,
-			theme: Pillar.News,
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
 		}}
 	>
 		A bullet point

--- a/apps-rendering/src/components/paragraph.stories.tsx
+++ b/apps-rendering/src/components/paragraph.stories.tsx
@@ -1,21 +1,26 @@
 // ----- Imports ----- //
 
-import { Design, Display, Pillar, Special } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import type { FC } from 'react';
 import Paragraph from './paragraph';
 
 // ----- Stories ----- //
 
 const standard = {
-	design: Design.Article,
-	display: Display.Standard,
-	theme: Pillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticlePillar.News,
 };
 
 const labs = {
-	design: Design.Article,
-	display: Display.Standard,
-	theme: Special.Labs,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticleSpecial.Labs,
 };
 
 const Default: FC = () => (

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -2,21 +2,21 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import { ArticleSpecial } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { body, textSans } from '@guardian/src-foundations/typography';
-import type { Format, Theme } from '@guardian/types';
-import { Special } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 
 // ----- Component ----- //
 
 interface Props {
 	children?: ReactNode;
-	format: Format;
+	format: ArticleFormat;
 }
 
-const styles = (theme: Theme): SerializedStyles => {
-	const labs = theme === Special.Labs ? textSans.medium() : null;
+const styles = (theme: ArticleTheme): SerializedStyles => {
+	const labs = theme === ArticleSpecial.Labs ? textSans.medium() : null;
 
 	return css`
 		${body.medium()}

--- a/apps-rendering/src/components/pullquote.tsx
+++ b/apps-rendering/src/components/pullquote.tsx
@@ -1,16 +1,17 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
-import type { Format, Option } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles } from 'themeStyles';
 
-const styles = (format: Format): SerializedStyles => {
+const styles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(format.theme);
 	return css`
 		color: ${kicker};
@@ -20,7 +21,7 @@ const styles = (format: Format): SerializedStyles => {
 	`;
 };
 
-const quoteStyles = (format: Format): SerializedStyles => {
+const quoteStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(format.theme);
 
 	return css`
@@ -43,7 +44,7 @@ const citeStyles = css`
 
 type Props = {
 	quote: string;
-	format: Format;
+	format: ArticleFormat;
 	attribution: Option<string>;
 };
 

--- a/apps-rendering/src/components/richLink.stories.tsx
+++ b/apps-rendering/src/components/richLink.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { Design, Display, Pillar } from '@guardian/types';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
 import { selectPillar } from '../storybookHelpers';
@@ -25,9 +25,9 @@ const Default: FC = () => (
 	<section css={overrideStyle}>
 		<RichLink
 			format={{
-				design: Design.Article,
-				display: Display.Standard,
-				theme: selectPillar(Pillar.News),
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: selectPillar(ArticlePillar.News),
 			}}
 			linkText={linkText()}
 			url={url()}

--- a/apps-rendering/src/components/richLink.tsx
+++ b/apps-rendering/src/components/richLink.tsx
@@ -1,12 +1,12 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
+import { ArticlePillar } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { Pillar } from '@guardian/types';
-import type { Format } from '@guardian/types';
 import { createElement as h } from 'react';
 import type { ReactElement } from 'react';
 import { backgroundColor, darkModeCss, darkModeStyles } from 'styles';
@@ -42,21 +42,21 @@ const richLinkPillarStyles = (kicker: string, inverted: string): string => {
 	`;
 };
 
-const richLinkStyles = (format: Format): SerializedStyles => {
+const richLinkStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker: newsKicker, inverted: newsInverted } = getThemeStyles(
-		Pillar.News,
+		ArticlePillar.News,
 	);
 	const { kicker: opinionKicker, inverted: opinionInverted } = getThemeStyles(
-		Pillar.Opinion,
+		ArticlePillar.Opinion,
 	);
 	const { kicker: sportKicker, inverted: sportInverted } = getThemeStyles(
-		Pillar.Sport,
+		ArticlePillar.Sport,
 	);
 	const { kicker: cultureKicker, inverted: cultureInverted } = getThemeStyles(
-		Pillar.Culture,
+		ArticlePillar.Culture,
 	);
 	const { kicker: lifestyleKicker, inverted: lifestyleInverted } =
-		getThemeStyles(Pillar.Lifestyle);
+		getThemeStyles(ArticlePillar.Lifestyle);
 
 	return css`
 		background: ${backgroundColor(format)};
@@ -158,7 +158,7 @@ const richLinkStyles = (format: Format): SerializedStyles => {
 const RichLink = (props: {
 	url: string;
 	linkText: string;
-	format: Format;
+	format: ArticleFormat;
 }): ReactElement => {
 	const { url, linkText, format } = props;
 	const webUrl = 'https://www.theguardian.com';

--- a/apps-rendering/src/components/series.tsx
+++ b/apps-rendering/src/components/series.tsx
@@ -2,12 +2,13 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { labs, neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import type { Format, Theme } from '@guardian/types';
-import { Design, Display, map, Special, withDefault } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
@@ -20,7 +21,7 @@ interface Props {
 	item: Item;
 }
 
-const standardLinkStyles = (theme: Theme): SerializedStyles => {
+const standardLinkStyles = (theme: ArticleTheme): SerializedStyles => {
 	const { kicker, inverted } = getThemeStyles(theme);
 
 	return css`
@@ -34,7 +35,7 @@ const standardLinkStyles = (theme: Theme): SerializedStyles => {
 	`;
 };
 
-const labsLinkStyles = (theme: Theme): SerializedStyles => css`
+const labsLinkStyles = (theme: ArticleTheme): SerializedStyles => css`
 	${textSans.medium({ lineHeight: 'loose', fontWeight: 'bold' })}
 	color: ${labs[300]};
 	text-decoration: none;
@@ -55,7 +56,7 @@ const immersiveLabsLinkStyles = css`
 	${textSans.medium({ lineHeight: 'loose', fontWeight: 'bold' })}
 `;
 
-const liveLinkStyles = (theme: Theme): SerializedStyles => css`
+const liveLinkStyles = (theme: ArticleTheme): SerializedStyles => css`
 	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
 	color: ${getThemeStyles(theme).liveblogKicker};
 	text-decoration: none;
@@ -65,29 +66,32 @@ const getLinkStyles = ({
 	design,
 	display,
 	theme,
-}: Format): SerializedStyles => {
-	if (display === Display.Immersive && theme === Special.Labs) {
+}: ArticleFormat): SerializedStyles => {
+	if (display === ArticleDisplay.Immersive && theme === ArticleSpecial.Labs) {
 		return css(immersiveLinkStyles, immersiveLabsLinkStyles);
 	}
 
-	if (display === Display.Immersive) {
+	if (display === ArticleDisplay.Immersive) {
 		return immersiveLinkStyles;
 	}
 
-	if (theme === Special.Labs) {
+	if (theme === ArticleSpecial.Labs) {
 		return labsLinkStyles(theme);
 	}
 
-	if (design === Design.LiveBlog || design === Design.DeadBlog) {
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return liveLinkStyles(theme);
 	}
 
 	return standardLinkStyles(theme);
 };
 
-const immersiveStyles = (theme: Theme): SerializedStyles => css`
+const immersiveStyles = (theme: ArticleTheme): SerializedStyles => css`
 	padding: ${remSpace[1]} ${remSpace[3]};
-	background-color: ${theme === Special.Labs
+	background-color: ${theme === ArticleSpecial.Labs
 		? palette.labs[300]
 		: getThemeStyles(theme).kicker};
 	position: absolute;
@@ -112,12 +116,19 @@ const standardStyles: SerializedStyles = css`
 	padding-top: ${remSpace[1]};
 `;
 
-const getStyles = ({ design, display, theme }: Format): SerializedStyles => {
-	if (display === Display.Immersive) {
+const getStyles = ({
+	design,
+	display,
+	theme,
+}: ArticleFormat): SerializedStyles => {
+	if (display === ArticleDisplay.Immersive) {
 		return css(immersiveStyles(theme));
 	}
 
-	if (design === Design.LiveBlog || design === Design.DeadBlog) {
+	if (
+		design === ArticleDesign.LiveBlog ||
+		design === ArticleDesign.DeadBlog
+	) {
 		return css();
 	}
 

--- a/apps-rendering/src/components/shared/articleBody.tsx
+++ b/apps-rendering/src/components/shared/articleBody.tsx
@@ -1,18 +1,18 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { background, neutral } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 
 interface ArticleBodyProps {
 	className: SerializedStyles[];
 	children: ReactNode[];
-	format: Format;
+	format: ArticleFormat;
 }
 
-const ArticleBodyStyles = (format: Format): SerializedStyles => css`
+const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	position: relative;
 	clear: both;
 

--- a/apps-rendering/src/components/shared/bylineCard.tsx
+++ b/apps-rendering/src/components/shared/bylineCard.tsx
@@ -1,18 +1,14 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { neutral, opinion, text } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgQuote } from '@guardian/src-icons';
-import type { Format, Option } from '@guardian/types';
-import {
-	Design,
-	Display,
-	fromNullable,
-	map,
-	withDefault,
-} from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { fromNullable, map, withDefault } from '@guardian/types';
 import { makeRelativeDate } from 'date';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
@@ -23,11 +19,11 @@ interface Props {
 	relatedItem: RelatedItem;
 }
 
-const borderColor = (format: Format): SerializedStyles => {
+const borderColor = (format: ArticleFormat): SerializedStyles => {
 	return css`1px solid ${getThemeStyles(format.theme).kicker}`;
 };
 
-const listStyles = (format: Format): SerializedStyles => {
+const listStyles = (format: ArticleFormat): SerializedStyles => {
 	return css`
 		background: white;
 		margin-right: ${remSpace[3]};
@@ -185,8 +181,8 @@ const BylineCard: FC<Props> = ({ relatedItem }) => {
 	const { link, pillar, lastModified } = relatedItem;
 	const format = {
 		theme: themeFromString(pillar.id),
-		design: Design.Article,
-		display: Display.Standard,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
 	};
 
 	const img = cardImage(relatedItem);

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import Img from '@guardian/common-rendering/src/components/img';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { palette, remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import {
@@ -14,20 +16,18 @@ import {
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { SvgAudio, SvgCamera, SvgQuote, SvgVideo } from '@guardian/src-icons';
 import {
-	Design,
-	Display,
 	fromNullable,
 	map,
 	none,
 	OptionKind,
 	withDefault,
 } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { stars } from 'components/starRating';
 import { formatSeconds, makeRelativeDate } from 'date';
 import { border } from 'editorialPalette';
 import type { Image } from 'image';
-import { convertFormatToArticleFormat, pipe } from 'lib';
+import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
 import { getThemeStyles, themeFromString } from 'themeStyles';
@@ -39,7 +39,7 @@ interface Props {
 
 const borderColor = (
 	type: RelatedItemType,
-	format: Format,
+	format: ArticleFormat,
 ): SerializedStyles => {
 	if (type === RelatedItemType.ADVERTISEMENT_FEATURE) {
 		return css`1px solid ${palette.labs[300]}`;
@@ -50,7 +50,7 @@ const borderColor = (
 
 const listStyles = (
 	type: RelatedItemType,
-	format: Format,
+	format: ArticleFormat,
 ): SerializedStyles => {
 	return css`
 		background: white;
@@ -188,7 +188,7 @@ const relativeFirstPublished = (
 
 const cardStyles = (
 	type: RelatedItemType,
-	format: Format,
+	format: ArticleFormat,
 ): SerializedStyles => {
 	switch (type) {
 		case RelatedItemType.FEATURE: {
@@ -282,7 +282,7 @@ const parentIconStyles: SerializedStyles = css`
 	}
 `;
 
-const iconStyles = (format: Format): SerializedStyles => {
+const iconStyles = (format: ArticleFormat): SerializedStyles => {
 	const { inverted } = getThemeStyles(format.theme);
 	return css`
 		width: 1.5rem;
@@ -304,7 +304,10 @@ const commentIconStyle: SerializedStyles = css`
 	margin-right: -2px;
 `;
 
-const icon = (type: RelatedItemType, format: Format): ReactElement | null => {
+const icon = (
+	type: RelatedItemType,
+	format: ArticleFormat,
+): ReactElement | null => {
 	switch (type) {
 		case RelatedItemType.GALLERY:
 			return (
@@ -331,7 +334,7 @@ const icon = (type: RelatedItemType, format: Format): ReactElement | null => {
 
 const quotationComment = (
 	type: RelatedItemType,
-	format: Format,
+	format: ArticleFormat,
 ): ReactElement | null => {
 	if (type === RelatedItemType.COMMENT) {
 		return (
@@ -398,8 +401,8 @@ const cardImage = (
 ): ReactElement | null => {
 	const format = {
 		theme: themeFromString(relatedItem.pillar.id),
-		design: Design.Article,
-		display: Display.Standard,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
 	};
 
 	return pipe(
@@ -415,7 +418,7 @@ const cardImage = (
 							],
 							default: '100%',
 						}}
-						format={convertFormatToArticleFormat(format)}
+						format={format}
 						className={none}
 						supportsDarkMode
 						lightbox={none}
@@ -432,8 +435,8 @@ const cardImage = (
 const Card: FC<Props> = ({ relatedItem, image }) => {
 	const format = {
 		theme: themeFromString(relatedItem.pillar.id),
-		design: Design.Article,
-		display: Display.Standard,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
 	};
 
 	const img = cardImage(image, relatedItem);

--- a/apps-rendering/src/components/shared/logo.tsx
+++ b/apps-rendering/src/components/shared/logo.tsx
@@ -1,9 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Branding } from '@guardian/apps-rendering-api-models/branding';
+import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace, text } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import Anchor from 'components/anchor';
 import { getFormat } from 'item';
@@ -15,11 +15,11 @@ import { getThemeStyles } from 'themeStyles';
 
 interface Props {
 	branding: Branding;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const styles = (
-	format: Format,
+	format: ArticleFormat,
 	lightModeImage: string,
 	darkModeImage?: string,
 ): SerializedStyles => {

--- a/apps-rendering/src/components/standfirst.stories.tsx
+++ b/apps-rendering/src/components/standfirst.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Display, Pillar } from '@guardian/types';
+import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { article, comment, feature, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -14,9 +14,9 @@ const Default = (): ReactElement => (
 		item={{
 			...article,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.News),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.News),
 		}}
 	/>
 );
@@ -26,9 +26,9 @@ const Review = (): ReactElement => (
 		item={{
 			...review,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.Culture),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.Culture),
 		}}
 	/>
 );
@@ -38,9 +38,9 @@ const Feature = (): ReactElement => (
 		item={{
 			...feature,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.Sport),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.Sport),
 		}}
 	/>
 );
@@ -50,9 +50,9 @@ const Comment = (): ReactElement => (
 		item={{
 			...comment,
 			display: boolean('Immersive', false)
-				? Display.Immersive
-				: Display.Standard,
-			theme: selectPillar(Pillar.Opinion),
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.Opinion),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/standfirst.tsx
+++ b/apps-rendering/src/components/standfirst.tsx
@@ -2,11 +2,12 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { background, neutral, text } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
-import { Design, Display, map, Special, withDefault } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { pipe } from 'lib';
@@ -30,10 +31,11 @@ const darkStyles: SerializedStyles = darkMode`
     }
 `;
 
-const isNotBlog = (format: Format): boolean =>
-	format.design !== Design.LiveBlog && format.design !== Design.DeadBlog;
+const isNotBlog = (format: ArticleFormat): boolean =>
+	format.design !== ArticleDesign.LiveBlog &&
+	format.design !== ArticleDesign.DeadBlog;
 
-const styles = (format: Format): SerializedStyles => css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	margin-bottom: ${remSpace[3]};
 	color: ${text.primary};
 
@@ -99,26 +101,26 @@ const advertisementFeature = css`
 
 const getStyles = (item: Item): SerializedStyles => {
 	const format = getFormat(item);
-	if (item.display === Display.Immersive) {
-		return item.theme === Special.Labs
+	if (item.display === ArticleDisplay.Immersive) {
+		return item.theme === ArticleSpecial.Labs
 			? css(styles(format), immersiveLabs)
 			: css(styles(format), immersive);
 	}
 
-	if (item.theme === Special.Labs) {
+	if (item.theme === ArticleSpecial.Labs) {
 		return css(styles(format), advertisementFeature);
 	}
 
 	switch (item.design) {
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return css(styles(format), liveblogStyles);
-		case Design.Review:
-		case Design.Feature:
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Review:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return css(styles(format), thinHeadline);
-		case Design.Media:
+		case ArticleDesign.Media:
 			return media;
 
 		default:
@@ -135,7 +137,7 @@ function content(standfirst: DocumentFragment, item: Item): ReactNode {
 	const bylineInStandfirst =
 		item.byline !== '' && standfirst.textContent?.includes(item.byline);
 
-	if (item.display === Display.Immersive && !bylineInStandfirst) {
+	if (item.display === ArticleDisplay.Immersive && !bylineInStandfirst) {
 		return pipe(
 			item.bylineHtml,
 			map((byline) => (

--- a/apps-rendering/src/components/starRating.tsx
+++ b/apps-rendering/src/components/starRating.tsx
@@ -1,12 +1,12 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	brandAltBackground,
 	brandAltLine,
 } from '@guardian/src-foundations/palette';
 import { SvgStar } from '@guardian/src-icons';
-import { Design } from '@guardian/types';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
@@ -58,7 +58,9 @@ interface Props {
 }
 
 const StarRating: FC<Props> = ({ item }) =>
-	item.design === Design.Review ? <div>{stars(item.starRating)}</div> : null;
+	item.design === ArticleDesign.Review ? (
+		<div>{stars(item.starRating)}</div>
+	) : null;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/tags.stories.tsx
+++ b/apps-rendering/src/components/tags.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import type { Format } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
 import Tags from 'components/tags';
 
@@ -13,7 +13,7 @@ const tag = {
 
 // ----- Stories ----- //
 
-const Default = (format: Format): JSX.Element => (
+const Default = (format: ArticleFormat): JSX.Element => (
 	<Tags tags={[tag, tag, tag]} format={format} />
 );
 

--- a/apps-rendering/src/components/tags.test.tsx
+++ b/apps-rendering/src/components/tags.test.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
 import { matchers } from '@emotion/jest';
-import type { Format } from '@guardian/types';
-import { Design, Display, Pillar } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import Tags from 'components/tags';
 import renderer from 'react-test-renderer';
 
@@ -15,10 +15,10 @@ const mockTag = {
 	webUrl: 'https://mapi.co.uk/tag',
 };
 
-const mockFormat: Format = {
-	theme: Pillar.News,
-	design: Design.Comment,
-	display: Display.Standard,
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Comment,
+	display: ArticleDisplay.Standard,
 };
 
 // ----- Tests ----- //

--- a/apps-rendering/src/components/tags.tsx
+++ b/apps-rendering/src/components/tags.tsx
@@ -2,23 +2,23 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { background, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import type { Format } from '@guardian/types';
-import { Design } from '@guardian/types';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const backgroundColour = (format: Format): string => {
+const backgroundColour = (format: ArticleFormat): string => {
 	switch (format.design) {
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
 			return neutral[86];
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return neutral[93];
 		default:
 			return neutral[97];
@@ -46,7 +46,7 @@ const tagStyles = css`
 	line-height: 0;
 `;
 
-const anchorStyles = (format: Format): SerializedStyles => css`
+const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	text-decoration: none;
 	white-space: nowrap;
 	padding: 6px 16px;
@@ -72,7 +72,7 @@ interface Props {
 		webTitle: string;
 	}>;
 	background?: string;
-	format: Format;
+	format: ArticleFormat;
 }
 
 const Tags: FC<Props> = ({ tags, format }) => (

--- a/apps-rendering/src/editorialPalette.ts
+++ b/apps-rendering/src/editorialPalette.ts
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
 
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import {
 	background as coreBackground,
 	text as coreText,
@@ -10,8 +12,6 @@ import {
 	opinion,
 	sport,
 } from '@guardian/src-foundations/palette';
-import type { Format } from '@guardian/types';
-import { Design, Display, Pillar } from '@guardian/types';
 
 // ----- Types ----- //
 
@@ -34,25 +34,28 @@ interface Palette {
 
 // ----- Functions ----- //
 
-const textHeadlinePrimary = (format: Format): Colour => {
+const textHeadlinePrimary = (format: ArticleFormat): Colour => {
 	if (
-		format.display === Display.Immersive ||
-		format.design === Design.Media ||
-		format.design === Design.LiveBlog ||
-		format.design === Design.DeadBlog
+		format.display === ArticleDisplay.Immersive ||
+		format.design === ArticleDesign.Media ||
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
 	) {
 		return neutral[100];
 	}
 
-	if (format.design === Design.Feature || format.design === Design.Review) {
+	if (
+		format.design === ArticleDesign.Feature ||
+		format.design === ArticleDesign.Review
+	) {
 		switch (format.theme) {
-			case Pillar.Opinion:
+			case ArticlePillar.Opinion:
 				return opinion[300];
-			case Pillar.Sport:
+			case ArticlePillar.Sport:
 				return sport[300];
-			case Pillar.Culture:
+			case ArticlePillar.Culture:
 				return culture[300];
-			case Pillar.Lifestyle:
+			case ArticlePillar.Lifestyle:
 				return lifestyle[300];
 			default:
 				return news[300];
@@ -62,10 +65,10 @@ const textHeadlinePrimary = (format: Format): Colour => {
 	return coreText.primary;
 };
 
-const textHeadlinePrimaryInverse = (format: Format): Colour => {
+const textHeadlinePrimaryInverse = (format: ArticleFormat): Colour => {
 	if (
-		format.design === Design.LiveBlog ||
-		format.design === Design.DeadBlog
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
 	) {
 		return neutral[93];
 	}
@@ -73,52 +76,52 @@ const textHeadlinePrimaryInverse = (format: Format): Colour => {
 	return neutral[86];
 };
 
-const backgroundHeadlinePrimary = (format: Format): Colour => {
-	if (format.display === Display.Immersive) {
+const backgroundHeadlinePrimary = (format: ArticleFormat): Colour => {
+	if (format.display === ArticleDisplay.Immersive) {
 		return neutral[7];
-	} else if (format.design === Design.LiveBlog) {
+	} else if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
-			case Pillar.Culture:
+			case ArticlePillar.Culture:
 				return culture[300];
-			case Pillar.Sport:
+			case ArticlePillar.Sport:
 				return sport[300];
-			case Pillar.Lifestyle:
+			case ArticlePillar.Lifestyle:
 				return lifestyle[300];
-			case Pillar.Opinion:
+			case ArticlePillar.Opinion:
 				return opinion[300];
-			case Pillar.News:
+			case ArticlePillar.News:
 				return news[300];
 			default:
 				return news[300];
 		}
 	} else if (
-		format.design === Design.Comment ||
-		format.design === Design.Letter ||
-		format.design === Design.Editorial
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Letter ||
+		format.design === ArticleDesign.Editorial
 	) {
 		return opinion[800];
-	} else if (format.design === Design.Media) {
+	} else if (format.design === ArticleDesign.Media) {
 		return coreBackground.inverse;
 	}
 
 	return coreBackground.primary;
 };
 
-const backgroundHeadlinePrimaryInverse = (format: Format): Colour => {
+const backgroundHeadlinePrimaryInverse = (format: ArticleFormat): Colour => {
 	if (
-		format.design === Design.LiveBlog ||
-		format.design === Design.DeadBlog
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
 	) {
 		switch (format.theme) {
-			case Pillar.Culture:
+			case ArticlePillar.Culture:
 				return culture[200];
-			case Pillar.Sport:
+			case ArticlePillar.Sport:
 				return sport[200];
-			case Pillar.Lifestyle:
+			case ArticlePillar.Lifestyle:
 				return lifestyle[200];
-			case Pillar.Opinion:
+			case ArticlePillar.Opinion:
 				return opinion[200];
-			case Pillar.News:
+			case ArticlePillar.News:
 				return news[200];
 			default:
 				return news[200];
@@ -127,17 +130,17 @@ const backgroundHeadlinePrimaryInverse = (format: Format): Colour => {
 	return coreBackground.inverse;
 };
 
-const borderPrimary = (format: Format): Colour => {
+const borderPrimary = (format: ArticleFormat): Colour => {
 	switch (format.theme) {
-		case Pillar.Opinion:
+		case ArticlePillar.Opinion:
 			return opinion[400];
-		case Pillar.Sport:
+		case ArticlePillar.Sport:
 			return sport[400];
-		case Pillar.Culture:
+		case ArticlePillar.Culture:
 			return culture[400];
-		case Pillar.Lifestyle:
+		case ArticlePillar.Lifestyle:
 			return lifestyle[400];
-		case Pillar.News:
+		case ArticlePillar.News:
 		default:
 			return news[400];
 	}
@@ -162,7 +165,7 @@ const border = {
 	primaryInverse: borderPrimaryInverse,
 };
 
-const palette = (format: Format): Palette => ({
+const palette = (format: ArticleFormat): Palette => ({
 	text: {
 		headlinePrimary: text.headlinePrimary(format),
 		headlinePrimaryInverse: text.headlinePrimaryInverse(format),

--- a/apps-rendering/src/editorialStyles.ts
+++ b/apps-rendering/src/editorialStyles.ts
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { Format } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import type { Colour } from 'editorialPalette';
 import { background, text } from 'editorialPalette';
 
@@ -27,16 +27,16 @@ const backgroundColour = (light: Colour, dark: Colour): SerializedStyles =>
 		}
 	`;
 
-const headlineTextColour = (format: Format): SerializedStyles =>
+const headlineTextColour = (format: ArticleFormat): SerializedStyles =>
 	textColour(
 		text.headlinePrimary(format),
 		text.headlinePrimaryInverse(format),
 	);
 
-const editionsHeadlineTextColour = (format: Format): SerializedStyles =>
+const editionsHeadlineTextColour = (format: ArticleFormat): SerializedStyles =>
 	textColour(text.headlinePrimary(format));
 
-const headlineBackgroundColour = (format: Format): SerializedStyles =>
+const headlineBackgroundColour = (format: ArticleFormat): SerializedStyles =>
 	backgroundColour(
 		background.headlinePrimary(format),
 		background.headlinePrimaryInverse(format),

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -1,17 +1,13 @@
 // ----- Imports ----- //
 
-import { ArticleElementRole } from '@guardian/libs';
 import {
-	Design,
-	Display,
-	none,
-	OptionKind,
-	Pillar,
-	ResultKind,
-	some,
-	Special,
-	toOption,
-} from '@guardian/types';
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleElementRole,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { none, OptionKind, ResultKind, some, toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -242,8 +238,8 @@ const matchScores: MatchScores = {
 };
 
 const fields = {
-	theme: Pillar.News,
-	display: Display.Standard,
+	theme: ArticlePillar.News,
+	display: ArticleDisplay.Standard,
 	body: body,
 	headline: headline,
 	standfirst: standfirst,
@@ -273,73 +269,73 @@ const fields = {
 };
 
 const article: Item = {
-	design: Design.Article,
+	design: ArticleDesign.Standard,
 	...fields,
 };
 
 const analysis: Item = {
-	design: Design.Analysis,
+	design: ArticleDesign.Analysis,
 	...fields,
 };
 
 const feature: Item = {
-	design: Design.Feature,
+	design: ArticleDesign.Feature,
 	...fields,
 };
 
 const review: Review = {
-	design: Design.Review,
+	design: ArticleDesign.Review,
 	starRating: 4,
 	...fields,
 };
 
 const labs: Item = {
-	design: Design.Article,
+	design: ArticleDesign.Standard,
 	...fields,
-	theme: Special.Labs,
+	theme: ArticleSpecial.Labs,
 };
 
 const comment: Item = {
-	design: Design.Comment,
+	design: ArticleDesign.Comment,
 	...fields,
 };
 
 const letter: Item = {
-	design: Design.Letter,
+	design: ArticleDesign.Letter,
 	...fields,
 };
 
 const editorial: Item = {
-	design: Design.Editorial,
+	design: ArticleDesign.Editorial,
 	...fields,
 };
 
 const interview: Item = {
-	design: Design.Interview,
+	design: ArticleDesign.Interview,
 	...fields,
 };
 
 const media: Item = {
-	design: Design.Media,
+	design: ArticleDesign.Media,
 	...fields,
 	body: galleryBody,
 };
 
 const cartoon: Item = {
-	design: Design.Media,
+	design: ArticleDesign.Media,
 	...fields,
 	body: [],
 };
 
 const matchReport: Item = {
-	design: Design.MatchReport,
+	design: ArticleDesign.MatchReport,
 	football: some(matchScores),
 	...fields,
 	body: galleryBody,
 };
 
 const correction: Item = {
-	design: Design.Correction,
+	design: ArticleDesign.Correction,
 	...fields,
 };
 // ----- Exports ----- //

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -1,15 +1,12 @@
 // ----- Imports ----- //
 
-import { ArticleElementRole } from '@guardian/libs';
 import {
-	Design,
-	Display,
-	none,
-	OptionKind,
-	Pillar,
-	some,
-	toOption,
-} from '@guardian/types';
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleElementRole,
+	ArticlePillar,
+} from '@guardian/libs';
+import { none, OptionKind, some, toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { parse } from 'client/parser';
 import type { MainMedia } from 'headerMedia';
@@ -226,8 +223,8 @@ const tags = [
 ];
 
 const fields = {
-	theme: Pillar.News,
-	display: Display.Standard,
+	theme: ArticlePillar.News,
+	display: ArticleDisplay.Standard,
 	body: [],
 	headline: headline,
 	standfirst: standfirst,
@@ -261,7 +258,7 @@ const fields = {
 };
 
 const live: LiveBlog = {
-	design: Design.LiveBlog,
+	design: ArticleDesign.LiveBlog,
 	...fields,
 	blocks: [
 		{

--- a/apps-rendering/src/image.test.ts
+++ b/apps-rendering/src/image.test.ts
@@ -6,12 +6,12 @@ import { parseCardImage, parseImage, Image } from 'image';
 import { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import { AssetType } from '@guardian/content-api-models/v1/assetType';
-import { none, OptionKind, Role, some, withDefault } from '@guardian/types';
+import { none, OptionKind, some, withDefault } from '@guardian/types';
+import { ArticleElementRole } from '@guardian/libs';
 import { ImageElementFields } from '@guardian/content-api-models/v1/imageElementFields';
 import { Context } from 'parserContext';
 import { Asset } from '@guardian/content-api-models/v1/asset';
 import { AssetFields } from '@guardian/content-api-models/v1/assetFields';
-import { ArticleElementRole } from '@guardian/libs';
 
 // ----- Mocks ----- //
 let imageBlock: BlockElement;
@@ -38,15 +38,15 @@ const defaultImage: Image = {
 const roleTestCases = [
 	{
 		role: 'thumbnail',
-		roleEnum: Role.Thumbnail,
+		roleEnum: ArticleElementRole.Thumbnail,
 	},
 	{
 		role: 'halfWidth',
-		roleEnum: Role.HalfWidth,
+		roleEnum: ArticleElementRole.HalfWidth,
 	},
 	{
 		role: 'thumanyThingElsebnail',
-		roleEnum: Role.Standard,
+		roleEnum: ArticleElementRole.Standard,
 	},
 ];
 const expectedSrcset =
@@ -104,7 +104,7 @@ describe('parseImage', () => {
 		expect(actual.caption.kind).toEqual(OptionKind.Some);
 		expect(actual.credit).toEqual(some(imageDataCredit));
 		expect(actual.nativeCaption).toEqual(some(imageData.caption));
-		expect(actual.role).toBe(Role.Standard);
+		expect(actual.role).toBe(ArticleElementRole.Standard);
 	});
 
 	test('returns none given no assets in element', () => {
@@ -234,7 +234,7 @@ describe('parseCardImage', () => {
 			caption: none,
 			credit: none,
 			nativeCaption: none,
-			role: Role.Standard,
+			role: ArticleElementRole.Standard,
 		};
 
 		const parsed = withDefault(defaultImage)(

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -5,7 +5,8 @@ import type { Image as ImageData } from '@guardian/common-rendering/src/image';
 import { Dpr, src, srcsets } from '@guardian/common-rendering/src/srcsets';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ArticleElementRole } from '@guardian/libs';
-import type { Format, Option } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
+import type { Option } from '@guardian/types';
 import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import { pipe } from 'lib';
 import type { Context } from 'parserContext';
@@ -22,7 +23,7 @@ interface Image extends ImageData {
 interface BodyImageProps {
 	image: Image;
 	children?: ReactNode;
-	format: Format;
+	format: ArticleFormat;
 }
 
 // ----- Functions ----- //

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -9,17 +9,19 @@ import { Atoms } from '@guardian/content-api-models/v1/atoms';
 import { fromCapi, Standard, Review, getFormat } from 'item';
 import { ElementKind, BodyElement } from 'bodyElement';
 import {
-	ArticleDesign,
-	ArticleDisplay,
 	err,
 	none,
 	ok,
 	resultAndThen,
 	resultMap,
-	ArticleSpecial,
 	toOption,
 	withDefault,
 } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { JSDOM } from 'jsdom';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { pipe } from 'lib';

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -9,14 +9,14 @@ import { Atoms } from '@guardian/content-api-models/v1/atoms';
 import { fromCapi, Standard, Review, getFormat } from 'item';
 import { ElementKind, BodyElement } from 'bodyElement';
 import {
-	Design,
-	Display,
+	ArticleDesign,
+	ArticleDisplay,
 	err,
 	none,
 	ok,
 	resultAndThen,
 	resultMap,
-	Special,
+	ArticleSpecial,
 	toOption,
 	withDefault,
 } from '@guardian/types';
@@ -209,72 +209,72 @@ const getFirstBody = (item: Review | Standard) =>
 describe('fromCapi returns correct Item', () => {
 	test('media', () => {
 		const item = f(contentWithTag('type/audio'));
-		expect(item.design).toBe(Design.Media);
+		expect(item.design).toBe(ArticleDesign.Media);
 	});
 
 	test('review', () => {
 		const item = f(reviewContent);
-		expect(item.design).toBe(Design.Review);
+		expect(item.design).toBe(ArticleDesign.Review);
 	});
 
 	test('analysis', () => {
 		const item = f(contentWithTag('tone/analysis'));
-		expect(item.design).toBe(Design.Analysis);
+		expect(item.design).toBe(ArticleDesign.Analysis);
 	});
 
 	test('comment', () => {
 		const item = f(contentWithTag('tone/comment'));
-		expect(item.design).toBe(Design.Comment);
+		expect(item.design).toBe(ArticleDesign.Comment);
 	});
 
 	test('feature', () => {
 		const item = f(contentWithTag('tone/features'));
-		expect(item.design).toBe(Design.Feature);
+		expect(item.design).toBe(ArticleDesign.Feature);
 	});
 
 	test('deadblog', () => {
 		const item = f(contentWithTag('tone/minutebyminute'));
-		expect(item.design).toBe(Design.DeadBlog);
+		expect(item.design).toBe(ArticleDesign.DeadBlog);
 	});
 
 	test('liveblog', () => {
 		const item = f(liveblogContent);
-		expect(item.design).toBe(Design.LiveBlog);
+		expect(item.design).toBe(ArticleDesign.LiveBlog);
 	});
 
 	test('recipe', () => {
 		const item = f(contentWithTag('tone/recipes'));
-		expect(item.design).toBe(Design.Recipe);
+		expect(item.design).toBe(ArticleDesign.Recipe);
 	});
 
 	test('matchreport', () => {
 		const item = f(contentWithTag('tone/matchreports'));
-		expect(item.design).toBe(Design.MatchReport);
+		expect(item.design).toBe(ArticleDesign.MatchReport);
 	});
 
 	test('interview', () => {
 		const item = f(contentWithTag('tone/interview'));
-		expect(item.design).toBe(Design.Interview);
+		expect(item.design).toBe(ArticleDesign.Interview);
 	});
 
 	test('editorial', () => {
 		const item = f(contentWithTag('tone/editorials'));
-		expect(item.design).toBe(Design.Editorial);
+		expect(item.design).toBe(ArticleDesign.Editorial);
 	});
 
 	test('quiz', () => {
 		const item = f(contentWithTag('tone/quizzes'));
-		expect(item.design).toBe(Design.Quiz);
+		expect(item.design).toBe(ArticleDesign.Quiz);
 	});
 
 	test('labs', () => {
 		const item = f(contentWithTag('tone/advertisement-features'));
-		expect(item.theme).toBe(Special.Labs);
+		expect(item.theme).toBe(ArticleSpecial.Labs);
 	});
 
 	test('article', () => {
 		const item = f(articleContent);
-		expect(item.design).toBe(Design.Article);
+		expect(item.design).toBe(ArticleDesign.Standard);
 	});
 });
 
@@ -774,12 +774,12 @@ describe('format', () => {
 	test('Uses immersive display', () => {
 		const item = f(immersive);
 		const format = getFormat(item);
-		expect(format.display).toBe(Display.Immersive);
+		expect(format.display).toBe(ArticleDisplay.Immersive);
 	});
 
 	test('Uses showcase display', () => {
 		const item = f(showcase);
 		const format = getFormat(item);
-		expect(format.display).toBe(Display.Showcase);
+		expect(format.display).toBe(ArticleDisplay.Showcase);
 	});
 });

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -9,15 +9,15 @@ import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Element } from '@guardian/content-api-models/v1/element';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import type { Format, Option } from '@guardian/types';
+import type { ArticleFormat } from '@guardian/libs';
 import {
-	Design,
-	Display,
-	fromNullable,
-	map,
-	Pillar,
-	Special,
-} from '@guardian/types';
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import type { Option } from '@guardian/types';
+import { fromNullable, map } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import type { Logo } from 'capi';
@@ -45,7 +45,7 @@ import { themeFromString } from 'themeStyles';
 
 // ----- Item Type ----- //
 
-interface Fields extends Format {
+interface Fields extends ArticleFormat {
 	headline: string;
 	standfirst: Option<DocumentFragment>;
 	byline: string;
@@ -66,7 +66,7 @@ interface Fields extends Format {
 }
 
 interface MatchReport extends Fields {
-	design: Design.MatchReport;
+	design: ArticleDesign.MatchReport;
 	body: Body;
 	football: Option<MatchScores>;
 }
@@ -76,64 +76,64 @@ interface ResizedRelatedContent extends RelatedContent {
 }
 
 interface LiveBlog extends Fields {
-	design: Design.LiveBlog;
+	design: ArticleDesign.LiveBlog;
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 }
 
 interface DeadBlog extends Fields {
-	design: Design.DeadBlog;
+	design: ArticleDesign.DeadBlog;
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 }
 
 interface Review extends Fields {
-	design: Design.Review;
+	design: ArticleDesign.Review;
 	body: Body;
 	starRating: number;
 }
 
 interface Comment extends Fields {
-	design: Design.Comment;
+	design: ArticleDesign.Comment;
 	body: Body;
 }
 
 interface Letter extends Fields {
-	design: Design.Letter;
+	design: ArticleDesign.Letter;
 	body: Body;
 }
 
 interface Editorial extends Fields {
-	design: Design.Editorial;
+	design: ArticleDesign.Editorial;
 	body: Body;
 }
 
 interface Interactive extends Fields {
-	design: Design.Interactive;
+	design: ArticleDesign.Interactive;
 	body: Body;
 }
 
 interface Obituary extends Fields {
-	design: Design.Obituary;
+	design: ArticleDesign.Obituary;
 	body: Body;
 }
 
 interface Correction extends Fields {
-	design: Design.Correction;
+	design: ArticleDesign.Correction;
 	body: Body;
 }
 
 // Catch-all for other Designs for now. As coverage of Designs increases,
-// this will likely be split out into each Design type.
+// this will likely be split out into each ArticleDesign type.
 interface Standard extends Fields {
 	design: Exclude<
-		Design,
-		| Design.LiveBlog
-		| Design.DeadBlog
-		| Design.Review
-		| Design.Comment
-		| Design.Letter
-		| Design.Editorial
+		ArticleDesign,
+		| ArticleDesign.LiveBlog
+		| ArticleDesign.DeadBlog
+		| ArticleDesign.Review
+		| ArticleDesign.Comment
+		| ArticleDesign.Letter
+		| ArticleDesign.Editorial
 	>;
 	body: Body;
 }
@@ -159,7 +159,7 @@ type ItemFieldsWithBody = ItemFields & { body: Body };
 
 // ----- Functions ----- //
 
-const getFormat = (item: Item): Format => ({
+const getFormat = (item: Item): ArticleFormat => ({
 	design: item.design,
 	display: item.display,
 	theme: item.theme,
@@ -188,16 +188,16 @@ const isShowcaseEmbed = (content: Content): boolean =>
 		(elem) => isMainEmbed(elem) && hasShowcaseAsset(elem.assets),
 	) ?? false;
 
-function getDisplay(content: Content): Display {
+function getDisplay(content: Content): ArticleDisplay {
 	if (isImmersive(content) || isPhotoEssay(content)) {
-		return Display.Immersive;
+		return ArticleDisplay.Immersive;
 		// This is meant to replicate the current logic in frontend:
 		// https://github.com/guardian/frontend/blob/88cfa609c73545085c3e5f3921631ec344a3eb83/common/app/model/meta.scala#L586
 	} else if (isShowcaseImage(content) || isShowcaseEmbed(content)) {
-		return Display.Showcase;
+		return ArticleDisplay.Showcase;
 	}
 
-	return Display.Standard;
+	return ArticleDisplay.Standard;
 }
 
 const itemFields = (
@@ -330,8 +330,8 @@ const fromCapiLiveBlog =
 		return {
 			design:
 				content.fields?.liveBloggingNow === true
-					? Design.LiveBlog
-					: Design.DeadBlog,
+					? ArticleDesign.LiveBlog
+					: ArticleDesign.DeadBlog,
 			blocks: parseLiveBlocks(body)(context),
 			totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
 			...itemFields(context, request),
@@ -348,83 +348,86 @@ const fromCapi =
 		// https://github.com/guardian/content-api-scala-client/blob/9e249bcef47cc048da483b3453c10dd7d2e9565d/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
 		if (isInteractive(content)) {
 			return {
-				design: Design.Interactive,
+				design: ArticleDesign.Interactive,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isMedia(tags)) {
 			return {
-				design: Design.Media,
+				design: ArticleDesign.Media,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (fields?.starRating !== undefined && isReview(tags)) {
 			return {
-				design: Design.Review,
+				design: ArticleDesign.Review,
 				starRating: fields.starRating,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isAnalysis(tags)) {
 			return {
-				design: Design.Analysis,
+				design: ArticleDesign.Analysis,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isCorrection(tags)) {
 			return {
-				design: Design.Correction,
+				design: ArticleDesign.Correction,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isLetter(tags)) {
 			return {
-				design: Design.Letter,
+				design: ArticleDesign.Letter,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isObituary(tags)) {
 			return {
-				design: Design.Obituary,
+				design: ArticleDesign.Obituary,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isGuardianView(tags)) {
 			return {
-				design: Design.Editorial,
+				design: ArticleDesign.Editorial,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isComment(tags)) {
 			const item = itemFieldsWithBody(context, request);
 			return {
-				design: Design.Comment,
+				design: ArticleDesign.Comment,
 				...item,
-				theme: item.theme === Pillar.News ? Pillar.Opinion : item.theme,
+				theme:
+					item.theme === ArticlePillar.News
+						? ArticlePillar.Opinion
+						: item.theme,
 			};
 		} else if (isInterview(tags)) {
 			return {
-				design: Design.Interview,
+				design: ArticleDesign.Interview,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isFeature(tags)) {
 			return {
-				design: Design.Feature,
+				design: ArticleDesign.Feature,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isLive(tags)) {
 			return fromCapiLiveBlog(context)(request);
 		} else if (isRecipe(tags)) {
 			return {
-				design: Design.Recipe,
+				design: ArticleDesign.Recipe,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isQuiz(tags)) {
 			return {
-				design: Design.Quiz,
+				design: ArticleDesign.Quiz,
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isLabs(tags)) {
 			return {
-				design: Design.Article,
+				design: ArticleDesign.Standard,
 				...itemFieldsWithBody(context, request),
-				theme: Special.Labs,
+				theme: ArticleSpecial.Labs,
 			};
 		} else if (isMatchReport(tags)) {
 			return {
-				design: Design.MatchReport,
+				design: ArticleDesign.MatchReport,
 				football: parseMatchScores(
 					fromNullable(request.footballContent),
 				),
@@ -433,7 +436,7 @@ const fromCapi =
 		}
 
 		return {
-			design: Design.Article,
+			design: ArticleDesign.Standard,
 			...itemFieldsWithBody(context, request),
 		};
 	};

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -1,27 +1,16 @@
 // ----- Imports ----- //
 
 import { maybeRender, pipe } from '@guardian/common-rendering/src/lib';
-import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import type { Option, Result } from '@guardian/types';
 import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticlePillar,
-	ArticleSpecial,
-} from '@guardian/libs';
-import type { Format, Option, Result, Theme } from '@guardian/types';
-import {
-	Design,
-	Display,
 	err,
 	fromNullable,
 	map,
 	none,
 	ok,
 	OptionKind,
-	Pillar,
 	ResultKind,
 	some,
-	Special,
 	withDefault,
 } from '@guardian/types';
 
@@ -145,93 +134,6 @@ const fold =
 		return withDefault(ifNone)(map(f)(opt));
 	};
 
-const convertFormatToArticleFormat = (format: Format): ArticleFormat => {
-	return {
-		design: convertDesignToArticleDesign(format.design),
-		display: convertDisplayToArticleDisplay(format.display),
-		theme: convertThemeToArticleTheme(format.theme),
-	};
-};
-
-const convertDesignToArticleDesign = (design: Design): ArticleDesign => {
-	switch (design) {
-		case Design.Media:
-			return ArticleDesign.Media;
-		case Design.Review:
-			return ArticleDesign.Review;
-		case Design.Analysis:
-			return ArticleDesign.Analysis;
-		case Design.Comment:
-			return ArticleDesign.Comment;
-		case Design.Letter:
-			return ArticleDesign.Letter;
-		case Design.Feature:
-			return ArticleDesign.Feature;
-		case Design.LiveBlog:
-			return ArticleDesign.LiveBlog;
-		case Design.DeadBlog:
-			return ArticleDesign.DeadBlog;
-		case Design.Recipe:
-			return ArticleDesign.Recipe;
-		case Design.MatchReport:
-			return ArticleDesign.MatchReport;
-		case Design.Interview:
-			return ArticleDesign.Interview;
-		case Design.Editorial:
-			return ArticleDesign.Editorial;
-		case Design.Quiz:
-			return ArticleDesign.Quiz;
-		case Design.Interactive:
-			return ArticleDesign.Interactive;
-		case Design.PhotoEssay:
-			return ArticleDesign.PhotoEssay;
-		case Design.PrintShop:
-			return ArticleDesign.PrintShop;
-		case Design.Obituary:
-			return ArticleDesign.Obituary;
-		case Design.Correction:
-			return ArticleDesign.Correction;
-		case Design.FullPageInteractive:
-			return ArticleDesign.FullPageInteractive;
-		case Design.Article:
-		default:
-			return ArticleDesign.Standard;
-	}
-};
-
-const convertDisplayToArticleDisplay = (display: Display): ArticleDisplay => {
-	switch (display) {
-		case Display.Immersive:
-			return ArticleDisplay.Immersive;
-		case Display.Showcase:
-			return ArticleDisplay.Showcase;
-		case Display.NumberedList:
-			return ArticleDisplay.NumberedList;
-		case Display.Standard:
-		default:
-			return ArticleDisplay.Standard;
-	}
-};
-
-const convertThemeToArticleTheme = (theme: Theme): ArticleTheme => {
-	switch (theme) {
-		case Pillar.Opinion:
-			return ArticlePillar.Opinion;
-		case Pillar.Sport:
-			return ArticlePillar.Sport;
-		case Pillar.Culture:
-			return ArticlePillar.Culture;
-		case Pillar.Lifestyle:
-			return ArticlePillar.Lifestyle;
-		case Special.SpecialReport:
-			return ArticleSpecial.SpecialReport;
-		case Special.Labs:
-			return ArticleSpecial.Labs;
-		case Pillar.News:
-		default:
-			return ArticlePillar.News;
-	}
-};
 // ----- Exports ----- //
 
 export {
@@ -253,6 +155,4 @@ export {
 	resultMap3,
 	resultToNullable,
 	fold,
-	convertFormatToArticleFormat,
-	convertThemeToArticleTheme,
 };

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -7,12 +7,12 @@ import {
 	transformHref,
 } from 'renderer';
 import { JSDOM } from 'jsdom';
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 import { isValidElement, ReactNode } from 'react';
 import { compose } from 'lib';
 import { BodyElement, ElementKind } from 'bodyElement';
 import { none, some } from '@guardian/types';
-import { Design, Display, Format } from '@guardian/types';
+import { ArticleDesign, ArticleDisplay, ArticleFormat } from '@guardian/libs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { act } from 'react-dom/test-utils';
 import { unmountComponentAtNode, render as renderDom } from 'react-dom';
@@ -20,10 +20,10 @@ import { EmbedKind } from 'embed';
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
 import { ArticleElementRole } from '@guardian/libs';
 
-const mockFormat: Format = {
-	theme: Pillar.News,
-	design: Design.Article,
-	display: Display.Standard,
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
 };
 
 beforeEach(() => {

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
 import { createHash } from 'crypto';
-import { Design, map, partition, withDefault } from '@guardian/types';
+import { ArticleDesign } from '@guardian/libs';
+import { map, partition, withDefault } from '@guardian/types';
 import type { Result } from '@guardian/types';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -48,7 +49,8 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 	);
 
 const getElements = (item: Item): Array<Result<string, BodyElement>> =>
-	item.design === Design.LiveBlog || item.design === Design.DeadBlog
+	item.design === ArticleDesign.LiveBlog ||
+	item.design === ArticleDesign.DeadBlog
 		? item.blocks.flatMap((block) => block.body)
 		: item.body;
 
@@ -98,7 +100,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'
 			: ''
 	};
-    script-src 'self' ${assetHashes(scripts)} 
+    script-src 'self' ${assetHashes(scripts)}
 	https://interactive.guim.co.uk https://s16.tiktokcdn.com https://www.tiktok.com/embed.js https://sf16-scmcdn-sg.ibytedtos.com/ ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'

--- a/apps-rendering/src/server/editionsPage.tsx
+++ b/apps-rendering/src/server/editionsPage.tsx
@@ -5,8 +5,9 @@ import { CacheProvider } from '@emotion/react';
 import { extractCritical } from '@emotion/server';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
+import type { ArticleTheme } from '@guardian/libs';
 import { resets } from '@guardian/src-foundations/utils';
-import type { Option, Theme } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
 import { getThirdPartyEmbeds } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
@@ -158,7 +159,7 @@ function render(
 	request: RenderingRequest,
 	res: Response,
 	getAssetLocation: (assetName: string) => string,
-	themeOverride: Option<Theme>,
+	themeOverride: Option<ArticleTheme>,
 ): Page {
 	const path = res.req.path;
 	const isPreview = res.req.query.isPreview === 'true';

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -5,10 +5,12 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { background } from '@guardian/src-foundations/palette';
 import { resets } from '@guardian/src-foundations/utils';
-import { Design, Display, map, none, some } from '@guardian/types';
-import type { Format, Option } from '@guardian/types';
+import { map, none, some } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { getThirdPartyEmbeds, requiresInlineStyles } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
 import { atomCss, atomScript } from 'components/interactiveAtom';
@@ -38,21 +40,23 @@ const emotionServer = createEmotionServer(emotionCache);
 
 // ----- Functions ----- //
 
-const scriptName = ({ design, display }: Format): Option<string> => {
+const scriptName = ({ design, display }: ArticleFormat): Option<string> => {
 	switch (design) {
-		case Design.LiveBlog:
+		case ArticleDesign.LiveBlog:
 			return some('liveblog.js');
-		case Design.Interactive:
-			return display !== Display.Immersive ? some('article.js') : none;
-		case Design.Editorial:
-		case Design.Letter:
-		case Design.Comment:
-		case Design.Feature:
-		case Design.Analysis:
-		case Design.Review:
-		case Design.Article:
-		case Design.Quiz:
-		case Design.Media:
+		case ArticleDesign.Interactive:
+			return display !== ArticleDisplay.Immersive
+				? some('article.js')
+				: none;
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Review:
+		case ArticleDesign.Standard:
+		case ArticleDesign.Quiz:
+		case ArticleDesign.Media:
 			return some('article.js');
 		default:
 			return none;
@@ -62,13 +66,13 @@ const scriptName = ({ design, display }: Format): Option<string> => {
 const shouldHideAds = (request: RenderingRequest): boolean =>
 	request.content.fields?.shouldHideAdverts ?? false;
 
-const styles = (format: Format): string => `
+const styles = (format: ArticleFormat): string => `
     ${pageFonts}
 	${resets.resetCSS}
 
     body {
         background: ${
-			format.design === Design.Media ? background.inverse : 'white'
+			format.design === ArticleDesign.Media ? background.inverse : 'white'
 		};
         margin: 0;
         font-family: 'Guardian Text Egyptian Web';

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -5,7 +5,9 @@ import path from 'path';
 import type { RelatedContent } from '@guardian/apps-rendering-api-models/relatedContent';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Content } from '@guardian/content-api-models/v1/content';
-import type { Option, Result, Theme } from '@guardian/types';
+import type { ArticleTheme } from '@guardian/libs';
+import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { Option, Result } from '@guardian/types';
 import {
 	either,
 	err,
@@ -13,9 +15,7 @@ import {
 	none,
 	ok,
 	OptionKind,
-	Pillar,
 	some,
-	Special,
 	withDefault,
 } from '@guardian/types';
 import { capiEndpoint } from 'capi';
@@ -58,22 +58,22 @@ type CapiReturn = Promise<Result<number, [Content, RelatedContent]>>;
 
 // ----- Functions ----- //
 
-function themeFromUnknown(a: unknown): Option<Theme> {
+function themeFromUnknown(a: unknown): Option<ArticleTheme> {
 	switch (a) {
 		case '0':
-			return some(Pillar.News);
+			return some(ArticlePillar.News);
 		case '1':
-			return some(Pillar.Opinion);
+			return some(ArticlePillar.Opinion);
 		case '2':
-			return some(Pillar.Sport);
+			return some(ArticlePillar.Sport);
 		case '3':
-			return some(Pillar.Culture);
+			return some(ArticlePillar.Culture);
 		case '4':
-			return some(Pillar.Lifestyle);
+			return some(ArticlePillar.Lifestyle);
 		case '5':
-			return some(Special.SpecialReport);
+			return some(ArticleSpecial.SpecialReport);
 		case '6':
-			return some(Special.Labs);
+			return some(ArticleSpecial.Labs);
 		default:
 			return none;
 	}
@@ -158,7 +158,7 @@ function serveArticleSwitch(
 	renderingRequest: RenderingRequest,
 	res: ExpressResponse,
 	isEditions: boolean,
-	themeOverride: Option<Theme>,
+	themeOverride: Option<ArticleTheme>,
 ): Promise<void> {
 	if (isEditions) {
 		return serveEditionsArticle(renderingRequest, res, themeOverride);
@@ -186,7 +186,7 @@ async function serveArticle(
 async function serveEditionsArticle(
 	request: RenderingRequest,
 	res: ExpressResponse,
-	themeOverride: Option<Theme>,
+	themeOverride: Option<ArticleTheme>,
 ): Promise<void> {
 	const imageSalt = await getConfigValue('apis.img.salt');
 

--- a/apps-rendering/src/storybookHelpers.ts
+++ b/apps-rendering/src/storybookHelpers.ts
@@ -1,43 +1,43 @@
 // ----- Imports ----- //
 
-import { Design, Pillar } from '@guardian/types';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { select } from '@storybook/addon-knobs';
 
 // ----- Helpers ----- //
 
 const pillarOptions = {
-	News: Pillar.News,
-	Opinion: Pillar.Opinion,
-	Sport: Pillar.Sport,
-	Culture: Pillar.Culture,
-	Lifestyle: Pillar.Lifestyle,
+	News: ArticlePillar.News,
+	Opinion: ArticlePillar.Opinion,
+	Sport: ArticlePillar.Sport,
+	Culture: ArticlePillar.Culture,
+	Lifestyle: ArticlePillar.Lifestyle,
 };
 
-const selectPillar = (initial: Pillar): Pillar =>
+const selectPillar = (initial: ArticlePillar): ArticlePillar =>
 	select('Pillar', pillarOptions, initial);
 
 const designOptions = {
-	Article: Design.Article,
-	Media: Design.Media,
-	Review: Design.Review,
-	Analysis: Design.Analysis,
-	Comment: Design.Comment,
-	Letter: Design.Letter,
-	Feature: Design.Feature,
-	LiveBlog: Design.LiveBlog,
-	DeadBlog: Design.DeadBlog,
-	Recipe: Design.Recipe,
-	MatchReport: Design.MatchReport,
-	Interview: Design.Interview,
-	Editorial: Design.Editorial,
-	Quiz: Design.Quiz,
-	Interactive: Design.Interactive,
-	PhotoEssay: Design.PhotoEssay,
-	PrintShop: Design.PrintShop,
+	Article: ArticleDesign.Standard,
+	Media: ArticleDesign.Media,
+	Review: ArticleDesign.Review,
+	Analysis: ArticleDesign.Analysis,
+	Comment: ArticleDesign.Comment,
+	Letter: ArticleDesign.Letter,
+	Feature: ArticleDesign.Feature,
+	LiveBlog: ArticleDesign.LiveBlog,
+	DeadBlog: ArticleDesign.DeadBlog,
+	Recipe: ArticleDesign.Recipe,
+	MatchReport: ArticleDesign.MatchReport,
+	Interview: ArticleDesign.Interview,
+	Editorial: ArticleDesign.Editorial,
+	Quiz: ArticleDesign.Quiz,
+	Interactive: ArticleDesign.Interactive,
+	PhotoEssay: ArticleDesign.PhotoEssay,
+	PrintShop: ArticleDesign.PrintShop,
 };
 
-const selectDesign = (initial: Design): Design =>
-	select('Design', designOptions, initial);
+const selectDesign = (initial: ArticleDesign): ArticleDesign =>
+	select('ArticleDesign', designOptions, initial);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/styles.test.ts
+++ b/apps-rendering/src/styles.test.ts
@@ -1,10 +1,10 @@
 import { darkModeCss } from './styles';
 import { getThemeStyles } from 'themeStyles';
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 describe('helper functions return correct styles', () => {
 	test('Returns correct pillar styles for pillar', () => {
-		const pillarStyles = getThemeStyles(Pillar.News);
+		const pillarStyles = getThemeStyles(ArticlePillar.News);
 		const expectedNewsPillarStyles = {
 			cameraIcon: '#FFF4F2',
 			cameraIconBackground: '#C70000',

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -1,5 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 import {
@@ -8,8 +10,8 @@ import {
 	neutral,
 } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import type { Format, Option } from '@guardian/types';
-import { Design, map, none, some, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { map, none, some, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 
 export const sidePadding = css`
@@ -118,14 +120,14 @@ export const onwardStyles: SerializedStyles = css`
 
 const adHeight = '258px';
 
-export const backgroundColor = (format: Format): string =>
-	format.design === Design.Comment ||
-	format.design === Design.Letter ||
-	format.design === Design.Editorial
+export const backgroundColor = (format: ArticleFormat): string =>
+	format.design === ArticleDesign.Comment ||
+	format.design === ArticleDesign.Letter ||
+	format.design === ArticleDesign.Editorial
 		? neutral[86]
 		: neutral[97];
 
-export const adStyles = (format: Format): SerializedStyles => {
+export const adStyles = (format: ArticleFormat): SerializedStyles => {
 	return css`
 		.ad-placeholder {
 			margin: ${remSpace[4]} 0;

--- a/apps-rendering/src/themeStyles.ts
+++ b/apps-rendering/src/themeStyles.ts
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
+import type { ArticleTheme } from '@guardian/libs';
+import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import * as palette from '@guardian/src-foundations/palette';
-import type { Theme } from '@guardian/types';
-import { Pillar, Special } from '@guardian/types';
 
 // ----- Types ----- //
 
@@ -18,11 +18,11 @@ interface ThemeStyles {
 }
 
 type ThemeColours = {
-	[theme in Theme]: ThemeStyles;
+	[theme in ArticleTheme]: ThemeStyles;
 };
 
 export const themeColours: ThemeColours = {
-	[Pillar.News]: {
+	[ArticlePillar.News]: {
 		kicker: palette.news[400],
 		inverted: palette.news[500],
 		liveblogKicker: palette.news[600],
@@ -32,7 +32,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.news[800],
 		cameraIconBackground: palette.news[400],
 	},
-	[Pillar.Opinion]: {
+	[ArticlePillar.Opinion]: {
 		kicker: palette.opinion[400],
 		inverted: palette.opinion[500],
 		liveblogKicker: palette.opinion[600],
@@ -42,7 +42,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.opinion[800],
 		cameraIconBackground: palette.opinion[400],
 	},
-	[Pillar.Sport]: {
+	[ArticlePillar.Sport]: {
 		kicker: palette.sport[400],
 		inverted: palette.sport[500],
 		liveblogKicker: palette.sport[600],
@@ -52,7 +52,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.sport[800],
 		cameraIconBackground: palette.sport[400],
 	},
-	[Pillar.Culture]: {
+	[ArticlePillar.Culture]: {
 		kicker: palette.culture[400],
 		inverted: palette.culture[500],
 		liveblogKicker: palette.culture[600],
@@ -62,7 +62,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.culture[800],
 		cameraIconBackground: palette.culture[400],
 	},
-	[Pillar.Lifestyle]: {
+	[ArticlePillar.Lifestyle]: {
 		kicker: palette.lifestyle[400],
 		inverted: palette.lifestyle[500],
 		liveblogKicker: palette.lifestyle[500],
@@ -72,7 +72,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.lifestyle[800],
 		cameraIconBackground: palette.lifestyle[400],
 	},
-	[Special.SpecialReport]: {
+	[ArticleSpecial.SpecialReport]: {
 		kicker: palette.specialReport[400],
 		inverted: palette.specialReport[500],
 		liveblogKicker: palette.specialReport[500],
@@ -82,7 +82,7 @@ export const themeColours: ThemeColours = {
 		cameraIcon: palette.specialReport[800],
 		cameraIconBackground: palette.specialReport[400],
 	},
-	[Special.Labs]: {
+	[ArticleSpecial.Labs]: {
 		kicker: palette.specialReport[400],
 		inverted: palette.specialReport[500],
 		liveblogKicker: palette.specialReport[500],
@@ -94,63 +94,64 @@ export const themeColours: ThemeColours = {
 	},
 };
 
-const getThemeStyles = (theme: Theme): ThemeStyles => themeColours[theme];
+const getThemeStyles = (theme: ArticleTheme): ThemeStyles =>
+	themeColours[theme];
 
-function themeFromString(theme: string | undefined): Pillar {
+function themeFromString(theme: string | undefined): ArticlePillar {
 	switch (theme) {
 		case 'pillar/opinion':
-			return Pillar.Opinion;
+			return ArticlePillar.Opinion;
 		case 'pillar/sport':
-			return Pillar.Sport;
+			return ArticlePillar.Sport;
 		case 'pillar/arts':
-			return Pillar.Culture;
+			return ArticlePillar.Culture;
 		case 'pillar/lifestyle':
-			return Pillar.Lifestyle;
+			return ArticlePillar.Lifestyle;
 		case 'pillar/news':
 		default:
-			return Pillar.News;
+			return ArticlePillar.News;
 	}
 }
 
-function themeToPillarString(theme: Theme): string {
+function themeToPillarString(theme: ArticleTheme): string {
 	switch (theme) {
-		case Pillar.Opinion:
+		case ArticlePillar.Opinion:
 			return 'opinion';
-		case Pillar.Sport:
+		case ArticlePillar.Sport:
 			return 'sport';
-		case Pillar.Culture:
+		case ArticlePillar.Culture:
 			return 'culture';
-		case Pillar.Lifestyle:
+		case ArticlePillar.Lifestyle:
 			return 'lifestyle';
-		case Pillar.News:
+		case ArticlePillar.News:
 		default:
 			return 'news';
 	}
 }
 
-function themeToPillar(theme: Theme): Pillar {
+function themeToPillar(theme: ArticleTheme): ArticlePillar {
 	switch (theme) {
-		case Special.SpecialReport:
-		case Special.Labs:
-			return Pillar.News;
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.Labs:
+			return ArticlePillar.News;
 		default:
 			return theme;
 	}
 }
-const stringToPillar = (pillar: string): Pillar => {
+const stringToPillar = (pillar: string): ArticlePillar => {
 	switch (pillar) {
 		case 'news':
-			return Pillar.News;
+			return ArticlePillar.News;
 		case 'opinion':
-			return Pillar.Opinion;
+			return ArticlePillar.Opinion;
 		case 'culture':
-			return Pillar.Culture;
+			return ArticlePillar.Culture;
 		case 'sport':
-			return Pillar.Sport;
+			return ArticlePillar.Sport;
 		case 'lifestyle':
-			return Pillar.Lifestyle;
+			return ArticlePillar.Lifestyle;
 		default:
-			return Pillar.News;
+			return ArticlePillar.News;
 	}
 };
 

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@emotion/react": "^11.4.1",
         "@guardian/libs": "^3.3.0",
-        "@guardian/types": "^8.0.0",
+        "@guardian/types": "^9.0.1",
         "react": "^17.0.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,10 +1669,10 @@
     "@guardian/src-helpers" "^3.10.3-rc.1"
     "@guardian/src-icons" "^3.10.3-rc.1"
 
-"@guardian/types@^8.0.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-8.1.0.tgz#520e16d93c1a8f2bf36c8f4faff5bea81fb9346d"
-  integrity sha512-6qpQxHW+DwvJqc4aPrWIN0GoErTN8R+WlQ4Cq/NJKiIWROvgOytC4P/2hiLNxoEpla93cT56293Fd1cYRUhnPA==
+"@guardian/types@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-9.0.1.tgz#a03682d9c2942560714f9c724a1cd7068f772a93"
+  integrity sha512-JTQe4giki1QYqE5bRkCbYWvelF2DtaQVlGmIbVwO8XWNc62TOQcBOUmqFb2EWpszWqkzBLEBB4rKKArgBZHTeA==
 
 "@hapi/hoek@^9.0.0":
   version "9.2.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Move all of apps-rendering's uses of @guardian/types (excl. Option, Result & Related) to @guardian/libs, this bring AR in line with the rest of the repo.

Update @guardian/types to the latest (and last) version to avoid it being accidentally used where it shouldn't

Work completed with @idrise (sorry I forgot to co-author you in the commit!)

## Why?

Health 🎉🎉🎉
