### PR TITLE
Remove @guardian/src-svgs as it is unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@guardian/src-layout": "^3.12.0",
     "@guardian/src-link": "^3.10.0",
     "@guardian/src-radio": "^3.10.0",
-    "@guardian/src-svgs": "^2.8.2",
     "@guardian/src-text-area": "^3.10.0",
     "@guardian/src-text-input": "^3.10.0",
     "@storybook/addon-essentials": "^6.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,11 +1639,6 @@
     "@guardian/src-label" "^3.10.3-rc.1"
     "@guardian/src-user-feedback" "^3.10.3-rc.1"
 
-"@guardian/src-svgs@^2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-2.8.2.tgz#4e05c4f144c8507d39166aa6aa8c146c8a3612ae"
-  integrity sha512-PyZJ6jwUKUMsHdKywz/Pgk7oHjvSDdEqTZq6vkiOPJLTjEraEdyO6amu7L7ynVO58CmgzJ+6SwOOAtilHU/LRw==
-
 "@guardian/src-text-area@^3.10.0":
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-text-area/-/src-text-area-3.11.0.tgz#4b2abd79969706f27c41b68b69fffc8625a0c153"


### PR DESCRIPTION
## What does this change?

Remove the `@guardian/src-svgs` package from the `package.json`...

## Why?

...because it's not used anywhere.