### PR TITLE
Send sectionId for epic targeting

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -45,7 +45,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^21.0.0",
-    "@guardian/automat-contributions": "^0.4.2",
+    "@guardian/automat-contributions": "^0.4.3",
     "@guardian/braze-components": "^4.2.0",
     "@guardian/commercial-core": "^0.26.0",
     "@guardian/consent-management-platform": "~6.11.5",

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1227,6 +1227,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					countryCode={countryCode}
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
+					sectionId={CAPI.config.section}
 					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
 					isMinuteArticle={CAPI.pageType.isMinuteArticle}
 					isPaidContent={CAPI.pageType.isPaidContent}

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -27,7 +27,6 @@ import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { cmp } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
 import { getCookie } from '../../browser/cookie';
-import {Targeting} from "@guardian/automat-contributions/lib/types";
 
 type PreEpicConfig = {
 	module: {

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -27,6 +27,7 @@ import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { cmp } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
 import { getCookie } from '../../browser/cookie';
+import {Targeting} from "@guardian/automat-contributions/lib/types";
 
 type PreEpicConfig = {
 	module: {
@@ -68,7 +69,7 @@ export type CanShowData = {
 	isSignedIn?: boolean;
 	countryCode?: string;
 	contentType: string;
-	sectionName?: string;
+	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	isMinuteArticle: boolean;
 	isPaidContent: boolean;
@@ -91,7 +92,7 @@ const buildPayload = async (data: CanShowData): Promise<Metadata> => {
 		},
 		targeting: {
 			contentType: data.contentType,
-			sectionName: data.sectionName || '', // TODO update client to reflect that this is optional
+			sectionId: data.sectionId,
 			shouldHideReaderRevenue: data.shouldHideReaderRevenue,
 			isMinuteArticle: data.isMinuteArticle,
 			isPaidContent: data.isPaidContent,

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -26,6 +26,7 @@ type Props = {
 	countryCode?: string;
 	contentType: string;
 	sectionName?: string;
+	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	isMinuteArticle: boolean;
 	isPaidContent: boolean;
@@ -82,6 +83,7 @@ export const SlotBodyEnd = ({
 	countryCode,
 	contentType,
 	sectionName,
+	sectionId,
 	shouldHideReaderRevenue,
 	isMinuteArticle,
 	isPaidContent,
@@ -99,7 +101,7 @@ export const SlotBodyEnd = ({
 			isSignedIn,
 			countryCode,
 			contentType,
-			sectionName,
+			sectionId,
 			shouldHideReaderRevenue,
 			isMinuteArticle,
 			isPaidContent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,10 +1482,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/automat-contributions@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.2.tgz#38eff2111ee032a1a25dc6bc32798cbf62a9db7e"
-  integrity sha512-6aSGaIHgkcVYLW5tgmiWYdv3N5k7I4NOCwv+YIz8HPWOq/QBHR43nx1tliF8+7LX9bKBVPuEEvPkND1i44tQbA==
+"@guardian/automat-contributions@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.3.tgz#3ef815d637022802cbeac7830813bbdf7326b43d"
+  integrity sha512-zSvPfrswfd0FGx0qfCwORmebeI46RMhkxgQQiZ8uCC6IRUDd+3UYl7/0hAILeGKGZ7qDUC8EwQ6TX0le7+2a1g==
 
 "@guardian/braze-components@^4.2.0":
   version "4.2.0"


### PR DESCRIPTION
Currently DCR sends the `sectionName` in the epic targeting payload to SDC.
This is inconsistent because for tag-based targeting we use `tagId`.
With this PR we send `sectionId` instead.

For a time SDC will support both fields:
https://github.com/guardian/support-dotcom-components/pull/559