### PR TITLE
Remove `palette` from `App.tsx`

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -84,7 +84,6 @@ import {
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
 import { trackPerformance } from '../browser/ga/ga';
-import { decidePalette } from '../lib/decidePalette';
 import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 import { CommercialMetrics } from './CommercialMetrics';
 
@@ -421,7 +420,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 		design,
 		theme: pillar,
 	};
-	const palette = decidePalette(format);
 
 	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
 
@@ -800,7 +798,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				>
 					<YoutubeBlockComponent
 						format={format}
-						palette={palette}
 						hideCaption={false}
 						// eslint-disable-next-line jsx-a11y/aria-role
 						role="inline"
@@ -827,7 +824,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						role={interactiveBlock.role}
 						caption={interactiveBlock.caption}
 						format={format}
-						palette={palette}
 					/>
 				</HydrateInteractiveOnce>
 			))}
@@ -878,7 +874,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							palette={palette}
 							format={format}
 						/>
 					</>
@@ -919,10 +914,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			))}
 			{callouts.map((callout) => (
 				<HydrateOnce rootId={callout.elementId}>
-					<CalloutBlockComponent
-						callout={callout}
-						palette={palette}
-					/>
+					<CalloutBlockComponent callout={callout} format={format} />
 				</HydrateOnce>
 			))}
 			{chartAtoms.map((chartAtom) => (
@@ -1136,7 +1128,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					>
 						<MapEmbedBlockComponent
 							format={format}
-							palette={palette}
 							embedUrl={map.embedUrl}
 							height={map.height}
 							width={map.width}
@@ -1161,7 +1152,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							width={spotify.width}
 							title={spotify.title}
 							format={format}
-							palette={palette}
 							caption={spotify.caption}
 							credit="Spotify"
 						/>
@@ -1178,7 +1168,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					>
 						<VideoFacebookBlockComponent
 							format={format}
-							palette={palette}
 							embedUrl={facebookVideo.embedUrl}
 							height={facebookVideo.height}
 							width={facebookVideo.width}
@@ -1290,11 +1279,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
 				<Discussion
+					format={format}
 					discussionApiUrl={CAPI.config.discussionApiUrl}
 					shortUrlId={CAPI.config.shortUrlId}
 					isCommentable={CAPI.isCommentable}
-					pillar={pillar}
-					palette={palette}
 					user={user || undefined}
 					discussionD2Uid={CAPI.config.discussionD2Uid}
 					discussionApiClientHeader={
@@ -1304,15 +1292,13 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isAdFreeUser={CAPI.isAdFreeUser}
 					shouldHideAds={CAPI.shouldHideAds}
 					beingHydrated={true}
-					display={display}
 				/>
 			</HydrateOnce>
 			<Portal rootId="most-viewed-footer">
 				<MostViewedFooter
-					palette={palette}
+					format={format}
 					sectionName={CAPI.sectionName}
 					ajaxUrl={CAPI.config.ajaxUrl}
-					display={display}
 				/>
 			</Portal>
 			<Portal rootId="reader-revenue-links-footer">

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -960,11 +960,6 @@ export const SpotifyBlockComponentStory = () => {
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
 							}}
-							palette={decidePalette({
-								theme: ArticlePillar.News,
-								display: ArticleDisplay.Standard,
-								design: ArticleDesign.Standard,
-							})}
 							credit="Spotify"
 						/>
 					</ClickToView>

--- a/dotcom-rendering/src/web/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.stories.tsx
@@ -1,5 +1,4 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '../lib/decidePalette';
 
 import { Discussion } from './Discussion';
 
@@ -14,19 +13,17 @@ export const Basic = () => {
 				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
 				shortUrlId="/p/4v8kk"
 				isCommentable={true}
-				pillar={3}
-				palette={decidePalette({
+				format={{
 					design: ArticleDesign.Standard,
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Culture,
-				})}
+				}}
 				discussionD2Uid="zHoBy6HNKsk"
 				discussionApiClientHeader="nextgen"
 				enableDiscussionSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
 				beingHydrated={true}
-				display={0}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -17,14 +17,13 @@ import { Hide } from '@frontend/web/components/Hide';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { joinUrl } from '@root/src/lib/joinUrl';
 import { useDiscussion } from '@root/src/web/lib/useDiscussion';
-import { ArticleDisplay } from '@guardian/libs';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
+	format: ArticleFormat;
 	discussionApiUrl: string;
 	shortUrlId: string;
 	isCommentable: boolean;
-	pillar: ArticleTheme;
-	palette: Palette;
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
@@ -45,7 +44,6 @@ type Props = {
 	// then thank you!
 	beingHydrated?: boolean;
 	// **************************************************************************
-	display: ArticleDisplay;
 };
 
 const commentIdFromUrl = () => {
@@ -58,11 +56,10 @@ const commentIdFromUrl = () => {
 };
 
 export const Discussion = ({
+	format,
 	discussionApiUrl,
 	shortUrlId,
 	isCommentable,
-	pillar,
-	palette,
 	user,
 	discussionD2Uid,
 	discussionApiClientHeader,
@@ -70,7 +67,6 @@ export const Discussion = ({
 	isAdFreeUser,
 	shouldHideAds,
 	beingHydrated,
-	display,
 }: Props) => {
 	const [commentPage, setCommentPage] = useState<number>();
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
@@ -85,6 +81,8 @@ export const Discussion = ({
 	const { commentCount, isClosedForComments } = useDiscussion(
 		joinUrl([discussionApiUrl, 'discussion', shortUrlId]),
 	);
+
+	const palette = decidePalette(format);
 
 	const hasCommentsHash =
 		typeof window !== 'undefined' &&
@@ -203,7 +201,7 @@ export const Discussion = ({
 							<Comments
 								user={user}
 								baseUrl={discussionApiUrl}
-								pillar={pillar}
+								pillar={format.theme}
 								initialPage={commentPage}
 								pageSizeOverride={commentPageSize}
 								isClosedForComments={
@@ -231,7 +229,7 @@ export const Discussion = ({
 								<Comments
 									user={user}
 									baseUrl={discussionApiUrl}
-									pillar={pillar}
+									pillar={format.theme}
 									initialPage={commentPage}
 									pageSizeOverride={commentPageSize}
 									isClosedForComments={
@@ -267,7 +265,7 @@ export const Discussion = ({
 								>
 									<AdSlot
 										position="comments"
-										display={display}
+										display={format.display}
 									/>
 								</div>
 							</RightColumn>

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -4,7 +4,6 @@ import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { ABProvider } from '@guardian/ab-react';
 
 import { ElementContainer } from '@frontend/web/components/ElementContainer';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 import {
 	responseWithTwoTabs,
 	responseWithOneTab,
@@ -45,14 +44,13 @@ export const withTwoTabs = () => {
 		<AbProvider>
 			<ElementContainer>
 				<MostViewedFooter
-					palette={decidePalette({
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					})}
+					}}
 					sectionName="politics"
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					display={ArticleDisplay.Standard}
 				/>
 			</ElementContainer>
 		</AbProvider>
@@ -70,13 +68,12 @@ export const withOneTabs = () => {
 		<AbProvider>
 			<ElementContainer>
 				<MostViewedFooter
-					palette={decidePalette({
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					})}
+					}}
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					display={ArticleDisplay.Standard}
 				/>
 			</ElementContainer>
 		</AbProvider>
@@ -94,13 +91,12 @@ export const withNoMostSharedImage = () => {
 		<AbProvider>
 			<ElementContainer>
 				<MostViewedFooter
-					palette={decidePalette({
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					})}
+					}}
 					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					display={ArticleDisplay.Standard}
 				/>
 			</ElementContainer>
 		</AbProvider>

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -11,7 +11,7 @@ import { Lazy } from '@root/src/web/components/Lazy';
 
 import { useAB } from '@guardian/ab-react';
 import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
-import { ArticleDisplay } from '@guardian/libs';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 const MostViewedFooterData = React.lazy(() => {
 	const { start, end } = initPerf('MostViewedFooterData');
@@ -93,17 +93,11 @@ const mostPopularAdStyle = css`
 
 interface Props {
 	sectionName?: string;
-	palette: Palette;
+	format: ArticleFormat;
 	ajaxUrl: string;
-	display: ArticleDisplay;
 }
 
-export const MostViewedFooter = ({
-	sectionName,
-	palette,
-	ajaxUrl,
-	display,
-}: Props) => {
+export const MostViewedFooter = ({ sectionName, format, ajaxUrl }: Props) => {
 	// Example usage of AB Tests
 	// Used in the Cypress tests as smoke test of the AB tests framework integration
 	const ABTestAPI = useAB();
@@ -116,6 +110,8 @@ export const MostViewedFooter = ({
 	const runnableTest = ABTestAPI.runnableTest(abTestTest);
 	const variantFromRunnable =
 		(runnableTest && runnableTest.variantToRun.id) || 'not-runnable';
+
+	const palette = decidePalette(format);
 
 	return (
 		<div
@@ -148,7 +144,7 @@ export const MostViewedFooter = ({
 							margin: 6px 0 0 10px;
 						`}
 					>
-						<AdSlot position="mostpop" display={display} />
+						<AdSlot position="mostpop" display={format.display} />
 					</div>
 				</section>
 			</div>

--- a/dotcom-rendering/src/web/components/SubNav/SubNav.tsx
+++ b/dotcom-rendering/src/web/components/SubNav/SubNav.tsx
@@ -8,7 +8,6 @@ import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
 	subNavSections: SubNavType;
-	palette: Palette;
 	currentNavLink: string;
 	format: ArticleFormat;
 };
@@ -78,13 +77,13 @@ const fontStyle = css`
 	}
 `;
 
-const linkStyle = (format: ArticleFormat) => css`
+const linkStyle = (palette: Palette) => css`
 	${fontStyle};
 	float: left;
 	text-decoration: none;
 
 	:hover {
-		color: ${decidePalette(format).text.articleLinkHover};
+		color: ${palette.text.articleLinkHover};
 	}
 
 	:focus {
@@ -150,15 +149,11 @@ const listItemStyles = (palette: Palette) => css`
 const trimLeadingSlash = (url: string): string =>
 	url.substr(0, 1) === '/' ? url.slice(1) : url;
 
-export const SubNav = ({
-	subNavSections,
-	palette,
-	currentNavLink,
-	format,
-}: Props) => {
+export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 	const [showMore, setShowMore] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const ulRef = useRef<HTMLUListElement>(null);
+	const palette = decidePalette(format);
 
 	useEffect(() => {
 		const ulEl = ulRef.current;
@@ -196,7 +191,7 @@ export const SubNav = ({
 					>
 						<a
 							data-src-focus-disabled={true}
-							css={linkStyle(format)}
+							css={linkStyle(palette)}
 							href={subNavSections.parent.url}
 						>
 							{subNavSections.parent.title}
@@ -206,7 +201,7 @@ export const SubNav = ({
 				{subNavSections.links.map((link) => (
 					<li key={link.url}>
 						<a
-							css={linkStyle(format)}
+							css={linkStyle(palette)}
 							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(

--- a/dotcom-rendering/src/web/components/elements/CalloutBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/elements/CalloutBlockComponent.stories.tsx
@@ -4,7 +4,6 @@ import fetchMock from 'fetch-mock';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 
 import { calloutCampaign } from '@root/fixtures/manual/calloutCampaign';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { CalloutBlockComponent } from './CalloutBlockComponent';
 
@@ -32,11 +31,11 @@ export const Default = () => {
 		>
 			<CalloutBlockComponent
 				callout={calloutCampaign}
-				palette={decidePalette({
+				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
-				})}
+				}}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/CalloutBlockComponent.tsx
@@ -8,6 +8,7 @@ import { Button } from '@guardian/src-button';
 import PlusIcon from '@frontend/static/icons/plus.svg';
 import MinusIcon from '@frontend/static/icons/minus.svg';
 
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { Form } from '../Callout/Form';
 
 const wrapperStyles = css`
@@ -125,10 +126,10 @@ type FormDataType = { [key in string]: any };
 
 export const CalloutBlockComponent = ({
 	callout,
-	palette,
+	format,
 }: {
 	callout: CalloutBlockElement;
-	palette: Palette;
+	format: ArticleFormat;
 }) => {
 	let expandFormButtonRef: HTMLButtonElement | null = null;
 	let firstFieldElementRef: HTMLElement | null = null;
@@ -137,6 +138,8 @@ export const CalloutBlockComponent = ({
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [error, setError] = useState('');
 	const [submissionSuccess, setSubmissionSuccess] = useState(false);
+
+	const palette = decidePalette(format);
 
 	const { title, description, formFields } = callout;
 

--- a/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.stories.tsx
@@ -6,7 +6,6 @@ import { InteractiveBlockComponent } from '@frontend/web/components/elements/Int
 import { Figure } from '@frontend/web/components/Figure';
 import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
 import { ArticlePillar, ArticleDesign, ArticleDisplay } from '@guardian/libs';
-import { decidePalette } from '@frontend/web/lib/decidePalette';
 
 export default {
 	component: InteractiveBlockComponent,
@@ -54,11 +53,6 @@ export const Default = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<SomeText />
@@ -85,11 +79,6 @@ export const InlineMap = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<SomeText />
@@ -115,11 +104,6 @@ export const Showcase = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<SomeText />
@@ -147,11 +131,6 @@ export const WithCaption = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<SomeText />
@@ -178,11 +157,6 @@ export const NonBootJs = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<SomeText />

--- a/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -8,6 +8,7 @@ import { Placeholder } from '@root/src/web/components/Placeholder';
 import { Caption } from '@root/src/web/components/Caption';
 import libDebounce from 'lodash.debounce';
 import { interactiveLegacyFigureClasses } from '@root/src/web/layouts/lib/interactiveLegacyStyling';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
 	url?: string;
@@ -16,7 +17,6 @@ type Props = {
 	role?: RoleType;
 	caption?: string;
 	format: ArticleFormat;
-	palette: Palette;
 	elementId?: string;
 };
 
@@ -232,12 +232,12 @@ export const InteractiveBlockComponent = ({
 	role = 'inline',
 	caption,
 	format,
-	palette,
 	elementId = '',
 }: Props) => {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
+	const palette = decidePalette(format);
 	useOnce(() => {
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
 		if (

--- a/dotcom-rendering/src/web/components/elements/MapEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/MapEmbedBlockComponent.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 
 import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
 import { Caption } from '@root/src/web/components/Caption';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 export const MapEmbedBlockComponent: React.FC<{
 	embedUrl?: string;
@@ -10,9 +11,8 @@ export const MapEmbedBlockComponent: React.FC<{
 	title?: string;
 	caption?: string;
 	format: ArticleFormat;
-	palette: Palette;
 	credit?: string;
-}> = ({ embedUrl, title, width, height, caption, format, palette, credit }) => {
+}> = ({ embedUrl, title, width, height, caption, format, credit }) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -29,6 +29,8 @@ export const MapEmbedBlockComponent: React.FC<{
 		width: 100%;
 		margin-bottom: ${hasCaption ? `0px` : `6px`};
 	`;
+
+	const palette = decidePalette(format);
 
 	return (
 		<div css={embedContainer}>

--- a/dotcom-rendering/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { Caption } from '@root/src/web/components/Caption';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 export const SpotifyBlockComponent: React.FC<{
 	embedUrl?: string;
@@ -7,16 +8,17 @@ export const SpotifyBlockComponent: React.FC<{
 	width?: number;
 	title?: string;
 	format: ArticleFormat;
-	palette: Palette;
 	caption?: string;
 	credit?: string;
-}> = ({ embedUrl, width, height, title, format, palette, caption, credit }) => {
+}> = ({ embedUrl, width, height, title, format, caption, credit }) => {
 	const embedContainer = css`
 		iframe {
 			width: 100%;
 		}
 		margin-bottom: 16px;
 	`;
+
+	const palette = decidePalette(format);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { VideoFacebookBlockComponent } from './VideoFacebookBlockComponent';
 
 export default {
@@ -36,11 +35,6 @@ export const largeAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 			<p>abc</p>
 		</Container>
@@ -64,11 +58,6 @@ export const verticalAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 			<p>abc</p>
 		</Container>

--- a/dotcom-rendering/src/web/components/elements/VideoFacebookBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/VideoFacebookBlockComponent.tsx
@@ -2,17 +2,17 @@ import { css } from '@emotion/react';
 
 import { Caption } from '@root/src/web/components/Caption';
 import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 export const VideoFacebookBlockComponent: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	embedUrl?: string;
 	height: number;
 	width: number;
 	caption?: string;
 	credit?: string;
 	title?: string;
-}> = ({ embedUrl, caption, title, format, palette, width, height, credit }) => {
+}> = ({ embedUrl, caption, title, format, width, height, credit }) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -27,6 +27,8 @@ export const VideoFacebookBlockComponent: React.FC<{
 		width: 100%;
 		margin-bottom: ${caption ? `0px` : `6px`};
 	`;
+
+	const palette = decidePalette(format);
 
 	return (
 		<div css={embedContainer}>

--- a/dotcom-rendering/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -2,8 +2,6 @@ import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
 
-import { decidePalette } from '@root/src/web/lib/decidePalette';
-
 import { ElementContainer } from '../ElementContainer';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
@@ -52,11 +50,6 @@ export const Default = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
@@ -90,11 +83,6 @@ export const Vertical = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
@@ -130,11 +118,6 @@ export const Expired = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
@@ -171,11 +154,6 @@ export const WithOverlayImage = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
@@ -213,11 +191,6 @@ export const WithPosterImage = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
@@ -276,11 +249,6 @@ export const WithPosterAndOverlayImage = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"

--- a/dotcom-rendering/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -11,6 +11,7 @@ import { trackVideoInteraction } from '@root/src/web/browser/ga/ga';
 import { record } from '@root/src/web/browser/ophan/ophan';
 
 import { Caption } from '@root/src/web/components/Caption';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
 	id: string;
@@ -19,7 +20,6 @@ type Props = {
 	assetId: string;
 	expired: boolean;
 	format: ArticleFormat;
-	palette: Palette;
 	role: RoleType;
 	hideCaption?: boolean;
 	overrideImage?: string;
@@ -76,7 +76,6 @@ export const YoutubeBlockComponent = ({
 	mediaTitle,
 	altText,
 	format,
-	palette,
 	hideCaption,
 	overrideImage,
 	posterImage,
@@ -90,6 +89,7 @@ export const YoutubeBlockComponent = ({
 	duration,
 	origin,
 }: Props): JSX.Element => {
+	const palette = decidePalette(format);
 	const shouldLimitWidth =
 		!isMainMedia &&
 		(role === 'showcase' || role === 'supporting' || role === 'immersive');

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -379,7 +379,6 @@ export const CommentLayout = ({
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								palette={palette}
 								format={format}
 							/>
 						</ElementContainer>
@@ -609,8 +608,7 @@ export const CommentLayout = ({
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -619,7 +617,6 @@ export const CommentLayout = ({
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -659,7 +656,6 @@ export const CommentLayout = ({
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -39,7 +39,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 						CAPI={CAPI}
 						NAV={NAV}
 						format={format}
-						palette={palette}
 					/>
 				);
 			}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -641,8 +641,7 @@ export const ImmersiveLayout = ({
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -651,7 +650,6 @@ export const ImmersiveLayout = ({
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -691,7 +689,6 @@ export const ImmersiveLayout = ({
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -31,12 +31,12 @@ import { renderElement } from '../lib/renderElement';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
+import { decidePalette } from '../lib/decidePalette';
 
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
 const Renderer: React.FC<{
@@ -110,7 +110,7 @@ const Renderer: React.FC<{
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
+const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	// Typically immersives use the slim nav, but this switch is used to force
 	// the full nav - typically during special events such as Project 200, or
 	// the Euros. The motivation is to better onboard new visitors; interactives
@@ -223,7 +223,6 @@ const NavHeader = ({ CAPI, NAV, format, palette }: Props): JSX.Element => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>
@@ -236,11 +235,12 @@ export const InteractiveImmersiveLayout = ({
 	CAPI,
 	NAV,
 	format,
-	palette,
 }: Props): JSX.Element => {
 	const {
 		config: { host },
 	} = CAPI;
+
+	const palette = decidePalette(format);
 
 	return (
 		<>
@@ -252,12 +252,7 @@ export const InteractiveImmersiveLayout = ({
 					background-color: ${palette.background.article};
 				`}
 			>
-				<NavHeader
-					CAPI={CAPI}
-					NAV={NAV}
-					format={format}
-					palette={palette}
-				/>
+				<NavHeader CAPI={CAPI} NAV={NAV} format={format} />
 
 				{format.theme === ArticleSpecial.Labs && (
 					<Stuck>
@@ -304,7 +299,6 @@ export const InteractiveImmersiveLayout = ({
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -323,7 +323,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							palette={palette}
 							format={format}
 						/>
 					</ElementContainer>
@@ -560,8 +559,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -570,7 +568,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -614,7 +611,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -282,7 +282,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								palette={palette}
 								format={format}
 							/>
 						</ElementContainer>
@@ -558,8 +557,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -568,7 +566,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -612,7 +609,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -321,7 +321,6 @@ export const ShowcaseLayout = ({
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										palette={palette}
 										format={format}
 									/>
 								</ElementContainer>
@@ -589,8 +588,7 @@ export const ShowcaseLayout = ({
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -599,7 +597,6 @@ export const ShowcaseLayout = ({
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -639,7 +636,6 @@ export const ShowcaseLayout = ({
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -406,7 +406,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									<SubNav
 										subNavSections={NAV.subNavSections}
 										currentNavLink={NAV.currentNavLink}
-										palette={palette}
 										format={format}
 									/>
 								</ElementContainer>
@@ -679,8 +678,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						discussionApiUrl={CAPI.config.discussionApiUrl}
 						shortUrlId={CAPI.config.shortUrlId}
 						isCommentable={CAPI.isCommentable}
-						pillar={format.theme}
-						palette={palette}
+						format={format}
 						discussionD2Uid={CAPI.config.discussionD2Uid}
 						discussionApiClientHeader={
 							CAPI.config.discussionApiClientHeader
@@ -689,7 +687,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						isAdFreeUser={CAPI.isAdFreeUser}
 						shouldHideAds={CAPI.shouldHideAds}
 						beingHydrated={false}
-						display={format.display}
 					/>
 				</ElementContainer>
 			)}
@@ -731,7 +728,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -154,7 +154,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.CalloutBlockElement':
 			return [
 				true,
-				<CalloutBlockComponent callout={element} palette={palette} />,
+				<CalloutBlockComponent callout={element} format={format} />,
 			];
 		case 'model.dotcomrendering.pageElements.CaptionBlockElement':
 			return [
@@ -372,7 +372,6 @@ export const renderElement = ({
 					alt={element.alt}
 					role={element.role}
 					format={format}
-					palette={palette}
 					elementId={element.elementId}
 				/>,
 			];
@@ -400,7 +399,6 @@ export const renderElement = ({
 				>
 					<MapEmbedBlockComponent
 						format={format}
-						palette={palette}
 						embedUrl={element.embedUrl}
 						height={element.height}
 						width={element.width}
@@ -532,7 +530,6 @@ export const renderElement = ({
 						width={element.width}
 						title={element.title}
 						format={format}
-						palette={palette}
 						caption={element.caption}
 						credit="Spotify"
 					/>
@@ -596,7 +593,6 @@ export const renderElement = ({
 				>
 					<VideoFacebookBlockComponent
 						format={format}
-						palette={palette}
 						embedUrl={element.embedUrl}
 						height={element.height}
 						width={element.width}
@@ -699,7 +695,6 @@ export const renderElement = ({
 				true,
 				<YoutubeBlockComponent
 					format={format}
-					palette={palette}
 					key={index}
 					hideCaption={hideCaption}
 					// eslint-disable-next-line jsx-a11y/aria-role


### PR DESCRIPTION
## What?
This deletes all usage of `palette` from `App.tsx`. We no longer have any components that are hydrated or inserted as portals that have this object as a prop.

## Why?
Because `palette` is quite large now and if we ever want to move away from centralised state to a more autonomous model where each component serialised it's own props in the dom, then we want those props to be as explicit and small as possible.