### PR TITLE
fix: Issue where width wasn't being set well for these articles

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -11,6 +11,10 @@ type Props = {
 
 const articleWidth = (format: ArticleFormat) => {
 	switch (format.design) {
+		case ArticleDesign.Interactive: {
+			// These articles use a special template which manages it's own width
+			return null;
+		}
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog: {
 			return css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the width for these articles to fix a production issue


### Before
<img width="1010" alt="Screenshot 2021-11-11 at 15 15 28" src="https://user-images.githubusercontent.com/1336821/141322573-4124fc70-3044-4cb4-966b-b29941655806.png">


### After
<img width="1010" alt="Screenshot 2021-11-11 at 15 13 38" src="https://user-images.githubusercontent.com/1336821/141322590-6bf0a86f-3c3d-49e7-a91a-8a16c964cde4.png">


