### PR TITLE
Pass styling to Editions hydrated share icon 

### DIFF
--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -86,10 +86,10 @@ const styles = (iconColor: string): SerializedStyles => {
 		justify-content: space-between;
 		font-style: italic;
 		svg {
-			flex: 0 0 1.875rem;
+			flex: 0 0 2.25rem;
 			padding-top: 0.375rem;
-			width: 1.875rem;
-			height: 1.875rem;
+			width: 2.25rem;
+			height: 2.25rem;
 
 			circle {
 				stroke: ${iconColor};
@@ -258,11 +258,7 @@ const Byline: FC<Props> = ({ item }) => {
 	return maybeRender(item.bylineHtml, (byline) => (
 		<div css={getBylineStyles(format, iconColor, hasImage)}>
 			<address>{renderText(byline, format)}</address>
-			{showShareIcon && (
-				<span className="js-share-button" role="button">
-					<ShareIcon />
-				</span>
-			)}
+			{showShareIcon && <ShareIcon />}
 			{hasAvatar(item) && (
 				<div css={avatarWrapperStyles}>
 					<EditionsAvatar item={item} />

--- a/apps-rendering/src/components/editions/shareIcon/index.tsx
+++ b/apps-rendering/src/components/editions/shareIcon/index.tsx
@@ -66,13 +66,12 @@ const AndroidShareIcon = (): ReactElement => (
 	</svg>
 );
 
-const buttonStyles = css`
-	background: none;
-	border: none;
-	padding: 0;
-	height: 2.5rem;
-
-	svg {
+const hydratedButtonStyles = css`
+	.share-button {
+		background: none;
+		border: none;
+		padding: 0;
+		height: 2.5rem;
 		box-sizing: content-box;
 	}
 `;
@@ -86,18 +85,24 @@ const ShareIcon: FC = () => {
 	}, []);
 
 	return showIcon ? (
-		<button
-			css={buttonStyles}
-			onClick={(): void =>
-				pingEditionsNative({ kind: MessageKind.Share })
-			}
+		<div
+			css={hydratedButtonStyles}
+			className="js-share-button"
+			role="button"
 		>
-			{platform === Platform.IOS ? (
-				<IOSShareIcon />
-			) : (
-				<AndroidShareIcon />
-			)}
-		</button>
+			<button
+				className="share-button"
+				onClick={(): void =>
+					pingEditionsNative({ kind: MessageKind.Share })
+				}
+			>
+				{platform === Platform.IOS ? (
+					<IOSShareIcon />
+				) : (
+					<AndroidShareIcon />
+				)}
+			</button>
+		</div>
 	) : null;
 };
 

--- a/apps-rendering/src/components/editions/standfirst/index.tsx
+++ b/apps-rendering/src/components/editions/standfirst/index.tsx
@@ -66,11 +66,11 @@ const styles = (kickerColor: string): SerializedStyles => css`
 	}
 
 	svg {
-		flex: 0 0 1.875rem;
+		flex: 0 0 2.25rem;
 		margin-top: 0.375rem;
 		padding-left: 0.5rem;
-		width: 1.875rem;
-		height: 1.875rem;
+		width: 2.25rem;
+		height: 2.25rem;
 
 		circle {
 			stroke: ${kickerColor};
@@ -136,11 +136,7 @@ const Standfirst: FC<Props> = ({ item, shareIcon }) => {
 			<div css={textContainerStyles}>
 				{renderStandfirstText(standfirst, item, isEditions)}
 			</div>
-			{shareIcon && (
-				<span className="js-share-button" role="button">
-					<ShareIcon />
-				</span>
-			)}
+			{shareIcon && <ShareIcon />}
 		</div>
 	));
 };


### PR DESCRIPTION
## What does this change?
Removes existing emotion styling and adds a parent div that passes a classname style down to the share icon. It also moves the existing span wrapper inside the share icon component file.

## Why?
The share icon for Editions gets hydrated by the client. Hydrated components can't use Emotion styling so the share icon is appearing un-styled. Instead we have to pass styles through with a classname on a parent div. 
### Before
 <img src="https://user-images.githubusercontent.com/20416599/141327591-c896b21e-ed35-4470-bee9-c7eba1f44c72.png" width="300px" />
### After
 <img src="https://user-images.githubusercontent.com/20416599/141327573-1f616d67-85b4-4737-8825-3ff2143dae22.png" width="300px" />

co-authored with @joecowton1 