### PR TITLE
Fixing the display of the contents block at narrow breakpoints

### DIFF
--- a/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/elements/InteractiveContentsBlockComponent.tsx
@@ -77,7 +77,8 @@ const stickyOlStyles = (showStickyNavOption: boolean) => css`
 	top: 0;
 	position: fixed;
 	margin-top: ${space[12]}px;
-
+	max-height: 90vh;
+	overflow-y: auto;
 	display: none;
 	${showStickyNavOption && 'display: grid;'}
 `;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the dropdown menu for the contents block when there are a lot of menu items. Previously, the menu did not scroll properly and it was not possible to see all of the items in the menu

## Why?
So that we can enable more contents block articles to be rendered in DCR

### Before

![Nov-12-2021 22-10-26](https://user-images.githubusercontent.com/2051501/141541085-e2867e63-5c64-4ab7-a869-aab21ed9bf0f.gif)
### After
![Nov-12-2021 22-10-41](https://user-images.githubusercontent.com/2051501/141541115-32897042-5650-4e2d-a27b-ee64bda1f3dc.gif)

