### PR TITLE
`buildAdTargeting` no longer accepts `CAPI`

### DIFF
--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -98,9 +98,14 @@ export const Body: React.FC<{
 	config: ConfigType;
 }> = ({ data, config }) => {
 	const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
-	const adTargeting = buildAdTargeting({
+	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: data.isAdFreeUser,
-		config,
+		isSensitive: config.isSensitive,
+		videoDuration: config.videoDuration,
+		edition: config.edition,
+		section: config.section,
+		sharedAdTargeting: config.sharedAdTargeting,
+		adUnit: config.adUnit,
 	});
 	const design = decideDesign(data.format);
 	const pillar = decideTheme(data.format);

--- a/dotcom-rendering/src/lib/ad-targeting.test.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.test.ts
@@ -1,63 +1,42 @@
-import { Article } from '@root/fixtures/generated/articles/Article';
 import { buildAdTargeting } from './ad-targeting';
 
-const CAPI = {
-	...Article,
-	config: {
-		...Article.config,
-		adUnit: '/59666047/theguardian.com/money/article/ng',
-		edition: 'UK',
-		section: 'money',
-		sharedAdTargeting: {
-			ct: 'article',
-			co: ['rob-davies'],
-			url: '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-			su: ['0'],
-			edition: 'uk',
-			tn: ['news'],
-			p: 'ng',
-			k: [
-				'ticket-prices',
-				'consumer-affairs',
-				'internet',
-				'viagogo',
-				'money',
-			],
-			sh: 'https://theguardian.com/p/64ak8',
-		},
-	},
+const sharedAdTargeting = {
+	co: ['rob-davies'],
+	ct: 'article',
+	edition: 'uk',
+	k: ['ticket-prices', 'consumer-affairs', 'internet', 'viagogo', 'money'],
+	p: 'ng',
+	sh: 'https://theguardian.com/p/64ak8',
+	su: ['0'],
+	tn: ['news'],
+	url: '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
 };
 
 describe('buildAdTargeting', () => {
 	const expectedAdTargeting = {
 		adUnit: '/59666047/theguardian.com/money/article/ng',
 		customParams: {
-			cc: 'UK',
-			co: ['rob-davies'],
-			ct: 'article',
-			edition: 'uk',
-			inskin: 'f',
-			k: [
-				'ticket-prices',
-				'consumer-affairs',
-				'internet',
-				'viagogo',
-				'money',
-			],
-			p: 'ng',
-			pa: 'f',
-			s: 'money',
-			sh: 'https://theguardian.com/p/64ak8',
-			su: ['0'],
-			tn: ['news'],
-			url: '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
 			sens: 'f',
 			si: 'f',
 			vl: 0,
+			cc: 'UK',
+			s: 'money',
+			inskin: 'f',
+			pa: 'f',
+			...sharedAdTargeting,
 		},
 	};
 
 	it('builds adTargeting correctly', () => {
-		expect(buildAdTargeting(CAPI)).toEqual(expectedAdTargeting);
+		expect(
+			buildAdTargeting({
+				isAdFreeUser: false,
+				isSensitive: false,
+				edition: 'UK',
+				section: 'money',
+				sharedAdTargeting,
+				adUnit: '/59666047/theguardian.com/money/article/ng',
+			}),
+		).toEqual(expectedAdTargeting);
 	});
 });

--- a/dotcom-rendering/src/lib/ad-targeting.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.ts
@@ -1,27 +1,37 @@
-export const buildAdTargeting = (
-	CAPI:
-		| CAPIType
-		| CAPIBrowserType
-		| Pick<CAPIType, 'isAdFreeUser' | 'config'>,
-): AdTargeting => {
-	if (CAPI.isAdFreeUser) {
+export const buildAdTargeting = ({
+	isAdFreeUser,
+	isSensitive,
+	edition,
+	section,
+	sharedAdTargeting,
+	adUnit,
+	videoDuration,
+}: {
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	edition: string;
+	section: string;
+	sharedAdTargeting: Record<string, unknown>;
+	adUnit: string;
+	videoDuration?: number;
+}): AdTargeting => {
+	if (isAdFreeUser) {
 		return {
 			disableAds: true,
 		};
 	}
-	const { config } = CAPI;
 	const customParams = {
-		sens: config.isSensitive ? 't' : 'f',
+		sens: isSensitive ? 't' : 'f',
 		si: 'f',
-		vl: config.videoDuration || 0,
-		cc: config.edition,
-		s: config.section,
+		vl: videoDuration || 0,
+		cc: edition,
+		s: section,
 		inskin: 'f',
-		...config.sharedAdTargeting,
+		...sharedAdTargeting,
 		pa: 'f',
 	};
 	return {
 		customParams,
-		adUnit: config.adUnit,
+		adUnit,
 	};
 };

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -423,7 +423,15 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	};
 	const palette = decidePalette(format);
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	// There are docs on loadable in ./docs/loadable-components.md
 	const YoutubeBlockComponent = loadable(

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -286,7 +286,15 @@ export const CommentLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -255,7 +255,15 @@ export const ImmersiveLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -237,7 +237,15 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const seriesTag = CAPI.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -189,7 +189,15 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -232,7 +232,15 @@ export const ShowcaseLayout = ({
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -303,7 +303,15 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPI;
 
-	const adTargeting: AdTargeting = buildAdTargeting(CAPI);
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: CAPI.isAdFreeUser,
+		isSensitive: CAPI.config.isSensitive,
+		videoDuration: CAPI.config.videoDuration,
+		edition: CAPI.config.edition,
+		section: CAPI.config.section,
+		sharedAdTargeting: CAPI.config.sharedAdTargeting,
+		adUnit: CAPI.config.adUnit,
+	});
 
 	const showBodyEndSlot =
 		parse(CAPI.slotMachineFlags || '').showBodyEnd ||


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This refactors the props for `buildAdTargeting` so that it no longer accepts `CAPI` and now accepts the specific props it needs

## Why?
Because we want to remove dependencies on CAPI, its a large object and having it as a contract is expensive.

### Before
```ts
type Props = {
    CAPI:
		| CAPIType
		| CAPIBrowserType
		| Pick<CAPIType, 'isAdFreeUser' | 'config'>,
}
```

### After
```ts
type Props = {
	isAdFreeUser: boolean;
	isSensitive: boolean;
	edition: string;
	section: string;
	sharedAdTargeting: Record<string, unknown>;
	adUnit: string;
	videoDuration?: number;
}
```