### PR TITLE
Set logged STAGE based on GU_STAGE

### DIFF
--- a/dotcom-rendering/src/app/logging.ts
+++ b/dotcom-rendering/src/app/logging.ts
@@ -12,11 +12,16 @@ const logLocation =
 		? '/var/log/dotcom-rendering/dotcom-rendering.log'
 		: `${path.resolve('logs')}/dotcom-rendering.log`;
 
+const stage =
+	typeof process.env.GU_STAGE === 'string'
+		? process.env.GU_STAGE.toUpperCase()
+		: 'DEV';
+
 const logFields = (logEvent: LoggingEvent): any => {
 	const coreFields = {
 		stack: 'frontend',
 		app: 'dotcom-rendering',
-		stage: 'CODE',
+		stage,
 		'@timestamp': logEvent.startTime,
 		'@version': 1,
 		level: logEvent.level.levelStr,


### PR DESCRIPTION
## What does this change?

Sets logged `stage` based on `GU_STAGE` environment variable.  `GU_STAGE` is set by the userdata script in cloudformation.yml

When you run the app locally `GU_STAGE` will not be set, and the logging stage will default to "DEV".

## Why?

We are currently sending all logs with `stage` set to "CODE", which causes confusion and makes it difficult to diagnose faults.

### Before

100% of logs in central ELK for `app: dotcom-rendering` are marked as "CODE"

### After

>0% of logs in central ELK for `app: dotcom-rendering` are marked as "PROD"
>0% of logs in central ELK for `app: dotcom-rendering` are marked as "CODE"
