### PR TITLE
More explicit props for the SignIn Gate

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1295,6 +1295,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}
 					host={CAPI.config.host}
+					pageId={CAPI.pageId}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1290,7 +1290,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isSignedIn={isSignedIn}
 					format={format}
 					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName || ''}
+					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}
@@ -1349,7 +1349,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					brazeMessages={brazeMessages}
 					asyncArticleCount={asyncArticleCount}
 					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName || ''}
+					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1297,6 +1297,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					host={CAPI.config.host}
 					pageId={CAPI.pageId}
 					idUrl={CAPI.config.idUrl}
+					pageViewId={pageViewId}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1293,6 +1293,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
+					isPreview={!!CAPI.isPreview}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
@@ -1343,12 +1344,12 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					asyncCountryCode={asyncCountryCode}
 					CAPI={CAPI}
 					brazeMessages={brazeMessages}
-					isPreview={!!CAPI.isPreview}
 					asyncArticleCount={asyncArticleCount}
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
+					isPreview={!!CAPI.isPreview}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1292,6 +1292,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
+					isPaidContent={CAPI.pageType.isPaidContent}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
@@ -1347,6 +1348,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
 					tags={CAPI.tags}
+					isPaidContent={CAPI.pageType.isPaidContent}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1290,6 +1290,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isSignedIn={isSignedIn}
 					CAPI={CAPI}
 					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
@@ -1343,6 +1344,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isPreview={!!CAPI.isPreview}
 					asyncArticleCount={asyncArticleCount}
 					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1290,7 +1290,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isSignedIn={isSignedIn}
 					CAPI={CAPI}
 					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName}
+					sectionName={CAPI.sectionName || ''}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}
@@ -1346,7 +1346,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					brazeMessages={brazeMessages}
 					asyncArticleCount={asyncArticleCount}
 					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName}
+					sectionName={CAPI.sectionName || ''}
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1296,6 +1296,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isPreview={!!CAPI.isPreview}
 					host={CAPI.config.host}
 					pageId={CAPI.pageId}
+					idUrl={CAPI.config.idUrl}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1291,6 +1291,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					CAPI={CAPI}
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
+					tags={CAPI.tags}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
@@ -1345,6 +1346,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					asyncArticleCount={asyncArticleCount}
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName}
+					tags={CAPI.tags}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1288,7 +1288,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			<Portal rootId="sign-in-gate">
 				<SignInGateSelector
 					isSignedIn={isSignedIn}
-					CAPI={CAPI}
+					format={format}
 					contentType={CAPI.contentType}
 					sectionName={CAPI.sectionName || ''}
 					tags={CAPI.tags}

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1286,7 +1286,11 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				</Lazy>
 			</Portal>
 			<Portal rootId="sign-in-gate">
-				<SignInGateSelector isSignedIn={isSignedIn} CAPI={CAPI} />
+				<SignInGateSelector
+					isSignedIn={isSignedIn}
+					CAPI={CAPI}
+					contentType={CAPI.contentType}
+				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>
 				<Discussion
@@ -1338,6 +1342,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					brazeMessages={brazeMessages}
 					isPreview={!!CAPI.isPreview}
 					asyncArticleCount={asyncArticleCount}
+					contentType={CAPI.contentType}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1294,6 +1294,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					tags={CAPI.tags}
 					isPaidContent={CAPI.pageType.isPaidContent}
 					isPreview={!!CAPI.isPreview}
+					host={CAPI.config.host}
 				/>
 			</Portal>
 			<HydrateOnce rootId="comments" waitFor={[user]}>

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -131,6 +131,7 @@ export const SignInGateSelector = ({
 	isPaidContent,
 	isPreview,
 	host,
+	pageId,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -194,7 +195,7 @@ export const SignInGateSelector = ({
 	}
 
 	const signInUrl = generateSignInUrl({
-		pageId: CAPI.pageId,
+		pageId,
 		host,
 		pageViewId: window.guardian.config.ophan.pageViewId,
 		idUrl: CAPI.config.idUrl,

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { constructQuery } from '@root/src/lib/querystring';
+import { ArticleDesign } from '@guardian/libs';
 
 import {
 	incrementUserDismissedGateCount,
@@ -25,7 +26,7 @@ import {
 interface ShowSignInGateProps {
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	abTest: CurrentSignInGateABTest;
-	CAPI: CAPIBrowserType;
+	format: ArticleFormat;
 	signInUrl: string;
 	gateVariant: SignInGateComponent;
 	host: string;
@@ -81,7 +82,7 @@ const generateSignInUrl = ({
 // fires a VIEW ophan component event
 // and show the gate component if it exists
 const ShowSignInGate = ({
-	CAPI,
+	format,
 	abTest,
 	setShowGate,
 	signInUrl,
@@ -112,8 +113,8 @@ const ShowSignInGate = ({
 			abTest,
 			ophanComponentId: signInGateTestIdToComponentId[abTest.id],
 			isComment:
-				CAPI.format.design === 'CommentDesign' ||
-				CAPI.format.design === 'EditorialDesign',
+				format.design === ArticleDesign.Comment ||
+				format.design === ArticleDesign.Editorial,
 		});
 	}
 	// return nothing if no gate needs to be shown
@@ -124,7 +125,7 @@ const ShowSignInGate = ({
 // should be shown on the current page
 export const SignInGateSelector = ({
 	isSignedIn,
-	CAPI,
+	format,
 	contentType,
 	sectionName,
 	tags,
@@ -208,7 +209,7 @@ export const SignInGateSelector = ({
 			{/* Sign In Gate Display Logic */}
 			{!isGateDismissed && canShowGate && (
 				<ShowSignInGate
-					CAPI={CAPI}
+					format={format}
 					abTest={currentTest}
 					setShowGate={(show) => setIsGateDismissed(!show)}
 					signInUrl={signInUrl}

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -44,12 +44,21 @@ const dismissGate = (
 
 // function to generate the profile.theguardian.com url with tracking params
 // and the return url (link to current article page)
-const generateSignInUrl = (
-	CAPI: CAPIBrowserType,
-	currentTest: CurrentSignInGateABTest,
-) => {
+const generateSignInUrl = ({
+	pageId,
+	pageViewId,
+	idUrl,
+	host,
+	currentTest,
+}: {
+	pageId: string;
+	pageViewId: string;
+	idUrl?: string;
+	host?: string;
+	currentTest: CurrentSignInGateABTest;
+}) => {
 	// url of the article, return user here after sign in/registration
-	const returnUrl = `${CAPI.config.host}/${CAPI.pageId}`;
+	const returnUrl = `${host}/${pageId}`;
 
 	// set the component event params to be included in the query
 	const queryParams: ComponentEventParams = {
@@ -57,14 +66,12 @@ const generateSignInUrl = (
 		componentId: signInGateTestIdToComponentId[currentTest.id],
 		abTestName: currentTest.name,
 		abTestVariant: currentTest.variant,
-		viewId: window.guardian.ophan.viewId,
+		viewId: pageViewId,
 		browserId: getCookie('bwid') || undefined,
 		visitId: getCookie('vsid') || undefined,
 	};
 
-	return `${
-		CAPI.config.idUrl
-	}/signin?returnUrl=${returnUrl}&componentEventParams=${encodeURIComponent(
+	return `${idUrl}/signin?returnUrl=${returnUrl}&componentEventParams=${encodeURIComponent(
 		constructQuery(queryParams),
 	)}`;
 };
@@ -161,7 +168,13 @@ export const SignInGateSelector = ({
 		return null;
 	}
 
-	const signInUrl = generateSignInUrl(CAPI, currentTest);
+	const signInUrl = generateSignInUrl({
+		pageId: CAPI.pageId,
+		host: CAPI.config.host,
+		pageViewId: window.guardian.config.ophan.pageViewId,
+		idUrl: CAPI.config.idUrl,
+		currentTest,
+	});
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -160,13 +160,13 @@ export const SignInGateSelector = ({
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
 				?.canShow({
-					CAPI,
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
+					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -54,7 +54,7 @@ const generateSignInUrl = ({
 }: {
 	pageId: string;
 	pageViewId: string;
-	idUrl?: string;
+	idUrl: string;
 	host?: string;
 	currentTest: CurrentSignInGateABTest;
 }) => {
@@ -132,6 +132,7 @@ export const SignInGateSelector = ({
 	isPreview,
 	host,
 	pageId,
+	idUrl = 'https://profile.theguardian.com',
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -198,7 +199,7 @@ export const SignInGateSelector = ({
 		pageId,
 		host,
 		pageViewId: window.guardian.config.ophan.pageViewId,
-		idUrl: CAPI.config.idUrl,
+		idUrl,
 		currentTest,
 	});
 

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -125,6 +125,7 @@ export const SignInGateSelector = ({
 	CAPI,
 	contentType,
 	sectionName,
+	tags,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -166,13 +167,21 @@ export const SignInGateSelector = ({
 					currentTest,
 					contentType,
 					sectionName,
-					tags: CAPI.tags,
+					tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
 					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType]);
+	}, [
+		currentTest,
+		gateVariant,
+		CAPI,
+		isSignedIn,
+		contentType,
+		sectionName,
+		tags,
+	]);
 
 	if (!currentTest || !gateVariant) {
 		return null;

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -28,6 +28,7 @@ interface ShowSignInGateProps {
 	CAPI: CAPIBrowserType;
 	signInUrl: string;
 	gateVariant: SignInGateComponent;
+	host?: string;
 }
 
 const dismissGate = (
@@ -85,6 +86,7 @@ const ShowSignInGate = ({
 	setShowGate,
 	signInUrl,
 	gateVariant,
+	host = 'https://theguardian.com/',
 }: ShowSignInGateProps) => {
 	// use effect hook to fire view event tracking only on initial render
 	useEffect(() => {
@@ -102,7 +104,7 @@ const ShowSignInGate = ({
 	// but still fire a view event if they are eligible to see the gate
 	if (gateVariant.gate) {
 		return gateVariant.gate({
-			guUrl: CAPI.config.host || 'https://theguardian.com/',
+			guUrl: host,
 			signInUrl,
 			dismissGate: () => {
 				dismissGate(setShowGate, abTest);
@@ -128,6 +130,7 @@ export const SignInGateSelector = ({
 	tags,
 	isPaidContent,
 	isPreview,
+	host,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -192,7 +195,7 @@ export const SignInGateSelector = ({
 
 	const signInUrl = generateSignInUrl({
 		pageId: CAPI.pageId,
-		host: CAPI.config.host,
+		host,
 		pageViewId: window.guardian.config.ophan.pageViewId,
 		idUrl: CAPI.config.idUrl,
 		currentTest,
@@ -208,6 +211,7 @@ export const SignInGateSelector = ({
 					setShowGate={(show) => setIsGateDismissed(!show)}
 					signInUrl={signInUrl}
 					gateVariant={gateVariant}
+					host={host}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -123,6 +123,7 @@ const ShowSignInGate = ({
 export const SignInGateSelector = ({
 	isSignedIn,
 	CAPI,
+	contentType,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -162,7 +163,7 @@ export const SignInGateSelector = ({
 				?.canShow({
 					isSignedIn: !!isSignedIn,
 					currentTest,
-					contentType: CAPI.contentType,
+					contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
@@ -170,7 +171,7 @@ export const SignInGateSelector = ({
 				})
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant, CAPI, isSignedIn]);
+	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType]);
 
 	if (!currentTest || !gateVariant) {
 		return null;

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -164,6 +164,7 @@ export const SignInGateSelector = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType: CAPI.contentType,
+					sectionName: CAPI.sectionName,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -124,6 +124,7 @@ export const SignInGateSelector = ({
 	isSignedIn,
 	CAPI,
 	contentType,
+	sectionName,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -164,7 +165,7 @@ export const SignInGateSelector = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType,
-					sectionName: CAPI.sectionName,
+					sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
 					isPreview: CAPI.isPreview,

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -159,7 +159,12 @@ export const SignInGateSelector = ({
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
-				?.canShow({ CAPI, isSignedIn: !!isSignedIn, currentTest })
+				?.canShow({
+					CAPI,
+					isSignedIn: !!isSignedIn,
+					currentTest,
+					contentType: CAPI.contentType,
+				})
 				.then(setCanShowGate);
 		}
 	}, [currentTest, gateVariant, CAPI, isSignedIn]);

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -134,6 +134,7 @@ export const SignInGateSelector = ({
 	host = 'https://theguardian.com/',
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
+	pageViewId,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -199,7 +200,7 @@ export const SignInGateSelector = ({
 	const signInUrl = generateSignInUrl({
 		pageId,
 		host,
-		pageViewId: window.guardian.config.ophan.pageViewId,
+		pageViewId,
 		idUrl,
 		currentTest,
 	});

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -28,7 +28,7 @@ interface ShowSignInGateProps {
 	CAPI: CAPIBrowserType;
 	signInUrl: string;
 	gateVariant: SignInGateComponent;
-	host?: string;
+	host: string;
 }
 
 const dismissGate = (
@@ -55,7 +55,7 @@ const generateSignInUrl = ({
 	pageId: string;
 	pageViewId: string;
 	idUrl: string;
-	host?: string;
+	host: string;
 	currentTest: CurrentSignInGateABTest;
 }) => {
 	// url of the article, return user here after sign in/registration
@@ -86,7 +86,7 @@ const ShowSignInGate = ({
 	setShowGate,
 	signInUrl,
 	gateVariant,
-	host = 'https://theguardian.com/',
+	host,
 }: ShowSignInGateProps) => {
 	// use effect hook to fire view event tracking only on initial render
 	useEffect(() => {
@@ -130,7 +130,7 @@ export const SignInGateSelector = ({
 	tags,
 	isPaidContent,
 	isPreview,
-	host,
+	host = 'https://theguardian.com/',
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 }: SignInGateSelectorProps) => {

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -159,7 +159,7 @@ export const SignInGateSelector = ({
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
-				?.canShow(CAPI, !!isSignedIn, currentTest)
+				?.canShow({ CAPI, isSignedIn: !!isSignedIn, currentTest })
 				.then(setCanShowGate);
 		}
 	}, [currentTest, gateVariant, CAPI, isSignedIn]);

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -166,6 +166,7 @@ export const SignInGateSelector = ({
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
+					isPaidContent: CAPI.pageType.isPaidContent,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -127,6 +127,7 @@ export const SignInGateSelector = ({
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -170,7 +171,7 @@ export const SignInGateSelector = ({
 					sectionName,
 					tags,
 					isPaidContent,
-					isPreview: CAPI.isPreview,
+					isPreview,
 				})
 				.then(setCanShowGate);
 		}
@@ -183,6 +184,7 @@ export const SignInGateSelector = ({
 		sectionName,
 		tags,
 		isPaidContent,
+		isPreview,
 	]);
 
 	if (!currentTest || !gateVariant) {

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -127,7 +127,7 @@ export const SignInGateSelector = ({
 	isSignedIn,
 	format,
 	contentType,
-	sectionName,
+	sectionName = '',
 	tags,
 	isPaidContent,
 	isPreview,

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -165,6 +165,7 @@ export const SignInGateSelector = ({
 					currentTest,
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
+					tags: CAPI.tags,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -178,7 +178,6 @@ export const SignInGateSelector = ({
 	}, [
 		currentTest,
 		gateVariant,
-		CAPI,
 		isSignedIn,
 		contentType,
 		sectionName,

--- a/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -126,6 +126,7 @@ export const SignInGateSelector = ({
 	contentType,
 	sectionName,
 	tags,
+	isPaidContent,
 }: SignInGateSelectorProps) => {
 	const [isGateDismissed, setIsGateDismissed] = useState<boolean | undefined>(
 		undefined,
@@ -168,7 +169,7 @@ export const SignInGateSelector = ({
 					contentType,
 					sectionName,
 					tags,
-					isPaidContent: CAPI.pageType.isPaidContent,
+					isPaidContent,
 					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
@@ -181,6 +182,7 @@ export const SignInGateSelector = ({
 		contentType,
 		sectionName,
 		tags,
+		isPaidContent,
 	]);
 
 	if (!currentTest || !gateVariant) {

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -121,28 +121,12 @@ describe('SignInGate - displayRule methods', () => {
 	});
 
 	describe('isValidContentType', () => {
-		let defaultCAPIBrowser: CAPIBrowserType;
-		let CAPIBrowser: CAPIBrowserType;
-
-		beforeAll(() => {
-			defaultCAPIBrowser = makeGuardianBrowserCAPI(CAPI);
-		});
-
-		beforeEach(() => {
-			// reset the CAPI data
-			CAPIBrowser = { ...defaultCAPIBrowser };
-		});
-
 		test('is a valid type - article', () => {
-			CAPIBrowser.contentType = 'Article';
-
-			expect(isValidContentType(CAPIBrowser)).toBe(true);
+			expect(isValidContentType('Article')).toBe(true);
 		});
 
 		test('is not a valid type - LiveBlog', () => {
-			CAPIBrowser.contentType = 'LiveBlog';
-
-			expect(isValidContentType(CAPIBrowser)).toBe(false);
+			expect(isValidContentType('LiveBlog')).toBe(false);
 		});
 	});
 

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -1,6 +1,4 @@
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
-import { Article } from '@root/fixtures/generated/articles/Article';
-import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
 import {
 	isNPageOrHigherPageView,
 	isIOS9,
@@ -8,8 +6,6 @@ import {
 	isValidSection,
 	isValidTag,
 } from './displayRule';
-
-const CAPI = Article;
 
 describe('SignInGate - displayRule methods', () => {
 	describe('isNPageOrHigherPageView', () => {
@@ -141,40 +137,28 @@ describe('SignInGate - displayRule methods', () => {
 	});
 
 	describe('isValidTag', () => {
-		let defaultCAPIBrowser: CAPIBrowserType;
-		let CAPIBrowser: CAPIBrowserType;
-
-		beforeAll(() => {
-			defaultCAPIBrowser = makeGuardianBrowserCAPI(CAPI);
-		});
-
-		beforeEach(() => {
-			// reset the CAPI data
-			CAPIBrowser = { ...defaultCAPIBrowser };
-		});
-
 		test('is valid tag - us-news/us-news - returns true', () => {
-			CAPIBrowser.tags = [
-				{
-					id: 'us-news/us-news',
-					type: 'Keyword',
-					title: 'US news',
-				},
-			];
-
-			expect(isValidTag(CAPIBrowser)).toBe(true);
+			expect(
+				isValidTag([
+					{
+						id: 'us-news/us-news',
+						type: 'Keyword',
+						title: 'US news',
+					},
+				]),
+			).toBe(true);
 		});
 
 		test('is valid tag - info/newsletter-sign-up - return false', () => {
-			CAPIBrowser.tags = [
-				{
-					id: 'info/newsletter-sign-up',
-					type: 'Keyword',
-					title: 'Newsletters',
-				},
-			];
-
-			expect(isValidTag(CAPIBrowser)).toBe(false);
+			expect(
+				isValidTag([
+					{
+						id: 'info/newsletter-sign-up',
+						type: 'Keyword',
+						title: 'Newsletters',
+					},
+				]),
+			).toBe(false);
 		});
 	});
 });

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -131,28 +131,12 @@ describe('SignInGate - displayRule methods', () => {
 	});
 
 	describe('isValidSection', () => {
-		let defaultCAPIBrowser: CAPIBrowserType;
-		let CAPIBrowser: CAPIBrowserType;
-
-		beforeAll(() => {
-			defaultCAPIBrowser = makeGuardianBrowserCAPI(CAPI);
-		});
-
-		beforeEach(() => {
-			// reset the CAPI data
-			CAPIBrowser = { ...defaultCAPIBrowser };
-		});
-
 		test('is valid section - politics - returns true', () => {
-			CAPIBrowser.sectionName = 'politics';
-
-			expect(isValidSection(CAPIBrowser)).toBe(true);
+			expect(isValidSection('politics')).toBe(true);
 		});
 
 		test('is valid section - membership - return false', () => {
-			CAPIBrowser.sectionName = 'membership';
-
-			expect(isValidSection(CAPIBrowser)).toBe(false);
+			expect(isValidSection('membership')).toBe(false);
 		});
 	});
 

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -108,6 +108,7 @@ export const canShowSignInGate = ({
 	CAPI,
 	isSignedIn,
 	currentTest,
+	contentType,
 }: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
@@ -117,7 +118,7 @@ export const canShowSignInGate = ({
 				5,
 			) &&
 			isNPageOrHigherPageView(3) &&
-			isValidContentType(CAPI.contentType) &&
+			isValidContentType(contentType) &&
 			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI.tags) &&
 			// hide the sign in gate on isPaidContent
@@ -131,14 +132,21 @@ export const canShowMandatoryUs: ({
 	CAPI,
 	isSignedIn,
 	currentTest,
+	contentType,
 }: CanShowGateProps) => Promise<boolean> = async ({
 	CAPI,
 	isSignedIn,
 	currentTest,
+	contentType,
 }: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
 		(await hasRequiredConsents()) &&
-		(await canShowSignInGate({ CAPI, isSignedIn, currentTest }))
+		(await canShowSignInGate({
+			CAPI,
+			isSignedIn,
+			currentTest,
+			contentType,
+		}))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -42,7 +42,7 @@ export const isValidContentType = (contentType: string): boolean => {
 };
 
 // hide the sign in gate on certain sections of the site, e.g info, about, help etc.
-export const isValidSection = (CAPI: CAPIBrowserType): boolean => {
+export const isValidSection = (sectionName?: string): boolean => {
 	const invalidSections = [
 		'about',
 		'info',
@@ -55,7 +55,7 @@ export const isValidSection = (CAPI: CAPIBrowserType): boolean => {
 	// we check for invalid section by reducing the above array, and then NOT the result so we know
 	// its a valid section
 	return !invalidSections.some(
-		(section: string): boolean => CAPI.sectionName === section,
+		(section: string): boolean => sectionName === section,
 	);
 };
 
@@ -126,7 +126,7 @@ export const canShowSignInGate = (
 			) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(CAPI.contentType) &&
-			isValidSection(CAPI) &&
+			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI) &&
 			!isPaidContent(CAPI) &&
 			!isPreview(CAPI) &&

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -7,7 +7,7 @@ import { onConsentChange } from '@guardian/consent-management-platform';
 import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { getLocale } from '@guardian/libs';
 import { hasUserDismissedGateMoreThanCount } from '@root/src/web/components/SignInGate/dismissGate';
-import { CurrentSignInGateABTest } from './types';
+import { CanShowGateProps } from './types';
 
 // in our case if this is the n-numbered article or higher the user has viewed then set the gate
 export const isNPageOrHigherPageView = (n: number = 2): boolean => {
@@ -108,11 +108,7 @@ export const canShowSignInGate = ({
 	CAPI,
 	isSignedIn,
 	currentTest,
-}: {
-	CAPI: CAPIBrowserType;
-	isSignedIn: boolean;
-	currentTest: CurrentSignInGateABTest;
-}): Promise<boolean> =>
+}: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGateMoreThanCount(
@@ -135,19 +131,11 @@ export const canShowMandatoryUs: ({
 	CAPI,
 	isSignedIn,
 	currentTest,
-}: {
-	CAPI: CAPIBrowserType;
-	isSignedIn: boolean;
-	currentTest: CurrentSignInGateABTest;
-}) => Promise<boolean> = async ({
+}: CanShowGateProps) => Promise<boolean> = async ({
 	CAPI,
 	isSignedIn,
 	currentTest,
-}: {
-	CAPI: CAPIBrowserType;
-	isSignedIn: boolean;
-	currentTest: CurrentSignInGateABTest;
-}) => {
+}: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
 		(await hasRequiredConsents()) &&

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -68,14 +68,6 @@ export const isValidTag = (tags: TagType[]): boolean => {
 	);
 };
 
-// hide the sign in gate on isPaidContent
-export const isPaidContent = (CAPI: CAPIBrowserType): boolean =>
-	CAPI.pageType.isPaidContent;
-
-// hide the sign in gate on internal tools preview
-export const isPreview = (CAPI: CAPIBrowserType): boolean =>
-	CAPI.isPreview || false;
-
 export const hasRequiredConsents = (): Promise<boolean> => {
 	const hasConsentedToAll = (state: ConsentState) => {
 		const consentFlags = state.tcfv2?.consents
@@ -128,8 +120,10 @@ export const canShowSignInGate = (
 			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI.tags) &&
-			!isPaidContent(CAPI) &&
-			!isPreview(CAPI) &&
+			// hide the sign in gate on isPaidContent
+			!CAPI.pageType.isPaidContent &&
+			// hide the sign in gate on internal tools preview &&
+			!CAPI.isPreview &&
 			!isIOS9(),
 	);
 

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -105,13 +105,13 @@ export const hasRequiredConsents = (): Promise<boolean> => {
 };
 
 export const canShowSignInGate = ({
-	CAPI,
 	isSignedIn,
 	currentTest,
 	contentType,
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
@@ -127,38 +127,38 @@ export const canShowSignInGate = ({
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
-			!CAPI.isPreview &&
+			!isPreview &&
 			!isIOS9(),
 	);
 
 export const canShowMandatoryUs: ({
-	CAPI,
 	isSignedIn,
 	currentTest,
 	contentType,
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: CanShowGateProps) => Promise<boolean> = async ({
-	CAPI,
 	isSignedIn,
 	currentTest,
 	contentType,
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
 		(await hasRequiredConsents()) &&
 		(await canShowSignInGate({
-			CAPI,
 			isSignedIn,
 			currentTest,
 			contentType,
 			sectionName,
 			tags,
 			isPaidContent,
+			isPreview,
 		}))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -110,6 +110,7 @@ export const canShowSignInGate = ({
 	currentTest,
 	contentType,
 	sectionName,
+	tags,
 }: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
@@ -120,8 +121,8 @@ export const canShowSignInGate = ({
 			) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(contentType) &&
-			isValidTag(CAPI.tags) &&
 			isValidSection(sectionName) &&
+			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
 			!CAPI.pageType.isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
@@ -135,12 +136,14 @@ export const canShowMandatoryUs: ({
 	currentTest,
 	contentType,
 	sectionName,
+	tags,
 }: CanShowGateProps) => Promise<boolean> = async ({
 	CAPI,
 	isSignedIn,
 	currentTest,
 	contentType,
 	sectionName,
+	tags,
 }: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
@@ -151,6 +154,7 @@ export const canShowMandatoryUs: ({
 			currentTest,
 			contentType,
 			sectionName,
+			tags,
 		}))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -60,11 +60,11 @@ export const isValidSection = (sectionName?: string): boolean => {
 };
 
 // hide the sign in gate for certain tags on the site
-export const isValidTag = (CAPI: CAPIBrowserType): boolean => {
+export const isValidTag = (tags: TagType[]): boolean => {
 	const invalidTags = ['info/newsletter-sign-up'];
 
 	return !invalidTags.some((invalidTag) =>
-		CAPI.tags.map((tag) => tag.id).includes(invalidTag),
+		tags.map((tag) => tag.id).includes(invalidTag),
 	);
 };
 
@@ -127,7 +127,7 @@ export const canShowSignInGate = (
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI.sectionName) &&
-			isValidTag(CAPI) &&
+			isValidTag(CAPI.tags) &&
 			!isPaidContent(CAPI) &&
 			!isPreview(CAPI) &&
 			!isIOS9(),

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -111,6 +111,7 @@ export const canShowSignInGate = ({
 	contentType,
 	sectionName,
 	tags,
+	isPaidContent,
 }: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
@@ -124,7 +125,7 @@ export const canShowSignInGate = ({
 			isValidSection(sectionName) &&
 			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
-			!CAPI.pageType.isPaidContent &&
+			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
 			!CAPI.isPreview &&
 			!isIOS9(),
@@ -137,6 +138,7 @@ export const canShowMandatoryUs: ({
 	contentType,
 	sectionName,
 	tags,
+	isPaidContent,
 }: CanShowGateProps) => Promise<boolean> = async ({
 	CAPI,
 	isSignedIn,
@@ -144,6 +146,7 @@ export const canShowMandatoryUs: ({
 	contentType,
 	sectionName,
 	tags,
+	isPaidContent,
 }: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
@@ -155,6 +158,7 @@ export const canShowMandatoryUs: ({
 			contentType,
 			sectionName,
 			tags,
+			isPaidContent,
 		}))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -109,6 +109,7 @@ export const canShowSignInGate = ({
 	isSignedIn,
 	currentTest,
 	contentType,
+	sectionName,
 }: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
@@ -119,8 +120,8 @@ export const canShowSignInGate = ({
 			) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(contentType) &&
-			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI.tags) &&
+			isValidSection(sectionName) &&
 			// hide the sign in gate on isPaidContent
 			!CAPI.pageType.isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
@@ -133,11 +134,13 @@ export const canShowMandatoryUs: ({
 	isSignedIn,
 	currentTest,
 	contentType,
+	sectionName,
 }: CanShowGateProps) => Promise<boolean> = async ({
 	CAPI,
 	isSignedIn,
 	currentTest,
 	contentType,
+	sectionName,
 }: CanShowGateProps) => {
 	return (
 		(await getLocale()) === 'US' &&
@@ -147,6 +150,7 @@ export const canShowMandatoryUs: ({
 			isSignedIn,
 			currentTest,
 			contentType,
+			sectionName,
 		}))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -104,11 +104,15 @@ export const hasRequiredConsents = (): Promise<boolean> => {
 	});
 };
 
-export const canShowSignInGate = (
-	CAPI: CAPIBrowserType,
-	isSignedIn: boolean,
-	currentTest: CurrentSignInGateABTest,
-): Promise<boolean> =>
+export const canShowSignInGate = ({
+	CAPI,
+	isSignedIn,
+	currentTest,
+}: {
+	CAPI: CAPIBrowserType;
+	isSignedIn: boolean;
+	currentTest: CurrentSignInGateABTest;
+}): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGateMoreThanCount(
@@ -127,18 +131,26 @@ export const canShowSignInGate = (
 			!isIOS9(),
 	);
 
-export const canShowMandatoryUs: (
-	CAPI: CAPIBrowserType,
-	isSignedIn: boolean,
-	currentTest: CurrentSignInGateABTest,
-) => Promise<boolean> = async (
-	CAPI: CAPIBrowserType,
-	isSignedIn: boolean,
-	currentTest: CurrentSignInGateABTest,
-) => {
+export const canShowMandatoryUs: ({
+	CAPI,
+	isSignedIn,
+	currentTest,
+}: {
+	CAPI: CAPIBrowserType;
+	isSignedIn: boolean;
+	currentTest: CurrentSignInGateABTest;
+}) => Promise<boolean> = async ({
+	CAPI,
+	isSignedIn,
+	currentTest,
+}: {
+	CAPI: CAPIBrowserType;
+	isSignedIn: boolean;
+	currentTest: CurrentSignInGateABTest;
+}) => {
 	return (
 		(await getLocale()) === 'US' &&
 		(await hasRequiredConsents()) &&
-		(await canShowSignInGate(CAPI, isSignedIn, currentTest))
+		(await canShowSignInGate({ CAPI, isSignedIn, currentTest }))
 	);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -33,14 +33,12 @@ export const isIOS9 = (): boolean => {
 };
 
 // hide the sign in gate on article types that are not supported
-export const isValidContentType = (CAPI: CAPIBrowserType): boolean => {
+export const isValidContentType = (contentType: string): boolean => {
 	// It's safer to definitively *include* types as we
 	// know new types will not break the sign-in-gate going forward
 	const validTypes = ['Article'];
 
-	return validTypes.some(
-		(type: string): boolean => CAPI.contentType === type,
-	);
+	return validTypes.some((type: string): boolean => contentType === type);
 };
 
 // hide the sign in gate on certain sections of the site, e.g info, about, help etc.
@@ -127,7 +125,7 @@ export const canShowSignInGate = (
 				5,
 			) &&
 			isNPageOrHigherPageView(3) &&
-			isValidContentType(CAPI) &&
+			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI) &&
 			isValidTag(CAPI) &&
 			!isPaidContent(CAPI) &&

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -24,7 +24,7 @@ const canShow = (
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI.sectionName) &&
-			isValidTag(CAPI) &&
+			isValidTag(CAPI.tags) &&
 			!isPaidContent(CAPI) &&
 			!isPreview(CAPI) &&
 			!isIOS9(),

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -23,7 +23,7 @@ const canShow = (
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
 			isNPageOrHigherPageView(3) &&
 			isValidContentType(CAPI.contentType) &&
-			isValidSection(CAPI) &&
+			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI) &&
 			!isPaidContent(CAPI) &&
 			!isPreview(CAPI) &&

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -29,7 +29,7 @@ const canShow = ({
 			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
-			// hide the sign in gate on internal tools preview &&
+			// hide the sign in gate on internal tools preview
 			!isPreview &&
 			!isIOS9(),
 	);

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -11,11 +11,15 @@ import {
 	isIOS9,
 } from '@frontend/web/components/SignInGate/displayRule';
 
-const canShow = (
-	CAPI: CAPIBrowserType,
-	isSignedIn: boolean,
-	currentTest: CurrentSignInGateABTest,
-): Promise<boolean> =>
+const canShow = ({
+	CAPI,
+	isSignedIn,
+	currentTest,
+}: {
+	CAPI: CAPIBrowserType;
+	isSignedIn: boolean;
+	currentTest: CurrentSignInGateABTest;
+}): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -1,6 +1,6 @@
 import { hasUserDismissedGate } from '@frontend/web/components/SignInGate/dismissGate';
 import {
-	CurrentSignInGateABTest,
+	CanShowGateProps,
 	SignInGateComponent,
 } from '@frontend/web/components/SignInGate/types';
 import {
@@ -12,25 +12,25 @@ import {
 } from '@frontend/web/components/SignInGate/displayRule';
 
 const canShow = ({
-	CAPI,
 	isSignedIn,
 	currentTest,
-}: {
-	CAPI: CAPIBrowserType;
-	isSignedIn: boolean;
-	currentTest: CurrentSignInGateABTest;
-}): Promise<boolean> =>
+	contentType,
+	sectionName,
+	tags,
+	isPaidContent,
+	isPreview,
+}: CanShowGateProps): Promise<boolean> =>
 	Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
 			isNPageOrHigherPageView(3) &&
-			isValidContentType(CAPI.contentType) &&
-			isValidSection(CAPI.sectionName) &&
-			isValidTag(CAPI.tags) &&
+			isValidContentType(contentType) &&
+			isValidSection(sectionName) &&
+			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
-			!CAPI.pageType.isPaidContent &&
+			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
-			!CAPI.isPreview &&
+			!isPreview &&
 			!isIOS9(),
 	);
 

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -8,8 +8,6 @@ import {
 	isValidContentType,
 	isValidSection,
 	isValidTag,
-	isPaidContent,
-	isPreview,
 	isIOS9,
 } from '@frontend/web/components/SignInGate/displayRule';
 
@@ -25,8 +23,10 @@ const canShow = (
 			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI.sectionName) &&
 			isValidTag(CAPI.tags) &&
-			!isPaidContent(CAPI) &&
-			!isPreview(CAPI) &&
+			// hide the sign in gate on isPaidContent
+			!CAPI.pageType.isPaidContent &&
+			// hide the sign in gate on internal tools preview &&
+			!CAPI.isPreview &&
 			!isIOS9(),
 	);
 

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-control.ts
@@ -22,7 +22,7 @@ const canShow = (
 		!isSignedIn &&
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
 			isNPageOrHigherPageView(3) &&
-			isValidContentType(CAPI) &&
+			isValidContentType(CAPI.contentType) &&
 			isValidSection(CAPI) &&
 			isValidTag(CAPI) &&
 			!isPaidContent(CAPI) &&

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -5,6 +5,7 @@ export type CanShowGateProps = {
 	contentType: string;
 	sectionName?: string;
 	tags: TagType[];
+	isPaidContent: boolean;
 };
 
 export type SignInGateComponent = {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -43,6 +43,7 @@ export interface SignInGateSelectorProps {
 	host?: string;
 	pageId: string;
 	idUrl?: string;
+	pageViewId: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -1,10 +1,14 @@
 export type SignInGateComponent = {
 	gate?: (props: SignInGateProps) => JSX.Element;
-	canShow: (
-		CAPI: CAPIBrowserType,
-		isSignedIn: boolean,
-		currentTest: CurrentSignInGateABTest,
-	) => Promise<boolean>;
+	canShow: ({
+		CAPI,
+		isSignedIn,
+		currentTest,
+	}: {
+		CAPI: CAPIBrowserType;
+		isSignedIn: boolean;
+		currentTest: CurrentSignInGateABTest;
+	}) => Promise<boolean>;
 };
 
 export interface SignInGateProps {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -39,6 +39,7 @@ export interface SignInGateSelectorProps {
 	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
+	isPreview: boolean;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -36,7 +36,7 @@ export interface SignInGateSelectorProps {
 	isSignedIn?: boolean;
 	format: ArticleFormat;
 	contentType: string;
-	sectionName: string;
+	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -36,6 +36,7 @@ export interface SignInGateSelectorProps {
 	isSignedIn?: boolean;
 	CAPI: CAPIBrowserType;
 	contentType: string;
+	sectionName?: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -2,6 +2,7 @@ export type CanShowGateProps = {
 	CAPI: CAPIBrowserType;
 	isSignedIn: boolean;
 	currentTest: CurrentSignInGateABTest;
+	contentType: string;
 };
 
 export type SignInGateComponent = {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -3,6 +3,7 @@ export type CanShowGateProps = {
 	isSignedIn: boolean;
 	currentTest: CurrentSignInGateABTest;
 	contentType: string;
+	sectionName?: string;
 };
 
 export type SignInGateComponent = {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -34,7 +34,7 @@ export type CurrentSignInGateABTest = {
 
 export interface SignInGateSelectorProps {
 	isSignedIn?: boolean;
-	CAPI: CAPIBrowserType;
+	format: ArticleFormat;
 	contentType: string;
 	sectionName: string;
 	tags: TagType[];

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -35,6 +35,7 @@ export type CurrentSignInGateABTest = {
 export interface SignInGateSelectorProps {
 	isSignedIn?: boolean;
 	CAPI: CAPIBrowserType;
+	contentType: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -41,6 +41,7 @@ export interface SignInGateSelectorProps {
 	isPaidContent: boolean;
 	isPreview: boolean;
 	host?: string;
+	pageId: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -42,6 +42,7 @@ export interface SignInGateSelectorProps {
 	isPreview: boolean;
 	host?: string;
 	pageId: string;
+	idUrl?: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -1,17 +1,16 @@
 export type CanShowGateProps = {
-	CAPI: CAPIBrowserType;
 	isSignedIn: boolean;
 	currentTest: CurrentSignInGateABTest;
 	contentType: string;
 	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
+	isPreview?: boolean;
 };
 
 export type SignInGateComponent = {
 	gate?: (props: SignInGateProps) => JSX.Element;
 	canShow: ({
-		CAPI,
 		isSignedIn,
 		currentTest,
 	}: CanShowGateProps) => Promise<boolean>;

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -36,7 +36,7 @@ export interface SignInGateSelectorProps {
 	isSignedIn?: boolean;
 	CAPI: CAPIBrowserType;
 	contentType: string;
-	sectionName?: string;
+	sectionName: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -38,6 +38,7 @@ export interface SignInGateSelectorProps {
 	contentType: string;
 	sectionName?: string;
 	tags: TagType[];
+	isPaidContent: boolean;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -1,14 +1,16 @@
+export type CanShowGateProps = {
+	CAPI: CAPIBrowserType;
+	isSignedIn: boolean;
+	currentTest: CurrentSignInGateABTest;
+};
+
 export type SignInGateComponent = {
 	gate?: (props: SignInGateProps) => JSX.Element;
 	canShow: ({
 		CAPI,
 		isSignedIn,
 		currentTest,
-	}: {
-		CAPI: CAPIBrowserType;
-		isSignedIn: boolean;
-		currentTest: CurrentSignInGateABTest;
-	}) => Promise<boolean>;
+	}: CanShowGateProps) => Promise<boolean>;
 };
 
 export interface SignInGateProps {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -37,6 +37,7 @@ export interface SignInGateSelectorProps {
 	CAPI: CAPIBrowserType;
 	contentType: string;
 	sectionName?: string;
+	tags: TagType[];
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -4,6 +4,7 @@ export type CanShowGateProps = {
 	currentTest: CurrentSignInGateABTest;
 	contentType: string;
 	sectionName?: string;
+	tags: TagType[];
 };
 
 export type SignInGateComponent = {

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -40,6 +40,7 @@ export interface SignInGateSelectorProps {
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;
+	host?: string;
 }
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -34,6 +34,7 @@ type Props = {
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 	contentType: string;
 	sectionName?: string;
+	tags: TagType[];
 };
 
 type RRBannerConfig = {
@@ -167,6 +168,7 @@ export const StickyBottomBanner = ({
 	asyncArticleCount,
 	contentType,
 	sectionName,
+	tags,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
@@ -174,6 +176,7 @@ export const StickyBottomBanner = ({
 		CAPI,
 		contentType,
 		sectionName,
+		tags,
 	});
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -175,7 +175,6 @@ export const StickyBottomBanner = ({
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
 		isSignedIn,
-		CAPI,
 		contentType,
 		sectionName,
 		tags,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -33,6 +33,7 @@ type Props = {
 	isPreview: boolean;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 	contentType: string;
+	sectionName?: string;
 };
 
 type RRBannerConfig = {
@@ -165,12 +166,14 @@ export const StickyBottomBanner = ({
 	isPreview,
 	asyncArticleCount,
 	contentType,
+	sectionName,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
 		isSignedIn,
 		CAPI,
 		contentType,
+		sectionName,
 	});
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -35,6 +35,7 @@ type Props = {
 	contentType: string;
 	sectionName?: string;
 	tags: TagType[];
+	isPaidContent: boolean;
 };
 
 type RRBannerConfig = {
@@ -169,6 +170,7 @@ export const StickyBottomBanner = ({
 	contentType,
 	sectionName,
 	tags,
+	isPaidContent,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
@@ -177,6 +179,7 @@ export const StickyBottomBanner = ({
 		contentType,
 		sectionName,
 		tags,
+		isPaidContent,
 	});
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -32,7 +32,7 @@ type Props = {
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 	contentType: string;
-	sectionName: string;
+	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -32,6 +32,7 @@ type Props = {
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	isPreview: boolean;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
+	contentType: string;
 };
 
 type RRBannerConfig = {
@@ -163,9 +164,14 @@ export const StickyBottomBanner = ({
 	brazeMessages,
 	isPreview,
 	asyncArticleCount,
+	contentType,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
-	const signInGateWillShow = useSignInGateWillShow({ isSignedIn, CAPI });
+	const signInGateWillShow = useSignInGateWillShow({
+		isSignedIn,
+		CAPI,
+		contentType,
+	});
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();
 		const puzzlesBanner = buildPuzzlesBannerConfig(

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -32,7 +32,7 @@ type Props = {
 	brazeMessages?: Promise<BrazeMessagesInterface>;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 	contentType: string;
-	sectionName?: string;
+	sectionName: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -30,12 +30,12 @@ type Props = {
 	asyncCountryCode?: Promise<CountryCode | null>;
 	CAPI: CAPIBrowserType;
 	brazeMessages?: Promise<BrazeMessagesInterface>;
-	isPreview: boolean;
 	asyncArticleCount?: Promise<WeeklyArticleHistory | undefined>;
 	contentType: string;
 	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
+	isPreview: boolean;
 };
 
 type RRBannerConfig = {
@@ -165,12 +165,12 @@ export const StickyBottomBanner = ({
 	asyncCountryCode,
 	CAPI,
 	brazeMessages,
-	isPreview,
 	asyncArticleCount,
 	contentType,
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
@@ -180,6 +180,7 @@ export const StickyBottomBanner = ({
 		sectionName,
 		tags,
 		isPaidContent,
+		isPreview,
 	});
 	useOnce(() => {
 		const CMP = buildCmpBannerConfig();

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -36,7 +36,7 @@ export const useSignInGateWillShow = ({
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
-				?.canShow(CAPI, !!isSignedIn, currentTest)
+				?.canShow({ CAPI, isSignedIn: !!isSignedIn, currentTest })
 				.then(setCanShowGate);
 		}
 	}, [currentTest, gateVariant, CAPI, isSignedIn]);

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -15,7 +15,6 @@ import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
  * */
 export const useSignInGateWillShow = ({
 	isSignedIn,
-	CAPI,
 	contentType,
 	sectionName,
 	tags,
@@ -55,7 +54,6 @@ export const useSignInGateWillShow = ({
 	}, [
 		currentTest,
 		gateVariant,
-		CAPI,
 		isSignedIn,
 		contentType,
 		sectionName,

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -41,6 +41,7 @@ export const useSignInGateWillShow = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType: CAPI.contentType,
+					sectionName: CAPI.sectionName,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -20,6 +20,7 @@ export const useSignInGateWillShow = ({
 	sectionName,
 	tags,
 	isPaidContent,
+	isPreview,
 }: SignInGateSelectorProps): boolean | undefined => {
 	const [gateVariant, setGateVariant] = useState<
 		SignInGateComponent | null | undefined
@@ -47,7 +48,7 @@ export const useSignInGateWillShow = ({
 					sectionName,
 					tags,
 					isPaidContent,
-					isPreview: CAPI.isPreview,
+					isPreview,
 				})
 				.then(setCanShowGate);
 		}
@@ -60,6 +61,7 @@ export const useSignInGateWillShow = ({
 		sectionName,
 		tags,
 		isPaidContent,
+		isPreview,
 	]);
 
 	return canShowGate && !!gateVariant && !!gateVariant.gate;

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -2,11 +2,18 @@ import { useEffect, useState } from 'react';
 import {
 	CurrentSignInGateABTest,
 	SignInGateComponent,
-	SignInGateSelectorProps,
 } from '@frontend/web/components/SignInGate/types';
 import { useOnce } from '@frontend/web/lib/useOnce';
 import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
 
+type Props = {
+	isSignedIn?: boolean;
+	contentType: string;
+	sectionName: string;
+	tags: TagType[];
+	isPaidContent: boolean;
+	isPreview: boolean;
+};
 /**
  * @description
  * A custom hook to determine if a sign in gate will show on the current page
@@ -20,7 +27,7 @@ export const useSignInGateWillShow = ({
 	tags,
 	isPaidContent,
 	isPreview,
-}: SignInGateSelectorProps): boolean | undefined => {
+}: Props): boolean | undefined => {
 	const [gateVariant, setGateVariant] = useState<
 		SignInGateComponent | null | undefined
 	>(undefined);

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -37,13 +37,13 @@ export const useSignInGateWillShow = ({
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
 				?.canShow({
-					CAPI,
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
+					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -17,6 +17,7 @@ export const useSignInGateWillShow = ({
 	isSignedIn,
 	CAPI,
 	contentType,
+	sectionName,
 }: SignInGateSelectorProps): boolean | undefined => {
 	const [gateVariant, setGateVariant] = useState<
 		SignInGateComponent | null | undefined
@@ -41,14 +42,14 @@ export const useSignInGateWillShow = ({
 					isSignedIn: !!isSignedIn,
 					currentTest,
 					contentType,
-					sectionName: CAPI.sectionName,
+					sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
 					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType]);
+	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType, sectionName]);
 
 	return canShowGate && !!gateVariant && !!gateVariant.gate;
 };

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -18,6 +18,8 @@ export const useSignInGateWillShow = ({
 	CAPI,
 	contentType,
 	sectionName,
+	tags,
+	isPaidContent,
 }: SignInGateSelectorProps): boolean | undefined => {
 	const [gateVariant, setGateVariant] = useState<
 		SignInGateComponent | null | undefined
@@ -43,13 +45,22 @@ export const useSignInGateWillShow = ({
 					currentTest,
 					contentType,
 					sectionName,
-					tags: CAPI.tags,
-					isPaidContent: CAPI.pageType.isPaidContent,
+					tags,
+					isPaidContent,
 					isPreview: CAPI.isPreview,
 				})
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType, sectionName]);
+	}, [
+		currentTest,
+		gateVariant,
+		CAPI,
+		isSignedIn,
+		contentType,
+		sectionName,
+		tags,
+		isPaidContent,
+	]);
 
 	return canShowGate && !!gateVariant && !!gateVariant.gate;
 };

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -43,6 +43,7 @@ export const useSignInGateWillShow = ({
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
+					isPaidContent: CAPI.pageType.isPaidContent,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -16,6 +16,7 @@ import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
 export const useSignInGateWillShow = ({
 	isSignedIn,
 	CAPI,
+	contentType,
 }: SignInGateSelectorProps): boolean | undefined => {
 	const [gateVariant, setGateVariant] = useState<
 		SignInGateComponent | null | undefined
@@ -39,7 +40,7 @@ export const useSignInGateWillShow = ({
 				?.canShow({
 					isSignedIn: !!isSignedIn,
 					currentTest,
-					contentType: CAPI.contentType,
+					contentType,
 					sectionName: CAPI.sectionName,
 					tags: CAPI.tags,
 					isPaidContent: CAPI.pageType.isPaidContent,
@@ -47,7 +48,7 @@ export const useSignInGateWillShow = ({
 				})
 				.then(setCanShowGate);
 		}
-	}, [currentTest, gateVariant, CAPI, isSignedIn]);
+	}, [currentTest, gateVariant, CAPI, isSignedIn, contentType]);
 
 	return canShowGate && !!gateVariant && !!gateVariant.gate;
 };

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -42,6 +42,7 @@ export const useSignInGateWillShow = ({
 					currentTest,
 					contentType: CAPI.contentType,
 					sectionName: CAPI.sectionName,
+					tags: CAPI.tags,
 				})
 				.then(setCanShowGate);
 		}

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -36,7 +36,12 @@ export const useSignInGateWillShow = ({
 		if (gateVariant && currentTest) {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			gateVariant
-				?.canShow({ CAPI, isSignedIn: !!isSignedIn, currentTest })
+				?.canShow({
+					CAPI,
+					isSignedIn: !!isSignedIn,
+					currentTest,
+					contentType: CAPI.contentType,
+				})
 				.then(setCanShowGate);
 		}
 	}, [currentTest, gateVariant, CAPI, isSignedIn]);

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -9,7 +9,7 @@ import { useSignInGateSelector } from '@frontend/web/lib/useSignInGateSelector';
 type Props = {
 	isSignedIn?: boolean;
 	contentType: string;
-	sectionName: string;
+	sectionName?: string;
 	tags: TagType[];
 	isPaidContent: boolean;
 	isPreview: boolean;


### PR DESCRIPTION
**👉 Please review commit by commit for a a more enjoyable experience 👈**

## What does this change?
Removes the use of `CAPI` as a prop from `SignInGateSelector`, `useSignInGateWillShow` and `StickyBottomBanner`, replaces it with explicit properties

## Why?
`CAPI` is 30Kb and having it as a prop creates a contract the the platform needs to support. We'd like to refactor `App.tsx` but we need to better understand our contracts first

