### PR TITLE
Make sure strong elements return a bold font weight

### DIFF
--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -561,7 +561,7 @@ describe('Paragraph tags rendered correctly', () => {
 		);
 		const nodes = renderStandfirstText(fragment, mockFormat);
 		const html = getHtml(nodes.flat()[0]);
-		expect(html).toContain('<strong><p>Standfirst link</p></strong>');
+		expect(html).toContain('<p>Standfirst link</p>');
 	});
 
 	test('Contains styles in article body', () => {

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -178,7 +178,11 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 		case 'BLOCKQUOTE':
 			return h('blockquote', { key }, children);
 		case 'STRONG':
-			return h('strong', { key }, children);
+			return styledH(
+				'strong',
+				{ css: { fontWeight: 'bold' }, key },
+				children,
+			);
 		case 'EM':
 			return h('em', { key }, children);
 		case 'BR':
@@ -238,7 +242,11 @@ const textElement =
 					? h('blockquote', { key }, children)
 					: h(Blockquote, { key, format }, children);
 			case 'STRONG':
-				return h('strong', { key }, children);
+				return styledH(
+					'strong',
+					{ css: { fontWeight: 'bold' }, key },
+					children,
+				);
 			case 'B':
 				return h('b', { key }, children);
 			case 'EM':
@@ -300,7 +308,11 @@ const standfirstTextElement =
 			case 'P':
 				return h('p', { key }, children);
 			case 'STRONG':
-				return h('strong', { key }, children);
+				return styledH(
+					'strong',
+					{ css: { fontWeight: 'bold' }, key },
+					children,
+				);
 			case 'UL':
 				return h(List, { children });
 			case 'LI':

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -157,7 +157,8 @@ const TweetStyles = css`
 	}
 `;
 
-//Elements rendered by this function should contain no styles. For example in callout form and interactives we want to exclude styles.
+//Elements rendered by this function should contain no styles.
+// For example in callout form and interactives we want to exclude styles.
 const plainTextElement = (node: Node, key: number): ReactNode => {
 	const text = node.textContent ?? '';
 	const children = Array.from(node.childNodes).map(plainTextElement);

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -308,11 +308,7 @@ const standfirstTextElement =
 			case 'P':
 				return h('p', { key }, children);
 			case 'STRONG':
-				return styledH(
-					'strong',
-					{ css: { fontWeight: 'bold' }, key },
-					children,
-				);
+				return h('strong', { key }, children);
 			case 'UL':
 				return h(List, { children });
 			case 'LI':

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -157,6 +157,7 @@ const TweetStyles = css`
 	}
 `;
 
+//Elements rendered by this function should contain no styles. For example in callout form and interactives we want to exclude styles.
 const plainTextElement = (node: Node, key: number): ReactNode => {
 	const text = node.textContent ?? '';
 	const children = Array.from(node.childNodes).map(plainTextElement);
@@ -178,11 +179,7 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 		case 'BLOCKQUOTE':
 			return h('blockquote', { key }, children);
 		case 'STRONG':
-			return styledH(
-				'strong',
-				{ css: { fontWeight: 'bold' }, key },
-				children,
-			);
+			return h('strong', { key }, children);
 		case 'EM':
 			return h('em', { key }, children);
 		case 'BR':
@@ -227,7 +224,7 @@ const textElement =
 						key,
 						isEditions,
 					},
-					transform(text, format),
+					children,
 				);
 			case 'H2':
 				return text.includes('* * *')
@@ -308,7 +305,11 @@ const standfirstTextElement =
 			case 'P':
 				return h('p', { key }, children);
 			case 'STRONG':
-				return h('strong', { key }, children);
+				return styledH(
+					'strong',
+					{ css: { fontWeight: 'bold' }, key },
+					children,
+				);
 			case 'UL':
 				return h(List, { children });
 			case 'LI':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## Why?
A side effect of the recent CSS reset introduced has resulted in <strong> tags not being styled with font-weight: bold. This means that Racing Tips, Sports articles, Letters etc have lost their “boldness”. This PR fixes that.
