### PR TITLE
move firstPublished and lastUpdated to common

### DIFF
--- a/common-rendering/src/components/FirstPublished.stories.tsx
+++ b/common-rendering/src/components/FirstPublished.stories.tsx
@@ -1,0 +1,23 @@
+// ----- Imports ----- //
+
+import type { FC } from "react";
+
+import { FirstPublished } from "./FirstPublished";
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+	<FirstPublished
+		firstPublished={1613763003000}
+		blockLink={"#block-60300f5f8f08ad21ea60071e"}
+	/>
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: FirstPublished,
+	title: "Common/Components/FirstPublished",
+};
+
+export { Default };

--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -18,7 +18,6 @@ const FirstPublished = ({
 		<a
 			href={blockLink}
 			data-ignore="global-link-styling"
-			// title={publishedDate.toLocaleString()}
 			css={css`
 				${textSans.xxsmall({ fontWeight: "bold" })}
 				margin-bottom: ${space[1]}px;

--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -1,0 +1,58 @@
+import { css } from "@emotion/react";
+import { timeAgo } from "@guardian/libs";
+import { neutral, space } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+
+// TODO: update this code to use shared version when it is available
+const padString = (time: number) => (time < 10 ? `0${time}` : time);
+
+const FirstPublished = ({
+	firstPublished,
+	blockLink,
+}: {
+	firstPublished: number;
+	blockLink: string;
+}) => {
+	const publishedDate = new Date(firstPublished);
+	return (
+		<a
+			href={blockLink}
+			data-ignore="global-link-styling"
+			// title={publishedDate.toLocaleString()}
+			css={css`
+				${textSans.xxsmall({ fontWeight: "bold" })}
+				margin-bottom: ${space[1]}px;
+				padding-top: ${space[1]}px;
+				display: flex;
+				flex-direction: row;
+				text-decoration: none;
+				:hover {
+					filter: brightness(30%);
+				}
+			`}
+		>
+			<time
+				dateTime={publishedDate.toISOString()}
+				css={css`
+					color: ${neutral[46]};
+					font-weight: bold;
+					margin-right: ${space[2]}px;
+				`}
+			>
+				{timeAgo(firstPublished)}
+			</time>
+			<span
+				css={css`
+					${textSans.xxsmall()};
+					color: ${neutral[46]};
+				`}
+			>
+				{`${padString(publishedDate.getHours())}:${padString(
+					publishedDate.getMinutes()
+				)}`}
+			</span>
+		</a>
+	);
+};
+
+export { FirstPublished };

--- a/common-rendering/src/components/LastUpdated.stories.tsx
+++ b/common-rendering/src/components/LastUpdated.stories.tsx
@@ -1,0 +1,20 @@
+// ----- Imports ----- //
+
+import type { FC } from "react";
+
+import { LastUpdated } from "./LastUpdated";
+
+// ----- Stories ----- //
+
+const Default: FC = () => (
+	<LastUpdated lastUpdated={1613763519000} lastUpdatedDisplay={"19.38 GMT"} />
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: LastUpdated,
+	title: "Common/Components/LastUpdated",
+};
+
+export { Default };

--- a/common-rendering/src/components/LastUpdated.tsx
+++ b/common-rendering/src/components/LastUpdated.tsx
@@ -1,0 +1,28 @@
+import { css } from "@emotion/react";
+import { neutral } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+
+const LastUpdated = ({
+	lastUpdatedDisplay,
+	lastUpdated,
+}: {
+	lastUpdatedDisplay: string;
+	lastUpdated: number;
+}) => {
+	return (
+		<div
+			css={css`
+				display: flex;
+				align-items: flex-end;
+				${textSans.xxsmall()};
+				color: ${neutral[46]};
+			`}
+		>
+			<time dateTime={new Date(lastUpdated).toISOString()}>
+				{`Updated at ${lastUpdatedDisplay}`}
+			</time>
+		</div>
+	);
+};
+
+export { LastUpdated };

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,15 +1,16 @@
 import { css } from '@emotion/react';
 
-import { neutral, space } from '@guardian/src-foundations';
-import { timeAgo } from '@guardian/libs';
+import { space } from '@guardian/src-foundations';
 
 import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { Hide } from '@root/src/web/components/Hide';
 import { ShareIcons } from '@root/src/web/components/ShareIcons';
-import { headline, textSans } from '@guardian/src-foundations/typography';
+import { headline } from '@guardian/src-foundations/typography';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
+import { LastUpdated } from '@guardian/common-rendering/src/components/LastUpdated';
 
 type Props = {
 	format: ArticleFormat;
@@ -44,81 +45,6 @@ const BlockTitle = ({ title }: { title: string }) => {
 		>
 			{title}
 		</h2>
-	);
-};
-
-const LastUpdated = ({
-	lastUpdatedDisplay,
-	lastUpdated,
-}: {
-	lastUpdatedDisplay: string;
-	lastUpdated: number;
-}) => {
-	return (
-		<div
-			css={css`
-				display: flex;
-				align-items: flex-end;
-				${textSans.xxsmall()};
-				color: ${neutral[46]};
-			`}
-		>
-			<time dateTime={new Date(lastUpdated).toISOString()}>
-				{`Updated at ${lastUpdatedDisplay}`}
-			</time>
-		</div>
-	);
-};
-
-// TODO: update this code to use shared version when it is available
-const padString = (time: number) => (time < 10 ? `0${time}` : time);
-
-const FirstPublished = ({
-	firstPublished,
-	blockLink,
-}: {
-	firstPublished: number;
-	blockLink: string;
-}) => {
-	const publishedDate = new Date(firstPublished);
-	return (
-		<a
-			href={blockLink}
-			data-ignore="global-link-styling"
-			// title={publishedDate.toLocaleString()}
-			css={css`
-				${textSans.xxsmall({ fontWeight: 'bold' })}
-				margin-bottom: ${space[1]}px;
-				padding-top: ${space[1]}px;
-				display: flex;
-				flex-direction: row;
-				text-decoration: none;
-				:hover {
-					filter: brightness(30%);
-				}
-			`}
-		>
-			<time
-				dateTime={publishedDate.toISOString()}
-				css={css`
-					color: ${neutral[46]};
-					font-weight: bold;
-					margin-right: ${space[2]}px;
-				`}
-			>
-				{timeAgo(firstPublished)}
-			</time>
-			<span
-				css={css`
-					${textSans.xxsmall()};
-					color: ${neutral[46]};
-				`}
-			>
-				{`${padString(publishedDate.getHours())}:${padString(
-					publishedDate.getMinutes(),
-				)}`}
-			</span>
-		</a>
 	);
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR moved the `FirstPublished` & `LastUpdated` components to common-rendering. 
## Why?
In order to share these components between AR & DCR
### Before

### After
