### PR TITLE
update standfirst bullet styling for deadblogs

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -126,6 +126,7 @@ type Palette = {
 		headline: Colour;
 		headlineByline: Colour;
 		bullet: Colour;
+		bulletStandfirst: Colour;
 		header: Colour;
 		standfirst: Colour;
 		richLink: Colour;

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -119,7 +119,7 @@ export const LiveBlog = () => {
 					design: ArticleDesign.LiveBlog,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how LiveBlog standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="<p>This is how a Liveblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p><ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -148,7 +148,7 @@ export const DeadBlog = () => {
 					design: ArticleDesign.DeadBlog,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how DeadBlog standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="<p>This is how a Deadblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p><ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -31,7 +31,7 @@ const nestedStyles = (palette: Palette) => css`
 		height: ${space[3]}px;
 		width: ${space[3]}px;
 		margin-right: ${space[2]}px;
-		background-color: ${neutral[86]};
+		background-color: ${palette.background.bullet};
 		margin-left: -20px;
 	}
 
@@ -50,7 +50,7 @@ const nestedStyles = (palette: Palette) => css`
 		height: 15.2px;
 		width: 15.2px;
 		margin-right: 2px;
-		background-color: ${neutral[86]};
+		background-color: ${palette.background.bullet};
 	}
 
 	a {

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -31,7 +31,7 @@ const nestedStyles = (palette: Palette) => css`
 		height: ${space[3]}px;
 		width: ${space[3]}px;
 		margin-right: ${space[2]}px;
-		background-color: ${palette.background.bullet};
+		background-color: ${palette.background.bulletStandfirst};
 		margin-left: -20px;
 	}
 
@@ -50,7 +50,7 @@ const nestedStyles = (palette: Palette) => css`
 		height: 15.2px;
 		width: 15.2px;
 		margin-right: 2px;
-		background-color: ${palette.background.bullet};
+		background-color: ${palette.background.bulletStandfirst};
 	}
 
 	a {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -487,16 +487,18 @@ const backgroundHeadlineByline = (format: ArticleFormat): string => {
 };
 
 const backgroundBullet = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.Labs) return BLACK;
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return specialReport[300];
+	return pillarPalette[format.theme].main;
+};
+
+const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.DeadBlog:
 			return neutral[60];
-		case ArticleDesign.LiveBlog:
-			return neutral[86]; // default previously defined in Standfirst.tsx
 		default:
-			if (format.theme === ArticleSpecial.Labs) return BLACK;
-			if (format.theme === ArticleSpecial.SpecialReport)
-				return specialReport[300];
-			return pillarPalette[format.theme].main;
+			return neutral[86]; // default previously defined in Standfirst.tsx
 	}
 };
 
@@ -860,6 +862,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),
+			bulletStandfirst: backgroundBulletStandfirst(format),
 			header: backgroundHeader(format),
 			standfirst: backgroundStandfirst(format),
 			richLink: backgroundRichLink(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -487,10 +487,17 @@ const backgroundHeadlineByline = (format: ArticleFormat): string => {
 };
 
 const backgroundBullet = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[300];
-	return pillarPalette[format.theme].main;
+	switch (format.design) {
+		case ArticleDesign.DeadBlog:
+			return neutral[60];
+		case ArticleDesign.LiveBlog:
+			return neutral[86]; // default previously defined in Standfirst.tsx
+		default:
+			if (format.theme === ArticleSpecial.Labs) return BLACK;
+			if (format.theme === ArticleSpecial.SpecialReport)
+				return specialReport[300];
+			return pillarPalette[format.theme].main;
+	}
 };
 
 const backgroundHeader = (format: ArticleFormat): string => {
@@ -507,7 +514,7 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 		case ArticleDesign.LiveBlog:
 			return pillarPalette[format.theme][300];
 		case ArticleDesign.DeadBlog:
-			return neutral[86];
+			return neutral[93];
 		default:
 			return backgroundArticle(format);
 	}


### PR DESCRIPTION
## What does this change?
For deadblogs bullets in the standfirst appeared to be missing. This change ensures the bullet colour, and standfirst background colour, is correct (deadblogs only).

NB: there are some other snags related to this change (deadblog standfirst links have incorrect styling, layout background colour doesn't match the design) but these will be dealt with under separate PRs.

## Why?
To ensure deadblogs in dcr achieve parity with the design.

### Before
<img width="1168" alt="Screenshot 2021-11-16 at 12 26 39" src="https://user-images.githubusercontent.com/45561419/141985173-b7c5f6a5-9fb9-477a-bc28-bf269c36e8e4.png">

### After
<img width="1208" alt="Screenshot 2021-11-16 at 12 26 48" src="https://user-images.githubusercontent.com/45561419/141985210-0e184326-daac-4bf7-9544-9f3c2d353c39.png">
