### PR TITLE
Make key events sticky and share dropdown functionality for live blocks

### DIFF
--- a/common-rendering/src/components/dropDown.tsx
+++ b/common-rendering/src/components/dropDown.tsx
@@ -16,6 +16,8 @@ interface DropDownProps {
 	children: React.ReactNode;
 	supportsDarkMode: boolean;
 	dropDownTitle: string;
+	backgroundBody?: SerializedStyles;
+	backgroundTitle?: SerializedStyles;
 }
 
 const detailsStyles: SerializedStyles = css`
@@ -31,7 +33,6 @@ const detailsStyles: SerializedStyles = css`
 
 const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	position: relative;
-	margin: 0 ${remSpace[1]} 0 ${remSpace[3]};
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -54,10 +55,6 @@ const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 		}
 	`}
 
-	${from.phablet} {
-		margin: ${remSpace[1]} ${remSpace[4]} 0;
-	}
-
 	${from.desktop} {
 		display: none;
 	}
@@ -66,26 +63,49 @@ const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 const titleStyle = (supportsDarkMode: boolean): SerializedStyles => css`
 	${headline.xxsmall({ fontWeight: "bold", lineHeight: "tight" })};
 	color: ${neutral[7]};
+	padding: 0 ${remSpace[1]} 0 ${remSpace[3]};
 
 	${darkModeCss(supportsDarkMode)`
 		color: ${neutral[86]};
 	`}
+
+	${from.phablet} {
+		margin: ${remSpace[1]} ${remSpace[4]} 0;
+	}
 `;
 
-const DropDown = ({ children, supportsDarkMode, dropDownTitle }: DropDownProps) => {
+const paddingBody: SerializedStyles = css`
+	padding: ${remSpace[3]};
+
+	${from.phablet} {
+		padding: ${remSpace[3]} ${remSpace[5]} 0;
+	}
+
+	${from.desktop} {
+		padding: 0;
+	}
+`;
+
+const DropDown = ({
+	children,
+	supportsDarkMode,
+	dropDownTitle,
+	backgroundTitle,
+	backgroundBody,
+}: DropDownProps) => {
 	return (
-			<details open css={detailsStyles}>
-				<summary css={titleRowStyles(supportsDarkMode)}>
-					<h2 css={titleStyle(supportsDarkMode)}>{dropDownTitle}</h2>
-					<span className="is-off">
-						<SvgChevronDownSingle />
-					</span>
-					<span className="is-on">
-						<SvgChevronUpSingle />
-					</span>
-				</summary>
-				{children}
-			</details>
+		<details open css={[detailsStyles]}>
+			<summary css={[titleRowStyles(supportsDarkMode), backgroundTitle]}>
+				<h2 css={titleStyle(supportsDarkMode)}>{dropDownTitle}</h2>
+				<span className="is-off">
+					<SvgChevronDownSingle />
+				</span>
+				<span className="is-on">
+					<SvgChevronUpSingle />
+				</span>
+			</summary>
+			<div css={[backgroundBody, paddingBody]}>{children}</div>
+		</details>
 	);
 };
 

--- a/common-rendering/src/components/dropDown.tsx
+++ b/common-rendering/src/components/dropDown.tsx
@@ -1,0 +1,94 @@
+// ----- Imports ----- //
+
+import { css } from "@emotion/react";
+import type { SerializedStyles } from "@emotion/react";
+import { neutral } from "@guardian/src-foundations/palette";
+import { headline } from "@guardian/src-foundations/typography";
+import { remSpace } from "@guardian/src-foundations";
+import { focusHalo } from "@guardian/src-foundations/accessibility";
+import { SvgChevronUpSingle, SvgChevronDownSingle } from "@guardian/src-icons";
+import { from } from "@guardian/src-foundations/mq";
+import { darkModeCss } from "../lib";
+
+// ----- Component ----- //
+
+interface DropDownProps {
+	children: React.ReactNode;
+	supportsDarkMode: boolean;
+	dropDownTitle: string;
+}
+
+const detailsStyles: SerializedStyles = css`
+	&:not([open]) .is-on,
+	&[open] .is-off {
+		display: none;
+	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
+`;
+
+const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	position: relative;
+	margin: 0 ${remSpace[1]} 0 ${remSpace[3]};
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	&:focus {
+		${focusHalo}
+	}
+
+	path {
+		fill: ${neutral[46]};
+	}
+
+	svg {
+		height: 2rem;
+	}
+
+	${darkModeCss(supportsDarkMode)`
+		path {
+			fill: ${neutral[60]};
+		}
+	`}
+
+	${from.phablet} {
+		margin: ${remSpace[1]} ${remSpace[4]} 0;
+	}
+
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const titleStyle = (supportsDarkMode: boolean): SerializedStyles => css`
+	${headline.xxsmall({ fontWeight: "bold", lineHeight: "tight" })};
+	color: ${neutral[7]};
+
+	${darkModeCss(supportsDarkMode)`
+		color: ${neutral[86]};
+	`}
+`;
+
+const DropDown = ({ children, supportsDarkMode, dropDownTitle }: DropDownProps) => {
+	return (
+			<details open css={detailsStyles}>
+				<summary css={titleRowStyles(supportsDarkMode)}>
+					<h2 css={titleStyle(supportsDarkMode)}>{dropDownTitle}</h2>
+					<span className="is-off">
+						<SvgChevronDownSingle />
+					</span>
+					<span className="is-on">
+						<SvgChevronUpSingle />
+					</span>
+				</summary>
+				{children}
+			</details>
+	);
+};
+
+// ----- Exports ----- //
+
+export default DropDown;

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -4,7 +4,6 @@ import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
 import { textSans, headline } from "@guardian/src-foundations/typography";
 import { remSpace } from "@guardian/src-foundations";
-import { focusHalo } from "@guardian/src-foundations/accessibility";
 import {
 	culture,
 	lifestyle,
@@ -12,12 +11,12 @@ import {
 	news,
 	sport,
 	opinion,
-} from "@guardian/src-foundations/palette";
-import { SvgChevronUpSingle, SvgChevronDownSingle } from "@guardian/src-icons";
+} from "@guardian/src-foundations/palette"
 import { Link } from "@guardian/src-link";
 import { ArticlePillar, ArticleTheme } from "@guardian/libs";
 import { from } from "@guardian/src-foundations/mq";
 import { darkModeCss } from "../lib";
+import DropDown from "./dropDown";
 
 // ----- Component ----- //
 type paletteId = 300 | 400 | 500;
@@ -66,60 +65,6 @@ const keyEventWrapperStyles = (
 
 	${darkModeCss(supportsDarkMode)`
 		background-color: ${neutral[10]};
-	`}
-`;
-
-const detailsStyles: SerializedStyles = css`
-	&:not([open]) .is-on,
-	&[open] .is-off {
-		display: none;
-	}
-
-	summary::-webkit-details-marker {
-		display: none;
-	}
-`;
-
-const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	position: relative;
-	margin: 0 ${remSpace[1]} 0 ${remSpace[3]};
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	&:focus {
-		${focusHalo}
-	}
-
-	path {
-		fill: ${neutral[46]};
-	}
-
-	svg {
-		height: 2rem;
-	}
-
-	${darkModeCss(supportsDarkMode)`
-		path {
-			fill: ${neutral[60]};
-		}
-	`}
-
-	${from.phablet} {
-		margin: ${remSpace[1]} ${remSpace[4]} 0;
-	}
-
-	${from.desktop} {
-		display: none;
-	}
-`;
-
-const titleStyle = (supportsDarkMode: boolean): SerializedStyles => css`
-	${headline.xxsmall({ fontWeight: "bold", lineHeight: "tight" })};
-	color: ${neutral[7]};
-
-	${darkModeCss(supportsDarkMode)`
-		color: ${neutral[86]};
 	`}
 `;
 
@@ -220,16 +165,7 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 	return (
 		<div css={keyEventWrapperStyles(supportsDarkMode)}>
-			<details open css={detailsStyles}>
-				<summary css={titleRowStyles(supportsDarkMode)}>
-					<h2 css={titleStyle(supportsDarkMode)}>Key Events</h2>
-					<span className="is-off">
-						<SvgChevronDownSingle />
-					</span>
-					<span className="is-on">
-						<SvgChevronUpSingle />
-					</span>
-				</summary>
+			<DropDown supportsDarkMode={supportsDarkMode} dropDownTitle="Key events">
 				<ul css={listStyles(supportsDarkMode)}>
 					{keyEvents.slice(0, 7).map((event, index) => (
 						<ListItem
@@ -240,7 +176,7 @@ const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 						/>
 					))}
 				</ul>
-			</details>
+			</DropDown>
 		</div>
 	);
 };

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -11,10 +11,11 @@ import {
 	news,
 	sport,
 	opinion,
+	background,
 } from "@guardian/src-foundations/palette"
 import { Link } from "@guardian/src-link";
 import { ArticlePillar, ArticleTheme } from "@guardian/libs";
-import { from } from "@guardian/src-foundations/mq";
+import { from, until } from "@guardian/src-foundations/mq";
 import { darkModeCss } from "../lib";
 import DropDown from "./dropDown";
 
@@ -54,6 +55,12 @@ const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
 	}
 };
 
+const whiteBackground: SerializedStyles = css`
+	${until.desktop} {
+		background-color: ${background.primary};
+	}
+`;
+
 const keyEventWrapperStyles = (
 	supportsDarkMode: boolean
 ): SerializedStyles => css`
@@ -69,16 +76,6 @@ const keyEventWrapperStyles = (
 `;
 
 const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	margin: ${remSpace[3]};
-
-	${from.phablet} {
-		margin: ${remSpace[3]} ${remSpace[5]} 0;
-	}
-
-	${from.desktop} {
-		margin: ${remSpace[1]} 0 0;
-	}
-
 	li::before {
 		content: "";
 		border-color: transparent ${neutral[7]};
@@ -165,7 +162,12 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 	return (
 		<div css={keyEventWrapperStyles(supportsDarkMode)}>
-			<DropDown supportsDarkMode={supportsDarkMode} dropDownTitle="Key events">
+			<DropDown
+				supportsDarkMode={supportsDarkMode}
+				dropDownTitle="Key events"
+				backgroundBody={whiteBackground}
+				backgroundTitle={whiteBackground}
+			>
 				<ul css={listStyles(supportsDarkMode)}>
 					{keyEvents.slice(0, 7).map((event, index) => (
 						<ListItem

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -134,6 +134,8 @@ type Palette = {
 		carouselDotFocus: Colour;
 		headlineTag: Colour;
 		mostViewedTab: Colour;
+		liveblogDropDownBody: Colour;
+		liveblogDropDownTitle: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/components/GridItem.tsx
+++ b/dotcom-rendering/src/web/components/GridItem.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/src-foundations/mq';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/GridItem.tsx
+++ b/dotcom-rendering/src/web/components/GridItem.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
@@ -34,17 +33,6 @@ const gridAreaStyles = (area: string) => {
 			grid-area: ${area};
 			/* Pop me above the right column */
 			${getZIndex('bodyArea')}
-		`;
-	}
-
-	if (area === 'keyevents') {
-		return css`
-			grid-area: ${area};
-
-			${from.desktop} {
-				position: sticky;
-				top: 10px;
-			}
 		`;
 	}
 

--- a/dotcom-rendering/src/web/components/GridItem.tsx
+++ b/dotcom-rendering/src/web/components/GridItem.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
@@ -32,6 +34,20 @@ const gridAreaStyles = (area: string) => {
 			grid-area: ${area};
 			/* Pop me above the right column */
 			${getZIndex('bodyArea')}
+		`;
+	}
+
+	if (area === 'keyevents') {
+		return css`
+			grid-area: ${area};
+			background: white;
+			margin-bottom: ${space[5]}px;
+
+			${from.desktop} {
+				position: sticky;
+				top: 10px;
+				background: none;
+			}
 		`;
 	}
 

--- a/dotcom-rendering/src/web/components/GridItem.tsx
+++ b/dotcom-rendering/src/web/components/GridItem.tsx
@@ -40,13 +40,10 @@ const gridAreaStyles = (area: string) => {
 	if (area === 'keyevents') {
 		return css`
 			grid-area: ${area};
-			background: white;
-			margin-bottom: ${space[5]}px;
 
 			${from.desktop} {
 				position: sticky;
 				top: 10px;
-				background: none;
 			}
 		`;
 	}

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -27,18 +27,6 @@ const mainMedia = css`
 	}
 `;
 
-const noGutters = css`
-	${until.phablet} {
-		margin-left: -20px;
-		margin-right: -20px;
-	}
-
-	${until.mobileLandscape} {
-		margin-left: -10px;
-		margin-right: -10px;
-	}
-`;
-
 const immersiveWrapper = css`
 	/*
         Immersive main media is wrapped in a flex div with height 100vw and then
@@ -74,9 +62,7 @@ export const MainMedia: React.FC<{
 	<div
 		css={[
 			mainMedia,
-			format.display === ArticleDisplay.Immersive
-				? immersiveWrapper
-				: noGutters,
+			format.display === ArticleDisplay.Immersive && immersiveWrapper,
 		]}
 	>
 		{elements.map((element, index) =>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -8,6 +8,7 @@ import {
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
+import { Accordion } from '@guardian/src-accordion';
 import type { ArticleFormat } from '@guardian/libs';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 
@@ -79,11 +80,12 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Right Column
 				*/
 				${from.desktop} {
-					grid-template-columns: 309px 1px 1fr;
+					grid-template-columns: 220px 1px 1fr;
 					grid-template-areas:
 						'lines		border media'
 						'meta		border media'
 						'keyevents	border media'
+						'keyevents	border body'
 						'.			border body'
 						'. 			border .';
 				}
@@ -94,6 +96,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'lines 		border media right-column'
 						'meta  		border media right-column'
 						'keyevents  border media right-column'
+						'keyevents  border body right-column'
 						'.  		border body  right-column'
 						'.			border .     right-column';
 				}
@@ -129,6 +132,24 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 const maxWidth = css`
 	${from.desktop} {
 		max-width: 700px;
+	}
+`;
+
+const hideOnMobile = css`
+	${until.desktop} {
+		display: none;
+	}
+`;
+
+const hideOnDesktop = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const marginBottom = css`
+	${until.desktop} {
+		margin-bottom: ${space[4]}px;
 	}
 `;
 
@@ -361,6 +382,34 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							format={format}
 							standfirst={CAPI.standfirst}
 						/>
+						<div css={[stretchLines, hideOnDesktop]}>
+							<Lines
+								count={decideLineCount(
+												format.design,
+											)}
+								effect={decideLineEffect(
+												format.design,
+												format.theme,
+											)}
+										/>
+						</div>
+						<div css={hideOnDesktop}>
+							<ArticleMeta
+								branding={branding}
+								format={format}
+								palette={palette}
+								pageId={CAPI.pageId}
+								webTitle={CAPI.webTitle}
+								author={CAPI.author}
+								tags={CAPI.tags}
+								primaryDateline={
+											CAPI.webPublicationDateDisplay
+										}
+								secondaryDateline={
+											CAPI.webPublicationSecondaryDateDisplay
+										}
+									/>
+						</div>
 					</ContainerLayout>
 
 					<ElementContainer
@@ -379,10 +428,11 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						showTopBorder={false}
 						backgroundColour={palette.background.article}
 						borderColour={palette.border.article}
+						padded={false}
 					>
 						<LiveGrid>
 							<GridItem area="media">
-								<div css={maxWidth}>
+								<div css={[maxWidth, marginBottom]}>
 									<MainMedia
 										format={format}
 										palette={palette}
@@ -399,7 +449,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							</GridItem>
 							<GridItem area="lines">
 								<div css={maxWidth}>
-									<div css={stretchLines}>
+									<div css={[stretchLines, hideOnMobile]}>
 										<Lines
 											count={decideLineCount(
 												format.design,
@@ -413,7 +463,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								</div>
 							</GridItem>
 							<GridItem area="meta" element="aside">
-								<div css={maxWidth}>
+								<div css={[maxWidth, hideOnMobile]}>
 									<ArticleMeta
 										branding={branding}
 										format={format}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -8,7 +8,6 @@ import {
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
-import { Accordion } from '@guardian/src-accordion';
 import type { ArticleFormat } from '@guardian/libs';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -150,6 +150,13 @@ const marginBottomMobile = css`
 	}
 `;
 
+const sticky = css`
+	${from.desktop} {
+		position: sticky;
+		top: 10px;
+	}
+`;
+
 const stretchLines = css`
 	${until.phablet} {
 		margin-left: -20px;
@@ -467,6 +474,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<GridItem area="keyevents">
 								<div
 									css={[
+										sticky,
 										keyEventsBottomMargin,
 										sidePaddingDesktop,
 									]}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -49,6 +49,7 @@ import {
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
 import { space } from '@guardian/src-foundations';
+import DropDown from '@guardian/common-rendering/src/components/dropDown';
 import { ContainerLayout } from '../components/ContainerLayout';
 
 const LiveGrid = ({ children }: { children: React.ReactNode }) => (
@@ -79,7 +80,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Right Column
 				*/
 				${from.desktop} {
-					grid-template-columns: 220px 1px 1fr;
+					grid-template-columns: 260px 1px 1fr;
 					grid-template-areas:
 						'lines		border media'
 						'meta		border media'
@@ -90,7 +91,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				}
 
 				${from.wide} {
-					grid-template-columns: 309px 1px 1fr 340px;
+					grid-template-columns: 260px 1px 1fr 340px;
 					grid-template-areas:
 						'lines 		border media right-column'
 						'meta  		border media right-column'
@@ -101,16 +102,6 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				}
 
 				${until.desktop} {
-					grid-template-columns: 1fr; /* Main content */
-					grid-template-areas:
-						'media'
-						'lines'
-						'meta'
-						'keyevents'
-						'body';
-				}
-
-				${until.tablet} {
 					grid-column-gap: 0px;
 
 					grid-template-columns: 1fr; /* Main content */
@@ -134,19 +125,26 @@ const maxWidth = css`
 	}
 `;
 
-const hideOnMobile = css`
-	${until.desktop} {
-		display: none;
-	}
-`;
-
-const hideOnDesktop = css`
+const sidePaddingDesktop = css`
 	${from.desktop} {
-		display: none;
+		padding-left: ${space[5]}px;
 	}
 `;
 
-const marginBottom = css`
+const sidePaddingMobile = css`
+	${until.desktop} {
+		padding-left: 10px;
+	}
+`;
+
+const keyEventsBottomMargin = css`
+	margin-bottom: ${space[3]}px;
+	${from.desktop} {
+		margin-bottom: ${space[5]}px;
+	}
+`;
+
+const marginBottomMobile = css`
 	${until.desktop} {
 		margin-bottom: ${space[4]}px;
 	}
@@ -194,6 +192,18 @@ const ageWarningMargins = css`
 	${from.leftCol} {
 		margin-left: -10px;
 		margin-top: 0;
+	}
+`;
+
+const backgroundBody = (palette: Palette) => css`
+	${until.desktop} {
+		background-color: ${palette.background.liveblogDropDownBody};
+	}
+`;
+
+const backgroundTitle = (palette: Palette) => css`
+	${until.desktop} {
+		background-color: ${palette.background.liveblogDropDownTitle};
 	}
 `;
 
@@ -381,30 +391,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							format={format}
 							standfirst={CAPI.standfirst}
 						/>
-						<div css={[stretchLines, hideOnDesktop]}>
-							<Lines
-								count={decideLineCount(format.design)}
-								effect={decideLineEffect(
-									format.design,
-									format.theme,
-								)}
-							/>
-						</div>
-						<div css={hideOnDesktop}>
-							<ArticleMeta
-								branding={branding}
-								format={format}
-								palette={palette}
-								pageId={CAPI.pageId}
-								webTitle={CAPI.webTitle}
-								author={CAPI.author}
-								tags={CAPI.tags}
-								primaryDateline={CAPI.webPublicationDateDisplay}
-								secondaryDateline={
-									CAPI.webPublicationSecondaryDateDisplay
-								}
-							/>
-						</div>
 					</ContainerLayout>
 
 					<ElementContainer
@@ -427,7 +413,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					>
 						<LiveGrid>
 							<GridItem area="media">
-								<div css={[maxWidth, marginBottom]}>
+								<div css={[maxWidth, marginBottomMobile]}>
 									<MainMedia
 										format={format}
 										palette={palette}
@@ -443,22 +429,24 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<></>
 							</GridItem>
 							<GridItem area="lines">
-								<div css={maxWidth}>
-									<div css={[stretchLines, hideOnMobile]}>
-										<Lines
-											count={decideLineCount(
-												format.design,
-											)}
-											effect={decideLineEffect(
-												format.design,
-												format.theme,
-											)}
-										/>
-									</div>
+								<div css={[sidePaddingDesktop, stretchLines]}>
+									<Lines
+										count={decideLineCount(format.design)}
+										effect={decideLineEffect(
+											format.design,
+											format.theme,
+										)}
+									/>
 								</div>
 							</GridItem>
 							<GridItem area="meta" element="aside">
-								<div css={[maxWidth, hideOnMobile]}>
+								<div
+									css={[
+										sidePaddingDesktop,
+										sidePaddingMobile,
+										marginBottomMobile,
+									]}
+								>
 									<ArticleMeta
 										branding={branding}
 										format={format}
@@ -477,82 +465,113 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								</div>
 							</GridItem>
 							<GridItem area="keyevents">
-								<KeyEventsContainer
-									format={format}
-									keyEvents={CAPI.keyEvents}
-								/>
+								<div
+									css={[
+										keyEventsBottomMargin,
+										sidePaddingDesktop,
+									]}
+								>
+									<KeyEventsContainer
+										format={format}
+										keyEvents={CAPI.keyEvents}
+									/>
+								</div>
 							</GridItem>
 							<GridItem area="body">
-								<ArticleContainer format={format}>
-									{CAPI.pagination &&
-										CAPI.pagination.currentPage !== 1 && (
-											<Pagination
-												currentPage={
-													CAPI.pagination
-														?.currentPage || 1
-												}
-												totalPages={
-													CAPI.pagination
-														?.totalPages || 1
-												}
-												newest={CAPI.pagination?.newest}
-												oldest={CAPI.pagination?.oldest}
-												newer={CAPI.pagination?.newer}
-												older={CAPI.pagination?.older}
-											/>
+								<DropDown
+									supportsDarkMode={false}
+									dropDownTitle="Live feed"
+									backgroundBody={backgroundBody(palette)}
+									backgroundTitle={backgroundTitle(palette)}
+								>
+									<ArticleContainer format={format}>
+										{CAPI.pagination &&
+											CAPI.pagination.currentPage !==
+												1 && (
+												<Pagination
+													currentPage={
+														CAPI.pagination
+															?.currentPage || 1
+													}
+													totalPages={
+														CAPI.pagination
+															?.totalPages || 1
+													}
+													newest={
+														CAPI.pagination?.newest
+													}
+													oldest={
+														CAPI.pagination?.oldest
+													}
+													newer={
+														CAPI.pagination?.newer
+													}
+													older={
+														CAPI.pagination?.older
+													}
+												/>
+											)}
+										<ArticleBody
+											format={format}
+											palette={palette}
+											blocks={CAPI.blocks}
+											adTargeting={adTargeting}
+											host={host}
+											pageId={CAPI.pageId}
+											webTitle={CAPI.webTitle}
+										/>
+										{CAPI.pagination &&
+											CAPI.pagination.totalPages > 1 && (
+												<Pagination
+													currentPage={
+														CAPI.pagination
+															?.currentPage || 1
+													}
+													totalPages={
+														CAPI.pagination
+															?.totalPages || 1
+													}
+													newest={
+														CAPI.pagination?.newest
+													}
+													oldest={
+														CAPI.pagination?.oldest
+													}
+													newer={
+														CAPI.pagination?.newer
+													}
+													older={
+														CAPI.pagination?.older
+													}
+												/>
+											)}
+										{showBodyEndSlot && (
+											<div id="slot-body-end" />
 										)}
-									<ArticleBody
-										format={format}
-										palette={palette}
-										blocks={CAPI.blocks}
-										adTargeting={adTargeting}
-										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-									/>
-									{CAPI.pagination &&
-										CAPI.pagination.totalPages > 1 && (
-											<Pagination
-												currentPage={
-													CAPI.pagination
-														?.currentPage || 1
-												}
-												totalPages={
-													CAPI.pagination
-														?.totalPages || 1
-												}
-												newest={CAPI.pagination?.newest}
-												oldest={CAPI.pagination?.oldest}
-												newer={CAPI.pagination?.newer}
-												older={CAPI.pagination?.older}
-											/>
-										)}
-									{showBodyEndSlot && (
-										<div id="slot-body-end" />
-									)}
-									<Lines
-										data-print-layout="hide"
-										count={4}
-										effect="straight"
-									/>
-									<SubMeta
-										palette={palette}
-										format={format}
-										subMetaKeywordLinks={
-											CAPI.subMetaKeywordLinks
-										}
-										subMetaSectionLinks={
-											CAPI.subMetaSectionLinks
-										}
-										pageId={CAPI.pageId}
-										webUrl={CAPI.webURL}
-										webTitle={CAPI.webTitle}
-										showBottomSocialButtons={
-											CAPI.showBottomSocialButtons
-										}
-										badge={CAPI.badge}
-									/>
-								</ArticleContainer>
+										<Lines
+											data-print-layout="hide"
+											count={4}
+											effect="straight"
+										/>
+										<SubMeta
+											palette={palette}
+											format={format}
+											subMetaKeywordLinks={
+												CAPI.subMetaKeywordLinks
+											}
+											subMetaSectionLinks={
+												CAPI.subMetaSectionLinks
+											}
+											pageId={CAPI.pageId}
+											webUrl={CAPI.webURL}
+											webTitle={CAPI.webTitle}
+											showBottomSocialButtons={
+												CAPI.showBottomSocialButtons
+											}
+											badge={CAPI.badge}
+										/>
+									</ArticleContainer>
+								</DropDown>
 							</GridItem>
 							<GridItem area="right-column">
 								<div

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -384,14 +384,12 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 						<div css={[stretchLines, hideOnDesktop]}>
 							<Lines
-								count={decideLineCount(
-												format.design,
-											)}
+								count={decideLineCount(format.design)}
 								effect={decideLineEffect(
-												format.design,
-												format.theme,
-											)}
-										/>
+									format.design,
+									format.theme,
+								)}
+							/>
 						</div>
 						<div css={hideOnDesktop}>
 							<ArticleMeta
@@ -402,13 +400,11 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								webTitle={CAPI.webTitle}
 								author={CAPI.author}
 								tags={CAPI.tags}
-								primaryDateline={
-											CAPI.webPublicationDateDisplay
-										}
+								primaryDateline={CAPI.webPublicationDateDisplay}
 								secondaryDateline={
-											CAPI.webPublicationSecondaryDateDisplay
-										}
-									/>
+									CAPI.webPublicationSecondaryDateDisplay
+								}
+							/>
 						</div>
 					</ContainerLayout>
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -521,6 +521,14 @@ const backgroundSpeechBubble = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].main;
 };
 
+const backgroundLiveblogCard = (): string => {
+	return '#F6F6F6';
+};
+
+const backgroundLiveblogTitle = (): string => {
+	return '#FFFFFF';
+};
+
 const fillCommentCount = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -835,6 +843,8 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			carouselDotFocus: backgroundCarouselDotFocus(format),
 			headlineTag: backgroundHeadlineTag(format),
 			mostViewedTab: backgroundMostViewedTab(format),
+			liveblogDropDownBody: backgroundLiveblogCard(),
+			liveblogDropDownTitle: backgroundLiveblogTitle(),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),


### PR DESCRIPTION
## What does this change?
This makes the key events element stick to the view on desktop and up. It is not sticky on smaller breakpoints.

At smaller breakpoints (below desktop), the key events element is in a dropdown container, which is also needed for the live blocks on these breakpoints. This refactors the dropdown functionality from key events into a separate component so it can be shared between key events and live blocks.

## Why?
Making key events sticky makes it easier for users to navigate to key blocks in our liveblogs. The other changes bring the key events and liveblocks closer to matching the new designs on smaller breakpoints.

### Stickiness
![Screen Shot 2021-11-16 at 13 54 14](https://user-images.githubusercontent.com/16781258/141998642-c41c8f2a-288a-4439-a1b5-f76ed3281793.png)

![Screen Shot 2021-11-16 at 13 54 29](https://user-images.githubusercontent.com/16781258/141998678-49817341-3fe1-477c-8cce-5228d8df3f2b.png)

### Dropdown
![Screen Shot 2021-11-16 at 13 55 11](https://user-images.githubusercontent.com/16781258/141998747-82d43a44-bb26-4566-a115-7f6b0144b684.png)

![Screen Shot 2021-11-16 at 13 55 26](https://user-images.githubusercontent.com/16781258/141998770-d0d9bfd8-6521-4459-9063-72b17922d879.png)
