### PR TITLE
Increase caption bottom padding if display is Showcase and design is Review

### DIFF
--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -1,11 +1,13 @@
 import { ElementContainer } from '@frontend/web/components/ElementContainer';
 import { Caption } from '@frontend/web/components/Caption';
+import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import {
 	ArticleDisplay,
 	ArticleDesign,
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
+import { css } from '@emotion/react';
 import { decidePalette } from '../lib/decidePalette';
 
 export default {
@@ -181,3 +183,90 @@ export const Padded = () => (
 	</ElementContainer>
 );
 Padded.story = { name: 'when padded' };
+
+export const Overlayed = () => (
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
+		<div
+			css={css`
+				position: relative;
+				height: 600px;
+				width: 800px;
+
+				img {
+					height: 100%;
+					width: 100%;
+					object-fit: cover;
+				}
+			`}
+		>
+			<img
+				alt=""
+				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
+			/>
+			<Caption
+				isOverlayed={true}
+				captionText="This is how a caption looks when it's overlayed"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				palette={decidePalette({
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				})}
+				padCaption={true}
+			/>
+		</div>
+	</ElementContainer>
+);
+Overlayed.story = { name: 'when overlayed' };
+
+export const OverlayedWithStars = () => (
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
+		<div
+			css={css`
+				position: relative;
+				height: 600px;
+				width: 800px;
+
+				img {
+					height: 100%;
+					width: 100%;
+					object-fit: cover;
+				}
+			`}
+		>
+			<img
+				alt=""
+				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
+			/>
+			<Caption
+				isOverlayed={true}
+				captionText="This is how a caption looks when it's overlayed with stars"
+				format={{
+					display: ArticleDisplay.Showcase,
+					design: ArticleDesign.Review,
+					theme: ArticlePillar.News,
+				}}
+				palette={decidePalette({
+					display: ArticleDisplay.Showcase,
+					design: ArticleDesign.Review,
+					theme: ArticlePillar.News,
+				})}
+				padCaption={true}
+			/>
+			<div
+				css={css`
+					position: absolute;
+					bottom: 0;
+					background-color: yellow; ;
+				`}
+			>
+				<StarRating rating={3} size="large" />
+			</div>
+		</div>
+	</ElementContainer>
+);
+OverlayedWithStars.story = { name: 'when overlayed on stars' };

--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -261,7 +261,7 @@ export const OverlayedWithStars = () => (
 				css={css`
 					position: absolute;
 					bottom: 0;
-					background-color: yellow; ;
+					background-color: yellow;
 				`}
 			>
 				<StarRating rating={3} size="large" />

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -3,7 +3,12 @@ import { css } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { ArticleDisplay, ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import {
+	ArticleDisplay,
+	ArticleDesign,
+	ArticleSpecial,
+	ArticleFormat,
+} from '@guardian/libs';
 
 import CameraSvg from '@frontend/static/icons/camera.svg';
 import VideoSvg from '@frontend/static/icons/video-icon.svg';
@@ -38,7 +43,21 @@ const bottomMargin = css`
 	margin-bottom: 6px;
 `;
 
-const overlayedStyles = (palette: Palette) => css`
+const overlayedBottomPadding = (format: ArticleFormat) => {
+	if (
+		format.display === ArticleDisplay.Showcase &&
+		format.design === ArticleDesign.Review
+	) {
+		return css`
+			padding-bottom: 2.5rem;
+		`;
+	}
+	return css`
+		padding-bottom: 0.375rem;
+	`;
+};
+
+const overlayedStyles = (palette: Palette, format: ArticleFormat) => css`
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -60,7 +79,7 @@ const overlayedStyles = (palette: Palette) => css`
 	padding-top: 0.375rem;
 	padding-right: 2.5rem;
 	padding-left: 0.75rem;
-	padding-bottom: 0.375rem;
+	${overlayedBottomPadding(format)};
 
 	flex-grow: 1;
 	min-height: 2.25rem;
@@ -197,7 +216,7 @@ export const Caption = ({
 				captionStyle(palette),
 				shouldLimitWidth && limitedWidth,
 				!isOverlayed && bottomMargin,
-				isOverlayed && overlayedStyles(palette),
+				isOverlayed && overlayedStyles(palette, format),
 				padCaption && captionPadding,
 			]}
 		>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Increases padding-bottom in caption if display is Showcase and design is Review.

## Why?
Star rating was obscuring the photo caption in fillm review in mobile

### Before
![image](https://user-images.githubusercontent.com/19683595/142003795-00eba638-676d-43db-b9dd-f3a375ac3bad.png)

### After
![image](https://user-images.githubusercontent.com/19683595/142003896-e1b1d37c-f0e9-45bb-9017-6605aa03682a.png)

