### PR TITLE
LIVE-3078: Updates sbt-scrooge-typescript plugin version for resolving from non-bintray repo

### DIFF
--- a/apps-rendering/README.md
+++ b/apps-rendering/README.md
@@ -100,7 +100,7 @@ Stories are deployed on [GitHub pages](https://guardian.github.io/apps-rendering
 
 In order to release the models you'll need to:
 
-- have a bintray account with access to the guardian organisation
+- have a Sonatype account with access to the guardian organisation
 - have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
 
 Make sure you set upstream `git push --set-upstream origin <BRANCH_NAME>`

--- a/apps-rendering/project/plugins.sbt
+++ b/apps-rendering/project/plugins.sbt
@@ -1,8 +1,6 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.5")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 


### PR DESCRIPTION
## What does this change?
Updates version of `sbt-scrooge-typescript` SBT plugin so it resolves corrrectly.

## Why?
With the move away from Bintray for hosting Guardian artifacts, the existing plugin version `1.2.5` does not get resolved. This pull request upgrades the version of the plugin so it can be correctly [resolved](https://repo1.maven.org/maven2/com/gu/sbt-scrooge-typescript_2.12_1.0/).

