### PR TITLE
Add support for amazon ads on AMP pages via RTC

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.test.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.test.tsx
@@ -1,22 +1,7 @@
 import { render } from '@testing-library/react';
 import { Ad } from '@root/src/amp/components/Ad';
 
-type ObjectType = { [key: string]: any };
-
-describe('AdComponent', () => {
-	const edition = 'UK';
-	const section = '';
-	const contentType = '';
-	const commercialConfig = {
-		usePrebid: true,
-		usePermutive: true,
-	};
-	const commercialProperties = {
-		UK: { adTargeting: [] },
-		US: { adTargeting: [] },
-		AU: { adTargeting: [] },
-		INT: { adTargeting: [] },
-	};
+describe('Ad', () => {
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
 	const usPrebidURL =
@@ -26,19 +11,23 @@ describe('AdComponent', () => {
 	const rowPrebidURL =
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 
-	beforeEach(() => {
-		commercialConfig.usePermutive = true;
-		commercialConfig.usePrebid = true;
-	});
-
-	it('rtc-config returns correctly formed Permutive and PreBid URLs when usePermutive and usePrebid flags are set to true', () => {
+	it('rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
 			<Ad
-				edition={edition}
-				section={section || ''}
-				contentType={contentType}
-				config={commercialConfig}
-				commercialProperties={commercialProperties}
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: true,
+					usePermutive: true,
+					useAmazon: false,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
 			/>,
 		);
 
@@ -46,52 +35,41 @@ describe('AdComponent', () => {
 
 		expect(ampAdElement).not.toBeNull();
 
-		if (ampAdElement) {
-			const usRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[0].getAttribute('rtc-config') || '{}',
-			);
-			const auRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[1].getAttribute('rtc-config') || '{}',
-			);
-			const rowRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[2].getAttribute('rtc-config') || '{}',
-			);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
 
-			expect(usRtcAttribute).not.toBeNull();
-			expect(auRtcAttribute).not.toBeNull();
-			expect(rowRtcAttribute).not.toBeNull();
-
-			if (usRtcAttribute) {
-				expect(usRtcAttribute.urls).toMatchObject([
-					usPrebidURL,
-					permutiveURL,
-				]);
-			}
-			if (auRtcAttribute) {
-				expect(auRtcAttribute.urls).toMatchObject([
-					auPrebidURL,
-					permutiveURL,
-				]);
-			}
-			if (rowRtcAttribute) {
-				expect(rowRtcAttribute.urls).toMatchObject([
-					rowPrebidURL,
-					permutiveURL,
-				]);
-			}
-		}
+		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL, permutiveURL]);
+		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL, permutiveURL]);
+		expect(rowRtcAttribute.urls).toMatchObject([
+			rowPrebidURL,
+			permutiveURL,
+		]);
 	});
 
-	it('rtc-config returns only the correctly formed PreBid URL when usePermutive flag is set to false and usePrebid flag is set to true', () => {
-		commercialConfig.usePermutive = false;
-
+	it('rtc-config contains just the prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
 		const { container } = render(
 			<Ad
-				edition={edition}
-				section={section || ''}
-				contentType={contentType}
-				config={commercialConfig}
-				commercialProperties={commercialProperties}
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: true,
+					usePermutive: false,
+					useAmazon: false,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
 			/>,
 		);
 
@@ -99,43 +77,38 @@ describe('AdComponent', () => {
 
 		expect(ampAdElement).not.toBeNull();
 
-		if (ampAdElement) {
-			const usRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[0].getAttribute('rtc-config') || '{}',
-			);
-			const auRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[1].getAttribute('rtc-config') || '{}',
-			);
-			const rowRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[2].getAttribute('rtc-config') || '{}',
-			);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
 
-			expect(usRtcAttribute).not.toBeNull();
-			expect(auRtcAttribute).not.toBeNull();
-			expect(rowRtcAttribute).not.toBeNull();
-
-			if (usRtcAttribute) {
-				expect(usRtcAttribute.urls).toMatchObject([usPrebidURL]);
-			}
-			if (auRtcAttribute) {
-				expect(auRtcAttribute.urls).toMatchObject([auPrebidURL]);
-			}
-			if (rowRtcAttribute) {
-				expect(rowRtcAttribute.urls).toMatchObject([rowPrebidURL]);
-			}
-		}
+		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL]);
+		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL]);
+		expect(rowRtcAttribute.urls).toMatchObject([rowPrebidURL]);
 	});
 
-	it('rtc-config returns only the Permutive URL when usePermutive flags is set to true and usePrebid flag is set to false', () => {
-		commercialConfig.usePrebid = false;
-
+	it('rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
 		const { container } = render(
 			<Ad
-				edition={edition}
-				section={section || ''}
-				contentType={contentType}
-				config={commercialConfig}
-				commercialProperties={commercialProperties}
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: false,
+					usePermutive: true,
+					useAmazon: false,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
 			/>,
 		);
 
@@ -143,44 +116,38 @@ describe('AdComponent', () => {
 
 		expect(ampAdElement).not.toBeNull();
 
-		if (ampAdElement) {
-			const usRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[0].getAttribute('rtc-config') || '{}',
-			);
-			const auRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[1].getAttribute('rtc-config') || '{}',
-			);
-			const rowRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[2].getAttribute('rtc-config') || '{}',
-			);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
 
-			expect(usRtcAttribute).not.toBeNull();
-			expect(auRtcAttribute).not.toBeNull();
-			expect(rowRtcAttribute).not.toBeNull();
-
-			if (usRtcAttribute) {
-				expect(usRtcAttribute.urls).toMatchObject([permutiveURL]);
-			}
-			if (auRtcAttribute) {
-				expect(auRtcAttribute.urls).toMatchObject([permutiveURL]);
-			}
-			if (rowRtcAttribute) {
-				expect(rowRtcAttribute.urls).toMatchObject([permutiveURL]);
-			}
-		}
+		expect(usRtcAttribute.urls).toMatchObject([permutiveURL]);
+		expect(auRtcAttribute.urls).toMatchObject([permutiveURL]);
+		expect(rowRtcAttribute.urls).toMatchObject([permutiveURL]);
 	});
 
-	it('rtc-config returns no URLs when usePermutive and usePrebid flags are set to false', () => {
-		commercialConfig.usePrebid = false;
-		commercialConfig.usePermutive = false;
-
+	it('rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
 		const { container } = render(
 			<Ad
-				edition={edition}
-				section={section || ''}
-				contentType={contentType}
-				config={commercialConfig}
-				commercialProperties={commercialProperties}
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: false,
+					usePermutive: false,
+					useAmazon: false,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
 			/>,
 		);
 
@@ -188,30 +155,18 @@ describe('AdComponent', () => {
 
 		expect(ampAdElement).not.toBeNull();
 
-		if (ampAdElement) {
-			const usRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[0].getAttribute('rtc-config') || '{}',
-			);
-			const auRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[1].getAttribute('rtc-config') || '{}',
-			);
-			const rowRtcAttribute: ObjectType = JSON.parse(
-				ampAdElement[2].getAttribute('rtc-config') || '{}',
-			);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
 
-			expect(usRtcAttribute).not.toBeNull();
-			expect(auRtcAttribute).not.toBeNull();
-			expect(rowRtcAttribute).not.toBeNull();
-
-			if (usRtcAttribute) {
-				expect(usRtcAttribute.urls).toMatchObject([]);
-			}
-			if (auRtcAttribute) {
-				expect(auRtcAttribute.urls).toMatchObject([]);
-			}
-			if (rowRtcAttribute) {
-				expect(rowRtcAttribute.urls).toMatchObject([]);
-			}
-		}
+		expect(usRtcAttribute.urls).toHaveLength(0);
+		expect(auRtcAttribute.urls).toHaveLength(0);
+		expect(rowRtcAttribute.urls).toHaveLength(0);
 	});
 });

--- a/dotcom-rendering/src/amp/components/Ad.test.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.test.tsx
@@ -169,4 +169,86 @@ describe('Ad', () => {
 		expect(auRtcAttribute.urls).toHaveLength(0);
 		expect(rowRtcAttribute.urls).toHaveLength(0);
 	});
+
+	it('rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
+		const { container } = render(
+			<Ad
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: false,
+					usePermutive: false,
+					useAmazon: true,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
+			/>,
+		);
+
+		const ampAdElement = container.querySelectorAll('amp-ad');
+
+		expect(ampAdElement).not.toBeNull();
+
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+
+		const apsVendorObj = {
+			aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
+		};
+
+		expect(usRtcAttribute.vendors).toMatchObject(apsVendorObj);
+		expect(auRtcAttribute.vendors).toMatchObject(apsVendorObj);
+		expect(rowRtcAttribute.vendors).toMatchObject(apsVendorObj);
+	});
+
+	it('rtc-config contains no vendor config when `useAmazon` is set to false', () => {
+		const { container } = render(
+			<Ad
+				edition="UK"
+				section=""
+				contentType=""
+				config={{
+					usePrebid: false,
+					usePermutive: false,
+					useAmazon: false,
+				}}
+				commercialProperties={{
+					UK: { adTargeting: [] },
+					US: { adTargeting: [] },
+					AU: { adTargeting: [] },
+					INT: { adTargeting: [] },
+				}}
+			/>,
+		);
+
+		const ampAdElement = container.querySelectorAll('amp-ad');
+
+		expect(ampAdElement).not.toBeNull();
+
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+
+		expect(usRtcAttribute.vendors).toMatchObject({});
+		expect(auRtcAttribute.vendors).toMatchObject({});
+		expect(rowRtcAttribute.vendors).toMatchObject({});
+	});
 });

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -178,7 +178,7 @@ export const Ad = ({
 }: AdProps) => (
 	<>
 		{adRegions.map((adRegion) => (
-			<ClassNames>
+			<ClassNames key={adRegion}>
 				{({ css, cx }) => (
 					<div
 						className={cx(

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -30,6 +30,12 @@ const ampData = (section: string, contentType: string): string => {
 	return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
+const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
+const permutiveURL = 'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+const amazonConfig = {
+	aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
+};
+
 /**
  * Determine the Placement ID that is used to look up a given stored bid request
  *
@@ -62,11 +68,9 @@ const realTimeConfig = (
 	adRegion: AdRegion,
 	usePrebid: boolean,
 	usePermutive: boolean,
-): any => {
+	useAmazon: boolean,
+): string => {
 	const placementID = getPlacementId(isSticky, adRegion);
-	const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
-	const permutiveURL =
-		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
 	const prebidURL = [
 		// The tag_id in the URL is used to look up the bulk of the request
 		// In this case it corresponds to the placement ID of the bid requests
@@ -86,11 +90,16 @@ const realTimeConfig = (
 		'gdpr_consent=CONSENT_STRING',
 	].join('&');
 
+	const urls = [
+		usePrebid ? prebidURL : '',
+		usePermutive ? permutiveURL : '',
+	].filter(Boolean); // remove empty strings, which are falsey
+
+	const vendors = useAmazon ? amazonConfig : {};
+
 	const data = {
-		urls: [
-			usePrebid ? prebidURL : '',
-			usePermutive ? permutiveURL : '',
-		].filter((url) => url),
+		urls,
+		vendors,
 	};
 
 	return JSON.stringify(data);
@@ -99,6 +108,7 @@ const realTimeConfig = (
 interface CommercialConfig {
 	usePrebid: boolean;
 	usePermutive: boolean;
+	useAmazon: boolean;
 }
 
 export interface AdProps {
@@ -152,6 +162,7 @@ export const RegionalAd = ({
 				adRegion,
 				config.usePrebid,
 				config.usePermutive,
+				config.useAmazon,
 			)}
 		/>
 	);

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -126,12 +126,14 @@ export const Blocks: React.FunctionComponent<{
 		switches: {
 			ampPrebid: switches.ampPrebid,
 			permutive: switches.permutive,
+			ampAmazon: switches.ampAmazon,
 		},
 	};
 
 	const adConfig = {
 		usePrebid: adInfo.switches.ampPrebid,
 		usePermutive: adInfo.switches.permutive,
+		useAmazon: adInfo.switches.ampAmazon,
 	};
 	return (
 		<>

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -125,12 +125,14 @@ export const Body: React.FC<{
 		switches: {
 			ampPrebid: config.switches.ampPrebid,
 			permutive: config.switches.permutive,
+			ampAmazon: config.switches.ampAmazon,
 		},
 	};
 
 	const adConfig = {
 		usePrebid: adInfo.switches.ampPrebid,
 		usePermutive: adInfo.switches.permutive,
+		useAmazon: adInfo.switches.ampAmazon,
 	};
 	const elements = data.shouldHideAds ? (
 		<>{elementsWithoutAds}</>


### PR DESCRIPTION
## What does this change?

Adds support for amazon ads on AMP pages via RCT ("real time config"). This is enabled via the `ampAmazon` switch, which is being added to frontend in a [separate PR](https://github.com/guardian/frontend/pull/24395).

## Why?

So we can make more money on Black Friday

## Still TODO

- [ ] Add new line items in GAM. Apparently Amazon can do this for us?

## References

APS ("amazon publisher services") docs:

![Screenshot 2021-11-16 at 16 04 21](https://user-images.githubusercontent.com/7423751/142021225-04826608-238b-4a78-925c-d787154444fb.png)