### PR TITLE
Refactor title and headline in liveblogs to use HeadlineGrid

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -51,6 +51,55 @@ import {
 import { space } from '@guardian/src-foundations';
 import { ContainerLayout } from '../components/ContainerLayout';
 
+const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			/* IE Fallback */
+			display: flex;
+			flex-direction: column;
+			${until.desktop} {
+				margin-left: 0px;
+			}
+			${from.desktop} {
+				margin-left: 320px;
+			}
+
+			@supports (display: grid) {
+				display: grid;
+				width: 100%;
+				margin-left: 0;
+
+				grid-column-gap: 10px;
+
+				/*
+					Explanation of each unit of grid-template-columns
+
+					Main content
+					Empty border for spacing
+					Right Column
+				*/
+				${from.desktop} {
+					grid-template-columns: 309px 1px 1fr;
+					grid-template-areas: 'title		border headline';
+				}
+
+				${until.desktop} {
+					grid-template-columns: 1fr; /* Main content */
+					grid-template-areas:
+						'title'
+						'headline';
+				}
+
+				${until.tablet} {
+					grid-column-gap: 0px;
+				}
+			}
+		`}
+	>
+		{children}
+	</div>
+);
+
 const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
@@ -304,58 +353,62 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 			<main>
 				<article>
-					<ContainerLayout
+					<ElementContainer
 						showTopBorder={false}
 						backgroundColour={palette.background.header}
 						borderColour={palette.border.headline}
-						sideBorders={true}
-						leftColSize="wide"
-						leftContent={
-							// eslint-disable-next-line react/jsx-wrap-multilines
-							<ArticleTitle
-								format={format}
-								palette={palette}
-								tags={CAPI.tags}
-								sectionLabel={CAPI.sectionLabel}
-								sectionUrl={CAPI.sectionUrl}
-								guardianBaseURL={CAPI.guardianBaseURL}
-								badge={CAPI.badge}
-							/>
-						}
 					>
-						<div css={maxWidth}>
-							<ArticleHeadlinePadding design={format.design}>
-								{age && (
-									<div css={ageWarningMargins}>
-										<AgeWarning age={age} />
-									</div>
-								)}
-								<ArticleHeadline
+						<HeadlineGrid>
+							<GridItem area="title">
+								<ArticleTitle
 									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
-									byline={CAPI.author.byline}
 									palette={palette}
+									tags={CAPI.tags}
+									sectionLabel={CAPI.sectionLabel}
+									sectionUrl={CAPI.sectionUrl}
+									guardianBaseURL={CAPI.guardianBaseURL}
+									badge={CAPI.badge}
 								/>
-								{age && (
-									<AgeWarning
-										age={age}
-										isScreenReader={true}
-									/>
+							</GridItem>
+							<GridItem area="headline">
+								<div css={maxWidth}>
+									<ArticleHeadlinePadding
+										design={format.design}
+									>
+										{age && (
+											<div css={ageWarningMargins}>
+												<AgeWarning age={age} />
+											</div>
+										)}
+										<ArticleHeadline
+											format={format}
+											headlineString={CAPI.headline}
+											tags={CAPI.tags}
+											byline={CAPI.author.byline}
+											palette={palette}
+										/>
+										{age && (
+											<AgeWarning
+												age={age}
+												isScreenReader={true}
+											/>
+										)}
+									</ArticleHeadlinePadding>
+								</div>
+								{CAPI.starRating || CAPI.starRating === 0 ? (
+									<div css={starWrapper}>
+										<StarRating
+											rating={CAPI.starRating}
+											size="large"
+										/>
+									</div>
+								) : (
+									<></>
 								)}
-							</ArticleHeadlinePadding>
-						</div>
-						{CAPI.starRating || CAPI.starRating === 0 ? (
-							<div css={starWrapper}>
-								<StarRating
-									rating={CAPI.starRating}
-									size="large"
-								/>
-							</div>
-						) : (
-							<></>
-						)}
-					</ContainerLayout>
+							</GridItem>
+						</HeadlineGrid>
+					</ElementContainer>
+
 					<ContainerLayout
 						showTopBorder={false}
 						backgroundColour={palette.background.standfirst}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -80,7 +80,7 @@ const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 				*/
 				${from.desktop} {
 					grid-template-columns: 309px 1px 1fr;
-					grid-template-areas: 'title		border headline';
+					grid-template-areas: 'title	border headline';
 				}
 
 				${until.desktop} {

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -27,8 +27,8 @@ import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
-import { DecideLayout } from './DecideLayout';
 import { breakpoints } from '@guardian/src-foundations';
+import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
 

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -28,6 +28,7 @@ import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
+import { breakpoints } from '@guardian/src-foundations';
 
 mockRESTCalls();
 
@@ -112,7 +113,14 @@ export const LiveStory = (): React.ReactNode => {
 	const ServerCAPI = convertToShowcase(LiveBlog);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-LiveStory.story = { name: 'LiveBlog' };
+LiveStory.story = {
+	name: 'LiveBlog',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.tablet, breakpoints.wide],
+		},
+	},
+};
 
 export const DeadStory = (): React.ReactNode => {
 	const DeadBlog = {
@@ -125,7 +133,14 @@ export const DeadStory = (): React.ReactNode => {
 	const ServerCAPI = convertToShowcase(DeadBlog);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-DeadStory.story = { name: 'DeadBlog' };
+DeadStory.story = {
+	name: 'DeadBlog',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.tablet, breakpoints.wide],
+		},
+	},
+};
 
 export const EditorialStory = (): React.ReactNode => {
 	const ServerCAPI = convertToShowcase(Editorial);

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -183,7 +183,14 @@ export const LiveStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(LiveBlog);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-LiveStory.story = { name: 'LiveBlog' };
+LiveStory.story = {
+	name: 'LiveBlog',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.tablet, breakpoints.wide],
+		},
+	},
+};
 
 export const DeadStory = (): React.ReactNode => {
 	const DeadBlog = {
@@ -196,7 +203,14 @@ export const DeadStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(DeadBlog);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-DeadStory.story = { name: 'DeadBlog' };
+DeadStory.story = {
+	name: 'DeadBlog',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.tablet, breakpoints.wide],
+		},
+	},
+};
 
 export const EditorialStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(Editorial);


### PR DESCRIPTION
Co-authored-by: Oliver Lloyd <oliver@oliverlloyd.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Refactors title and headline in liveblog to use a HeadlineGrid.

## Why?
Previous wrapper was causing the title to disappear in screens less than 980px.

### Before
![image](https://user-images.githubusercontent.com/19683595/142036066-130a47ae-40b9-486e-95d1-4bcc410fcc4c.png)

### After
![image](https://user-images.githubusercontent.com/19683595/142035982-57a1a371-f70f-4cf3-bff5-7d9d28d381de.png)

