### PR TITLE
remove duration from cypress test

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -53,7 +53,6 @@ describe('Interactivity', function () {
 				cy.visit(`/Article?url=${articleUrl}`);
 				cy.contains('Lifestyle');
 				cy.get('[data-component="most-popular"]').scrollIntoView({
-					duration: 300,
 					offset: { top: 150 },
 				});
 				cy.wait('@getMostReadGeo');


### PR DESCRIPTION
## What does this change?
There have been a number of team city builds failing recently because of a cypress test failing. The failing cypress test (article.interactivity.spec.js - 'should change the list of most viewed items when a tab is clicked') fails only some of the time on `cy.wait('@getMostRead')`. Here the cypress test is waiting for a mocked api call to be made.

The most view footer data is lazy loaded. The getMostRead api call is therefore only made when the `most-popular` container is in view. 

We believe there is some interactivity/hydration on the page causing the scrolled to element (the "most-popular" container) never to appear in the viewport, meaning the mock api call is never triggered. Removing the duration is an attempt to give consistency in test results.

## Why?
So cypress tests don't fail and builds aren't blocked.

