### PR TITLE
Add Criteo AB test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.tsx
@@ -6,6 +6,7 @@ import { useAB } from '@guardian/ab-react';
 import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-test';
 import { useDocumentVisibilityState } from '../lib/useDocumentHidden';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
+import { integrateCriteo } from '../experiments/tests/integrate-criteo-test';
 
 // TODO disallow undefined browserIds by placing conditional in App.tsx
 // so that we wait to render this component until browserId is defined.
@@ -21,7 +22,7 @@ export const CommercialMetrics: React.FC<{
 	const isHidden = visibilityState === 'hidden' || undefined;
 
 	useOnce(() => {
-		const testsToForceMetrics: ABTest[] = [prebidTimeout];
+		const testsToForceMetrics: ABTest[] = [prebidTimeout, integrateCriteo];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),
 		);

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -7,6 +7,7 @@ import {
 	newsletterMerchUnitLighthouseVariants,
 } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
 import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-test';
+import { integrateCriteo } from './tests/integrate-criteo-test';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	prebidTimeout,
+	integrateCriteo,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/integrate-criteo-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/integrate-criteo-test.ts
@@ -6,7 +6,7 @@ export const integrateCriteo: ABTest = {
 	start: '2021-11-22',
 	expiry: '2022-01-10',
 	audience: 2 / 100,
-	audienceOffset: 0,
+	audienceOffset: 96 / 100,
 	audienceCriteria: 'All users',
 	description:
 		'Integrate new Prebid bidder and measure revenue uplift / impact of commercial performance metrics',

--- a/dotcom-rendering/src/web/experiments/tests/integrate-criteo-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/integrate-criteo-test.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const integrateCriteo: ABTest = {
+	id: 'IntegrateCriteo',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2021-11-22',
+	expiry: '2022-01-10',
+	audience: 2 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'All users',
+	description:
+		'Integrate new Prebid bidder and measure revenue uplift / impact of commercial performance metrics',
+	successMeasure:
+		'Revenue uplift with no significant impact on performance metrics',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

This adds the corresponding DCR client-side AB to the one defined in [frontend #24407](https://github.com/guardian/frontend/pull/24407) and forces commercial metrics for those in the test. This PR has more details about the test itself.

## Why?

So that we can  collect metrics for each of the pageviews arising from content-types supported by DCR.
