### PR TITLE
Fix series kicker not showing in 980 breakpoint

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -432,6 +432,7 @@ export const ArticleHeadline = ({
 								standardFont,
 								css`
 									color: ${palette.text.headline};
+									padding-bottom: ${space[9]}px;
 								`,
 							]}
 						>

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -26,14 +26,37 @@ const sectionLabelLink = css`
 	}
 `;
 
-const rowBelowLeftCol = css`
-	flex-direction: column;
-	display: inline-block;
-	${until.leftCol} {
-		display: flex;
-		flex-direction: row;
+const rowBelowLeftCol = (format: ArticleFormat) => {
+	if (
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
+	) {
+		return css`
+			display: inline-block;
+			flex-direction: column;
+
+			${from.tablet} {
+				display: flex;
+				flex-direction: row;
+			}
+
+			${from.desktop} {
+				display: flex;
+				flex-direction: column;
+			}
+		`;
 	}
-`;
+
+	return css`
+		flex-direction: column;
+		display: inline-block;
+
+		${until.leftCol} {
+			display: flex;
+			flex-direction: row;
+		}
+	`;
+};
 
 const marginBottom = css`
 	margin-bottom: 5px;
@@ -168,7 +191,7 @@ export const SeriesSectionLink = ({
 						// We have a tag, we're not immersive, show both series and section titles
 						return (
 							// Sometimes the tags/titles are shown inline, sometimes stacked
-							<div css={!badge && rowBelowLeftCol}>
+							<div css={!badge && rowBelowLeftCol(format)}>
 								<a
 									href={`${guardianBaseURL}/${tag.id}`}
 									css={[
@@ -311,7 +334,7 @@ export const SeriesSectionLink = ({
 				// We have a tag, we're not immersive, show both series and section titles
 				return (
 					// Sometimes the tags/titles are shown inline, sometimes stacked
-					<div css={!badge && rowBelowLeftCol}>
+					<div css={!badge && rowBelowLeftCol(format)}>
 						<a
 							href={`${guardianBaseURL}/${tag.id}`}
 							css={[

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -52,6 +52,49 @@ import { space } from '@guardian/src-foundations';
 import { ContainerLayout } from '../components/ContainerLayout';
 import { Placeholder } from '../components/Placeholder';
 
+const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			/* IE Fallback */
+			display: flex;
+			flex-direction: column;
+			${until.desktop} {
+				margin-left: 0px;
+			}
+			${from.desktop} {
+				margin-left: 320px;
+			}
+			@supports (display: grid) {
+				display: grid;
+				width: 100%;
+				margin-left: 0;
+				grid-column-gap: 10px;
+				/*
+					Explanation of each unit of grid-template-columns
+					Main content
+					Empty border for spacing
+					Right Column
+				*/
+				${from.desktop} {
+					grid-template-columns: 309px 1px 1fr;
+					grid-template-areas: 'title	border headline';
+				}
+				${until.desktop} {
+					grid-template-columns: 1fr; /* Main content */
+					grid-template-areas:
+						'title'
+						'headline';
+				}
+				${until.tablet} {
+					grid-column-gap: 0px;
+				}
+			}
+		`}
+	>
+		{children}
+	</div>
+);
+
 const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
@@ -307,61 +350,68 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 			<main>
 				<article>
-					<ContainerLayout
+					<ElementContainer
 						showTopBorder={false}
 						backgroundColour={palette.background.header}
 						borderColour={palette.border.headline}
-						sideBorders={true}
-						leftColSize="wide"
-						leftContent={
-							// eslint-disable-next-line react/jsx-wrap-multilines
-							<ArticleTitle
-								format={format}
-								palette={palette}
-								tags={CAPI.tags}
-								sectionLabel={CAPI.sectionLabel}
-								sectionUrl={CAPI.sectionUrl}
-								guardianBaseURL={CAPI.guardianBaseURL}
-								badge={CAPI.badge}
-							/>
-						}
 					>
-						{CAPI.matchUrl && showMatchTabs && (
-							<Placeholder rootId="match-tabs" height={40} />
-						)}
-						<div css={maxWidth}>
-							<ArticleHeadlinePadding design={format.design}>
-								{age && (
-									<div css={ageWarningMargins}>
-										<AgeWarning age={age} />
-									</div>
-								)}
-								<ArticleHeadline
+						<HeadlineGrid>
+							<GridItem area="title">
+								<ArticleTitle
 									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
-									byline={CAPI.author.byline}
 									palette={palette}
+									tags={CAPI.tags}
+									sectionLabel={CAPI.sectionLabel}
+									sectionUrl={CAPI.sectionUrl}
+									guardianBaseURL={CAPI.guardianBaseURL}
+									badge={CAPI.badge}
 								/>
-								{age && (
-									<AgeWarning
-										age={age}
-										isScreenReader={true}
+							</GridItem>
+							<GridItem area="headline">
+								{CAPI.matchUrl && showMatchTabs && (
+									<Placeholder
+										rootId="match-tabs"
+										height={40}
 									/>
 								)}
-							</ArticleHeadlinePadding>
-						</div>
-						{CAPI.starRating || CAPI.starRating === 0 ? (
-							<div css={starWrapper}>
-								<StarRating
-									rating={CAPI.starRating}
-									size="large"
-								/>
-							</div>
-						) : (
-							<></>
-						)}
-					</ContainerLayout>
+								<div css={maxWidth}>
+									<ArticleHeadlinePadding
+										design={format.design}
+									>
+										{age && (
+											<div css={ageWarningMargins}>
+												<AgeWarning age={age} />
+											</div>
+										)}
+										<ArticleHeadline
+											format={format}
+											headlineString={CAPI.headline}
+											tags={CAPI.tags}
+											byline={CAPI.author.byline}
+											palette={palette}
+										/>
+										{age && (
+											<AgeWarning
+												age={age}
+												isScreenReader={true}
+											/>
+										)}
+									</ArticleHeadlinePadding>
+								</div>
+								{CAPI.starRating || CAPI.starRating === 0 ? (
+									<div css={starWrapper}>
+										<StarRating
+											rating={CAPI.starRating}
+											size="large"
+										/>
+									</div>
+								) : (
+									<></>
+								)}
+							</GridItem>
+						</HeadlineGrid>
+					</ElementContainer>
+
 					<ContainerLayout
 						showTopBorder={false}
 						backgroundColour={palette.background.standfirst}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
* Refactors title and headline in liveblog to use a HeadlineGrid

## Why?
To fix series kicker not showing after 980 breakpoint

### Before
<img width="390" alt="image" src="https://user-images.githubusercontent.com/19683595/142640467-590151a3-0d9d-4d79-8d07-59c6d345ca53.png">


### After
<img width="390" alt="image" src="https://user-images.githubusercontent.com/19683595/142640788-5d91605b-db88-4fe7-afb3-3288b36ebcde.png">

