### PR TITLE
Update live layout grid to fix right column

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -583,7 +583,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<GridItem area="right-column">
 								<div
 									css={css`
-										padding-top: 6px;
 										height: 100%;
 										${from.desktop} {
 											/* above 980 */

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -119,36 +119,35 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Explanation of each unit of grid-template-columns
 
 					Main content
-					Empty border for spacing
 					Right Column
 				*/
 				// from desktop define fixed body width
 				${from.desktop} {
-					grid-column-gap: 10px;
+					grid-column-gap: 20px;
 
-					grid-template-columns: 219px 1px 700px;
+					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'lines		border media'
-						'meta		border media'
-						'keyevents	border media'
-						'.			border body'
-						'. 			border .';
+						'lines		media'
+						'meta		media'
+						'keyevents	media'
+						'.			body'
+						'. 			.';
 				}
 
 				// from wide define fixed body width
 				${from.wide} {
-					grid-column-gap: 10px;
+					grid-column-gap: 20px;
 
-					grid-template-columns: 219px 1px 700px 1fr;
+					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'lines 		border media right-column'
-						'meta  		border media right-column'
-						'keyevents  border media right-column'
-						'.  		border body  right-column'
-						'.			border .     right-column';
+						'lines 		media right-column'
+						'meta  		media right-column'
+						'keyevents  media right-column'
+						'.  		body  right-column'
+						'.			.     right-column';
 				}
 
-				// until desktop we define fixed body width
+				// until desktop define fixed body width
 				${until.desktop} {
 					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
@@ -463,9 +462,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									/>
 								</div>
 							</GridItem>
-							<GridItem area="border">
-								<></>
-							</GridItem>
 							<GridItem area="lines">
 								<div css={maxWidth}>
 									<div css={stretchLines}>
@@ -590,10 +586,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											margin-right: -20px;
 										}
 										${from.leftCol} {
-											/* above 1140 we need 20px between
-											body and ad slot, grid column gap
-											is only 10px */
-											margin-left: 10px;
+											/* above 1140 */
+											margin-left: 0px;
 											margin-right: 0px;
 										}
 									`}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -578,6 +578,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<div
 									css={css`
 										padding-top: 6px;
+										padding-left: 10px;
 										height: 100%;
 										${from.desktop} {
 											/* above 980 */

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -133,7 +133,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				}
 
 				${from.wide} {
-					grid-template-columns: 219px 1px 1fr 340px;
+					grid-template-columns: 219px 1px 1fr 330px;
 					grid-template-areas:
 						'lines 		border media right-column'
 						'meta  		border media right-column'

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -121,7 +121,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 					Right Column
 				*/
-				// from desktop define fixed body width
+				/* from desktop define fixed body width */
 				${from.desktop} {
 					grid-column-gap: 20px;
 
@@ -135,7 +135,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'. 			.';
 				}
 
-				// from wide define fixed body width
+				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
 
@@ -149,7 +149,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.			.     right-column';
 				}
 
-				// until desktop define fixed body width
+				/* until desktop define fixed body width */
 				${until.desktop} {
 					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
@@ -160,7 +160,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'body';
 				}
 
-				// fluid until tablet
+				/* fluid until tablet */
 				${until.tablet} {
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -113,7 +113,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				width: 100%;
 				margin-left: 0;
 
-				grid-column-gap: 10px;
+				grid-column-gap: 0px;
 
 				/*
 					Explanation of each unit of grid-template-columns
@@ -122,8 +122,11 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Empty border for spacing
 					Right Column
 				*/
+				// from desktop define fixed body width
 				${from.desktop} {
-					grid-template-columns: 219px 1px 1fr;
+					grid-column-gap: 10px;
+
+					grid-template-columns: 219px 1px 700px;
 					grid-template-areas:
 						'lines		border media'
 						'meta		border media'
@@ -132,8 +135,11 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'. 			border .';
 				}
 
+				// from wide define fixed body width
 				${from.wide} {
-					grid-template-columns: 219px 1px 1fr 330px;
+					grid-column-gap: 10px;
+
+					grid-template-columns: 219px 1px 700px 1fr;
 					grid-template-areas:
 						'lines 		border media right-column'
 						'meta  		border media right-column'
@@ -142,8 +148,9 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.			border .     right-column';
 				}
 
+				// until desktop we define fixed body width
 				${until.desktop} {
-					grid-template-columns: 1fr; /* Main content */
+					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
 						'media'
 						'lines'
@@ -152,9 +159,8 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'body';
 				}
 
+				// fluid until tablet
 				${until.tablet} {
-					grid-column-gap: 0px;
-
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
 						'media'
@@ -578,7 +584,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<div
 									css={css`
 										padding-top: 6px;
-										padding-left: 10px;
 										height: 100%;
 										${from.desktop} {
 											/* above 980 */
@@ -586,8 +591,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											margin-right: -20px;
 										}
 										${from.leftCol} {
-											/* above 1140 */
-											margin-left: 0px;
+											/* above 1140 we need 20px between
+											body and ad slot, grid column gap
+											is only 10px */
+											margin-left: 10px;
 											margin-right: 0px;
 										}
 									`}


### PR DESCRIPTION
## What does this change?
Previously the right column width wasn't quite right meaning the ads didn't display correctly. This PR alters the width and padding to match the intended design.

I reviewed the grid layout with @HarryFischer and made the following changes:
- Remove the top padding from the ad slot
- Ensure the body is fluid only up until tablet
- Ensure the body has a fixed width when greater than tablet
- Remove the border grid item and increase the grid-column-gap to achieve consistency in spacing between columns.

## Why?
To achieve parity with design. The screenshots below are at wide breakpoint, but see the chromatic build for how this impacts the live layout at different breakpoints (https://www.chromatic.com/build?appId=5dfcbf3012392c0020e7140b&number=8941).

### Before
Ad slot extends beyond right col
<img width="1297" alt="Screenshot 2021-11-22 at 17 30 36" src="https://user-images.githubusercontent.com/45561419/142907866-5a35b960-9ea4-4ff2-9895-0a311576657c.png">


### After
Ad slot sits within right col
<img width="1235" alt="Screenshot 2021-11-23 at 16 36 01" src="https://user-images.githubusercontent.com/45561419/143065499-3e63fd7f-0a3a-43fd-a94b-aa3ea2511986.png">



