### PR TITLE
Ma/matchtabs in standard layout

### DIFF
--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -483,14 +483,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											height={230}
 										/>
 									)}
-								{format.design === ArticleDesign.DeadBlog ||
-									(ArticleDesign.LiveBlog &&
-										CAPI.matchUrl && (
-											<Placeholder
-												rootId="match-tabs"
-												height={40}
-											/>
-										))}
 							</div>
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -492,14 +492,12 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
-								{format.design === ArticleDesign.DeadBlog ||
-									(format.design === ArticleDesign.LiveBlog &&
-										CAPI.matchUrl && (
-											<Placeholder
-												rootId="match-tabs"
-												height={40}
-											/>
-										))}
+								{CAPI.matchUrl && (
+									<Placeholder
+										rootId="match-tabs"
+										height={40}
+									/>
+								)}
 							</div>
 						</GridItem>
 						<GridItem area="headline">

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -492,14 +492,14 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
-								{format.design === ArticleDesign.DeadBlog ||
-									(ArticleDesign.LiveBlog &&
-										CAPI.matchUrl && (
-											<Placeholder
-												rootId="match-tabs"
-												height={40}
-											/>
-										))}
+								{(format.design === ArticleDesign.DeadBlog ||
+									format.design === ArticleDesign.LiveBlog) &&
+									CAPI.matchUrl && (
+										<Placeholder
+											rootId="match-tabs"
+											height={40}
+										/>
+									)}
 							</div>
 						</GridItem>
 						<GridItem area="headline">

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -483,6 +483,26 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											height={230}
 										/>
 									)}
+								{format.design === ArticleDesign.DeadBlog ||
+									(ArticleDesign.LiveBlog &&
+										CAPI.matchUrl && (
+											<Placeholder
+												rootId="match-tabs"
+												height={40}
+											/>
+										))}
+							</div>
+						</GridItem>
+						<GridItem area="matchtabs" element="aside">
+							<div css={maxWidth}>
+								{format.design === ArticleDesign.DeadBlog ||
+									(ArticleDesign.LiveBlog &&
+										CAPI.matchUrl && (
+											<Placeholder
+												rootId="match-tabs"
+												height={40}
+											/>
+										))}
 							</div>
 						</GridItem>
 						<GridItem area="headline">

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -95,6 +95,7 @@ const StandardGrid = ({
 						? css`
 								grid-template-areas:
 									'title  border  matchNav     right-column'
+									'title  border  matchtabs    right-column'
 									'.      border  headline     right-column'
 									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
@@ -128,6 +129,7 @@ const StandardGrid = ({
 						? css`
 								grid-template-areas:
 									'title  border  matchNav     right-column'
+									'title  border  matchtabs    right-column'
 									'.      border  headline     right-column'
 									'.      border  standfirst   right-column'
 									'lines  border  media        right-column'
@@ -158,6 +160,7 @@ const StandardGrid = ({
 						? css`
 								grid-template-areas:
 									'matchNav      right-column'
+									'matchtabs	   right-column'
 									'title         right-column'
 									'headline      right-column'
 									'standfirst    right-column'
@@ -186,6 +189,7 @@ const StandardGrid = ({
 						? css`
 								grid-template-areas:
 									'matchNav'
+									'matchtabs'
 									'title'
 									'headline'
 									'standfirst'
@@ -214,6 +218,7 @@ const StandardGrid = ({
 						? css`
 								grid-template-areas:
 									'matchNav'
+									'matchtabs'
 									'media'
 									'title'
 									'headline'

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -492,14 +492,14 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
-								{(format.design === ArticleDesign.DeadBlog ||
-									format.design === ArticleDesign.LiveBlog) &&
-									CAPI.matchUrl && (
-										<Placeholder
-											rootId="match-tabs"
-											height={40}
-										/>
-									)}
+								{format.design === ArticleDesign.DeadBlog ||
+									(format.design === ArticleDesign.LiveBlog &&
+										CAPI.matchUrl && (
+											<Placeholder
+												rootId="match-tabs"
+												height={40}
+											/>
+										))}
 							</div>
 						</GridItem>
 						<GridItem area="headline">


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Matchtabs were not showing on test pages in DCR and this is potentially because they weren't included in the StandardLayout file. This adds them to it.

### After

<img width="1077" alt="Screenshot 2021-11-23 at 09 35 46" src="https://user-images.githubusercontent.com/35331926/143002527-99456fa2-81a5-497b-9710-cfbd82838df6.png">

Tested locally.
