### PR TITLE
Adds webPublicationDate in RelatedItem

### DIFF
--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.3-SNAPSHOT"
+version in ThisBuild := "0.11.3"

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.3"
+version in ThisBuild := "0.11.4-SNAPSHOT"

--- a/apps-rendering/api-models/thrift/src/main/thrift/appsRendering.thrift
+++ b/apps-rendering/api-models/thrift/src/main/thrift/appsRendering.thrift
@@ -35,6 +35,7 @@ struct RelatedItem {
     8: optional string starRating
     9: optional string byline
     10: optional string bylineImage
+    11: optional v1.CapiDateTime webPublicationDate
 }
 
 struct RelatedContent {


### PR DESCRIPTION
## What does this change?

Updates thrift definition to add `webPublicationDate` in `RelatedItem`.

## Why?
This updates `apps-rendering-api-models` Scala and Typescript definitions which can be used to fix LIVE-3078.

NOTE: Corresponding Scala and Typescript packages have been published to Sonatype and NPM respectively.