### PR TITLE
Hide pagination next and oldest buttons on last page

### DIFF
--- a/dotcom-rendering/src/web/components/Pagination.tsx
+++ b/dotcom-rendering/src/web/components/Pagination.tsx
@@ -40,17 +40,17 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 );
 
 const Section = ({
-	isFirst = false,
+	hide = false,
 	children,
 }: {
-	isFirst?: boolean;
+	hide?: boolean;
 	children: React.ReactNode;
 }) => (
 	<section
 		css={css`
 			display: flex;
 			align-items: center;
-			visibility: ${isFirst ? 'hidden' : 'visible'};
+			visibility: ${hide ? 'hidden' : 'visible'};
 		`}
 	>
 		{children}
@@ -115,7 +115,7 @@ export const Pagination = ({
 
 	return (
 		<Container>
-			<Section isFirst={currentPage === 1}>
+			<Section hide={currentPage === 1}>
 				<Hide when="above" breakpoint="phablet">
 					<LinkButton
 						size="small"
@@ -160,7 +160,7 @@ export const Pagination = ({
 					<Bold>{totalPages}</Bold>
 				</Position>
 			</Section>
-			<Section>
+			<Section hide={currentPage === totalPages}>
 				<LinkButton
 					size="small"
 					priority="tertiary"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Expand the 'hiding' functionality of pagination to hide the next & last buttons when you're on the final page

## Why?

Designs & Parity with the first page behaviour

### Before

![image](https://user-images.githubusercontent.com/9575458/143044767-cc3ad363-1096-4e43-874d-5c41d608a383.png)

### After

![image](https://user-images.githubusercontent.com/9575458/143044845-896b750b-9515-4247-8814-1a38b99891c4.png)

