### PR TITLE
LIVE-3078: Uses webPublicationDate instead of lastModified for rendering relatedItems

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2843,9 +2843,9 @@
       }
     },
     "@guardian/apps-rendering-api-models": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-0.11.2.tgz",
-      "integrity": "sha512-hSjX0FxwBNLQTsZ3WBq73HbQwuKXG6R00g73HHRj4RTIJOdVUvoS9xhm0df4R0HavAaUSAaCJf7RHtOWT9sqtg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-0.11.3.tgz",
+      "integrity": "sha512-nkerHpU/YwG/6FO4VP4IcoqijWrbnlstcwvVtCRe2T5TulPskhUlem/49vhceslpTjCse+QEIH71KXVg2s278Q==",
       "requires": {
         "@guardian/content-api-models": "^15.9.1",
         "@guardian/content-atom-model": "^3.2.2",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -29,7 +29,7 @@
   "prettier": "@guardian/prettier",
   "dependencies": {
     "@creditkarma/thrift-server-core": "^0.16.1",
-    "@guardian/apps-rendering-api-models": "^0.11.2",
+    "@guardian/apps-rendering-api-models": "^0.11.3",
     "@guardian/atoms-rendering": "^21.0.0",
     "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.1.1",

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -443,10 +443,13 @@ const Card: FC<Props> = ({ relatedItem, image }) => {
 	const img = cardImage(image, relatedItem);
 	const { type, title, mediaDuration, link, byline } = relatedItem;
 
-	const lastModified = relatedItem.lastModified?.iso8601;
+	const webPublicationDate = relatedItem.webPublicationDate?.iso8601;
 	const date =
-		lastModified && type !== RelatedItemType.ADVERTISEMENT_FEATURE
-			? relativeFirstPublished(fromNullable(new Date(lastModified)), type)
+		webPublicationDate && type !== RelatedItemType.ADVERTISEMENT_FEATURE
+			? relativeFirstPublished(
+					fromNullable(new Date(webPublicationDate)),
+					type,
+			  )
 			: null;
 	const starRating =
 		relatedItem.starRating &&

--- a/apps-rendering/src/relatedContent.test.ts
+++ b/apps-rendering/src/relatedContent.test.ts
@@ -1,6 +1,5 @@
 import { RelatedContent } from '@guardian/apps-rendering-api-models/relatedContent';
 import { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime';
-import { ContentFields } from '@guardian/content-api-models/v1/contentFields';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { ContentType } from '@guardian/content-api-models/v1/contentType';
 import { parseRelatedContent } from 'relatedContent';
@@ -81,19 +80,16 @@ describe('parseRelatedContent', () => {
 		expect(actual.relatedItems[0].pillar.name).toEqual('news');
 	});
 
-	it('returns lastModified DateTime in response given content has lastModified field', () => {
+	it('returns webPublicationDate DateTime in response given content has webPublicationDate field', () => {
 		const capiDateTime: CapiDateTime = {
 			dateTime: new Int64(6545664),
 			iso8601: 'iso',
 		};
-		const contentFields: ContentFields = {
-			lastModified: capiDateTime,
-		};
-		defaultContent.fields = contentFields;
+		defaultContent.webPublicationDate = capiDateTime;
 
 		const actual = parseRelatedContent([defaultContent]);
 
-		expect(actual.relatedItems[0].lastModified).toEqual(capiDateTime);
+		expect(actual.relatedItems[0].webPublicationDate).toEqual(capiDateTime);
 	});
 
 	it('returns the first 4 related content given more than 4 content items', () => {

--- a/apps-rendering/src/relatedContent.ts
+++ b/apps-rendering/src/relatedContent.ts
@@ -75,7 +75,7 @@ const parseRelatedContent = (relatedContent: Content[]): RelatedContent => {
 			.map((content) => {
 				return {
 					title: content.webTitle,
-					lastModified: content.fields?.lastModified,
+					webPublicationDate: content.webPublicationDate,
 					headerImage: parseHeaderImage(content),
 					link: content.id,
 					type: parseRelatedItemType(content),


### PR DESCRIPTION
## Why are you doing this?
Dates shown on related items in MAPI/AR are currently based on their `lastModified` value. Dotcom uses the `webPublicationDate` value instead. This PR makes things consistent by using `webPublicationDate` in MAPI/AR.


## Changes

- Use updated version of `apps-rendering-api-models` that has support for `webPublicationDate`
- Replace usage of `lastModified` in related items with `webPublicationDate`

## Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/91967886/143064596-7c2d5e36-1931-426d-b920-e9c7e8518e66.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/91967886/143064729-ca38ebf8-8a0b-4ee4-b35d-81cc4be679c6.png" width="300px" />
