### PR TITLE
Fix live layout header alignment

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -62,22 +62,21 @@ const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 				margin-left: 0px;
 			}
 			${from.desktop} {
-				margin-left: 320px;
+				margin-left: 240px;
 			}
 			@supports (display: grid) {
 				display: grid;
 				width: 100%;
 				margin-left: 0;
-				grid-column-gap: 10px;
+				grid-column-gap: 20px;
 				/*
 					Explanation of each unit of grid-template-columns
 					Main content
-					Empty border for spacing
 					Right Column
 				*/
 				${from.desktop} {
-					grid-template-columns: 309px 1px 1fr;
-					grid-template-areas: 'title	border headline';
+					grid-template-columns: 220px 1fr;
+					grid-template-areas: 'title	headline';
 				}
 				${until.desktop} {
 					grid-template-columns: 1fr; /* Main content */


### PR DESCRIPTION
## What does this change?
After the change to the left column the live layout header alignment wasn't quite right. This changes fixes the alignment.

## Why?
To meet parity with the design.

### Before
<img width="981" alt="Screenshot 2021-11-24 at 08 56 22" src="https://user-images.githubusercontent.com/45561419/143206150-5fd5c8b3-27ad-44aa-8d64-8ffa75c4f7ff.png">


### After
<img width="1239" alt="Screenshot 2021-11-24 at 08 56 32" src="https://user-images.githubusercontent.com/45561419/143206174-060f359f-0630-4d56-b6b7-540dfb6d2b5b.png">
