### PR TITLE
Initial addition of MatchNavs and better placement of MatchTabs

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -137,6 +137,7 @@ type Palette = {
 		carouselDotFocus: Colour;
 		headlineTag: Colour;
 		mostViewedTab: Colour;
+		matchNav: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -457,7 +457,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								</GridItem>
 								<GridItem area="headline">
 									<div css={maxWidth}>
-										
 										<ArticleHeadlinePadding
 											design={format.design}
 										>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -52,7 +52,7 @@ import {
 } from '@root/src/web/layouts/lib/stickiness';
 import { Hide } from '@guardian/source-react-components';
 import { Placeholder } from '../components/Placeholder';
-import { ContainerLayout } from './ContainerLayout';
+import { ContainerLayout } from '../components/ContainerLayout';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -161,25 +161,25 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'lines		border matchtabs'
-						'meta		border media'
-						'meta		border media'
-						'keyevents	border media'
-						'keyevents	border body'
-						'keyevents	border body'
-						'. 			border .';
+						'lines		 matchtabs'
+						'meta		 media'
+						'meta		 media'
+						'keyevents	 media'
+						'keyevents	 body'
+						'keyevents	 body'
+						'. 			 .';
 				}
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'lines 		border matchtabs right-column'
-						'meta  		border media right-column'
-						'keyevents  border media right-column'
-						'keyevents  border body  right-column'
-						'keyevents  border body  right-column'
-						'.			border .     right-column';
+						'lines 		 matchtabs right-column'
+						'meta  		 media     right-column'
+						'keyevents   media 	   right-column'
+						'keyevents   body      right-column'
+						'keyevents   body      right-column'
+						'.			 .         right-column';
 				}
 				/* until desktop define fixed body width */
 				${until.desktop} {
@@ -420,7 +420,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							padContent={false}
 							verticalMargins={false}
 						>
-							<Hide when="above" breakpoint="leftCol">
+							<Hide above="leftCol">
 								<ArticleTitle
 									format={format}
 									palette={palette}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -378,7 +378,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
 								format={format}
-								palette={palette}
 							/>
 						</ElementContainer>
 					)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -378,6 +378,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
 								format={format}
+								palette={palette}
 							/>
 						</ElementContainer>
 					)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -52,6 +52,7 @@ import {
 } from '@root/src/web/layouts/lib/stickiness';
 import { Hide } from '@guardian/source-react-components';
 import { Placeholder } from '../components/Placeholder';
+import { ContainerLayout } from './ContainerLayout';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -160,29 +161,31 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'lines		media'
-						'meta		media'
-						'keyevents	media'
-						'keyevents	body'
-						'keyevents	body'
-						'. 			.';
+						'lines		border matchtabs'
+						'meta		border media'
+						'meta		border media'
+						'keyevents	border media'
+						'keyevents	border body'
+						'keyevents	border body'
+						'. 			border .';
 				}
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'lines 		media right-column'
-						'meta  		media right-column'
-						'keyevents  media right-column'
-						'keyevents  body  right-column'
-						'keyevents  body  right-column'
-						'.			.     right-column';
+						'lines 		border matchtabs right-column'
+						'meta  		border media right-column'
+						'keyevents  border media right-column'
+						'keyevents  border body  right-column'
+						'keyevents  border body  right-column'
+						'.			border .     right-column';
 				}
 				/* until desktop define fixed body width */
 				${until.desktop} {
 					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
+						'matchtabs'
 						'media'
 						'lines'
 						'meta'
@@ -193,6 +196,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				${until.tablet} {
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
+						'matchtabs'
 						'media'
 						'lines'
 						'meta'
@@ -395,13 +399,12 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 			<main>
 				<article>
-					<ElementContainer
-						showTopBorder={false}
-						backgroundColour={palette.background.header}
-						borderColour={palette.border.headline}
-					>
-						<HeadlineGrid>
-							<GridItem area="title">
+					{CAPI.matchUrl ? (
+						<ContainerLayout
+							showTopBorder={false}
+							backgroundColour={palette.background.matchNav}
+							borderColour={palette.border.headline}
+							leftContent={
 								<ArticleTitle
 									format={format}
 									palette={palette}
@@ -411,51 +414,92 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									guardianBaseURL={CAPI.guardianBaseURL}
 									badge={CAPI.badge}
 								/>
-							</GridItem>
-							<GridItem area="headline">
-								{CAPI.matchUrl && showMatchTabs && (
-									<Placeholder
-										rootId="match-tabs"
-										height={40}
+							}
+							leftColSize="wide"
+							sideBorders={true}
+							padContent={false}
+							verticalMargins={false}
+						>
+							<Hide when="above" breakpoint="leftCol">
+								<ArticleTitle
+									format={format}
+									palette={palette}
+									tags={CAPI.tags}
+									sectionLabel={CAPI.sectionLabel}
+									sectionUrl={CAPI.sectionUrl}
+									guardianBaseURL={CAPI.guardianBaseURL}
+									badge={CAPI.badge}
+								/>
+							</Hide>
+							<Placeholder
+								shouldShimmer={false}
+								rootId="match-nav"
+								height={230}
+							/>
+						</ContainerLayout>
+					) : (
+						<ElementContainer
+							showTopBorder={false}
+							backgroundColour={palette.background.header}
+							borderColour={palette.border.headline}
+						>
+							<HeadlineGrid>
+								<GridItem area="title">
+									<ArticleTitle
+										format={format}
+										palette={palette}
+										tags={CAPI.tags}
+										sectionLabel={CAPI.sectionLabel}
+										sectionUrl={CAPI.sectionUrl}
+										guardianBaseURL={CAPI.guardianBaseURL}
+										badge={CAPI.badge}
 									/>
-								)}
-								<div css={maxWidth}>
-									<ArticleHeadlinePadding
-										design={format.design}
-									>
-										{age && (
-											<div css={ageWarningMargins}>
-												<AgeWarning age={age} />
-											</div>
-										)}
-										<ArticleHeadline
-											format={format}
-											headlineString={CAPI.headline}
-											tags={CAPI.tags}
-											byline={CAPI.author.byline}
-											palette={palette}
-										/>
-										{age && (
-											<AgeWarning
-												age={age}
-												isScreenReader={true}
-											/>
-										)}
-									</ArticleHeadlinePadding>
-								</div>
-								{CAPI.starRating || CAPI.starRating === 0 ? (
-									<div css={starWrapper}>
-										<StarRating
-											rating={CAPI.starRating}
-											size="large"
-										/>
+								</GridItem>
+								<GridItem area="headline">
+									<div css={maxWidth}>
+										
+										<ArticleHeadlinePadding
+											design={format.design}
+										>
+											{age && (
+												<div css={ageWarningMargins}>
+													<AgeWarning age={age} />
+												</div>
+											)}
+											{!CAPI.matchUrl && (
+												<ArticleHeadline
+													format={format}
+													headlineString={
+														CAPI.headline
+													}
+													tags={CAPI.tags}
+													byline={CAPI.author.byline}
+													palette={palette}
+												/>
+											)}
+											{age && (
+												<AgeWarning
+													age={age}
+													isScreenReader={true}
+												/>
+											)}
+										</ArticleHeadlinePadding>
 									</div>
-								) : (
-									<></>
-								)}
-							</GridItem>
-						</HeadlineGrid>
-					</ElementContainer>
+									{CAPI.starRating ||
+									CAPI.starRating === 0 ? (
+										<div css={starWrapper}>
+											<StarRating
+												rating={CAPI.starRating}
+												size="large"
+											/>
+										</div>
+									) : (
+										<></>
+									)}
+								</GridItem>
+							</HeadlineGrid>
+						</ElementContainer>
+					)}
 
 					<ElementContainer
 						showTopBorder={false}
@@ -532,6 +576,16 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						borderColour={palette.border.article}
 					>
 						<LiveGrid>
+							<GridItem area="matchtabs" element="aside">
+								<div css={maxWidth}>
+									{CAPI.matchUrl && showMatchTabs && (
+										<Placeholder
+											rootId="match-tabs"
+											height={40}
+										/>
+									)}
+								</div>
+							</GridItem>
 							<GridItem area="media">
 								<div css={maxWidth}>
 									<MainMedia

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -657,6 +657,10 @@ const activeMatchTab = (): string => {
 	return sport[300];
 };
 
+const backgroundMatchNav = (): string => {
+	return brandAlt[400];
+};
+
 const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -880,6 +884,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			carouselDotFocus: backgroundCarouselDotFocus(format),
 			headlineTag: backgroundHeadlineTag(format),
 			mostViewedTab: backgroundMostViewedTab(format),
+			matchNav: backgroundMatchNav(),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

**MatchTabs and MatchNav still need work done**, this is just the start piece so they at least appear in the right place. Things like match tabs aren't responsive at the moment, but again, it's a starting point for further improvement.

## Why?

Needs to be done!

### Before

<img width="1634" alt="Screenshot 2021-11-24 at 09 05 34" src="https://user-images.githubusercontent.com/35331926/143209902-07f597c5-6e8c-40a2-8ed0-14c0749e0e06.png">

### After

<img width="1634" alt="Screenshot 2021-11-24 at 09 04 45" src="https://user-images.githubusercontent.com/35331926/143209946-c6fb5335-4976-42fd-8d41-74479f5b97f9.png">


