### PR TITLE
New Immersive Interactive Layout, post CAPI changes (merge 3/5)

### DIFF
--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -13,6 +13,7 @@ import { ImmersiveLayout } from './ImmersiveLayout';
 import { LiveLayout } from './LiveLayout';
 import { InteractiveLayout } from './InteractiveLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
+import { InteractiveImmersiveLayout } from './InteractiveImmersiveLayout';
 
 type Props = {
 	CAPI: CAPIType;
@@ -35,15 +36,15 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 		case ArticleDisplay.Immersive: {
 			switch (design) {
 				case ArticleDesign.Interactive: {
-					// Render all 'immersive interactives' until switchover date as 'FullPageInteractive'
-					// TBD: After 'immersive interactive' changes to CAPI are merged, add logic here to either use
-					// 'InteractiveImmersiveLayout' if published after switchover date, or 'FullPageInteractiveLayout'
-					// if published before.
+					// CAPI changes have gone through, so now format Immersive (display) + Interactive (design)
+					// points to InteractiveImmersiveLayout which is the "new" layout. Articles that use the
+					// "old" layout are now formatted as Standard (display) + FullPage (design), as at line 108.
 					return (
-						<FullPageInteractiveLayout
+						<InteractiveImmersiveLayout
 							CAPI={CAPI}
 							NAV={NAV}
 							format={format}
+							palette={palette}
 						/>
 					);
 				}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This is the third merge in adding a new template to DCR.

In brief, step one changed DecideLayout.tsx such that the following to formats resolved to use the old layout: `Interactive (Display) + Immersive (Design)` and `Standard (Display) + FullPageInteractive (Design)`

This change comes after the changes to CAPI have resolved such that we only need format `Standard (Display) + FullPageInteractive (Design)` to resolve to display the old layout, and format `Interactive (Display) + Immersive (Design)` can point to the new layout.

Related PRs:
1st (DCR): https://github.com/guardian/dotcom-rendering/pull/3401
2nd (CAPI): https://github.com/guardian/content-api-scala-client/pull/338