### PR TITLE
AB test for new Smart bidder integration

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.tsx
@@ -26,7 +26,7 @@ export const CommercialMetrics: React.FC<{
 		const testsToForceMetrics: ABTest[] = [
 			prebidTimeout,
 			integrateCriteo,
-			integrateSmart
+			integrateSmart,
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/components/CommercialMetrics.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.tsx
@@ -7,6 +7,7 @@ import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-te
 import { useDocumentVisibilityState } from '../lib/useDocumentHidden';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { integrateCriteo } from '../experiments/tests/integrate-criteo-test';
+import { integrateSmart } from '../experiments/tests/integrate-smart-test';
 
 // TODO disallow undefined browserIds by placing conditional in App.tsx
 // so that we wait to render this component until browserId is defined.
@@ -22,7 +23,11 @@ export const CommercialMetrics: React.FC<{
 	const isHidden = visibilityState === 'hidden' || undefined;
 
 	useOnce(() => {
-		const testsToForceMetrics: ABTest[] = [prebidTimeout, integrateCriteo];
+		const testsToForceMetrics: ABTest[] = [
+			prebidTimeout,
+			integrateCriteo,
+			integrateSmart
+		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),
 		);

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -8,6 +8,7 @@ import {
 } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
 import { prebidTimeout } from '@frontend/web/experiments/tests/prebid-timeout-test';
 import { integrateCriteo } from './tests/integrate-criteo-test';
+import { integrateSmart } from './tests/integrate-smart-test';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseVariants,
 	prebidTimeout,
 	integrateCriteo,
+	integrateSmart,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/integrate-smart-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/integrate-smart-test.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const integrateSmart: ABTest = {
+	id: 'IntegrateSmart',
+	author: 'Fred OBrien (@frederickobrien)',
+	start: '2021-11-23',
+	expiry: '2022-01-10',
+	audience: 2 / 100,
+	audienceOffset: 98 / 100,
+	audienceCriteria: 'All users',
+	description:
+		'Integrate new Prebid bidder and measure revenue uplift / impact of commercial performance metrics',
+	successMeasure:
+		'Revenue uplift with no significant impact on performance metrics',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};

--- a/dotcom-rendering/src/web/experiments/tests/integrate-smart-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/integrate-smart-test.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const integrateSmart: ABTest = {
 	id: 'IntegrateSmart',
-	author: 'Fred OBrien (@frederickobrien)',
+	author: 'Commercial Dev (@guardian/commercial-dev)',
 	start: '2021-11-23',
 	expiry: '2022-01-10',
 	audience: 2 / 100,


### PR DESCRIPTION
Sister PR to https://github.com/guardian/frontend/pull/24432, allowing us to measure performance of Smart, a bidder being added to our Prebid setup.
