### PR TITLE
zero padding on standfirst livelayouts until desktop

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -8,6 +8,7 @@ import { Flex } from '@root/src/web/components/Flex';
 
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
+import { ArticleFormat, ArticleDesign } from '@guardian/libs';
 
 type Props = {
 	title?: string;
@@ -27,6 +28,7 @@ type Props = {
 	children?: React.ReactNode;
 	stretchRight?: boolean;
 	leftColSize?: LeftColSize;
+	format?: ArticleFormat;
 };
 
 const containerStyles = css`
@@ -51,25 +53,41 @@ const rightMargin = css`
 	}
 `;
 
-const padding = css`
-	padding: 0 10px;
-`;
+const padding = (format?: ArticleFormat) => {
+	switch (format?.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return css`
+				padding: 0;
+
+				${from.desktop} {
+					padding: 0 10px;
+				}
+			`;
+		default:
+			return css`
+				padding: 0 10px;
+			`;
+	}
+};
 
 const Container = ({
 	children,
 	padded,
 	verticalMargins,
 	stretchRight,
+	format,
 }: {
 	children: React.ReactNode;
 	padded: boolean;
 	verticalMargins: boolean;
 	stretchRight: boolean;
+	format?: ArticleFormat;
 }) => (
 	<div
 		css={[
 			containerStyles,
-			padded && padding,
+			padded && padding(format),
 			verticalMargins && margins,
 			!stretchRight && rightMargin,
 		]}
@@ -96,6 +114,7 @@ export const ContainerLayout = ({
 	leftContent,
 	stretchRight = false,
 	leftColSize,
+	format,
 }: Props) => (
 	<ElementContainer
 		sectionId={sectionId}
@@ -125,6 +144,7 @@ export const ContainerLayout = ({
 				padded={padContent}
 				verticalMargins={verticalMargins}
 				stretchRight={stretchRight}
+				format={format}
 			>
 				<Hide when="above" breakpoint="leftCol">
 					<ContainerTitle

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -438,6 +438,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						sideBorders={true}
 						leftColSize="wide"
 						verticalMargins={false}
+						format={format}
 					>
 						<Standfirst
 							format={format}

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -117,7 +117,12 @@ LiveStory.story = {
 	name: 'LiveBlog',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.tablet, breakpoints.wide],
+			viewports: [
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
 		},
 	},
 };
@@ -137,7 +142,12 @@ DeadStory.story = {
 	name: 'DeadBlog',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.tablet, breakpoints.wide],
+			viewports: [
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -187,7 +187,12 @@ LiveStory.story = {
 	name: 'LiveBlog',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.tablet, breakpoints.wide],
+			viewports: [
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
 		},
 	},
 };
@@ -207,7 +212,12 @@ DeadStory.story = {
 	name: 'DeadBlog',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.tablet, breakpoints.wide],
+			viewports: [
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
 		},
 	},
 };


### PR DESCRIPTION
Co-authored-by: Mark Addis <mark.addis@guardian.co.uk>

## What does this change?
This change removes the standfirst padding for livelayouts until desktop breakpoint.

We also added extra breakpoints in the live/deadblog stories as some unintended changes at desktop and leftCol had slipped through the net.

## Why?
To meet parity with design.

### Before
<img width="733" alt="Screenshot 2021-11-24 at 17 00 50" src="https://user-images.githubusercontent.com/45561419/143282640-7f259ad6-df6c-407f-9d32-39b8e711872b.png">

### After
<img width="548" alt="Screenshot 2021-11-24 at 17 02 24" src="https://user-images.githubusercontent.com/45561419/143282849-da0d22f8-7a1c-450e-b8e8-17e2ff2a9b57.png">


