### PR TITLE
use non strict sanctions check when getting the discussion profile

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -28,7 +28,11 @@ describe('Signed in readers', function () {
 			return false;
 		});
 		// Mock call to 'profile/me'
-		cy.intercept('GET', '**/profile/me', profileResponse);
+		cy.intercept(
+			'GET',
+			'**/profile/me?strict_sanctions_check=false',
+			profileResponse,
+		);
 		cy.visit(`Article?url=${articleUrl}`);
 		// This text is shown in the header for signed in users
 		cy.contains('My account');

--- a/dotcom-rendering/src/web/lib/getUser.ts
+++ b/dotcom-rendering/src/web/lib/getUser.ts
@@ -19,7 +19,7 @@ const callApi = (url: string) => {
 };
 
 export const getUser = async (ajaxUrl: string): Promise<UserProfile | void> => {
-	const url = joinUrl([ajaxUrl, 'profile/me']);
+	const url = joinUrl([ajaxUrl, 'profile/me?strict_sanctions_check=false']);
 	return callApi(url)
 		.catch((error) => {
 			window.guardian.modules.sentry.reportError(error, 'get-user');


### PR DESCRIPTION
## What does this change?
I'm not super familiar with DCR so I would appreciate if someone could take a look to make sure this change makes sense.
Currently, when loading pages with comments we are making a request to /profile/me in `discussion-api`.
This PR adds a new parameter to perform a more lightweight call at the cost of a slightly less strict check for sanctions.  In most cases this should return the same thing, but in some corner cases it would return that the user is allowed to comment even though they are not.

## Why?
we want to reduce the load on identity. In most cases nothing should change, but in some corner cases it would not notify the user in advance that they are banned before they try to comment. For more details look at the [discussion PR that added the new parameter](https://github.com/guardian/discussion-api/pull/695)

### Before (corner case)
![image](https://user-images.githubusercontent.com/15324270/143286090-0269e293-5822-4d03-b68f-e2e55c54d177.png)

### After(corner case)
The "commenting disabled" message is not displayed but the user still cannot comment if they try (this screenshot is after attempting to post a comment)
![image](https://user-images.githubusercontent.com/15324270/143287990-d04b6cc2-be90-426b-9a3b-f4fba81b61b9.png)
