### PR TITLE
Add padding to video caption on mobile breakpoints

### DIFF
--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -8,6 +8,7 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import { css } from '@emotion/react';
+import { breakpoints } from '@guardian/src-foundations';
 import { decidePalette } from '../lib/decidePalette';
 
 export default {
@@ -270,3 +271,34 @@ export const OverlayedWithStars = () => (
 	</ElementContainer>
 );
 OverlayedWithStars.story = { name: 'when overlayed on stars' };
+
+export const VideoCaption = () => (
+	<ElementContainer showTopBorder={false} showSideBorders={false}>
+		<Caption
+			captionText="This is how an Article caption looks"
+			format={{
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			}}
+			palette={decidePalette({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.Standard,
+				theme: ArticlePillar.News,
+			})}
+			mediaType="Video"
+		/>
+	</ElementContainer>
+);
+VideoCaption.story = {
+	name: 'for videos',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+			],
+		},
+	},
+};

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { from, until } from '@guardian/src-foundations/mq';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import {
@@ -114,6 +114,15 @@ const captionPadding = css`
 	padding-right: 8px;
 `;
 
+const videoPadding = css`
+	${until.mobileLandscape} {
+		margin-left: 10px;
+	}
+	${between.mobileLandscape.and.phablet} {
+		margin-left: ${space[5]}px;
+	}
+`;
+
 const bigLeftMargin = css`
 	width: inherit;
 	margin-left: ${space[9]}px;
@@ -218,6 +227,7 @@ export const Caption = ({
 				!isOverlayed && bottomMargin,
 				isOverlayed && overlayedStyles(palette, format),
 				padCaption && captionPadding,
+				mediaType === 'Video' && videoPadding,
 			]}
 		>
 			{mediaType === 'Video' ? (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds padding at lower breakpoint on mobile. In this case we line the caption up with the rest of the article.

## Why?

Videos occupy 100% width, and therefor need padding on the caption.

### Before
![image](https://user-images.githubusercontent.com/9575458/143478787-9f071b3e-5e8f-449c-a8df-dc6457f7d920.png)

### After
![image](https://user-images.githubusercontent.com/9575458/143478885-30f87653-0fcf-44a2-aa1d-682ee0029e34.png)
![image](https://user-images.githubusercontent.com/9575458/143478849-8671aaf4-cf08-436a-a0f6-f5d618865f11.png)

