### PR TITLE
`SkipToKeyEvents`

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -60,7 +60,7 @@ const keyEventWrapperStyles = (
 	width: 100%;
 
 	${from.desktop} {
-		border-top: #CDCDCD 1px solid;
+		border-top: #cdcdcd 1px solid;
 		padding-top: ${remSpace[2]};
 	}
 

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -159,7 +159,11 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 
 const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 	return (
-		<div css={keyEventWrapperStyles(supportsDarkMode)}>
+		<nav
+			id="keyevents"
+			css={keyEventWrapperStyles(supportsDarkMode)}
+			aria-label="Key Events"
+		>
 			<Accordion
 				supportsDarkMode={supportsDarkMode}
 				accordionTitle="Key events"
@@ -176,7 +180,7 @@ const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 					))}
 				</ul>
 			</Accordion>
-		</div>
+		</nav>
 	);
 };
 

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -160,6 +160,8 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 	return (
 		<nav
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+			tabIndex={0}
 			id="keyevents"
 			css={keyEventWrapperStyles(supportsDarkMode)}
 			aria-label="Key Events"

--- a/dotcom-rendering/src/web/components/SkipTo.tsx
+++ b/dotcom-rendering/src/web/components/SkipTo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, border } from '@guardian/src-foundations/palette';
 
-type Identifier = 'maincontent' | 'navigation';
+type Identifier = 'maincontent' | 'navigation' | 'keyevents';
 
 type Props = {
 	id: Identifier;

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -323,6 +323,15 @@ export const document = ({ data }: Props): string => {
 	const skipToNavigation = renderToString(
 		<SkipTo id="navigation" label="Skip to navigation" />,
 	);
+	let skipToKeyEvents;
+	if (
+		CAPI.format.design === 'LiveBlogDesign' ||
+		CAPI.format.design === 'DeadBlogDesign'
+	) {
+		skipToKeyEvents = renderToString(
+			<SkipTo id="keyevents" label="Skip to key events" />,
+		);
+	}
 
 	return htmlTemplate({
 		linkedData,
@@ -342,5 +351,6 @@ export const document = ({ data }: Props): string => {
 		keywords,
 		skipToMainContent,
 		skipToNavigation,
+		skipToKeyEvents,
 	});
 };

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -288,11 +288,10 @@ https://workforus.theguardian.com/careers/product-engineering/
                 ${priorityScriptTags.join('\n')}
                 <style class="webfont">${getFontsCss()}</style>
                 <style>${resets.resetCSS}${css}</style>
+				<link rel="stylesheet" media="print" href="${CDN}static/frontend/css/print.css">
+			</head>
 
-                <link rel="stylesheet" media="print" href="${CDN}static/frontend/css/print.css">
-            </head>
-
-            <body>
+			<body>
 				${skipToMainContent}
 				${skipToNavigation}
 				${skipToKeyEvents || ''}

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -22,6 +22,7 @@ export const htmlTemplate = ({
 	keywords,
 	skipToMainContent,
 	skipToNavigation,
+	skipToKeyEvents,
 }: {
 	title?: string;
 	description: string;
@@ -40,6 +41,7 @@ export const htmlTemplate = ({
 	keywords: string;
 	skipToMainContent: string;
 	skipToNavigation: string;
+	skipToKeyEvents?: string;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -293,6 +295,7 @@ https://workforus.theguardian.com/careers/product-engineering/
             <body>
 				${skipToMainContent}
 				${skipToNavigation}
+				${skipToKeyEvents || ''}
                 <div id="react-root"></div>
                 ${html}
                 ${[...lowPriorityScriptTags].join('\n')}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This recognises the Key Events component as a navigation aid, wrapping it in a `nav` tag (with a descriptive aria label) and then adds an additional skip to link to aid discoverability.

## Why?
We've been adding more focus on Key Events recently and as part of that we want to make this navigation aid as accessible as possible

