### PR TITLE
Add `maincontent` id for liveblogs

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -89,7 +89,12 @@ export const ArticleBody = ({
 		format.design === ArticleDesign.DeadBlog
 	) {
 		return (
-			<div css={[globalStrongStyles, globalLinkStyles(palette)]}>
+			<div
+				// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+				tabIndex={0}
+				id="maincontent"
+				css={[globalStrongStyles, globalLinkStyles(palette)]}
+			>
 				<LiveBlogRenderer
 					format={format}
 					blocks={blocks}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We didn't have a `maincontent` id for the Skip To Main Content accessibility link to use for live blogs, we do now

## Why?
So keyboard users can quickly access the main content of the page

