### PR TITLE
fix: Only render MatchNav for MatchReports

### DIFF
--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -97,7 +97,7 @@ const StandardGrid = ({
 									'title  border  matchNav     right-column'
 									'title  border  matchtabs    right-column'
 									'.      border  headline     right-column'
-									'.      border  standfirst    right-column'
+									'.      border  standfirst   right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -106,7 +106,7 @@ const StandardGrid = ({
 						: css`
 								grid-template-areas:
 									'title  border  headline     right-column'
-									'.      border  standfirst    right-column'
+									'.      border  standfirst   right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -140,7 +140,7 @@ const StandardGrid = ({
 						: css`
 								grid-template-areas:
 									'title  border  headline     right-column'
-									'.      border  standfirst    right-column'
+									'.      border  standfirst   right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -492,12 +492,13 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
-								{CAPI.matchUrl && (
-									<Placeholder
-										rootId="match-tabs"
-										height={40}
-									/>
-								)}
+								{format.design === ArticleDesign.MatchReport &&
+									CAPI.matchUrl && (
+										<Placeholder
+											rootId="match-tabs"
+											height={40}
+										/>
+									)}
 							</div>
 						</GridItem>
 						<GridItem area="headline">


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds an additional check for when deciding if we should render `MatchNav`. In addition to looking for `CAPI.matchUrl` we now also check if `Design.MatchReport`

## Why?
An issue was raised in an email where some [articles](https://www.theguardian.com/football/2021/nov/28/chelsea-1-1-manchester-united-player-ratings-from-stamford-bridge) have a `matchUrl` value but are not match reports and because we try to add `MatchNav` when it isn't expected by the grid this causes the page layout to break

### Before
<img width="1095" alt="Screenshot 2021-11-29 at 08 16 51" src="https://user-images.githubusercontent.com/1336821/143831513-d068a2ec-8f16-49d0-a368-9055d8d8034c.png">


### After
<img width="1095" alt="Screenshot 2021-11-29 at 08 15 24" src="https://user-images.githubusercontent.com/1336821/143831370-3da629a1-6b9b-4220-b453-f8172c21d81a.png">

