### PR TITLE
Identity | Sign In Gate | Extend the sign in gate test expiry date

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const signInGateMainControl: ABTest = {
 	id: 'SignInGateMainControl',
 	start: '2020-05-20',
-	expiry: '2021-12-01',
+	expiry: '2022-12-01',
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Control Audience.',

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const signInGateMainVariant: ABTest = {
 	id: 'SignInGateMainVariant',
 	start: '2020-06-09',
-	expiry: '2021-12-01',
+	expiry: '2022-12-01',
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',


### PR DESCRIPTION
## What does this change?
- Extend the test by another year so the test/builds do not stop or fail.
  - We'll be resuming sign in tests properly shortly, this is a stop gap before that happens.

[Frontend PR](https://github.com/guardian/frontend/pull/24446)