### PR TITLE
Relative time

### DIFF
--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -32,6 +32,7 @@ const FirstPublished = ({
 		>
 			<time
 				dateTime={publishedDate.toISOString()}
+				data-relativeformat="med"
 				css={css`
 					color: ${neutral[46]};
 					font-weight: bold;

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -51,6 +51,7 @@ const fileExists = async (glob) => {
 		'atomIframe',
 		'embedIframe',
 		'newsletterEmbedIframe',
+		'relativeTime',
 	].map((name) => {
 		if (loadableManifest.assetsByChunkName[name]) {
 			console.log(`Loadable manifest returned value ${name}`);

--- a/dotcom-rendering/scripts/webpack/browser.js
+++ b/dotcom-rendering/scripts/webpack/browser.js
@@ -43,6 +43,7 @@ module.exports = ({ isLegacyJS }) => ({
 		coreVitals: scriptPath('coreVitals'),
 		embedIframe: scriptPath('embedIframe'),
 		newsletterEmbedIframe: scriptPath('newsletterEmbedIframe'),
+		relativeTime: scriptPath('relativeTime'),
 	},
 	output: {
 		filename: generateName(isLegacyJS),

--- a/dotcom-rendering/src/web/browser/relativeTime/init.ts
+++ b/dotcom-rendering/src/web/browser/relativeTime/init.ts
@@ -1,0 +1,14 @@
+import '../webpackPublicPath';
+import { startup } from '@root/src/web/browser/startup';
+import { updateTimeElements } from './updateTimeElements';
+
+const init = (): Promise<void> => {
+	updateTimeElements();
+	window.setInterval(() => {
+		updateTimeElements();
+	}, 5000);
+
+	return Promise.resolve();
+};
+
+startup('relativeTime', null, init);

--- a/dotcom-rendering/src/web/browser/relativeTime/init.ts
+++ b/dotcom-rendering/src/web/browser/relativeTime/init.ts
@@ -6,7 +6,7 @@ const init = (): Promise<void> => {
 	updateTimeElements();
 	window.setInterval(() => {
 		updateTimeElements();
-	}, 5000);
+	}, 15000);
 
 	return Promise.resolve();
 };

--- a/dotcom-rendering/src/web/browser/relativeTime/updateTimeElements.test.tsx
+++ b/dotcom-rendering/src/web/browser/relativeTime/updateTimeElements.test.tsx
@@ -1,0 +1,90 @@
+import MockDate from 'mockdate';
+
+import { render, screen } from '@testing-library/react';
+
+import { updateTimeElements } from './updateTimeElements';
+
+function setup(html: string) {
+	function TestComponent() {
+		return <div dangerouslySetInnerHTML={{ __html: html }} />;
+	}
+	return render(<TestComponent />);
+}
+
+const now = new Date().valueOf();
+const nowIso = new Date(now).toISOString();
+
+const oneMinute = 60 * 1000 * 1;
+const fifteenSeconds = 1000 * 15;
+const twentySeconds = 20 * 1000;
+const thirtySeconds = 30 * 1000;
+
+describe('updateTimeElements', () => {
+	beforeEach(() => {
+		MockDate.reset();
+	});
+
+	it('only updates time elements that have the data-relativeformat and datetime attributes', async () => {
+		const html = `
+			<div>
+				<time data-testid="1" datetime="${nowIso}">I am missing data-relativeformat</time>
+				<div data-testid="2" datetime="${nowIso}" data-relativeformat="med">I am a div, not time</div>
+				<time data-testid="3" data-relativeformat="med">I am missing datatime</time>
+				<time data-testid="4" datetime="${nowIso}" data-relativeformat="med">Original value</time>
+			</div>`;
+		setup(html);
+		MockDate.set(now + fifteenSeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent(
+			'I am missing data-relativeformat',
+		);
+		expect(screen.getByTestId('2')).toHaveTextContent(
+			'I am a div, not time',
+		);
+		expect(screen.getByTestId('3')).toHaveTextContent(
+			'I am missing datatime',
+		);
+		expect(screen.getByTestId('4')).toHaveTextContent('15s');
+	});
+
+	it('fails gracefully if format is invalid', async () => {
+		const html = `<time data-testid="1" datetime="${nowIso}" data-relativeformat="INVALID">Original value</time>`;
+		setup(html);
+		MockDate.set(now + fifteenSeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('Original value');
+	});
+
+	it('updates the text shown in time elements as time progresses', async () => {
+		const html = `<time data-testid="1" datetime="${nowIso}" data-relativeformat="med">now</time>`;
+		setup(html);
+		MockDate.set(now);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('now');
+		MockDate.set(now + fifteenSeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('15s');
+		MockDate.set(now + thirtySeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('30s');
+		MockDate.set(now + oneMinute);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('1m');
+	});
+
+	it('respects if long format is passed', async () => {
+		const html = `<time data-testid="1" datetime="${nowIso}" data-relativeformat="long">1 second ago</time>`;
+		setup(html);
+		MockDate.set(now + fifteenSeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('15 seconds ago');
+	});
+
+	it('respects if short format is passed', async () => {
+		const html = `<time data-testid="1" datetime="${nowIso}" data-relativeformat="short">now</time>`;
+		setup(html);
+		MockDate.set(now + twentySeconds);
+		updateTimeElements();
+		expect(screen.getByTestId('1')).toHaveTextContent('20s');
+	});
+});

--- a/dotcom-rendering/src/web/browser/relativeTime/updateTimeElements.ts
+++ b/dotcom-rendering/src/web/browser/relativeTime/updateTimeElements.ts
@@ -1,0 +1,31 @@
+import { timeAgo } from '@guardian/libs';
+
+export const updateTimeElements = (): void => {
+	document
+		.querySelectorAll('time[data-relativeformat]')
+		.forEach((element) => {
+			if (element instanceof HTMLElement) {
+				// Get required values
+				const { relativeformat: relativeFormat } = element.dataset;
+				const absoluteTime = element.getAttribute('datetime');
+				if (!absoluteTime || !relativeFormat) return;
+
+				let newTime;
+				switch (relativeFormat) {
+					case 'short':
+					case 'med':
+						newTime = timeAgo(new Date(absoluteTime).getTime(), {
+							verbose: false,
+						});
+						break;
+					case 'long':
+						newTime = timeAgo(new Date(absoluteTime).getTime(), {
+							verbose: true,
+						});
+						break;
+				}
+				const oldTime = element.innerText;
+				if (newTime && newTime !== oldTime) element.innerHTML = newTime;
+			}
+		});
+};

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -60,7 +60,9 @@ export const CardAge = ({
 		<span css={ageStyles(format, palette)}>
 			<span>
 				{showClock && <ClockIcon />}
-				<time dateTime={webPublicationDate}>{displayString}</time>
+				<time dateTime={webPublicationDate} data-relativeformat="med">
+					{displayString}
+				</time>
 			</span>
 		</span>
 	);

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -277,6 +277,7 @@ export const document = ({ data }: Props): string => {
 		...getScriptArrayFromChunkName('atomIframe'),
 		...getScriptArrayFromChunkName('embedIframe'),
 		...getScriptArrayFromChunkName('newsletterEmbedIframe'),
+		...getScriptArrayFromChunkName('relativeTime'),
 	]);
 
 	const gaChunk = getScriptArrayFromChunkName('ga');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds support for relative time on DCR.

There has been previous work in this space [here where we added](https://github.com/guardian/libs/pull/134) timeAgo to @guardian/libs and also [here where the first proposal](https://github.com/guardian/dotcom-rendering/pull/3426) was made to introduce the use of this lib in DCR.


https://user-images.githubusercontent.com/1336821/144039588-8d34eaf3-2199-408c-bd88-08de966af174.mov

(Note. The interval in the video above is artificially fast to keep you entertained)

## Usage
Any `time` element with [a valid datetime](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) (`dateTime` in React) and also a `data-relativeformat` attribute will be kept up to date.

`datetime`: Must be a [valid datetime value](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values)
`data-relativeformat`: 'short' | 'med' | 'long'*

*short and med are the same but we respect 'short' to honour older contracts.

## Why?
A convention was started at the Guardian 9 years ago in the [38th PR on Frontend](https://github.com/guardian/frontend/pull/38) saying that `time` elements should be able to show 'relative' time. That contract today states that if a `time` element has both `datetime` and `data-relativetime` attributes then the page should respect the contract this establishes and ensure this element shows a relative time string, such as `5m ago`.

## What about `useTimeAgo`?
Previous work in this area leaned on React to make time elements relative but in this PR we just use vanilla javascript because the action of setting an interval to read and mutate the dom is a lot simpler to achieve outside of react.
