### PR TITLE
feat: Use an absolute Date for KeyEvents

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -21,7 +21,7 @@ const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
 				? [
 						...events,
 						{
-							time: block.firstPublished.value.toUTCString(),
+							date: block.firstPublished.value,
 							text: block.title,
 							url: `#block-${block.id}`,
 						},

--- a/common-rendering/src/components/keyEvents.stories.tsx
+++ b/common-rendering/src/components/keyEvents.stories.tsx
@@ -9,53 +9,44 @@ import { css } from "@emotion/react";
 
 const events: KeyEvent[] = [
 	{
-		time: "1m ago",
+		date: new Date(1 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "2m ago",
-		text:
-			"Ben Maher goes into the gold medal sport in the equestrian jumps",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		date: new Date(2 * 60 * 1000),
+		text: "Ben Maher goes into the gold medal sport in the equestrian jumps",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "3m ago",
+		date: new Date(3 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "5m ago",
+		date: new Date(5 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "9m ago",
+		date: new Date(9 * 60 * 1000),
 		text: "Jodie Williams qualifies for the 400m final",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "15m ago",
+		date: new Date(15 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "20m ago",
+		date: new Date(20 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 	{
-		time: "35m ago",
+		date: new Date(35 * 60 * 1000),
 		text: "Gold for Uganda",
-		url:
-			"https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
+		url: "https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy",
 	},
 ];
 
@@ -70,24 +61,25 @@ const KeyEventComp = (dark: boolean, theme: ArticleTheme, title: string) => (
 	</div>
 );
 
-const keyEventWithTheme = (dark: boolean) => () => (
-	<div
-		css={css`
-			display: flex;
-			flex-direction: row;
-			justify-content: space-between;
-			flex-wrap: wrap;
-		`}
-	>
-		{KeyEventComp(dark, ArticlePillar.News, "News")}
-		{KeyEventComp(dark, ArticlePillar.Culture, "Culture")}
-		{KeyEventComp(dark, ArticlePillar.Lifestyle, "Lifestyle")}
-		{KeyEventComp(dark, ArticlePillar.Opinion, "Opinion")}
-		{KeyEventComp(dark, ArticlePillar.Sport, "Sport")}
-		{KeyEventComp(dark, ArticleSpecial.Labs, "Labs")}
-		{KeyEventComp(dark, ArticleSpecial.SpecialReport, "SpecialReport")}
-	</div>
-);
+const keyEventWithTheme = (dark: boolean) => () =>
+	(
+		<div
+			css={css`
+				display: flex;
+				flex-direction: row;
+				justify-content: space-between;
+				flex-wrap: wrap;
+			`}
+		>
+			{KeyEventComp(dark, ArticlePillar.News, "News")}
+			{KeyEventComp(dark, ArticlePillar.Culture, "Culture")}
+			{KeyEventComp(dark, ArticlePillar.Lifestyle, "Lifestyle")}
+			{KeyEventComp(dark, ArticlePillar.Opinion, "Opinion")}
+			{KeyEventComp(dark, ArticlePillar.Sport, "Sport")}
+			{KeyEventComp(dark, ArticleSpecial.Labs, "Labs")}
+			{KeyEventComp(dark, ArticleSpecial.SpecialReport, "SpecialReport")}
+		</div>
+	);
 
 const Default = keyEventWithTheme(false);
 const Dark = keyEventWithTheme(true);

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -13,7 +13,7 @@ import {
 	opinion,
 } from "@guardian/src-foundations/palette";
 import { Link } from "@guardian/src-link";
-import { ArticlePillar, ArticleTheme } from "@guardian/libs";
+import { ArticlePillar, ArticleTheme, timeAgo } from "@guardian/libs";
 import { from } from "@guardian/src-foundations/mq";
 import { darkModeCss } from "../lib";
 import Accordion from "./accordion";
@@ -22,7 +22,7 @@ import Accordion from "./accordion";
 type paletteId = 300 | 400 | 500;
 
 interface KeyEvent {
-	time: string;
+	date: Date;
 	text: string;
 	url: string;
 }
@@ -144,7 +144,14 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 	return (
 		<li css={listItemStyles(supportsDarkMode)}>
 			<div css={timeTextWrapperStyles}>
-				<time css={timeStyles(supportsDarkMode)}>{keyEvent.time}</time>
+				<time
+					dateTime={keyEvent.date.toISOString()}
+					data-relativeformat="long"
+					title={keyEvent.date.toLocaleTimeString()}
+					css={timeStyles(supportsDarkMode)}
+				>
+					{timeAgo(keyEvent.date.getTime(), { verbose: true })}
+				</time>
 				<Link
 					priority="secondary"
 					css={textStyles(theme, supportsDarkMode)}

--- a/dotcom-rendering/src/web/components/KeyEventsContainer.test.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.test.tsx
@@ -22,8 +22,7 @@ describe('KeyEventsContainer', () => {
 				keyEvents={[
 					{
 						...baseProperties,
-						blockFirstPublishedDisplay:
-							'blockFirstPublishedDisplay',
+						blockFirstPublished: 1638279933000,
 						title: 'title',
 					},
 				]}
@@ -32,7 +31,7 @@ describe('KeyEventsContainer', () => {
 		expect(container).toHaveTextContent('title');
 	});
 
-	it('It should not render events without a blockFirstPublishedDisplay property', () => {
+	it('It should not render events without a blockFirstPublished property', () => {
 		const { container } = render(
 			<KeyEventsContainer
 				format={{
@@ -43,8 +42,7 @@ describe('KeyEventsContainer', () => {
 				keyEvents={[
 					{
 						...baseProperties,
-						blockFirstPublishedDisplay:
-							'blockFirstPublishedDisplay',
+						blockFirstPublished: 1638279933000,
 						title: 'title',
 					},
 					{ ...baseProperties, title: 'should not exist' },
@@ -66,17 +64,17 @@ describe('KeyEventsContainer', () => {
 				keyEvents={[
 					{
 						...baseProperties,
-						blockFirstPublishedDisplay: 'should exist',
+						blockFirstPublished: 1638279933000,
 						title: 'title',
 					},
 					{
 						...baseProperties,
-						blockFirstPublishedDisplay: 'should not exist',
+						blockFirstPublished: 1638279933000,
 					},
 				]}
 			/>,
 		);
 		expect(container).toHaveTextContent('title');
-		expect(container).not.toHaveTextContent('should not exist');
+		expect(container.getElementsByTagName('time')).toHaveLength(1);
 	});
 });

--- a/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
@@ -16,7 +16,7 @@ export const KeyEventsContainer = ({ keyEvents, format }: Props) => {
 			return {
 				text: keyEvent.title || '', // We fallback to '' here purely to keep ts happy
 				url: `?page=with:block-${keyEvent.id}#block-${keyEvent.id}`,
-				time: keyEvent.blockFirstPublishedDisplay || '', // We fallback to '' here purely to keep ts happy
+				date: new Date(keyEvent.blockFirstPublished || ''), // We fallback to '' here purely to keep ts happy
 			};
 		});
 

--- a/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const KeyEventsContainer = ({ keyEvents, format }: Props) => {
 	const transformedKeyEvents: KeyEvent[] = keyEvents
 		.filter((keyEvent) => {
-			return keyEvent.title && keyEvent.blockFirstPublishedDisplay;
+			return keyEvent.title && keyEvent.blockFirstPublished;
 		})
 		.map((keyEvent) => {
 			return {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces `time: string` with `date: Date` on `KeyEvents`

## Why?
So that we can use `timeAgo` to display the relative time and also setup the required attributes on this `time` element to keep it accessible and live. See: #3704 

### Before
<img width="547" alt="Screenshot 2021-11-30 at 13 35 43" src="https://user-images.githubusercontent.com/1336821/144057076-c7983c17-df7d-4fb6-b061-64ffe53467c4.png">



### After
<img width="539" alt="Screenshot 2021-11-30 at 13 17 36" src="https://user-images.githubusercontent.com/1336821/144054834-fbb5b72c-d07c-4c4c-805d-aca520d96a22.png">
