### PR TITLE
Create a new WazuhSecurityGroup with another name

### DIFF
--- a/apps-rendering/config/cloudformation.yaml
+++ b/apps-rendering/config/cloudformation.yaml
@@ -70,7 +70,7 @@ Parameters:
     Description: A security group id for editions backend preview lambda to access AR
   EditionsBackendPublishedLambdaSecurityGroupId:
     Type: String
-    Description: A security group id for editions backend published lambda to access AR    
+    Description: A security group id for editions backend published lambda to access AR
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -125,7 +125,7 @@ Resources:
         - FromPort: '443'
           IpProtocol: tcp
           ToPort: '443'
-          SourceSecurityGroupId: !Ref EditionsBackendPublishedLambdaSecurityGroupId      
+          SourceSecurityGroupId: !Ref EditionsBackendPublishedLambdaSecurityGroupId
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
   Listener:
@@ -317,6 +317,17 @@ Resources:
                 ToPort: 1515
                 CidrIp: 0.0.0.0/0
 
+  WazuhSecurityGroupNew:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+          GroupDescription: Allow outbound traffic from wazuh agent to manager
+          VpcId: !ImportValue MobileAppsApiVPC-VpcId
+          SecurityGroupEgress:
+              - IpProtocol: tcp
+                FromPort: 1514
+                ToPort: 1515
+                CidrIp: 0.0.0.0/0
+
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -328,7 +339,7 @@ Resources:
         - !Ref InstanceSecurityGroup
         - Fn::ImportValue: !Sub SecurityGroups-${Stage}-MapiGuardianLondonSSH
         - !Ref DefaultVpcSecurityGroup
-        - !Ref WazuhSecurityGroup
+        - !Ref WazuhSecurityGroupNew
       MetadataOptions:
           HttpTokens: required
       UserData:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

We found that there was name clash in the resource "WazuhSecurityGroupNew" between the GuCDK and the one Apps-rendering is currently using.  We cannot change the name of resources in GuCDK so we are changing the name of WazuhSecurityGroup currently used by Apps-rendering in two steps:

1) Create a new WazuhSecurityGroup with a new name "WazuhSecurityGroupNew"

2) After new instances are created with the new WazuhSecurityGroupNew, we remove the WazuhSecurityGroup (the one with the old name)

This PR is the step 1 

## Why?

To resolve the name clash

### Before

The WazuhSecurityGroup resource has the name WazuhSecurityGroup

### After

A new resource "WazuhSecurityGroupNew" is created and it is used in the launcher script instead of the "WazuhSecurityGroup".
