### PR TITLE
Remove the WazuhSecurityGroup (with the old name)

### DIFF
--- a/apps-rendering/config/cloudformation.yaml
+++ b/apps-rendering/config/cloudformation.yaml
@@ -306,17 +306,6 @@ Resources:
           ToPort: 3040
       VpcId: !ImportValue MobileAppsApiVPC-VpcId
 
-  WazuhSecurityGroup:
-      Type: AWS::EC2::SecurityGroup
-      Properties:
-          GroupDescription: Allow outbound traffic from wazuh agent to manager
-          VpcId: !ImportValue MobileAppsApiVPC-VpcId
-          SecurityGroupEgress:
-              - IpProtocol: tcp
-                FromPort: 1514
-                ToPort: 1515
-                CidrIp: 0.0.0.0/0
-
   WazuhSecurityGroupNew:
       Type: AWS::EC2::SecurityGroup
       Properties:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

We found that there was name clash in the resource "WazuhSecurityGroupNew" between the GuCDK and the one Apps-rendering is currently using. We cannot change the name of resources in GuCDK so we are changing the name of WazuhSecurityGroup currently used by Apps-rendering in two steps:

1) Create a new WazuhSecurityGroup with a new name "WazuhSecurityGroupNew"

2) After new instances are created with the new WazuhSecurityGroupNew, we remove the WazuhSecurityGroup (the one with the old name)

This PR is the step 2

## Why?

To resolve the name class

### Before

We have a WazuhSecurityGroup (with the old name) which is not referenced.  The WazuhSecurityGroupNew is being used.

### After

The WazuhSecurityGroup (old name) is removed.
