### PR TITLE
Listen for messages from the email embed in the footer

### DIFF
--- a/dotcom-rendering/src/web/browser/newsletterEmbedIframe/init.ts
+++ b/dotcom-rendering/src/web/browser/newsletterEmbedIframe/init.ts
@@ -5,7 +5,7 @@ type NewsletterHeightEventType = { source: { location: { href: string } } };
 
 const init = (): Promise<void> => {
 	const allIframes: HTMLIFrameElement[] = [].slice.call(
-		document.querySelectorAll('.email-sub__iframe'),
+		document.querySelectorAll('.email-sub__iframe, #footer__email-form'),
 	);
 
 	window.addEventListener('message', (event) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This enables the email embed in the footer to send messages via `iframeMessenger`

## Why?

So that it can resize (by sending `set-height`) itself

### Before

### After
