### PR TITLE
Move stories from layouts to their components

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -17,6 +17,7 @@ import { MainMedia } from './MainMedia';
 import { Standfirst } from './Standfirst';
 import { mainMediaElements } from './ArticleHeadline.mocks';
 import { decidePalette } from '../lib/decidePalette';
+import { ArticleHeadlinePadding } from './ArticleHeadlinePadding';
 
 export default {
 	component: ArticleHeadline,
@@ -686,3 +687,39 @@ export const DeadBlog = () => {
 	);
 };
 DeadBlog.story = { name: 'DeadBlog' };
+
+export const ReviewWithoutStars = () => {
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Review,
+		theme: ArticlePillar.Culture,
+	};
+	return (
+		<ElementContainer>
+			<Flex>
+				<LeftColumn borderType="full">
+					<></>
+				</LeftColumn>
+				<ArticleContainer format={format}>
+					<ArticleHeadlinePadding
+						design={format.design}
+						starRating={undefined}
+					>
+						<ArticleHeadline
+							headlineString="This is a Review headline."
+							palette={decidePalette(format)}
+							format={format}
+							tags={[]}
+							byline="Byline text"
+						/>
+					</ArticleHeadlinePadding>
+					<Standfirst
+						format={format}
+						standfirst="This is the standfirst text. We include here to demonstrate we have the correct amount of padding below the headline when there are no stars."
+					/>
+				</ArticleContainer>
+			</Flex>
+		</ElementContainer>
+	);
+};
+ReviewWithoutStars.story = { name: 'Review without stars' };

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -100,13 +100,6 @@ ArticleStory.story = {
 	},
 };
 
-export const ArticleWithNoBylineStory = (): React.ReactNode => {
-	const ServerCAPI = convertToImmersive(Article);
-	ServerCAPI.author.byline = '';
-	return <HydratedLayout ServerCAPI={ServerCAPI} />;
-};
-ArticleWithNoBylineStory.story = { name: 'Article with no byline' };
-
 export const ReviewStory = (): React.ReactNode => {
 	const ServerCAPI = convertToImmersive(Review);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -87,46 +87,11 @@ export const ArticleStory = (): React.ReactNode => {
 };
 ArticleStory.story = { name: 'Article' };
 
-export const ArticlePrintStory = (): React.ReactNode => {
-	const ServerCAPI = convertToStandard(Article);
-	return (
-		<HydratedLayout
-			ServerCAPI={ServerCAPI}
-			modifyPage={() => {
-				const styleTag = document.createElement('link');
-				styleTag.setAttribute('href', '/css/print.css');
-				styleTag.setAttribute('rel', 'stylesheet');
-				document.getElementById('root')?.prepend(styleTag);
-			}}
-		/>
-	);
-};
-ArticlePrintStory.story = {
-	name: 'Article Print',
-};
-
-ArticlePrintStory.parameters = {
-	viewport: {
-		defaultViewport: 'tablet',
-	},
-	chromatic: { viewports: [740] },
-};
-
 export const ReviewStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(Review);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 ReviewStory.story = { name: 'Review' };
-
-export const ReviewNoStarStory = (): React.ReactNode => {
-	const ReviewWithoutStars = {
-		...Review,
-		starRating: undefined,
-	};
-	const ServerCAPI = convertToStandard(ReviewWithoutStars);
-	return <HydratedLayout ServerCAPI={ServerCAPI} />;
-};
-ReviewNoStarStory.story = { name: 'Review without stars' };
 
 export const PrintShopStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(PrintShop);


### PR DESCRIPTION
Co-authored-by: Oliver Lloyd <oliver@oliverlloyd.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## Why?
This is the first PR in a series of Storybook refactoring / clean up / covering gaps PRs. The end goal is to recursively create one story for each design in every layout. This PR moves / removes stories from layouts that can be tested in components.

## What?
* Removes `ArticleWithNoBylineStory` from `Immersive.stories` --> There is already a story that covers this in `HeadlineByline`.
* Moves story `ReviewNoStarStory` from `Standard.stories` to `ArticleHeadline.stories`.
* Removes story `ArticlePrintStory` from `Standard.stories`. It was not working as expected, so a separate card was created   for this.
