### PR TITLE
Show liveblock share icons and last updated time below phablet breakpoints

### DIFF
--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -5,7 +5,6 @@ import { space, headline } from '@guardian/source-foundations';
 import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
-import { Hide } from '@root/src/web/components/Hide';
 import { ShareIcons } from '@root/src/web/components/ShareIcons';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
@@ -93,36 +92,30 @@ export const LiveBlock = ({
 					webTitle,
 				}),
 			)}
-			<div>
-				<Hide when="below" breakpoint="phablet">
-					<footer
-						css={css`
-							display: flex;
-							justify-content: space-between;
-						`}
-					>
-						<ShareIcons
-							pageId={pageId}
-							webTitle={webTitle}
-							displayIcons={['facebook', 'twitter']}
-							palette={palette}
-							format={format}
-							size="small"
-							context="LiveBlock"
+			<footer
+				css={css`
+					display: flex;
+					justify-content: space-between;
+				`}
+			>
+				<ShareIcons
+					pageId={pageId}
+					webTitle={webTitle}
+					displayIcons={['facebook', 'twitter']}
+					palette={palette}
+					format={format}
+					size="small"
+					context="LiveBlock"
+				/>
+				{showLastUpdated &&
+					block.blockLastUpdated &&
+					block.blockLastUpdatedDisplay && (
+						<LastUpdated
+							lastUpdated={block.blockLastUpdated}
+							lastUpdatedDisplay={block.blockLastUpdatedDisplay}
 						/>
-						{showLastUpdated &&
-							block.blockLastUpdated &&
-							block.blockLastUpdatedDisplay && (
-								<LastUpdated
-									lastUpdated={block.blockLastUpdated}
-									lastUpdatedDisplay={
-										block.blockLastUpdatedDisplay
-									}
-								/>
-							)}
-					</footer>
-				</Hide>
-			</div>
+					)}
+			</footer>
 		</LiveBlockContainer>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The live layout design includes share icons and the last updated time across all breakpoints. For web we should respect the design.

This change removes the hiding of share icons and lastUpdated time below phablet.

## Why?
To achieve parity with the design.

### Before
Below phablet liveblock share icons and last updated time are missing:
<img width="376" alt="Screenshot 2021-12-02 at 10 07 51" src="https://user-images.githubusercontent.com/45561419/144401266-a3847d87-42b2-40cb-9c71-a4b563ab0478.png">

### After
Below phablet liveblock share icons and last updated time are visible:
<img width="408" alt="Screenshot 2021-12-02 at 10 08 06" src="https://user-images.githubusercontent.com/45561419/144401321-2e1c1fdb-2fbf-4ba6-9bc8-c1b8391f5a30.png">
