### PR TITLE
Picture/Image Optimisations - Desktop immersive main-media  (Part 2/?)  

### DIFF
--- a/dotcom-rendering/docs/architecture/027-pictures.md
+++ b/dotcom-rendering/docs/architecture/027-pictures.md
@@ -142,7 +142,7 @@ For regular images, we'll loop through each breakpoint and pick an appropriate s
 
 Our largest breakpoint is 1300px, for a full-width image we then know we'd want a 1300px image. But what if we have a scren larger than that? Say 2000px? Even if we had a 2000px source available to us, we couldn't use it because our largest breakpoint was 1300px.
 
-The solution to this is that rather than looping through each breakpoint, and picking an appropriate image source, we can instead loop through each image source we have (provided by frontend) and use its own width as the breakpoints. This is what you can see in `landscapeImmersiveMainMediaSource` in `Picture.tsx` - by doing this we're taking advantage of the full range of images sources offered to us by Frontend, improving image quality available to larger displays.
+The solution to this is that rather than looping through each breakpoint, and picking an appropriate image source, we can instead loop through each image source we have (provided by frontend) and use its own width as the breakpoints. This is what you can see in `landscapeImmersiveMainMediaSource` in `Picture.tsx` - by doing this we're taking advantage of the full range of image sources offered to us by Frontend, improving image quality available to larger displays.
 
 #### Mobile / Portrait
 

--- a/dotcom-rendering/docs/architecture/027-pictures.md
+++ b/dotcom-rendering/docs/architecture/027-pictures.md
@@ -126,3 +126,24 @@ For Example:
     <img alt="The Palace Theatre, London, showing Harry Potter and the Cursed Child" src="https://i.guim.co.uk/img/media/picture.jpg?width=465&;quality=45&;auto=format&;fit=max&;dpr=2&;s=0492ab78e73c5167d8b4b841e601fbd4" height="1200" width="2000" class="dcr-b5pnrc-css">
 </picture>
 ```
+
+### Immersive Main Media
+
+Immersive main media gets special treatment for images ~ due to 2 unique qualities not found elsewhere in other images:
+
+1. Desktop full width - The images will always fill 100vw on all desktop breakpoints
+2. Portrait full height- On portrait devices, filling 100vh must be handled differently
+
+Each of these specific cases are not not handled optimally by the original solution handled above, however immserive main media images can often hold more value in content, as they're often the only thing on screen when an article loads, so getting them right is important.
+
+#### Desktop
+
+For regular images, we'll loop through each breakpoint and pick an appropriate source based on the desired width at that breakpoint. This works well on non-responsive (e.g fixed width images) because we know exactly what size image we want at each breakpoint. A side-effect of this is that we always use image sources which exist within the confines of our breakpoints, which can cause a problem for higher screen resolutions.
+
+Our largest breakpoint is 1300px, for a full-width image we then know we'd want a 1300px image. But what if we have a scren larger than that? Say 2000px? Even if we had a 2000px source available to us, we couldn't use it because our largest breakpoint was 1300px.
+
+The solution to this is that rather than looping through each breakpoint, and picking an appropriate image source, we can instead loop through each image source we have (provided by frontend) and use its own width as the breakpoints. This is what you can see in `landscapeImmersiveMainMediaSource` in `Picture.tsx` - by doing this we're taking advantage of the full range of images sources offered to us by Frontend, improving image quality available to larger displays.
+
+#### Mobile / Portrait
+
+Coming soon

--- a/dotcom-rendering/docs/architecture/027-pictures.md
+++ b/dotcom-rendering/docs/architecture/027-pictures.md
@@ -129,7 +129,7 @@ For Example:
 
 ### Immersive Main Media
 
-Immersive main media gets special treatment for images ~ due to 2 unique qualities not found elsewhere in other images:
+Immersive main media gets special treatment for images ~ due to 2 unique qualities:
 
 1. Desktop full width - The images will always fill 100vw on all desktop breakpoints
 2. Portrait full height- On portrait devices, filling 100vh must be handled differently

--- a/dotcom-rendering/docs/architecture/027-pictures.md
+++ b/dotcom-rendering/docs/architecture/027-pictures.md
@@ -134,7 +134,7 @@ Immersive main media gets special treatment for images ~ due to 2 unique qualiti
 1. Desktop full width - The images will always fill 100vw on all desktop breakpoints
 2. Portrait full height- On portrait devices, filling 100vh must be handled differently
 
-Each of these specific cases are not not handled optimally by the original solution handled above, however immserive main media images can often hold more value in content, as they're often the only thing on screen when an article loads, so getting them right is important.
+Each of these specific cases are not handled optimally by the original solution. However, immersive main media images often have more content value as they're sometimes the only thing on screen when an article loads, so getting them right is important.
 
 #### Desktop
 

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -117,9 +117,6 @@ const getDesiredWidthForBreakpoint = (
 	isMainMedia: boolean,
 	format: ArticleFormat,
 ): Pixel => {
-	if (format.display === ArticleDisplay.Immersive && isMainMedia)
-		return breakpoint;
-
 	if (
 		(format.display === ArticleDisplay.Showcase ||
 			format.display === ArticleDisplay.NumberedList) &&
@@ -181,7 +178,7 @@ const getSourceForDesiredWidth = (
 
 // Create sourcesets for portrait immersive
 // TODO: In a future PR this system will be updated to solve scaling issues with DPR
-const portraitImmersiveSource = (
+const portraitImmersiveMainMediaSource = (
 	sources: SrcSetItem[],
 	resolution: ResolutionType,
 ) => (
@@ -203,6 +200,41 @@ const portraitImmersiveSource = (
 			.join(',')}
 	/>
 );
+
+// Create sourcesets for landscape immersive
+const landscapeImmersiveMainMediaSource = (
+	sources: SrcSetItem[],
+	resolution: ResolutionType,
+) => {
+	const sortedSources = sources.slice().sort((a, b) => b.width - a.width);
+
+	const getMedia = (sourceWidth: number, isLast: boolean): string => {
+		const width = resolution === 'hdpi' ? sourceWidth / 2 : sourceWidth;
+		const breakpoint = isLast ? 0 : width;
+
+		return resolution === 'hdpi'
+			? `(min-width: ${breakpoint}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${breakpoint}px) and (min-resolution: 120dpi)`
+			: `(min-width: ${breakpoint}px)`;
+	};
+
+	return (
+		<>
+			{/* For immersive main media, images will always take up 100% of the screen width,
+				therefor it is more beneficial to loop through all the image sources, instead of the breakpoints.
+				This means that we are not limited to sources within the boundaries of the breakpoints, and can provide
+				more appropriately sized images where applicable. */}
+			{sortedSources.map((sourceSet, index) => (
+				<source
+					srcSet={`${sourceSet.src} ${sourceSet.width}w`}
+					media={getMedia(
+						sourceSet.width,
+						index === sortedSources.length - 1,
+					)}
+				/>
+			))}
+		</>
+	);
+};
 
 export const Picture = ({
 	imageSources,
@@ -252,39 +284,48 @@ export const Picture = ({
 	const desiredWidths: DesiredWidth[] =
 		removeRedundantWidths(allDesiredWidths);
 
+	const isImmersiveMainMedia =
+		format.display === ArticleDisplay.Immersive && isMainMedia;
+
 	return (
 		<picture itemProp="contentUrl">
-			{format.display === ArticleDisplay.Immersive && isMainMedia && (
+			{/* Rendering for Immersive Main Media! */}
+			{isImmersiveMainMedia && (
 				<>
-					{portraitImmersiveSource(hdpiSourceSets, 'hdpi')}
-					{portraitImmersiveSource(mdpiSourceSets, 'mdpi')}
+					{portraitImmersiveMainMediaSource(hdpiSourceSets, 'hdpi')}
+					{portraitImmersiveMainMediaSource(mdpiSourceSets, 'mdpi')}
+
+					{landscapeImmersiveMainMediaSource(hdpiSourceSets, 'hdpi')}
+					{landscapeImmersiveMainMediaSource(mdpiSourceSets, 'mdpi')}
 				</>
 			)}
 
-			{desiredWidths.map(({ breakpoint, width: desiredWidth }) => (
-				<>
-					{/* HDPI Source (DPR2) - images in this srcset have `dpr=2&quality=45` in the url */}
-					{hdpiSourceSets.length > 0 && (
+			{/* rendering for all other image types */}
+			{!isImmersiveMainMedia &&
+				desiredWidths.map(({ breakpoint, width: desiredWidth }) => (
+					<>
+						{/* HDPI Source (DPR2) - images in this srcset have `dpr=2&quality=45` in the url */}
+						{hdpiSourceSets.length > 0 && (
+							<source
+								srcSet={getSourceForDesiredWidth(
+									desiredWidth,
+									hdpiSourceSets,
+									'hdpi',
+								)}
+								media={`(min-width: ${breakpoint}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${breakpoint}px) and (min-resolution: 120dpi)`}
+							/>
+						)}
+						{/* MDPI Source - images in this srcset have `quality=85` in the url */}
 						<source
 							srcSet={getSourceForDesiredWidth(
 								desiredWidth,
-								hdpiSourceSets,
-								'hdpi',
+								mdpiSourceSets,
+								'mdpi',
 							)}
-							media={`(min-width: ${breakpoint}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${breakpoint}px) and (min-resolution: 120dpi)`}
+							media={`(min-width: ${breakpoint}px)`}
 						/>
-					)}
-					{/* MDPI Source - images in this srcset have `quality=85` in the url */}
-					<source
-						srcSet={getSourceForDesiredWidth(
-							desiredWidth,
-							mdpiSourceSets,
-							'mdpi',
-						)}
-						media={`(min-width: ${breakpoint}px)`}
-					/>
-				</>
-			))}
+					</>
+				))}
 
 			<img
 				alt={alt}

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -220,7 +220,7 @@ const landscapeImmersiveMainMediaSource = (
 	return (
 		<>
 			{/* For immersive main media, images will always take up 100% of the screen width,
-				therefor it is more beneficial to loop through all the image sources, instead of the breakpoints.
+				therefore it is more beneficial to loop through all the image sources, instead of the breakpoints.
 				This means that we are not limited to sources within the boundaries of the breakpoints, and can provide
 				more appropriately sized images where applicable. */}
 			{sortedSources.map((sourceSet, index) => (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9575458/144464185-0f4905e7-89fb-435b-ba6c-75f7462918f8.png)
## TL;DR 📚

The solution we used for solving "The DPR Problem" in #3641 (knowingly) introduced a regression in quality for Immersive Main Media on high resolution devices.

This PR introduces a new way of creating `<source />` elements for immersive main-media pictures to render source elements by their source-sets rather than by breakpoints. This prevents the resolutions of images available being limited to confines of our breakpoint range.

## The "Desktop immersive main-media" Problem  🖥

The "desktop main-media" problem is a regression in the quality of images on larger / high resolution desktop devices, due to how we now render sources.

Imagine we have an array of sources with the following sizes:
```[400px, 700px, 1000px, 1300px, 1900px]```

Previously, we'd place all of these sources within the `srcset` attribute, and allow the browser to pick the most appropriate image source. This was great in that it made all of our image sources available to the browser, but not so good in that it allowed the browser to use [DPR to select the wrong image
](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/architecture/027-pictures.md#the-dpr-problem).

The current solution, which solves the DPR problem, will only select 1 matching source per breakpoint. This works well for fixed size images, but not so well for dynamic images like immersive main media. Imagine our breakpoints look like:
```[320px, 660px, 980px, 1300px]```

When we're matching up breakpoints to sources for an immersive main media we get:
```js 
[
    // breakpoint : source
    320px: 400px,
    700px: 700px,
    980px: 1000px,
    1300px: 1300px
]
```

This works well, but what happened to our 1900px source? Since we only chose sources in the confines of our breakpoints, it gets lost.

The solution to this is then to skip the breakpoints entirely when an image is fully dynamic, and instead just loop over our sources to create the elements on the page:

```js
// before
sourcesMatchedToBreakpoints.map(sourceSet => <source ... >)

// after
ourSorces.map(sourceSet => <source ... >)
```

### Final Before & After
Before:
```html
<picture itemprop="contentUrl">
    /* Portrait immersive sources have been removed */
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1300&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 2600w" media="(min-width: 1300px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 1300px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1300&amp;quality=85&amp;auto=format&amp;fit=max 1300w" media="(min-width: 1300px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1140&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 2280w" media="(min-width: 1140px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 1140px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1140&amp;quality=85&amp;auto=format&amp;fit=max 1140w" media="(min-width: 1140px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=980&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 1960w" media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=980&amp;quality=85&amp;auto=format&amp;fit=max 980w" media="(min-width: 980px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=740&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 1480w" media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=740&amp;quality=85&amp;auto=format&amp;fit=max 740w" media="(min-width: 740px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=660&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 1320w" media="(min-width: 660px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 660px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=660&amp;quality=85&amp;auto=format&amp;fit=max 660w" media="(min-width: 660px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 960w" media="(min-width: 480px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 480px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=85&amp;auto=format&amp;fit=max 480w" media="(min-width: 480px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 960w" media="(min-width: 375px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 375px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=85&amp;auto=format&amp;fit=max 480w" media="(min-width: 375px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 960w" media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=85&amp;auto=format&amp;fit=max 480w" media="(min-width: 320px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2 960w" media="(min-width: 0px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 0px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=85&amp;auto=format&amp;fit=max 480w" media="(min-width: 0px)">
    <img alt=" ... " src="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2" height="1200" width="2000" class="dcr-1989ovb">
</picture>
```
After:
```html
<picture itemprop="contentUrl">
    /* Portrait immersive sources have been removed */
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1900&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  3800w" media="(min-width: 1900px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 1900px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1300&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  2600w" media="(min-width: 1300px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 1300px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1140&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  2280w" media="(min-width: 1140px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 1140px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=980&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  1960w" media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=740&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  1480w" media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=660&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  1320w" media="(min-width: 660px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 660px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2  960w" media="(min-width: 0px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 0px) and (min-resolution: 120dpi)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1900&amp;quality=85&amp;auto=format&amp;fit=max  1900w" media="(min-width: 1900px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1300&amp;quality=85&amp;auto=format&amp;fit=max  1300w" media="(min-width: 1300px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=1140&amp;quality=85&amp;auto=format&amp;fit=max  1140w" media="(min-width: 1140px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=980&amp;quality=85&amp;auto=format&amp;fit=max  980w" media="(min-width: 980px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=740&amp;quality=85&amp;auto=format&amp;fit=max  740w" media="(min-width: 740px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=660&amp;quality=85&amp;auto=format&amp;fit=max  660w" media="(min-width: 660px)">
    <source srcset="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=85&amp;auto=format&amp;fit=max  480w" media="(min-width: 0px)">
    <img alt=" ... " src="https://i.guim.co.uk/img/media/image/4383.jpg?width=480&amp;quality=45&amp;auto=format&amp;fit=max&amp;dpr=2&amp;s=c1403c3e36d19db989bbb0cb5ce76e7c" height="1200" width="2000" class="dcr-b5pnrc-css">
</picture>
```

