### PR TITLE
Refactor `document`

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -4,59 +4,58 @@ import 'jest-dom/extend-expect';
 import { WindowGuardianConfig } from '@root/src/model/window-guardian';
 
 const windowGuardianConfig = {
-    page: {
-        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-        sentryHost: 'app.getsentry.com/35463',
-        dcrSentryDsn:
-            'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-    },
+	page: {
+		sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+		sentryHost: 'app.getsentry.com/35463',
+		dcrSentryDsn:
+			'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+	},
 } as WindowGuardianConfig;
 
 const windowGuardian = {
-    app: {
-        data: {},
-        cssIDs: [],
-    },
-    config: windowGuardianConfig,
-    mustardCut: false,
-    polyfilled: false,
-    onPolyfilled: () => undefined,
-    queue: [],
-    ophan: {
-        setEventEmitter: () => null,
-        trackComponentAttention: () => null,
-        record: ({}: { [key: string]: any }) => null,
-        viewId: '',
-        pageViewId: '',
-    },
-    modules: {
-        sentry: {
-            reportError: (error: Error): void => {
-                // eslint-disable-next-line no-console
-                console.log(
-                    `Error: attempting to log error without having registered sentry.\nError is: ${error.message}`,
-                );
-            },
-        },
-    },
-    functions: {
-        import: (url: string) => import(url),
-    },
-    automat: {
-        react: undefined,
-        preact: undefined,
-        emotion: undefined,
-        emotionCore: undefined,
-        emotionTheming: undefined,
-    },
-    readerRevenue: {
-        changeGeolocation: () => {},
-        showMeTheEpic: () => {},
-        showMeTheBanner: () => {},
-        showNextVariant: () => {},
-        showPreviousVariant: () => {},
-    },
-    gaPath: "/assets/ga.js",
+	app: {
+		data: {},
+	},
+	config: windowGuardianConfig,
+	mustardCut: false,
+	polyfilled: false,
+	onPolyfilled: () => undefined,
+	queue: [],
+	ophan: {
+		setEventEmitter: () => null,
+		trackComponentAttention: () => null,
+		record: ({}: { [key: string]: any }) => null,
+		viewId: '',
+		pageViewId: '',
+	},
+	modules: {
+		sentry: {
+			reportError: (error: Error): void => {
+				// eslint-disable-next-line no-console
+				console.log(
+					`Error: attempting to log error without having registered sentry.\nError is: ${error.message}`,
+				);
+			},
+		},
+	},
+	functions: {
+		import: (url: string) => import(url),
+	},
+	automat: {
+		react: undefined,
+		preact: undefined,
+		emotion: undefined,
+		emotionCore: undefined,
+		emotionTheming: undefined,
+	},
+	readerRevenue: {
+		changeGeolocation: () => {},
+		showMeTheEpic: () => {},
+		showMeTheBanner: () => {},
+		showNextVariant: () => {},
+		showPreviousVariant: () => {},
+	},
+	gaPath: '/assets/ga.js',
 };
 
 // Stub global Guardian object
@@ -69,25 +68,25 @@ window.guardian = windowGuardian;
 // See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
 // eslint-disable-next-line func-names
 const localStorageMock = (function () {
-    let store: {
-        [key: string]: string;
-    } = {};
-    return {
-        getItem(key: string) {
-            return store[key] || null;
-        },
-        setItem(key: string, value: string) {
-            store[key] = value.toString();
-        },
-        removeItem(key: string) {
-            delete store[key];
-        },
-        clear() {
-            store = {};
-        },
-    };
+	let store: {
+		[key: string]: string;
+	} = {};
+	return {
+		getItem(key: string) {
+			return store[key] || null;
+		},
+		setItem(key: string, value: string) {
+			store[key] = value.toString();
+		},
+		removeItem(key: string) {
+			delete store[key];
+		},
+		clear() {
+			store = {};
+		},
+	};
 })();
 
 Object.defineProperty(window, 'localStorage', {
-    value: localStorageMock,
+	value: localStorageMock,
 });

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -223,7 +223,6 @@ export interface WindowGuardian {
 	// for performance reasons
 	app: {
 		data: DCRBrowserDocumentData;
-		cssIDs: string[];
 	};
 
 	// The 'config' attribute is derived from DCRServerDocumentData and contains
@@ -249,11 +248,9 @@ export const makeGuardianBrowserNav = (nav: NavType): BrowserNavType => {
 
 export const makeWindowGuardian = (
 	dcrDocumentData: DCRServerDocumentData,
-	cssIDs: string[],
 ): WindowGuardian => {
 	return {
 		app: {
-			cssIDs,
 			data: {
 				...dcrDocumentData,
 				NAV: makeGuardianBrowserNav(dcrDocumentData.NAV),

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -1,47 +1,41 @@
 import React, { StrictMode } from 'react';
-import { EmotionCache } from '@emotion/cache';
-import { CacheProvider, Global, css } from '@emotion/react';
+import { Global, css } from '@emotion/react';
 import { focusHalo } from '@guardian/source-foundations';
 import { SkipTo } from '../components/SkipTo';
 import { ArticleDesign } from '@guardian/libs';
 
 type Props = {
 	children: React.ReactNode;
-	cache: EmotionCache;
 	format: ArticleFormat;
 };
 
 /**
  * @description
- * Page is a high level wrapper for pages on Dotcom. Sets strict mode, some globals
- * and the Emotion cache
+ * Page is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
  * @param {ReactNode} children - What gets rendered on the page
- * @param {EmotionCache} cache - Provides the Emotion cache
  * @param {ArticleFormat} format - The format model for the article
  * */
-export const Page = ({ children, cache, format }: Props) => {
+export const Page = ({ children, format }: Props) => {
 	return (
-		<CacheProvider value={cache}>
-			<StrictMode>
-				<Global
-					styles={css`
-						/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-						/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-						*:focus {
-							${focusHalo}
-						}
-					`}
-				/>
-				<SkipTo id="maincontent" label="Skip to main content" />
-				<SkipTo id="navigation" label="Skip to navigation" />
-				{format.design === ArticleDesign.LiveBlog ||
-					(format.design === ArticleDesign.DeadBlog && (
-						<SkipTo id="keyevents" label="Skip to key events" />
-					))}
-				<div id="react-root"></div>
-				{children}
-			</StrictMode>
-		</CacheProvider>
+		<StrictMode>
+			<Global
+				styles={css`
+					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+					*:focus {
+						${focusHalo}
+					}
+				`}
+			/>
+			<SkipTo id="maincontent" label="Skip to main content" />
+			<SkipTo id="navigation" label="Skip to navigation" />
+			{format.design === ArticleDesign.LiveBlog ||
+				(format.design === ArticleDesign.DeadBlog && (
+					<SkipTo id="keyevents" label="Skip to key events" />
+				))}
+			<div id="react-root"></div>
+			{children}
+		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -1,11 +1,13 @@
-import React, { StrictMode } from 'react';
+import { StrictMode } from 'react';
 import { Global, css } from '@emotion/react';
 import { focusHalo } from '@guardian/source-foundations';
-import { SkipTo } from '../components/SkipTo';
 import { ArticleDesign } from '@guardian/libs';
+import { SkipTo } from '../components/SkipTo';
+import { DecideLayout } from '../layouts/DecideLayout';
 
 type Props = {
-	children: React.ReactNode;
+	CAPI: CAPIType;
+	NAV: NavType;
 	format: ArticleFormat;
 };
 
@@ -13,10 +15,11 @@ type Props = {
  * @description
  * Page is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
- * @param {ReactNode} children - What gets rendered on the page
+ * @param {CAPIType} CAPI - The article JSON data
+ * @param {NAVType} NAV - The article JSON data
  * @param {ArticleFormat} format - The format model for the article
  * */
-export const Page = ({ children, format }: Props) => {
+export const Page = ({ CAPI, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global
@@ -35,7 +38,7 @@ export const Page = ({ children, format }: Props) => {
 					<SkipTo id="keyevents" label="Skip to key events" />
 				))}
 			<div id="react-root"></div>
-			{children}
+			<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { Global, css } from '@emotion/react';
 import { focusHalo } from '@guardian/source-foundations';
 import { ArticleDesign } from '@guardian/libs';
-import { SkipTo } from '../components/SkipTo';
+import { SkipTo } from './SkipTo';
 import { DecideLayout } from '../layouts/DecideLayout';
 
 type Props = {
@@ -37,7 +37,7 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 				(format.design === ArticleDesign.DeadBlog && (
 					<SkipTo id="keyevents" label="Skip to key events" />
 				))}
-			<div id="react-root"></div>
+			<div id="react-root" />
 			<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
 		</StrictMode>
 	);

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -33,10 +33,10 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
-			{format.design === ArticleDesign.LiveBlog ||
-				(format.design === ArticleDesign.DeadBlog && (
-					<SkipTo id="keyevents" label="Skip to key events" />
-				))}
+			{(format.design === ArticleDesign.LiveBlog ||
+				format.design === ArticleDesign.DeadBlog) && (
+				<SkipTo id="keyevents" label="Skip to key events" />
+			)}
 			<div id="react-root" />
 			<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
 		</StrictMode>

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -2,10 +2,13 @@ import React, { StrictMode } from 'react';
 import { EmotionCache } from '@emotion/cache';
 import { CacheProvider, Global, css } from '@emotion/react';
 import { focusHalo } from '@guardian/source-foundations';
+import { SkipTo } from '../components/SkipTo';
+import { ArticleDesign } from '@guardian/libs';
 
 type Props = {
 	children: React.ReactNode;
 	cache: EmotionCache;
+	format: ArticleFormat;
 };
 
 /**
@@ -15,8 +18,9 @@ type Props = {
  *
  * @param {ReactNode} children - What gets rendered on the page
  * @param {EmotionCache} cache - Provides the Emotion cache
+ * @param {ArticleFormat} format - The format model for the article
  * */
-export const Page = ({ children, cache }: Props) => {
+export const Page = ({ children, cache, format }: Props) => {
 	return (
 		<CacheProvider value={cache}>
 			<StrictMode>
@@ -29,6 +33,13 @@ export const Page = ({ children, cache }: Props) => {
 						}
 					`}
 				/>
+				<SkipTo id="maincontent" label="Skip to main content" />
+				<SkipTo id="navigation" label="Skip to navigation" />
+				{format.design === ArticleDesign.LiveBlog ||
+					(format.design === ArticleDesign.DeadBlog && (
+						<SkipTo id="keyevents" label="Skip to key events" />
+					))}
+				<div id="react-root"></div>
 				{children}
 			</StrictMode>
 		</CacheProvider>

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -1,10 +1,7 @@
 import { ArticleDisplay, ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { decideTheme } from '@root/src/web/lib/decideTheme';
-import { decideDisplay } from '@root/src/web/lib/decideDisplay';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
-import { decideDesign } from '@root/src/web/lib/decideDesign';
 
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
@@ -17,23 +14,16 @@ import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
 type Props = {
 	CAPI: CAPIType;
 	NAV: NavType;
+	format: ArticleFormat;
 };
 
-export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
-	const display: ArticleDisplay = decideDisplay(CAPI.format);
-	const design: ArticleDesign = decideDesign(CAPI.format);
-	const theme: ArticlePillar = decideTheme(CAPI.format);
-	const format: ArticleFormat = {
-		display,
-		design,
-		theme,
-	};
+export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const palette = decidePalette(format);
 
 	// TODO we can probably better express this as data
-	switch (display) {
+	switch (format.display) {
 		case ArticleDisplay.Immersive: {
-			switch (design) {
+			switch (format.design) {
 				case ArticleDesign.Interactive: {
 					// Render all 'immersive interactives' until switchover date as 'FullPageInteractive'
 					// TBD: After 'immersive interactive' changes to CAPI are merged, add logic here to either use
@@ -61,7 +51,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 		}
 		case ArticleDisplay.NumberedList:
 		case ArticleDisplay.Showcase: {
-			switch (design) {
+			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 					return (
@@ -96,7 +86,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 		}
 		case ArticleDisplay.Standard:
 		default: {
-			switch (design) {
+			switch (format.design) {
 				case ArticleDesign.Interactive:
 					return (
 						<InteractiveLayout

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -6,6 +6,11 @@ import {
 	makeGuardianBrowserCAPI,
 	makeGuardianBrowserNav,
 } from '@root/src/model/window-guardian';
+
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+
 import { Article } from '@root/fixtures/generated/articles/Article';
 import { PhotoEssay } from '@root/fixtures/generated/articles/PhotoEssay';
 import { Review } from '@root/fixtures/generated/articles/Review';
@@ -70,6 +75,11 @@ const convertToImmersive = (CAPI: CAPIType) => ({
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
+	const format: ArticleFormat = {
+		display: decideDisplay(ServerCAPI.format),
+		design: decideDesign(ServerCAPI.format),
+		theme: decideTheme(ServerCAPI.format),
+	};
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		BootReact({ CAPI, NAV: makeGuardianBrowserNav(NAV) });
@@ -77,7 +87,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);
 	}, [ServerCAPI, NAV]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
+	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -4,6 +4,11 @@ import {
 	makeGuardianBrowserCAPI,
 	makeGuardianBrowserNav,
 } from '@root/src/model/window-guardian';
+
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+
 import { Article } from '@root/fixtures/generated/articles/Article';
 
 import { BootReact } from '@root/src/web/components/BootReact';
@@ -40,6 +45,11 @@ const convertToInteractiveImmersive = (CAPI: CAPIType) => {
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
+	const format: ArticleFormat = {
+		display: decideDisplay(ServerCAPI.format),
+		design: decideDesign(ServerCAPI.format),
+		theme: decideTheme(ServerCAPI.format),
+	};
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
@@ -48,7 +58,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);
 	}, [ServerCAPI, NAV]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
+	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -4,6 +4,11 @@ import {
 	makeGuardianBrowserCAPI,
 	makeGuardianBrowserNav,
 } from '@root/src/model/window-guardian';
+
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+
 import { Article } from '@root/fixtures/generated/articles/Article';
 import { PhotoEssay } from '@root/fixtures/generated/articles/PhotoEssay';
 import { Review } from '@root/fixtures/generated/articles/Review';
@@ -55,6 +60,11 @@ const convertToShowcase = (CAPI: CAPIType) => {
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
+	const format: ArticleFormat = {
+		display: decideDisplay(ServerCAPI.format),
+		design: decideDesign(ServerCAPI.format),
+		theme: decideTheme(ServerCAPI.format),
+	};
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
@@ -63,7 +73,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);
 	}, [ServerCAPI, NAV]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
+	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -6,6 +6,11 @@ import {
 	makeGuardianBrowserCAPI,
 	makeGuardianBrowserNav,
 } from '@root/src/model/window-guardian';
+
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+
 import { Article } from '@root/fixtures/generated/articles/Article';
 import { PhotoEssay } from '@root/fixtures/generated/articles/PhotoEssay';
 import { Review } from '@root/fixtures/generated/articles/Review';
@@ -67,6 +72,11 @@ const HydratedLayout = ({
 }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
+	const format: ArticleFormat = {
+		display: decideDisplay(ServerCAPI.format),
+		design: decideDesign(ServerCAPI.format),
+		theme: decideTheme(ServerCAPI.format),
+	};
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
@@ -78,7 +88,7 @@ const HydratedLayout = ({
 	if (modifyPage) {
 		modifyPage();
 	}
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
+	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -20,7 +20,6 @@ import {
 import { makeWindowGuardian } from '@root/src/model/window-guardian';
 import { ChunkExtractor } from '@loadable/server';
 import { ArticlePillar } from '@guardian/libs';
-import { DecideLayout } from '../layouts/DecideLayout';
 import { htmlTemplate } from './htmlTemplate';
 
 interface Props {
@@ -70,9 +69,7 @@ export const document = ({ data }: Props): string => {
 
 	const html = renderToString(
 		<CacheProvider value={cache}>
-			<Page format={format}>
-				<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
-			</Page>
+			<Page format={format} CAPI={CAPI} NAV={NAV} />
 		</CacheProvider>,
 	);
 

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -58,6 +58,7 @@ export const document = ({ data }: Props): string => {
 	const key = 'dcr';
 	const cache = createCache({ key });
 
+	// eslint-disable-next-line @typescript-eslint/unbound-method
 	const { extractCriticalToChunks, constructStyleTagsFromChunks } =
 		createEmotionServer(cache);
 

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -73,11 +73,7 @@ export const document = ({ data }: Props): string => {
 		theme: decideTheme(CAPI.format),
 	};
 
-	const {
-		html,
-		css: extractedCss,
-		ids: cssIDs,
-	}: RenderToStringResult = extractCritical(
+	const { html, css: extractedCss }: RenderToStringResult = extractCritical(
 		renderToString(
 			<Page cache={cache} format={format}>
 				<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
@@ -304,9 +300,7 @@ export const document = ({ data }: Props): string => {
 	 * We escape windowGuardian here to prevent errors when the data
 	 * is placed in a script tag on the page
 	 */
-	const windowGuardian = escapeData(
-		JSON.stringify(makeWindowGuardian(data, cssIDs)),
-	);
+	const windowGuardian = escapeData(JSON.stringify(makeWindowGuardian(data)));
 
 	const hasAmpInteractiveTag = CAPI.tags.some(
 		(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -19,9 +19,6 @@ export const htmlTemplate = ({
 	openGraphData,
 	twitterData,
 	keywords,
-	skipToMainContent,
-	skipToNavigation,
-	skipToKeyEvents,
 }: {
 	title?: string;
 	description: string;
@@ -38,9 +35,6 @@ export const htmlTemplate = ({
 	openGraphData: { [key: string]: string };
 	twitterData: { [key: string]: string };
 	keywords: string;
-	skipToMainContent: string;
-	skipToNavigation: string;
-	skipToKeyEvents?: string;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -291,10 +285,6 @@ https://workforus.theguardian.com/careers/product-engineering/
 			</head>
 
 			<body>
-				${skipToMainContent}
-				${skipToNavigation}
-				${skipToKeyEvents || ''}
-                <div id="react-root"></div>
                 ${html}
                 ${[...lowPriorityScriptTags].join('\n')}
             </body>

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -280,7 +280,8 @@ https://workforus.theguardian.com/careers/product-engineering/
                 ${loadableConfigScripts.join('\n')}
                 ${priorityScriptTags.join('\n')}
                 <style class="webfont">${getFontsCss()}</style>
-                <style>${resets.resetCSS}${css}</style>
+                <style>${resets.resetCSS}</style>
+				${css}
 				<link rel="stylesheet" media="print" href="${CDN}static/frontend/css/print.css">
 			</head>
 

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -2,65 +2,63 @@ import { WindowGuardianConfig } from '@root/src/model/window-guardian';
 import { ReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 
 declare global {
-    /* ~ Here, declare things that go in the global namespace, or augment
-     *~ existing declarations in the global namespace
-     */
-    interface Window {
-        guardian: {
-            app: {
-                data: {
-                    GA: { [key: string]: any }
-                    [key: string]: any
-                    CAPI: CAPIBrowserType
-                };
-                cssIDs: string[];
-
-            };
-            mustardCut: boolean;
-            polyfilled: boolean;
-            onPolyfilled: () => void;
-            queue: Array<() => void>;
-            config: WindowGuardianConfig;
-            ophan: {
-                setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
-                trackComponentAttention: (
-                    name: string,
-                    el: Element,
-                    visiblityThreshold: number,
-                ) => void;
-                record: ({}) => void;
-                viewId: string;
-                pageViewId: string;
-            };
-            modules: {
-                sentry: {
-                    reportError: (error: Error, feature: string) => void;
-                };
-            };
-            // TODO expose as type from Automat client lib
-            automat: {
-                react: any;
+	/* ~ Here, declare things that go in the global namespace, or augment
+	 *~ existing declarations in the global namespace
+	 */
+	interface Window {
+		guardian: {
+			app: {
+				data: {
+					GA: { [key: string]: any };
+					[key: string]: any;
+					CAPI: CAPIBrowserType;
+				};
+			};
+			mustardCut: boolean;
+			polyfilled: boolean;
+			onPolyfilled: () => void;
+			queue: Array<() => void>;
+			config: WindowGuardianConfig;
+			ophan: {
+				setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
+				trackComponentAttention: (
+					name: string,
+					el: Element,
+					visiblityThreshold: number,
+				) => void;
+				record: ({}) => void;
+				viewId: string;
+				pageViewId: string;
+			};
+			modules: {
+				sentry: {
+					reportError: (error: Error, feature: string) => void;
+				};
+			};
+			// TODO expose as type from Automat client lib
+			automat: {
+				react: any;
 				emotionReact: any;
 				emotionReactJsxRuntime: any;
-            };
-            readerRevenue: ReaderRevenueDevUtils;
-            gaPath:  string;
-        };
-        GoogleAnalyticsObject: string;
-        ga: UniversalAnalytics.ga | null;
-        /**
-         * ES6 module import, possibly polyfilled depending on the current
-         * browser. There are three categories:
-         *
-         * 1. Full support out of the box
-         * 2. ES6 module support but not dynamic modules
-         * 3. No module support
-         *
-         * This gives support across all 3 cases.
-         */
-        guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
-        Cypress: any; // for checking if running within cypress
-    }
+			};
+			readerRevenue: ReaderRevenueDevUtils;
+			gaPath: string;
+		};
+		GoogleAnalyticsObject: string;
+		ga: UniversalAnalytics.ga | null;
+		/**
+		 * ES6 module import, possibly polyfilled depending on the current
+		 * browser. There are three categories:
+		 *
+		 * 1. Full support out of the box
+		 * 2. ES6 module support but not dynamic modules
+		 * 3. No module support
+		 *
+		 * This gives support across all 3 cases.
+		 */
+		guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
+		Cypress: any; // for checking if running within cypress
+	}
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
 export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,7 +4520,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/serve-static@*", "@types/serve-static@^1.13.9":
+"@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This is a PR to refactor the way we server side render the page. This is mostly tidying up and moving things around.

- `Page` no longer takes `children`
- `Page` is responsible for `SkipTo` links
- Removed unused `ccsIDs`
- Refactored SSR using Emotion to follow recommendations

## Why?
We were using [an older method](https://emotion.sh/docs/ssr#when-using-emotioncss) for SSR with Emotion based on @emotion/css but now that we're using @emotion/react we can use the [recommended approach](https://emotion.sh/docs/ssr#when-using-emotionreact).

This allows us to remove the unused `cssIDs` property, reducing the bundle size, and also simplifies the code by aligning us with the standards for Emotion.

