### PR TITLE
Revert "Initial addition of MatchNavs and better placement of MatchTabs"

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -137,7 +137,6 @@ type Palette = {
 		carouselDotFocus: Colour;
 		headlineTag: Colour;
 		mostViewedTab: Colour;
-		matchNav: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -52,7 +52,6 @@ import {
 } from '@root/src/web/layouts/lib/stickiness';
 import { Hide } from '@guardian/source-react-components';
 import { Placeholder } from '../components/Placeholder';
-import { ContainerLayout } from '../components/ContainerLayout';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -161,31 +160,29 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'lines		 matchtabs'
-						'meta		 media'
-						'meta		 media'
-						'keyevents	 media'
-						'keyevents	 body'
-						'keyevents	 body'
-						'. 			 .';
+						'lines		media'
+						'meta		media'
+						'keyevents	media'
+						'keyevents	body'
+						'keyevents	body'
+						'. 			.';
 				}
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'lines 		 matchtabs right-column'
-						'meta  		 media     right-column'
-						'keyevents   media 	   right-column'
-						'keyevents   body      right-column'
-						'keyevents   body      right-column'
-						'.			 .         right-column';
+						'lines 		media right-column'
+						'meta  		media right-column'
+						'keyevents  media right-column'
+						'keyevents  body  right-column'
+						'keyevents  body  right-column'
+						'.			.     right-column';
 				}
 				/* until desktop define fixed body width */
 				${until.desktop} {
 					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
-						'matchtabs'
 						'media'
 						'lines'
 						'meta'
@@ -196,7 +193,6 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				${until.tablet} {
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'matchtabs'
 						'media'
 						'lines'
 						'meta'
@@ -399,12 +395,13 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 
 			<main>
 				<article>
-					{CAPI.matchUrl ? (
-						<ContainerLayout
-							showTopBorder={false}
-							backgroundColour={palette.background.matchNav}
-							borderColour={palette.border.headline}
-							leftContent={
+					<ElementContainer
+						showTopBorder={false}
+						backgroundColour={palette.background.header}
+						borderColour={palette.border.headline}
+					>
+						<HeadlineGrid>
+							<GridItem area="title">
 								<ArticleTitle
 									format={format}
 									palette={palette}
@@ -414,91 +411,51 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									guardianBaseURL={CAPI.guardianBaseURL}
 									badge={CAPI.badge}
 								/>
-							}
-							leftColSize="wide"
-							sideBorders={true}
-							padContent={false}
-							verticalMargins={false}
-						>
-							<Hide above="leftCol">
-								<ArticleTitle
-									format={format}
-									palette={palette}
-									tags={CAPI.tags}
-									sectionLabel={CAPI.sectionLabel}
-									sectionUrl={CAPI.sectionUrl}
-									guardianBaseURL={CAPI.guardianBaseURL}
-									badge={CAPI.badge}
-								/>
-							</Hide>
-							<Placeholder
-								shouldShimmer={false}
-								rootId="match-nav"
-								height={230}
-							/>
-						</ContainerLayout>
-					) : (
-						<ElementContainer
-							showTopBorder={false}
-							backgroundColour={palette.background.header}
-							borderColour={palette.border.headline}
-						>
-							<HeadlineGrid>
-								<GridItem area="title">
-									<ArticleTitle
-										format={format}
-										palette={palette}
-										tags={CAPI.tags}
-										sectionLabel={CAPI.sectionLabel}
-										sectionUrl={CAPI.sectionUrl}
-										guardianBaseURL={CAPI.guardianBaseURL}
-										badge={CAPI.badge}
+							</GridItem>
+							<GridItem area="headline">
+								{CAPI.matchUrl && showMatchTabs && (
+									<Placeholder
+										rootId="match-tabs"
+										height={40}
 									/>
-								</GridItem>
-								<GridItem area="headline">
-									<div css={maxWidth}>
-										<ArticleHeadlinePadding
-											design={format.design}
-										>
-											{age && (
-												<div css={ageWarningMargins}>
-													<AgeWarning age={age} />
-												</div>
-											)}
-											{!CAPI.matchUrl && (
-												<ArticleHeadline
-													format={format}
-													headlineString={
-														CAPI.headline
-													}
-													tags={CAPI.tags}
-													byline={CAPI.author.byline}
-													palette={palette}
-												/>
-											)}
-											{age && (
-												<AgeWarning
-													age={age}
-													isScreenReader={true}
-												/>
-											)}
-										</ArticleHeadlinePadding>
-									</div>
-									{CAPI.starRating ||
-									CAPI.starRating === 0 ? (
-										<div css={starWrapper}>
-											<StarRating
-												rating={CAPI.starRating}
-												size="large"
+								)}
+								<div css={maxWidth}>
+									<ArticleHeadlinePadding
+										design={format.design}
+									>
+										{age && (
+											<div css={ageWarningMargins}>
+												<AgeWarning age={age} />
+											</div>
+										)}
+										<ArticleHeadline
+											format={format}
+											headlineString={CAPI.headline}
+											tags={CAPI.tags}
+											byline={CAPI.author.byline}
+											palette={palette}
+										/>
+										{age && (
+											<AgeWarning
+												age={age}
+												isScreenReader={true}
 											/>
-										</div>
-									) : (
-										<></>
-									)}
-								</GridItem>
-							</HeadlineGrid>
-						</ElementContainer>
-					)}
+										)}
+									</ArticleHeadlinePadding>
+								</div>
+								{CAPI.starRating || CAPI.starRating === 0 ? (
+									<div css={starWrapper}>
+										<StarRating
+											rating={CAPI.starRating}
+											size="large"
+										/>
+									</div>
+								) : (
+									<></>
+								)}
+							</GridItem>
+						</HeadlineGrid>
+					</ElementContainer>
 
 					<ElementContainer
 						showTopBorder={false}
@@ -575,16 +532,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						borderColour={palette.border.article}
 					>
 						<LiveGrid>
-							<GridItem area="matchtabs" element="aside">
-								<div css={maxWidth}>
-									{CAPI.matchUrl && showMatchTabs && (
-										<Placeholder
-											rootId="match-tabs"
-											height={40}
-										/>
-									)}
-								</div>
-							</GridItem>
 							<GridItem area="media">
 								<div css={maxWidth}>
 									<MainMedia

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -657,10 +657,6 @@ const activeMatchTab = (): string => {
 	return sport[300];
 };
 
-const backgroundMatchNav = (): string => {
-	return brandAlt[400];
-};
-
 const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -884,7 +880,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			carouselDotFocus: backgroundCarouselDotFocus(format),
 			headlineTag: backgroundHeadlineTag(format),
 			mostViewedTab: backgroundMostViewedTab(format),
-			matchNav: backgroundMatchNav(),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3679

It adds additional spacing to deadblogs

<img width="1141" alt="Screenshot 2021-12-06 at 13 03 05" src="https://user-images.githubusercontent.com/35331926/144853705-a8b3c427-7303-4165-99af-41b33b48fdd5.png">


