### PR TITLE
Fixed width for comment ad element

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -301,6 +301,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							css`
 								position: sticky;
 								top: 0;
+								width: 300px;
 							`,
 							adStyles,
 						]}


### PR DESCRIPTION
This addresses one half of an issue documented [here](https://trello.com/c/LgxmPnuH/1665-large-cls-jumps-raised-by-user-help) in which refreshed ads cause [cumulative layout shift](https://web.dev/cls/). Because the ad slot beside comments did not have a fixed height, if the new ad had different dimensions to the previous one that would change the width of the whole slot, which in turn changed the width of the comment section.

As shown below, giving the `dfp-ad--comments` element a fixed width of 300px, its size remains consistent regardless of the dimensions of the ad inside it. 

![image](https://user-images.githubusercontent.com/11380557/145192881-b204729f-e4f7-4884-a257-e31b8ddc37eb.png)

![image](https://user-images.githubusercontent.com/11380557/145193587-ff9851d4-449d-41f0-8349-311707ddadb1.png)

![image](https://user-images.githubusercontent.com/11380557/145193631-392385b2-3d0b-409a-b8b9-1cc32269a8f1.png)
