### PR TITLE
upgrade commercial-core

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -47,7 +47,7 @@
     "@guardian/atoms-rendering": "^22.1.1",
     "@guardian/automat-contributions": "^0.4.3",
     "@guardian/braze-components": "^5.0.0-0",
-    "@guardian/commercial-core": "^0.31.0",
+    "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "~6.11.5",
     "@guardian/discussion-rendering": "^9.0.0",
     "@guardian/libs": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,10 +2264,10 @@
   resolved "https://registry.npmjs.org/@guardian/braze-components/-/braze-components-5.0.0-0.tgz#d2406b55448d6090e957a59fbe7d294f321c3075"
   integrity sha512-0rBJQwjtJxtoQjsO3wJvEH+L/y9kqb+A6pu+VmaDHysA0EsHlTfIhGXf9BSCzPjS4S2grj7lYYA/d8qrlvr0Cw==
 
-"@guardian/commercial-core@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.31.0.tgz#fdcc7aea80b1cbde125fdb493f56c10df916e373"
-  integrity sha512-4ePq0hB+kEr2G7Dd8jqDUwDYSxDmwWf940Bewufk9lqQ2Iml5x30/0LCrxOWHy3jfh9qV9NEumUYtZW0nR6eUw==
+"@guardian/commercial-core@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.32.0.tgz#c6cbbd2072e59ac75e0f511e87b26dd762fac3dd"
+  integrity sha512-wPEPy7m2lAk3anNWJl1LjOnE55SDzkbbUKWUuxSA7QoJRdkSr5s0lexnKnANa7wLNiZGcoepoIiqftj1xacuWQ==
 
 "@guardian/consent-management-platform@~6.11.5":
   version "6.11.5"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Upgrades commercial core library to version 0.32.0
The same change on frontend pr is https://github.com/guardian/frontend/pull/24475

## Why?
[v0.32.0](https://github.com/guardian/commercial-core/compare/v0.31.0...v0.32.0) includes a change making eventTimer.mark a private method, enforcing the use of eventTimer.trigger
