### PR TITLE
Add border to bottom of Container

### DIFF
--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -29,7 +29,7 @@ const LiveBlockContainer = ({
 					padding: ${space[2]}px ${SIDE_MARGIN}px;
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
-				border-bottom: inset;
+				border-bottom: 1px solid ${neutral[86]};
 			`}
 		>
 			{children}

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -29,6 +29,7 @@ const LiveBlockContainer = ({
 					padding: ${space[2]}px ${SIDE_MARGIN}px;
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
+				border-bottom: inset;
 			`}
 		>
 			{children}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a border to the bottom of a deadblog container to maintain parity.

### Before

<img width="884" alt="Screenshot 2021-12-08 at 12 36 03" src="https://user-images.githubusercontent.com/35331926/145210207-f1a53b87-37ee-4042-bf5e-a05844fc8767.png">

### After

<img width="884" alt="Screenshot 2021-12-09 at 09 40 31" src="https://user-images.githubusercontent.com/35331926/145372098-b0f39d97-8ace-4538-9698-0a05452e04ec.png">


