### PR TITLE
Add highlighting of underline on hover

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -171,7 +171,7 @@ type Palette = {
 	hover: {
 		headlineByline: Colour;
 		pagination: Colour;
-		liveBlogStandfirst: Colour;
+		standfirstLink: Colour;
 	};
 };
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -171,6 +171,7 @@ type Palette = {
 	hover: {
 		headlineByline: Colour;
 		pagination: Colour;
+		liveBlogStandfirst: Colour;
 	};
 };
 

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -146,11 +146,6 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
 						color: ${palette.text.standfirst};
-
-						a:hover {
-							border-bottom: solid 1px
-								${palette.hover.standfirstLink};
-						}
 					`;
 				default:
 					switch (format.theme) {
@@ -163,9 +158,6 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 								a {
 									color: ${neutral[7]};
 									border-bottom: 1px solid ${neutral[60]};
-								}
-								a:hover {
-									border-bottom: 1px solid ${neutral[7]};
 								}
 							`;
 						default:
@@ -184,13 +176,25 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 	}
 };
 
+const hoverStyles = (palette: Palette) => {
+	return css`
+		a:hover {
+			border-bottom: solid 1px ${palette.hover.standfirstLink};
+		}
+	`;
+};
+
 export const Standfirst = ({ format, standfirst }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
 		<div
 			data-print-layout="hide"
-			css={[nestedStyles(palette), standfirstStyles(format, palette)]}
+			css={[
+				nestedStyles(palette),
+				standfirstStyles(format, palette),
+				hoverStyles(palette),
+			]}
 			className={
 				format.design === ArticleDesign.Interactive
 					? interactiveLegacyClasses.standFirst

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -148,8 +148,8 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						color: ${palette.text.standfirst};
 
 						a:hover {
-							border-bottom: solid 0.0625rem
-								${palette.hover.liveBlogStandfirst};
+							border-bottom: solid 1px
+								${palette.hover.standfirstLink};
 						}
 					`;
 				default:

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -146,6 +146,11 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
 						color: ${palette.text.standfirst};
+
+						a:hover {
+							border-bottom: solid 0.0625rem
+								${palette.hover.liveBlogStandfirst};
+						}
 					`;
 				default:
 					switch (format.theme) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -686,7 +686,7 @@ const textRichLink: (format: ArticleFormat) => string = (format) => {
 	return pillarPalette[ArticlePillar.News][400];
 };
 
-const hoverLiveblog = (format: ArticleFormat): string => {
+const hoverStandfirstLink = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].main;
 };
 
@@ -922,7 +922,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 		hover: {
 			headlineByline: hoverHeadlineByline(format),
 			pagination: hoverPagination(format),
-			standfirstLink: hoverLiveblog(format),
+			standfirstLink: hoverStandfirstLink(format),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -687,7 +687,14 @@ const textRichLink: (format: ArticleFormat) => string = (format) => {
 };
 
 const hoverStandfirstLink = (format: ArticleFormat): string => {
-	return pillarPalette[format.theme].main;
+	if (format.design === ArticleDesign.DeadBlog)
+		return pillarPalette[format.theme].main;
+	if (format.design === ArticleDesign.LiveBlog) {
+		return pillarPalette[format.theme].dark;
+	}
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return specialReport[400];
+	return border.secondary;
 };
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -686,6 +686,13 @@ const textRichLink: (format: ArticleFormat) => string = (format) => {
 	return pillarPalette[ArticlePillar.News][400];
 };
 
+const hoverLiveblog = (format: ArticleFormat): string => {
+	if (format) {
+		return pillarPalette[format.theme].main;
+	}
+	return pillarPalette[ArticlePillar.News][400];
+};
+
 const borderRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
 		return pillarPalette[format.theme].main;
@@ -918,6 +925,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 		hover: {
 			headlineByline: hoverHeadlineByline(format),
 			pagination: hoverPagination(format),
+			liveBlogStandfirst: hoverLiveblog(format),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -687,10 +687,7 @@ const textRichLink: (format: ArticleFormat) => string = (format) => {
 };
 
 const hoverLiveblog = (format: ArticleFormat): string => {
-	if (format) {
-		return pillarPalette[format.theme].main;
-	}
-	return pillarPalette[ArticlePillar.News][400];
+	return pillarPalette[format.theme].main;
 };
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {
@@ -925,7 +922,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 		hover: {
 			headlineByline: hoverHeadlineByline(format),
 			pagination: hoverPagination(format),
-			liveBlogStandfirst: hoverLiveblog(format),
+			standfirstLink: hoverLiveblog(format),
 		},
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds colour to the standfirst links when hovered to maintain parity.

### Before

<img width="884" alt="Screenshot 2021-12-08 at 13 13 31" src="https://user-images.githubusercontent.com/35331926/145214804-93457750-3fae-4a34-8c32-a4572f2b5b2d.png">

### After

<img width="884" alt="Screenshot 2021-12-08 at 13 13 40" src="https://user-images.githubusercontent.com/35331926/145214837-0c286790-48cc-4fe7-9dda-9d6b4a75ddb0.png">

