### PR TITLE
chore: Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,37 @@
+## We're hiring!
+
+Ever thought about joining us?
+[https://workforus.theguardian.com/careers/product-engineering/](https://workforus.theguardian.com/careers/product-engineering/)
+
 # Dotcom/Apps Rendering
 
-This repository has become a monorepo containing dotcom-rendering and apps-rendering as separate applications. The purpose of the monorepo is to make it easier for the two projects to share code and reduce duplication. The projects are swimlaned for fault isolation, and share the same node version.
+This repository contains the rendering logic for articles on theguardian.com. It is a monorepo with 3 projects, `apps-rendering`, `common-rendering` and `dotcom-rendering`.
 
 You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `npm run watch` for apps-rendering) except for storybook. Linting, imports, builds and github actions should work as before.
 
-<!-- TEMPORARY : This section is just here as an initial guide for the first few days post-migration -->
+## `apps rendering`
 
-## Storybook
+Go to [apps rendering](apps-rendering/README.md) for more details.
 
-While most DCR scripts should be run from within the `dotcom-rendering` subdirectory, storybook remains at the root of the project. So make sure you're _not_ in a subdirectory before running `yarn storybook` or `yarn build-storybook` as before.
+## `dotcom rendering`
 
-## Quick start
+Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
+
+## `common rendering`
+
+Go to [apps rendering](common-rendering/README.md) for more details.
+
+## Root actions
+
+Most commands are run from within each project but the following are managed from the monorepo root:
+
+### Storybook/Chromatic
+
+`yarn storybook` - Runs Storybook for all projects
+`yarn build-storybook` - Builds Storybook for all projects
+`yarn chromatic` - Builds and uploads Chromatic snapshots for all projects\*
+
+-   You need the `CHROMATIC_PROJECT_TOKEN` environment variable set. You can find the token (here)[https://www.chromatic.com/manage?appId=5dfcbf3012392c0020e7140b&view=configure]
 
 ### Install Node.js
 
@@ -20,37 +41,4 @@ We recommend using [nvm](https://github.com/creationix/nvm) (especially combined
 
 ### Install Packages
 
-run `yarn` in the root directory of this project to install packages for `dotcom-rendering`, `apps-rendering` (currently post-install), and `common-rendering`.
-
-### dotcom rendering
-
-Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
-
-### apps rendering
-
-Go to [apps rendering](apps-rendering/README.md) for more details.
-
-## Using yarn workspaces
-
-> Note: This is only being used for dotcom-rendering and common-rendering, not apps-rendering
-
-When updating, adding, or removing packages for a specific sub-project (e.g dotcom-rendering), it should be done with the `yarn workspace` command in the root directory.
-
-Some examples (all run in root directory)
-
-```
-# General usage
-yarn workspace <package name> <yarn command> < ... ags >
-# <package name> should be the "name" specified in the package.json, not the subdirectory name, e.g @guardian/common-rendering, or @guardian/dotcom-rendering
-
-# e.g
-
-# Add a package
-yarn workspace @guardian/dotcom-rendering add my-new-package
-
-# Remove a package
-yarn workspace @guardian/dotcom-rendering remove my-new-package
-
-# Update a package
-yarn workspace @guardian/dotcom-rendering upgrade my-new-package
-```
+Run `yarn` in the root directory of this project to install packages

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -6,22 +6,22 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Dotcom Rendering](#dotcom-rendering)
-  - [Quick start](#quick-start)
-    - [Install Node.js](#install-nodejs)
-    - [Running instructions](#running-instructions)
-    - [Detailed Setup](#detailed-setup)
-    - [Technologies](#technologies)
-    - [Architecture Diagram](#architecture-diagram)
-    - [Concepts](#concepts)
-    - [Feedback](#feedback)
-  - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
-  - [Code Quality](#code-quality)
-    - [Snyk Code Scanning](#snyk-code-scanning)
-  - [IDE setup](#ide-setup)
-    - [Extensions](#extensions)
-    - [Auto fix on save](#auto-fix-on-save)
-  - [Thanks](#thanks)
+-   [Dotcom Rendering](#dotcom-rendering)
+    -   [Quick start](#quick-start)
+        -   [Install Node.js](#install-nodejs)
+        -   [Running instructions](#running-instructions)
+        -   [Detailed Setup](#detailed-setup)
+        -   [Technologies](#technologies)
+        -   [Architecture Diagram](#architecture-diagram)
+        -   [Concepts](#concepts)
+        -   [Feedback](#feedback)
+    -   [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+    -   [Code Quality](#code-quality)
+        -   [Snyk Code Scanning](#snyk-code-scanning)
+    -   [IDE setup](#ide-setup)
+        -   [Extensions](#extensions)
+        -   [Auto fix on save](#auto-fix-on-save)
+    -   [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -37,15 +37,17 @@ We recommend using [nvm](https://github.com/creationix/nvm) (especially combined
 
 ### Running instructions
 
-Clone the repo, then CD into the `dotcom-rendering` subdirectory before running any commands -
+Clone the repo, run `yarn` in the root, then CD into the `dotcom-rendering` subdirectory -
 
 ```
 $ git clone git@github.com:guardian/dotcom-rendering.git
+$ yarn install
 $ cd dotcom-rendering/dotcom-rendering
 $ make dev
 ```
 
 `make dev` will start the development server on port 3030: [http://localhost:3030](http://localhost:3030).
+`make build && make start` will start the production server on port 9000: [http://localhost:9000](http://localhost:9000).
 
 Visit the [root path of the dev server](http://localhost:3030) for some example URLs to visit.
 
@@ -54,7 +56,6 @@ You can render a specific article by [specifying the production URL in the query
 You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to
 
 http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey
-
 
 ### Detailed Setup
 
@@ -93,7 +94,6 @@ There are some concepts to learn, that will make working with Dotcom Rendering c
 
 After completing this setup guide, we would greatly appreciate it if you could complete our [dotcom-rendering setup
 questionnaire](https://docs.google.com/forms/d/e/1FAIpQLSdwFc05qejwW_Gtl3pyW4N22KqmY5zXoDKAUAjrkOwb2uXNcQ/viewform?vc=0&c=0&w=1). It should only take 3 minutes and will help us improve this documentation and the setup process in the future. Thank you! 🙏
-
 
 ## Where can I see Dotcom Rendering in Production?
 
@@ -134,6 +134,7 @@ See [the makefile](https://github.com/guardian/dotcom-rendering/blob/main/makefi
 [Read about testing tools and testing strategy](docs/testing.md).
 
 ### Snyk Code Scanning
+
 There's a Github action set up on the repository to scan for vulnerabilities. This is set to "continue on error" and so will show a green tick regardless. In order to check the vulnerabilities we can use the Github code scanning feature in the security tab and this will list all vulnerabilities for a given branch etc. You should use this if adding/removing/updating packages to see if there are any vulnerabilities.
 
 ## IDE setup
@@ -160,10 +161,10 @@ We recommend you update your workspace settings to automatically fix formatting 
 
 If you prefer not to use an editor like VSCode then you can use the following commands to manage formatting:
 
-- `yarn prettier:check` &rarr; Checks for prettier issues
-- `yarn prettier:fix` &rarr; Checks and fixes prettier issues
-- `yarn lint` &rarr; Checks for linting issues
-- `yarn lint --fix` &rarr; Checks and fixes linting issues
+-   `yarn prettier:check` &rarr; Checks for prettier issues
+-   `yarn prettier:fix` &rarr; Checks and fixes prettier issues
+-   `yarn lint` &rarr; Checks for linting issues
+-   `yarn lint --fix` &rarr; Checks and fixes linting issues
 
 ## Thanks
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes some changes to our READMEs

## Why?
To better reflect recent updates to the production build and the monorepo
