### PR TITLE
feat: Add another legacy interactive class for the count icons container

### DIFF
--- a/dotcom-rendering/docs/contracts/003-extra-classes-for-interactives.md
+++ b/dotcom-rendering/docs/contracts/003-extra-classes-for-interactives.md
@@ -4,10 +4,11 @@
 
 We have added extra classes to the standfirst and main meta sections of the interactives layout:
 
-- Standfirst: class class `content__standfirst` applied to the div that contains the standfirst paragraph.
-- Meta container: class `content__meta_container_dcr` applied to the div that contains the article meta. Note that the class name in frontend (`content__meta_container`) comes with extra horizontal lines which is duplicated in DCR. The the slight name change avoids this duplication.
-- Byline: class `byline` applied to the div that contains the authors of the article.
-- Share icons: class `meta__social` applied to the div that contains the list of share icons.
+-   Standfirst: class class `content__standfirst` applied to the div that contains the standfirst paragraph.
+-   Meta container: class `content__meta_container_dcr` applied to the div that contains the article meta. Note that the class name in frontend (`content__meta_container`) comes with extra horizontal lines which is duplicated in DCR. The the slight name change avoids this duplication.
+-   Byline: class `byline` applied to the div that contains the authors of the article.
+-   Share icons: class `meta__social` applied to the div that contains the list of share icons.
+-   Share and Comment counts: class `meta__comment` applied to the div that contains the share and comment counts.
 
 We have not included classes on all grid elements, only on those identified as most useful when customising interactives.
 

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -389,7 +389,7 @@ export const ArticleMeta = ({
 					<div
 						className={
 							isInteractive
-								? interactiveLegacyClasses.countIcons
+								? interactiveLegacyClasses.shareAndCommentCounts
 								: ''
 						}
 						css={[

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -361,7 +361,14 @@ export const ArticleMeta = ({
 							context="ArticleMeta"
 						/>
 					</div>
-					<div css={metaNumbers(palette)}>
+					<div
+						className={
+							isInteractive
+								? interactiveLegacyClasses.countIcons
+								: ''
+						}
+						css={metaNumbers(palette)}
+					>
 						<Counts>
 							{/* The meta-number css is needed by Counts.tsx */}
 							<div

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -35,6 +35,7 @@ export const interactiveLegacyClasses = {
 	standFirst: 'content__standfirst',
 	byline: 'byline',
 	shareIcons: 'meta__social',
+	countIcons: 'meta__comment',
 
 	// some legacy interactives do not use the content--interactive container
 	// to ensure all editorial content has correct font, we need to target this too

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -35,7 +35,7 @@ export const interactiveLegacyClasses = {
 	standFirst: 'content__standfirst',
 	byline: 'byline',
 	shareIcons: 'meta__social',
-	countIcons: 'meta__comment',
+	shareAndCommentCounts: 'meta__comment',
 
 	// some legacy interactives do not use the content--interactive container
 	// to ensure all editorial content has correct font, we need to target this too


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `interactiveLegacyClasses.countIcons`

## Why?
So the css that lives inside the legacy interactive templates can access the count icons inside `ArticleMeta` and applying styles to them.

Yes, I agree. This is creating a brittle code coupling between two very separate codebases and is likely to cause issues if anyone wants to refactor the layout of these components in the future. If that person is you, and if you are struggling to maintain this contract, then consider pressing the interactive content or asking the Visuals team to revisit their strategy.

Example: https://www.theguardian.com/books/ng-interactive/2021/dec/08/the-best-books-of-2021
