### PR TITLE
Reintroduce server-side tests in config

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -688,6 +688,11 @@ interface CommercialConfigType {
 	ampIframeUrl: string;
 }
 
+type ServerSideTests = {
+    [k: `${string}Variant`]: "variant";
+    [k: `${string}Control`]: "control";
+};
+
 /**
  * the config model will contain useful app/site
  * level data. Although currently derived from the config model
@@ -700,7 +705,7 @@ interface ConfigType extends CommercialConfigType {
 	sentryHost: string;
 	dcrSentryDsn: string;
 	switches: { [key: string]: boolean };
-	abTests: Record<string, 'control' | 'variant'>;
+	abTests: ServerSideTests;
 	dfpAccountId: string;
 	commercialBundleUrl: string;
 	revisionNumber: string;

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -23,7 +23,7 @@ export interface WindowGuardianConfig {
 		googletag: string;
 	};
 	switches: { [key: string]: boolean };
-	tests?: { [key: string]: string };
+	tests: ServerSideTests;
 	ophan: {
 		pageViewId: string;
 		browserId: string;
@@ -58,6 +58,7 @@ const makeWindowGuardianConfig = (
 			googletag: config.googletagUrl,
 		},
 		switches: config.switches,
+		tests: config.abTests,
 		ophan: {
 			pageViewId: '',
 			browserId: '',


### PR DESCRIPTION
## What does this change?

Reintroduce server side tests location on the config object. Adds a narrower type, which ensures correct usage.

## Why?

We need parity between `frontend` and DCR. It was removed in df58cd0, without fanfare.

### Before

`window.guardian.config.tests` is `undefined`

### After

`window.guardian.config.tests` is `{}`
