### PR TITLE
Refactor `<ContributionSlot>`

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -7,7 +7,6 @@ import { MostViewedFooter } from '@frontend/web/components/MostViewed/MostViewed
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { SlotBodyEnd } from '@root/src/web/components/SlotBodyEnd/SlotBodyEnd';
 import { Links } from '@frontend/web/components/Links';
-import { WhenAdBlockInUse } from '@frontend/web/components/WhenAdBlockInUse';
 import { ContributionSlot } from '@frontend/web/components/ContributionSlot';
 import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 import { GetMatchNav } from '@frontend/web/components/GetMatchNav';
@@ -804,15 +803,13 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 				Note. We specifically say isSignedIn === false so that we prevent render until the cookie has been
 				checked to avoid flashing this content
 			*/}
-			{!CAPI.shouldHideReaderRevenue &&
-				!CAPI.pageType.isPaidContent &&
-				isSignedIn === false && (
-					<WhenAdBlockInUse>
-						<Portal rootId="top-right-ad-slot">
-							<ContributionSlot />
-						</Portal>
-					</WhenAdBlockInUse>
-				)}
+
+			<Portal rootId="top-right-ad-slot">
+				<ContributionSlot
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isPaidContent={CAPI.pageType.isPaidContent}
+				/>
+			</Portal>
 			{richLinks.map((richLink, index) => (
 				<Portal rootId={richLink.elementId}>
 					<RichLinkComponent

--- a/dotcom-rendering/src/web/components/ContributionSlot.tsx
+++ b/dotcom-rendering/src/web/components/ContributionSlot.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react';
+import { getCookie } from '@guardian/libs';
+import { WhenAdBlockInUse } from '@frontend/web/components/WhenAdBlockInUse';
 
 const params = new URLSearchParams();
 params.set(
@@ -12,23 +14,34 @@ params.set(
 );
 params.set('INTCMP', 'shady_pie_open_2019');
 
-export const ContributionSlot = () => {
+export const ContributionSlot = ({
+	shouldHideReaderRevenue,
+	isPaidContent,
+}: {
+	shouldHideReaderRevenue: boolean;
+	isPaidContent: boolean;
+}) => {
+	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
+	if (isPaidContent || shouldHideReaderRevenue || isSignedIn) return null;
+
 	return (
-		<div
-			css={css`
-				position: sticky;
-				top: 0;
-			`}
-		>
-			<a
-				href={`https://support.theguardian.com/uk/subscribe/digital?${params.toString()}`}
+		<WhenAdBlockInUse>
+			<div
+				css={css`
+					position: sticky;
+					top: 0;
+				`}
 			>
-				<img
-					src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png"
-					width="300"
-					alt=""
-				/>
-			</a>
-		</div>
+				<a
+					href={`https://support.theguardian.com/uk/subscribe/digital?${params.toString()}`}
+				>
+					<img
+						src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png"
+						width="300"
+						alt=""
+					/>
+				</a>
+			</div>
+		</WhenAdBlockInUse>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR moves the decision logic for when to show the `ContributionSlot` away from `App.tsx` and down inside the component instead.

## Why?
This is part of a wider effort to remove global state from `App.tsx`. See [this document](https://docs.google.com/document/d/1kSrZZrJ8hSw6bek5hGa9onE8QDz5TRHFqHV52EOFjts/edit#heading=h.gsod33a0pc47) for more details on this.

This refactor also creates a more declarative pattern, given the component the information it needs to make choices, rather than imperatively telling it what to do