### PR TITLE
Refactor `buildBrazeMessages`

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -306,10 +306,8 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	}, [CAPI.shouldHideReaderRevenue]);
 
 	useOnce(() => {
-		setBrazeMessages(
-			buildBrazeMessages(isSignedIn as boolean, CAPI.config.idApiUrl),
-		);
-	}, [isSignedIn, CAPI.config.idApiUrl]);
+		setBrazeMessages(buildBrazeMessages(CAPI.config.idApiUrl));
+	}, [CAPI.config.idApiUrl]);
 
 	const display: ArticleDisplay = decideDisplay(CAPI.format);
 	const design: ArticleDesign = decideDesign(CAPI.format);

--- a/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
+++ b/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
@@ -11,7 +11,7 @@ import {
 	LocalMessageCache,
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
-import { log, storage } from '@guardian/libs';
+import { getCookie, log, storage } from '@guardian/libs';
 import { checkBrazeDependencies } from './checkBrazeDependencies';
 import { getInitialisedAppboy } from './initialiseAppboy';
 
@@ -42,9 +42,10 @@ const maybeWipeUserData = async (
 };
 
 export const buildBrazeMessages = async (
-	isSignedIn: boolean,
 	idApiUrl: string,
 ): Promise<BrazeMessagesInterface> => {
+	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
+
 	if (!storage.local.isAvailable()) {
 		return new NullBrazeMessages();
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR removes the `isSignedIn` parameter from the `buildBrazeMessages` function, preferring the function to look this value up itself.

## Why?
This is part of a wider effort to remove global state from `App.tsx`. See [this document](https://docs.google.com/document/d/1kSrZZrJ8hSw6bek5hGa9onE8QDz5TRHFqHV52EOFjts/edit#heading=h.gsod33a0pc47) for more details on this.