### PR TITLE
Add sticky key events for apps rendering live layout

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -62,6 +62,14 @@ const metadataWrapperStyles = css`
 	background-color: ${news[200]};
 `;
 
+const keyEventsWrapperStyles = css`
+	${from.desktop} {
+		position: sticky;
+		top: 10px;
+		margin-bottom: 12px;
+	}
+`;
+
 const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
 	blocks.reduce<KeyEvent[]>(
 		(events, block) =>
@@ -92,11 +100,13 @@ const Live: FC<Props> = ({ item }) => (
 				</div>
 			</GridItem>
 			<GridItem area="key-events">
-				<KeyEvents
-					keyEvents={keyEvents(item.blocks)}
-					theme={item.theme}
-					supportsDarkMode
-				/>
+				<div css={keyEventsWrapperStyles}>
+					<KeyEvents
+						keyEvents={keyEvents(item.blocks)}
+						theme={item.theme}
+						supportsDarkMode
+					/>
+				</div>
 			</GridItem>
 			<GridItem area="main-media">
 				<HeaderMedia item={item} />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Make key events sticky for key events on AR live layout

## Why?

Parity with designs & dcr

### Before
![image](https://user-images.githubusercontent.com/9575458/145558987-15aa7f2c-87ed-47f1-b891-061d0f3de160.png)


### After
![image](https://user-images.githubusercontent.com/9575458/145559047-cc3183ed-2a4d-4b62-9786-91a048e3cd4c.png)

