### PR TITLE
Move liveblock header into common-rendering

### DIFF
--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -1,13 +1,10 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
 import { LastUpdated } from '@guardian/common-rendering/src/components/LastUpdated';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { headline, remSpace } from '@guardian/source-foundations';
 import { OptionKind, partition } from '@guardian/types';
-import { maybeRender } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { renderAll } from 'renderer';
@@ -18,23 +15,6 @@ interface LiveBlocksProps {
 	format: ArticleFormat;
 }
 
-interface BlockTitleProps {
-	title: string;
-}
-
-const BlockTitle: FC<BlockTitleProps> = ({ title }) => {
-	return (
-		<h2
-			css={css`
-				${headline.xxsmall({ fontWeight: 'bold' })}
-				margin-bottom: ${remSpace[2]}px;
-			`}
-		>
-			{title}
-		</h2>
-	);
-};
-
 const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 	return (
 		<>
@@ -43,33 +23,19 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 			{blocks.map((block) => {
 				// TODO: get page number
 				const blockLink = `${1}#block-${block.id}`;
+				const blockFirstPublished = block.firstPublished.kind === OptionKind.Some
+					? Number(block.firstPublished.value)
+					: undefined;
 
 				return (
 					<LiveBlockContainer
 						key={block.id}
 						id={block.id}
 						borderColour="black"
+						blockTitle={block.title}
+						blockFirstPublished={blockFirstPublished}
+						blockLink={blockLink}
 					>
-						<header
-							css={css`
-								padding-right: ${remSpace[3]}px;
-								display: flex;
-								flex-direction: column;
-							`}
-						>
-							{maybeRender(
-								block.firstPublished,
-								(firstPublished) => (
-									<FirstPublished
-										firstPublished={Number(firstPublished)}
-										blockLink={blockLink}
-									/>
-								),
-							)}
-							{block.title !== '' ? (
-								<BlockTitle title={block.title} />
-							) : null}
-						</header>
 
 						{renderAll(format, partition(block.body).oks)}
 

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -4,7 +4,8 @@ import { css } from '@emotion/react';
 import { LastUpdated } from '@guardian/common-rendering/src/components/LastUpdated';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { OptionKind, partition } from '@guardian/types';
+import { map, OptionKind, partition } from '@guardian/types';
+import { pipe, toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { renderAll } from 'renderer';
@@ -23,9 +24,11 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 			{blocks.map((block) => {
 				// TODO: get page number
 				const blockLink = `${1}#block-${block.id}`;
-				const blockFirstPublished = block.firstPublished.kind === OptionKind.Some
-					? Number(block.firstPublished.value)
-					: undefined;
+				const blockFirstPublished = pipe(
+					block.firstPublished,
+					map(Number),
+					toNullable,
+				);
 
 				return (
 					<LiveBlockContainer
@@ -36,7 +39,6 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 						blockFirstPublished={blockFirstPublished}
 						blockLink={blockLink}
 					>
-
 						{renderAll(format, partition(block.body).oks)}
 
 						<footer

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -134,6 +134,9 @@ const fold =
 		return withDefault(ifNone)(map(f)(opt));
 	};
 
+const toNullable = <A>(opt: Option<A>): A | undefined =>
+	withDefault<A | undefined>(undefined)(opt);
+
 // ----- Exports ----- //
 
 export {
@@ -155,4 +158,5 @@ export {
 	resultMap3,
 	resultToNullable,
 	fold,
+	toNullable,
 };

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { neutral, from, space, remSpace, headline } from '@guardian/source-foundations';
+import { neutral, from, space, headline } from '@guardian/source-foundations';
 import { FirstPublished } from './FirstPublished';
 
 const LEFT_MARGIN_DESKTOP = 60;
@@ -10,7 +10,7 @@ const Header = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<header
 			css={css`
-				padding-right: ${remSpace[3]};
+				padding-right: ${space[3]}px;
 				display: flex;
 				flex-direction: column;
 			`}
@@ -25,7 +25,7 @@ const BlockTitle = ({ title }: { title: string }) => {
 		<h2
 			css={css`
 				${headline.xxsmall({ fontWeight: 'bold' })}
-				margin-bottom: ${remSpace[2]};
+				margin-bottom: ${space[2]}px;
 			`}
 		>
 			{title}
@@ -53,12 +53,12 @@ const LiveBlockContainer = ({
 			id={`block-${id}`}
 			key={id}
 			css={css`
-				padding: ${remSpace[2]} ${SIDE_MARGIN_MOBILE}px;
-				margin-bottom: ${remSpace[3]};
+				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
+				margin-bottom: ${space[3]}px;
 				background: ${neutral[100]};
 				border-top: 1px solid ${borderColour};
 				${from.tablet} {
-					padding: ${remSpace[2]} ${SIDE_MARGIN}px;
+					padding: ${space[2]}px ${SIDE_MARGIN}px;
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
 			`}

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
-import { neutral, from, remSpace, headline } from '@guardian/source-foundations';
+import { neutral, from, space, remSpace, headline } from '@guardian/source-foundations';
 import { FirstPublished } from './FirstPublished';
 
 const LEFT_MARGIN_DESKTOP = 60;
-const SIDE_MARGIN = remSpace[5];
+const SIDE_MARGIN = space[5];
 const SIDE_MARGIN_MOBILE = 10;
 
 const Header = ({ children }: { children: React.ReactNode }) => {

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,36 +1,77 @@
 import { css } from "@emotion/react";
-
-import { from } from "@guardian/source-foundations";
-import { neutral, space } from "@guardian/source-foundations";
+import { neutral, from, remSpace, headline } from '@guardian/source-foundations';
+import { FirstPublished } from './FirstPublished';
 
 const LEFT_MARGIN_DESKTOP = 60;
-const SIDE_MARGIN = space[5];
+const SIDE_MARGIN = remSpace[5];
 const SIDE_MARGIN_MOBILE = 10;
+
+const Header = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<header
+			css={css`
+				padding-right: ${remSpace[3]};
+				display: flex;
+				flex-direction: column;
+			`}
+		>
+			{children}
+		</header>
+	);
+};
+
+const BlockTitle = ({ title }: { title: string }) => {
+	return (
+		<h2
+			css={css`
+				${headline.xxsmall({ fontWeight: 'bold' })}
+				margin-bottom: ${remSpace[2]};
+			`}
+		>
+			{title}
+		</h2>
+	);
+};
 
 const LiveBlockContainer = ({
 	id,
 	children,
 	borderColour,
+	blockTitle,
+	blockFirstPublished,
+	blockLink,
 }: {
 	id: string;
 	children: React.ReactNode;
 	borderColour: string;
+	blockTitle?: string;
+	blockFirstPublished?: number;
+	blockLink: string;
 }) => {
 	return (
 		<article
 			id={`block-${id}`}
 			key={id}
 			css={css`
-				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
-				margin-bottom: ${space[3]}px;
+				padding: ${remSpace[2]} ${SIDE_MARGIN_MOBILE}px;
+				margin-bottom: ${remSpace[3]};
 				background: ${neutral[100]};
 				border-top: 1px solid ${borderColour};
 				${from.tablet} {
-					padding: ${space[2]}px ${SIDE_MARGIN}px;
+					padding: ${remSpace[2]} ${SIDE_MARGIN}px;
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
 			`}
 		>
+			<Header>
+				{blockFirstPublished && (
+					<FirstPublished
+						firstPublished={blockFirstPublished}
+						blockLink={blockLink}
+					/>
+				)}
+				{blockTitle ? <BlockTitle title={blockTitle} /> : null}
+			</Header>
 			{children}
 		</article>
 	);

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,13 +1,10 @@
 import { css } from '@emotion/react';
 
-import { space, headline } from '@guardian/source-foundations';
-
 import { renderArticleElement } from '@root/src/web/lib/renderElement';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { ShareIcons } from '@root/src/web/components/ShareIcons';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
-import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
 import { LastUpdated } from '@guardian/common-rendering/src/components/LastUpdated';
 
 type Props = {
@@ -17,33 +14,6 @@ type Props = {
 	webTitle: string;
 	adTargeting: AdTargeting;
 	host?: string;
-};
-
-const Header = ({ children }: { children: React.ReactNode }) => {
-	return (
-		<header
-			css={css`
-				padding-right: ${space[3]}px;
-				display: flex;
-				flex-direction: column;
-			`}
-		>
-			{children}
-		</header>
-	);
-};
-
-const BlockTitle = ({ title }: { title: string }) => {
-	return (
-		<h2
-			css={css`
-				${headline.xxsmall({ fontWeight: 'bold' })}
-				margin-bottom: ${space[2]}px;
-			`}
-		>
-			{title}
-		</h2>
-	);
 };
 
 export const LiveBlock = ({
@@ -69,16 +39,10 @@ export const LiveBlock = ({
 		<LiveBlockContainer
 			id={block.id}
 			borderColour={palette.border.liveBlock}
+			blockTitle={block.title}
+			blockFirstPublished={block.blockFirstPublished}
+			blockLink={blockLink}
 		>
-			<Header>
-				{block.blockFirstPublished && (
-					<FirstPublished
-						firstPublished={block.blockFirstPublished}
-						blockLink={blockLink}
-					/>
-				)}
-				{block.title && <BlockTitle title={block.title} />}
-			</Header>
 			{block.elements.map((element, index) =>
 				renderArticleElement({
 					format,


### PR DESCRIPTION
## What does this change?
This moves the header that was in the dotcom-rendering LiveBlock component into the common-rendering LiveBlockContainer component, so the header can be shared between AR and DCR.

## Why?
So we can share components between the two projects and reduce the maintenance cost.

[Trello card](https://trello.com/c/hwXjOTe0/387-lp-000%C6%92%CB%99-or-the-artist-formerly-known-as-move-liveblock-header-into-common-rendering)