### PR TITLE
fix: Remove duplicate declaration

### DIFF
--- a/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
+++ b/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
@@ -44,11 +44,11 @@ const maybeWipeUserData = async (
 export const buildBrazeMessages = async (
 	idApiUrl: string,
 ): Promise<BrazeMessagesInterface> => {
-	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
-
 	if (!storage.local.isAvailable()) {
 		return new NullBrazeMessages();
 	}
+
+	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
 
 	const dependenciesResult = await checkBrazeDependencies(
 		isSignedIn,

--- a/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
+++ b/dotcom-rendering/src/web/lib/braze/buildBrazeMessages.ts
@@ -50,8 +50,6 @@ export const buildBrazeMessages = async (
 		return new NullBrazeMessages();
 	}
 
-	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
-
 	const dependenciesResult = await checkBrazeDependencies(
 		isSignedIn,
 		idApiUrl,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes a duplicate declartion for `isSignedIn` in `buildBrazeMessages`

## Why?
Because it shouldn't be there! I have no idea how this got onto `main`. I am guessing it happened during a merge somewhere but in theory that shouldn't be possible as this code fails various code checks
