### PR TITLE
Upgrades SBT version to 1.5.6

### DIFF
--- a/apps-rendering/.gitignore
+++ b/apps-rendering/.gitignore
@@ -12,6 +12,10 @@ node_modules
 .vscode/*
 !.vscode/extensions.json
 .metals/
+.bloop/
+project/.bloop/
+project/metals.sbt
+.bsp/
 
 # System files
 .DS_Store

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.4-SNAPSHOT"
+ThisBuild / version := "0.11.4-SNAPSHOT"

--- a/apps-rendering/build.sbt
+++ b/apps-rendering/build.sbt
@@ -28,9 +28,9 @@ lazy val scalaApiModels = project.in(file("api-models") / "scala")
     name := "apps-rendering-api-models",
     description := "Models used by the apps-rendering API",
 
-    scroogeLanguages in Compile := Seq("scala"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftDependencies in Compile ++= scroogeDependencies,
+	Compile / scroogeLanguages := Seq("scala"),
+	Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+	Compile / scroogeThriftDependencies ++= scroogeDependencies,
 
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.12.0",
@@ -80,9 +80,9 @@ lazy val tsApiModels = project.in(file("api-models") / "ts")
     description := "Models used by the apps-rendering API",
 
     scroogeTypescriptPackageLicense := "Apache-2.0",
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeLanguages in Compile := Seq("typescript"),
-    scroogeThriftDependencies in Compile ++= scroogeDependencies,
+	Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+	Compile / scroogeLanguages := Seq("typescript"),
+	Compile / scroogeThriftDependencies ++= scroogeDependencies,
 
     scroogeTypescriptPackageMapping := Map(
       "content-api-models" -> "@guardian/content-api-models",

--- a/apps-rendering/project/build.properties
+++ b/apps-rendering/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.9
+sbt.version = 1.5.6

--- a/apps-rendering/project/plugins.sbt
+++ b/apps-rendering/project/plugins.sbt
@@ -7,3 +7,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
+
+addDependencyTreePlugin
+

--- a/apps-rendering/version.sbt
+++ b/apps-rendering/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+ThisBuild / version := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Upgrades the SBT version used by the Scala project within apps-rendering

## Why?

Addresses [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) in Log4j. SBT version [1.5.6](https://github.com/sbt/sbt/releases/tag/v1.5.6) fixes this.

### Before
`sbt.version = 1.3.9`

### After
`sbt.version = 1.5.6`