### PR TITLE
feat: Reduce the length of the relative time string for key events

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -146,7 +146,7 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 			<div css={timeTextWrapperStyles}>
 				<time
 					dateTime={keyEvent.date.toISOString()}
-					data-relativeformat="long"
+					data-relativeformat="med"
 					title={keyEvent.date.toLocaleTimeString()}
 					css={timeStyles(supportsDarkMode)}
 				>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces `long` with `med` for the `time` element used on key events. This means the relative string shown will be formatted as '2ms ago' instead of '2 minutes ago'

### Before
<img width="229" alt="Screenshot 2021-12-14 at 15 03 57" src="https://user-images.githubusercontent.com/1336821/146023953-2606cb45-2b9c-4832-8439-3a4f39483bed.png">


### After
<img width="229" alt="Screenshot 2021-12-14 at 15 01 38" src="https://user-images.githubusercontent.com/1336821/146023503-c427b7c3-f7e3-4ef8-abfc-2cb701730e82.png">

