### PR TITLE
fix: Don't hide standfirst in print view

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -189,7 +189,6 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 
 	return (
 		<div
-			data-print-layout="hide"
 			css={[
 				nestedStyles(palette),
 				standfirstStyles(format, palette),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We [removed the standfirst from the print view previously](https://github.com/guardian/dotcom-rendering/pull/2234) but it's part of the article and should be included so this PR ensures that it appears


| BEFORE | AFTER |
|--------|-------|
| <img width="631" alt="Screenshot 2021-12-15 at 13 20 58" src="https://user-images.githubusercontent.com/1336821/146194086-2e56e5c5-3f2c-4c27-8966-546cc55dc645.png">   | <img width="631" alt="Screenshot 2021-12-15 at 13 25 52" src="https://user-images.githubusercontent.com/1336821/146194746-0dc28807-9989-40a7-b8a2-ea37dcb4c95f.png">  |
