### PR TITLE
Update to Ophan v1.3.29 to fix Attention Time clock-update susceptibility

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -98,7 +98,7 @@
     "log4js": "6.3.0",
     "minify-css-string": "^1.0.0",
     "node-fetch": "2.6.1",
-    "ophan-tracker-js": "^1.3.28",
+    "ophan-tracker-js": "^1.3.29",
     "pm2": "5.0.0",
     "prettier-eslint": "^11.0.0",
     "pretty-bytes": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14386,10 +14386,10 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-ophan-tracker-js@^1.3.28:
-  version "1.3.28"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.28.tgz#52d24a03a507dc491b0c27f2ded51b1ad44bae8b"
-  integrity sha512-1azFLoS1MS1mUX3+LN/MR0tkYqJd+PHByf5AkHsfoNxKz0O+G5L92x7AGdTfPvNiQZ0BCO1qhMoLyRo1OgNMSA==
+ophan-tracker-js@^1.3.29:
+  version "1.3.29"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.29.tgz#db211a121065173ebf45c1250d57768898f49cbb"
+  integrity sha512-PQ9iKiZ5hegavEzviZbrjCBHPYFMNKpyqyi49elD0Ehlt9Aeh75Yr8IM2GoP7iMS3nmtVjhMCmYNL8xSMCh7sQ==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
## What does this change?

Ophan Tracker JS [v1.3.29](https://www.npmjs.com/package/ophan-tracker-js/v/1.3.29) introduces just one change: https://github.com/guardian/ophan/pull/4358. This switches Tracker JS to using `performance.now()` in preference to `new Date().getTime()` for calculating Attention Time durations.

## Why?

This should stop a major source of _negative_ Attention Times (as well as fix many Attention Times that are incorrect but not _obviously_ so) - the wrong Attention Time being reported when the user's system time is updated _while_ they're viewing the page.

### Before & After

*  browser on the left ⬅️  ...shows current production Ophan Tracker JS running on the live site, when the system time is updated, we see an incorrect **negative** Attention Time at time position 13s.
* browser on the right ➡️  ...shows a local copy of [DCR](https://github.com/guardian/dotcom-rendering/) running with this PR's the updated Tracker JS. When the system time is updated, the attention time is recorded **correctly**

https://user-images.githubusercontent.com/52038/145476925-87c9812a-0293-4d6f-8b2c-c0d48d1d77d7.mov