### PR TITLE
Fix banner geolocation targeting

### DIFF
--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -206,7 +206,7 @@ export const StickyBottomBanner = ({
 	idApiUrl,
 	switches,
 }: Props) => {
-	const asyncCountryCode = getLocaleCode;
+	const asyncCountryCode = getLocaleCode();
 	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	const signInGateWillShow = useSignInGateWillShow({
@@ -221,7 +221,7 @@ export const StickyBottomBanner = ({
 		const CMP = buildCmpBannerConfig();
 		const puzzlesBanner = buildPuzzlesBannerConfig({
 			isSignedIn,
-			asyncCountryCode: asyncCountryCode as unknown as Promise<string>,
+			asyncCountryCode: asyncCountryCode as Promise<string>,
 			isPreview,
 			asyncArticleCount: asyncArticleCount as Promise<
 				WeeklyArticleHistory | undefined
@@ -239,7 +239,7 @@ export const StickyBottomBanner = ({
 		});
 		const readerRevenue = buildReaderRevenueBannerConfig({
 			isSignedIn,
-			asyncCountryCode: asyncCountryCode as unknown as Promise<string>,
+			asyncCountryCode: asyncCountryCode as Promise<string>,
 			isPreview,
 			asyncArticleCount: asyncArticleCount as Promise<
 				WeeklyArticleHistory | undefined


### PR DESCRIPTION
This was broken by https://github.com/guardian/dotcom-rendering/pull/3743
It's currently passing through a function rather than a Promise containing the geolocation

### Before:
![Screen Shot 2021-12-16 at 08 45 32](https://user-images.githubusercontent.com/1513454/146338048-a12647a8-8b3b-4f72-9d03-516dc68df063.png)

### After:
![Screen Shot 2021-12-16 at 08 42 52](https://user-images.githubusercontent.com/1513454/146337934-cb742c29-224e-4f28-b256-1723ef1d0df2.png)

We should really have some tests in DCR to prevent this type of regression