### PR TITLE
SBT version upgrade to 1.5.7

### DIFF
--- a/apps-rendering/project/build.properties
+++ b/apps-rendering/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.6
+sbt.version = 1.5.7


### PR DESCRIPTION
## What does this change?

Upgrades SBT version in apps-rendering

## Why?

To fix Log4j vulnerability.

### Before
`sbt.version = 1.5.6`

### After
`sbt.version = 1.5.7`