### PR TITLE
fix: Disable Chromatic for these third party embeds

### DIFF
--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -4,11 +4,10 @@ import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType
 import { some } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import { EmbedKind } from 'embed';
-import type { FC } from 'react';
 import { EmbedComponentWrapper } from './embedWrapper';
 
 // ----- Stories ----- //
-const Generic: FC = () => (
+const Generic = () => (
 	<div>
 		<p>
 			This is an example of the embed wrapper rendering a Spotify
@@ -46,8 +45,13 @@ const Generic: FC = () => (
 		/>
 	</div>
 );
+Generic.story = {
+	parameters: {
+		chromatic: { disable: true },
+	},
+};
 
-const Youtube: FC = () => (
+const Youtube = () => (
 	<div>
 		<p>
 			This is an example of the embed wrapper rendering a YouTube
@@ -79,8 +83,13 @@ const Youtube: FC = () => (
 		/>
 	</div>
 );
+Youtube.story = {
+	parameters: {
+		chromatic: { disable: true },
+	},
+};
 
-const Spotify: FC = () => (
+const Spotify = () => (
 	<div>
 		<p>
 			This is an example of the embed wrapper rendering a spotify
@@ -112,12 +121,12 @@ const Spotify: FC = () => (
 		/>
 	</div>
 );
+Spotify.story = {
+	parameters: {
+		chromatic: { disable: true },
+	},
+};
 
-// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
-// popped up after I removed the FC type which was causing problems when I tried to set parameters
-// on an individual story. Ideally, we'd use the type from Storybook directly
-// but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Instagram = () => (
 	<div>
 		<p>

--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -1,9 +1,3 @@
-// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
-// popped up after I removed the FC type which was causing problems when I tried to set parameters
-// on an individual story. Ideally, we'd use the type from Storybook directly
-// but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable @typescript-eslint/explicit-function-return-type -- because 👆
-
 // ----- Imports ----- //
 
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
@@ -13,6 +7,11 @@ import { EmbedKind } from 'embed';
 import { EmbedComponentWrapper } from './embedWrapper';
 
 // ----- Stories ----- //
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Generic = () => (
 	<div>
 		<p>
@@ -57,6 +56,11 @@ Generic.story = {
 	},
 };
 
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Youtube = () => (
 	<div>
 		<p>
@@ -95,6 +99,11 @@ Youtube.story = {
 	},
 };
 
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Spotify = () => (
 	<div>
 		<p>
@@ -133,6 +142,11 @@ Spotify.story = {
 	},
 };
 
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
 const Instagram = () => (
 	<div>
 		<p>

--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -1,3 +1,9 @@
+// I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
+// popped up after I removed the FC type which was causing problems when I tried to set parameters
+// on an individual story. Ideally, we'd use the type from Storybook directly
+// but https://github.com/storybookjs/storybook/issues/13486
+// eslint-disable @typescript-eslint/explicit-function-return-type -- because 👆
+
 // ----- Imports ----- //
 
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Turns off Chromatic for these stories

## Why?
They keep causing diffs on PRs but it's just because the third party content they are loading changes, not our content
