### PR TITLE
feat: Added make cmd for running without logging

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -57,6 +57,9 @@ logs:
 
 run: stop build start
 
+run-ci: stop build start-ci
+
+
 # dev #########################################
 
 dev: clear clean-dist install


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `make run-ci`

## Why?
This runs the same commands as `make run` (Starts a production server) but it does so without the logging, preventing error
