### PR TITLE
Update match tabs logic to display at the correct time

### DIFF
--- a/dotcom-rendering/src/web/components/GetMatchTabs.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchTabs.tsx
@@ -23,7 +23,7 @@ export const GetMatchTabs = ({ matchUrl, format }: Props) => {
 
 		return null;
 	}
-	if (data) {
+	if (data && data.minByMinUrl && data.reportUrl) {
 		return (
 			<MatchTabs
 				minByMinUrl={data.minByMinUrl}

--- a/dotcom-rendering/src/web/components/MatchTabs.tsx
+++ b/dotcom-rendering/src/web/components/MatchTabs.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import { space, headline } from '@guardian/source-foundations';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
@@ -31,11 +32,11 @@ const tab = (palette: Palette) => css`
 	flex-basis: 50%;
 	height: 40px;
 	border-top: 3px solid ${palette.border.matchTab};
-
-	:nth-child(1) {
-		border-top: 3px solid ${palette.border.activeMatchTab};
-	}
 `;
+
+const activeTab = (palette: Palette) => css`
+	border-top: 3px solid ${palette.border.activeMatchTab};
+`
 
 const tabLink = (palette: Palette) => css`
 	color: ${palette.border.activeMatchTab};
@@ -63,7 +64,7 @@ export const MatchTabs = ({ minByMinUrl, reportUrl, format }: Props) => {
 	return (
 		<div>
 			<ul css={tabsContainer(palette)}>
-				<li css={tab(palette)}>
+				<li css={[tab(palette), format.design===ArticleDesign.MatchReport && activeTab(palette)]}>
 					<a
 						href={reportUrl}
 						data-link-name="report"
@@ -73,7 +74,7 @@ export const MatchTabs = ({ minByMinUrl, reportUrl, format }: Props) => {
 					</a>
 				</li>
 				<GreyBorder palette={palette} />
-				<li css={tab(palette)}>
+				<li css={[tab(palette), (format.design===ArticleDesign.DeadBlog || format.design===ArticleDesign.LiveBlog) && activeTab(palette)]}>
 					<a
 						href={minByMinUrl}
 						data-link-name="Min-by-min"

--- a/dotcom-rendering/src/web/components/MatchTabs.tsx
+++ b/dotcom-rendering/src/web/components/MatchTabs.tsx
@@ -36,7 +36,7 @@ const tab = (palette: Palette) => css`
 
 const activeTab = (palette: Palette) => css`
 	border-top: 3px solid ${palette.border.activeMatchTab};
-`
+`;
 
 const tabLink = (palette: Palette) => css`
 	color: ${palette.border.activeMatchTab};
@@ -64,7 +64,13 @@ export const MatchTabs = ({ minByMinUrl, reportUrl, format }: Props) => {
 	return (
 		<div>
 			<ul css={tabsContainer(palette)}>
-				<li css={[tab(palette), format.design===ArticleDesign.MatchReport && activeTab(palette)]}>
+				<li
+					css={[
+						tab(palette),
+						format.design === ArticleDesign.MatchReport &&
+							activeTab(palette),
+					]}
+				>
 					<a
 						href={reportUrl}
 						data-link-name="report"
@@ -74,7 +80,14 @@ export const MatchTabs = ({ minByMinUrl, reportUrl, format }: Props) => {
 					</a>
 				</li>
 				<GreyBorder palette={palette} />
-				<li css={[tab(palette), (format.design===ArticleDesign.DeadBlog || format.design===ArticleDesign.LiveBlog) && activeTab(palette)]}>
+				<li
+					css={[
+						tab(palette),
+						(format.design === ArticleDesign.DeadBlog ||
+							format.design === ArticleDesign.LiveBlog) &&
+							activeTab(palette),
+					]}
+				>
 					<a
 						href={minByMinUrl}
 						data-link-name="Min-by-min"

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -689,7 +689,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								</GridItem>
 								<GridItem area="meta" element="aside">
 									<Hide until="desktop">
-										<div css={[maxWidth, sidePaddingDesktop]}>
+										<div
+											css={[maxWidth, sidePaddingDesktop]}
+										>
 											<ArticleMeta
 												branding={branding}
 												format={format}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -689,7 +689,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								</GridItem>
 								<GridItem area="meta" element="aside">
 									<Hide until="desktop">
-										<div css={maxWidth}>
+										<div css={[maxWidth, sidePaddingDesktop]}>
 											<ArticleMeta
 												branding={branding}
 												format={format}


### PR DESCRIPTION
## What does this change?
This adds the logic to only show the match-tabs component at the right time. We have a production issue whereby the component is showing on match report articles when there is no accompanying minute by minute. This will also mean that we end up displaying the tab correctly when we have a LIVE liveblog that does not yet have a match report associated to it. 

It also ensures that we make the correct tab have the 'active' state.

### Before - incorrect active tab
![Screen Shot 2021-12-17 at 16 53 21](https://user-images.githubusercontent.com/2051501/146580363-a5583811-00f5-4d16-b57a-828ed4937fe2.png)

### After - incorrect active tab
![Screen Shot 2021-12-17 at 16 52 49](https://user-images.githubusercontent.com/2051501/146580411-7b581ed5-debe-4b09-9b5a-43230e30c1de.png)

### Before - Showing tabs incorrectly on match report

### After - Tabs are not shown on match report where no liveblog is available

