### PR TITLE
Run Spacefinder on deadblogs

### DIFF
--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -52,6 +52,7 @@ const LiveBlockContainer = ({
 		<article
 			id={`block-${id}`}
 			key={id}
+			// This classname is used by Spacefinder as a possible candidate before which it can insert an inline ad
 			className="block"
 			css={css`
 				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
-import { neutral, from, space, headline } from '@guardian/source-foundations';
-import { FirstPublished } from './FirstPublished';
+import { neutral, from, space, headline } from "@guardian/source-foundations";
+import { FirstPublished } from "./FirstPublished";
 
 const LEFT_MARGIN_DESKTOP = 60;
 const SIDE_MARGIN = space[5];
@@ -24,7 +24,7 @@ const BlockTitle = ({ title }: { title: string }) => {
 	return (
 		<h2
 			css={css`
-				${headline.xxsmall({ fontWeight: 'bold' })}
+				${headline.xxsmall({ fontWeight: "bold" })}
 				margin-bottom: ${space[2]}px;
 			`}
 		>
@@ -52,6 +52,7 @@ const LiveBlockContainer = ({
 		<article
 			id={`block-${id}`}
 			key={id}
+			className="block"
 			css={css`
 				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
 				margin-bottom: ${space[3]}px;

--- a/dotcom-rendering/docs/contracts/001-commercial-selectors.md
+++ b/dotcom-rendering/docs/contracts/001-commercial-selectors.md
@@ -2,7 +2,10 @@
 
 ## What is the contract?
 
-We place the `article-body-commercial-selector` class on the container element of the article body. (TODO: are there others?)
+We place the following classes on the container element of the article body:
+
+-   `article-body-commercial-selector` on the ArticleRenderer
+-   `js-liveblog-body` on the ArticleBody when rendering a Liveblog/Deadblog
 
 ## Where is it relied upon?
 

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -91,6 +91,8 @@ export const ArticleBody = ({
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
 				tabIndex={0}
 				id="maincontent"
+				// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
+				className="js-liveblog-body"
 				css={[globalStrongStyles, globalLinkStyles(palette)]}
 			>
 				<LiveBlogRenderer

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { from, until } from '@guardian/source-foundations';
+import { from, neutral, space, until } from '@guardian/source-foundations';
 
 import { labelStyles, carrotAdStyles } from '@root/src/web/components/AdSlot';
 
@@ -62,7 +62,8 @@ const articleAdStyles = css`
 			width: auto;
 		}
 	}
-	.ad-slot--inline {
+	.ad-slot--inline,
+	.ad-slot-liveblog--inline {
 		width: 300px;
 		margin: 12px auto;
 		min-width: 160px;
@@ -99,7 +100,6 @@ const articleAdStyles = css`
 		${from.tablet} {
 			margin-left: 0;
 			width: 100%;
-
 			.ad-slot__label {
 				margin-left: 35px;
 				margin-right: 35px;
@@ -108,6 +108,41 @@ const articleAdStyles = css`
 	}
 	.ad-slot--fluid {
 		width: 100%;
+	}
+	.ad-slot--liveblog-inline {
+		margin: 0 auto ${space[3]}px;
+
+		.ad-slot__label {
+			color: ${neutral[46]};
+			border-top-color: ${neutral[86]};
+		}
+
+		&.ad-slot--outstream {
+			${from.tablet} {
+				width: 620px;
+			}
+		}
+
+		&:not(.ad-slot--outstream) {
+			width: 300px;
+			background-color: ${neutral[93]};
+
+			${from.tablet} {
+				width: 100%;
+				padding-bottom: ${space[6]}px;
+
+				& > div:not(.ad-slot__label) {
+					width: 300px;
+					margin-left: auto;
+					margin-right: auto;
+				}
+			}
+		}
+
+		&.ad-slot--fluid {
+			background-color: green;
+			width: 100%;
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -126,6 +126,7 @@ const articleAdStyles = css`
 		&:not(.ad-slot--outstream) {
 			width: 300px;
 			background-color: ${neutral[93]};
+			text-align: center;
 
 			${from.tablet} {
 				width: 100%;


### PR DESCRIPTION
## What does this change?

Add support for running Spacefinder on DCR deadblogs. The code in the commercial bundle already runs on these pages, this PR adds the hints necessary to insert inline ad slots between liveblocks.

These hints take the form of two added classnames:
- `js-liveblog-body` applied to `ArticleBody` when rendering a liveblog/deadblog. This represents the container in which Spacefinder will attempt to insert inline ads.
- `block` applied to each of the `Liveblock` components. Spacefinder will select for these as the candidates before which inline ads can be inserted. Candidates are the direct descendants of the container above.

Additionally, the adverts that are inserted into liveblogs by Spacefinder require some additional styling. These styles are added to the `ArticleContainer` along with other dynamic ad styles, and scoped to target the classes of slots added by Spacefinder.

### Before

![Screenshot 2022-01-07 at 09 26 38](https://user-images.githubusercontent.com/8000415/148522743-78dd027a-72bc-4b78-b271-84419168f575.png)

### After

![Screenshot 2022-01-07 at 09 26 11](https://user-images.githubusercontent.com/8000415/148522723-0c23033f-40f9-4a1f-9421-bdbaa7fd1ee1.png)

## Why?

As migration to DCR continues it's necessary to also migrate the ability to include inline ads on these new pages.