### PR TITLE
Upgrade to SBT version 1.6.0-RC2

### DIFF
--- a/apps-rendering/project/build.properties
+++ b/apps-rendering/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.7
+sbt.version = 1.6.0-RC2


### PR DESCRIPTION
## What does this change?
Upgrading version of SBT.

## Why?
Addressed identified [security vulnerability](https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0) in log4j, which is used internally in SBT

### Before
`sbt.version = 1.5.7`

### After
`sbt.version = 1.6.0-RC2`