### PR TITLE
Braze section filter by id (instead of name)

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1234,7 +1234,6 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 					isSignedIn={isSignedIn}
 					countryCode={countryCode}
 					contentType={CAPI.contentType}
-					sectionName={CAPI.sectionName}
 					sectionId={CAPI.config.section}
 					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
 					isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -25,7 +25,6 @@ type Props = {
 	isSignedIn?: boolean;
 	countryCode?: string;
 	contentType: string;
-	sectionName?: string;
 	sectionId: string;
 	shouldHideReaderRevenue: boolean;
 	isMinuteArticle: boolean;

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -82,7 +82,6 @@ export const SlotBodyEnd = ({
 	isSignedIn,
 	countryCode,
 	contentType,
-	sectionName,
 	sectionId,
 	shouldHideReaderRevenue,
 	isMinuteArticle,
@@ -115,7 +114,7 @@ export const SlotBodyEnd = ({
 			browserId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
-			section: sectionName,
+			section: sectionId,
 		};
 		const brazeEpic = buildBrazeEpicConfig(
 			brazeMessages as Promise<BrazeMessagesInterface>,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -258,7 +258,7 @@ export const StickyBottomBanner = ({
 			switches,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
-			section
+			section,
 		};
 		const brazeBanner = buildBrazeBanner(
 			brazeMessages as Promise<BrazeMessagesInterface>,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -258,7 +258,7 @@ export const StickyBottomBanner = ({
 			switches,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
-			section: sectionName,
+			section
 		};
 		const brazeBanner = buildBrazeBanner(
 			brazeMessages as Promise<BrazeMessagesInterface>,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Use section id instead of name when filtering by section for Braze banners and end of article components.

## Why?
The new down to earth newsletter epic uses section filtering to show up only on environment articles.
This works because the section filtering on the braze side is case insensitive, and ignoring case the section id and name for environment are the same. However if section filtering is used for a section where this isn't the case it will not work.

### Before
Braze banners/epics with braze message prop section will only show where that prop matches the section **name**

### After
Braze banners/epics with braze message prop section will only show where that prop matches the section **id**