### PR TITLE
Pass ophan component id to Braze banner. If not available use component name.

### DIFF
--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -97,7 +97,9 @@ const BrazeBannerWithSatisfiedDependencies = ({
 		submitComponentEvent({
 			component: {
 				componentType: 'RETENTION_ENGAGEMENT_BANNER',
-				id: meta.dataFromBraze.componentName,
+				id:
+					meta.dataFromBraze.ophanComponentId ??
+					meta.dataFromBraze.componentName,
 			},
 			action: 'VIEW',
 		});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Pass ophan component id from braze messages to braze components. If none is available use the braze component name.

Frontend PR: https://github.com/guardian/frontend/pull/24501
Trello ticket: https://trello.com/c/2JtmxMVR/1306-add-componentid-level-tracking-on-banner

## Why?
This allows for more detailed analytics of which particular braze banners are being used (as ophan component id is provided by marketing and is more specific than component name)

### Before
When logging events in ophan from Braze banners the ophanComponentId provided was the Braze component name (e.g DigitalSubscriberAppBanner).

### After
When logging events in ophan from Braze banners the ophanComponentId will now be set based on the ophanComponentId from the braze message. If none is provided (as is currently the case for most banner campaigns) then the component name will be used instead.