### PR TITLE
Update riff-raff aws-s3 publicReadAcl

### DIFF
--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -33,3 +33,4 @@ deployments:
       bucket: mobile-apps-rendering-assets
       cacheControl: public, max-age=315360000
       prefixStack: false
+      publicReadAcl: true

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -30,3 +30,4 @@ deployments:
       bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
+      publicReadAcl: true


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Explicitly sets `publicReadAcl: true` in `riff-raff.yaml` for `aws-s3`.

## Why?
Previously the parameter was optional. After this change: https://github.com/guardian/riff-raff/pull/665, it is required. The default value is `true`.
