### PR TITLE
Remove the need for global state when expanding comments

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -49,7 +49,7 @@
     "@guardian/braze-components": "^5.1.0",
     "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "~6.11.5",
-    "@guardian/discussion-rendering": "^9.0.0",
+    "@guardian/discussion-rendering": "^9.1.0",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",
     "@hkdobrev/run-if-changed": "^0.3.1",

--- a/dotcom-rendering/src/web/components/CommentCount.stories.tsx
+++ b/dotcom-rendering/src/web/components/CommentCount.stories.tsx
@@ -28,7 +28,6 @@ export const SpecialReportStory = () => {
 		>
 			<CommentCount
 				isCommentable={true}
-				setIsExpanded={() => {}}
 				commentCount={306}
 				palette={decidePalette({
 					theme: ArticleSpecial.SpecialReport,
@@ -52,7 +51,6 @@ export const NewsStory = () => {
 		>
 			<CommentCount
 				isCommentable={true}
-				setIsExpanded={() => {}}
 				commentCount={36}
 				palette={decidePalette({
 					theme: ArticlePillar.News,
@@ -76,7 +74,6 @@ export const LargeNumber = () => {
 		>
 			<CommentCount
 				isCommentable={true}
-				setIsExpanded={() => {}}
 				commentCount={10836}
 				palette={decidePalette({
 					theme: ArticlePillar.Opinion,
@@ -100,7 +97,6 @@ export const Zero = () => {
 		>
 			<CommentCount
 				isCommentable={true}
-				setIsExpanded={() => {}}
 				commentCount={0}
 				palette={decidePalette({
 					theme: ArticlePillar.Opinion,
@@ -124,7 +120,6 @@ export const Undefined = () => {
 		>
 			<CommentCount
 				isCommentable={true}
-				setIsExpanded={() => {}}
 				palette={decidePalette({
 					theme: ArticlePillar.Opinion,
 					display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/web/components/CommentCount.test.tsx
+++ b/dotcom-rendering/src/web/components/CommentCount.test.tsx
@@ -17,7 +17,6 @@ describe('CommentCount', () => {
 				isCommentable={false}
 				commentCount={123}
 				palette={decidePalette(standardNewsFormat)}
-				setIsExpanded={() => {}}
 			/>,
 		);
 
@@ -30,7 +29,6 @@ describe('CommentCount', () => {
 				isCommentable={true}
 				commentCount={123}
 				palette={decidePalette(standardNewsFormat)}
-				setIsExpanded={() => {}}
 			/>,
 		);
 
@@ -44,7 +42,6 @@ describe('CommentCount', () => {
 				isCommentable={true}
 				commentCount={92878}
 				palette={decidePalette(standardNewsFormat)}
-				setIsExpanded={() => {}}
 			/>,
 		);
 
@@ -58,7 +55,6 @@ describe('CommentCount', () => {
 				isCommentable={true}
 				commentCount={0}
 				palette={decidePalette(standardNewsFormat)}
-				setIsExpanded={() => {}}
 			/>,
 		);
 
@@ -71,7 +67,6 @@ describe('CommentCount', () => {
 			<CommentCount
 				isCommentable={true}
 				palette={decidePalette(standardNewsFormat)}
-				setIsExpanded={() => {}}
 			/>,
 		);
 

--- a/dotcom-rendering/src/web/components/CommentCount.tsx
+++ b/dotcom-rendering/src/web/components/CommentCount.tsx
@@ -9,7 +9,6 @@ type Props = {
 	palette: Palette;
 	isCommentable: boolean;
 	commentCount?: number;
-	setIsExpanded: (isExpanded: boolean) => void;
 };
 
 const containerStyles = (palette: Palette) => css`
@@ -75,7 +74,6 @@ export const CommentCount = ({
 	isCommentable,
 	commentCount,
 	palette,
-	setIsExpanded,
 }: Props) => {
 	if (!isCommentable) return null;
 
@@ -91,7 +89,6 @@ export const CommentCount = ({
 				href="#comments"
 				css={linkStyles}
 				aria-label={`${short} Comments`}
-				onClick={() => setIsExpanded(true)}
 			>
 				<div css={iconContainerStyles}>
 					<CommentIcon css={iconStyles(palette)} />

--- a/dotcom-rendering/src/web/components/Counts.stories.tsx
+++ b/dotcom-rendering/src/web/components/Counts.stories.tsx
@@ -62,7 +62,6 @@ export const Both = () => {
 						isCommentable={true}
 						commentCount={239}
 						palette={decidePalette(format)}
-						setIsExpanded={() => {}}
 					/>
 				</div>
 			</Counts>
@@ -103,7 +102,6 @@ export const ShareOnly = () => {
 						isCommentable={false}
 						commentCount={239}
 						palette={decidePalette(format)}
-						setIsExpanded={() => {}}
 					/>
 				</div>
 			</Counts>
@@ -144,7 +142,6 @@ export const CommentOnly = () => {
 						isCommentable={true}
 						commentCount={239}
 						palette={decidePalette(format)}
-						setIsExpanded={() => {}}
 					/>
 				</div>
 			</Counts>
@@ -185,7 +182,6 @@ export const ZeroComments = () => {
 						isCommentable={true}
 						commentCount={0}
 						palette={decidePalette(format)}
-						setIsExpanded={() => {}}
 					/>
 				</div>
 			</Counts>
@@ -226,7 +222,6 @@ export const BigNumbers = () => {
 						isCommentable={true}
 						commentCount={4320}
 						palette={decidePalette(format)}
-						setIsExpanded={() => {}}
 					/>
 				</div>
 			</Counts>

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -147,7 +147,6 @@ export const Discussion = ({
 						isCommentable={isCommentable}
 						commentCount={commentCount}
 						palette={palette}
-						setIsExpanded={setIsExpanded}
 					/>
 				</Portal>
 			)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1723,10 +1723,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.7.7":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.13.10", "@babel/runtime@^7.7.7":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.13":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2137,10 +2144,10 @@
   dependencies:
     "@guardian/libs" "^1"
 
-"@guardian/discussion-rendering@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/@guardian/discussion-rendering/-/discussion-rendering-9.0.0.tgz#b2fde97e2ddec5fc07cf450a45d4704dd74d7ed6"
-  integrity sha512-2djqkCS6LEs9ATERFZJLwf5OXVbQVChNt5ot/KCkWHobJazJU8e8b5J/urW/ahfLBH43OENDrgz2Z+s6vk+9aA==
+"@guardian/discussion-rendering@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-9.1.0.tgz#fd5fe5088d0657b96506457844f3211927756f7e"
+  integrity sha512-W/Br3CnSOnq1VV2SHK3YMYTvFDlXRG+pBjve9wmvPH3w5oJ+IvaNIAgRZfF9kfwvkLXdxDPIpW5wbC8V8QmzkQ==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"
@@ -9556,10 +9563,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.9.1:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.9.2.tgz#9d30918aaa99b1b97677731053d017f82a540d5b"
-  integrity sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==
+focus-lock@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.10.1.tgz#5f46fa74fefb87144479c2f8e276f0eedd8081b2"
+  integrity sha512-b9yUklCi4fTu2GXn7dnaVf4hiLVVBp7xTiZarAHMODV2To6Bitf6F/UI67RmKbdgJQeVwI1UO0d9HYNbXt3GkA==
   dependencies:
     tslib "^2.0.3"
 
@@ -15650,12 +15657,12 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
 react-focus-lock@^2.2.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.2.tgz#f1e4db5e25cd8789351f2bd5ebe91e9dcb9c2922"
-  integrity sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.7.1.tgz#a9fbb3fa4efaee32162406e5eb96ae658964193b"
+  integrity sha512-ImSeVmcrLKNMqzUsIdqOkXwTVltj79OPu43oT8tVun7eIckA4VdM7UmYUFo3H/UC2nRVgagMZGFnAOQEDiDYcA==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.9.1"
+    focus-lock "^0.10.1"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.5"
     use-callback-ref "^1.2.5"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds `@guardian/discussion-rendering@9.1.0` which will expand comments if it sees `#comments` in the url. This removes the need to manually call `setIsExpanded` and allows the `CommentCount` component to work in isolation.

## Why?
By making `CommentCount` independent we can break it out into it's own [Island](https://github.com/guardian/dotcom-rendering/pull/3784), removing the need for global state and furthering the wider goal of [deleting App.tsx](https://docs.google.com/document/d/1kSrZZrJ8hSw6bek5hGa9onE8QDz5TRHFqHV52EOFjts/edit#heading=h.gsod33a0pc47)

## What next?
To achieve the stated aim of removing the count of comments as a piece of global state, we will also need to drop down the api call to get details for a discussion. This will result in the same api call being made twice but by using [SWR](https://swr.vercel.app/) we expect to prevent any increase in origin traffic
