### PR TITLE
Explicitly set the aws-s3 publicReadAcl property 

### DIFF
--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -33,3 +33,4 @@ deployments:
       bucket: mobile-apps-rendering-assets
       cacheControl: public, max-age=315360000
       prefixStack: false
+      publicReadAcl: false

--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -33,4 +33,4 @@ deployments:
       bucket: mobile-apps-rendering-assets
       cacheControl: public, max-age=315360000
       prefixStack: false
-      publicReadAcl: false
+      publicReadAcl: true


### PR DESCRIPTION
## What does this change?
Explicitly sets the aws-s3 type parameter publicReadAcl

From DevX:

One of Riff-Raff's deployment types provides the ability to upload files to S3. The publicReadAcl parameter controls whether or not the public read ACL is added to the uploaded files. This ACL means:

Owner gets FULL_CONTROL. The AllUsers group (see Who is a grantee?) gets READ access.

The default for this value was true, which doesn't follow the principle of least privilege as it means objects are publicly viewable by default.

We want to change this to default to false instead.


## How to test
Successfully deploy to CODE - test articles still render ok
