### PR TITLE
Hydrate Storybook Islands

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
+++ b/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { getName } from '@root/src/web/browser/islands/getName';
-import { getProps } from '@root/src/web/browser/islands/getProps';
+import { getName } from './getName';
+import { getProps } from './getProps';
 
 /**
  * This is a cut down version of the islands/doHydration function that is

--- a/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
+++ b/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
@@ -27,7 +27,7 @@ export const doStorybookHydration = () => {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			import(
 				/* webpackInclude: /\.importable\.(tsx|jsx)$/ */
-				`../components/${name}.importable`
+				`../../components/${name}.importable`
 			).then((module) => {
 				ReactDOM.hydrate(
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -34,7 +34,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
-import { doStorybookHydration } from '../lib/doStorybookHydration';
+import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
 
 mockRESTCalls();
 

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -34,6 +34,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
+import { doStorybookHydration } from '../lib/doStorybookHydration';
 
 mockRESTCalls();
 
@@ -86,6 +87,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 		);
 		// Manually updates the footer DOM because it's not hydrated
 		injectPrivacySettingsLink();
+		doStorybookHydration();
 	}, [ServerCAPI]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -16,6 +16,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
+import { doStorybookHydration } from '../lib/doStorybookHydration';
 
 mockRESTCalls();
 
@@ -57,6 +58,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 		);
 		// Manually updates the footer DOM because it's not hydrated
 		injectPrivacySettingsLink();
+		doStorybookHydration();
 	}, [ServerCAPI]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -16,7 +16,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
-import { doStorybookHydration } from '../lib/doStorybookHydration';
+import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
 
 mockRESTCalls();
 

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -32,6 +32,7 @@ import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { breakpoints } from '@guardian/source-foundations';
 import { DecideLayout } from './DecideLayout';
+import { doStorybookHydration } from '../lib/doStorybookHydration';
 
 mockRESTCalls();
 
@@ -72,6 +73,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 		);
 		// Manually updates the footer DOM because it's not hydrated
 		injectPrivacySettingsLink();
+		doStorybookHydration();
 	}, [ServerCAPI]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
 };

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -32,7 +32,7 @@ import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { breakpoints } from '@guardian/source-foundations';
 import { DecideLayout } from './DecideLayout';
-import { doStorybookHydration } from '../lib/doStorybookHydration';
+import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
 
 mockRESTCalls();
 

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -34,7 +34,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
-import { doStorybookHydration } from '../lib/doStorybookHydration';
+import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
 
 mockRESTCalls();
 

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -34,6 +34,7 @@ import { injectPrivacySettingsLink } from '@root/src/web/lib/injectPrivacySettin
 import { extractNAV } from '@root/src/model/extract-nav';
 import { fireAndResetHydrationState } from '@root/src/web/components/HydrateOnce';
 import { DecideLayout } from './DecideLayout';
+import { doStorybookHydration } from '../lib/doStorybookHydration';
 
 mockRESTCalls();
 
@@ -84,6 +85,7 @@ const HydratedLayout = ({
 		);
 		// Manually updates the footer DOM because it's not hydrated
 		injectPrivacySettingsLink();
+		doStorybookHydration();
 	}, [ServerCAPI]);
 	if (modifyPage) {
 		modifyPage();

--- a/dotcom-rendering/src/web/lib/doStorybookHydration.js
+++ b/dotcom-rendering/src/web/lib/doStorybookHydration.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { getName } from '@root/src/web/browser/islands/getName';
+import { getProps } from '@root/src/web/browser/islands/getProps';
+
+/**
+ * This is a cut down version of the islands/doHydration function that is
+ * used as part of the Islands flow for hydrating DCR pages.
+ *
+ * We don't use that specific function directly for two reasons:
+ *
+ * 1) We need to use React here, not Preact. Otherwise we get errors about
+ *    conflicting versions of React
+ *
+ * 2) We don't want to defer hydration as this could affect our Chromatic
+ *    snapshots
+ */
+export const doStorybookHydration = () => {
+	document.querySelectorAll('gu-island').forEach((element) => {
+		if (element instanceof HTMLElement) {
+			const name = getName(element);
+			const props = getProps(element);
+
+			if (!name) return;
+
+			// eslint-disable-next-line @typescript-eslint/no-floating-promises
+			import(
+				/* webpackInclude: /\.importable\.(tsx|jsx)$/ */
+				`../components/${name}.importable`
+			).then((module) => {
+				ReactDOM.hydrate(
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					React.createElement(module[name], props),
+					element,
+				);
+			});
+		}
+	});
+};


### PR DESCRIPTION
## What does this change?
Adds support for hydration of `Islands` within our stories

## Why?
We want the full page stories that we use to test layout code to be as fully featured as possible. To achieve this we need to hydrate the content.

But our storybook pages are not created using the same build process as normal pages so we need a custom solution for hydration - we kind of have to simulate the SSR/Browser flow, except in Storybook it's all happening in the browser.

## Why are we not using the same `doHydration` function as we use on production?
We already have a function that checks the page for `gu-island` tags and hydrates those based on the given props so why not use this? There are two reasons:

1) We don't want to defer hydration because this could cause the snapshots we create in Chromatic to be incomplete.
2) Because we don't have the server/browser separation we started to see errors complaining about different versions of React. By having a custom `doStorybookHydration` function we can work around this.
