### PR TITLE
Upgrade cmp version 10

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
     "@guardian/automat-contributions": "^0.4.3",
     "@guardian/braze-components": "^5.1.0",
     "@guardian/commercial-core": "^0.32.0",
-    "@guardian/consent-management-platform": "~6.11.5",
+    "@guardian/consent-management-platform": "^10.1.0",
     "@guardian/discussion-rendering": "^9.1.0",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,12 +2137,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.32.0.tgz#c6cbbd2072e59ac75e0f511e87b26dd762fac3dd"
   integrity sha512-wPEPy7m2lAk3anNWJl1LjOnE55SDzkbbUKWUuxSA7QoJRdkSr5s0lexnKnANa7wLNiZGcoepoIiqftj1xacuWQ==
 
-"@guardian/consent-management-platform@~6.11.5":
-  version "6.11.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.5.tgz#93681cbf61de0fadb4b65d835d7fc445cb847b31"
-  integrity sha512-ap7b09qk8I/EfoWB3NR8kT63hBpm4ATFGpRicCQ61DLMw2PgCWunMvizdbSmo5wNCQKPFgmX9cfRT5IGfPneKw==
+"@guardian/consent-management-platform@^10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.0.tgz#defabd279ca3e8344bfbfbb0d604e42ba549ae1c"
+  integrity sha512-7q4mb8b5jVcecOMYp0cTN02OIz7ZHw0HgKKVID7mOjV7NwSNBY+Lwtj85VyYAR/cnC2SJFbpezPivFdvyE5rTg==
   dependencies:
-    "@guardian/libs" "^1"
+    "@guardian/libs" "1.6.1 - 3.3.0"
 
 "@guardian/discussion-rendering@^9.1.0":
   version "9.1.0"
@@ -2172,10 +2172,10 @@
     "@typescript-eslint/eslint-plugin" "4.29.2"
     "@typescript-eslint/parser" "4.29.2"
 
-"@guardian/libs@^1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
-  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
+"@guardian/libs@1.6.1 - 3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
+  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
 "@guardian/libs@^3.3.0", "@guardian/libs@^3.4.1":
   version "3.4.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Upgrades the consent-management-platform to version 10.1.0
- Same change of frontend: https://github.com/guardian/frontend/pull/24511

## Why?
- Keeps dependencies up to date and skips version 9 which uses a version of SourcePoint which is currently broken. 