### PR TITLE
Temporarily remove sign up and log in option when discussion is disab…

### DIFF
--- a/dotcom-rendering/src/web/components/SignedInAs.tsx
+++ b/dotcom-rendering/src/web/components/SignedInAs.tsx
@@ -127,25 +127,7 @@ export const SignedInAs = ({
 			<div css={containerStyles}>
 				<CommentCount count={commentCount} />
 				<span css={headlineStyles}>
-					Commenting has been disabled at this time but you can still{' '}
-					<a
-						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
-							'signin_to_comment',
-						)}`}
-						css={linkStyles(palette)}
-					>
-						sign in
-					</a>{' '}
-					or{' '}
-					<a
-						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
-							'register_to_comment',
-						)}`}
-						css={linkStyles(palette)}
-					>
-						create your Guardian account
-					</a>{' '}
-					to join the discussion when it&apos;s back
+					Commenting has been disabled at this time
 				</span>
 			</div>
 		);


### PR DESCRIPTION
…led and user is logged out

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

### Before

### After
