### PR TITLE
Bump @guardian/braze-components to 5.2.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.1.1",
     "@guardian/automat-contributions": "^0.4.3",
-    "@guardian/braze-components": "^5.1.0",
+    "@guardian/braze-components": "^5.2.0",
     "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "^10.1.0",
     "@guardian/discussion-rendering": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,10 +2127,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.3.tgz#3ef815d637022802cbeac7830813bbdf7326b43d"
   integrity sha512-zSvPfrswfd0FGx0qfCwORmebeI46RMhkxgQQiZ8uCC6IRUDd+3UYl7/0hAILeGKGZ7qDUC8EwQ6TX0le7+2a1g==
 
-"@guardian/braze-components@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.1.0.tgz#76675e7fb441d77f235b75d0b0f2c4af81303f03"
-  integrity sha512-x1WjcEbYiy8KfwEjr+DflG7DNWRRFEfJzdXvb9wq29gO1NZjuzaHmMJT3YfQsBHtGNoDWmdvvfavC1Xnl43cVQ==
+"@guardian/braze-components@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.2.0.tgz#2df527364471bdc8905824f34e67312214b7684e"
+  integrity sha512-8x5iyWIOIvlF/XMVbNxzBxaAlekbicc5XqqvPRJRPVOQBTnZalwOin2XzfaUuE73q/00cICQXCtgAnqr1clCKw==
 
 "@guardian/commercial-core@^0.32.0":
   version "0.32.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bump @guardian/braze-components to 5.2.0.

## Why?

This release includes the new BannerWithLink component.

Tested the new banner with a test canvas in CODE (copy and image aren't the real thing):

![Screenshot 2022-01-12 at 10 00 19](https://user-images.githubusercontent.com/379839/149119918-ba8c6afa-fff7-4178-87ea-195884af1ef2.png)

