### PR TITLE
Fix deadblog colours for metadata and liveblock

### DIFF
--- a/apps-rendering/src/components/anchor.stories.tsx
+++ b/apps-rendering/src/components/anchor.stories.tsx
@@ -1,5 +1,9 @@
 // ----- Imports ----- //
 
+import {
+	getAllThemes,
+	getThemeNameAsString,
+} from '@guardian/common-rendering/src/fixtures/article';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import type { FC } from 'react';
@@ -28,6 +32,33 @@ const Default: FC = () => (
 	</Anchor>
 );
 
+const Liveblock: FC = () => {
+	return (
+		<>
+			{getAllThemes({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.DeadBlog,
+			}).map((format) => (
+				<div key={format.theme}>
+					<p>{getThemeNameAsString(format)}</p>
+					<Anchor
+						format={{
+							design: ArticleDesign.DeadBlog,
+							display: ArticleDisplay.Standard,
+							theme: format.theme,
+						}}
+						href={link()}
+					>
+						{copy()}
+					</Anchor>
+					<br />
+					<br />
+				</div>
+			))}
+		</>
+	);
+};
+
 // ----- Exports ----- //
 
 export default {
@@ -36,4 +67,4 @@ export default {
 	decorators: [withKnobs],
 };
 
-export { Default };
+export { Default, Liveblock };

--- a/apps-rendering/src/components/anchor.tsx
+++ b/apps-rendering/src/components/anchor.tsx
@@ -29,7 +29,7 @@ const styles = (isEditions: boolean): SerializedStyles => css`
 `;
 
 const colour = (format: ArticleFormat): SerializedStyles => {
-	const inverted = text.invertedLink(format);
+	const linkDark = text.linkDark(format);
 	const link = text.articleLink(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
@@ -45,7 +45,7 @@ const colour = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
 		case ArticleDesign.Media:
 			return css`
-				color: ${inverted};
+				color: ${linkDark};
 				border-bottom: 0.0625rem solid ${neutral[20]};
 			`;
 		default:

--- a/apps-rendering/src/components/anchor.tsx
+++ b/apps-rendering/src/components/anchor.tsx
@@ -2,12 +2,12 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { labs, neutral } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
-import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
@@ -29,7 +29,9 @@ const styles = (isEditions: boolean): SerializedStyles => css`
 `;
 
 const colour = (format: ArticleFormat): SerializedStyles => {
-	const { link, inverted } = getThemeStyles(format.theme);
+	const inverted = text.invertedLink(format);
+	const link = text.articleLink(format);
+
 	if (format.theme === ArticleSpecial.Labs) {
 		return css`
 			color: ${labs[300]};

--- a/apps-rendering/src/components/blockquote.tsx
+++ b/apps-rendering/src/components/blockquote.tsx
@@ -19,7 +19,6 @@ interface Props {
 const styles = (format: ArticleFormat): SerializedStyles => {
 	const blockquoteFill = fill.blockquoteIcon(format);
 
-
 	return css`
 		font-style: italic;
 		position: relative;

--- a/apps-rendering/src/components/blockquote.tsx
+++ b/apps-rendering/src/components/blockquote.tsx
@@ -2,12 +2,12 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { fill } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/source-foundations';
 import { SvgQuote } from '@guardian/source-react-components';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
-import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
@@ -17,7 +17,9 @@ interface Props {
 }
 
 const styles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker } = getThemeStyles(format.theme);
+	const blockquoteFill = fill.blockquoteIcon(format);
+
+
 	return css`
 		font-style: italic;
 		position: relative;
@@ -28,7 +30,7 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 			margin-left: -9.2625px;
 			margin-bottom: -12px;
 			margin-top: 4.4px;
-			fill: ${kicker};
+			fill: ${blockquoteFill};
 		}
 
 		${darkModeCss`

--- a/apps-rendering/src/components/byline.stories.tsx
+++ b/apps-rendering/src/components/byline.stories.tsx
@@ -1,6 +1,10 @@
 // ----- Imports ----- //
 
 import {
+	getAllThemes,
+	getThemeNameAsString,
+} from '@guardian/common-rendering/src/fixtures/article';
+import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticlePillar,
@@ -63,6 +67,28 @@ const Labs: FC = () => (
 	/>
 );
 
+const Deadblog: FC = () => {
+	return (
+		<>
+			{getAllThemes({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.DeadBlog,
+			}).map((format) => (
+				<div key={format.theme}>
+					<p>{getThemeNameAsString(format)}</p>
+					<Byline
+						theme={format.theme}
+						design={ArticleDesign.DeadBlog}
+						display={ArticleDisplay.Standard}
+						bylineHtml={mockBylineHtml()}
+					/>
+					<br />
+				</div>
+			))}
+		</>
+	);
+};
+
 // ----- Exports ----- //
 
 export default {
@@ -71,4 +97,4 @@ export default {
 	decorators: [withKnobs],
 };
 
-export { Default, Comment, Labs };
+export { Default, Comment, Labs, Deadblog };

--- a/apps-rendering/src/components/byline.tsx
+++ b/apps-rendering/src/components/byline.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
@@ -115,7 +116,8 @@ const labsAnchorStyles = css`
 `;
 
 const getStyles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker, link, inverted } = getThemeStyles(format.theme);
+	const byline = text.byline(format);
+	const invertedByline = text.invertedByline(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
 		return labsStyles;
@@ -123,20 +125,26 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
-			return css(blogStyles, blogColor(neutral[100], link, inverted));
+			return css(
+				blogStyles,
+				blogColor(neutral[100], byline, invertedByline),
+			);
 		case ArticleDesign.DeadBlog:
-			return css(blogStyles, blogColor(link, link, neutral[93]));
+			return css(blogStyles, blogColor(byline, byline, neutral[93]));
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
-			return commentStyles(kicker);
+			return commentStyles(byline);
 		default:
-			return styles(kicker);
+			return styles(byline);
 	}
 };
 
 const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted, link } = getThemeStyles(format.theme);
+	const byline = text.byline(format);
+	const invertedByline = text.invertedByline(format);
+
 	if (format.theme === ArticleSpecial.Labs) {
 		return labsAnchorStyles;
 	}
@@ -147,7 +155,10 @@ const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 				blogColor(neutral[100], link, inverted),
 			);
 		case ArticleDesign.DeadBlog:
-			return css(blogAnchorStyles, blogColor(link, link, inverted));
+			return css(
+				blogAnchorStyles,
+				blogColor(byline, byline, invertedByline),
+			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:

--- a/apps-rendering/src/components/byline.tsx
+++ b/apps-rendering/src/components/byline.tsx
@@ -116,9 +116,9 @@ const labsAnchorStyles = css`
 `;
 
 const getStyles = (format: ArticleFormat): SerializedStyles => {
-	const bylineLightGrayBackground = text.bylineLightGrayBackground(format);
-	const bylineDarkGrayBackground = text.bylineDarkGrayBackground(format);
-	const invertedByline = text.invertedByline(format);
+	const bylineLeftColumn = text.bylineLeftColumn(format);
+	const bylineInline = text.bylineInline(format);
+	const bylineDark = text.bylineDark(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
 		return labsStyles;
@@ -128,35 +128,27 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.LiveBlog:
 			return css(
 				blogStyles,
-				blogColor(
-					neutral[100],
-					bylineLightGrayBackground,
-					invertedByline,
-				),
+				blogColor(neutral[100], bylineLeftColumn, bylineDark),
 			);
 		case ArticleDesign.DeadBlog:
 			return css(
 				blogStyles,
-				blogColor(
-					bylineDarkGrayBackground,
-					bylineLightGrayBackground,
-					neutral[93],
-				),
+				blogColor(bylineInline, bylineLeftColumn, neutral[93]),
 			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
-			return commentStyles(bylineLightGrayBackground);
+			return commentStyles(bylineLeftColumn);
 		default:
-			return styles(bylineLightGrayBackground);
+			return styles(bylineLeftColumn);
 	}
 };
 
 const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted, link } = getThemeStyles(format.theme);
-	const bylineWhiteGrayBackground = text.bylineLightGrayBackground(format);
-	const bylineDarkGrayBackground = text.bylineDarkGrayBackground(format);
-	const invertedByline = text.invertedByline(format);
+	const bylineLeftColumn = text.bylineLeftColumn(format);
+	const bylineInline = text.bylineInline(format);
+	const bylineDark = text.bylineDark(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
 		return labsAnchorStyles;
@@ -170,11 +162,7 @@ const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.DeadBlog:
 			return css(
 				blogAnchorStyles,
-				blogColor(
-					bylineDarkGrayBackground,
-					bylineWhiteGrayBackground,
-					invertedByline,
-				),
+				blogColor(bylineInline, bylineLeftColumn, bylineDark),
 			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:

--- a/apps-rendering/src/components/byline.tsx
+++ b/apps-rendering/src/components/byline.tsx
@@ -116,7 +116,8 @@ const labsAnchorStyles = css`
 `;
 
 const getStyles = (format: ArticleFormat): SerializedStyles => {
-	const byline = text.byline(format);
+	const bylineLightGrayBackground = text.bylineLightGrayBackground(format);
+	const bylineDarkGrayBackground = text.bylineDarkGrayBackground(format);
 	const invertedByline = text.invertedByline(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
@@ -127,22 +128,34 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.LiveBlog:
 			return css(
 				blogStyles,
-				blogColor(neutral[100], byline, invertedByline),
+				blogColor(
+					neutral[100],
+					bylineLightGrayBackground,
+					invertedByline,
+				),
 			);
 		case ArticleDesign.DeadBlog:
-			return css(blogStyles, blogColor(byline, byline, neutral[93]));
+			return css(
+				blogStyles,
+				blogColor(
+					bylineDarkGrayBackground,
+					bylineLightGrayBackground,
+					neutral[93],
+				),
+			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
-			return commentStyles(byline);
+			return commentStyles(bylineLightGrayBackground);
 		default:
-			return styles(byline);
+			return styles(bylineLightGrayBackground);
 	}
 };
 
 const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 	const { kicker, inverted, link } = getThemeStyles(format.theme);
-	const byline = text.byline(format);
+	const bylineWhiteGrayBackground = text.bylineLightGrayBackground(format);
+	const bylineDarkGrayBackground = text.bylineDarkGrayBackground(format);
 	const invertedByline = text.invertedByline(format);
 
 	if (format.theme === ArticleSpecial.Labs) {
@@ -157,7 +170,11 @@ const getAnchorStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.DeadBlog:
 			return css(
 				blogAnchorStyles,
-				blogColor(byline, byline, invertedByline),
+				blogColor(
+					bylineDarkGrayBackground,
+					bylineWhiteGrayBackground,
+					invertedByline,
+				),
 			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:

--- a/apps-rendering/src/components/commentCount.stories.tsx
+++ b/apps-rendering/src/components/commentCount.stories.tsx
@@ -1,9 +1,14 @@
 // ----- Imports ----- //
 
+import {
+	getAllThemes,
+	getThemeNameAsString,
+} from '@guardian/common-rendering/src/fixtures/article';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
 import { some } from '@guardian/types';
 import { boolean, number, withKnobs } from '@storybook/addon-knobs';
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import CommentCount from './commentCount';
 
@@ -19,6 +24,37 @@ const Default: FC = () => (
 	/>
 );
 
+const Deadblogs = (): ReactElement => {
+	return (
+		<>
+			{getAllThemes({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.DeadBlog,
+			}).map((format) => (
+				<div key={format.theme}>
+					<p>{getThemeNameAsString(format)}</p>
+					<CommentCount
+						count={some(number('Count', 1234, { min: 0 }))}
+						theme={format.theme}
+						design={ArticleDesign.DeadBlog}
+						display={ArticleDisplay.Standard}
+						commentable={boolean('Commentable', true)}
+					/>
+					<br />
+				</div>
+			))}
+		</>
+	);
+};
+
+Deadblogs.story = {
+	name: 'Deadblogs comment count below desktop',
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: { viewports: [breakpoints.tablet] },
+	},
+};
+
 // ----- Exports ----- //
 
 export default {
@@ -27,4 +63,4 @@ export default {
 	decorators: [withKnobs],
 };
 
-export { Default };
+export { Default, Deadblogs };

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { fill } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import {
@@ -71,14 +72,15 @@ const deadblogStyles = css`
 	}
 `;
 
-const getStyles = ({ theme, design }: ArticleFormat): SerializedStyles => {
-	const colours = getThemeStyles(theme);
+const getStyles = (format: ArticleFormat): SerializedStyles => {
+	const colours = getThemeStyles(format.theme);
+	const commentCount = fill.commentCount(format);
 
-	switch (design) {
+	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			return blogStyles(neutral[93]);
 		case ArticleDesign.DeadBlog:
-			return css(blogStyles(colours.link), deadblogStyles);
+			return css(blogStyles(commentCount), deadblogStyles);
 		default:
 			return styles(colours.kicker, border.secondary, neutral[20]);
 	}
@@ -98,19 +100,17 @@ const deadblogBubbleStyles = (color: string): SerializedStyles => css`
 	}
 `;
 
-const getBubbleStyles = ({
-	theme,
-	design,
-}: ArticleFormat): SerializedStyles => {
-	const colours = getThemeStyles(theme);
+const getBubbleStyles = (format: ArticleFormat): SerializedStyles => {
+	const colours = getThemeStyles(format.theme);
+	const commentCount = fill.commentCount(format);
 
-	switch (design) {
+	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			return css(bubbleStyles(neutral[93]), liveblogBubbleStyles);
 		case ArticleDesign.DeadBlog:
 			return css(
 				bubbleStyles(neutral[93]),
-				deadblogBubbleStyles(colours.link),
+				deadblogBubbleStyles(commentCount),
 			);
 		default:
 			return bubbleStyles(colours.kicker);

--- a/apps-rendering/src/components/follow.stories.tsx
+++ b/apps-rendering/src/components/follow.stories.tsx
@@ -1,5 +1,9 @@
 // ----- Imports ----- //
 
+import {
+	getAllThemes,
+	getThemeNameAsString,
+} from '@guardian/common-rendering/src/fixtures/article';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { none } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
@@ -25,6 +29,35 @@ const Default: FC = () => (
 	/>
 );
 
+const Deadblogs: FC = () => {
+	return (
+		<>
+			{getAllThemes({
+				display: ArticleDisplay.Standard,
+				design: ArticleDesign.DeadBlog,
+			}).map((format) => (
+				<div key={format.theme}>
+					<p>{getThemeNameAsString(format)}</p>
+					<Follow
+						contributors={[
+							{
+								id: 'profile/janesmith',
+								apiUrl: 'janesmith.com',
+								name: 'Jane Smith',
+								image: none,
+							},
+						]}
+						theme={format.theme}
+						design={ArticleDesign.DeadBlog}
+						display={ArticleDisplay.Standard}
+					/>
+					<br />
+				</div>
+			))}
+		</>
+	);
+};
+
 // ----- Exports ----- //
 
 export default {
@@ -33,4 +66,4 @@ export default {
 	decorators: [withKnobs],
 };
 
-export { Default };
+export { Default, Deadblogs };

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { remSpace, textSans, until } from '@guardian/source-foundations';
+import { remSpace, textSans } from '@guardian/source-foundations';
 import FollowStatus from 'components/followStatus';
 import type { Contributor } from 'contributor';
 import { isSingleContributor } from 'contributor';

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { remSpace, textSans } from '@guardian/source-foundations';
+import { remSpace, textSans, until } from '@guardian/source-foundations';
 import FollowStatus from 'components/followStatus';
 import type { Contributor } from 'contributor';
 import { isSingleContributor } from 'contributor';

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -20,7 +20,7 @@ interface Props extends ArticleFormat {
 
 const styles = (format: ArticleFormat): SerializedStyles => {
 	const follow = text.follow(format);
-	const invertedFollow = text.invertedFollow(format);
+	const followDark = text.followDark(format);
 
 	return css`
 		${textSans.small()}
@@ -42,7 +42,7 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 		}
 
 		${darkModeCss`
-			color: ${invertedFollow};
+			color: ${followDark};
 		`}
 	`;
 };

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { remSpace, textSans } from '@guardian/source-foundations';
@@ -10,7 +11,6 @@ import type { Contributor } from 'contributor';
 import { isSingleContributor } from 'contributor';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
-import { getThemeStyles } from 'themeStyles';
 
 // ----- Component ----- //
 
@@ -18,12 +18,13 @@ interface Props extends ArticleFormat {
 	contributors: Contributor[];
 }
 
-const styles = ({ theme }: ArticleFormat): SerializedStyles => {
-	const { kicker, inverted } = getThemeStyles(theme);
+const styles = (format: ArticleFormat): SerializedStyles => {
+	const follow = text.follow(format);
+	const invertedFollow = text.invertedFollow(format);
 
 	return css`
 		${textSans.small()}
-		color: ${kicker};
+		color: ${follow};
 		display: flex;
 		align-items: center;
 		column-gap: 0.2em;
@@ -41,7 +42,7 @@ const styles = ({ theme }: ArticleFormat): SerializedStyles => {
 		}
 
 		${darkModeCss`
-			color: ${inverted};
+			color: ${invertedFollow};
 		`}
 	`;
 };

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -1,8 +1,11 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
 import KeyEvents from '@guardian/common-rendering/src/components/keyEvents';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, news, remSpace } from '@guardian/source-foundations';
 import { OptionKind } from '@guardian/types';
 import Footer from 'components/footer';
@@ -58,9 +61,18 @@ const mainStyles = css`
 	}
 `;
 
-const metadataWrapperStyles = css`
-	background-color: ${news[200]};
-`;
+const metadataWrapperStyles = (format: ArticleFormat): SerializedStyles => {
+	switch (format.design) {
+		case ArticleDesign.DeadBlog:
+			return css`
+				background-color: ${neutral[93]};
+			`;
+		default:
+			return css`
+				background-color: ${news[200]};
+			`;
+	}
+};
 
 const keyEventsWrapperStyles = css`
 	${from.desktop} {
@@ -95,7 +107,7 @@ const Live: FC<Props> = ({ item }) => (
 		<LiveblogHeader item={item} />
 		<main css={mainStyles}>
 			<GridItem area="metadata">
-				<div css={metadataWrapperStyles}>
+				<div css={metadataWrapperStyles(item)}>
 					<Metadata item={item} />
 				</div>
 			</GridItem>

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -115,7 +115,7 @@ const Live: FC<Props> = ({ item }) => (
 				<div css={keyEventsWrapperStyles}>
 					<KeyEvents
 						keyEvents={keyEvents(item.blocks)}
-						theme={item.theme}
+						format={item}
 						supportsDarkMode
 					/>
 				</div>

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -2,6 +2,7 @@
 
 import { css } from '@emotion/react';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import { border } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { map, OptionKind, partition } from '@guardian/types';
 import { LastUpdated } from 'components/lastUpdated';
@@ -25,6 +26,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 			{blocks.map((block) => {
 				// TODO: get page number
 				const blockLink = `${1}#block-${block.id}`;
+				const borderLiveBlock = border.liveBlock(format);
 				const blockFirstPublished = pipe(
 					block.firstPublished,
 					map(Number),
@@ -35,7 +37,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 					<LiveBlockContainer
 						key={block.id}
 						id={block.id}
-						borderColour="black"
+						borderColour={borderLiveBlock}
 						blockTitle={block.title}
 						blockFirstPublished={blockFirstPublished}
 						blockLink={blockLink}

--- a/common-rendering/src/components/keyEvents.stories.tsx
+++ b/common-rendering/src/components/keyEvents.stories.tsx
@@ -2,7 +2,7 @@
 
 import { KeyEvent } from "./keyEvents";
 import KeyEvents from "./keyEvents";
-import { ArticlePillar, ArticleSpecial, ArticleTheme } from "@guardian/libs";
+import { ArticleDesign, ArticleDisplay, ArticleFormat, ArticlePillar, ArticleSpecial, ArticleTheme } from "@guardian/libs";
 import { css } from "@emotion/react";
 
 // ----- Stories ----- //
@@ -50,16 +50,24 @@ const events: KeyEvent[] = [
 	},
 ];
 
-const KeyEventComp = (dark: boolean, theme: ArticleTheme, title: string) => (
+const KeyEventComp = (dark: boolean, format: ArticleFormat, title: string) => (
 	<div
 		css={css`
 			flex-grow: 1;
 		`}
 	>
 		<div>{title}</div>
-		<KeyEvents keyEvents={events} theme={theme} supportsDarkMode={dark} />
+		<KeyEvents keyEvents={events} format={format} supportsDarkMode={dark} />
 	</div>
 );
+
+const getFormat = (theme: ArticleTheme) => {
+	return {
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
+		theme: theme,
+	}
+}
 
 const keyEventWithTheme = (dark: boolean) => () =>
 	(
@@ -71,13 +79,13 @@ const keyEventWithTheme = (dark: boolean) => () =>
 				flex-wrap: wrap;
 			`}
 		>
-			{KeyEventComp(dark, ArticlePillar.News, "News")}
-			{KeyEventComp(dark, ArticlePillar.Culture, "Culture")}
-			{KeyEventComp(dark, ArticlePillar.Lifestyle, "Lifestyle")}
-			{KeyEventComp(dark, ArticlePillar.Opinion, "Opinion")}
-			{KeyEventComp(dark, ArticlePillar.Sport, "Sport")}
-			{KeyEventComp(dark, ArticleSpecial.Labs, "Labs")}
-			{KeyEventComp(dark, ArticleSpecial.SpecialReport, "SpecialReport")}
+			{KeyEventComp(dark, getFormat(ArticlePillar.News), "News")}
+			{KeyEventComp(dark, getFormat(ArticlePillar.Culture), "Culture")}
+			{KeyEventComp(dark, getFormat(ArticlePillar.Lifestyle), "Lifestyle")}
+			{KeyEventComp(dark, getFormat(ArticlePillar.Opinion), "Opinion")}
+			{KeyEventComp(dark, getFormat(ArticlePillar.Sport), "Sport")}
+			{KeyEventComp(dark, getFormat(ArticleSpecial.Labs), "Labs")}
+			{KeyEventComp(dark, getFormat(ArticleSpecial.SpecialReport), "SpecialReport")}
 		</div>
 	);
 

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -2,7 +2,7 @@
 
 import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
-import { textSans, headline } from "@guardian/source-foundations";
+import { textSans, headline, specialReport, labs } from "@guardian/source-foundations";
 import { remSpace } from "@guardian/source-foundations";
 import {
 	culture,
@@ -13,7 +13,7 @@ import {
 	opinion,
 } from "@guardian/source-foundations";
 import { Link } from "@guardian/source-react-components";
-import { ArticlePillar, ArticleTheme, timeAgo } from "@guardian/libs";
+import { ArticlePillar, ArticleSpecial, ArticleTheme, timeAgo } from "@guardian/libs";
 import { from } from "@guardian/source-foundations";
 import { darkModeCss } from "../lib";
 import Accordion from "./accordion";
@@ -112,20 +112,47 @@ const timeTextWrapperStyles: SerializedStyles = css`
 const keyEventsTextGrayBackground = (theme: ArticleTheme): string => {
 	switch (theme) {
 		case ArticlePillar.News:
-		case ArticlePillar.Lifestyle:
+			return news[400];
 		case ArticlePillar.Sport:
-			return getColor(theme, 400);
-		default:
-			return getColor(theme, 300);
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
 	}
 };
+
+const keyEventsTextWhiteBackground = (theme: ArticleTheme): string => {
+	switch (theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Culture:
+			return culture[350];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
+	}
+}
 
 const textStyles = (
 	theme: ArticleTheme,
 	supportsDarkMode: boolean
 ): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
-	color: ${getColor(theme, 400)};
+	color: ${keyEventsTextWhiteBackground(theme)};
 
 	text-decoration: none;
 

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -110,20 +110,20 @@ const textStyles = (
 	supportsDarkMode: boolean
 ): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
-	color: ${text.keyEventsWhiteBackground(format)};
+	color: ${text.keyEventsInline(format)};
 
 	text-decoration: none;
 
 	&:hover {
-		color: ${text.keyEventsWhiteBackground(format)};
+		color: ${text.keyEventsInline(format)};
 		text-decoration: underline;
 	}
 
 	${from.desktop} {
-		color: ${text.keyEventsGrayBackground(format)};
+		color: ${text.keyEventsLeftColumn(format)};
 
 		&:hover {
-			color: ${text.keyEventsGrayBackground(format)};
+			color: ${text.keyEventsLeftColumn(format)};
 			text-decoration: underline;
 		}
 	}

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -2,19 +2,20 @@
 
 import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
-import { textSans, headline } from "@guardian/source-foundations";
+import { textSans, headline, sport, culture, lifestyle, opinion, news } from "@guardian/source-foundations";
 import { remSpace } from "@guardian/source-foundations";
 import {
 	neutral,
 } from "@guardian/source-foundations";
 import { Link } from "@guardian/source-react-components";
-import { ArticleFormat, timeAgo } from "@guardian/libs";
+import { ArticleFormat, ArticlePillar, ArticleTheme, timeAgo } from "@guardian/libs";
 import { from } from "@guardian/source-foundations";
 import { darkModeCss } from "../lib";
 import Accordion from "./accordion";
 import { text } from "../editorialPalette";
 
 // ----- Component ----- //
+type paletteId = 300 | 400 | 500;
 interface KeyEvent {
 	date: Date;
 	text: string;
@@ -32,6 +33,21 @@ interface ListItemProps {
 	format: ArticleFormat;
 	supportsDarkMode: boolean;
 }
+
+const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
+	switch (theme) {
+		case ArticlePillar.Sport:
+			return sport[paletteId];
+		case ArticlePillar.Culture:
+			return culture[paletteId];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[paletteId];
+		case ArticlePillar.Opinion:
+			return opinion[paletteId];
+		default:
+			return news[paletteId];
+	}
+};
 
 const keyEventWrapperStyles = (
 	supportsDarkMode: boolean
@@ -113,9 +129,9 @@ const textStyles = (
 	}
 
 	${darkModeCss(supportsDarkMode)`
-		color: ${text.invertedLink(format)};
+		color: ${getColor(format.theme, 500)};
 		&:hover {
-			color: ${text.invertedLink(format)};
+			color: ${getColor(format.theme, 500)};
 		}
 	`}
 

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -2,25 +2,19 @@
 
 import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
-import { textSans, headline, specialReport, labs } from "@guardian/source-foundations";
+import { textSans, headline } from "@guardian/source-foundations";
 import { remSpace } from "@guardian/source-foundations";
 import {
-	culture,
-	lifestyle,
 	neutral,
-	news,
-	sport,
-	opinion,
 } from "@guardian/source-foundations";
 import { Link } from "@guardian/source-react-components";
-import { ArticlePillar, ArticleSpecial, ArticleTheme, timeAgo } from "@guardian/libs";
+import { ArticleFormat, timeAgo } from "@guardian/libs";
 import { from } from "@guardian/source-foundations";
 import { darkModeCss } from "../lib";
 import Accordion from "./accordion";
+import { text } from "../editorialPalette";
 
 // ----- Component ----- //
-type paletteId = 300 | 400 | 500;
-
 interface KeyEvent {
 	date: Date;
 	text: string;
@@ -29,30 +23,15 @@ interface KeyEvent {
 
 interface KeyEventsProps {
 	keyEvents: KeyEvent[];
-	theme: ArticleTheme;
+	format: ArticleFormat;
 	supportsDarkMode: boolean;
 }
 
 interface ListItemProps {
 	keyEvent: KeyEvent;
-	theme: ArticleTheme;
+	format: ArticleFormat;
 	supportsDarkMode: boolean;
 }
-
-const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
-	switch (theme) {
-		case ArticlePillar.Sport:
-			return sport[paletteId];
-		case ArticlePillar.Culture:
-			return culture[paletteId];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[paletteId];
-		case ArticlePillar.Opinion:
-			return opinion[paletteId];
-		default:
-			return news[paletteId];
-	}
-};
 
 const keyEventWrapperStyles = (
 	supportsDarkMode: boolean
@@ -109,71 +88,34 @@ const timeTextWrapperStyles: SerializedStyles = css`
 	margin-left: ${remSpace[4]};
 `;
 
-const keyEventsTextGrayBackground = (theme: ArticleTheme): string => {
-	switch (theme) {
-		case ArticlePillar.News:
-			return news[400];
-		case ArticlePillar.Sport:
-			return sport[400];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
-		case ArticlePillar.Culture:
-			return culture[300];
-		case ArticlePillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-	}
-};
-
-const keyEventsTextWhiteBackground = (theme: ArticleTheme): string => {
-	switch (theme) {
-		case ArticlePillar.News:
-			return news[400];
-		case ArticlePillar.Sport:
-			return sport[400];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
-		case ArticlePillar.Culture:
-			return culture[350];
-		case ArticlePillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[400];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
-	}
-}
 
 const textStyles = (
-	theme: ArticleTheme,
+	format: ArticleFormat,
 	supportsDarkMode: boolean
 ): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
-	color: ${keyEventsTextWhiteBackground(theme)};
+	color: ${text.keyEventsWhiteBackground(format)};
 
 	text-decoration: none;
 
 	&:hover {
-		color: ${getColor(theme, 400)};
+		color: ${text.keyEventsWhiteBackground(format)};
 		text-decoration: underline;
 	}
 
 	${from.desktop} {
-		color: ${keyEventsTextGrayBackground(theme)};
+		color: ${text.keyEventsGrayBackground(format)};
 
 		&:hover {
-			color: ${keyEventsTextGrayBackground(theme)};
+			color: ${text.keyEventsGrayBackground(format)};
 			text-decoration: underline;
 		}
 	}
 
 	${darkModeCss(supportsDarkMode)`
-		color: ${getColor(theme, 500)};
+		color: ${text.invertedLink(format)};
 		&:hover {
-			color: ${getColor(theme, 500)};
+			color: ${text.invertedLink(format)};
 		}
 	`}
 
@@ -189,7 +131,7 @@ const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	`}
 `;
 
-const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
+const ListItem = ({ keyEvent, format, supportsDarkMode }: ListItemProps) => {
 	return (
 		<li css={listItemStyles(supportsDarkMode)}>
 			<div css={timeTextWrapperStyles}>
@@ -203,7 +145,7 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 				</time>
 				<Link
 					priority="secondary"
-					css={textStyles(theme, supportsDarkMode)}
+					css={textStyles(format, supportsDarkMode)}
 					href={keyEvent.url}
 				>
 					{keyEvent.text}
@@ -213,7 +155,7 @@ const ListItem = ({ keyEvent, theme, supportsDarkMode }: ListItemProps) => {
 	);
 };
 
-const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
+const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
 	return (
 		<nav
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
@@ -232,7 +174,7 @@ const KeyEvents = ({ keyEvents, theme, supportsDarkMode }: KeyEventsProps) => {
 						<ListItem
 							key={`${event.url}${index}`}
 							keyEvent={event}
-							theme={theme}
+							format={format}
 							supportsDarkMode={supportsDarkMode}
 						/>
 					))}

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -348,7 +348,7 @@ const textStandfirstLink = (format: ArticleFormat): Colour => {
 				case ArticlePillar.Culture:
 					return culture[300];
 				case ArticlePillar.Opinion:
-					return opinion[300];
+					return opinion[200];
 				case ArticleSpecial.Labs:
 					return labs[300];
 				case ArticleSpecial.SpecialReport:

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -21,7 +21,9 @@ interface Palette {
 		headline: Colour;
 		headlineDark: Colour;
 		byline: Colour;
+		follow: Colour;
 		invertedByline: Colour;
+		invertedFollow: Colour;
 		standfirst: Colour;
 		standfirstDark: Colour;
 		standfirstLink: Colour;
@@ -150,7 +152,45 @@ const textByline = (format: ArticleFormat): Colour => {
 	}
 }
 
+const textFollow = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Culture:
+				return culture[300];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return labs[300];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+	}
+}
+
 const textInvertedByline = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+			return news[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticleSpecial.Labs:
+			return specialReport[500];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
+	}
+}
+
+const textInvertedFollow = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 			return news[500];
@@ -451,7 +491,9 @@ const text = {
 	headline: textHeadline,
 	headlineDark: textHeadlineDark,
 	byline: textByline,
+	follow: textFollow,
 	invertedByline: textInvertedByline,
+	invertedFollow: textInvertedFollow,
 	standfirst: textStandfirst,
 	standfirstDark: textStandfirstDark,
 	standfirstLink: textStandfirstLink,
@@ -482,7 +524,9 @@ const palette = (format: ArticleFormat): Palette => ({
 		headline: text.headline(format),
 		headlineDark: text.headlineDark(format),
 		byline: text.byline(format),
+		follow: text.follow(format),
 		invertedByline: text.invertedByline(format),
+		invertedFollow: text.invertedFollow(format),
 		standfirst: text.standfirst(format),
 		standfirstDark: text.standfirstDark(format),
 		standfirstLink: text.standfirstLink(format),

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -494,9 +494,9 @@ const borderLiveBlock = (format: ArticleFormat): Colour => {
 		case ArticlePillar.Sport:
 			return sport[400];
 		case ArticlePillar.Culture:
-			return culture[400];
+			return culture[350];
 		case ArticlePillar.Opinion:
-			return opinion[400];
+			return opinion[300];
 		case ArticleSpecial.Labs:
 			return labs[400];
 		case ArticleSpecial.SpecialReport:

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -342,9 +342,9 @@ const textStandfirstLink = (format: ArticleFormat): Colour => {
 				case ArticlePillar.News:
 					return news[400];
 				case ArticlePillar.Lifestyle:
-					return lifestyle[400];
+					return lifestyle[300];
 				case ArticlePillar.Sport:
-					return sport[400];
+					return sport[300];
 				case ArticlePillar.Culture:
 					return culture[300];
 				case ArticlePillar.Opinion:

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -244,9 +244,9 @@ const textArticleLink = (format: ArticleFormat): Colour => {
 				case ArticlePillar.Sport:
 					return sport[400];
 				case ArticlePillar.Culture:
-					return culture[400];
+					return culture[350];
 				case ArticlePillar.Opinion:
-					return opinion[400];
+					return opinion[300];
 				case ArticleSpecial.Labs:
 					return specialReport[400];
 				case ArticleSpecial.SpecialReport:

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -20,6 +20,8 @@ interface Palette {
 	text: {
 		headline: Colour;
 		headlineDark: Colour;
+		byline: Colour;
+		invertedByline: Colour;
 		standfirst: Colour;
 		standfirstDark: Colour;
 		standfirstLink: Colour;
@@ -91,6 +93,81 @@ const textHeadlineDark = (format: ArticleFormat): Colour => {
 			return neutral[86];
 	}
 };
+
+const textByline = (format: ArticleFormat): Colour => {
+	switch(format.design) {
+		case ArticleDesign.DeadBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+			}
+		case ArticleDesign.LiveBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+			}
+		default:
+			switch(format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+			}
+	}
+}
+
+const textInvertedByline = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+			return news[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticleSpecial.Labs:
+			return specialReport[500];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
+	}
+}
 
 const textStandfirst = ({ design }: ArticleFormat): Colour => {
 	switch (design) {
@@ -373,6 +450,8 @@ const fillIconDark = (format: ArticleFormat): Colour => {
 const text = {
 	headline: textHeadline,
 	headlineDark: textHeadlineDark,
+	byline: textByline,
+	invertedByline: textInvertedByline,
 	standfirst: textStandfirst,
 	standfirstDark: textStandfirstDark,
 	standfirstLink: textStandfirstLink,
@@ -402,6 +481,8 @@ const palette = (format: ArticleFormat): Palette => ({
 	text: {
 		headline: text.headline(format),
 		headlineDark: text.headlineDark(format),
+		byline: text.byline(format),
+		invertedByline: text.invertedByline(format),
 		standfirst: text.standfirst(format),
 		standfirstDark: text.standfirstDark(format),
 		standfirstLink: text.standfirstLink(format),

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -50,6 +50,7 @@ interface Palette {
 	commentCount: Colour;
     icon: Colour;
     iconDark: Colour;
+	blockquoteIcon: Colour;
   }
 }
 
@@ -626,6 +627,47 @@ const fillIconDark = (format: ArticleFormat): Colour => {
   }
 };
 
+const fillBlockquoteIcon = (format: ArticleFormat): Colour => {
+	switch(format.design) {
+		case ArticleDesign.DeadBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[350];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+			}
+		default:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+			}
+	}
+
+
+}
+
 // ----- API ----- //
 
 const text = {
@@ -664,6 +706,7 @@ const fill = {
   commentCount: fillCommentCount,
   icon: fillIcon,
   iconDark: fillIconDark,
+  blockquoteIcon: fillBlockquoteIcon,
 };
 
 const palette = (format: ArticleFormat): Palette => ({
@@ -700,6 +743,7 @@ const palette = (format: ArticleFormat): Palette => ({
 	commentCount: fill.commentCount(format),
     icon: fill.icon(format),
     iconDark: fill.iconDark(format),
+	blockquoteIcon: fill.blockquoteIcon(format),
   }
 });
 

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -19,16 +19,16 @@ type Colour = string;
 interface Palette {
 	text: {
 		articleLink: Colour;
-		bylineLightGrayBackground: Colour;
-		bylineDarkGrayBackground: Colour;
+		bylineLeftColumn: Colour;
+		bylineInline: Colour;
+		bylineDark: Colour;
 		follow: Colour;
+		followDark: Colour;
 		headline: Colour;
 		headlineDark: Colour;
-		invertedByline: Colour;
-		invertedFollow: Colour;
-		invertedLink: Colour;
-		keyEventsWhiteBackground: Colour;
-		keyEventsGrayBackground: Colour;
+		keyEventsInline: Colour;
+		keyEventsLeftColumn: Colour;
+		linkDark: Colour;
 		standfirst: Colour;
 		standfirstDark: Colour;
 		standfirstLink: Colour;
@@ -104,7 +104,7 @@ const textHeadlineDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const textBylineLightGrayBackground = (format: ArticleFormat): Colour => {
+const textBylineLeftColumn = (format: ArticleFormat): Colour => {
 	switch(format.design) {
 		case ArticleDesign.DeadBlog:
 			switch (format.theme) {
@@ -160,7 +160,7 @@ const textBylineLightGrayBackground = (format: ArticleFormat): Colour => {
 	}
 }
 
-const textBylineDarkGrayBackground = (format: ArticleFormat): Colour => {
+const textBylineInline = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 				return news[400];
@@ -199,7 +199,7 @@ const textFollow = (format: ArticleFormat): Colour => {
 }
 
 
-const textInvertedByline = (format: ArticleFormat): Colour => {
+const textBylineDark = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 			return news[500];
@@ -218,7 +218,7 @@ const textInvertedByline = (format: ArticleFormat): Colour => {
 	}
 }
 
-const textInvertedFollow = (format: ArticleFormat): Colour => {
+const textFollowDark = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 			return news[500];
@@ -237,7 +237,7 @@ const textInvertedFollow = (format: ArticleFormat): Colour => {
 	}
 }
 
-const textInvertedLink = (format: ArticleFormat): Colour => {
+const textLinkDark = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 			return news[500];
@@ -296,7 +296,7 @@ const textArticleLink = (format: ArticleFormat): Colour => {
 	}
 }
 
-const textKeyEventsWhiteBackground = ({theme}: ArticleFormat): Colour => {
+const textKeyEventsInline = ({theme}: ArticleFormat): Colour => {
 	switch (theme) {
 		case ArticlePillar.News:
 			return news[400];
@@ -315,7 +315,7 @@ const textKeyEventsWhiteBackground = ({theme}: ArticleFormat): Colour => {
 	}
 }
 
-const textKeyEventsGrayBackground = ({theme} : ArticleFormat): Colour => {
+const textKeyEventsLeftColumn = ({theme} : ArticleFormat): Colour => {
 	switch (theme) {
 		case ArticlePillar.News:
 			return news[400];
@@ -512,17 +512,17 @@ const borderLiveBlock = (format: ArticleFormat): Colour => {
 		case ArticlePillar.News:
 			return news[400];
 		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
+			return lifestyle[300];
 		case ArticlePillar.Sport:
-			return sport[400];
+			return sport[300];
 		case ArticlePillar.Culture:
-			return culture[350];
+			return culture[300];
 		case ArticlePillar.Opinion:
 			return opinion[300];
 		case ArticleSpecial.Labs:
-			return labs[400];
+			return labs[300];
 		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
+			return specialReport[300];
 	}
 }
 
@@ -693,16 +693,16 @@ const fillBlockquoteIcon = (format: ArticleFormat): Colour => {
 
 const text = {
 	articleLink: textArticleLink,
-	bylineLightGrayBackground: textBylineLightGrayBackground,
-	bylineDarkGrayBackground: textBylineDarkGrayBackground,
+	bylineLeftColumn: textBylineLeftColumn,
+	bylineInline: textBylineInline,
+	bylineDark: textBylineDark,
 	follow: textFollow,
+	followDark: textFollowDark,
 	headline: textHeadline,
 	headlineDark: textHeadlineDark,
-	invertedByline: textInvertedByline,
-	invertedFollow: textInvertedFollow,
-	invertedLink: textInvertedLink,
-	keyEventsWhiteBackground: textKeyEventsWhiteBackground,
-	keyEventsGrayBackground: textKeyEventsGrayBackground,
+	keyEventsInline: textKeyEventsInline,
+	keyEventsLeftColumn: textKeyEventsLeftColumn,
+	linkDark: textLinkDark,
 	standfirst: textStandfirst,
 	standfirstDark: textStandfirstDark,
 	standfirstLink: textStandfirstLink,
@@ -734,16 +734,16 @@ const fill = {
 const palette = (format: ArticleFormat): Palette => ({
 	text: {
 		articleLink: text.articleLink(format),
-		bylineLightGrayBackground: text.bylineLightGrayBackground(format),
-		bylineDarkGrayBackground: text.bylineDarkGrayBackground(format),
+		bylineLeftColumn: text.bylineLeftColumn(format),
+		bylineInline: text.bylineInline(format),
+		bylineDark: text.bylineDark(format),
 		follow: text.follow(format),
+		followDark: text.followDark(format),
 		headline: text.headline(format),
 		headlineDark: text.headlineDark(format),
-		invertedByline: text.invertedByline(format),
-		invertedFollow: text.invertedFollow(format),
-		invertedLink: text.invertedLink(format),
-		keyEventsWhiteBackground: text.keyEventsWhiteBackground(format),
-		keyEventsGrayBackground: text.keyEventsGrayBackground(format),
+		keyEventsInline: text.keyEventsInline(format),
+		keyEventsLeftColumn: text.keyEventsLeftColumn(format),
+		linkDark: text.linkDark(format),
 		standfirst: text.standfirst(format),
 		standfirstDark: text.standfirstDark(format),
 		standfirstLink: text.standfirstLink(format),

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -18,14 +18,16 @@ type Colour = string;
 
 interface Palette {
 	text: {
-		headline: Colour;
-		headlineDark: Colour;
+		articleLink: Colour;
 		byline: Colour;
 		follow: Colour;
+		headline: Colour;
+		headlineDark: Colour;
 		invertedByline: Colour;
 		invertedFollow: Colour;
 		invertedLink: Colour;
-		articleLink: Colour;
+		keyEventsWhiteBackground: Colour;
+		keyEventsGrayBackground: Colour;
 		standfirst: Colour;
 		standfirstDark: Colour;
 		standfirstLink: Colour;
@@ -269,6 +271,44 @@ const textArticleLink = (format: ArticleFormat): Colour => {
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
 			}
+	}
+}
+
+const textKeyEventsWhiteBackground = ({theme}: ArticleFormat): Colour => {
+	switch (theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Culture:
+			return culture[350];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
+	}
+}
+
+const textKeyEventsGrayBackground = ({theme} : ArticleFormat): Colour => {
+	switch (theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
 	}
 }
 
@@ -589,14 +629,16 @@ const fillIconDark = (format: ArticleFormat): Colour => {
 // ----- API ----- //
 
 const text = {
-	headline: textHeadline,
-	headlineDark: textHeadlineDark,
+	articleLink: textArticleLink,
 	byline: textByline,
 	follow: textFollow,
+	headline: textHeadline,
+	headlineDark: textHeadlineDark,
 	invertedByline: textInvertedByline,
 	invertedFollow: textInvertedFollow,
 	invertedLink: textInvertedLink,
-	articleLink: textArticleLink,
+	keyEventsWhiteBackground: textKeyEventsWhiteBackground,
+	keyEventsGrayBackground: textKeyEventsGrayBackground,
 	standfirst: textStandfirst,
 	standfirstDark: textStandfirstDark,
 	standfirstLink: textStandfirstLink,
@@ -626,14 +668,16 @@ const fill = {
 
 const palette = (format: ArticleFormat): Palette => ({
 	text: {
-		headline: text.headline(format),
-		headlineDark: text.headlineDark(format),
+		articleLink: text.articleLink(format),
 		byline: text.byline(format),
 		follow: text.follow(format),
+		headline: text.headline(format),
+		headlineDark: text.headlineDark(format),
 		invertedByline: text.invertedByline(format),
 		invertedFollow: text.invertedFollow(format),
 		invertedLink: text.invertedLink(format),
-		articleLink: text.articleLink(format),
+		keyEventsWhiteBackground: text.keyEventsWhiteBackground(format),
+		keyEventsGrayBackground: text.keyEventsGrayBackground(format),
 		standfirst: text.standfirst(format),
 		standfirstDark: text.standfirstDark(format),
 		standfirstLink: text.standfirstLink(format),

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -42,6 +42,7 @@ interface Palette {
 		standfirstLinkDark: Colour;
 	};
   fill: {
+	commentCount: Colour;
     icon: Colour;
     iconDark: Colour;
   }
@@ -449,6 +450,25 @@ const backgroundStandfirstDark = ({
 	}
 };
 
+const fillCommentCount = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+	}
+}
+
 const fillIcon = (format: ArticleFormat): Colour => {
   switch (format.theme) {
     case ArticlePillar.Opinion:
@@ -515,6 +535,7 @@ const border = {
 };
 
 const fill = {
+  commentCount: fillCommentCount,
   icon: fillIcon,
   iconDark: fillIconDark,
 };
@@ -545,6 +566,7 @@ const palette = (format: ArticleFormat): Palette => ({
 		standfirstLinkDark: border.standfirstLinkDark(format),
 	},
   fill: {
+	commentCount: fill.commentCount(format),
     icon: fill.icon(format),
     iconDark: fill.iconDark(format),
   }

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -19,7 +19,8 @@ type Colour = string;
 interface Palette {
 	text: {
 		articleLink: Colour;
-		byline: Colour;
+		bylineLightGrayBackground: Colour;
+		bylineDarkGrayBackground: Colour;
 		follow: Colour;
 		headline: Colour;
 		headlineDark: Colour;
@@ -103,16 +104,16 @@ const textHeadlineDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const textByline = (format: ArticleFormat): Colour => {
+const textBylineLightGrayBackground = (format: ArticleFormat): Colour => {
 	switch(format.design) {
 		case ArticleDesign.DeadBlog:
 			switch (format.theme) {
 				case ArticlePillar.News:
 					return news[400];
 				case ArticlePillar.Lifestyle:
-					return lifestyle[400];
+					return lifestyle[300];
 				case ArticlePillar.Sport:
-					return sport[400];
+					return sport[300];
 				case ArticlePillar.Culture:
 					return culture[300];
 				case ArticlePillar.Opinion:
@@ -159,24 +160,44 @@ const textByline = (format: ArticleFormat): Colour => {
 	}
 }
 
-const textFollow = (format: ArticleFormat): Colour => {
+const textBylineDarkGrayBackground = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
 		case ArticlePillar.News:
 				return news[400];
 			case ArticlePillar.Lifestyle:
-				return lifestyle[400];
+				return lifestyle[300];
 			case ArticlePillar.Sport:
-				return sport[400];
+				return sport[300];
 			case ArticlePillar.Culture:
 				return culture[300];
 			case ArticlePillar.Opinion:
-				return opinion[300];
+				return opinion[200];
 			case ArticleSpecial.Labs:
 				return labs[300];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
 	}
 }
+
+const textFollow = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[300];
+			case ArticlePillar.Culture:
+				return culture[300];
+			case ArticlePillar.Opinion:
+				return opinion[200];
+			case ArticleSpecial.Labs:
+				return labs[300];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+	}
+}
+
 
 const textInvertedByline = (format: ArticleFormat): Colour => {
 	switch(format.theme) {
@@ -299,9 +320,9 @@ const textKeyEventsGrayBackground = ({theme} : ArticleFormat): Colour => {
 		case ArticlePillar.News:
 			return news[400];
 		case ArticlePillar.Sport:
-			return sport[400];
+			return sport[300];
 		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
+			return lifestyle[300];
 		case ArticlePillar.Culture:
 			return culture[300];
 		case ArticlePillar.Opinion:
@@ -577,13 +598,13 @@ const fillCommentCount = (format: ArticleFormat): Colour => {
 		case ArticlePillar.News:
 			return news[400];
 		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
+			return lifestyle[300];
 		case ArticlePillar.Sport:
-			return sport[400];
+			return sport[300];
 		case ArticlePillar.Culture:
 			return culture[300];
 		case ArticlePillar.Opinion:
-			return opinion[300];
+			return opinion[200];
 		case ArticleSpecial.Labs:
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
@@ -672,7 +693,8 @@ const fillBlockquoteIcon = (format: ArticleFormat): Colour => {
 
 const text = {
 	articleLink: textArticleLink,
-	byline: textByline,
+	bylineLightGrayBackground: textBylineLightGrayBackground,
+	bylineDarkGrayBackground: textBylineDarkGrayBackground,
 	follow: textFollow,
 	headline: textHeadline,
 	headlineDark: textHeadlineDark,
@@ -712,7 +734,8 @@ const fill = {
 const palette = (format: ArticleFormat): Palette => ({
 	text: {
 		articleLink: text.articleLink(format),
-		byline: text.byline(format),
+		bylineLightGrayBackground: text.bylineLightGrayBackground(format),
+		bylineDarkGrayBackground: text.bylineDarkGrayBackground(format),
 		follow: text.follow(format),
 		headline: text.headline(format),
 		headlineDark: text.headlineDark(format),

--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -24,6 +24,8 @@ interface Palette {
 		follow: Colour;
 		invertedByline: Colour;
 		invertedFollow: Colour;
+		invertedLink: Colour;
+		articleLink: Colour;
 		standfirst: Colour;
 		standfirstDark: Colour;
 		standfirstLink: Colour;
@@ -38,6 +40,7 @@ interface Palette {
 	border: {
 		articleLink: Colour;
 		articleLinkDark: Colour;
+		liveBlock: Colour;
 		standfirstLink: Colour;
 		standfirstLinkDark: Colour;
 	};
@@ -207,6 +210,65 @@ const textInvertedFollow = (format: ArticleFormat): Colour => {
 			return specialReport[500];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+	}
+}
+
+const textInvertedLink = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+			return news[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticleSpecial.Labs:
+			return specialReport[500];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
+	}
+}
+
+const textArticleLink = (format: ArticleFormat): Colour => {
+	switch(format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			switch(format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return specialReport[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+			}
+		default:
+			switch(format.theme) {
+				case ArticlePillar.News:
+					return news[300];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[300];
+				case ArticlePillar.Sport:
+					return sport[300];
+				case ArticlePillar.Culture:
+					return culture[300];
+				case ArticlePillar.Opinion:
+					return opinion[300];
+				case ArticleSpecial.Labs:
+					return specialReport[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
+			}
 	}
 }
 
@@ -383,6 +445,25 @@ const borderArticleLink = (format: ArticleFormat): Colour => {
 
 const borderArticleLinkDark = borderArticleLink;
 
+const borderLiveBlock = (format: ArticleFormat): Colour => {
+	switch(format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
+	}
+}
+
 const borderStandfirstLink = (format: ArticleFormat): Colour => {
 	if (format.design === ArticleDesign.LiveBlog) {
 		return neutral[100];
@@ -514,6 +595,8 @@ const text = {
 	follow: textFollow,
 	invertedByline: textInvertedByline,
 	invertedFollow: textInvertedFollow,
+	invertedLink: textInvertedLink,
+	articleLink: textArticleLink,
 	standfirst: textStandfirst,
 	standfirstDark: textStandfirstDark,
 	standfirstLink: textStandfirstLink,
@@ -530,6 +613,7 @@ const background = {
 const border = {
 	articleLink: borderArticleLink,
 	articleLinkDark: borderArticleLinkDark,
+	liveBlock: borderLiveBlock,
 	standfirstLink: borderStandfirstLink,
 	standfirstLinkDark: borderStandfirstLinkDark,
 };
@@ -548,6 +632,8 @@ const palette = (format: ArticleFormat): Palette => ({
 		follow: text.follow(format),
 		invertedByline: text.invertedByline(format),
 		invertedFollow: text.invertedFollow(format),
+		invertedLink: text.invertedLink(format),
+		articleLink: text.articleLink(format),
 		standfirst: text.standfirst(format),
 		standfirstDark: text.standfirstDark(format),
 		standfirstLink: text.standfirstLink(format),
@@ -562,6 +648,7 @@ const palette = (format: ArticleFormat): Palette => ({
 	border: {
 		articleLink: border.articleLink(format),
 		articleLinkDark: border.articleLinkDark(format),
+		liveBlock: border.liveBlock(format),
 		standfirstLink: border.standfirstLink(format),
 		standfirstLinkDark: border.standfirstLinkDark(format),
 	},

--- a/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
@@ -22,7 +22,7 @@ export const KeyEventsContainer = ({ keyEvents, format }: Props) => {
 
 	return (
 		<KeyEvents
-			theme={format.theme}
+			format={format}
 			keyEvents={transformedKeyEvents}
 			supportsDarkMode={false}
 		/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes metadata and liveblock colours for deadblogs in AR.

## Why?
To match the designs and follow accessibility standards. 

| Background | White | Gray |
|------------|-------|------|
| News       | 400   | 400  |
| Sport      | 400   | 300  |
| Lifestyle  | 400   | 300  |
| Culture    | 350   | 300  |
| Opinion    | 300   | 200 for dark gray and 300 for light gray  |


| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/19683595/149002835-2e1e683a-350d-489a-a2df-801fd06c7b7e.png)      | ![image](https://user-images.githubusercontent.com/19683595/149001117-55b352cd-7699-44a7-a615-8e273e81a687.png)       |
| ![image](https://user-images.githubusercontent.com/19683595/149003060-7f7f61bd-33bb-4448-91fa-3bf855c1d788.png)   | ![image](https://user-images.githubusercontent.com/19683595/149001721-cc8f8819-bc81-4b9d-9321-7e0132f19403.png)        |
| ![image](https://user-images.githubusercontent.com/19683595/149003267-7d55fadc-abbd-483a-9661-93ec6bde6ae7.png)  | ![image](https://user-images.githubusercontent.com/19683595/149169924-ef3cff2e-5d8d-4aa8-8d88-1996da7f8a12.png) |
| ![image](https://user-images.githubusercontent.com/19683595/149003167-4ca154d5-2cee-4970-93d2-8c846e9f598e.png)  | ![image](https://user-images.githubusercontent.com/19683595/149168971-3d735d26-5461-412b-9435-3dd0efe7cfed.png)      ​|
| ![image](https://user-images.githubusercontent.com/19683595/149002707-0b113e8f-58d9-4803-9d97-9333eb267ae6.png) | ![image](https://user-images.githubusercontent.com/19683595/149002018-61067411-b8cc-426f-9371-7868b01a07e4.png)       ​|
| ![image](https://user-images.githubusercontent.com/19683595/149170518-4b60935a-1758-4370-9d5a-65ba63634b72.png) | ![image](https://user-images.githubusercontent.com/19683595/149169173-9d9b0306-60ef-499b-b47a-d71895c07309.png)       ​|
| ![image](https://user-images.githubusercontent.com/19683595/149170660-835cd2bc-52b4-4224-b951-0dc310581536.png) | ![image](https://user-images.githubusercontent.com/19683595/149169203-08bd52da-c456-49ac-a972-77fe09ff7b67.png)       ​|
| ![image](https://user-images.githubusercontent.com/19683595/149347355-c2201fe5-4fd6-4b95-b1ea-67ce8330ca8c.png) | ![image](https://user-images.githubusercontent.com/19683595/149347102-182d8c8c-5bd3-486f-91d2-20609d2aa8d5.png)  ​|

