### PR TITLE
Default to `SpecialReport` instead of `News` for more greys

### DIFF
--- a/dotcom-rendering/src/web/components/DefaultRichLink.tsx
+++ b/dotcom-rendering/src/web/components/DefaultRichLink.tsx
@@ -1,4 +1,4 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 
 import { RichLink } from '@root/src/web/components/RichLink';
 
@@ -33,7 +33,7 @@ export const DefaultRichLink: React.FC<DefaultProps> = ({
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
+				theme: ArticleSpecial.SpecialReport,
 			}}
 			tags={[]}
 			sponsorName=""

--- a/dotcom-rendering/src/web/components/DefaultRichLink.tsx
+++ b/dotcom-rendering/src/web/components/DefaultRichLink.tsx
@@ -33,6 +33,8 @@ export const DefaultRichLink: React.FC<DefaultProps> = ({
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
+				// We default to SpecialReport here purely because the greys of this theme
+				// look better as the defaults
 				theme: ArticleSpecial.SpecialReport,
 			}}
 			tags={[]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This changes the format used for the `DefaultRichLink` which is the server rendered, basic version of a rich link that gets shown prior to the client side enhancement

## Why?
It's not accurate to, for example, show sport rich links using the reds of news. Arguably `SpecialReport` is equally 'incorrect' but like this we get neutral greys which serve as better defaults

## Why not create custom default colours?
I considered making `format` optional and creating a custom version of the component for when no `format` was known (pre client enhancement) but this would be a lot of extra code and is less declarative that just using `SpecialReport`

## Why are we not enhancing liveblock richlinks?
This is outside the scope of this PR but you'll notice the chromatic diffs are showing the unenhanced default rich links. This is because we still need to implement this feature for this type of article in storybook

### Before
<img width="608" alt="Screenshot 2022-01-14 at 14 29 40" src="https://user-images.githubusercontent.com/1336821/149531731-75237b2c-bad7-41b9-864f-50b2868d92fe.png">


### After
<img width="608" alt="Screenshot 2022-01-14 at 14 27 33" src="https://user-images.githubusercontent.com/1336821/149531442-0274e49a-e1a9-484d-a840-1346700d78c3.png">

