### PR TITLE
Always return `DefaultRichLink` if there's no client side data 

### DIFF
--- a/dotcom-rendering/src/web/components/RichLinkComponent.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.tsx
@@ -57,12 +57,15 @@ export const RichLinkComponent = ({
 	richLinkIndex,
 }: Props) => {
 	const url = buildUrl(element, ajaxEndpoint);
-	const { data, loading, error } = useApi<CAPIRichLinkType>(url);
+	const { data, error } = useApi<CAPIRichLinkType>(url);
 
 	if (error) {
-		// Send the error to Sentry and then prevent the element from rendering
+		// Send the error to Sentry
 		window.guardian.modules.sentry.reportError(error, 'rich-link');
+	}
 
+	if (!data) {
+		// Continue to return the default (server side rendered) version of the richlink
 		return (
 			<DefaultRichLink
 				index={richLinkIndex}
@@ -70,11 +73,6 @@ export const RichLinkComponent = ({
 				url={element.url}
 			/>
 		);
-	}
-
-	if (loading || !data) {
-		// Only render once data is available
-		return null;
 	}
 
 	const richLinkImageData: RichLinkImageData = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This slightly refactors the code used to enhance richlinks such that we're now more explicit about what we're returning.

On the server, we render `DefaultRichLink`
On the client we make an api call and if we got an error or we're still waiting for a response, we render `DefaultRichLink`
Only when the api responds with `data` do we render the enhanced version of a richlink

For context, the different versions are

## Default
_no image, no brand colouring_
<img width="608" alt="Screenshot 2022-01-14 at 14 27 33" src="https://user-images.githubusercontent.com/1336821/149768720-1bd00810-d328-4059-8c64-4f12635b300c.png">




## Enhanced
_with image, coloured to the News pillar (brand)_
<img width="236" alt="Screenshot 2022-01-17 at 12 23 28" src="https://user-images.githubusercontent.com/1336821/149768910-d3b96209-9ae8-4a10-9d35-8ae808c12db5.png">

