### PR TITLE
Allow fetch options to be passed to `useApi`

### DIFF
--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -10,8 +10,8 @@ function checkForErrors(response: Response) {
 	return response;
 }
 
-const fetcher = (url: string) =>
-	fetch(url)
+const fetcher = (init?: RequestInit) => (url: string) =>
+	fetch(url, init)
 		.then(checkForErrors)
 		.then((res) => res.json());
 
@@ -27,12 +27,14 @@ interface ApiResponse<T> {
  * returns { loading, error, data }
  * @param {String} url - The url to fetch
  * @param {SWRConfiguration} options - The SWR config object - https://swr.vercel.app/docs/options
+ * @param {RequestInit} init - The fetch init object - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options
  * */
 export const useApi = <T,>(
 	url: string,
 	options?: SWRConfiguration,
+	init?: RequestInit,
 ): ApiResponse<T> => {
-	const { data, error } = useSWR(url, fetcher, options);
+	const { data, error } = useSWR(url, fetcher(init), options);
 
 	return {
 		data,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the ability to pass in a an options object to `useApi` that can be used to customise the `fetch` request

## Why?
We have a use case to use `credentials: 'include'` for a particular call in the future but that's not possible at the moment

## Thanks
Props to @mxdvl and @coldlink for essentially doing all the heavy lifting on this