### PR TITLE
The Dangly Comma,

### DIFF
--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -29,7 +29,7 @@ interface ApiResponse<T> {
  * @param {SWRConfiguration} options - The SWR config object - https://swr.vercel.app/docs/options
  * @param {RequestInit} init - The fetch init object - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options
  * */
-export const useApi = <T,>(
+export const useApi = <T extends unknown>(
 	url: string,
 	options?: SWRConfiguration,
 	init?: RequestInit,

--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -34,7 +34,7 @@ export const useApi = <T extends unknown>(
 	options?: SWRConfiguration,
 	init?: RequestInit,
 ): ApiResponse<T> => {
-	const { data, error } = useSWR(url, fetcher(init), options);
+	const { data, error } = useSWR<T, Error>(url, fetcher(init), options);
 
 	return {
 		data,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR refactors `useApi` to remove the dangly comma we were getting after the 'T'.

## Why?
It looked weird.
