### PR TITLE
Refactor Links.tsx to use react islands

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -6,7 +6,6 @@ import { ShareCount } from '@frontend/web/components/ShareCount';
 import { MostViewedFooter } from '@frontend/web/components/MostViewed/MostViewedFooter/MostViewedFooter';
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { SlotBodyEnd } from '@root/src/web/components/SlotBodyEnd/SlotBodyEnd';
-import { Links } from '@frontend/web/components/Links';
 import { ContributionSlot } from '@frontend/web/components/ContributionSlot';
 import { GetMatchNav } from '@frontend/web/components/GetMatchNav';
 import { Discussion } from '@frontend/web/components/Discussion';
@@ -536,14 +535,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 					ophanRecord={ophanRecord}
 				/>
 			</Portal>
-			<HydrateOnce rootId="links-root" waitFor={[user]}>
-				<Links
-					supporterCTA={CAPI.nav.readerRevenueLinks.header.supporter}
-					userId={user ? user.userId : undefined}
-					idUrl={CAPI.config.idUrl}
-					mmaUrl={CAPI.config.mmaUrl}
-				/>
-			</HydrateOnce>
 			<HydrateOnce rootId="labs-header">
 				<LabsHeader />
 			</HydrateOnce>

--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 
 import { Hide } from '@root/src/web/components/Hide';
 import { Logo } from '@frontend/web/components/Logo';
-import { Links } from '@frontend/web/components/Links';
+import { Links } from '@root/src/web/components/Links.importable';
 import { brand } from '@guardian/source-foundations';
 import { Island } from './Island';
 import { EditionDropdown } from './EditionDropdown.importable';
@@ -20,9 +20,18 @@ type Props = {
 	idUrl?: string;
 	mmaUrl?: string;
 	isAnniversary?: boolean; // Temporary for G200 anniversary
+	supporterCTA: string;
+	discussionApiUrl: string;
 };
 
-export const Header = ({ edition, idUrl, mmaUrl, isAnniversary }: Props) => (
+export const Header = ({
+	edition,
+	idUrl,
+	mmaUrl,
+	isAnniversary,
+	supporterCTA,
+	discussionApiUrl,
+}: Props) => (
 	<div css={headerStyles}>
 		<Hide when="below" breakpoint="desktop">
 			<Island deferUntil="idle">
@@ -35,7 +44,14 @@ export const Header = ({ edition, idUrl, mmaUrl, isAnniversary }: Props) => (
 		<Logo isAnniversary={isAnniversary} edition={edition} />
 		<div id="reader-revenue-links-header" />
 		<div id="links-root">
-			<Links supporterCTA="" idUrl={idUrl} mmaUrl={mmaUrl} />
+			<Island>
+				<Links
+					supporterCTA={supporterCTA}
+					idUrl={idUrl}
+					mmaUrl={mmaUrl}
+					discussionApiUrl={discussionApiUrl}
+				/>
+			</Island>
 		</div>
 	</div>
 );

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 
 import SearchIcon from '@frontend/static/icons/search.svg';
@@ -15,13 +14,13 @@ import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { createAuthenticationEventParams } from '@root/src/lib/identity-component-event';
-import { useOnce } from '@frontend/web/lib/useOnce';
-import { getCookie } from '@guardian/libs';
+import { getCookie, joinUrl } from '@guardian/libs';
+import { useApi } from '@root/src/web/lib/useApi';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
 	supporterCTA: string;
-	userId?: string;
+	discussionApiUrl: string;
 	idUrl?: string;
 	mmaUrl?: string;
 };
@@ -135,34 +134,37 @@ const linksStyles = css`
 	}
 `;
 
-export const Links = ({
-	userId,
-	supporterCTA,
-	idUrl: idUrlFromConfig,
-	mmaUrl: mmaUrlFromConfig,
-}: Props) => {
-	const [showSupporterCTA, setShowSupporterCTA] = useState<boolean>();
-	const [userIsDefined, setUserIsDefined] = useState<boolean>();
+const SignIn = ({ idUrl }: { idUrl: string }) => (
+	<a
+		css={linkStyles}
+		href={`${idUrl}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
+			'guardian_signin_header',
+		)}`}
+		data-link-name="nav2 : topbar : signin"
+	>
+		<ProfileIcon /> Sign in
+	</a>
+);
 
-	// show supporter CTA if support messaging isn't shown
-	useEffect(() => {
-		setShowSupporterCTA(
-			getCookie({
-				name: 'gu_hide_support_messaging',
-				shouldMemoize: true,
-			}) === 'true',
-		);
-	}, []);
+const MyAccount = ({
+	mmaUrl,
+	idUrl,
+	discussionApiUrl,
+}: {
+	mmaUrl: string;
+	idUrl: string;
+	discussionApiUrl: string;
+}) => {
+	const { data } = useApi<{ userProfile: UserProfile }>(
+		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
+		{},
+		{
+			credentials: 'include',
+		},
+	);
 
-	// we intentionally re-render here because we know the DOM structure could be different
-	// from the server rendered version. This forces a full validation
-	useOnce(() => {
-		setUserIsDefined(!!userId);
-	}, [userId]);
-
-	// Fall back on prod URLs just in case these aren't set for any reason
-	const idUrl = idUrlFromConfig || 'https://profile.theguardian.com';
-	const mmaUrl = mmaUrlFromConfig || 'https://manage.theguardian.com';
+	// If we don't have user data display sign in to the user. SWR will retry in the background if the request failed
+	if (!data?.userProfile?.userId) return <SignIn idUrl={idUrl} />;
 
 	const identityLinks: DropdownLinkType[] = [
 		{
@@ -191,7 +193,7 @@ export const Links = ({
 			dataLinkName: 'nav2 : topbar : help',
 		},
 		{
-			url: `${idUrl}/user/id/${userId}`,
+			url: `${idUrl}/user/id/${data.userProfile.userId}`,
 			title: 'Comments & replies',
 			dataLinkName: 'nav2 : topbar : comment activity',
 		},
@@ -201,6 +203,45 @@ export const Links = ({
 			dataLinkName: 'nav2 : topbar : sign out',
 		},
 	];
+
+	return (
+		<div css={linkStyles}>
+			<ProfileIcon />
+			<Dropdown
+				label="My account"
+				links={identityLinks}
+				id="my-account"
+				dataLinkName="nav2 : topbar: my account"
+			/>
+		</div>
+	);
+};
+
+export const Links = ({
+	supporterCTA,
+	discussionApiUrl: discussionApiUrlFromConfig,
+	idUrl: idUrlServerFromConfig,
+	mmaUrl: mmaUrlServerFromConfig,
+}: Props) => {
+	// Fall back on prod URLs just in case these aren't set for any reason
+	const discussionApiUrl =
+		discussionApiUrlFromConfig ||
+		'https://discussion.theguardian.com/discussion-api';
+	const idUrl = idUrlServerFromConfig || 'https://profile.theguardian.com';
+	const mmaUrl = mmaUrlServerFromConfig || 'https://manage.theguardian.com';
+
+	const isServer = typeof window === 'undefined';
+
+	const showSupporterCTA =
+		!isServer &&
+		getCookie({
+			name: 'gu_hide_support_messaging',
+			shouldMemoize: true,
+		}) === 'true';
+
+	const isSignedIn =
+		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
+
 	return (
 		<div data-print-layout="hide" css={linksStyles}>
 			{showSupporterCTA && supporterCTA !== '' && (
@@ -226,26 +267,14 @@ export const Links = ({
 			</a>
 			<div css={seperatorHideStyles} />
 
-			{userIsDefined ? (
-				<div css={linkStyles}>
-					<ProfileIcon />
-					<Dropdown
-						label="My account"
-						links={identityLinks}
-						id="my-account"
-						dataLinkName="nav2 : topbar: my account"
-					/>
-				</div>
+			{isSignedIn ? (
+				<MyAccount
+					mmaUrl={mmaUrl}
+					idUrl={idUrl}
+					discussionApiUrl={discussionApiUrl}
+				/>
 			) : (
-				<a
-					css={linkStyles}
-					href={`${idUrl}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
-						'guardian_signin_header',
-					)}`}
-					data-link-name="nav2 : topbar : signin"
-				>
-					<ProfileIcon /> Sign in
-				</a>
+				<SignIn idUrl={idUrl} />
 			)}
 
 			<Search

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -155,7 +155,7 @@ const MyAccount = ({
 	idUrl: string;
 	discussionApiUrl: string;
 }) => {
-	const { data } = useApi<{ userProfile: UserProfile }>(
+	const { data, error } = useApi<{ userProfile: UserProfile }>(
 		joinUrl(discussionApiUrl, 'profile/me?strict_sanctions_check=false'),
 		{},
 		{
@@ -163,8 +163,9 @@ const MyAccount = ({
 		},
 	);
 
-	// If we don't have user data display sign in to the user. SWR will retry in the background if the request failed
-	if (!data?.userProfile?.userId) return <SignIn idUrl={idUrl} />;
+	// If we encounter an error or don't have user data display sign in to the user.
+	// SWR will retry in the background if the request failed
+	if (error || !data?.userProfile?.userId) return <SignIn idUrl={idUrl} />;
 
 	const identityLinks: DropdownLinkType[] = [
 		{

--- a/dotcom-rendering/src/web/examples/Front.stories.tsx
+++ b/dotcom-rendering/src/web/examples/Front.stories.tsx
@@ -49,7 +49,12 @@ export const Front = () => (
 			padded={false}
 			backgroundColour={brandBackground.primary}
 		>
-			<Header edition="UK" isAnniversary={true} />
+			<Header
+				edition="UK"
+				isAnniversary={true}
+				discussionApiUrl=""
+				supporterCTA=""
+			/>
 		</ElementContainer>
 		<ElementContainer
 			showSideBorders={true}
@@ -548,7 +553,12 @@ export const Front2 = () => (
 			padded={false}
 			backgroundColour={brandBackground.primary}
 		>
-			<Header edition="US" isAnniversary={true} />
+			<Header
+				edition="US"
+				isAnniversary={true}
+				discussionApiUrl=""
+				supporterCTA=""
+			/>
 		</ElementContainer>
 		<ElementContainer
 			showSideBorders={true}

--- a/dotcom-rendering/src/web/examples/Sections.stories.tsx
+++ b/dotcom-rendering/src/web/examples/Sections.stories.tsx
@@ -58,7 +58,7 @@ export const Sections = (): React.ReactNode => (
 			padded={false}
 			backgroundColour={brandBackground.primary}
 		>
-			<Header edition="UK" />
+			<Header edition="UK" supporterCTA="" discussionApiUrl="" />
 		</ElementContainer>
 		<ElementContainer
 			showSideBorders={true}

--- a/dotcom-rendering/src/web/examples/Writers.stories.tsx
+++ b/dotcom-rendering/src/web/examples/Writers.stories.tsx
@@ -73,7 +73,7 @@ export const Writers = (): React.ReactNode => (
 			padded={false}
 			backgroundColour={brandBackground.primary}
 		>
-			<Header edition="UK" />
+			<Header edition="UK" discussionApiUrl="" supporterCTA="" />
 		</ElementContainer>
 		<ElementContainer
 			showSideBorders={true}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -354,6 +354,10 @@ export const CommentLayout = ({
 								edition={CAPI.editionId}
 								idUrl={CAPI.config.idUrl}
 								mmaUrl={CAPI.config.mmaUrl}
+								supporterCTA={
+									CAPI.nav.readerRevenueLinks.header.supporter
+								}
+								discussionApiUrl={CAPI.config.discussionApiUrl}
 								isAnniversary={
 									CAPI.config.switches.anniversaryHeaderSvg
 								}

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -191,6 +191,10 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							edition={CAPI.editionId}
 							idUrl={CAPI.config.idUrl}
 							mmaUrl={CAPI.config.mmaUrl}
+							supporterCTA={
+								CAPI.nav.readerRevenueLinks.header.supporter
+							}
+							discussionApiUrl={CAPI.config.discussionApiUrl}
 							isAnniversary={
 								CAPI.config.switches.anniversaryHeaderSvg
 							}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -297,6 +297,10 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								edition={CAPI.editionId}
 								idUrl={CAPI.config.idUrl}
 								mmaUrl={CAPI.config.mmaUrl}
+								supporterCTA={
+									CAPI.nav.readerRevenueLinks.header.supporter
+								}
+								discussionApiUrl={CAPI.config.discussionApiUrl}
 								isAnniversary={
 									CAPI.config.switches.anniversaryHeaderSvg
 								}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -410,6 +410,10 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							edition={CAPI.editionId}
 							idUrl={CAPI.config.idUrl}
 							mmaUrl={CAPI.config.mmaUrl}
+							supporterCTA={
+								CAPI.nav.readerRevenueLinks.header.supporter
+							}
+							discussionApiUrl={CAPI.config.discussionApiUrl}
 							isAnniversary={
 								CAPI.config.switches.anniversaryHeaderSvg
 							}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -294,6 +294,13 @@ export const ShowcaseLayout = ({
 									edition={CAPI.editionId}
 									idUrl={CAPI.config.idUrl}
 									mmaUrl={CAPI.config.mmaUrl}
+									supporterCTA={
+										CAPI.nav.readerRevenueLinks.header
+											.supporter
+									}
+									discussionApiUrl={
+										CAPI.config.discussionApiUrl
+									}
 									isAnniversary={
 										CAPI.config.switches
 											.anniversaryHeaderSvg

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -382,6 +382,10 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								edition={CAPI.editionId}
 								idUrl={CAPI.config.idUrl}
 								mmaUrl={CAPI.config.mmaUrl}
+								supporterCTA={
+									CAPI.nav.readerRevenueLinks.header.supporter
+								}
+								discussionApiUrl={CAPI.config.discussionApiUrl}
 								isAnniversary={
 									CAPI.config.switches.anniversaryHeaderSvg
 								}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Refactors Links.tsx to use react islands

To achieve this I had to move the previously global state `userId` to within the component. We only want to request the user profile on the client, creating the `MyAccount` component allowed us to ensure it only requests the profile there.

I also generally refactored the component around how it hydrates. We can do this because now that this react component renders as it's own island, it's no longer affecting renders for anything else.

Inspiration for this credited to https://github.com/guardian/dotcom-rendering/pull/3747 (thanks @oliverlloyd)

> Note: This will introduce a duplicate call to the profile endpoint as Discussion also makes use of the App.tsx call we refactored away from. This duplication is only temporary as once discussion is migrated to use Islands, SWR will cache any duplicate calls. You can track progress on discussion migration in https://github.com/guardian/dotcom-rendering/pull/3839

## Why?

This helps with our general goal of migrating away from and deleting App.tsx, but also unblocks https://github.com/guardian/dotcom-rendering/pull/3832, which is having a hydration problem which is solved by islands.

## Testing

I've tested this locally, however since logging in does not work locally, we should also test on CODE to ensure functionality
