### PR TITLE
Update to latest Source versions

### DIFF
--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -237,6 +237,7 @@ const MetadataWithAlertSwitch: FC<Props> = ({ item }: Props) => {
 				{isLive(design) && (
 					<div css={css(toggleStyles, liveBlogPadding)}>
 						<ToggleSwitch
+							platform="ios"
 							checked={checked}
 							label={'Get alerts on this story'}
 							cssOverrides={toggleOverrideStyles}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
 	"devDependencies": {
 		"@babel/core": "^7.15.0",
 		"@guardian/eslint-plugin-source-react-components": "^4.0.0-rc.3",
-		"@guardian/source-foundations": "^4.0.0-rc.5",
-		"@guardian/source-react-components": "^4.0.0-rc.3",
-		"@guardian/source-react-components-development-kitchen": "^1.0.0-rc.1",
+		"@guardian/source-foundations": "^4.0.0-rc.7",
+		"@guardian/source-react-components": "^4.0.0-rc.5",
+		"@guardian/source-react-components-development-kitchen": "^0.0.25-rc.2",
 		"@storybook/addon-essentials": "^6.3.7",
 		"@storybook/addon-knobs": "^6.3.1",
 		"@storybook/builder-webpack5": "^6.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,22 +2837,22 @@
   dependencies:
     tslib "^2.0.0"
 
-"@guardian/source-foundations@^4.0.0-rc.5":
-  version "4.0.0-rc.5"
-  resolved "https://registry.npmjs.org/@guardian/source-foundations/-/source-foundations-4.0.0-rc.5.tgz#be6648111b14943a3f212004e324534b41941282"
-  integrity sha512-XGgcpP2BAHCeEog7UjUlvzPpNcZGHMUnD9NQS8F1+w35yQ5lz6fG0te/ZZm5y5i6a0Jq5utJ2ppFC7y94fjmTA==
+"@guardian/source-foundations@^4.0.0-rc.7":
+  version "4.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-4.0.0-rc.7.tgz#7111c5a268a1bea75bcbbd2d0ca3e49f14a0708a"
+  integrity sha512-lEgumDnkWEp150sKgk5C3EtynS6TDMM1dnl/Koz6ETF3eiAYYK/8HRb5MxVAF27wYFD3NhwsedictXCeevXFTw==
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-1.0.0-rc.1.tgz#399fe021d1575fa86d036c305e96494a180ae0d1"
-  integrity sha512-2oDvN7z7JLTEtbkf2hXFQ9BpOABRTOiH/HhgMRr7KmwBkFFP5y01E+/MZ7m8F63KrXMoseLPA1DtZYAZBaeZ/g==
+"@guardian/source-react-components-development-kitchen@^0.0.25-rc.2":
+  version "0.0.25-rc.2"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-0.0.25-rc.2.tgz#6dc794e981e156a047244f553b8e46152d320f23"
+  integrity sha512-PWY4G4xoNVuuHB0EasXNtXlPy8PUNwNV1BdSwi1gvocDbhJvqddW9560U79IIVNeUxx0YipTrtAGrza4KK19/Q==
 
-"@guardian/source-react-components@^4.0.0-rc.3":
-  version "4.0.0-rc.3"
-  resolved "https://registry.npmjs.org/@guardian/source-react-components/-/source-react-components-4.0.0-rc.3.tgz#ef1faccad3e6a9816472e8546864fe72fd4d2780"
-  integrity sha512-QBpfqS4TqnEzDHmebtZDPj1kof8RVizyu5jTC0JWuv0n1lja9385bQkVwMQyr2av1f8JvOE+LHv8lUdagtJgPw==
+"@guardian/source-react-components@^4.0.0-rc.5":
+  version "4.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.0.0-rc.5.tgz#fc38d9c297b44e3c63fc1d0731e935b8f19004e4"
+  integrity sha512-DscDPAa4b3pOL0h8LkQ+G8OQEiFwwYe+XOj8mLjfN9BEKCcKpmMrx9Vf4p8xBvRmr3jKvkSj6jZaZMjUtNjqjQ==
 
 "@guardian/types@^9.0.1":
   version "9.0.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates Source deps to the following:


`"@guardian/source-foundations": "^4.0.0-rc.7",`
`"@guardian/source-react-components": "^4.0.0-rc.5",`
`"@guardian/source-react-components-development-kitchen": "^0.0.25-rc.2",`

In order to maintain the existing styling on the `ToggleSwitch` Source component in AR's `MetaData` component I've added a `platform="ios"` prop. 

## Why?

So we can use the latest Source components in DCAR.




