### PR TITLE
Upgrade @guardian/braze-components to v5.3.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.1.1",
     "@guardian/automat-contributions": "^0.4.3",
-    "@guardian/braze-components": "^5.2.0",
+    "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "^10.1.0",
     "@guardian/discussion-rendering": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,10 +2770,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-contributions/-/automat-contributions-0.4.3.tgz#3ef815d637022802cbeac7830813bbdf7326b43d"
   integrity sha512-zSvPfrswfd0FGx0qfCwORmebeI46RMhkxgQQiZ8uCC6IRUDd+3UYl7/0hAILeGKGZ7qDUC8EwQ6TX0le7+2a1g==
 
-"@guardian/braze-components@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.2.0.tgz#2df527364471bdc8905824f34e67312214b7684e"
-  integrity sha512-8x5iyWIOIvlF/XMVbNxzBxaAlekbicc5XqqvPRJRPVOQBTnZalwOin2XzfaUuE73q/00cICQXCtgAnqr1clCKw==
+"@guardian/braze-components@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.3.0.tgz#abe79666e5636ad2a0064cb2f227a64239231d2f"
+  integrity sha512-3tljnI79cIR2e3RrnXMc0liSPAuFjezDZ50MCpXw9Y3KX8jD92AqWDAfjsC0XrpGj946ZB149Z/EarhrSRQ/hg==
 
 "@guardian/commercial-core@^0.32.0":
   version "0.32.0"


### PR DESCRIPTION
## What does this change?

This release contains style changes to the BannerWithLink component to support the new year campaign.

## Why?

### Before

`@guardian/braze-components` v5.2.0

### After

`@guardian/braze-components` v5.3.0