### PR TITLE
fix: Observer tag showing when publication tag is not set to observer

### DIFF
--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -178,7 +178,8 @@ export const SeriesSectionLink = ({
 		(thisTag) =>
 			thisTag.type === 'Blog' ||
 			thisTag.type === 'Series' ||
-			thisTag.title === 'The Observer',
+			(thisTag.type === 'Publication' &&
+				thisTag.title === 'The Observer'),
 	);
 
 	const hasSeriesTag = tag && tag.type === 'Series';


### PR DESCRIPTION
fix: Observer tag showing when publication tag is not set to observer (Co-Author: email@oliverlloyd.com)

## What does this change?

Updates tagging logic.

## Why?

Previous logic scanned ALL tags included in an article and added a "The Observer" line to the page if it found any tags that had a title of "The Observer".

In reality we should be only checking if there is a tag of type "Publication" with the title "The Observer" before we add the observer line to the article.

See below for a Guardian article that has been incorrectly tagged as an Observer article.

### Before

![image](https://user-images.githubusercontent.com/21217225/150140237-81e7ebea-dd0c-4e05-bf38-9bee32df0341.png)


### After

![image](https://user-images.githubusercontent.com/21217225/150140169-44655556-b171-4bd3-8eff-c63d3874782d.png)

