### PR TITLE
Add `urlkw` and `sens` to amp ad targeting

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -203,6 +203,8 @@ interface AdTargetParam {
 }
 
 type CustomParams = {
+	sens: 't' | 'f';
+	urlkw: string[];
 	[key: string]: string | string[] | number | number[] | boolean | boolean[];
 };
 

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -28,6 +28,24 @@ const amazonConfig = {
 	aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
 };
 
+const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
+	const adTargetingMapped: AdTargetParam[] = [];
+
+	if (!adTargeting.disableAds) {
+		adTargetingMapped.push({
+			name: 'sens',
+			value: adTargeting.customParams.sens,
+		});
+
+		adTargetingMapped.push({
+			name: 'urlkw',
+			value: adTargeting.customParams.urlkw,
+		});
+	}
+
+	return adTargetingMapped;
+};
+
 export const realTimeConfig = (
 	usePrebid: boolean,
 	usePermutive: boolean,
@@ -79,6 +97,7 @@ export interface BaseAdProps {
 	section: string;
 	contentType: string;
 	commercialProperties: CommercialProperties;
+	adTargeting: AdTargeting;
 }
 
 interface AdProps extends BaseAdProps {
@@ -93,6 +112,7 @@ export const Ad = ({
 	contentType,
 	commercialProperties,
 	rtcConfig,
+	adTargeting,
 }: AdProps) => {
 	const adSizes = isSticky ? stickySizes : inlineSizes;
 	// Set Primary ad size as first element (should be the largest)
@@ -116,7 +136,12 @@ export const Ad = ({
 			data-loading-strategy="prefer-viewability-over-views"
 			layout="fixed"
 			type="doubleclick"
-			json={stringify(adJson(commercialProperties[edition].adTargeting))}
+			json={stringify(
+				adJson([
+					...commercialProperties[edition].adTargeting,
+					...mapAdTargeting(adTargeting),
+				]),
+			)}
 			data-slot={ampData(section, contentType)}
 			rtc-config={rtcConfig}
 		/>

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -71,6 +71,7 @@ export const Blocks: React.FunctionComponent<{
 	commercialProperties: CommercialProperties;
 	url: string;
 	shouldHideAds: boolean;
+	adTargeting: AdTargeting;
 }> = ({
 	blocks,
 	pillar,
@@ -81,6 +82,7 @@ export const Blocks: React.FunctionComponent<{
 	commercialProperties,
 	url,
 	shouldHideAds,
+	adTargeting,
 }) => {
 	// TODO add last updated for blocks to show here
 	const liveBlogBlocks = blocks.map((block) => {
@@ -152,6 +154,7 @@ export const Blocks: React.FunctionComponent<{
 									contentType={contentType}
 									config={adConfig}
 									commercialProperties={commercialProperties}
+									adTargeting={adTargeting}
 								/>
 							</div>
 						</>

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -160,6 +160,7 @@ export const Body: React.FC<{
 									commercialProperties={
 										adInfo.commercialProperties
 									}
+									adTargeting={adTargeting}
 								/>
 							</div>
 						</>
@@ -200,6 +201,7 @@ export const Body: React.FC<{
 				contentType={adInfo.contentType}
 				config={adConfig}
 				commercialProperties={adInfo.commercialProperties}
+				adTargeting={adTargeting}
 			/>
 
 			<SubMeta

--- a/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
+++ b/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
@@ -15,6 +15,7 @@ import RefreshIcon from '@frontend/static/icons/refresh.svg';
 import { Pagination } from '@root/src/amp/components/Pagination';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 
 // TODO check if liveblog background colours are more complex - like regular
 // article is
@@ -81,6 +82,15 @@ export const Body: React.FC<{
 	data: ArticleModel;
 	config: ConfigType;
 }> = ({ data, config }) => {
+	const adTargeting: AdTargeting = buildAdTargeting({
+		isAdFreeUser: data.isAdFreeUser,
+		isSensitive: config.isSensitive,
+		videoDuration: config.videoDuration,
+		edition: config.edition,
+		section: config.section,
+		sharedAdTargeting: config.sharedAdTargeting,
+		adUnit: config.adUnit,
+	});
 	const pillar = decideTheme(data.format);
 	const url = `${data.guardianBaseURL}/${data.pageId}`;
 	const isFirstPage = data.pagination
@@ -118,6 +128,7 @@ export const Body: React.FC<{
 						commercialProperties={data.commercialProperties}
 						url={url}
 						shouldHideAds={data.shouldHideAds}
+						adTargeting={adTargeting}
 					/>
 				</div>
 			</amp-live-list>

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -28,6 +28,10 @@ describe('RegionalAd', () => {
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
 				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 			/>,
 		);
 
@@ -70,6 +74,10 @@ describe('RegionalAd', () => {
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
 				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 			/>,
 		);
 
@@ -108,6 +116,10 @@ describe('RegionalAd', () => {
 					US: { adTargeting: [] },
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
+				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
 				}}
 			/>,
 		);
@@ -148,6 +160,10 @@ describe('RegionalAd', () => {
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
 				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 			/>,
 		);
 
@@ -186,6 +202,10 @@ describe('RegionalAd', () => {
 					US: { adTargeting: [] },
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
+				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
 				}}
 			/>,
 		);
@@ -229,6 +249,10 @@ describe('RegionalAd', () => {
 					US: { adTargeting: [] },
 					AU: { adTargeting: [] },
 					INT: { adTargeting: [] },
+				}}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
 				}}
 			/>,
 		);

--- a/dotcom-rendering/src/amp/components/RegionalAd.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.tsx
@@ -46,6 +46,7 @@ export const RegionalAd = ({
 	contentType,
 	commercialProperties,
 	config,
+	adTargeting,
 }: RegionalAdProps) => (
 	<>
 		{adRegions.map((adRegion) => (
@@ -70,6 +71,7 @@ export const RegionalAd = ({
 								config.useAmazon,
 								getPlacementIdByAdRegion(adRegion),
 							)}
+							adTargeting={adTargeting}
 						/>
 					</div>
 				)}

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -27,6 +27,7 @@ export const StickyAd = ({
 	contentType,
 	config,
 	commercialProperties,
+	adTargeting,
 }: StickyAdProps) => {
 	return (
 		<amp-sticky-ad layout="nodisplay">
@@ -42,6 +43,7 @@ export const StickyAd = ({
 					config.useAmazon,
 					mobileStickyPlacementId,
 				)}
+				adTargeting={adTargeting}
 			/>
 		</amp-sticky-ad>
 	);

--- a/dotcom-rendering/src/lib/ad-targeting.test.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.test.ts
@@ -23,6 +23,17 @@ describe('buildAdTargeting', () => {
 			s: 'money',
 			inskin: 'f',
 			pa: 'f',
+			urlkw: [
+				'ministers',
+				'to',
+				'criminalise',
+				'use',
+				'of',
+				'ticket',
+				'tout',
+				'harvesting',
+				'software',
+			],
 			...sharedAdTargeting,
 		},
 	};

--- a/dotcom-rendering/src/lib/ad-targeting.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.ts
@@ -1,3 +1,15 @@
+import { isString } from '@guardian/libs';
+
+// TODO: this function already exists in commercial-core, consider exporting it to avoid duplication
+const getUrlKeywords = (url: string): string[] => {
+	const lastSegment = url
+		.split('/')
+		.filter(Boolean) // This handles a trailing slash
+		.slice(-1)[0];
+
+	return isString(lastSegment) ? lastSegment.split('-').filter(Boolean) : [];
+};
+
 export const buildAdTargeting = ({
 	isAdFreeUser,
 	isSensitive,
@@ -29,6 +41,7 @@ export const buildAdTargeting = ({
 		inskin: 'f',
 		...sharedAdTargeting,
 		pa: 'f',
+		urlkw: getUrlKeywords(String(sharedAdTargeting.url)),
 	};
 	return {
 		customParams,

--- a/dotcom-rendering/src/lib/ad-targeting.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.ts
@@ -33,7 +33,7 @@ export const buildAdTargeting = ({
 		};
 	}
 	const customParams = {
-		sens: isSensitive ? 't' : 'f',
+		sens: isSensitive ? ('t' as const) : ('f' as const),
 		si: 'f',
 		vl: videoDuration || 0,
 		cc: edition,

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -90,7 +90,10 @@ export const VideoAsSecond = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -132,7 +135,10 @@ export const Title = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -195,7 +201,10 @@ export const Video = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -233,7 +242,10 @@ export const RichLink = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -262,7 +274,10 @@ export const FirstImage = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -292,7 +307,10 @@ export const ImaheAndTitle = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,
@@ -318,7 +336,10 @@ export const Updated = () => {
 	return (
 		<Wrapper>
 			<LiveBlock
-				adTargeting={{ adUnit: '', customParams: {} }}
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.LiveBlog,


### PR DESCRIPTION
Co-Authored-By: Chris Jones 

## What does this change?

Adds `urlkw` (URL keywords) and `sens` (sensitive) to amp ad targeting.

This applies to ads on articles and live blogs.

![Screenshot 2022-01-20 at 11 58 25](https://user-images.githubusercontent.com/7423751/150334787-6b8a3ae3-c0eb-4744-8b1c-d5d7932a2ee4.png)

## Why?

Spencer says "Adding this in will help with direct and Teads deal brand safety targeting" (see [ticket](https://trello.com/c/2fGmqIna/1419-sensitive-key-or-urlkw-added-as-value-in-amp))