### PR TITLE
Hf interactive figure padding

### DIFF
--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -62,7 +62,11 @@ const RoleStory = ({
 					level. Truffaut street art edison bulb, banh mi cliche
 					post-ironic mixtape
 				</p>
-				<Figure isMainMedia={false} role={role}>
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role={role}>
 					<ClickToView
 						role={role}
 						isTracking={true}
@@ -453,7 +457,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={facebookEmbed.source}
@@ -474,7 +482,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vimeoEmbedEmbed.source}
@@ -495,7 +507,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={youtubeEmbedEmbed.source}
@@ -516,7 +532,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={spotifyEmbedEmbed.source}
@@ -537,7 +557,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={bandcampEmbedEmbed.source}
@@ -558,7 +582,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={ourworldindataEmbedEmbed.source}
@@ -579,7 +607,11 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={bbcEmbedEmbed.source}
@@ -624,7 +656,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={instagramEmbedEmbed.source}
@@ -648,7 +684,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={formStackEmbed.source}
@@ -673,7 +713,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={scribdEmbedEmbed.source}
@@ -698,7 +742,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={tiktokEmbedEmbed.source}
@@ -723,7 +771,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={twitterEmbedEmbed.source}
@@ -773,7 +825,11 @@ export const VimeoBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vimeoVideoEmbed.source}
@@ -832,7 +888,11 @@ export const DocumentBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={scribdDocumentEmbed.source}
@@ -879,7 +939,11 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudAudioEmbed.source}
@@ -898,7 +962,11 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudEmbedEmbed.source}
@@ -942,7 +1010,11 @@ export const SpotifyBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={spotifyAudioEmbed.source}
@@ -1000,7 +1072,11 @@ export const TweetBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={twitterTweetEmbed.source}
@@ -1041,7 +1117,11 @@ export const InstagramBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 					<InstagramBlockComponent
 						key={1}
 						element={instagramInstramEmbed}

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -62,11 +62,15 @@ const RoleStory = ({
 					level. Truffaut street art edison bulb, banh mi cliche
 					post-ironic mixtape
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role={role}>
+					}}
+					isMainMedia={false}
+					role={role}
+				>
 					<ClickToView
 						role={role}
 						isTracking={true}
@@ -457,11 +461,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={facebookEmbed.source}
@@ -482,11 +490,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={vimeoEmbedEmbed.source}
@@ -507,11 +519,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={youtubeEmbedEmbed.source}
@@ -532,11 +548,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={spotifyEmbedEmbed.source}
@@ -557,11 +577,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={bandcampEmbedEmbed.source}
@@ -582,11 +606,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={ourworldindataEmbedEmbed.source}
@@ -607,11 +635,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={bbcEmbedEmbed.source}
@@ -656,11 +688,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={instagramEmbedEmbed.source}
@@ -684,11 +720,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={formStackEmbed.source}
@@ -713,11 +753,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={scribdEmbedEmbed.source}
@@ -742,11 +786,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={tiktokEmbedEmbed.source}
@@ -771,11 +819,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={twitterEmbedEmbed.source}
@@ -825,11 +877,15 @@ export const VimeoBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={vimeoVideoEmbed.source}
@@ -888,11 +944,15 @@ export const DocumentBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={scribdDocumentEmbed.source}
@@ -939,11 +999,15 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={soundcloudAudioEmbed.source}
@@ -962,11 +1026,15 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={soundcloudEmbedEmbed.source}
@@ -1010,11 +1078,15 @@ export const SpotifyBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={spotifyAudioEmbed.source}
@@ -1072,11 +1144,15 @@ export const TweetBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={twitterTweetEmbed.source}
@@ -1117,11 +1193,15 @@ export const InstagramBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure format={{
+				<Figure
+					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<InstagramBlockComponent
 						key={1}
 						element={instagramInstramEmbed}

--- a/dotcom-rendering/src/web/components/Figure.stories.tsx
+++ b/dotcom-rendering/src/web/components/Figure.stories.tsx
@@ -73,7 +73,11 @@ export const InlineStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false}>
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false}>
 						<Grey />
 					</Figure>
 					<SomeText />
@@ -103,7 +107,11 @@ export const SupportingStory = () => {
 				>
 					<SomeText />
 					<SomeText />
-					<Figure isMainMedia={false} role="supporting">
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="supporting">
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -136,7 +144,11 @@ export const ImmersiveStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="immersive">
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="immersive">
 						<Grey heightInPixels={700} />
 					</Figure>
 					<SomeText />
@@ -165,7 +177,11 @@ export const ThumbnailStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="thumbnail">
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="thumbnail">
 						<Grey heightInPixels={200} />
 					</Figure>
 					<SomeText />
@@ -195,7 +211,11 @@ export const ShowcaseStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="showcase">
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="showcase">
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -224,7 +244,11 @@ export const HalfWidthStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="halfWidth">
+					<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="halfWidth">
 						<Grey />
 					</Figure>
 					<SomeText />

--- a/dotcom-rendering/src/web/components/Figure.stories.tsx
+++ b/dotcom-rendering/src/web/components/Figure.stories.tsx
@@ -73,11 +73,14 @@ export const InlineStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false}>
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+					>
 						<Grey />
 					</Figure>
 					<SomeText />
@@ -107,11 +110,15 @@ export const SupportingStory = () => {
 				>
 					<SomeText />
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="supporting">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="supporting"
+					>
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -144,11 +151,15 @@ export const ImmersiveStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="immersive">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="immersive"
+					>
 						<Grey heightInPixels={700} />
 					</Figure>
 					<SomeText />
@@ -177,11 +188,15 @@ export const ThumbnailStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="thumbnail">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="thumbnail"
+					>
 						<Grey heightInPixels={200} />
 					</Figure>
 					<SomeText />
@@ -211,11 +226,15 @@ export const ShowcaseStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="showcase">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="showcase"
+					>
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -244,11 +263,15 @@ export const HalfWidthStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="halfWidth">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="halfWidth"
+					>
 						<Grey />
 					</Figure>
 					<SomeText />

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -171,7 +171,7 @@ export const Figure = ({
 			<figure id={id} key={id}>
 				{children}
 			</figure>
-		)
+		);
 	}
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 
 import { from, until, space } from '@guardian/source-foundations';
 
@@ -149,6 +150,7 @@ type Props = {
 	id?: string;
 	isNumberedListTitle?: boolean;
 	className?: string;
+	format: ArticleFormat;
 };
 
 const mainMediaFigureStyles = css`
@@ -162,7 +164,15 @@ export const Figure = ({
 	isMainMedia,
 	isNumberedListTitle = false,
 	className = '',
+	format,
 }: Props) => {
+	if (format.design === ArticleDesign.Interactive) {
+		return (
+			<figure id={id} key={id}>
+				{children}
+			</figure>
+		)
+	}
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
 		// TODO: If we want to support other element types having role position, such

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -57,11 +57,15 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 export const StandardArticle = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -86,11 +90,15 @@ StandardArticle.story = {
 export const Immersive = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="immersive">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="immersive"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -115,11 +123,15 @@ Immersive.story = {
 export const Showcase = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -144,11 +156,15 @@ Showcase.story = {
 export const Thumbnail = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="thumbnail">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="thumbnail"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'thumbnail' }}
 					format={{
@@ -173,11 +189,15 @@ Thumbnail.story = {
 export const Supporting = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="supporting">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="supporting"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'supporting' }}
 					format={{
@@ -202,11 +222,15 @@ Supporting.story = {
 export const HideCaption = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -232,11 +256,15 @@ HideCaption.story = {
 export const InlineTitle = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -267,11 +295,15 @@ InlineTitle.story = {
 export const InlineTitleMobile = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -302,11 +334,15 @@ InlineTitleMobile.story = {
 export const ImmersiveTitle = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="immersive">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="immersive"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -333,11 +369,15 @@ ImmersiveTitle.story = {
 export const ShowcaseTitle = () => {
 	return (
 		<Container>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -388,11 +428,15 @@ export const HalfWidth = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -457,11 +501,15 @@ export const HalfWidthMobile = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -526,11 +574,15 @@ export const HalfWidthWide = () => {
 				sint occaecat cupidatat non proident, sunt in culpa qui officia
 				deserunt mollit anim id est laborum.
 			</p>
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -57,7 +57,11 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 export const StandardArticle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -82,7 +86,11 @@ StandardArticle.story = {
 export const Immersive = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="immersive">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="immersive">
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -107,7 +115,11 @@ Immersive.story = {
 export const Showcase = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="showcase">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="showcase">
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -132,7 +144,11 @@ Showcase.story = {
 export const Thumbnail = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="thumbnail">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="thumbnail">
 				<ImageBlockComponent
 					element={{ ...image, role: 'thumbnail' }}
 					format={{
@@ -157,7 +173,11 @@ Thumbnail.story = {
 export const Supporting = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="supporting">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="supporting">
 				<ImageBlockComponent
 					element={{ ...image, role: 'supporting' }}
 					format={{
@@ -182,7 +202,11 @@ Supporting.story = {
 export const HideCaption = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -208,7 +232,11 @@ HideCaption.story = {
 export const InlineTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -239,7 +267,11 @@ InlineTitle.story = {
 export const InlineTitleMobile = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -270,7 +302,11 @@ InlineTitleMobile.story = {
 export const ImmersiveTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="immersive">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="immersive">
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -297,7 +333,11 @@ ImmersiveTitle.story = {
 export const ShowcaseTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="showcase">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="showcase">
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -348,7 +388,11 @@ export const HalfWidth = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -413,7 +457,11 @@ export const HalfWidthMobile = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -478,7 +526,11 @@ export const HalfWidthWide = () => {
 				sint occaecat cupidatat non proident, sunt in culpa qui officia
 				deserunt mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
@@ -42,11 +42,15 @@ export const Default = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="supporting">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="supporting"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2018/01/archive-zip/giv-3902O7VEVpcWiCO7/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -72,11 +76,15 @@ export const InlineMap = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -101,11 +109,15 @@ export const Showcase = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/embed/from-tool/photo-collage/index.html?vertical=News&opinion-tint=false&left-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F84bd48ec5962601f8550286bfb5c2093fa0a3ffe%3Fcrop%3D0_70_3500_2100&left-caption=A%20woman%20stands%20during%20a%20song%20ahead%20of%20Trump’s%20remarks%20at%20the%20King%20Jesus%20International%20Ministry%20in%20Miami.%20Photo%3A%20Tom%20Brenner%2FReuters&right-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F9eb6381555963f1dc58c637adf2f3dc08f283e58%3Fcrop%3D0_26_3000_1800&right-caption=People%20give%20thumbs%20down%20to%20media%20covering%20the%20Trump%20campaign%20event%20held%20at%20the%20King%20Jesus%20International%20Ministry.%20Photo%3A%20Joe%20Raedle%2FGetty&always-place-captions-below=false"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -131,11 +143,15 @@ export const WithCaption = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -162,11 +178,15 @@ export const NonBootJs = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					scriptUrl="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
@@ -42,7 +42,11 @@ export const Default = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="supporting">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="supporting">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2018/01/archive-zip/giv-3902O7VEVpcWiCO7/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -68,7 +72,11 @@ export const InlineMap = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -93,7 +101,11 @@ export const Showcase = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="showcase">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="showcase">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/embed/from-tool/photo-collage/index.html?vertical=News&opinion-tint=false&left-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F84bd48ec5962601f8550286bfb5c2093fa0a3ffe%3Fcrop%3D0_70_3500_2100&left-caption=A%20woman%20stands%20during%20a%20song%20ahead%20of%20Trump’s%20remarks%20at%20the%20King%20Jesus%20International%20Ministry%20in%20Miami.%20Photo%3A%20Tom%20Brenner%2FReuters&right-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F9eb6381555963f1dc58c637adf2f3dc08f283e58%3Fcrop%3D0_26_3000_1800&right-caption=People%20give%20thumbs%20down%20to%20media%20covering%20the%20Trump%20campaign%20event%20held%20at%20the%20King%20Jesus%20International%20Ministry.%20Photo%3A%20Joe%20Raedle%2FGetty&always-place-captions-below=false"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -119,7 +131,11 @@ export const WithCaption = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -146,7 +162,11 @@ export const NonBootJs = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}} isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					scriptUrl="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -31,11 +31,15 @@ export default {
 export const Article = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
@@ -59,11 +63,15 @@ export const Article = () => {
 export const Network = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="special-report"
@@ -93,11 +101,15 @@ Network.story = {
 export const SectionStory = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="live"
@@ -124,11 +136,15 @@ SectionStory.story = {
 export const Inline = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -155,11 +171,15 @@ Inline.story = {
 export const ImageContent = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="dead"
@@ -189,11 +209,15 @@ ImageContent.story = {
 export const Interactive = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="feature"
@@ -222,11 +246,15 @@ Interactive.story = {
 export const Gallery = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -256,11 +284,15 @@ Gallery.story = {
 export const Video = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -291,11 +323,15 @@ Video.story = {
 export const Audio = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="podcast"
@@ -319,11 +355,15 @@ export const Audio = () => {
 export const LiveBlog = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="media"
@@ -353,11 +393,15 @@ LiveBlog.story = {
 export const Tag = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="analysis"
@@ -381,11 +425,15 @@ export const Tag = () => {
 export const Index = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="review"
@@ -416,11 +464,15 @@ export const Index = () => {
 export const Crossword = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="letters"
@@ -444,11 +496,15 @@ export const Crossword = () => {
 export const Survey = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -472,11 +528,15 @@ export const Survey = () => {
 export const Signup = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -501,11 +561,15 @@ export const Signup = () => {
 export const Userid = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="editorial"
@@ -529,11 +593,15 @@ export const Userid = () => {
 export const PaidFor = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.Opinion,
-					}} isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Opinion,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -31,7 +31,11 @@ export default {
 export const Article = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
@@ -55,7 +59,11 @@ export const Article = () => {
 export const Network = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="special-report"
@@ -85,7 +93,11 @@ Network.story = {
 export const SectionStory = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="live"
@@ -112,7 +124,11 @@ SectionStory.story = {
 export const Inline = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="inline">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="inline">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -139,7 +155,11 @@ Inline.story = {
 export const ImageContent = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="dead"
@@ -169,7 +189,11 @@ ImageContent.story = {
 export const Interactive = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="feature"
@@ -198,7 +222,11 @@ Interactive.story = {
 export const Gallery = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -228,7 +256,11 @@ Gallery.story = {
 export const Video = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -259,7 +291,11 @@ Video.story = {
 export const Audio = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="podcast"
@@ -283,7 +319,11 @@ export const Audio = () => {
 export const LiveBlog = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="media"
@@ -313,7 +353,11 @@ LiveBlog.story = {
 export const Tag = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="analysis"
@@ -337,7 +381,11 @@ export const Tag = () => {
 export const Index = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="review"
@@ -368,7 +416,11 @@ export const Index = () => {
 export const Crossword = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="letters"
@@ -392,7 +444,11 @@ export const Crossword = () => {
 export const Survey = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -416,7 +472,11 @@ export const Survey = () => {
 export const Signup = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -441,7 +501,11 @@ export const Signup = () => {
 export const Userid = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="editorial"
@@ -465,7 +529,11 @@ export const Userid = () => {
 export const PaidFor = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}} isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -783,6 +783,7 @@ export const renderArticleElement = ({
 			isMainMedia={isMainMedia}
 			id={'elementId' in element ? element.elementId : undefined}
 			role={role}
+			format={format}
 			className={
 				isInteractive(format.design)
 					? interactiveLegacyFigureClasses(element._type, role)


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the css for Figure elements in interactive articles

## Why?
Currently the Figure element expects the article grid to add a left column. Interactive articles don't have a left column by default and therefore the margin-left and margin-right are not needed.
Css to position these elements can now be included via a simple enhancer.scss file within the interactive-atom-template-2019 repo

### Before
![Screenshot 2022-01-20 at 15 43 24](https://user-images.githubusercontent.com/20658471/150372058-0ab41412-2d5f-4ddc-a62a-ab05f1fc49f6.png)
![Screenshot 2022-01-20 at 15 43 33](https://user-images.githubusercontent.com/20658471/150372075-1d9ba422-2afb-4900-bfe3-2898c60d9ecb.png)


### After
![Screenshot 2022-01-20 at 15 38 05](https://user-images.githubusercontent.com/20658471/150371758-7caa6216-70f3-408c-936e-a9f561551268.png)
![Screenshot 2022-01-20 at 15 38 12](https://user-images.githubusercontent.com/20658471/150371776-e7fab449-efaf-4765-937f-dc9dc64c74e9.png)

