### PR TITLE
Set publicReadAcl to false for mobile-apps-rendering-assets bucket

### DIFF
--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -34,4 +34,4 @@ deployments:
       bucket: mobile-apps-rendering-assets
       cacheControl: public, max-age=315360000
       prefixStack: false
-      publicReadAcl: true
+      publicReadAcl: false


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
It sets `publicReadAcl: false` in `apps-rendering/riff-raff.yaml` for s3 bucket `mobile-apps-rendering-assets`.

## Why?
`mobile-apps-rendering-assets` is set as public so the individual files don't need a public read ACL
