### PR TITLE
`defer` > `deferuntil`

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -52,9 +52,8 @@ describe('Interactivity', function () {
 			it('should change the list of most viewed items when a tab is clicked', function () {
 				cy.visit(`/Article?url=${articleUrl}`);
 				cy.contains('Lifestyle');
-				cy.get('[data-component="most-popular"]').scrollIntoView({
-					offset: { top: 150 },
-				});
+				// Scroll to bottom to trigger hydration
+				cy.scrollTo('bottom', { duration: 300 });
 				cy.wait('@getMostReadGeo');
 				cy.wait('@getMostRead');
 				cy.get('[data-cy=tab-body-0]').should('be.visible');
@@ -170,6 +169,8 @@ describe('Interactivity', function () {
 				cy.get('[data-cy=subnav-toggle]').first().click();
 				// The first button now shows 'Less'
 				cy.get('[data-cy=subnav-toggle]').first().contains('Less');
+				// Scroll to bottom to trigger hydration
+				cy.scrollTo('bottom', { duration: 300 });
 				// The other subnav still shows 'More'
 				cy.get('[data-cy=subnav-toggle]').last().contains('More');
 				// Click Show more on the last sub nav

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -52,10 +52,13 @@ describe('Interactivity', function () {
 			it('should change the list of most viewed items when a tab is clicked', function () {
 				cy.visit(`/Article?url=${articleUrl}`);
 				cy.contains('Lifestyle');
+				// Make sure the most viewed html isn't even in the dom yet
+				cy.get('[data-cy=mostviewed-footer]').should('not.exist');
 				// Scroll to bottom to trigger hydration
 				cy.scrollTo('bottom', { duration: 300 });
 				cy.wait('@getMostReadGeo');
 				cy.wait('@getMostRead');
+				cy.get('[data-cy=mostviewed-footer]').should('exist');
 				cy.get('[data-cy=tab-body-0]').should('be.visible');
 				cy.get('[data-cy=tab-body-1]').should('not.be.visible');
 				cy.get('[data-cy=tab-heading-1]').click();

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -161,9 +161,8 @@ describe('Interactivity', function () {
 				cy.viewport('iphone-x');
 				cy.visit(`/Article?url=${articleUrl}`);
 				// Wait for hydration
-				cy.get('[data-cy=sub-nav]')
+				cy.get('gu-island[name=SubNav]')
 					.first()
-					.parent()
 					.should('have.attr', 'data-gu-hydrated', 'true');
 				// Both subnav buttons show 'More'
 				cy.get('[data-cy=subnav-toggle]').first().contains('More');
@@ -174,6 +173,10 @@ describe('Interactivity', function () {
 				cy.get('[data-cy=subnav-toggle]').first().contains('Less');
 				// Scroll to bottom to trigger hydration
 				cy.scrollTo('bottom', { duration: 300 });
+				// Wait for hydration
+				cy.get('gu-island[name=SubNav]')
+					.last()
+					.should('have.attr', 'data-gu-hydrated', 'true');
 				// The other subnav still shows 'More'
 				cy.get('[data-cy=subnav-toggle]').last().contains('More');
 				// Click Show more on the last sub nav

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -56,6 +56,10 @@ describe('Interactivity', function () {
 				cy.get('[data-cy=mostviewed-footer]').should('not.exist');
 				// Scroll to bottom to trigger hydration
 				cy.scrollTo('bottom', { duration: 300 });
+				// We need this second call to fix flakiness where content loads in pushing the page
+				// down and preventing the scroll request to actually reach the bottom. We will fix
+				// this later when we've defined fixed heights for these containers, preventing CLS
+				cy.scrollTo('bottom', { duration: 300 });
 				cy.wait('@getMostReadGeo', { timeout: 15000 });
 				cy.wait('@getMostRead', { timeout: 15000 });
 				cy.get('[data-cy=mostviewed-footer]').should('exist');

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -56,8 +56,8 @@ describe('Interactivity', function () {
 				cy.get('[data-cy=mostviewed-footer]').should('not.exist');
 				// Scroll to bottom to trigger hydration
 				cy.scrollTo('bottom', { duration: 300 });
-				cy.wait('@getMostReadGeo');
-				cy.wait('@getMostRead');
+				cy.wait('@getMostReadGeo', { timeout: 15000 });
+				cy.wait('@getMostRead', { timeout: 15000 });
 				cy.get('[data-cy=mostviewed-footer]').should('exist');
 				cy.get('[data-cy=tab-body-0]').should('be.visible');
 				cy.get('[data-cy=tab-body-1]').should('not.be.visible');

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -60,8 +60,8 @@ describe('Interactivity', function () {
 				// down and preventing the scroll request to actually reach the bottom. We will fix
 				// this later when we've defined fixed heights for these containers, preventing CLS
 				cy.scrollTo('bottom', { duration: 300 });
-				cy.wait('@getMostReadGeo', { timeout: 15000 });
-				cy.wait('@getMostRead', { timeout: 15000 });
+				cy.wait('@getMostReadGeo');
+				cy.wait('@getMostRead');
 				cy.get('[data-cy=mostviewed-footer]').should('exist');
 				cy.get('[data-cy=tab-body-0]').should('be.visible');
 				cy.get('[data-cy=tab-body-1]').should('not.be.visible');

--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -173,6 +173,10 @@ describe('Interactivity', function () {
 				cy.get('[data-cy=subnav-toggle]').first().contains('Less');
 				// Scroll to bottom to trigger hydration
 				cy.scrollTo('bottom', { duration: 300 });
+				// We need this second call to fix flakiness where content loads in pushing the page
+				// down and preventing the scroll request to actually reach the bottom. We will fix
+				// this later when we've defined fixed heights for these containers, preventing CLS
+				cy.scrollTo('bottom', { duration: 300 });
 				// Wait for hydration
 				cy.get('gu-island[name=SubNav]')
 					.last()

--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -41,6 +41,12 @@ describe('Signed in readers', function () {
 	it('should not display signed in texts when users are not signed in', function () {
 		cy.visit(`Article?url=${articleUrl}`);
 		cy.scrollTo('bottom', { duration: 300 });
+		// Wait for hydration
+		cy.get('gu-island[name=DiscussionContainer]').should(
+			'have.attr',
+			'data-gu-hydrated',
+			'true',
+		);
 		// Check that the page is showing the reader as signed out
 		cy.contains('sign in or create');
 	});

--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -40,6 +40,7 @@ describe('Signed in readers', function () {
 
 	it('should not display signed in texts when users are not signed in', function () {
 		cy.visit(`Article?url=${articleUrl}`);
+		cy.scrollTo('bottom', { duration: 300 });
 		// Check that the page is showing the reader as signed out
 		cy.contains('sign in or create');
 	});

--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -41,6 +41,10 @@ describe('Signed in readers', function () {
 	it('should not display signed in texts when users are not signed in', function () {
 		cy.visit(`Article?url=${articleUrl}`);
 		cy.scrollTo('bottom', { duration: 300 });
+		// We need this second call to fix flakiness where content loads in pushing the page
+		// down and preventing the scroll request to actually reach the bottom. We will fix
+		// this later when we've defined fixed heights for these containers, preventing CLS
+		cy.scrollTo('bottom', { duration: 300 });
 		// Wait for hydration
 		cy.get('gu-island[name=DiscussionContainer]').should(
 			'have.attr',

--- a/dotcom-rendering/src/web/browser/islands/init.ts
+++ b/dotcom-rendering/src/web/browser/islands/init.ts
@@ -15,7 +15,7 @@ const init = () => {
 	 * The code here looks for parts of the dom that have been marked using the `gu-island`
 	 * marker, hydrating/rendering each one using the following properties:
 	 *
-	 * defer - Used to optionally defer execution
+	 * deferUntil - Used to optionally defer execution
 	 * name - The name of the component. Used to dynamically import the code
 	 * props - The data for the component that has been serialised in the dom
 	 * element - The `gu-island` custom element which is wrapping the content
@@ -28,8 +28,8 @@ const init = () => {
 			if (!name) return;
 			log('dotcom', `Hydrating ${name}`);
 
-			const defer = element.getAttribute('deferuntil');
-			switch (defer) {
+			const deferUntil = element.getAttribute('deferuntil');
+			switch (deferUntil) {
 				case 'idle': {
 					whenIdle(() => {
 						doHydration(name, props, element);

--- a/dotcom-rendering/src/web/browser/islands/init.ts
+++ b/dotcom-rendering/src/web/browser/islands/init.ts
@@ -28,7 +28,7 @@ const init = () => {
 			if (!name) return;
 			log('dotcom', `Hydrating ${name}`);
 
-			const defer = element.getAttribute('defer');
+			const defer = element.getAttribute('deferuntil');
 			switch (defer) {
 				case 'idle': {
 					whenIdle(() => {

--- a/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/dotcom-rendering/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -72,6 +72,7 @@ export const MostViewedFooterData = ({
 				css={css`
 					width: 100%;
 				`}
+				data-cy="mostviewed-footer"
 			>
 				<MostViewedFooterGrid
 					data={transformTabs(tabs)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes an issue where we were reading the value for the `deferuntil` attribute incorrectly

## Why?
By not reading the right value we are not deferring hydration
