### PR TITLE
Bump CMP for Prebid ID

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
     "@guardian/automat-contributions": "^0.4.3",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.32.0",
-    "@guardian/consent-management-platform": "^10.1.0",
+    "@guardian/consent-management-platform": "^10.1.1",
     "@guardian/discussion-rendering": "^9.1.1",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,10 +2773,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.32.0.tgz#c6cbbd2072e59ac75e0f511e87b26dd762fac3dd"
   integrity sha512-wPEPy7m2lAk3anNWJl1LjOnE55SDzkbbUKWUuxSA7QoJRdkSr5s0lexnKnANa7wLNiZGcoepoIiqftj1xacuWQ==
 
-"@guardian/consent-management-platform@^10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.0.tgz#defabd279ca3e8344bfbfbb0d604e42ba549ae1c"
-  integrity sha512-7q4mb8b5jVcecOMYp0cTN02OIz7ZHw0HgKKVID7mOjV7NwSNBY+Lwtj85VyYAR/cnC2SJFbpezPivFdvyE5rTg==
+"@guardian/consent-management-platform@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.1.tgz#c49ccdde26582b571accd925f576fb178c619004"
+  integrity sha512-hzhmrlhNVkwshKXKYVQUrl4NBA6iCkyFg79LQHUD3nDpo5IjxzwOGlUU4ML1gzFFID4lZ1AM2klxkM7ZUfYySg==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 
@@ -5081,7 +5081,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/serve-static@*":
+"@types/serve-static@*", "@types/serve-static@^1.13.9":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==


### PR DESCRIPTION
## What does this change?

Bumps the CMP library to include the new Prebid IAB ID

## Why?

No consent for Prebid otherwise.

https://github.com/guardian/frontend/pull/24581
