### PR TITLE
Added "modern" To Footer To Distinguish AR

### DIFF
--- a/apps-rendering/src/components/footerContent.tsx
+++ b/apps-rendering/src/components/footerContent.tsx
@@ -44,7 +44,7 @@ const FooterContent: FC<Props> = ({ isCcpa }) => {
 	return (
 		<div id="js-footer">
 			&#169; {currentYear} Guardian News and Media Limited or its
-			affiliated companies. All rights reserved.
+			affiliated companies. All rights reserved. (modern)
 			<br />
 			<PrivacySettings isCcpa={isCcpa} />
 			<a


### PR DESCRIPTION
## Why?

It's useful for developers, designers, userhelp etc. to be able to quickly figure out whether an article they're looking at in the app is rendering via AR or the old templates. This can be very helpful when debugging an issue.

This was also important during the development of DCR to distinguish it from frontend, and the Dotcom team established the convention of including the word `(modern)` in the footer to signify a DCR-rendered article.

This PR applies the same convention to AR.

## Changes

- Added "modern" to footer to distinguish AR

## Screenshots

| Before | After | DCR |
| - | - | - |
| ![modern-before](https://user-images.githubusercontent.com/53781962/150789074-ba88f32f-338f-4a8f-9d5d-c18ffce45f42.jpg) | ![modern-after](https://user-images.githubusercontent.com/53781962/150789080-1573c957-5ba1-443d-bfda-ada1951985d6.jpg) | ![modern-dcr](https://user-images.githubusercontent.com/53781962/150789082-41ceea8f-6ce6-4af3-b77d-20610f6de311.jpg) |
