### PR TITLE
Update gu-stats-report-plugin to use prod API

### DIFF
--- a/dotcom-rendering/scripts/webpack/gu-stats-report-plugin.js
+++ b/dotcom-rendering/scripts/webpack/gu-stats-report-plugin.js
@@ -58,7 +58,7 @@ class GuStatsReportPlugin {
 					'[gu-stats-report] Unable to report stats - invalid config',
 				);
 
-			const URL = 'https://logs.code.dev-guardianapis.com/log';
+			const URL = 'https://logs.guardianapis.com/log';
 			fetch(URL, {
 				method: 'POST',
 				body: JSON.stringify({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Update gu-stats-report-plugin to use prod API - I accidentally left it as the CODE endpoint

