### PR TITLE
Modernise related content section

### DIFF
--- a/apps-rendering/src/components/footer.tsx
+++ b/apps-rendering/src/components/footer.tsx
@@ -7,6 +7,7 @@ import {
 	neutral,
 	remSpace,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import FooterContent from 'components/footerContent';
 import type { FC } from 'react';
@@ -17,14 +18,16 @@ import { darkModeCss } from 'styles';
 const styles = css`
 	border-width: 0 1px;
 	${textSans.small({ lineHeight: 'regular' })};
-	margin-left: ${remSpace[3]};
-	margin-right: ${remSpace[3]};
+	margin-left: 0;
+	margin-right: 0;
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
 	padding-top: ${remSpace[4]};
 	padding-bottom: ${remSpace[4]};
 
 	${from.wide} {
-		width: ${breakpoints.wide}px;
 		margin: 0 auto;
+		width: ${breakpoints.wide}px;
 	}
 
 	a {
@@ -35,6 +38,7 @@ const styles = css`
 
 	${darkModeCss`
         color: ${neutral[60]};
+		background: ${neutral[0]};
 
         a {
             color: ${neutral[60]};

--- a/apps-rendering/src/components/footer.tsx
+++ b/apps-rendering/src/components/footer.tsx
@@ -7,7 +7,6 @@ import {
 	neutral,
 	remSpace,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import FooterContent from 'components/footerContent';
 import type { FC } from 'react';

--- a/apps-rendering/src/components/shared/bylineCard.tsx
+++ b/apps-rendering/src/components/shared/bylineCard.tsx
@@ -19,23 +19,18 @@ import { makeRelativeDate } from 'date';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import { darkModeCss } from 'styles';
-import { getThemeStyles, themeFromString } from 'themeStyles';
+import { themeFromString } from 'themeStyles';
 
 interface Props {
 	relatedItem: RelatedItem;
 }
 
-const borderColor = (format: ArticleFormat): SerializedStyles => {
-	return css`1px solid ${getThemeStyles(format.theme).kicker}`;
-};
-
 const listStyles = (format: ArticleFormat): SerializedStyles => {
 	return css`
-		background: white;
 		margin-right: ${remSpace[2]};
 		flex: 0 0 42vw;
 		justify-content: space-between;
-		border-top: ${borderColor(format)};
+		border-top: 1px solid ${neutral[86]};
 		max-width: 10rem;
 
 		&.fade {
@@ -118,7 +113,6 @@ const headingStyles: SerializedStyles = css`
 `;
 
 const cardStyles: SerializedStyles = css`
-	background-color: ${neutral[100]};
 	${headline.xxsmall()}
 `;
 

--- a/apps-rendering/src/components/shared/bylineCard.tsx
+++ b/apps-rendering/src/components/shared/bylineCard.tsx
@@ -38,7 +38,8 @@ const listStyles = (format: ArticleFormat): SerializedStyles => {
 		}
 
 		${darkModeCss`
-            background: ${neutral[7]};
+			border-top: 1px solid ${neutral[20]};
+            background: ${neutral[0]};
         `}
 
 		${from.tablet} {
@@ -175,25 +176,6 @@ const dateStyles = css`
 	font-weight: 700;
 `;
 
-const lineStyles = css`
-	background-image: repeating-linear-gradient(
-		${neutral[86]},
-		${neutral[86]} 1px,
-		transparent 1px,
-		transparent 0.25rem
-	);
-	background-repeat: repeat-x;
-	background-position: center top;
-	background-size: 1px calc(0.75rem + 1px);
-	height: calc(0.75rem + 1px);
-	flex-grow: 1;
-	margin-right: ${remSpace[3]};
-	align-self: flex-end;
-	${darkModeCss`
-        background-image: repeating-linear-gradient(${neutral[20]}, ${neutral[20]} 1px, transparent 1px, transparent 0.25rem);
-    `}
-`;
-
 const relativeFirstPublished = (date: Option<Date>): ReactElement | null =>
 	pipe(
 		date,
@@ -242,7 +224,7 @@ const BylineCard: FC<Props> = ({ relatedItem }) => {
 				<section>
 					{img}
 					<footer css={footerStyles}>
-						<div css={lineStyles}></div>
+						<div css={dateStyles}></div>
 						{date}
 					</footer>
 				</section>

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -28,6 +28,7 @@ import {
 	map,
 	none,
 	OptionKind,
+	some,
 	withDefault,
 } from '@guardian/types';
 import type { Option } from '@guardian/types';
@@ -44,29 +45,18 @@ interface Props {
 	image: Option<Image>;
 }
 
-const borderColor = (
-	type: RelatedItemType,
-	format: ArticleFormat,
-): SerializedStyles => {
-	if (type === RelatedItemType.ADVERTISEMENT_FEATURE) {
-		return css`1px solid ${labs[300]}`;
-	} else {
-		return css`1px solid ${getThemeStyles(format.theme).kicker}`;
-	}
-};
-
 const listStyles = (
 	type: RelatedItemType,
 	format: ArticleFormat,
 ): SerializedStyles => {
 	return css`
-		background: white;
 		margin-right: ${remSpace[2]};
 		flex: 0 0 42vw;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		border-top: ${borderColor(type, format)};
+		border-top: 1px solid ${neutral[86]};
+		border-radius: 0 0 0.75rem 0.75rem;
 		max-width: 10rem;
 
 		&.fade {
@@ -101,6 +91,10 @@ const fullWidthImage = css`
 
 		position: relative;
 	}
+`;
+
+const imgStyles = css`
+	border-radius: 0.75rem;
 `;
 
 const timeStyles = (type: RelatedItemType): SerializedStyles => {
@@ -432,7 +426,7 @@ const cardImage = (
 							default: '100%',
 						}}
 						format={format}
-						className={none}
+						className={some(imgStyles)}
 						supportsDarkMode
 						lightbox={none}
 					/>

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -67,8 +67,8 @@ const listStyles = (
 				}
 
 				${darkModeCss`
-            background: ${neutral[10]};
-        `}
+					background: ${neutral[10]};
+				`}
 
 				${from.tablet} {
 					margin-right: ${remSpace[5]};
@@ -99,9 +99,9 @@ const listStyles = (
 				}
 
 				${darkModeCss`
-			border-top: 1px solid ${neutral[20]};
-            background: ${neutral[0]};
-        `}
+					border-top: 1px solid ${neutral[20]};
+					background: ${neutral[0]};
+        		`}
 
 				${from.tablet} {
 					margin-right: ${remSpace[5]};
@@ -311,7 +311,7 @@ const cardStyles = (
 
 		case RelatedItemType.COMMENT: {
 			return css`
-				background-color: ${neutral[100]};
+				background-color: ${neutral[97]};
 				${headline.xxsmall()}
 			`;
 		}

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -49,36 +49,76 @@ const listStyles = (
 	type: RelatedItemType,
 	format: ArticleFormat,
 ): SerializedStyles => {
-	return css`
-		margin-right: ${remSpace[2]};
-		flex: 0 0 42vw;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		border-top: 1px solid ${neutral[86]};
-		border-radius: 0 0 0.75rem 0.75rem;
-		max-width: 10rem;
+	switch (type) {
+		case RelatedItemType.VIDEO:
+		case RelatedItemType.AUDIO:
+		case RelatedItemType.GALLERY: {
+			return css`
+				margin-right: ${remSpace[2]};
+				flex: 0 0 42vw;
+				display: flex;
+				flex-direction: column;
+				justify-content: space-between;
+				border-top: 1px solid ${neutral[86]};
+				border-radius: 0.75rem;
+				max-width: 10rem;
 
-		&.fade {
-			opacity: 0.7;
-		}
+				&.fade {
+					opacity: 0.7;
+				}
 
-		${darkModeCss`
-            background: ${neutral[7]};
+				${darkModeCss`
+			border-top: none;
+            background: ${neutral[10]};
         `}
 
-		${from.tablet} {
-			margin-right: ${remSpace[5]};
-		}
+				${from.tablet} {
+					margin-right: ${remSpace[5]};
+				}
 
-		${from.desktop} {
-			max-width: 13.75rem;
-		}
+				${from.desktop} {
+					max-width: 13.75rem;
+				}
 
-		&:last-of-type {
-			margin-right: 0;
+				&:last-of-type {
+					margin-right: 0;
+				}
+			`;
 		}
-	`;
+		default: {
+			return css`
+				margin-right: ${remSpace[2]};
+				flex: 0 0 42vw;
+				display: flex;
+				flex-direction: column;
+				justify-content: space-between;
+				border-top: 1px solid ${neutral[86]};
+				border-radius: 0 0 0.75rem 0.75rem;
+				max-width: 10rem;
+
+				&.fade {
+					opacity: 0.7;
+				}
+
+				${darkModeCss`
+			border-top: 1px solid ${neutral[20]};
+            background: ${neutral[0]};
+        `}
+
+				${from.tablet} {
+					margin-right: ${remSpace[5]};
+				}
+
+				${from.desktop} {
+					max-width: 13.75rem;
+				}
+
+				&:last-of-type {
+					margin-right: 0;
+				}
+			`;
+		}
+	}
 };
 
 const fullWidthImage = css`
@@ -148,18 +188,18 @@ const headingWrapperStyles = (type: RelatedItemType) => {
 		case RelatedItemType.AUDIO:
 		case RelatedItemType.GALLERY: {
 			return css`
-			padding: 0.125rem ${remSpace[2]} ${remSpace[4]};
-			flex-grow: 1;
+				padding: 0.125rem ${remSpace[2]} ${remSpace[4]};
+				flex-grow: 1;
 			`;
 		}
 		default: {
 			return css`
-			padding: 0.125rem 0 ${remSpace[4]} 0;
-			flex-grow: 1;
-			`
+				padding: 0.125rem 0 ${remSpace[4]} 0;
+				flex-grow: 1;
+			`;
 		}
 	}
-}
+};
 
 const headingStyles = (type: RelatedItemType): SerializedStyles => {
 	if (type === RelatedItemType.ADVERTISEMENT_FEATURE) {

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -44,6 +44,31 @@ interface Props {
 	image: Option<Image>;
 }
 
+const listBaseStyles = css`
+	margin-right: ${remSpace[2]};
+	flex: 0 0 42vw;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-width: 10rem;
+
+	&.fade {
+		opacity: 0.7;
+	}
+
+	${from.tablet} {
+		margin-right: ${remSpace[5]};
+	}
+
+	${from.desktop} {
+		max-width: 13.75rem;
+	}
+
+	&:last-of-type {
+		margin-right: 0;
+	}
+`;
+
 const listStyles = (
 	type: RelatedItemType,
 	format: ArticleFormat,
@@ -53,67 +78,25 @@ const listStyles = (
 		case RelatedItemType.AUDIO:
 		case RelatedItemType.GALLERY: {
 			return css`
-				margin-right: ${remSpace[2]};
-				flex: 0 0 42vw;
-				display: flex;
-				flex-direction: column;
-				justify-content: space-between;
+				${listBaseStyles}
 				border-radius: ${remSpace[2]};
-				max-width: 10rem;
 				padding-top: 0.125rem;
-
-				&.fade {
-					opacity: 0.7;
-				}
 
 				${darkModeCss`
 					background: ${neutral[10]};
 				`}
-
-				${from.tablet} {
-					margin-right: ${remSpace[5]};
-				}
-
-				${from.desktop} {
-					max-width: 13.75rem;
-				}
-
-				&:last-of-type {
-					margin-right: 0;
-				}
 			`;
 		}
 		default: {
 			return css`
-				margin-right: ${remSpace[2]};
-				flex: 0 0 42vw;
-				display: flex;
-				flex-direction: column;
-				justify-content: space-between;
+				${listBaseStyles}
 				border-top: 1px solid ${neutral[86]};
 				border-radius: 0 0 ${remSpace[2]} ${remSpace[2]};
-				max-width: 10rem;
-
-				&.fade {
-					opacity: 0.7;
-				}
 
 				${darkModeCss`
 					border-top: 1px solid ${neutral[20]};
 					background: ${neutral[0]};
         		`}
-
-				${from.tablet} {
-					margin-right: ${remSpace[5]};
-				}
-
-				${from.desktop} {
-					max-width: 13.75rem;
-				}
-
-				&:last-of-type {
-					margin-right: 0;
-				}
 			`;
 		}
 	}

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -180,7 +180,7 @@ const anchorStyles = css`
 	height: 100%;
 `;
 
-const headingWrapperStyles = (type: RelatedItemType) => {
+const headingWrapperStyles = (type: RelatedItemType): SerializedStyles => {
 	switch (type) {
 		case RelatedItemType.VIDEO:
 		case RelatedItemType.AUDIO:

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -10,7 +10,6 @@ import {
 	background,
 	from,
 	headline,
-	labs,
 	neutral,
 	opinion,
 	remSpace,

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -142,10 +142,24 @@ const anchorStyles = css`
 	height: 100%;
 `;
 
-const headingWrapperStyles = css`
-	padding: 0.125rem ${remSpace[2]} ${remSpace[4]};
-	flex-grow: 1;
-`;
+const headingWrapperStyles = (type: RelatedItemType) => {
+	switch (type) {
+		case RelatedItemType.VIDEO:
+		case RelatedItemType.AUDIO:
+		case RelatedItemType.GALLERY: {
+			return css`
+			padding: 0.125rem ${remSpace[2]} ${remSpace[4]};
+			flex-grow: 1;
+			`;
+		}
+		default: {
+			return css`
+			padding: 0.125rem 0 ${remSpace[4]} 0;
+			flex-grow: 1;
+			`
+		}
+	}
+}
 
 const headingStyles = (type: RelatedItemType): SerializedStyles => {
 	if (type === RelatedItemType.ADVERTISEMENT_FEATURE) {
@@ -470,7 +484,7 @@ const Card: FC<Props> = ({ relatedItem, image }) => {
 			css={[listStyles(type, format), cardStyles(type, format)]}
 		>
 			<a css={anchorStyles} href={`https://theguardian.com/${link}`}>
-				<section css={headingWrapperStyles}>
+				<section css={headingWrapperStyles(type)}>
 					<h3 css={headingStyles(type)}>
 						{quotationComment(type, format)}
 						{title}

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -58,16 +58,15 @@ const listStyles = (
 				display: flex;
 				flex-direction: column;
 				justify-content: space-between;
-				border-top: 1px solid ${neutral[86]};
 				border-radius: 0.75rem;
 				max-width: 10rem;
+				padding-top: 0.125rem;
 
 				&.fade {
 					opacity: 0.7;
 				}
 
 				${darkModeCss`
-			border-top: none;
             background: ${neutral[10]};
         `}
 

--- a/apps-rendering/src/components/shared/card.tsx
+++ b/apps-rendering/src/components/shared/card.tsx
@@ -58,7 +58,7 @@ const listStyles = (
 				display: flex;
 				flex-direction: column;
 				justify-content: space-between;
-				border-radius: 0.75rem;
+				border-radius: ${remSpace[2]};
 				max-width: 10rem;
 				padding-top: 0.125rem;
 
@@ -91,7 +91,7 @@ const listStyles = (
 				flex-direction: column;
 				justify-content: space-between;
 				border-top: 1px solid ${neutral[86]};
-				border-radius: 0 0 0.75rem 0.75rem;
+				border-radius: 0 0 ${remSpace[2]} ${remSpace[2]};
 				max-width: 10rem;
 
 				&.fade {
@@ -132,7 +132,7 @@ const fullWidthImage = css`
 `;
 
 const imgStyles = css`
-	border-radius: 0.75rem;
+	border-radius: ${remSpace[2]};
 `;
 
 const timeStyles = (type: RelatedItemType): SerializedStyles => {

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -5,6 +5,7 @@ import {
 	headline,
 	neutral,
 	remSpace,
+	until,
 } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
@@ -87,6 +88,17 @@ const listStyles = css`
 const styles = css`
 	border-top: 1px solid ${neutral[46]};
 	padding-top: ${remSpace[3]};
+	padding-left: ${remSpace[4]};
+	padding-right: ${remSpace[4]};
+
+	${until.wide} {
+		margin-left: -${remSpace[4]};
+		margin-right: -${remSpace[4]};
+	}
+
+	${darkModeCss`
+		background: ${neutral[0]};
+	`}
 `;
 
 const COMMENT = RelatedItemType.COMMENT;

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -84,6 +84,11 @@ const listStyles = css`
 	}
 `;
 
+const styles = css`
+	border-top: 1px solid ${neutral[46]};
+	padding-top: ${remSpace[3]};
+`;
+
 const COMMENT = RelatedItemType.COMMENT;
 
 const RelatedContent: FC<Props> = ({ content }) => {
@@ -95,7 +100,7 @@ const RelatedContent: FC<Props> = ({ content }) => {
 			}
 
 			return (
-				<section>
+				<section css={styles}>
 					<h2 css={headingStyles}>{title}</h2>
 					<ul css={listStyles}>
 						{relatedItems.map((relatedItem, key) => {


### PR DESCRIPTION
## Why?
UI modernisation as per request from @ajbreuer

The main changes are:

- Images with rounded corners
- Media cards with rounded corners
- Background colours of cards
- Related content section background colour
- Top border for the related content section
- No more lines on byline cards

These changes reflect what the app currently looks like.

### Light mode wide breakpoint (before)
![image](https://user-images.githubusercontent.com/57295823/150838176-7eb04110-cd94-4b04-bb07-f240febd778a.png)
### Light mode wide breakpoint (after)
![image](https://user-images.githubusercontent.com/57295823/150828329-851b7dee-253a-44d6-9c17-b2570a7f2ff2.png)
---
### Light mode narrow breakpoint (before)
![image](https://user-images.githubusercontent.com/57295823/150838503-2aea8854-9317-4489-91c9-82fede6f9535.png)
### Light mode narrow breakpoint (after)
![image](https://user-images.githubusercontent.com/57295823/150834602-bdeab9e4-821b-4a1c-b7b4-7128ce6c045a.png)
---
### Light mode byline/comment card (before)
![image](https://user-images.githubusercontent.com/57295823/150838713-0da8f35b-b48d-4996-af58-e154b40fb52f.png)
### Light mode byline/comment card (after)
![image](https://user-images.githubusercontent.com/57295823/150836933-47063a01-1772-4274-a61a-52f2461291e0.png)
---
### Dark mode wide breakpoint (before)
![image](https://user-images.githubusercontent.com/57295823/150839068-631746bf-2c28-4446-b0d9-b2fec2ee79d4.png)
### Dark-mode wide breakpoint (after)
![image](https://user-images.githubusercontent.com/57295823/150834849-bb3a8de8-a61d-46af-a88e-fe3c12f9c9f2.png)
---
### Dark mode narrow breakpoint (before)
![image](https://user-images.githubusercontent.com/57295823/150838960-db6c1eca-ef3b-462a-a009-b23f0768a462.png)
### Dark mode narrow breakpoint (after)
![image](https://user-images.githubusercontent.com/57295823/150837256-19bd72c5-4985-445a-bf00-c226b52133d6.png)
--
### Dark mode byline/comment card (before)
![image](https://user-images.githubusercontent.com/57295823/150839368-8b80ab61-be21-4407-9954-32e828d6c7fe.png)

### Dark mode byline/comment card (after)
![image](https://user-images.githubusercontent.com/57295823/150837148-11713771-5347-4c65-a8cd-f86339d03bfc.png)
