### PR TITLE
Only Hydrate Once

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -167,7 +167,7 @@ describe('Interactivity', function () {
 				// Wait for hydration
 				cy.get('gu-island[name=SubNav]')
 					.first()
-					.should('have.attr', 'data-gu-hydrated', 'true');
+					.should('have.attr', 'data-gu-ready', 'true');
 				// Both subnav buttons show 'More'
 				cy.get('[data-cy=subnav-toggle]').first().contains('More');
 				cy.get('[data-cy=subnav-toggle]').last().contains('More');
@@ -184,7 +184,7 @@ describe('Interactivity', function () {
 				// Wait for hydration
 				cy.get('gu-island[name=SubNav]')
 					.last()
-					.should('have.attr', 'data-gu-hydrated', 'true');
+					.should('have.attr', 'data-gu-ready', 'true');
 				// The other subnav still shows 'More'
 				cy.get('[data-cy=subnav-toggle]').last().contains('More');
 				// Click Show more on the last sub nav

--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -48,7 +48,7 @@ describe('Signed in readers', function () {
 		// Wait for hydration
 		cy.get('gu-island[name=DiscussionContainer]').should(
 			'have.attr',
-			'data-gu-hydrated',
+			'data-gu-ready',
 			'true',
 		);
 		// Check that the page is showing the reader as signed out

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -39,7 +39,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
-			.should('have.attr', 'data-gu-hydrated', 'true');
+			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
 		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
@@ -86,7 +86,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
-			.should('have.attr', 'data-gu-hydrated', 'true');
+			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
 		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
@@ -126,7 +126,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
-			.should('have.attr', 'data-gu-hydrated', 'true');
+			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
 		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
@@ -165,7 +165,7 @@ describe('YouTube Atom', function () {
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
 			.parent()
-			.should('have.attr', 'data-gu-hydrated', 'true');
+			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent(

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -14,6 +14,11 @@ import { initPerf } from '../initPerf';
  * @param element The location on the DOM where the component to hydrate exists
  */
 export const doHydration = (name: string, data: any, element: HTMLElement) => {
+	// If this function has already been run for an element then don't try to
+	// run it a second time
+	const alreadyHydrated = element.dataset.guReady;
+	if (alreadyHydrated) return;
+
 	const { start, end } = initPerf(`hydrate-${name}`);
 	start();
 	import(

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -22,7 +22,7 @@ export const doHydration = (name: string, data: any, element: HTMLElement) => {
 	)
 		.then((module) => {
 			hydrate(h(module[name], data), element);
-			element.setAttribute('data-gu-hydrated', 'true');
+			element.setAttribute('data-gu-ready', 'true');
 			end();
 		})
 		.catch((error) => {

--- a/dotcom-rendering/src/web/components/HydrateOnce.tsx
+++ b/dotcom-rendering/src/web/components/HydrateOnce.tsx
@@ -51,7 +51,7 @@ export const HydrateOnce = ({ rootId, children, waitFor = [] }: Props) => {
 	if (!element) return null;
 	start();
 	ReactDOM.hydrate(children, element, () => {
-		element.setAttribute('data-gu-hydrated', 'true');
+		element.setAttribute('data-gu-ready', 'true');
 		end();
 	});
 	setAlreadyHydrated(true);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds a check to `doHydration` to exit early if the element being passed in has already been hydrated

## Why?
We have some use cases coming up that will need this:

1) Discussion permalinks. We want to be able to force hydrate components early (not when they are deferred to) but if we do this we want to make sure the deferred call will be blocked

2) Liveblogs. When inserting new blocks we want to run a manual hydration command. This command _could_ be us simply repeating the page wide hydration step but this only works if we have this guard in place.

