### PR TITLE
Make map embed element an island

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -856,11 +856,6 @@ interface DocumentBlockLoadable extends ComponentNameChunkMap {
 	addWhen: DocumentBlockElement['_type'];
 }
 
-interface MapBlockLoadable extends ComponentNameChunkMap {
-	chunkName: 'MapEmbedBlockComponent';
-	addWhen: MapBlockElement['_type'];
-}
-
 interface FacebookVideoBlockLoadable extends ComponentNameChunkMap {
 	chunkName: 'VideoFacebookBlockComponent';
 	addWhen: VideoFacebookBlockElement['_type'];
@@ -877,7 +872,6 @@ type LoadableComponents = [
 	InteractiveContentsBlockLoadable,
 	CalloutBlockLoadable,
 	DocumentBlockLoadable,
-	MapBlockLoadable,
 	FacebookVideoBlockLoadable,
 	VineBlockLoadable,
 ];

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -325,26 +325,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		},
 	);
 
-	const MapEmbedBlockComponent = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.MapBlockElement',
-				).length > 0
-			) {
-				return import(
-					'@frontend/web/components/MapEmbedBlockComponent'
-				);
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) => module.MapEmbedBlockComponent,
-		},
-	);
-
 	const VideoFacebookBlockComponent = loadable(
 		() => {
 			if (
@@ -435,10 +415,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 	const embeds = elementsByType<EmbedBlockElement>(
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.EmbedBlockElement',
-	);
-	const maps = elementsByType<MapBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.MapBlockElement',
 	);
 	const facebookVideos = elementsByType<VideoFacebookBlockElement>(
 		CAPI.elementsToHydrate,
@@ -782,26 +758,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 							/>
 						</ClickToView>
 					)}
-				</HydrateOnce>
-			))}
-			{maps.map((map) => (
-				<HydrateOnce rootId={map.elementId}>
-					<ClickToView
-						role={map.role}
-						isTracking={map.isThirdPartyTracking}
-						source={map.source}
-						sourceDomain={map.sourceDomain}
-					>
-						<MapEmbedBlockComponent
-							format={format}
-							embedUrl={map.embedUrl}
-							height={map.height}
-							width={map.width}
-							caption={map.caption}
-							credit={map.source}
-							title={map.title}
-						/>
-					</ClickToView>
 				</HydrateOnce>
 			))}
 			{facebookVideos.map((facebookVideo) => (

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -17,6 +17,7 @@ import { DocumentBlockComponent } from './DocumentBlockComponent';
 import { SoundcloudBlockComponent } from './SoundcloudBlockComponent';
 import { TweetBlockComponent } from './TweetBlockComponent';
 import { InstagramBlockComponent } from './InstagramBlockComponent.importable';
+import { MapEmbedBlockComponent } from './MapEmbedBlockComponent.importable';
 
 import { ClickToView } from './ClickToView';
 
@@ -429,6 +430,22 @@ const bbcEmbedEmbed: EmbedBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
 	html: '<iframe width="fullwidth" height="500" frameborder="0" src="https://www.bbc.co.uk/programmes/p08tfnfb/player"></iframe>',
 	isMandatory: false,
+};
+
+const mapEmbedEmbed: MapBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.MapBlockElement',
+	elementId: 'mockId',
+	embedUrl:
+		'https://www.google.com/maps/d/embed?mid=1e_aGDEcGY9Lu3UMKQKhR-itRBDg&hl=en_US',
+	originalUrl:
+		'https://www.google.com/maps/d/embed?mid=1e_aGDEcGY9Lu3UMKQKhR-itRBDg&hl=en_US',
+	title: "Women's March on London",
+	height: 345,
+	width: 460,
+	caption: 'Google Maps',
+	source: 'Google',
+	sourceDomain: 'google.com',
+	isThirdPartyTracking: false,
 };
 
 export const EmbedBlockComponentStory = () => {
@@ -1056,4 +1073,59 @@ export const InstagramBlockComponentStory = () => {
 };
 InstagramBlockComponentStory.story = {
 	name: 'Click to view wrapping InstagramBlockComponent',
+};
+export const MapBlockComponentStory = () => {
+	return (
+		<ContainerLayout
+			sideBorders={true}
+			title="Embedded Content"
+			centralBorder="full"
+		>
+			<div
+				css={css`
+					max-width: 620px;
+					clear: left;
+					strong {
+						font-weight: bold;
+					}
+				`}
+			>
+				<p css={paragraphStyle}>
+					Example of a map embed, the embed source article is{' '}
+					<a href="https://www.theguardian.com/world/2017/jan/19/womens-marches-across-the-uk-what-you-need-to-know">
+						here
+					</a>
+				</p>
+				<Figure isMainMedia={false} role="inline">
+					<ClickToView
+						isTracking={true}
+						source={mapEmbedEmbed.source}
+						sourceDomain={mapEmbedEmbed.sourceDomain}
+						role="inline"
+					>
+						<MapEmbedBlockComponent
+							embedUrl={mapEmbedEmbed.embedUrl}
+							height={mapEmbedEmbed.height}
+							width={mapEmbedEmbed.width}
+							title={mapEmbedEmbed.title}
+							caption={mapEmbedEmbed.caption}
+							format={{
+								theme: ArticlePillar.News,
+								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+							}}
+							credit="Google Maps"
+							role="inline"
+							isTracking={false}
+							isMainMedia={false}
+						/>
+					</ClickToView>
+				</Figure>
+				<p css={paragraphStyle}>The end.</p>
+			</div>
+		</ContainerLayout>
+	);
+};
+MapBlockComponentStory.story = {
+	name: 'Click to view wrapping MapEmbedBlockComponent',
 };

--- a/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
@@ -3,8 +3,9 @@ import { css } from '@emotion/react';
 import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
 import { Caption } from '@root/src/web/components/Caption';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
+import { ClickToView } from './ClickToView';
 
-export const MapEmbedBlockComponent: React.FC<{
+type Props = {
 	embedUrl?: string;
 	height: number;
 	width: number;
@@ -12,7 +13,27 @@ export const MapEmbedBlockComponent: React.FC<{
 	caption?: string;
 	format: ArticleFormat;
 	credit?: string;
-}> = ({ embedUrl, title, width, height, caption, format, credit }) => {
+	role?: RoleType;
+	isTracking: boolean;
+	isMainMedia: boolean;
+	source?: string;
+	sourceDomain?: string;
+};
+
+export const MapEmbedBlockComponent = ({
+	embedUrl,
+	title,
+	width,
+	height,
+	caption,
+	format,
+	credit,
+	role,
+	isTracking,
+	isMainMedia,
+	source,
+	sourceDomain,
+}: Props) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -33,24 +54,32 @@ export const MapEmbedBlockComponent: React.FC<{
 	const palette = decidePalette(format);
 
 	return (
-		<div css={embedContainer}>
-			<MaintainAspectRatio height={height} width={width}>
-				<iframe
-					src={embedUrl}
-					title={title}
-					height={height}
-					width={width}
-					allowFullScreen={true}
-				/>
-			</MaintainAspectRatio>
-			{hasCaption && (
-				<Caption
-					captionText={caption}
-					format={format}
-					palette={palette}
-					credit={credit}
-				/>
-			)}
-		</div>
+		<ClickToView
+			role={role}
+			isTracking={isTracking}
+			isMainMedia={isMainMedia}
+			source={source}
+			sourceDomain={sourceDomain}
+		>
+			<div css={embedContainer}>
+				<MaintainAspectRatio height={height} width={width}>
+					<iframe
+						src={embedUrl}
+						title={title}
+						height={height}
+						width={width}
+						allowFullScreen={true}
+					/>
+				</MaintainAspectRatio>
+				{hasCaption && (
+					<Caption
+						captionText={caption}
+						format={format}
+						palette={palette}
+						credit={credit}
+					/>
+				)}
+			</div>
+		</ClickToView>
 	);
 };

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -18,7 +18,7 @@ import { ItemLinkBlockElement } from '@root/src/web/components/ItemLinkBlockElem
 import { InteractiveContentsBlockComponent } from '@root/src/web/components/InteractiveContentsBlockComponent';
 import { MainMediaEmbedBlockComponent } from '@root/src/web/components/MainMediaEmbedBlockComponent';
 import { NumberedTitleBlockComponent } from '@root/src/web/components/NumberedTitleBlockComponent';
-import { MapEmbedBlockComponent } from '@root/src/web/components/MapEmbedBlockComponent';
+import { MapEmbedBlockComponent } from '@root/src/web/components/MapEmbedBlockComponent.importable';
 import { MultiImageBlockComponent } from '@root/src/web/components/MultiImageBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/SoundcloudBlockComponent';
@@ -386,13 +386,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.MapBlockElement':
 			return [
 				true,
-				<ClickToView
-					role={element.role}
-					isTracking={element.isThirdPartyTracking}
-					isMainMedia={isMainMedia}
-					source={element.source}
-					sourceDomain={element.sourceDomain}
-				>
+				<Island deferUntil="visible">
 					<MapEmbedBlockComponent
 						format={format}
 						embedUrl={element.embedUrl}
@@ -401,8 +395,13 @@ export const renderElement = ({
 						caption={element.caption}
 						credit={element.source}
 						title={element.title}
+						role={element.role}
+						isTracking={element.isThirdPartyTracking}
+						isMainMedia={isMainMedia}
+						source={element.source}
+						sourceDomain={element.sourceDomain}
 					/>
-				</ClickToView>,
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
 			return [

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -115,10 +115,6 @@ export const document = ({ data }: Props): string => {
 			addWhen: 'model.dotcomrendering.pageElements.DocumentBlockElement',
 		},
 		{
-			chunkName: 'MapEmbedBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.MapBlockElement',
-		},
-		{
 			chunkName: 'VideoFacebookBlockComponent',
 			addWhen:
 				'model.dotcomrendering.pageElements.VideoFacebookBlockElement',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This change makes the map embed element an island. In this PR we:
- remove the loadable component definition from App.tsx
- include the click to view wrapper in the map embed element component
- include the importable component in renderElement.tsx (taking account of updated props)

There weren't any stories for the map embed so I added an extra one to ClickToView - I think that makes sense given all map embeds are wrapped by the click to view.

## Why?

Moves us closer to being able to delete App.tsx.
