### PR TITLE
Fix Follow Status

### DIFF
--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -73,14 +73,20 @@ function followToggle(topic: Topic): void {
 		if (following) {
 			void notificationsClient.unfollow(topic).then((_) => {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: false, contributorName: topic.displayName }),
+					h(FollowStatus, {
+						isFollowing: false,
+						contributorName: topic.displayName,
+					}),
 					followStatus,
 				);
 			});
 		} else {
 			void notificationsClient.follow(topic).then((_) => {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: true, contributorName: topic.displayName }),
+					h(FollowStatus, {
+						isFollowing: true,
+						contributorName: topic.displayName,
+					}),
 					followStatus,
 				);
 			});
@@ -108,7 +114,10 @@ function topics(): void {
 		void notificationsClient.isFollowing(topic).then((following) => {
 			if (following && followStatus) {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: true, contributorName: topic.displayName }),
+					h(FollowStatus, {
+						isFollowing: true,
+						contributorName: topic.displayName,
+					}),
 					followStatus,
 				);
 			}

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -73,14 +73,14 @@ function followToggle(topic: Topic): void {
 		if (following) {
 			void notificationsClient.unfollow(topic).then((_) => {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: false }),
+					h(FollowStatus, { isFollowing: false, contributorName: topic.displayName }),
 					followStatus,
 				);
 			});
 		} else {
 			void notificationsClient.follow(topic).then((_) => {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: true }),
+					h(FollowStatus, { isFollowing: true, contributorName: topic.displayName }),
 					followStatus,
 				);
 			});
@@ -108,7 +108,7 @@ function topics(): void {
 		void notificationsClient.isFollowing(topic).then((following) => {
 			if (following && followStatus) {
 				ReactDOM.render(
-					h(FollowStatus, { isFollowing: true }),
+					h(FollowStatus, { isFollowing: true, contributorName: topic.displayName }),
 					followStatus,
 				);
 			}

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -67,7 +67,10 @@ const Follow: FC<Props> = ({ contributors, ...format }) => {
 				data-display-name={contributor.name}
 			>
 				<span className="js-follow-status" css={followStatusStyles}>
-					<FollowStatus isFollowing={false} contributorName={contributor.name} />
+					<FollowStatus
+						isFollowing={false}
+						contributorName={contributor.name}
+					/>
 				</span>
 			</button>
 		);

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -25,9 +25,7 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 	return css`
 		${textSans.small()}
 		color: ${follow};
-		display: flex;
-		align-items: center;
-		column-gap: 0.2em;
+		display: block;
 		padding: 0;
 		border: none;
 		background: none;
@@ -47,6 +45,12 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 	`;
 };
 
+const followStatusStyles = css`
+	display: flex;
+	align-items: center;
+	column-gap: 0.2em;
+`;
+
 const Follow: FC<Props> = ({ contributors, ...format }) => {
 	const [contributor] = contributors;
 
@@ -62,8 +66,8 @@ const Follow: FC<Props> = ({ contributors, ...format }) => {
 				data-id={contributor.id}
 				data-display-name={contributor.name}
 			>
-				<span className="js-follow-status">
-					<FollowStatus isFollowing={false} /> {contributor.name}
+				<span className="js-follow-status" css={followStatusStyles}>
+					<FollowStatus isFollowing={false} contributorName={contributor.name} />
 				</span>
 			</button>
 		);

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -62,7 +62,9 @@ const Follow: FC<Props> = ({ contributors, ...format }) => {
 				data-id={contributor.id}
 				data-display-name={contributor.name}
 			>
-				<FollowStatus isFollowing={false} /> {contributor.name}
+				<span className="js-follow-status">
+					<FollowStatus isFollowing={false} /> {contributor.name}
+				</span>
 			</button>
 		);
 	}

--- a/apps-rendering/src/components/followStatus.tsx
+++ b/apps-rendering/src/components/followStatus.tsx
@@ -40,7 +40,9 @@ const FollowIcon: FC<IconProps> = ({ isFollowing }) => {
 const FollowStatus: FC<Props> = ({ isFollowing, contributorName }) => (
 	<>
 		<FollowIcon isFollowing={isFollowing} />
-		<span>{isFollowing ? 'Following' : 'Follow'} {contributorName}</span>
+		<span>
+			{isFollowing ? 'Following' : 'Follow'} {contributorName}
+		</span>
 	</>
 );
 

--- a/apps-rendering/src/components/followStatus.tsx
+++ b/apps-rendering/src/components/followStatus.tsx
@@ -6,9 +6,12 @@ import type { FC } from 'react';
 
 interface Props {
 	isFollowing: boolean;
+	contributorName: string;
 }
 
-type IconProps = Props;
+type IconProps = {
+	isFollowing: boolean;
+};
 
 const FollowIcon: FC<IconProps> = ({ isFollowing }) => {
 	const check =
@@ -34,10 +37,10 @@ const FollowIcon: FC<IconProps> = ({ isFollowing }) => {
 	);
 };
 
-const FollowStatus: FC<Props> = ({ isFollowing }) => (
+const FollowStatus: FC<Props> = ({ isFollowing, contributorName }) => (
 	<>
 		<FollowIcon isFollowing={isFollowing} />
-		<span>{isFollowing ? 'Following' : 'Follow'}</span>
+		<span>{isFollowing ? 'Following' : 'Follow'} {contributorName}</span>
 	</>
 );
 


### PR DESCRIPTION
## Why?

**TL;DR** Following journalists isn't currently working in AR; this fixes it.

Unfortunately the changes in #3794 inadvertently removed the `js-follow-status` class from the HTML. This is relied upon by the client-side code to look up the follow status component and apply event listeners/hydrate. This PR reinstates that class. 

**Note:** This is currently live on CODE if anyone would like to test it.

## Changes

- Reinstated the `js-follow-status` class, so the client-side code can look up the follow status component
- Moved the rendering of the contributor name into the `FollowStatus` component, so that it lines up with the "Follow"/"Following" text
