### PR TITLE
fix: Disables warnings on previously disabled errors

### DIFF
--- a/apps-rendering/src/components/embedWrapper.stories.tsx
+++ b/apps-rendering/src/components/embedWrapper.stories.tsx
@@ -11,7 +11,7 @@ import { EmbedComponentWrapper } from './embedWrapper';
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
 // on an individual story. Ideally, we'd use the type from Storybook directly
 // but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
+// eslint-disable-next-line -- because 👆
 const Generic = () => (
 	<div>
 		<p>
@@ -60,7 +60,7 @@ Generic.story = {
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
 // on an individual story. Ideally, we'd use the type from Storybook directly
 // but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
+// eslint-disable-next-line -- because 👆
 const Youtube = () => (
 	<div>
 		<p>
@@ -103,7 +103,7 @@ Youtube.story = {
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
 // on an individual story. Ideally, we'd use the type from Storybook directly
 // but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
+// eslint-disable-next-line -- because 👆
 const Spotify = () => (
 	<div>
 		<p>
@@ -146,7 +146,7 @@ Spotify.story = {
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
 // on an individual story. Ideally, we'd use the type from Storybook directly
 // but https://github.com/storybookjs/storybook/issues/13486
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- because 👆
+// eslint-disable-next-line -- because 👆
 const Instagram = () => (
 	<div>
 		<p>


### PR DESCRIPTION
## What does this change?

Github released a new feature in its "Files Changed" preview which shows check annotations on all files (not just edited files)

![image](https://user-images.githubusercontent.com/21217225/151014454-f75d059f-9212-4f3a-b7f7-fadb2b8ed940.png)

These 4 warnings are showing up in almost every single PR.

Hopefully this PR should stop those warnings showing in Github until the underlying issue can be resolved. (Mostly for our sanity)