### PR TITLE
run snyk on github action pull_request

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,4 @@
-# This action runs every day at 6 AM and on every push
+# This action runs every day at 6 AM, on every push not from dependabot, and every pull_request from dependabot
 # If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
 # Otherwise it will run snyk test
 name: DCR Snyk
@@ -6,9 +6,17 @@ name: DCR Snyk
 on:
     schedule:
         - cron: '0 6 * * *'
-    push:
+    push: 
         paths-ignore:
             - "apps-rendering/**"
+        # @dependabot push events have readon-only access and CodeQL needs write access
+        # see: https://github.com/guardian/dotcom-rendering/pull/3883
+        branches-ignore:
+            - "dependabot/**"
+    pull_request:
+        # @dependabot pull_request actions have write access for CodeQL to run
+        branches:
+            - "dependabot/**"
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ name: DCR Snyk
 on:
     schedule:
         - cron: '0 6 * * *'
-    push: 
+    push:
         paths-ignore:
             - "apps-rendering/**"
         # @dependabot push events have readon-only access and CodeQL needs write access


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

part of #3882

## What does this change?
This runs our snyk github workflow on `pull_request` rather than on `push`.

## Why?
We would like to have the @dependabot chore PRs have all green checks. This runs @dependabot on `pull_request` instead of `push` as it then runs in `write` mode instead of `read-only` mode.

It seems a little convoluted, but I didn't want to lose running CodeQL on each push, so have opted to keep that and ignore dependabot PRs.

[The error](https://github.com/guardian/dotcom-rendering/runs/4950955741?check_suite_focus=true#step:6:52) we are getting from the task.

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

[Others also seem](https://github.com/cisagov/con-pca-api/commit/0d726beaa314e0229af0104fb082232eed1ef54f) to [be doing something similar](https://github.com/Skyscanner/applicationset-progressive-sync/issues/80).



