### PR TITLE
Track errors in the Supporter Revenue header links

### DIFF
--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
@@ -221,6 +221,15 @@ const ReaderRevenueLinksRemote: React.FC<{
 					new Error(msg),
 					'rr-header-links',
 				);
+				submitComponentEvent({
+					component: {
+						// Do not record this as ACQUISITIONS_HEADER to avoid confusing with successful INSERT events
+						componentType: 'ACQUISITIONS_OTHER',
+					},
+					action: 'INSERT',
+					id: 'header-error',
+					value: msg,
+				});
 			});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [countryCode]);


### PR DESCRIPTION
We can see various errors in sentry relating to the fetching/rendering of this component. It's hard to get a sense of the scale of the problem in sentry, or to see patterns in user agents/devices.
With this PR we send a componentEvent to ophan if the header links component fails to load for any reason. We can then use BigQuery to explore this data.

### Current behaviour if header links component is successfully inserted:
![Screen Shot 2022-01-28 at 14 26 41](https://user-images.githubusercontent.com/1513454/151563976-7deaac57-3d4f-4087-81e7-e192263ee777.png)

### New behaviour if header links component insertion fails:
![Screen Shot 2022-01-28 at 14 19 19](https://user-images.githubusercontent.com/1513454/151563947-f806fef6-7feb-4f95-a9b8-65f75b1c968c.png)

