### PR TITLE
Fix deadblog colours for DCR

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -831,7 +831,7 @@ const textRichLink: (format: ArticleFormat) => string = (format) => {
 			case ArticleSpecial.Labs:
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
+				return specialReport[400];
 		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
@@ -864,7 +864,7 @@ const borderRichLink: (format: ArticleFormat) => string = (format) => {
 			case ArticleSpecial.Labs:
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
+				return specialReport[400];
 		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
@@ -909,9 +909,9 @@ const fillRichLink: (format: ArticleFormat) => string = (format) => {
 			case ArticlePillar.Opinion:
 				return opinion[300];
 			case ArticleSpecial.Labs:
-				return BLACK;
+				return labs[400];
 			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
+				return specialReport[400];
 		}
 	}
 	return pillarPalette[ArticlePillar.News][400];

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -862,7 +862,7 @@ const borderRichLink: (format: ArticleFormat) => string = (format) => {
 			case ArticlePillar.Opinion:
 				return opinion[300];
 			case ArticleSpecial.Labs:
-				return BLACK;
+				return labs[400];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[400];
 		}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -30,8 +30,6 @@ const BLACK = neutral[7];
 const blogsGrayBackgroundPalette = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.News:
-		case ArticlePillar.Lifestyle:
-		case ArticlePillar.Sport:
 			return pillarPalette[format.theme].main;
 		default:
 			return pillarPalette[format.theme].dark;
@@ -204,6 +202,25 @@ const textSyndicationButton = (format: ArticleFormat): string => {
 };
 
 const textArticleLink = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.DeadBlog) {
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[400];
+		}
+	}
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
@@ -234,6 +251,17 @@ const textPullQuote = (format: ArticleFormat): string => {
 
 const textStandfirstLink = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+	if (format.design === ArticleDesign.DeadBlog) {
+		switch (format.theme) {
+			case ArticlePillar.Opinion:
+				return opinion[200];
+			case ArticlePillar.News:
+				return news[400];
+			default:
+				return pillarPalette[format.theme].dark;
+		}
+	}
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
 	switch (format.theme) {
@@ -251,6 +279,25 @@ const textBranding = (format: ArticleFormat): string => {
 };
 
 const textArticleLinkHover = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.DeadBlog) {
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[100];
+		}
+	}
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
@@ -569,9 +616,29 @@ const fillCommentCountUntilDesktop = (format: ArticleFormat): string => {
 };
 
 const fillShareIcon = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.DeadBlog) {
+		switch (format.theme) {
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
+	}
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
 	return pillarPalette[format.theme].main;
 };
 
@@ -670,6 +737,25 @@ const borderSubNav = (format: ArticleFormat): string => {
 };
 
 const borderLiveBlock = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.DeadBlog) {
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return labs[400];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[400];
+		}
+	}
+
 	return pillarPalette[format.theme].main;
 };
 
@@ -731,7 +817,22 @@ const hoverHeadlineByline = (format: ArticleFormat): string => {
 
 const textRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -749,7 +850,22 @@ const hoverStandfirstLink = (format: ArticleFormat): string => {
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -781,7 +897,22 @@ const backgroundRichLink: (format: ArticleFormat) => string = (format) => {
 
 const fillRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -817,22 +817,7 @@ const hoverHeadlineByline = (format: ArticleFormat): string => {
 
 const textRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[400];
-			case ArticlePillar.Culture:
-				return culture[350];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-		}
+		return pillarPalette[format.theme].main;
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -850,22 +835,7 @@ const hoverStandfirstLink = (format: ArticleFormat): string => {
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[400];
-			case ArticlePillar.Culture:
-				return culture[350];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-		}
+		return pillarPalette[format.theme].main;
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -897,22 +867,7 @@ const backgroundRichLink: (format: ArticleFormat) => string = (format) => {
 
 const fillRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[400];
-			case ArticlePillar.Culture:
-				return culture[350];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-		}
+		return pillarPalette[format.theme].main;
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -817,7 +817,22 @@ const hoverHeadlineByline = (format: ArticleFormat): string => {
 
 const textRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -835,7 +850,22 @@ const hoverStandfirstLink = (format: ArticleFormat): string => {
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };
@@ -867,7 +897,22 @@ const backgroundRichLink: (format: ArticleFormat) => string = (format) => {
 
 const fillRichLink: (format: ArticleFormat) => string = (format) => {
 	if (format) {
-		return pillarPalette[format.theme].main;
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Culture:
+				return culture[350];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[300];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[300];
+			case ArticleSpecial.Labs:
+				return BLACK;
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+		}
 	}
 	return pillarPalette[ArticlePillar.News][400];
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes DCR deadblog colours the same as AR as per this PR: https://github.com/guardian/dotcom-rendering/pull/3823

## Why?
To match the designs and follow accessibility standards.


Background | White | Gray
-- | -- | --
News | 400 | 400
Sport | 400 | 300
Lifestyle | 400 | 300
Culture | 350 | 300
Opinion | 300 | 200 for dark gray and 300 for light gray


| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/19683595/151763052-4080a809-1453-46c6-9f9b-c6f16b14bf1b.png)      | ![image](https://user-images.githubusercontent.com/19683595/151763154-d710572e-1a15-4511-b7c9-89fec929b635.png)       |
| ![image](https://user-images.githubusercontent.com/19683595/151763231-c17cb160-ee71-4606-b5d2-4cc62294a46e.png)   | ![image](https://user-images.githubusercontent.com/19683595/151763264-3631db6a-542f-4824-994a-1f54683db559.png)  |
| ![image](https://user-images.githubusercontent.com/19683595/151763453-921d1c58-af7d-4854-9db8-739860b7c2dd.png) | ![image](https://user-images.githubusercontent.com/19683595/151763495-6b503c85-39c4-4894-ad41-dd6be844a4bc.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151763657-d13525dd-dd92-486f-abfc-564ecfdc4053.png) | ![image](https://user-images.githubusercontent.com/19683595/151763713-80c0f6d2-db96-42fc-a2da-1ecac40449a9.png)  |
| ![image](https://user-images.githubusercontent.com/19683595/151763937-9d5fe042-e430-491a-8863-37bc1361e1fe.png) | ![image](https://user-images.githubusercontent.com/19683595/151763822-7c220531-aee3-4ccf-82c7-b53462d3d837.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151764068-d22a4480-aa83-42ec-8139-4af49def8226.png) | ![image](https://user-images.githubusercontent.com/19683595/151764110-424dc721-1cfb-49f4-919e-c0f97ef56f9d.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151764543-c6d4f057-9d31-4d04-a29c-a51403c7c006.png) | ![image](https://user-images.githubusercontent.com/19683595/151764503-0fc5655b-ff41-424c-a105-3e1ae2a2c4ed.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151764779-4f60edc2-e869-4060-ac8d-b4ec22049ad5.png) | ![image](https://user-images.githubusercontent.com/19683595/151764828-0ede0588-a8ed-4cf2-99d3-899abc731fba.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151764917-4c460f77-c9e5-4503-82e3-761ee24f8a8b.png) | ![image](https://user-images.githubusercontent.com/19683595/151764958-dc2f7868-aad1-438e-9feb-b281798427fd.png) |
| ![image](https://user-images.githubusercontent.com/19683595/151765246-8aace4e1-0683-46d1-af8e-a68208412a3a.png) | ![image](https://user-images.githubusercontent.com/19683595/151765131-7098b8bd-37bf-45fc-bcfd-89764bc0a990.png) |

