### PR TITLE
Collapse spacing between article and related content

### DIFF
--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -90,7 +90,6 @@ const styles = css`
 	padding-top: ${remSpace[3]};
 	padding-left: ${remSpace[4]};
 	padding-right: ${remSpace[4]};
-	margin-top: -0.125rem;
 
 	${until.wide} {
 		margin-left: -${remSpace[4]};

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -90,6 +90,7 @@ const styles = css`
 	padding-top: ${remSpace[3]};
 	padding-left: ${remSpace[4]};
 	padding-right: ${remSpace[4]};
+	margin-top: -0.125rem;
 
 	${until.wide} {
 		margin-left: -${remSpace[4]};

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -112,7 +112,6 @@ export const onwardStyles: SerializedStyles = css`
         background: ${background.inverse};
     `};
 
-	padding: 0.125rem 0 0;
 	${from.wide} {
 		width: 1300px;
 		margin-left: auto;


### PR DESCRIPTION
## Why?
#3866 introduced new styling for the Related Content section in Apps Rendering, including a top border for the section.
Adding a visibile border revealed a (barely perceptible) gap between the article and the related content section.
This PR removes addresses the issue.

### Before
![image](https://user-images.githubusercontent.com/57295823/151599996-972142ab-8348-4fe8-90f7-3830a7d1859c.png)

### After
![image](https://user-images.githubusercontent.com/57295823/151599963-ad540114-11a6-451d-a9f2-2133d369758c.png)
