### PR TITLE
add dotcom-platform and apps devs to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-dotcom-rendering/       @jlieb10 @nitro-marky @OllysCoding @lucymonie @DavidLawes
+*	@guardian/dotcom-platform @JamieB-gu @MarSavar


### PR DESCRIPTION
This will ping everyone on @guardian/dotcom-platform and our friends from MSS on all PRs. 

A thing to keep an eye on is whether people feel this creates too much noise with their already setup workflows.