### PR TITLE
fix: Changes cypress test for soundcloud to not look for specific content in the Soundcloud widget

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-1/article.elements.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-1/article.elements.spec.js
@@ -168,7 +168,7 @@ describe('Elements', function () {
 				'Article?url=https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
 			);
 
-			getIframeBody().contains('Cookie policy');
+			getIframeBody();
 		});
 
 		it('should render the football embed', function () {


### PR DESCRIPTION
## What does this change?

Changes the Cypress test that checks if the soundcloud embed is working to not look for `Cookie policy`

## Why?

- A recent change in soundcloud seems to have removed `Cookie policy` which we were previously scanning for. I've removed the check to look for specific content as we don't really have any control over how and when Soundcloud make changes to their widget so its not really practical for us to be checking their content.

