### PR TITLE
Fix related content margins

### DIFF
--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import {
-    from,
-    headline,
-    neutral,
-    remSpace,
-    until,
+	from,
+	headline,
+	neutral,
+	remSpace,
+	until,
 } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
@@ -17,84 +17,84 @@ import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
 interface Props {
-    content: Option<ResizedRelatedContent>;
+	content: Option<ResizedRelatedContent>;
 }
 
 const headingStyles = css`
-    ${headline.xsmall({ fontWeight: 'bold' })}
-    margin: 0 0 ${remSpace[4]} 0;
+	${headline.xsmall({ fontWeight: 'bold' })}
+	margin: 0 0 ${remSpace[4]} 0;
 
-    ${darkModeCss`
+	${darkModeCss`
         color: ${neutral[86]};
     `}
 `;
 
 const listStyles = css`
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    margin: 0;
-    padding: 0;
-    overflow-x: scroll;
+	list-style: none;
+	display: flex;
+	flex-direction: row;
+	margin: 0;
+	padding: 0;
+	overflow-x: scroll;
 
-    &::-webkit-scrollbar {
-        display: none;
-    }
+	&::-webkit-scrollbar {
+		display: none;
+	}
 
-    .js-android & {
-        li {
-            flex: 1 1 50%;
-            max-width: initial;
-        }
-        li:nth-child(n + 3) {
-            display: none;
-        }
-        li {
-            margin-right: 0;
-            margin-left: ${remSpace[2]};
-        }
+	.js-android & {
+		li {
+			flex: 1 1 50%;
+			max-width: initial;
+		}
+		li:nth-child(n + 3) {
+			display: none;
+		}
+		li {
+			margin-right: 0;
+			margin-left: ${remSpace[2]};
+		}
 
-        li:first-of-type {
-            margin-left: 0;
-        }
+		li:first-of-type {
+			margin-left: 0;
+		}
 
-        ${from.mobileLandscape} {
-            li {
-                flex: 1 1 33.33%;
-            }
-            li:nth-child(3) {
-                display: flex;
-            }
-        }
-        ${from.tablet} {
-            li {
-                flex: 0 0 10rem;
-            }
-            li:nth-child(n + 3) {
-                display: flex;
-            }
-            li:nth-child(n + 2) {
-                margin-left: ${remSpace[5]};
-            }
-        }
-        ${from.desktop} {
-            li {
-                flex: 0 0 13.75rem;
-            }
-        }
-    }
+		${from.mobileLandscape} {
+			li {
+				flex: 1 1 33.33%;
+			}
+			li:nth-child(3) {
+				display: flex;
+			}
+		}
+		${from.tablet} {
+			li {
+				flex: 0 0 10rem;
+			}
+			li:nth-child(n + 3) {
+				display: flex;
+			}
+			li:nth-child(n + 2) {
+				margin-left: ${remSpace[5]};
+			}
+		}
+		${from.desktop} {
+			li {
+				flex: 0 0 13.75rem;
+			}
+		}
+	}
 `;
 
 const styles = css`
-    border-top: 1px solid ${neutral[46]};
-    padding-top: ${remSpace[3]};
+	border-top: 1px solid ${neutral[46]};
+	padding-top: ${remSpace[3]};
 
-    ${until.wide} {
-        padding-left: ${remSpace[4]};
-        padding-right: ${remSpace[4]};
-    }
+	${until.wide} {
+		padding-left: ${remSpace[4]};
+		padding-right: ${remSpace[4]};
+	}
 
-    ${darkModeCss`
+	${darkModeCss`
         background: ${neutral[0]};
     `}
 `;
@@ -102,38 +102,38 @@ const styles = css`
 const COMMENT = RelatedItemType.COMMENT;
 
 const RelatedContent: FC<Props> = ({ content }) => {
-    return pipe(
-        content,
-        map(({ title, relatedItems, resizedImages }) => {
-            if (relatedItems.length === 0) {
-                return null;
-            }
+	return pipe(
+		content,
+		map(({ title, relatedItems, resizedImages }) => {
+			if (relatedItems.length === 0) {
+				return null;
+			}
 
-            return (
-                <section css={styles}>
-                    <h2 css={headingStyles}>{title}</h2>
-                    <ul css={listStyles}>
-                        {relatedItems.map((relatedItem, key) => {
-                            return relatedItem.type === COMMENT &&
-                                relatedItem.bylineImage ? (
-                                <BylineCard
-                                    key={key}
-                                    relatedItem={relatedItem}
-                                />
-                            ) : (
-                                <Card
-                                    key={key}
-                                    relatedItem={relatedItem}
-                                    image={resizedImages[key]}
-                                />
-                            );
-                        })}
-                    </ul>
-                </section>
-            );
-        }),
-        withDefault<JSX.Element | null>(null),
-    );
+			return (
+				<section css={styles}>
+					<h2 css={headingStyles}>{title}</h2>
+					<ul css={listStyles}>
+						{relatedItems.map((relatedItem, key) => {
+							return relatedItem.type === COMMENT &&
+								relatedItem.bylineImage ? (
+								<BylineCard
+									key={key}
+									relatedItem={relatedItem}
+								/>
+							) : (
+								<Card
+									key={key}
+									relatedItem={relatedItem}
+									image={resizedImages[key]}
+								/>
+							);
+						})}
+					</ul>
+				</section>
+			);
+		}),
+		withDefault<JSX.Element | null>(null),
+	);
 };
 
 export default RelatedContent;

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import {
-	from,
-	headline,
-	neutral,
-	remSpace,
-	until,
+    from,
+    headline,
+    neutral,
+    remSpace,
+    until,
 } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
@@ -17,125 +17,123 @@ import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
 interface Props {
-	content: Option<ResizedRelatedContent>;
+    content: Option<ResizedRelatedContent>;
 }
 
 const headingStyles = css`
-	${headline.xsmall({ fontWeight: 'bold' })}
-	margin: 0 0 ${remSpace[4]} 0;
+    ${headline.xsmall({ fontWeight: 'bold' })}
+    margin: 0 0 ${remSpace[4]} 0;
 
-	${darkModeCss`
+    ${darkModeCss`
         color: ${neutral[86]};
     `}
 `;
 
 const listStyles = css`
-	list-style: none;
-	display: flex;
-	flex-direction: row;
-	margin: 0;
-	padding: 0;
-	overflow-x: scroll;
+    list-style: none;
+    display: flex;
+    flex-direction: row;
+    margin: 0;
+    padding: 0;
+    overflow-x: scroll;
 
-	&::-webkit-scrollbar {
-		display: none;
-	}
+    &::-webkit-scrollbar {
+        display: none;
+    }
 
-	.js-android & {
-		li {
-			flex: 1 1 50%;
-			max-width: initial;
-		}
-		li:nth-child(n + 3) {
-			display: none;
-		}
-		li {
-			margin-right: 0;
-			margin-left: ${remSpace[2]};
-		}
+    .js-android & {
+        li {
+            flex: 1 1 50%;
+            max-width: initial;
+        }
+        li:nth-child(n + 3) {
+            display: none;
+        }
+        li {
+            margin-right: 0;
+            margin-left: ${remSpace[2]};
+        }
 
-		li:first-of-type {
-			margin-left: 0;
-		}
+        li:first-of-type {
+            margin-left: 0;
+        }
 
-		${from.mobileLandscape} {
-			li {
-				flex: 1 1 33.33%;
-			}
-			li:nth-child(3) {
-				display: flex;
-			}
-		}
-		${from.tablet} {
-			li {
-				flex: 0 0 10rem;
-			}
-			li:nth-child(n + 3) {
-				display: flex;
-			}
-			li:nth-child(n + 2) {
-				margin-left: ${remSpace[5]};
-			}
-		}
-		${from.desktop} {
-			li {
-				flex: 0 0 13.75rem;
-			}
-		}
-	}
+        ${from.mobileLandscape} {
+            li {
+                flex: 1 1 33.33%;
+            }
+            li:nth-child(3) {
+                display: flex;
+            }
+        }
+        ${from.tablet} {
+            li {
+                flex: 0 0 10rem;
+            }
+            li:nth-child(n + 3) {
+                display: flex;
+            }
+            li:nth-child(n + 2) {
+                margin-left: ${remSpace[5]};
+            }
+        }
+        ${from.desktop} {
+            li {
+                flex: 0 0 13.75rem;
+            }
+        }
+    }
 `;
 
 const styles = css`
-	border-top: 1px solid ${neutral[46]};
-	padding-top: ${remSpace[3]};
-	padding-left: ${remSpace[4]};
-	padding-right: ${remSpace[4]};
+    border-top: 1px solid ${neutral[46]};
+    padding-top: ${remSpace[3]};
 
-	${until.wide} {
-		margin-left: -${remSpace[4]};
-		margin-right: -${remSpace[4]};
-	}
+    ${until.wide} {
+        padding-left: ${remSpace[4]};
+        padding-right: ${remSpace[4]};
+    }
 
-	${darkModeCss`
-		background: ${neutral[0]};
-	`}
+    ${darkModeCss`
+        background: ${neutral[0]};
+    `}
 `;
 
 const COMMENT = RelatedItemType.COMMENT;
 
 const RelatedContent: FC<Props> = ({ content }) => {
-	return pipe(
-		content,
-		map(({ title, relatedItems, resizedImages }) => {
-			if (relatedItems.length === 0) {
-				return null;
-			}
+    return pipe(
+        content,
+        map(({ title, relatedItems, resizedImages }) => {
+            if (relatedItems.length === 0) {
+                return null;
+            }
 
-			return (
-				<section css={styles}>
-					<h2 css={headingStyles}>{title}</h2>
-					<ul css={listStyles}>
-						{relatedItems.map((relatedItem, key) => {
-							return relatedItem.type === COMMENT &&
-								relatedItem.bylineImage ? (
-								<BylineCard
-									key={key}
-									relatedItem={relatedItem}
-								/>
-							) : (
-								<Card
-									key={key}
-									relatedItem={relatedItem}
-									image={resizedImages[key]}
-								/>
-							);
-						})}
-					</ul>
-				</section>
-			);
-		}),
-		withDefault<JSX.Element | null>(null),
-	);
+            return (
+                <section css={styles}>
+                    <h2 css={headingStyles}>{title}</h2>
+                    <ul css={listStyles}>
+                        {relatedItems.map((relatedItem, key) => {
+                            return relatedItem.type === COMMENT &&
+                                relatedItem.bylineImage ? (
+                                <BylineCard
+                                    key={key}
+                                    relatedItem={relatedItem}
+                                />
+                            ) : (
+                                <Card
+                                    key={key}
+                                    relatedItem={relatedItem}
+                                    image={resizedImages[key]}
+                                />
+                            );
+                        })}
+                    </ul>
+                </section>
+            );
+        }),
+        withDefault<JSX.Element | null>(null),
+    );
 };
 
 export default RelatedContent;

--- a/apps-rendering/src/components/shared/relatedContent.tsx
+++ b/apps-rendering/src/components/shared/relatedContent.tsx
@@ -95,8 +95,8 @@ const styles = css`
 	}
 
 	${darkModeCss`
-        background: ${neutral[0]};
-    `}
+		background: ${neutral[0]};
+	`}
 `;
 
 const COMMENT = RelatedItemType.COMMENT;

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -111,7 +111,6 @@ export const onwardStyles: SerializedStyles = css`
         background: ${background.inverse};
     `};
 
-	padding: 0.125rem 0 0;
 	${from.wide} {
 		width: 1300px;
 		margin-left: auto;

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -106,7 +106,6 @@ export const lineStyles = css`
 
 export const onwardStyles: SerializedStyles = css`
 	background: ${neutral[97]};
-	margin: 0 ${remSpace[3]};
 
 	${darkModeCss`
         background: ${background.inverse};


### PR DESCRIPTION
## Why?
This PR fixes an issue in the related content section (Apps Rendering), which was causing swiping problems on the iOS app.
This is due to negative margins not being correctly rendered by all browsers.

I have also addressed a minor visual bug which was causing an almost invisible 2px gap between the article and the related content section.

I have tested this change in Chrome, Firefox and Safari.

## Before
### Margin close-up (Safari)
![image](https://user-images.githubusercontent.com/57295823/151829286-030d1e1a-5b62-4178-ac95-b258d82db429.png)

## After
### Margin close-up (Safari)
![image](https://user-images.githubusercontent.com/57295823/151829263-640c8ba6-8953-4ff8-9330-bbbf06c5ed80.png)
