### PR TITLE
feature: Mark old PR's as Stale and eventually close them

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Stale PR Handler"
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.0
+        id: stale
+        with:
+          stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 3 days"
+          days-before-issue-stale: -1
+          days-before-stale: 30
+          days-before-close: 3
+          exempt-pr-labels: "dependencies,DCR Dependency,AR Dependency"


### PR DESCRIPTION
## What does this change?

- Adds a new github workflow that runs once per day.
- The new workflow scans all PR's and marks any that have had no activity in 30 days with stale and leaves a comment.
- Closes all Stale PR's after 3 days.
- The author of the PR can either remove the stale tag, or, comment on the pr if they want to keep it open.
- Ignores dependabot PR's

## Why?

We currently have 61 (62 if you include this PR!) PR's open, including some that haven't seen any activity since last year. This encourages authors to follow up on their PR's and closes any PR's that are no longer necessary.
