### PR TITLE
exclude dependabot branches from chromatic action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,5 +20,6 @@ jobs:
 
       - uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          skip: dependabot/**

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,4 +22,3 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          skip: dependabot/**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
part of https://github.com/guardian/dotcom-rendering/issues/3882

## What does this change?
Stops Chromatic being run on dependabot PRs.

## TL;DR

Shall we err on the side of over-testing and run Chromatic on dependabot PRs while monitoring costs in Chromatic, or assume that costs might explode and find a way to run Chromatic tests when certain packages update?

## Why?
Now that `dependabot` can run Chromatic, I would prefer if it didn't. `dependabot` PRs can kick off a lot of workflows through rebasing etc etc, which in turn would cost 💰. 

## But...
We will need to run these on specific package updates especially as we have UI elements that could change in `@guardian/**` modules. I'm not sure if we use `dependabot` to do this for us, or if it's something we do more manually, so would like feedback on whether we think this would be an issue.

Another option would be to keep running the chromaui action and watch costs to see if that's an issue.

While writing this PR, it's made me think erring on the side of testing more, especially as we're add more automation into the CD pipeline, would be better if cost allows.

## Small refactor
`s/CHROMATIC_APP_CODE/CHROMATIC_PROJECT_TOKEN` <= this is to match 