### PR TITLE
rename CHROMATIC_APP_CODE => CHROMATIC_PROJECT_TOKEN

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,5 +20,5 @@ jobs:
 
       - uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the name of the env var for the chromatic token.

## Why?
Making it more consistent with external docs. We seem to [use](https://github.com/search?q=org%3Aguardian+CHROMATIC_PROJECT_TOKEN&type=code) a [combo](https://github.com/search?q=org%3Aguardian+CHROMATIC_APP_CODE&type=code) across our org, so being consistent externally felt liek the right choice.

This has been added to the repo already.