### PR TITLE
fix toggle styling regression

### DIFF
--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -98,12 +98,10 @@ const toggleOverrideStyles = css`
 	padding-right: ${remSpace[1]};
 
 	${until.desktop} {
+		color: ${neutral[100]};
+
 		button[aria-checked='false'] {
 			background-color: rgba(255, 255, 255, 0.5);
-		}
-
-		label {
-			color: ${neutral[100]};
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

Updates the `metadata` component in AR so the `cssOverride` prop correctly overrides the label styling on the Source `ToggleSwitch` component.

## Why?

We've recently [updated](https://github.com/guardian/source/pull/1249) the `ToggleSwitch` components' HTML structure to allow users to click the text. This means that the css `label` selector is no longer required.

### Before
<img width="322" alt="Screenshot 2022-02-01 at 11 34 35" src="https://user-images.githubusercontent.com/77005274/151961566-864bb9ca-09d8-47bb-b8cc-7cf532b56d9c.png">

### After
<img width="322" alt="Screenshot 2022-02-01 at 11 34 51" src="https://user-images.githubusercontent.com/77005274/151961579-a61b8bb3-d6e2-42d9-89e8-246be5b67aac.png">

