### PR TITLE
CAPIElement type safety!

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -303,7 +303,7 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 	// guaranteed but TS isn't so sure and needs assurance
 	const elementsByType = <T extends CAPIElement>(
 		elements: CAPIElement[],
-		type: string,
+		type: T['_type'],
 	): T[] => elements.filter((element) => element._type === type) as T[];
 
 	const youTubeAtoms = elementsByType<YoutubeBlockElement>(


### PR DESCRIPTION
## What does this change?

Assert that the `type` argument should match the type of block we check for.

## Why?

There’s a type assertion, so we did not have type safety. This resolves that.
