### PR TITLE
Atoms as islands

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@cypress/skip-test": "^2.6.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^22.1.1",
+    "@guardian/atoms-rendering": "^22.2.0",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "^10.1.1",

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -11,16 +11,6 @@ import { GetMatchNav } from '@frontend/web/components/GetMatchNav';
 import { StickyBottomBanner } from '@root/src/web/components/StickyBottomBanner/StickyBottomBanner';
 import { SignInGateSelector } from '@root/src/web/components/SignInGate/SignInGateSelector';
 
-import {
-	QandaAtom,
-	GuideAtom,
-	ProfileAtom,
-	TimelineAtom,
-	ChartAtom,
-	PersonalityQuizAtom,
-	KnowledgeQuizAtom,
-} from '@guardian/atoms-rendering';
-
 import { AudioAtomWrapper } from '@frontend/web/components/AudioAtomWrapper';
 
 import { Portal } from '@frontend/web/components/Portal';
@@ -41,7 +31,6 @@ import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount'
 import { hasOptedOutOfArticleCount } from '@frontend/web/lib/contributions';
 import { ReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { updateIframeHeight } from '@root/src/web/browser/updateIframeHeight';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import { LabsHeader } from '@root/src/web/components/LabsHeader';
@@ -55,10 +44,6 @@ import {
 	incrementWeeklyArticleCount,
 } from '@guardian/support-dotcom-components';
 import { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import {
-	submitComponentEvent,
-	OphanComponentEvent,
-} from '../browser/ophan/ophan';
 import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 import { CommercialMetrics } from './CommercialMetrics';
 import { GetMatchTabs } from './GetMatchTabs';
@@ -76,20 +61,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		useState<Promise<BrazeMessagesInterface>>();
 
 	const pageViewId = window.guardian?.config?.ophan?.pageViewId;
-
-	const componentEventHandler =
-		(componentType: any, id: any, action: any) => () => {
-			const componentEvent: OphanComponentEvent = {
-				component: {
-					componentType,
-					id,
-					products: [],
-					labels: [],
-				},
-				action,
-			};
-			submitComponentEvent(componentEvent, ophanRecord);
-		};
 
 	const [asyncArticleCount, setAsyncArticleCount] =
 		useState<Promise<WeeklyArticleHistory | undefined>>();
@@ -310,37 +281,13 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.YoutubeBlockElement',
 	);
-	const quizAtoms = elementsByType<QuizAtomBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.QuizAtomBlockElement',
-	);
 	const callouts = elementsByType<CalloutBlockElement>(
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.CalloutBlockElement',
 	);
-	const chartAtoms = elementsByType<ChartAtomBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.ChartAtomBlockElement',
-	);
 	const audioAtoms = elementsByType<AudioAtomBlockElement>(
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.AudioAtomBlockElement',
-	);
-	const qandaAtoms = elementsByType<QABlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.QABlockElement',
-	);
-	const guideAtoms = elementsByType<GuideAtomBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.GuideAtomBlockElement',
-	);
-	const profileAtoms = elementsByType<ProfileAtomBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.ProfileAtomBlockElement',
-	);
-	const timelineAtoms = elementsByType<TimelineBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.TimelineBlockElement',
 	);
 	const embeds = elementsByType<EmbedBlockElement>(
 		CAPI.elementsToHydrate,
@@ -442,36 +389,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 					/>
 				</HydrateOnce>
 			))}
-			{quizAtoms.map((quizAtom) => (
-				<HydrateOnce rootId={quizAtom.elementId}>
-					<>
-						{quizAtom.quizType === 'personality' && (
-							<PersonalityQuizAtom
-								id={quizAtom.id}
-								questions={quizAtom.questions}
-								resultBuckets={quizAtom.resultBuckets}
-								sharingUrls={getSharingUrls(
-									CAPI.pageId,
-									CAPI.webTitle,
-								)}
-								theme={format.theme}
-							/>
-						)}
-						{quizAtom.quizType === 'knowledge' && (
-							<KnowledgeQuizAtom
-								id={quizAtom.id}
-								questions={quizAtom.questions}
-								resultGroups={quizAtom.resultGroups}
-								sharingUrls={getSharingUrls(
-									CAPI.pageId,
-									CAPI.webTitle,
-								)}
-								theme={format.theme}
-							/>
-						)}
-					</>
-				</HydrateOnce>
-			))}
 
 			{CAPI.matchUrl && (
 				<Portal rootId="match-nav">
@@ -505,11 +422,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 					<CalloutBlockComponent callout={callout} format={format} />
 				</HydrateOnce>
 			))}
-			{chartAtoms.map((chartAtom) => (
-				<HydrateOnce rootId={chartAtom.elementId}>
-					<ChartAtom id={chartAtom.id} html={chartAtom.html} />
-				</HydrateOnce>
-			))}
 			{audioAtoms.map((audioAtom) => (
 				<HydrateOnce rootId={audioAtom.elementId}>
 					<AudioAtomWrapper
@@ -522,113 +434,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 						contentIsNotSensitive={!CAPI.config.isSensitive}
 						aCastisEnabled={CAPI.config.switches.acast}
 						readerCanBeShownAds={!CAPI.isAdFreeUser}
-					/>
-				</HydrateOnce>
-			))}
-			{qandaAtoms.map((qandaAtom) => (
-				<HydrateOnce rootId={qandaAtom.elementId}>
-					<QandaAtom
-						id={qandaAtom.id}
-						title={qandaAtom.title}
-						html={qandaAtom.html}
-						image={qandaAtom.img}
-						credit={qandaAtom.credit}
-						pillar={pillar}
-						likeHandler={componentEventHandler(
-							'QANDA_ATOM',
-							qandaAtom.id,
-							'LIKE',
-						)}
-						dislikeHandler={componentEventHandler(
-							'QANDA_ATOM',
-							qandaAtom.id,
-							'DISLIKE',
-						)}
-						expandCallback={componentEventHandler(
-							'QANDA_ATOM',
-							qandaAtom.id,
-							'EXPAND',
-						)}
-					/>
-				</HydrateOnce>
-			))}
-			{guideAtoms.map((guideAtom) => (
-				<HydrateOnce rootId={guideAtom.elementId}>
-					<GuideAtom
-						id={guideAtom.id}
-						title={guideAtom.title}
-						html={guideAtom.html}
-						image={guideAtom.img}
-						credit={guideAtom.credit}
-						pillar={pillar}
-						likeHandler={componentEventHandler(
-							'GUIDE_ATOM',
-							guideAtom.id,
-							'LIKE',
-						)}
-						dislikeHandler={componentEventHandler(
-							'GUIDE_ATOM',
-							guideAtom.id,
-							'DISLIKE',
-						)}
-						expandCallback={componentEventHandler(
-							'GUIDE_ATOM',
-							guideAtom.id,
-							'EXPAND',
-						)}
-					/>
-				</HydrateOnce>
-			))}
-			{profileAtoms.map((profileAtom) => (
-				<HydrateOnce rootId={profileAtom.elementId}>
-					<ProfileAtom
-						id={profileAtom.id}
-						title={profileAtom.title}
-						html={profileAtom.html}
-						image={profileAtom.img}
-						credit={profileAtom.credit}
-						pillar={pillar}
-						likeHandler={componentEventHandler(
-							'PROFILE_ATOM',
-							profileAtom.id,
-							'LIKE',
-						)}
-						dislikeHandler={componentEventHandler(
-							'PROFILE_ATOM',
-							profileAtom.id,
-							'DISLIKE',
-						)}
-						expandCallback={componentEventHandler(
-							'PROFILE_ATOM',
-							profileAtom.id,
-							'EXPAND',
-						)}
-					/>
-				</HydrateOnce>
-			))}
-			{timelineAtoms.map((timelineAtom) => (
-				<HydrateOnce rootId={timelineAtom.elementId}>
-					<TimelineAtom
-						id={timelineAtom.id}
-						title={timelineAtom.title}
-						events={timelineAtom.events}
-						description={timelineAtom.description}
-						pillar={pillar}
-						likeHandler={componentEventHandler(
-							'TIMELINE_ATOM',
-							timelineAtom.id,
-							'LIKE',
-						)}
-						dislikeHandler={componentEventHandler(
-							'TIMELINE_ATOM',
-							timelineAtom.id,
-							'DISLIKE',
-						)}
-						expandCallback={componentEventHandler(
-							'TIMELINE_ATOM',
-							timelineAtom.id,
-							'EXPAND',
-						)}
 					/>
 				</HydrateOnce>
 			))}

--- a/dotcom-rendering/src/web/components/ChartAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/ChartAtomWrapper.importable.tsx
@@ -1,0 +1,7 @@
+import { ChartAtom } from '@guardian/atoms-rendering';
+import { ChartAtomType } from '@guardian/atoms-rendering/dist/types/types';
+
+export const ChartAtomWrapper = (props: ChartAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <ChartAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/GuideAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/GuideAtomWrapper.importable.tsx
@@ -1,0 +1,7 @@
+import { GuideAtom } from '@guardian/atoms-rendering';
+import { GuideAtomType } from '@guardian/atoms-rendering/dist/types/types';
+
+export const GuideAtomWrapper = (props: GuideAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <GuideAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/KnowledgeQuizAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/KnowledgeQuizAtomWrapper.importable.tsx
@@ -1,0 +1,38 @@
+import { KnowledgeQuizAtom } from '@guardian/atoms-rendering';
+import { SharingUrlsType } from '@guardian/atoms-rendering/dist/types/types';
+
+// These types are duplicates of those defined in the atom file.
+type AnswerType = {
+	id: string;
+	text: string;
+	revealText?: string;
+	isCorrect: boolean;
+	answerBuckets: string[];
+};
+
+type QuestionType = {
+	id: string;
+	text: string;
+	answers: AnswerType[];
+	imageUrl?: string;
+};
+
+type ResultGroupsType = {
+	title: string;
+	shareText: string;
+	minScore: number;
+	id: string;
+};
+
+type QuizAtomType = {
+	id: string;
+	questions: QuestionType[];
+	resultGroups: ResultGroupsType[];
+	sharingUrls: SharingUrlsType;
+	theme: ArticleTheme;
+};
+
+export const KnowledgeQuizAtomWrapper = (props: QuizAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <KnowledgeQuizAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/PersonalityQuizAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/PersonalityQuizAtomWrapper.importable.tsx
@@ -1,0 +1,37 @@
+import { PersonalityQuizAtom } from '@guardian/atoms-rendering';
+import { SharingUrlsType } from '@guardian/atoms-rendering/dist/types/types';
+
+// These types are duplicates of those defined in the atom file.
+type AnswerType = {
+	id: string;
+	text: string;
+	revealText?: string;
+	isCorrect: boolean;
+	answerBuckets: string[];
+};
+
+type QuestionType = {
+	id: string;
+	text: string;
+	answers: AnswerType[];
+	imageUrl?: string;
+};
+
+type ResultsBucket = {
+	id: string;
+	title: string;
+	description: string;
+};
+
+type QuizAtomType = {
+	id: string;
+	questions: QuestionType[];
+	resultBuckets: ResultsBucket[];
+	sharingUrls: SharingUrlsType;
+	theme: ArticleTheme;
+};
+
+export const PersonalityQuizAtomWrapper = (props: QuizAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <PersonalityQuizAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/ProfileAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/ProfileAtomWrapper.importable.tsx
@@ -1,0 +1,7 @@
+import { ProfileAtom } from '@guardian/atoms-rendering';
+import { ProfileAtomType } from '@guardian/atoms-rendering/dist/types/types';
+
+export const ProfileAtomWrapper = (props: ProfileAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <ProfileAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/QandaAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/QandaAtomWrapper.importable.tsx
@@ -1,0 +1,7 @@
+import { QandaAtom } from '@guardian/atoms-rendering';
+import { QandaAtomType } from '@guardian/atoms-rendering/dist/types/types';
+
+export const QandaAtomWrapper = (props: QandaAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <QandaAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/components/TimelineAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/TimelineAtomWrapper.importable.tsx
@@ -1,0 +1,7 @@
+import { TimelineAtom } from '@guardian/atoms-rendering';
+import { TimelineAtomType } from '@guardian/atoms-rendering/dist/types/types';
+
+export const TimelineAtomWrapper = (props: TimelineAtomType) => {
+	// eslint-disable-next-line react/jsx-props-no-spreading
+	return <TimelineAtom {...props} />;
+};

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -63,8 +63,6 @@ import {
 	interactiveLegacyFigureClasses,
 } from '../layouts/lib/interactiveLegacyStyling';
 
-import { submitComponentEvent } from '../browser/ophan/ophan';
-
 import { Island } from '../components/Island';
 
 type Props = {
@@ -298,39 +296,6 @@ export const renderElement = ({
 						image={element.img}
 						credit={element.credit}
 						pillar={format.theme}
-						likeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'GUIDE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'LIKE',
-							})
-						}
-						dislikeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'GUIDE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'DISLIKE',
-							})
-						}
-						expandCallback={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'GUIDE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'EXPAND',
-							})
-						}
 					/>
 				</Island>,
 			];
@@ -483,39 +448,6 @@ export const renderElement = ({
 						image={element.img}
 						credit={element.credit}
 						pillar={format.theme}
-						likeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'PROFILE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'LIKE',
-							})
-						}
-						dislikeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'PROFILE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'DISLIKE',
-							})
-						}
-						expandCallback={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'PROFILE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'EXPAND',
-							})
-						}
 					/>
 				</Island>,
 			];
@@ -542,39 +474,6 @@ export const renderElement = ({
 						image={element.img}
 						credit={element.credit}
 						pillar={format.theme}
-						likeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'QANDA_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'LIKE',
-							})
-						}
-						dislikeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'QANDA_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'DISLIKE',
-							})
-						}
-						expandCallback={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'QANDA_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'EXPAND',
-							})
-						}
 					/>
 				</Island>,
 			];
@@ -679,39 +578,6 @@ export const renderElement = ({
 						pillar={format.theme}
 						events={element.events}
 						description={element.description}
-						likeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'TIMELINE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'LIKE',
-							})
-						}
-						dislikeHandler={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'TIMELINE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'DISLIKE',
-							})
-						}
-						expandCallback={() =>
-							submitComponentEvent({
-								component: {
-									componentType: 'TIMELINE_ATOM',
-									id: element.id,
-									products: [],
-									labels: [],
-								},
-								action: 'EXPAND',
-							})
-						}
 					/>
 				</Island>,
 			];

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -33,6 +33,13 @@ import { VimeoBlockComponent } from '@root/src/web/components/VimeoBlockComponen
 import { VineBlockComponent } from '@root/src/web/components/VineBlockComponent.importable';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/YoutubeBlockComponent';
+
+import { TimelineAtomWrapper } from '@root/src/web/components/TimelineAtomWrapper.importable';
+import { GuideAtomWrapper } from '@root/src/web/components/GuideAtomWrapper.importable';
+import { ChartAtomWrapper } from '@root/src/web/components/ChartAtomWrapper.importable';
+import { ProfileAtomWrapper } from '@root/src/web/components/ProfileAtomWrapper.importable';
+import { QandaAtomWrapper } from '@root/src/web/components/QandaAtomWrapper.importable';
+
 import {
 	WitnessVideoBlockComponent,
 	WitnessImageBlockComponent,
@@ -42,14 +49,9 @@ import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { ClickToView } from '@root/src/web/components/ClickToView';
 import {
 	AudioAtom,
-	ChartAtom,
 	ExplainerAtom,
 	InteractiveAtom,
 	InteractiveLayoutAtom,
-	QandaAtom,
-	GuideAtom,
-	ProfileAtom,
-	TimelineAtom,
 	VideoAtom,
 	PersonalityQuizAtom,
 	KnowledgeQuizAtom,
@@ -178,7 +180,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island deferUntil="visible">
-					<ChartAtom id={element.id} html={element.html} />
+					<ChartAtomWrapper id={element.id} html={element.html} />
 				</Island>,
 			];
 
@@ -289,7 +291,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island deferUntil="visible">
-					<GuideAtom
+					<GuideAtomWrapper
 						id={element.id}
 						title={element.title}
 						html={element.html}
@@ -474,7 +476,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island deferUntil="visible">
-					<ProfileAtom
+					<ProfileAtomWrapper
 						id={element.id}
 						title={element.title}
 						html={element.html}
@@ -533,7 +535,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island deferUntil="visible">
-					<QandaAtom
+					<QandaAtomWrapper
 						id={element.id}
 						title={element.title}
 						html={element.html}
@@ -671,7 +673,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island deferUntil="visible">
-					<TimelineAtom
+					<TimelineAtomWrapper
 						id={element.id}
 						title={element.title}
 						pillar={format.theme}

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -60,6 +60,9 @@ import {
 	isInteractive,
 	interactiveLegacyFigureClasses,
 } from '../layouts/lib/interactiveLegacyStyling';
+
+import { submitComponentEvent } from '../browser/ophan/ophan';
+
 import { Island } from '../components/Island';
 
 type Props = {
@@ -172,7 +175,13 @@ export const renderElement = ({
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-			return [true, <ChartAtom id={element.id} html={element.html} />];
+			return [
+				true,
+				<Island deferUntil="visible">
+					<ChartAtom id={element.id} html={element.html} />
+				</Island>,
+			];
+
 		case 'model.dotcomrendering.pageElements.CodeBlockElement':
 			return [
 				true,
@@ -279,17 +288,49 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
 			return [
 				true,
-				<GuideAtom
-					id={element.id}
-					title={element.title}
-					html={element.html}
-					image={element.img}
-					credit={element.credit}
-					pillar={format.theme}
-					likeHandler={() => {}}
-					dislikeHandler={() => {}}
-					expandCallback={() => {}}
-				/>,
+				<Island deferUntil="visible">
+					<GuideAtom
+						id={element.id}
+						title={element.title}
+						html={element.html}
+						image={element.img}
+						credit={element.credit}
+						pillar={format.theme}
+						likeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'GUIDE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
+							})
+						}
+						dislikeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'GUIDE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
+							})
+						}
+						expandCallback={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'GUIDE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'EXPAND',
+							})
+						}
+					/>
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
 			return [
@@ -432,17 +473,49 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.ProfileAtomBlockElement':
 			return [
 				true,
-				<ProfileAtom
-					id={element.id}
-					title={element.title}
-					html={element.html}
-					image={element.img}
-					credit={element.credit}
-					pillar={format.theme}
-					likeHandler={() => {}}
-					dislikeHandler={() => {}}
-					expandCallback={() => {}}
-				/>,
+				<Island deferUntil="visible">
+					<ProfileAtom
+						id={element.id}
+						title={element.title}
+						html={element.html}
+						image={element.img}
+						credit={element.credit}
+						pillar={format.theme}
+						likeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'PROFILE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
+							})
+						}
+						dislikeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'PROFILE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
+							})
+						}
+						expandCallback={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'PROFILE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'EXPAND',
+							})
+						}
+					/>
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
 			return [
@@ -459,39 +532,75 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.QABlockElement':
 			return [
 				true,
-				<QandaAtom
-					id={element.id}
-					title={element.title}
-					html={element.html}
-					image={element.img}
-					credit={element.credit}
-					pillar={format.theme}
-					likeHandler={() => {}}
-					dislikeHandler={() => {}}
-					expandCallback={() => {}}
-				/>,
+				<Island deferUntil="visible">
+					<QandaAtom
+						id={element.id}
+						title={element.title}
+						html={element.html}
+						image={element.img}
+						credit={element.credit}
+						pillar={format.theme}
+						likeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'QANDA_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
+							})
+						}
+						dislikeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'QANDA_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
+							})
+						}
+						expandCallback={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'QANDA_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'EXPAND',
+							})
+						}
+					/>
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.QuizAtomBlockElement':
 			return [
 				true,
 				<>
 					{element.quizType === 'personality' && (
-						<PersonalityQuizAtom
-							id={element.id}
-							questions={element.questions}
-							resultBuckets={element.resultBuckets}
-							sharingUrls={getSharingUrls(pageId, webTitle)}
-							theme={format.theme}
-						/>
+						<Island deferUntil="visible">
+							<PersonalityQuizAtom
+								id={element.id}
+								questions={element.questions}
+								resultBuckets={element.resultBuckets}
+								sharingUrls={getSharingUrls(pageId, webTitle)}
+								theme={format.theme}
+							/>
+						</Island>
 					)}
 					{element.quizType === 'knowledge' && (
-						<KnowledgeQuizAtom
-							id={element.id}
-							questions={element.questions}
-							resultGroups={element.resultGroups}
-							sharingUrls={getSharingUrls(pageId, webTitle)}
-							theme={format.theme}
-						/>
+						<Island deferUntil="visible">
+							<KnowledgeQuizAtom
+								id={element.id}
+								questions={element.questions}
+								resultGroups={element.resultGroups}
+								sharingUrls={getSharingUrls(pageId, webTitle)}
+								theme={format.theme}
+							/>
+						</Island>
 					)}
 				</>,
 			];
@@ -561,16 +670,48 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 			return [
 				true,
-				<TimelineAtom
-					id={element.id}
-					title={element.title}
-					pillar={format.theme}
-					events={element.events}
-					description={element.description}
-					likeHandler={() => {}}
-					dislikeHandler={() => {}}
-					expandCallback={() => {}}
-				/>,
+				<Island deferUntil="visible">
+					<TimelineAtom
+						id={element.id}
+						title={element.title}
+						pillar={format.theme}
+						events={element.events}
+						description={element.description}
+						likeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'TIMELINE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'LIKE',
+							})
+						}
+						dislikeHandler={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'TIMELINE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'DISLIKE',
+							})
+						}
+						expandCallback={() =>
+							submitComponentEvent({
+								component: {
+									componentType: 'TIMELINE_ATOM',
+									id: element.id,
+									products: [],
+									labels: [],
+								},
+								action: 'EXPAND',
+							})
+						}
+					/>
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.TweetBlockElement':
 			return [true, <TweetBlockComponent element={element} />];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,10 +2727,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^22.1.1":
-  version "22.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.1.1.tgz#a9a8df829ce3fbe12241a593e8f6da739fb0e429"
-  integrity sha512-6a+ZaBqYG8D/I0xwHYY5uEtwY7gRJHAxy1KsgZLSGhKqISYPJRMWfBNK/fOYBQGcoG0Nn8JeVF2FhFsrEBaNyw==
+"@guardian/atoms-rendering@^22.2.0":
+  version "22.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.2.0.tgz#ee2549bb57893bdddf87feccf2c4317e7ddb9db0"
+  integrity sha512-p4h19meQlZfC5X1ra1zuOF5J75Upe0Gipe5l9K0uo/L1LoWgXNxj+D8zIb5c3y4USh1fZ+Gmkg97uy3DVdbPjA==
   dependencies:
     youtube-player "^5.5.2"
 
@@ -5047,7 +5047,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/serve-static@*":
+"@types/serve-static@*", "@types/serve-static@^1.13.9":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,7 +5047,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/serve-static@*", "@types/serve-static@^1.13.9":
+"@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Here we're moving a bunch of atoms into Islands. Specifically,

```
	QandaAtom
	GuideAtom
	ProfileAtom
	TimelineAtom
	ChartAtom
	PersonalityQuizAtom
	KnowledgeQuizAtom
```

We're also add version `22.2.0` of `@guardian/atoms-rendering` which allows us to remove the tracking handlers

## Why?
Islands are cool.

Why are we removing the tracking handlers? Because adding these on the server and then trying to hydrate them was non intuitive and added complexity. By adding a default to the atom itself we can simply not include the handler and use the fallback instead.

## What are these wrapper components?
For code that's imported from an external lib it's not possible for our `Island` abstraction to dynamcally import it because we currently require island components to exist in `/component`. To get around this we use a simple wrapper, as shown here.
