### PR TITLE
Revert "Track errors in the Supporter Revenue header links"

### DIFF
--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
@@ -221,15 +221,6 @@ const ReaderRevenueLinksRemote: React.FC<{
 					new Error(msg),
 					'rr-header-links',
 				);
-				submitComponentEvent({
-					component: {
-						// Do not record this as ACQUISITIONS_HEADER to avoid confusing with successful INSERT events
-						componentType: 'ACQUISITIONS_OTHER',
-					},
-					action: 'INSERT',
-					id: 'header-error',
-					value: msg,
-				});
 			});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [countryCode]);


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#3888

We've gathered enough data to conclude it's mainly network errors and nothing to worry about.