### PR TITLE
tweaked css

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -60,7 +60,7 @@ const keyEventWrapperStyles = (
 	width: 100%;
 
 	${from.desktop} {
-		border-top: #cdcdcd 1px solid;
+		border-top: 1px solid ${neutral[86]};
 		padding-top: ${remSpace[2]};
 	}
 
@@ -76,14 +76,14 @@ const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 
 	li::before {
 		content: "";
-		border-color: transparent ${neutral[7]};
-		border-style: solid;
-		border-width: 0.4rem 0 0.4rem 0.5rem;
 		display: block;
-		height: 0;
-		width: 0;
-		top: 0;
 		position: absolute;
+		top: 0;
+		left: -6px;
+		height: 11px;
+		width: 11px;
+		border-radius: 50%;
+		background-color: ${neutral[46]};
 	}
 
 	${darkModeCss(supportsDarkMode)`
@@ -95,8 +95,10 @@ const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 
 const listItemStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	padding-bottom: ${remSpace[3]};
-	border-left: 1px solid ${neutral[7]};
+	border-left: 1px solid ${neutral[86]};
 	position: relative;
+	transform: translateY(-1px);
+	margin-left: 4px;
 	${darkModeCss(supportsDarkMode)`
 		border-left: 1px solid ${neutral[60]};
 	`}
@@ -125,6 +127,10 @@ const textStyles = (
 	supportsDarkMode: boolean
 ): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
+	/* TODO update with Source value when it's added */
+	${from.desktop} {
+		font-size:15px;
+	}
 	color: ${getColor(theme, 400)};
 
 	text-decoration: none;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes chevrons from key events component and replace with dots - also swapped black line for grey as it felt very heavy

## Why?
Looked off

### Before
![Screenshot 2022-02-02 at 15 29 43](https://user-images.githubusercontent.com/20658471/152185164-1bf13799-0821-49cb-9021-81887db6fc3f.png)


### After
![Screenshot 2022-02-02 at 15 29 33](https://user-images.githubusercontent.com/20658471/152185136-c7d7179c-a35c-4b40-abbf-c73d6a78648a.png)

