### PR TITLE
`CalloutBlockComponent` as an Island

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -867,17 +867,11 @@ interface InteractiveContentsBlockLoadable extends ComponentNameChunkMap {
 	addWhen: InteractiveContentsBlockElement['_type'];
 }
 
-interface CalloutBlockLoadable extends ComponentNameChunkMap {
-	chunkName: 'CalloutBlockComponent';
-	addWhen: CalloutBlockElement['_type'];
-}
-
 // There are docs on loadable in ./docs/loadable-components.md
 type LoadableComponents = [
 	YoutubeBlockLoadable,
 	InteractiveBlockLoadable,
 	InteractiveContentsBlockLoadable,
-	CalloutBlockLoadable,
 ];
 
 interface CarouselImagesMap {

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -230,24 +230,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		},
 	);
 
-	const CalloutBlockComponent = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.CalloutBlockElement',
-				).length > 0
-			) {
-				return import('@frontend/web/components/CalloutBlockComponent');
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) => module.CalloutBlockComponent,
-		},
-	);
-
 	// We use this function to filter the elementsToHydrate array by a particular
 	// type so that we can hydrate them. We use T to force the type and keep TS
 	// content because *we* know that if _type equals a thing then the type is
@@ -260,10 +242,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 	const youTubeAtoms = elementsByType<YoutubeBlockElement>(
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.YoutubeBlockElement',
-	);
-	const callouts = elementsByType<CalloutBlockElement>(
-		CAPI.elementsToHydrate,
-		'model.dotcomrendering.pageElements.CalloutBlockElement',
 	);
 	const audioAtoms = elementsByType<AudioAtomBlockElement>(
 		CAPI.elementsToHydrate,
@@ -393,11 +371,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 					isPaidContent={CAPI.pageType.isPaidContent}
 				/>
 			</Portal>
-			{callouts.map((callout) => (
-				<HydrateOnce rootId={callout.elementId}>
-					<CalloutBlockComponent callout={callout} format={format} />
-				</HydrateOnce>
-			))}
 			{audioAtoms.map((audioAtom) => (
 				<HydrateOnce rootId={audioAtom.elementId}>
 					<AudioAtomWrapper

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -157,7 +157,9 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.CalloutBlockElement':
 			return [
 				true,
-				<CalloutBlockComponent callout={element} format={format} />,
+				<Island deferUntil="visible">
+					<CalloutBlockComponent callout={element} format={format} />
+				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.CaptionBlockElement':
 			return [

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -106,10 +106,6 @@ export const document = ({ data }: Props): string => {
 			addWhen:
 				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
 		},
-		{
-			chunkName: 'CalloutBlockComponent',
-			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
-		},
 	];
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves `CalloutBlockComponent` over to the island pattern

## Why?
We like islands
