### PR TITLE
`InteractiveContentsBlockElement` as an island

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -862,11 +862,6 @@ interface InteractiveBlockLoadable extends ComponentNameChunkMap {
 	addWhen: InteractiveBlockElement['_type'];
 }
 
-interface InteractiveContentsBlockLoadable extends ComponentNameChunkMap {
-	chunkName: 'InteractiveContentsBlockComponent';
-	addWhen: InteractiveContentsBlockElement['_type'];
-}
-
 interface CalloutBlockLoadable extends ComponentNameChunkMap {
 	chunkName: 'CalloutBlockComponent';
 	addWhen: CalloutBlockElement['_type'];
@@ -876,7 +871,6 @@ interface CalloutBlockLoadable extends ComponentNameChunkMap {
 type LoadableComponents = [
 	YoutubeBlockLoadable,
 	InteractiveBlockLoadable,
-	InteractiveContentsBlockLoadable,
 	CalloutBlockLoadable,
 ];
 

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -74,7 +74,6 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		'model.dotcomrendering.pageElements.ChartAtomBlockElement',
 		'model.dotcomrendering.pageElements.GuideAtomBlockElement',
 		'model.dotcomrendering.pageElements.InteractiveBlockElement',
-		'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
 		'model.dotcomrendering.pageElements.ProfileAtomBlockElement',
 		'model.dotcomrendering.pageElements.QABlockElement',
 		'model.dotcomrendering.pageElements.QuizAtomBlockElement',

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -209,27 +209,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		},
 	);
 
-	const InteractiveContentsBlockElement = loadable(
-		() => {
-			if (
-				CAPI.elementsToHydrate.filter(
-					(element) =>
-						element._type ===
-						'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-				).length > 0
-			) {
-				return import(
-					'@frontend/web/components/InteractiveContentsBlockComponent'
-				);
-			}
-			return Promise.reject();
-		},
-		{
-			resolveComponent: (module) =>
-				module.InteractiveContentsBlockComponent,
-		},
-	);
-
 	const CalloutBlockComponent = loadable(
 		() => {
 			if (
@@ -277,11 +256,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 		CAPI.elementsToHydrate,
 		'model.dotcomrendering.pageElements.InteractiveBlockElement',
 	);
-	const interactiveContentsElement =
-		elementsByType<InteractiveContentsBlockElement>(
-			CAPI.elementsToHydrate,
-			'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-		);
 
 	return (
 		// Do you need to HydrateOnce or do you want a Portal?
@@ -354,16 +328,6 @@ export const App = ({ CAPI, ophanRecord }: Props) => {
 						format={format}
 					/>
 				</HydrateInteractiveOnce>
-			))}
-			{interactiveContentsElement.map((interactiveBlock) => (
-				<HydrateOnce rootId={interactiveBlock.elementId}>
-					<InteractiveContentsBlockElement
-						subheadingLinks={interactiveBlock.subheadingLinks}
-						endDocumentElementId={
-							interactiveBlock.endDocumentElementId
-						}
-					/>
-				</HydrateOnce>
 			))}
 
 			{CAPI.matchUrl && (

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -383,10 +383,12 @@ export const renderElement = ({
 			return [
 				true,
 				<div id={element.elementId}>
-					<InteractiveContentsBlockComponent
-						subheadingLinks={element.subheadingLinks}
-						endDocumentElementId={element.endDocumentElementId}
-					/>
+					<Island deferUntil="visible">
+						<InteractiveContentsBlockComponent
+							subheadingLinks={element.subheadingLinks}
+							endDocumentElementId={element.endDocumentElementId}
+						/>
+					</Island>
 				</div>,
 			];
 		case 'model.dotcomrendering.pageElements.MapBlockElement':

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -102,11 +102,6 @@ export const document = ({ data }: Props): string => {
 				'model.dotcomrendering.pageElements.InteractiveBlockElement',
 		},
 		{
-			chunkName: 'InteractiveContentsBlockComponent',
-			addWhen:
-				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-		},
-		{
 			chunkName: 'CalloutBlockComponent',
 			addWhen: 'model.dotcomrendering.pageElements.CalloutBlockElement',
 		},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
`InteractiveContentsBlockElement` is now an island

## Why?
🏖️ ❤️ 
