### PR TITLE
We should be using the wrapper, not the atom directly

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
@@ -17,6 +17,9 @@ const timelineUrl =
 const chartUrl =
 	'https://www.theguardian.com/technology/2020/aug/19/apple-becomes-wall-streets-first-2tn-company';
 
+const quizAtomUrl =
+	'https://www.theguardian.com/lifeandstyle/2022/jan/22/kids-quiz-wombats-square-poos-smallest-dog';
+
 const atomExpandableTests = (type, url) => {
 	describe(type, function () {
 		beforeEach(function () {
@@ -90,3 +93,48 @@ atomExpandableTests('guide', guideUrl);
 atomExpandableTests('profile', profileUrl);
 atomExpandableTests('timeline', timelineUrl);
 atomGenericTests('chart', chartUrl);
+
+describe('Why do wombats do square poos?', function () {
+	beforeEach(function () {
+		disableCMP();
+		setLocalBaseUrl();
+	});
+
+	it('when I get the answer wrong, it should display the right answer when I click Reveal', function () {
+		cy.visit(quizAtomUrl);
+		// Establish that the elements showing the results are not present
+		cy.get('[data-atom-type=knowledgequiz] fieldset')
+			.first()
+			.get('[data-answer-type=non-selected-correct-answer]')
+			.should('not.exist');
+		cy.get('[data-atom-type=knowledgequiz] fieldset')
+			.first()
+			.get('[data-answer-type=non-incorrect-answer]')
+			.should('not.exist');
+		// Click an incorrect answer
+		cy.contains('Because they have square bottoms').click();
+		// Click Reveal to show the results
+		cy.get('[data-atom-type=knowledgequiz]').contains('Reveal').click();
+		// We got the question wrong!
+		// Our choice is shown as wrong (red) and the actual correct answer is shown in green
+		cy.get('[data-answer-type=incorrect-answer]').should('exist');
+		cy.get('[data-answer-type=non-selected-correct-answer]').should(
+			'exist',
+		);
+	});
+
+	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
+		cy.visit(quizAtomUrl);
+		// Establish that the elements showing the results are not present
+		cy.get('[data-atom-type=knowledgequiz] fieldset')
+			.first()
+			.get('[data-answer-type=non-correct-selected-answer]')
+			.should('not.exist');
+		// Click the correct answer
+		cy.contains('So that their poos don’t roll away').click();
+		// Click Reveal to show the results
+		cy.get('[data-atom-type=knowledgequiz]').contains('Reveal').click();
+		// We were right!
+		cy.get('[data-answer-type=correct-selected-answer]').should('exist');
+	});
+});

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -39,6 +39,8 @@ import { GuideAtomWrapper } from '@root/src/web/components/GuideAtomWrapper.impo
 import { ChartAtomWrapper } from '@root/src/web/components/ChartAtomWrapper.importable';
 import { ProfileAtomWrapper } from '@root/src/web/components/ProfileAtomWrapper.importable';
 import { QandaAtomWrapper } from '@root/src/web/components/QandaAtomWrapper.importable';
+import { PersonalityQuizAtomWrapper } from '@root/src/web/components/PersonalityQuizAtomWrapper.importable';
+import { KnowledgeQuizAtomWrapper } from '@root/src/web/components/KnowledgeQuizAtomWrapper.importable';
 
 import {
 	WitnessVideoBlockComponent,
@@ -53,8 +55,6 @@ import {
 	InteractiveAtom,
 	InteractiveLayoutAtom,
 	VideoAtom,
-	PersonalityQuizAtom,
-	KnowledgeQuizAtom,
 } from '@guardian/atoms-rendering';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import { Figure } from '../components/Figure';
@@ -485,7 +485,7 @@ export const renderElement = ({
 				<>
 					{element.quizType === 'personality' && (
 						<Island deferUntil="visible">
-							<PersonalityQuizAtom
+							<PersonalityQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}
 								resultBuckets={element.resultBuckets}
@@ -496,7 +496,7 @@ export const renderElement = ({
 					)}
 					{element.quizType === 'knowledge' && (
 						<Island deferUntil="visible">
-							<KnowledgeQuizAtom
+							<KnowledgeQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}
 								resultGroups={element.resultGroups}


### PR DESCRIPTION
## What?
This fixes an issue introduced in an earlier PR where we broke hydration on quiz atoms

I had inadvertently missed an edit to use a wrapper component, causing the island hydration logic to throw.