### PR TITLE
Add `SpacefinderOkr1FilterNearby` test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.tsx
@@ -4,6 +4,7 @@ import { sendCommercialMetrics } from '@guardian/commercial-core';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { getCookie } from '@guardian/libs';
 import { useAB } from '@guardian/ab-react';
+import { spacefinderOkr1FilterNearby } from '@frontend/web/experiments/tests/spacefinder-okr-1-filter-nearby';
 import { useDocumentVisibilityState } from '../lib/useDocumentHidden';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 
@@ -23,6 +24,7 @@ export const CommercialMetrics: React.FC<{
 	useOnce(() => {
 		const testsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
+			spacefinderOkr1FilterNearby,
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -6,6 +6,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
+import { spacefinderOkr1FilterNearby } from '@frontend/web/experiments/tests/spacefinder-okr-1-filter-nearby';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -15,4 +16,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
+	spacefinderOkr1FilterNearby,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-1-filter-nearby.ts
+++ b/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-1-filter-nearby.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const spacefinderOkr1FilterNearby: ABTest = {
+	id: 'SpacefinderOkr1FilterNearby',
+	author: 'Simon Byford (@simonbyford)',
+	start: '2022-02-07',
+	expiry: '2022-02-21',
+	audience: 20 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'All pageviews on non-mobile, non-paid content articles',
+	successMeasure:
+		'Fixing the bug leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		"Check whether fixing a bug in spacefinder's nearby candidate filtering mechanism leads to an increase in inline programmatic revenue per 1000 pageviews",
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Introduces an A/B test in DCR which can be used to measure the impact of this change: https://github.com/guardian/frontend/pull/24592

This was the brief from Sara:

"In order to detect a statistically significant 1% change in inline programmatic revenue per 1000 pageviews we'd need a sample size of at least 7.4 million across both conditions.

We'd expect to reach these numbers after running a 10% test for 14 days.

This would mean setting up the test so that 5% of desktop web article page views were in the variant condition and 5% were in the control."

## Why?

The test definition must exist in both frontend and DCR