### PR TITLE
`Braze`

### DIFF
--- a/dotcom-rendering/src/web/components/Braze.tsx
+++ b/dotcom-rendering/src/web/components/Braze.tsx
@@ -34,7 +34,14 @@ type Props = {
 	format: ArticleFormat;
 };
 
-function shouldShow(format: ArticleFormat) {
+function shouldShowSlotBodyEnd(
+	format: ArticleFormat,
+	switches: Switches,
+	slotMachineFlags?: string,
+) {
+	if (!switches.slotBodyEnd) return false;
+	if (!parse(slotMachineFlags || '').showBodyEnd) return false;
+
 	switch (format.design) {
 		case ArticleDesign.Interactive:
 		case ArticleDesign.FullPageInteractive:
@@ -97,9 +104,11 @@ export const Braze = ({
 		);
 	}, [pageId, keywordIds]);
 
-	const showBodyEndSlot =
-		(parse(slotMachineFlags || '').showBodyEnd || switches.slotBodyEnd) &&
-		shouldShow(format);
+	const showBodyEndSlot = shouldShowSlotBodyEnd(
+		format,
+		switches,
+		slotMachineFlags,
+	);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/Braze.tsx
+++ b/dotcom-rendering/src/web/components/Braze.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { ArticleDesign, storage } from '@guardian/libs';
+import { BrazeMessagesInterface } from '@guardian/braze-components';
+import {
+	incrementWeeklyArticleCount,
+	getWeeklyArticleHistory,
+} from '@guardian/support-dotcom-components';
+import { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+import { parse } from 'src/lib/slot-machine-flags';
+import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
+import { SlotBodyEnd } from './SlotBodyEnd/SlotBodyEnd';
+import { StickyBottomBanner } from './StickyBottomBanner/StickyBottomBanner';
+import { hasOptedOutOfArticleCount } from '../lib/contributions';
+import { incrementDailyArticleCount } from '../lib/dailyArticleCount';
+import { useOnce } from '../lib/useOnce';
+
+type Props = {
+	idApiUrl: string;
+	contentType: string;
+	sectionName?: string;
+	shouldHideReaderRevenue: boolean;
+	isMinuteArticle: boolean;
+	isPaidContent: boolean;
+	tags: TagType[];
+	contributionsServiceUrl: string;
+	stage: string;
+	section: string;
+	isPreview: boolean;
+	isSensitive: boolean;
+	switches: Switches;
+	keywordIds: string;
+	pageId: string;
+	slotMachineFlags?: string;
+	format: ArticleFormat;
+};
+
+function shouldShow(format: ArticleFormat) {
+	switch (format.design) {
+		case ArticleDesign.Interactive:
+		case ArticleDesign.FullPageInteractive:
+			return false;
+		default:
+			return true;
+	}
+}
+
+export const Braze = ({
+	idApiUrl,
+	contentType,
+	sectionName,
+	shouldHideReaderRevenue,
+	isMinuteArticle,
+	isPaidContent,
+	tags,
+	contributionsServiceUrl,
+	stage,
+	section,
+	isPreview,
+	isSensitive,
+	switches,
+	keywordIds,
+	pageId,
+	slotMachineFlags,
+	format,
+}: Props) => {
+	const [brazeMessages, setBrazeMessages] =
+		useState<Promise<BrazeMessagesInterface>>();
+
+	const [asyncArticleCount, setAsyncArticleCount] =
+		useState<Promise<WeeklyArticleHistory | undefined>>();
+
+	useOnce(() => {
+		setBrazeMessages(buildBrazeMessages(idApiUrl));
+	}, [idApiUrl]);
+
+	// Log an article view using the Slot Machine client lib
+	// This function must be called once per article serving.
+	// We should monitor this function call to ensure it only happens within an
+	// article pages when other pages are supported by DCR.
+	useEffect(() => {
+		const incrementArticleCountsIfConsented = async () => {
+			const hasOptedOut = await hasOptedOutOfArticleCount();
+			if (!hasOptedOut) {
+				incrementDailyArticleCount();
+				incrementWeeklyArticleCount(
+					storage.local,
+					pageId,
+					keywordIds.split(','),
+				);
+			}
+		};
+
+		setAsyncArticleCount(
+			incrementArticleCountsIfConsented().then(() =>
+				getWeeklyArticleHistory(storage.local),
+			),
+		);
+	}, [pageId, keywordIds]);
+
+	const showBodyEndSlot =
+		(parse(slotMachineFlags || '').showBodyEnd || switches.slotBodyEnd) &&
+		shouldShow(format);
+
+	return (
+		<>
+			{showBodyEndSlot && (
+				<SlotBodyEnd
+					contentType={contentType}
+					sectionName={sectionName}
+					sectionId={section}
+					shouldHideReaderRevenue={shouldHideReaderRevenue}
+					isMinuteArticle={isMinuteArticle}
+					isPaidContent={isPaidContent}
+					tags={tags}
+					contributionsServiceUrl={contributionsServiceUrl}
+					brazeMessages={brazeMessages}
+					idApiUrl={idApiUrl}
+					stage={stage}
+					asyncArticleCount={asyncArticleCount}
+				/>
+			)}
+
+			<StickyBottomBanner
+				brazeMessages={brazeMessages}
+				asyncArticleCount={asyncArticleCount}
+				contentType={contentType}
+				sectionName={sectionName}
+				section={section}
+				tags={tags}
+				isPaidContent={isPaidContent}
+				isPreview={!!isPreview}
+				shouldHideReaderRevenue={shouldHideReaderRevenue}
+				isMinuteArticle={isMinuteArticle}
+				isSensitive={isSensitive}
+				contributionsServiceUrl={contributionsServiceUrl}
+				idApiUrl={idApiUrl}
+				switches={switches}
+			/>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/components/Braze.tsx
+++ b/dotcom-rendering/src/web/components/Braze.tsx
@@ -6,7 +6,7 @@ import {
 	getWeeklyArticleHistory,
 } from '@guardian/support-dotcom-components';
 import { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import { parse } from 'src/lib/slot-machine-flags';
+import { parse } from '@root/src/lib/slot-machine-flags';
 import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 import { SlotBodyEnd } from './SlotBodyEnd/SlotBodyEnd';
 import { StickyBottomBanner } from './StickyBottomBanner/StickyBottomBanner';

--- a/dotcom-rendering/src/web/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionContainer.importable.tsx
@@ -1,7 +1,7 @@
 import { getCookie } from '@guardian/libs';
 import { Discussion } from '@root/src/web/components/Discussion';
 import { DiscussionWhenSignedIn } from '@root/src/web/components/DiscussionWhenSignedIn';
-import type { Props as DiscussionProps } from 'src/web/components/Discussion';
+import type { Props as DiscussionProps } from '@root/src/web/components/Discussion';
 
 /**
  * DiscussionContainer

--- a/dotcom-rendering/src/web/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionWhenSignedIn.tsx
@@ -1,6 +1,6 @@
 import { joinUrl } from '@guardian/libs';
 import { Discussion } from '@root/src/web/components/Discussion';
-import type { Props as DiscussionProps } from 'src/web/components/Discussion';
+import type { Props as DiscussionProps } from '@root/src/web/components/Discussion';
 import { useApi } from '../lib/useApi';
 
 // eslint-disable-next-line react/destructuring-assignment

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -149,7 +149,14 @@ export const SlotBodyEnd = ({
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount]);
 
 	if (SelectedEpic) {
-		return <SelectedEpic />;
+		// The id on this aside element is used to add css in this file
+		// https://github.com/guardian/dotcom-rendering/blob/8f71e12d717f118d095834362f0fed58ea77ee3b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+		// It was added here after we removed the old Portal pattern and moved to an Island
+		return (
+			<aside id="slot-body-end">
+				<SelectedEpic />
+			</aside>
+		);
 	}
 
 	return null;

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { css } from '@emotion/react';
 import { cmp } from '@guardian/consent-management-platform';
 import {
 	canShowRRBanner,
@@ -22,6 +23,7 @@ import type {
 	BrazeArticleContext,
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
+import { getZIndexImportant } from '@root/src/web/lib/getZIndex';
 import { useSignInGateWillShow } from '@root/src/web/lib/useSignInGateWillShow';
 import { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { BrazeBanner, canShowBrazeBanner } from './BrazeBanner';
@@ -49,6 +51,23 @@ type RRBannerConfig = {
 	canShowFn: CanShowFunctionType<BannerProps>;
 	isEnabled: (switches: CAPIType['config']['switches']) => boolean;
 };
+
+// The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
+// Overflow is visible because puzzles banner needs it to render correctly
+const bannerWrapper = css`
+	/* stylelint-disable-next-line declaration-no-important */
+	position: fixed !important;
+	bottom: 0;
+	${getZIndexImportant('banner')}
+	max-height: 100vh;
+	overflow: visible;
+	/* stylelint-disable-next-line declaration-no-important */
+	width: 100% !important;
+	/* stylelint-disable-next-line declaration-no-important */
+	background: none !important;
+	/* stylelint-disable-next-line declaration-no-important */
+	top: auto !important;
+`;
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
 	const item = localStorage.getItem(`gu.prefs.${key}`) as undefined | string;
@@ -278,7 +297,11 @@ export const StickyBottomBanner = ({
 	}, [isSignedIn, asyncCountryCode, brazeMessages, asyncArticleCount]);
 
 	if (SelectedBanner) {
-		return <SelectedBanner />;
+		return (
+			<aside id="bottom-banner" css={bannerWrapper}>
+				<SelectedBanner />
+			</aside>
+		);
 	}
 
 	return null;

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -36,18 +36,14 @@ import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { DiscussionContainer } from '@root/src/web/components/DiscussionContainer.importable';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
-import {
-	Stuck,
-	SendToBack,
-	BannerWrapper,
-} from '@root/src/web/layouts/lib/stickiness';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Island } from '../components/Island';
 import { MostViewedRightWrapper } from '../components/MostViewedRightWrapper.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
+import { Braze } from '../components/Braze';
 
 const StandardGrid = ({
 	children,
@@ -299,10 +295,6 @@ export const CommentLayout = ({
 		sharedAdTargeting: CAPI.config.sharedAdTargeting,
 		adUnit: CAPI.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -556,9 +548,6 @@ export const CommentLayout = ({
 										webTitle={CAPI.webTitle}
 										ajaxUrl={CAPI.config.ajaxUrl}
 									/>
-									{showBodyEndSlot && (
-										<div id="slot-body-end" />
-									)}
 									<Lines count={4} effect="straight" />
 									<SubMeta
 										palette={palette}
@@ -733,7 +722,28 @@ export const CommentLayout = ({
 				/>
 			</ElementContainer>
 
-			<BannerWrapper />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -25,7 +25,7 @@ import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
-import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { Stuck } from '@root/src/web/layouts/lib/stickiness';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 
 import { renderElement } from '../lib/renderElement';
@@ -34,6 +34,7 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 import { Island } from '../components/Island';
+import { Braze } from '../components/Braze';
 
 interface Props {
 	CAPI: CAPIType;
@@ -333,7 +334,28 @@ export const FullPageInteractiveLayout = ({
 				/>
 			</ElementContainer>
 
-			<BannerWrapper />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -32,9 +32,7 @@ import { Hide } from '@root/src/web/components/Hide';
 import { GuardianLabsLines } from '@frontend/web/components/GuardianLabsLines';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { parse } from '@frontend/lib/slot-machine-flags';
 
-import { BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import {
 	decideLineCount,
 	decideLineEffect,
@@ -44,6 +42,7 @@ import { ImmersiveHeader } from './headers/ImmersiveHeader';
 import { Island } from '../components/Island';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Braze } from '../components/Braze';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -208,10 +207,6 @@ export const ImmersiveLayout = ({
 		sharedAdTargeting: CAPI.config.sharedAdTargeting,
 		adUnit: CAPI.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -382,7 +377,6 @@ export const ImmersiveLayout = ({
 									webTitle={CAPI.webTitle}
 									ajaxUrl={CAPI.config.ajaxUrl}
 								/>
-								{showBodyEndSlot && <div id="slot-body-end" />}
 								<Lines count={4} effect="straight" />
 								<SubMeta
 									palette={palette}
@@ -554,7 +548,28 @@ export const ImmersiveLayout = ({
 				/>
 			</ElementContainer>
 
-			<BannerWrapper />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -19,7 +19,6 @@ import {
 	labelStyles as adLabelStyles,
 	adCollapseStyles,
 } from '@root/src/web/components/AdSlot';
-import { BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { ImmersiveHeader } from './headers/ImmersiveHeader';
@@ -36,6 +35,7 @@ import { decideLineEffect, decideLineCount } from '../lib/layoutHelpers';
 import { Standfirst } from '../components/Standfirst';
 import { Caption } from '../components/Caption';
 import { Island } from '../components/Island';
+import { Braze } from '../components/Braze';
 
 const InteractiveImmersiveGrid = ({
 	children,
@@ -476,7 +476,28 @@ export const InteractiveImmersiveLayout = ({
 				/>
 			</ElementContainer>
 
-			<BannerWrapper />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -47,7 +47,7 @@ import {
 	decideLineEffect,
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { Stuck } from '@root/src/web/layouts/lib/stickiness';
 import {
 	interactiveGlobalStyles,
 	interactiveLegacyClasses,
@@ -55,6 +55,7 @@ import {
 import { Island } from '../components/Island';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Braze } from '../components/Braze';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -679,7 +680,28 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				/>
 			</ElementContainer>
 
-			<BannerWrapper data-print-layout="hide" />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer data-print-layout="hide" />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -38,18 +38,13 @@ import { Pagination } from '@frontend/web/components/Pagination';
 import { KeyEventsContainer } from '@frontend/web/components/KeyEventsContainer';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import {
-	Stuck,
-	SendToBack,
-	BannerWrapper,
-} from '@root/src/web/layouts/lib/stickiness';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import Accordion from '@guardian/common-rendering/src/components/accordion';
 import { Hide } from '@guardian/source-react-components';
 import { Placeholder } from '../components/Placeholder';
@@ -57,6 +52,7 @@ import { ContainerLayout } from '../components/ContainerLayout';
 import { Island } from '../components/Island';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Braze } from '../components/Braze';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -360,10 +356,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		sharedAdTargeting: CAPI.config.sharedAdTargeting,
 		adUnit: CAPI.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -813,9 +805,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 													format={format}
 												/>
 											)}
-										{showBodyEndSlot && (
-											<div id="slot-body-end" />
-										)}
 										<Lines
 											data-print-layout="hide"
 											count={4}
@@ -1033,9 +1022,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 															format={format}
 														/>
 													)}
-												{showBodyEndSlot && (
-													<div id="slot-body-end" />
-												)}
+
 												<Lines
 													data-print-layout="hide"
 													count={4}
@@ -1221,7 +1208,28 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				/>
 			</ElementContainer>
 
-			<BannerWrapper data-print-layout="hide" />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer data-print-layout="hide" />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -36,23 +36,19 @@ import { DiscussionContainer } from '@root/src/web/components/DiscussionContaine
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import {
-	Stuck,
-	SendToBack,
-	BannerWrapper,
-} from '@root/src/web/layouts/lib/stickiness';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { Island } from '../components/Island';
 import { MostViewedRightWrapper } from '../components/MostViewedRightWrapper.importable';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Braze } from '../components/Braze';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -245,10 +241,6 @@ export const ShowcaseLayout = ({
 		sharedAdTargeting: CAPI.config.sharedAdTargeting,
 		adUnit: CAPI.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -539,7 +531,6 @@ export const ShowcaseLayout = ({
 									webTitle={CAPI.webTitle}
 									ajaxUrl={CAPI.config.ajaxUrl}
 								/>
-								{showBodyEndSlot && <div id="slot-body-end" />}
 								<Lines count={4} effect="straight" />
 								<SubMeta
 									palette={palette}
@@ -713,7 +704,28 @@ export const ShowcaseLayout = ({
 				/>
 			</ElementContainer>
 
-			<BannerWrapper />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -41,20 +41,20 @@ import { LabsHeader } from '@frontend/web/components/LabsHeader';
 import { GuardianLabsLines } from '@frontend/web/components/GuardianLabsLines';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { Stuck } from '@root/src/web/layouts/lib/stickiness';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { Island } from '../components/Island';
 import { MostViewedRightWrapper } from '../components/MostViewedRightWrapper.importable';
 import { GetMatchStats } from '../components/GetMatchStats.importable';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Braze } from '../components/Braze';
 
 const StandardGrid = ({
 	children,
@@ -322,10 +322,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		sharedAdTargeting: CAPI.config.sharedAdTargeting,
 		adUnit: CAPI.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -637,8 +633,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										/>
 									</Island>
 								)}
-
-								{showBodyEndSlot && <div id="slot-body-end" />}
 								<Lines
 									data-print-layout="hide"
 									count={4}
@@ -829,7 +823,28 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				/>
 			</ElementContainer>
 
-			<BannerWrapper data-print-layout="hide" />
+			<Island clientOnly={true}>
+				<Braze
+					idApiUrl={CAPI.config.idApiUrl}
+					contentType={CAPI.contentType}
+					sectionName={CAPI.sectionName}
+					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					isMinuteArticle={CAPI.pageType.isMinuteArticle}
+					isPaidContent={CAPI.pageType.isPaidContent}
+					tags={CAPI.tags}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					stage={CAPI.config.stage}
+					section={CAPI.config.section}
+					isPreview={CAPI.pageType.isPreview}
+					isSensitive={CAPI.config.isSensitive}
+					switches={CAPI.config.switches}
+					keywordIds={CAPI.config.keywordIds}
+					pageId={CAPI.pageId}
+					slotMachineFlags={CAPI.slotMachineFlags}
+					format={format}
+				/>
+			</Island>
+
 			<MobileStickyContainer data-print-layout="hide" />
 		</>
 	);

--- a/dotcom-rendering/src/web/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/web/layouts/lib/stickiness.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { getZIndex, getZIndexImportant } from '@frontend/web/lib/getZIndex';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
 	children?: React.ReactNode;
@@ -29,23 +29,6 @@ const headerWrapper = css`
 	${getZIndex('headerWrapper')}
 `;
 
-// The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
-// Overflow is visible because puzzles banner needs it to render correctly
-const bannerWrapper = css`
-	/* stylelint-disable-next-line declaration-no-important */
-	position: fixed !important;
-	bottom: 0;
-	${getZIndexImportant('banner')}
-	max-height: 100vh;
-	overflow: visible;
-	/* stylelint-disable-next-line declaration-no-important */
-	width: 100% !important;
-	/* stylelint-disable-next-line declaration-no-important */
-	background: none !important;
-	/* stylelint-disable-next-line declaration-no-important */
-	top: auto !important;
-`;
-
 export const Stuck = ({ children, zIndex }: StuckProps) => (
 	<div css={[stickyStyles, addZindex(zIndex), whiteBackground]}>
 		{children}
@@ -54,10 +37,4 @@ export const Stuck = ({ children, zIndex }: StuckProps) => (
 
 export const SendToBack = ({ children }: Props) => (
 	<div css={headerWrapper}>{children}</div>
-);
-
-export const BannerWrapper = ({ children }: Props) => (
-	<aside id="bottom-banner" css={bannerWrapper}>
-		{children}
-	</aside>
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces `Braze` a component designed to hold the shared logic between `SlotBodyEnd` and `StickyBottomBanner`

## Why?
Because I think this is the safest refactor in order to make progress towards deleting `App.tsx`. It probably is possible to isolate each of these components and remove the global state shared between them but this logic is complex and I decided to take this approach as a stepping stone towards this goal instead of diving in.

## `slot-body-end`
This id was previously used by the `Portal` component as the marker for where to insert the element. But it has also been picked up as an id that can be used for some css styling. By removing the `Portal` I would break this styling code so I have added an `aside` wrapper around the component.

## `bannerWrapper`
This css previously existed in the `stickiness` lib and was added in the layout files. I've moved it down into the banner component directly as this seemed the more logical location for this code.

## `shouldShowSlotBodyEnd`
Previously we rendered the `SlotBodyEnd` and `StickyBottomBanner` components independently but they did not always appear together. For `Interactive` and `FullPageInteractive` articles `SlotBodyEnd` is not included and we also checked some flags. This function encapsulates this logic.
