### PR TITLE
`getCmp`

### DIFF
--- a/dotcom-rendering/src/web/lib/getCmp.ts
+++ b/dotcom-rendering/src/web/lib/getCmp.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns the cmp object so you don't need to import it
+ *
+ * The @guardian/consent-management-platform sets the window.guCmpHotFix
+ * value to equal the `cmp` object.
+ *
+ * If this function is called before this value has been set then an error
+ * is thrown allowing us to gather stats on any race conditions that could
+ * exist with this pattern
+ *
+ * @returns the cmp object
+ */
+export const getCmp = () => {
+	if (typeof window === 'undefined') return undefined;
+	if (!window.guCmpHotFix) {
+		window.guardian.modules.sentry.reportError(
+			new Error(
+				`Tried to access window.guCmpHotFix but it was falsy: ${window.guCmpHotFix}. This is indicative of a race condition`,
+			),
+			'cmp',
+		);
+	}
+	return window.guCmpHotFix;
+};

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -1,5 +1,9 @@
 import { WindowGuardianConfig } from '@root/src/model/window-guardian';
 import { ReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
+import type {
+	Callback,
+	CMP,
+} from '@guardian/consent-management-platform/dist/types';
 
 declare global {
 	/* ~ Here, declare things that go in the global namespace, or augment
@@ -58,6 +62,12 @@ declare global {
 		 */
 		guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
 		Cypress: any; // for checking if running within cypress
+		guCmpHotFix: {
+			initialised?: boolean;
+			cmp?: CMP;
+			onConsentChange?: (fn: Callback) => void;
+			getConsentFor?: (fn: Callback) => void;
+		};
 	}
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds a small lib called `getCmp` which returns the version of the `cmp` object that gets placed on `window.guCmpHotFix`

## Why?
As we move more code over to the `Island` pattern we are starting to hit issues where the cmp lib is not server safe. If we refactor DCR's access to cmp to use this window object then this allows us to avoid the import, which is where we're getting errors on the server.

This abstraction is a helper utility to make that refactor. The main thing it provides is a check and a call to Sentry in the event that the property is not available. We believe that the property will always be there - we run `bootCmp` very early - but it might not be and we want to be aware if this happens. If we do see these errors, then it suggests we have a race condition and that we will need to implement some form of queue while the code waits for this value to be set.
