### PR TITLE
Wombat poo problem

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
@@ -101,7 +101,7 @@ describe('Why do wombats do square poos?', function () {
 	});
 
 	it('when I get the answer wrong, it should display the right answer when I click Reveal', function () {
-		cy.visit(quizAtomUrl);
+		cy.visit(`/Article?url=${quizAtomUrl}`);
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()

--- a/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
@@ -102,7 +102,6 @@ describe('Why do wombats do square poos?', function () {
 
 	it('when I get the answer wrong, it should display the right answer when I click Reveal', function () {
 		cy.visit(quizAtomUrl);
-		cy.scrollTo('0', '200px');
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()
@@ -130,7 +129,6 @@ describe('Why do wombats do square poos?', function () {
 
 	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
 		cy.visit(quizAtomUrl);
-		cy.scrollTo('0', '200px');
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()

--- a/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
@@ -102,6 +102,11 @@ describe('Why do wombats do square poos?', function () {
 
 	it('when I get the answer wrong, it should display the right answer when I click Reveal', function () {
 		cy.visit(quizAtomUrl);
+		cy.scrollTo('0', '200px');
+		// Wait for hydration
+		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
+			.first()
+			.should('have.attr', 'data-gu-ready', 'true');
 		// Establish that the elements showing the results are not present
 		cy.get('[data-atom-type=knowledgequiz] fieldset')
 			.first()
@@ -125,6 +130,11 @@ describe('Why do wombats do square poos?', function () {
 
 	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
 		cy.visit(quizAtomUrl);
+		cy.scrollTo('0', '200px');
+		// Wait for hydration
+		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
+			.first()
+			.should('have.attr', 'data-gu-ready', 'true');
 		// Establish that the elements showing the results are not present
 		cy.get('[data-atom-type=knowledgequiz] fieldset')
 			.first()

--- a/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/atom.interactivity.spec.js
@@ -128,7 +128,7 @@ describe('Why do wombats do square poos?', function () {
 	});
 
 	it('when I get the answer right, it should commend my skills when I click Reveal', function () {
-		cy.visit(quizAtomUrl);
+		cy.visit(`/Article?url=${quizAtomUrl}`);
 		// Wait for hydration
 		cy.get('gu-island[name=KnowledgeQuizAtomWrapper]')
 			.first()

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -486,7 +486,7 @@ export const renderElement = ({
 				true,
 				<>
 					{element.quizType === 'personality' && (
-						<Island deferUntil="visible">
+						<Island>
 							<PersonalityQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}
@@ -497,7 +497,7 @@ export const renderElement = ({
 						</Island>
 					)}
 					{element.quizType === 'knowledge' && (
-						<Island deferUntil="visible">
+						<Island>
 							<KnowledgeQuizAtomWrapper
 								id={element.id}
 								questions={element.questions}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We were trying to answer the question [Why do wombats do square poos?](https://www.theguardian.com/lifeandstyle/2022/jan/22/kids-quiz-wombats-square-poos-smallest-dog) but the test was failing because the elements were not interactive

The solution (to the test failing) was to ask Cypress to wait for hydration to complete before trying to interact with the page

## Why?
Why do they do square poos? It's [so it doesn't roll away](https://www.bbc.co.uk/newsround/55857258).

## Why this PR?
Because @joecowton1 was surprised when his PR failed with questions about square poo and raised it in the Dotcom channel
