### PR TITLE
Tweak css to align bullets correctly in both standfirst and textBlockComponent

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -23,7 +23,7 @@ export const Article = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -39,7 +39,7 @@ export const Comment = () => {
 					design: ArticleDesign.Comment,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -55,7 +55,7 @@ export const Letter = () => {
 					design: ArticleDesign.Letter,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Letter standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Letter standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -71,7 +71,7 @@ export const Feature = () => {
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -87,7 +87,7 @@ export const Immersive = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -103,7 +103,7 @@ export const Review = () => {
 					design: ArticleDesign.Review,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -119,7 +119,7 @@ export const LiveBlog = () => {
 					design: ArticleDesign.LiveBlog,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="<p>This is how a Liveblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p><ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
+				standfirst="<p>This is how a Liveblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p> <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -148,7 +148,7 @@ export const DeadBlog = () => {
 					design: ArticleDesign.DeadBlog,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="<p>This is how a Deadblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p><ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
+				standfirst="<p>This is how a Deadblog with bullets looks. Aut explicabo officia delectus omnis repellendus voluptas</p> <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -164,7 +164,7 @@ export const Interview = () => {
 					design: ArticleDesign.Interview,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -180,7 +180,7 @@ export const Analysis = () => {
 					design: ArticleDesign.Analysis,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -196,7 +196,7 @@ export const Media = () => {
 					design: ArticleDesign.Media,
 					theme: ArticlePillar.Culture,
 				}}
-				standfirst="This is how Media standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Media standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -212,7 +212,7 @@ export const Recipe = () => {
 					design: ArticleDesign.Recipe,
 					theme: ArticlePillar.Lifestyle,
 				}}
-				standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -228,7 +228,7 @@ export const MatchReport = () => {
 					design: ArticleDesign.MatchReport,
 					theme: ArticlePillar.Sport,
 				}}
-				standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -244,7 +244,7 @@ export const Quiz = () => {
 					design: ArticleDesign.Quiz,
 					theme: ArticlePillar.Lifestyle,
 				}}
-				standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -260,7 +260,7 @@ export const SpecialReport = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticleSpecial.SpecialReport,
 				}}
-				standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -276,7 +276,7 @@ export const Editorial = () => {
 					design: ArticleDesign.Editorial,
 					theme: ArticlePillar.Opinion,
 				}}
-				standfirst="This is how Editorial standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how Editorial standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);
@@ -292,7 +292,7 @@ export const PhotoEssay = () => {
 					design: ArticleDesign.PhotoEssay,
 					theme: ArticlePillar.News,
 				}}
-				standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+				standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
 			/>
 		</ElementContainer>
 	);

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -30,9 +30,9 @@ const nestedStyles = (palette: Palette) => css`
 	li:before {
 		display: inline-block;
 		content: '';
-		border-radius: 6px;
-		height: ${space[3]}px;
-		width: ${space[3]}px;
+		border-radius: 50%;
+		height: 12px;
+		width: 12px;
 		margin-right: ${space[2]}px;
 		background-color: ${palette.background.bulletStandfirst};
 		margin-left: -20px;
@@ -49,9 +49,9 @@ const nestedStyles = (palette: Palette) => css`
 	[data-dcr-style='bullet'] {
 		display: inline-block;
 		content: '';
-		border-radius: 100%;
-		height: 15.2px;
-		width: 15.2px;
+		border-radius: 50%;
+		height: 13px;
+		width: 13px;
 		margin-right: 2px;
 		background-color: ${palette.background.bulletStandfirst};
 	}
@@ -104,6 +104,11 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 							max-width: 460px;
 						}
 						color: ${palette.text.standfirst};
+
+						li:before {
+							height: 17px;
+							width: 17px;
+						}
 					`;
 			}
 
@@ -134,6 +139,10 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;
 						color: ${palette.text.standfirst};
+						li:before {
+							height: 15px;
+							width: 15px;
+						}
 					`;
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -157,9 +157,9 @@ export const TextBlockComponent = ({
 				li:before {
 					display: inline-block;
 					content: '';
-					border-radius: 6px;
-					height: 12px;
-					width: 12px;
+					border-radius: 50%;
+					height: 13px;
+					width: 13px;
 					margin-right: 8px;
 					background-color: ${neutral[86]};
 					margin-left: -20px;
@@ -185,9 +185,9 @@ export const TextBlockComponent = ({
 				[data-dcr-style='bullet'] {
 					display: inline-block;
 					content: '';
-					border-radius: 100%;
-					height: 15.2px;
-					width: 15.2px;
+					border-radius: 50%;
+					height: 13px;
+					width: 13px;
 					margin-right: 0.2px;
 					background-color: ${decidePalette(format).background
 						.bullet};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes height and width of bullets

## Why?
They were a little too small

### Before
Standfirst: 
![image](https://user-images.githubusercontent.com/20658471/152560154-d8d4d1fb-65f7-422c-8113-100344edc0e2.png)

### After
Standfirst:
![image](https://user-images.githubusercontent.com/20658471/152560214-287a0c47-1f9a-46ad-8b32-b8421fdf625f.png)
