### PR TITLE
Fix caption svg alignment

### DIFF
--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -159,7 +159,6 @@ const iconStyle = (palette: Palette) => css`
 	::before {
 		content: ' ';
 		display: block;
-		padding-top: 72.222%;
 		padding-top: ${pictureRatio}%;
 	}
 	svg {

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -152,7 +152,7 @@ const iconStyle = (palette: Palette) => css`
 	display: inline-block;
 	/* vertical-align: middle; */
 	height: 10px;
-    width: 14px;
+	width: 14px;
 	svg {
 		height: 100%;
 		width: 100%;

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -151,10 +151,10 @@ const iconStyle = (palette: Palette) => css`
 	margin-right: ${space[1]}px;
 	display: inline-block;
 	position: relative;
-    width: 1em;
-    vertical-align: baseline;
+	width: 1em;
+	vertical-align: baseline;
 	::before {
-		content: " ";
+		content: ' ';
 		display: block;
 		padding-top: 72.222%;
 	}
@@ -171,7 +171,7 @@ const iconStyle = (palette: Palette) => css`
 
 const videoIconStyle = css`
 	::before {
-		content: " ";
+		content: ' ';
 		display: block;
 		padding-top: 72.222%;
 	}

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -150,16 +150,19 @@ const iconStyle = (palette: Palette) => css`
 	fill: ${palette.fill.cameraCaptionIcon};
 	margin-right: ${space[1]}px;
 	display: inline-block;
-	vertical-align: middle;
+	/* vertical-align: middle; */
+	height: 10px;
+    width: 14px;
 	svg {
-		width: 14px;
-		display: inline-block;
+		height: 100%;
+		width: 100%;
 	}
 `;
 
 const videoIconStyle = css`
 	svg {
-		height: 11px;
+		height: 100%;
+		width: 100%;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -146,6 +146,9 @@ const hideIconBelowLeftCol = css`
 	}
 `;
 
+const pictureRatio = (13 / 18) * 100;
+const videoRatio = (23 / 36) * 100;
+
 const iconStyle = (palette: Palette) => css`
 	fill: ${palette.fill.cameraCaptionIcon};
 	margin-right: ${space[1]}px;
@@ -157,6 +160,7 @@ const iconStyle = (palette: Palette) => css`
 		content: ' ';
 		display: block;
 		padding-top: 72.222%;
+		padding-top: ${pictureRatio}%;
 	}
 	svg {
 		top: 0px;
@@ -170,19 +174,9 @@ const iconStyle = (palette: Palette) => css`
 `;
 
 const videoIconStyle = css`
+	width: 1.1em;
 	::before {
-		content: ' ';
-		display: block;
-		padding-top: 72.222%;
-	}
-	svg {
-		top: 0px;
-		right: 0px;
-		bottom: 0px;
-		left: 0px;
-		width: 100%;
-		position: absolute;
-		height: 100%;
+		padding-top: ${videoRatio}%;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -150,19 +150,39 @@ const iconStyle = (palette: Palette) => css`
 	fill: ${palette.fill.cameraCaptionIcon};
 	margin-right: ${space[1]}px;
 	display: inline-block;
-	/* vertical-align: middle; */
-	height: 10px;
-	width: 14px;
+	position: relative;
+    width: 1em;
+    vertical-align: baseline;
+	::before {
+		content: " ";
+		display: block;
+		padding-top: 72.222%;
+	}
 	svg {
-		height: 100%;
+		top: 0px;
+		right: 0px;
+		bottom: 0px;
+		left: 0px;
 		width: 100%;
+		position: absolute;
+		height: 100%;
 	}
 `;
 
 const videoIconStyle = css`
+	::before {
+		content: " ";
+		display: block;
+		padding-top: 72.222%;
+	}
 	svg {
-		height: 100%;
+		top: 0px;
+		right: 0px;
+		bottom: 0px;
+		left: 0px;
 		width: 100%;
+		position: absolute;
+		height: 100%;
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Aligns svgs with caption text better

## Why?
Was slightly off - should align with the cap height

### Before
![image](https://user-images.githubusercontent.com/20658471/152569295-2a08f273-f04a-41d6-b7fe-1807530a1845.png)

### After
![image](https://user-images.githubusercontent.com/20658471/152569342-0a249eb4-a91c-43fb-b1df-a7ed605581b5.png)
![image](https://user-images.githubusercontent.com/20658471/152569403-8d41127f-81e5-488b-9b05-f92ebaa09071.png)
