### PR TITLE
Email signups in AR should take caption from the alt field instead of the caption field

### DIFF
--- a/apps-rendering/src/components/emailSignup.tsx
+++ b/apps-rendering/src/components/emailSignup.tsx
@@ -32,8 +32,8 @@ const EmailSignupEmbed: FC<Props> = ({ embed }) => (
 			height="52"
 			title={withDefault('Email newsletter signup embed')(embed.alt)}
 		></iframe>
-		{maybeRender(embed.caption, (caption) => (
-			<figcaption css={captionStyles}>{caption}</figcaption>
+		{maybeRender(embed.alt, (alt) => (
+			<figcaption css={captionStyles}>{alt}</figcaption>
 		))}
 	</figure>
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Uses the `alt` field from CAPI to render an email signup's caption, instead of the `caption` field

## Why?

* `caption` is currently unavailable in the CAPI model used by AR
* Previously, `genericEmbed` was also taking the caption content from the `alt` field