### PR TITLE
tidy up meta container in AR and fix size of bullets for Lists

### DIFF
--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -162,7 +162,7 @@ export ASSETS_MANIFEST="/opt/${appName}/manifest.json"
 			recordName: props.recordPrefix,
 			ttl: Duration.hours(1),
 		});
-		const defaultChild = recordSet.node.defaultChild;
+    const defaultChild = recordSet.node.defaultChild as CfnElement;
 		defaultChild.overrideLogicalId('DnsRecord');
 	}
 }

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -162,7 +162,7 @@ export ASSETS_MANIFEST="/opt/${appName}/manifest.json"
 			recordName: props.recordPrefix,
 			ttl: Duration.hours(1),
 		});
-		const defaultChild = recordSet.node.defaultChild as CfnElement;
+		const defaultChild = recordSet.node.defaultChild;
 		defaultChild.overrideLogicalId('DnsRecord');
 	}
 }

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -162,7 +162,7 @@ export ASSETS_MANIFEST="/opt/${appName}/manifest.json"
 			recordName: props.recordPrefix,
 			ttl: Duration.hours(1),
 		});
-    const defaultChild = recordSet.node.defaultChild as CfnElement;
+		const defaultChild = recordSet.node.defaultChild as CfnElement;
 		defaultChild.overrideLogicalId('DnsRecord');
 	}
 }

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -37,6 +37,9 @@ const styles = (
 	border-left: 1px solid ${borderColor};
 	padding-top: ${remSpace[3]};
 	color: ${colour};
+	line-height: 1;
+	padding-bottom: 0;
+    padding-right: 0;
 	${darkModeCss`
         border-left: 1px solid ${darkBorderColour};
     `}

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -38,7 +38,7 @@ const styles = (
 	padding-top: ${remSpace[3]};
 	color: ${colour};
 	padding-bottom: 0;
-    padding-right: 0;
+	padding-right: 0;
 	line-height: 0.8;
 	height: max-content;
 	${darkModeCss`

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -37,9 +37,10 @@ const styles = (
 	border-left: 1px solid ${borderColor};
 	padding-top: ${remSpace[3]};
 	color: ${colour};
-	line-height: 1;
 	padding-bottom: 0;
     padding-right: 0;
+	line-height: 0.8;
+	height: max-content;
 	${darkModeCss`
         border-left: 1px solid ${darkBorderColour};
     `}
@@ -50,6 +51,7 @@ const bubbleStyles = (colour: string): SerializedStyles => css`
 	display: block;
 	margin-left: auto;
 	fill: ${colour};
+	margin-bottom: ${remSpace[1]};
 `;
 
 const blogStyles = (color: string): SerializedStyles => css`

--- a/apps-rendering/src/components/dateline.tsx
+++ b/apps-rendering/src/components/dateline.tsx
@@ -38,8 +38,9 @@ const commentDatelineStyles = css`
 `;
 
 const blogDatelineStyles = (color: string): SerializedStyles => css`
-	${textSans.xxsmall()}
+	${textSans.xxsmall({lineHeight: "tight"})}
 	color: ${color};
+	display: block;
 
 	${from.desktop} {
 		color: ${neutral[20]};

--- a/apps-rendering/src/components/dateline.tsx
+++ b/apps-rendering/src/components/dateline.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const darkStyles = darkMode`
-    color: ${neutral[60]};
+	color: ${neutral[60]};
 `;
 
 const styles = css`

--- a/apps-rendering/src/components/dateline.tsx
+++ b/apps-rendering/src/components/dateline.tsx
@@ -38,7 +38,7 @@ const commentDatelineStyles = css`
 `;
 
 const blogDatelineStyles = (color: string): SerializedStyles => css`
-	${textSans.xxsmall({lineHeight: "tight"})}
+	${textSans.xxsmall({ lineHeight: 'tight' })}
 	color: ${color};
 	display: block;
 

--- a/apps-rendering/src/components/list.tsx
+++ b/apps-rendering/src/components/list.tsx
@@ -16,9 +16,10 @@ const styles: SerializedStyles = css`
 	> li::before {
 		display: inline-block;
 		content: '';
-		border-radius: 0.5rem;
-		height: 1rem;
-		width: 1rem;
+		border-radius: 50%;
+		height: 0.75em;
+		width: 0.75em;
+		transform: translateY(-0.1em);
 		margin-right: ${remSpace[2]};
 		background-color: ${neutral[86]};
 		margin-left: -${remSpace[6]};

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -96,6 +96,7 @@ const liveBlogPadding = css`
 
 const toggleOverrideStyles = css`
 	padding-right: ${remSpace[1]};
+	width: 9.375rem;
 
 	${until.desktop} {
 		color: ${neutral[100]};

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -97,6 +97,8 @@ const liveBlogPadding = css`
 const toggleOverrideStyles = css`
 	padding-right: ${remSpace[1]};
 	width: 9.375rem;
+	line-height: 1.15;
+	padding: ${remSpace[2]} 0;
 
 	${until.desktop} {
 		color: ${neutral[100]};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Tidy up of AR liveblog meta data – also aligned standfirst bullets better

## Why?
Details

### Before
![image](https://user-images.githubusercontent.com/20658471/152836758-430354f2-7fe6-49b1-ae71-a21349ac2113.png)

### After
![image](https://user-images.githubusercontent.com/20658471/152836793-2d684229-121d-42bf-bb19-1853f968bc4c.png)
