### PR TITLE
Bump content API models version

### DIFF
--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0"
+version in ThisBuild := "0.12.1-SNAPSHOT"

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.11.4-SNAPSHOT"
+version in ThisBuild := "0.12.0"

--- a/apps-rendering/build.sbt
+++ b/apps-rendering/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 val contentEntityVersion = "2.0.6"
 val contentAtomVersion = "3.2.2"
 val storyPackageVersion = "2.0.4"
-val contentApiModelsVersion = "15.9.1"
+val contentApiModelsVersion = "17.1.1"
 
 val scroogeDependencies = Seq(
   "content-api-models",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Bumps the version of content API models used by `@guardian/apps-rendering-api-models`

There are two paths to decoding content, using `ItemResponseSerde` from `@guardian/content-api-models` and `RenderingRequestSerde` from `@guardian/apps-rendering-api-models`.

`@guardian/apps-rendering-api-models` bundles a version of `@guardian/content-api-models`, which is currently out of date.