### PR TITLE
Smaller toggle click area

### DIFF
--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -12,7 +12,7 @@ const cssOverrides = css`
 	}
 `;
 
-const spanStyles = css`
+const toggleWrapperStyles = css`
 	display: flex;
 
 	${from.desktop} {
@@ -39,13 +39,15 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 
 	return (
 		<>
-			<span id="filter-toggle" css={spanStyles} />
-			<ToggleSwitch
-				label="Show key events only"
-				checked={checked}
-				onClick={() => handleClick()}
-				cssOverrides={cssOverrides}
-			/>
+			<span id="filter-toggle" />
+			<div css={toggleWrapperStyles}>
+				<ToggleSwitch
+					label="Show key events only"
+					checked={checked}
+					onClick={() => handleClick()}
+					cssOverrides={cssOverrides}
+				/>
+			</div>
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -4,10 +4,18 @@ import { ToggleSwitch } from '@guardian/source-react-components-development-kitc
 import { useState } from 'react';
 
 const cssOverrides = css`
+	display: inline-flex;
 	padding-bottom: ${remSpace[3]};
 
 	${from.desktop} {
 		padding: ${remSpace[3]} 0;
+	}
+`;
+
+const spanStyles = css`
+	display: flex;
+
+	${from.desktop} {
 		border-top: 1px solid ${neutral[86]};
 	}
 `;
@@ -31,7 +39,7 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 
 	return (
 		<>
-			<span id="filter-toggle" />
+			<span id="filter-toggle" css={spanStyles} />
 			<ToggleSwitch
 				label="Show key events only"
 				checked={checked}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes a bug where the toggle label was stretching to full width.

### Before
![Screenshot 2022-02-08 at 15 03 25](https://user-images.githubusercontent.com/77005274/153014519-df476af2-dfe2-4eb4-9810-459eeb425862.png)

### After

![Screenshot 2022-02-08 at 15 02 45](https://user-images.githubusercontent.com/77005274/153014507-7028e86e-f484-44fd-9b11-4bb195a2dabc.png)

