### PR TITLE
Fetch Full Git History For Chromatic Action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
       - uses: guardian/actions-setup-node@main
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install


### PR DESCRIPTION
## Why?

Version 2 of the checkout action now only fetches a single commit: https://github.com/actions/checkout/releases/tag/v2.0.0

Chromatic requires more history than that to perform its snapshot comparisons. The suggested solution is to set `fetch-depth` to `0`: https://www.chromatic.com/docs/github-actions#support-for-codeactionscheckoutv2code

## Changes

- Set checkout action fetch depth to 0 for Chromatic workflow
