### PR TITLE
More Recent Chromatic Mock Date

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,9 +17,7 @@ Picture.disableLazyLoading = isChromatic();
 
 if (isChromatic()) {
 	// Fix the date to prevent false negatives
-	// And not just any date... 200 years! 🎉
-	// https://www.theguardian.com/gnm-press-office/2021/apr/30/the-guardian-celebrates-200-extraordinary-years
-	MockDate.set('Wed May 5 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+	MockDate.set('Sat Jan 1 2022 12:00:00 GMT+0000 (Greenwich Mean Time)');
 }
 
 mockRESTCalls();


### PR DESCRIPTION
## Why?

We set an artificial "current" datetime in Chromatic to make sure any UI snapshots that rely on it appear static.

When using `timeAgo` (#3706), we attempt to calculate the difference in time between a given timestamp and "now". Unfortunately, when the timestamp is more recent than "now" this causes problems because the difference in time is negative (which isn't possible in this context). This issue has recently started breaking the UI on some of the liveblog snapshots.

There are a few ways to solve this (including updating the fixtures that set the liveblog timestamps). However the simplest is probably just to update the artificial datetime in Chromatic to be more recent, which is what this PR does.

## Changes

- Updated the Chromatic mock date to be more recent
