### PR TITLE
repalce `jpoissonnier.vscode-styled-components` recommended extention

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
         "editorconfig.editorconfig",
         "dbaeumer.vscode-eslint",
         "stkb.rewrap",
-        "jpoissonnier.vscode-styled-components",
+        "styled-components.vscode-styled-components",
         "stylelint.vscode-stylelint",
         "eamodio.gitlens",
         "streetsidesoftware.code-spell-checker"


### PR DESCRIPTION
it's been removed and replaced with [styled-components.vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components)
