### PR TITLE
Move `FocusStylesManager` into an island

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import loadable from '@loadable/component';
 
-import { FocusStyleManager } from '@guardian/source-foundations';
 import { ArticleDisplay, ArticleDesign, storage, log } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
@@ -84,13 +83,6 @@ export const App = ({ CAPI }: Props) => {
 			),
 		);
 	}, [CAPI.pageId, CAPI.config.keywordIds]);
-
-	// Ensure the focus state of any buttons/inputs in any of the Source
-	// components are only applied when navigating via keyboard.
-	// READ: https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb
-	useEffect(() => {
-		FocusStyleManager.onlyShowFocusOnTabs();
-	}, []);
 
 	useEffect(() => {
 		// Used internally only, so only import each function on demand

--- a/dotcom-rendering/src/web/components/FocusStyles.importable.tsx
+++ b/dotcom-rendering/src/web/components/FocusStyles.importable.tsx
@@ -1,0 +1,13 @@
+import { FocusStyleManager } from '@guardian/source-foundations';
+import { useEffect } from 'react';
+
+export const FocusStyles = () => {
+	// Ensure the focus state of any buttons/inputs in any of the Source
+	// components are only applied when navigating via keyboard.
+	// READ: https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb
+	useEffect(() => {
+		FocusStyleManager.onlyShowFocusOnTabs();
+	}, []);
+	// Nothing is rendered by this component
+	return null;
+};

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -6,6 +6,7 @@ import { SkipTo } from './SkipTo';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { CommercialMetrics } from './CommercialMetrics.importable';
 import { Island } from './Island';
+import { FocusStyles } from './FocusStyles.importable';
 
 type Props = {
 	CAPI: CAPIType;
@@ -35,6 +36,13 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 			/>
 			<SkipTo id="maincontent" label="Skip to main content" />
 			<SkipTo id="navigation" label="Skip to navigation" />
+			{(format.design === ArticleDesign.LiveBlog ||
+				format.design === ArticleDesign.DeadBlog) && (
+				<SkipTo id="keyevents" label="Skip to key events" />
+			)}
+			<Island clientOnly={true} deferUntil="idle">
+				<FocusStyles />
+			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<CommercialMetrics
 					enabled={CAPI.config.switches.commercialMetrics}
@@ -43,10 +51,6 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 					isDev={CAPI.config.isDev}
 				/>
 			</Island>
-			{(format.design === ArticleDesign.LiveBlog ||
-				format.design === ArticleDesign.DeadBlog) && (
-				<SkipTo id="keyevents" label="Skip to key events" />
-			)}
 			<div id="react-root" />
 			<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
 		</StrictMode>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves `FocusStylesManager` into it's own component and then into an island

## Why?
We want to move all code out of App.tsx