### PR TITLE
Stick `MostViewedRight` longer

### DIFF
--- a/dotcom-rendering/src/web/components/ContributionSlot.tsx
+++ b/dotcom-rendering/src/web/components/ContributionSlot.tsx
@@ -1,18 +1,7 @@
 import { css } from '@emotion/react';
 import { getCookie } from '@guardian/libs';
+import { ShadyPie } from './ShadyPie';
 import { WhenAdBlockInUse } from './WhenAdBlockInUse';
-
-const params = new URLSearchParams();
-params.set(
-	'acquisitionData',
-	JSON.stringify({
-		componentType: 'ACQUISITIONS_OTHER',
-		source: 'GUARDIAN_WEB',
-		campaignCode: 'shady_pie_open_2019',
-		componentId: 'shady_pie_open_2019',
-	}),
-);
-params.set('INTCMP', 'shady_pie_open_2019');
 
 export const ContributionSlot = ({
 	shouldHideReaderRevenue,
@@ -32,15 +21,7 @@ export const ContributionSlot = ({
 					top: 0;
 				`}
 			>
-				<a
-					href={`https://support.theguardian.com/uk/subscribe/digital?${params.toString()}`}
-				>
-					<img
-						src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png"
-						width="300"
-						alt=""
-					/>
-				</a>
+				<ShadyPie />
 			</div>
 		</WhenAdBlockInUse>
 	);

--- a/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
@@ -45,7 +45,10 @@ export const defaultStory = () => {
 						showTopBorder={false}
 						padded={false}
 					>
-						<MostViewedRight isAdFreeUser={false} />
+						<MostViewedRight
+							isAdFreeUser={false}
+							adBlockerDetected={false}
+						/>
 					</ElementContainer>
 				</RightColumn>
 			</Flex>
@@ -81,7 +84,11 @@ export const limitItemsStory = () => {
 						showTopBorder={false}
 						padded={false}
 					>
-						<MostViewedRight limitItems={3} isAdFreeUser={false} />
+						<MostViewedRight
+							limitItems={3}
+							isAdFreeUser={false}
+							adBlockerDetected={false}
+						/>
 					</ElementContainer>
 				</RightColumn>
 			</Flex>
@@ -98,7 +105,7 @@ export const outsideContextStory = () => {
 
 	return (
 		<ElementContainer>
-			<MostViewedRight isAdFreeUser={false} />
+			<MostViewedRight isAdFreeUser={false} adBlockerDetected={false} />
 		</ElementContainer>
 	);
 };

--- a/dotcom-rendering/src/web/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.test.tsx
@@ -20,7 +20,7 @@ describe('MostViewedList', () => {
 		useApi.mockReturnValue(response);
 
 		const { asFragment, getAllByText } = render(
-			<MostViewedRight isAdFreeUser={false} />,
+			<MostViewedRight isAdFreeUser={false} adBlockerDetected={false} />,
 		);
 
 		// Calls api once only
@@ -61,7 +61,11 @@ describe('MostViewedList', () => {
 		useApi.mockReturnValue(response);
 
 		const { getAllByText } = render(
-			<MostViewedRight limitItems={3} isAdFreeUser={false} />,
+			<MostViewedRight
+				limitItems={3}
+				isAdFreeUser={false}
+				adBlockerDetected={false}
+			/>,
 		);
 
 		// Calls api once only
@@ -80,7 +84,9 @@ describe('MostViewedList', () => {
 	it('should show a byline when this property is set to true', async () => {
 		useApi.mockReturnValue(response);
 
-		const { getByText } = render(<MostViewedRight isAdFreeUser={false} />);
+		const { getByText } = render(
+			<MostViewedRight isAdFreeUser={false} adBlockerDetected={false} />,
+		);
 
 		expect(
 			getByText('Jennifer Rankin and Daniel Boffey'),

--- a/dotcom-rendering/src/web/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.tsx
@@ -4,7 +4,6 @@ import { headline } from '@guardian/source-foundations';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 
 import { useApi } from '../lib/useApi';
-import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { decideTrail } from '../lib/decideTrail';
 
 import { MostViewedRightItem } from './MostViewedRightItem';
@@ -29,11 +28,14 @@ const headingStyles = css`
 interface Props {
 	limitItems?: number;
 	isAdFreeUser: boolean;
+	adBlockerDetected: boolean;
 }
 
-export const MostViewedRight = ({ limitItems = 5, isAdFreeUser }: Props) => {
-	const adBlockerDetected = useAdBlockInUse();
-
+export const MostViewedRight = ({
+	limitItems = 5,
+	isAdFreeUser,
+	adBlockerDetected,
+}: Props) => {
 	const endpointUrl: string =
 		'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true';
 	const { data, error } = useApi<CAPITrailTabType>(endpointUrl);

--- a/dotcom-rendering/src/web/components/MostViewedRightWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightWrapper.importable.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect, RefObject } from 'react';
 import { css } from '@emotion/react';
 
 import { MostViewedRight } from './MostViewedRight';
+import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 
 type Props = {
 	limitItems?: number;
@@ -13,16 +14,19 @@ const HEIGHT_REQUIRED = 482 + 24 + 24;
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
 
-// Styling the data island root so it stretches to cover the full height available in the container.
-// Requires us to subtract the height of its sibling in the container (StickyAd).
-const stretchWrapperHeight = css`
-	height: ${`calc(100% - ${MOSTVIEWED_STICKY_HEIGHT}px)`};
-`;
-
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
 export const MostViewedRightWrapper = ({ limitItems, isAdFreeUser }: Props) => {
+	const adBlockerDetected = useAdBlockInUse();
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const [heightIsAvailable, setHeightIsAvailable] = useState<boolean>(false);
+
+	// Styling the data island root so it stretches to cover the full height available in the container.
+	// Requires us to subtract the height of its sibling in the container (StickyAd).
+	const stretchWrapperHeight = css`
+		height: ${adBlockerDetected
+			? `calc(100% - 300px)`
+			: `calc(100% - ${MOSTVIEWED_STICKY_HEIGHT}px)`};
+	`;
 
 	useEffect(() => {
 		const checkHeight = (ref: RefObject<HTMLDivElement>) => {
@@ -52,6 +56,7 @@ export const MostViewedRightWrapper = ({ limitItems, isAdFreeUser }: Props) => {
 				<MostViewedRight
 					limitItems={limitItems}
 					isAdFreeUser={isAdFreeUser}
+					adBlockerDetected={!!adBlockerDetected}
 				/>
 			) : null}
 		</div>

--- a/dotcom-rendering/src/web/components/ShadyPie.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.tsx
@@ -1,0 +1,25 @@
+const params = new URLSearchParams();
+params.set(
+	'acquisitionData',
+	JSON.stringify({
+		componentType: 'ACQUISITIONS_OTHER',
+		source: 'GUARDIAN_WEB',
+		campaignCode: 'shady_pie_open_2019',
+		componentId: 'shady_pie_open_2019',
+	}),
+);
+params.set('INTCMP', 'shady_pie_open_2019');
+
+export const ShadyPie = () => {
+	return (
+		<a
+			href={`https://support.theguardian.com/uk/subscribe/digital?${params.toString()}`}
+		>
+			<img
+				src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png"
+				width="300"
+				alt=""
+			/>
+		</a>
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces a change that means the `MostViewedRight` component will stay in the viewport for longer for reader's that use ad blockers.

We stick most viewed only when an ad blocker is detected to stop it overlaying inline ads but we stopped the stickiness at the same point that we stop sticking the top right ad slot.

## Why?
Because there's no reason to not continue sticking it all the way. I use this component all the time and now I get to see it more!