### PR TITLE
Renamed Editions `Article` To `Layout`

### DIFF
--- a/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/galleryImage.stories.tsx
@@ -5,7 +5,7 @@ import imageFixture from 'fixtures/galleryImage';
 import { article } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
-import { galleryWrapperStyles } from '../article';
+import { galleryWrapperStyles } from '../layout';
 import GalleryImage from './index';
 
 // ----- Stories ----- //

--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -159,7 +159,7 @@ const getSectionStyles = (item: ArticleFormat): SerializedStyles[] => {
 	return [headerStyles, articleStyles];
 };
 
-const Article: FC<Props> = ({ item }) => {
+const Layout: FC<Props> = ({ item }) => {
 	if (
 		item.design === ArticleDesign.Analysis ||
 		item.design === ArticleDesign.Standard ||
@@ -211,4 +211,4 @@ const Article: FC<Props> = ({ item }) => {
 
 // ----- Exports ----- //
 
-export default Article;
+export default Layout;

--- a/apps-rendering/src/components/editions/layout/layout.stories.tsx
+++ b/apps-rendering/src/components/editions/layout/layout.stories.tsx
@@ -26,7 +26,7 @@ import {
 import type { Image } from 'image';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
-import Article from '../article';
+import Layout from '.';
 
 // ----- Setup ------ //
 
@@ -88,7 +88,7 @@ const getTag = (id: string, webTitle: string): Tag => ({
 // ----- Stories ----- //
 
 const Default = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...article,
 			...isImmersive(),
@@ -99,7 +99,7 @@ const Default = (): ReactElement => (
 );
 
 const Analysis = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...analysis,
 			...isImmersive(),
@@ -112,7 +112,7 @@ const Analysis = (): ReactElement => (
 );
 
 const Editorial = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...editorial,
 			tags: [getTag('tone/editorials', 'View from the Guardian ')],
@@ -125,7 +125,7 @@ const Editorial = (): ReactElement => (
 );
 
 const Feature = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...feature,
 			...isImmersive(),
@@ -137,7 +137,7 @@ const Feature = (): ReactElement => (
 );
 
 const Review = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...review,
 			...hasShareIcon(),
@@ -148,7 +148,7 @@ const Review = (): ReactElement => (
 );
 
 const Showcase = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...article,
 			...hasShareIcon(),
@@ -160,7 +160,7 @@ const Showcase = (): ReactElement => (
 );
 
 const Interview = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...interview,
 			...hasShareIcon(),
@@ -172,7 +172,7 @@ const Interview = (): ReactElement => (
 );
 
 const Comment = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...comment,
 			...hasShareIcon(),
@@ -184,7 +184,7 @@ const Comment = (): ReactElement => (
 );
 
 const Letter = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...letter,
 			...hasShareIcon(),
@@ -195,7 +195,7 @@ const Letter = (): ReactElement => (
 );
 
 const Correction = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...correction,
 			tags: [
@@ -210,7 +210,7 @@ const Correction = (): ReactElement => (
 );
 
 const MatchReport = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...matchReport,
 			...hasShareIcon(),
@@ -221,7 +221,7 @@ const MatchReport = (): ReactElement => (
 );
 
 const Cartoon = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...cartoon,
 			...hasShareIcon(),
@@ -231,7 +231,7 @@ const Cartoon = (): ReactElement => (
 );
 
 const Gallery = (): ReactElement => (
-	<Article
+	<Layout
 		item={{
 			...media,
 			...hasShareIcon(),
@@ -250,8 +250,8 @@ Gallery.parameters = {
 // ----- Exports ----- //
 
 export default {
-	component: Article,
-	title: 'AR/Editions/Article',
+	component: Layout,
+	title: 'Editions/Layouts',
 	decorators: [withKnobs],
 	parameters: {
 		layout: 'fullscreen',

--- a/apps-rendering/src/server/editionsPage.tsx
+++ b/apps-rendering/src/server/editionsPage.tsx
@@ -11,7 +11,7 @@ import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
 import { getThirdPartyEmbeds } from 'capi';
 import type { ThirdPartyEmbeds } from 'capi';
-import Article from 'components/editions/article';
+import Layout from 'components/editions/layout';
 import { atomCss, atomScript } from 'components/interactiveAtom';
 import Meta from 'components/meta';
 import Scripts from 'components/scripts';
@@ -133,7 +133,7 @@ const renderBody = (item: Item): EmotionCritical =>
 		renderToString,
 	)(
 		<CacheProvider value={cache}>
-			<Article item={item} />
+			<Layout item={item} />
 		</CacheProvider>,
 	);
 


### PR DESCRIPTION
## Why?

The dotcom and apps parts of the codebase use the term "layout" to describe the structure of a full page. This brings Editions into line with that terminology. Consistency should make it easier for people to browse and understand the codebase.

**Note:** I've also begun the work of creating a top-level `Editions` folder in storybook, to reduce the confusing amount of nesting we have at the moment. This should also make understanding the codebase easier.

## Changes

- Renamed Editions `Article` component to `Layout`
- Renamed stories to `Editions/Layouts`
