### PR TITLE
Bump Apps Rendering Api Model version

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2843,11 +2843,11 @@
       }
     },
     "@guardian/apps-rendering-api-models": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-0.11.3.tgz",
-      "integrity": "sha512-nkerHpU/YwG/6FO4VP4IcoqijWrbnlstcwvVtCRe2T5TulPskhUlem/49vhceslpTjCse+QEIH71KXVg2s278Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-0.12.0.tgz",
+      "integrity": "sha512-+MpyqbWHR8Y+wXmCZWPD0bZbdyyq4CPLALGaUzG1g0cMNtneAiJa05ccKuxsxWtZ5Vut+kfwBk2WtcJh+8F7qA==",
       "requires": {
-        "@guardian/content-api-models": "^15.9.1",
+        "@guardian/content-api-models": "^17.1.1",
         "@guardian/content-atom-model": "^3.2.2",
         "@guardian/content-entity-model": "^2.0.6",
         "@guardian/story-packages-model": "^2.0.4",
@@ -2855,22 +2855,6 @@
         "@types/thrift": "^0.10.9",
         "node-int64": "^0.4.0",
         "thrift": "^0.12.0"
-      },
-      "dependencies": {
-        "@guardian/content-api-models": {
-          "version": "15.10.2",
-          "resolved": "https://registry.npmjs.org/@guardian/content-api-models/-/content-api-models-15.10.2.tgz",
-          "integrity": "sha512-lt6US8bQ90rmEcQZ/KR32iT7zZbGrq9xYe+0bhZPzA9efwqPvaZ2cickHHi3IC6uMSEKoMOFNfnGiJ+9T+d9Iw==",
-          "requires": {
-            "@guardian/content-atom-model": "^3.2.4",
-            "@guardian/content-entity-model": "^2.0.6",
-            "@guardian/story-packages-model": "^2.0.4",
-            "@types/node-int64": "^0.4.29",
-            "@types/thrift": "^0.10.9",
-            "node-int64": "^0.4.0",
-            "thrift": "^0.12.0"
-          }
-        }
       }
     },
     "@guardian/atoms-rendering": {

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -29,8 +29,8 @@
   "prettier": "@guardian/prettier",
   "dependencies": {
     "@creditkarma/thrift-server-core": "^0.16.1",
+    "@guardian/apps-rendering-api-models": "^0.12.0",
     "@guardian/atoms-rendering": "^22.0.0",
-    "@guardian/apps-rendering-api-models": "^0.11.3",
     "@guardian/bridget": "^1.11.0",
     "@guardian/content-api-models": "^17.1.1",
     "@guardian/content-atom-model": "^3.2.4",


### PR DESCRIPTION
Bumping this version will bring a newer version of the CAPI models to Apps Rendering, which will provide new fields such as embed captions. Which newsletters need to use for email embeds.