### PR TITLE
Remove `@babel/preset-modules`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -98,7 +98,6 @@
     "@babel/plugin-transform-react-jsx": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.13.8",
     "@babel/preset-env": "^7.14.1",
-    "@babel/preset-modules": "^0.1.4",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.12.7",
     "@babel/runtime": "^7.12.5",

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -5,7 +5,6 @@ const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
 const GITHUB = process.env.CI_ENV === 'github';
 
-// We need to distinguish files compiled by @babel/preset-env with the prefix "legacy"
 const generateName = (isLegacyJS) => {
 	const legacyString = isLegacyJS ? '.legacy' : '';
 	const chunkhashString = PROD && !GITHUB ? '.[chunkhash]' : '';
@@ -59,9 +58,6 @@ module.exports = ({ isLegacyJS, sessionId }) => ({
 						options: {
 							presets: [
 								'@babel/preset-react',
-								// @babel/preset-env is used for legacy browsers
-								// @babel/preset-modules is used for modern browsers
-								// this allows us to reduce bundle sizes
 								isLegacyJS
 									? [
 											'@babel/preset-env',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,7 +2338,7 @@
     "@babel/helper-validator-option" "^7.14.5"
     "@babel/plugin-transform-flow-strip-types" "^7.16.5"
 
-"@babel/preset-modules@^0.1.4", "@babel/preset-modules@^0.1.5":
+"@babel/preset-modules@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
   integrity sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==


### PR DESCRIPTION
## Why?

`@babel/preset-modules` was deprecated by an [option](https://babeljs.io/docs/en/babel-preset-env#bugfixes) in `@babel/preset-env` .

It looks like the webpack loaders were updated to reflect this.

However the dependency and outdated comments relating to `preset-modules` are still present.

