### PR TITLE
Fix the way we remove placeholders post-render

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1029,6 +1029,7 @@ declare namespace JSX {
 		'gu-island': {
 			name: string;
 			deferUntil?: 'idle' | 'visible';
+			clientOnly?: boolean,
 			props: any;
 			children: React.ReactNode;
 		};

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { hydrate, h } from 'preact';
+import { hydrate, render, h } from 'preact';
 import { initPerf } from '../initPerf';
 
 /**
@@ -26,7 +26,15 @@ export const doHydration = (name: string, data: any, element: HTMLElement) => {
 		`../../components/${name}.importable`
 	)
 		.then((module) => {
-			hydrate(h(module[name], data), element);
+			const clientOnly = element.getAttribute('clientOnly') === 'true';
+
+			if (clientOnly) {
+				element.querySelector('[data-name="placeholder"]')?.remove();
+				render(h(module[name], data), element);
+			} else {
+				hydrate(h(module[name], data), element);
+			}
+
 			element.setAttribute('data-gu-ready', 'true');
 			end();
 		})

--- a/dotcom-rendering/src/web/components/Island.tsx
+++ b/dotcom-rendering/src/web/components/Island.tsx
@@ -60,6 +60,7 @@ export const Island = ({
 		name={children.type.name}
 		deferUntil={deferUntil}
 		props={JSON.stringify(children.props)}
+		clientOnly={clientOnly}
 	>
 		{decideChildren(children, clientOnly, placeholderHeight)}
 	</gu-island>

--- a/dotcom-rendering/src/web/components/Placeholder.tsx
+++ b/dotcom-rendering/src/web/components/Placeholder.tsx
@@ -46,9 +46,9 @@ export const Placeholder = ({
 		css={css`
 			flex-grow: 1;
 		`}
+		data-name="placeholder"
 	>
 		<div
-			data-name="placeholder"
 			css={css`
 				height: ${height}px;
 				width: ${width ? `${width}px` : '100%'};

--- a/dotcom-rendering/src/web/components/Portal.tsx
+++ b/dotcom-rendering/src/web/components/Portal.tsx
@@ -17,10 +17,7 @@ export const Portal = ({ rootId, children }: Props) => {
 	// the root divs where the Portal is being inserted so the page is rendered with the placeholder
 	// showing (to reduce jank). But ReactDOM.createPortal won't replace content so we need to
 	// manually remove it here.
-	const placeholderElement = element.querySelector(
-		'[data-name="placeholder"]',
-	);
-	if (placeholderElement) placeholderElement.remove();
+	element.firstChild?.remove();
 	const result = ReactDOM.createPortal(children, element);
 	return result;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- moves `data-name=placeholder` to root of `Placeholder`
- refactors `Portal` code to remove the root element's child because of ☝️ 
- allows us to hydrate conditionally in `doHydration` so we can `render` instead of `hydrate` if we're `clientOnly` as we shouldn't be hydrating non SSRed content

## Why?
We're seeing the way placeholders are found and removed to be buggy. This is a little more specific and easy to understand. And it fixes the bug. 

This could probably use a little tidy up, but mostly round the `Portal` code that we're removing anyway.

### Before
<img width="743" alt="Screenshot 2022-02-11 at 15 12 50" src="https://user-images.githubusercontent.com/31692/153617163-223388b1-acd1-4a6c-a6c4-1b11b8a1a3b9.png">

### After
<img width="905" alt="Screenshot 2022-02-11 at 15 13 35" src="https://user-images.githubusercontent.com/31692/153617236-70481323-ab4a-4da9-82d2-cae6443633ea.png">

