### PR TITLE
Added `dcr` param to liveblog polling call

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -81,6 +81,7 @@ function getKey(
 		const url = new URL(`${pageId}.json`, ajaxUrl);
 		url.searchParams.set('lastUpdate', latestBlockId);
 		url.searchParams.set('isLivePage', 'true');
+		url.searchParams.set('dcr', 'true');
 		url.searchParams.set(
 			'filterKeyEvents',
 			filterKeyEvents ? 'true' : 'false',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `dcr=true` param to polling requests sent from liveblogs

## Why?
Because this is [what Frontend will soon expect](https://github.com/guardian/frontend/pull/24591)
