### PR TITLE
Hydrate blocks

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1029,7 +1029,7 @@ declare namespace JSX {
 		'gu-island': {
 			name: string;
 			deferUntil?: 'idle' | 'visible';
-			clientOnly?: boolean,
+			clientOnly?: boolean;
 			props: any;
 			children: React.ReactNode;
 		};

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { log } from '@guardian/libs';
 import { hydrate, render, h } from 'preact';
 import { initPerf } from '../initPerf';
 
@@ -30,8 +31,10 @@ export const doHydration = (name: string, data: any, element: HTMLElement) => {
 
 			if (clientOnly) {
 				element.querySelector('[data-name="placeholder"]')?.remove();
+				log('dotcom', `Rendering island ${name}`);
 				render(h(module[name], data), element);
 			} else {
+				log('dotcom', `Hydrating island ${name}`);
 				hydrate(h(module[name], data), element);
 			}
 

--- a/dotcom-rendering/src/web/browser/islands/init.ts
+++ b/dotcom-rendering/src/web/browser/islands/init.ts
@@ -1,53 +1,11 @@
 import '../webpackPublicPath';
 
-import { log } from '@guardian/libs';
 import { startup } from '../startup';
-import { whenVisible } from './whenVisible';
-import { whenIdle } from './whenIdle';
-import { doHydration } from './doHydration';
-import { getName } from './getName';
-import { getProps } from './getProps';
+import { initHydration } from './initHydration';
 
 const init = () => {
-	/**
-	 * Partial Hydration / React Islands
-	 *
-	 * The code here looks for parts of the dom that have been marked using the `gu-island`
-	 * marker, hydrating/rendering each one using the following properties:
-	 *
-	 * deferUntil - Used to optionally defer execution
-	 * name - The name of the component. Used to dynamically import the code
-	 * props - The data for the component that has been serialised in the dom
-	 * element - The `gu-island` custom element which is wrapping the content
-	 */
-	document.querySelectorAll('gu-island').forEach((element) => {
-		if (element instanceof HTMLElement) {
-			const name = getName(element);
-			const props = getProps(element);
-
-			if (!name) return;
-			log('dotcom', `Hydrating ${name}`);
-
-			const deferUntil = element.getAttribute('deferuntil');
-			switch (deferUntil) {
-				case 'idle': {
-					whenIdle(() => {
-						doHydration(name, props, element);
-					});
-					break;
-				}
-				case 'visible': {
-					whenVisible(element, () => {
-						doHydration(name, props, element);
-					});
-					break;
-				}
-				default: {
-					doHydration(name, props, element);
-				}
-			}
-		}
-	});
+	const elements = document.querySelectorAll('gu-island');
+	initHydration(elements);
 
 	return Promise.resolve();
 };

--- a/dotcom-rendering/src/web/browser/islands/initHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/initHydration.ts
@@ -1,0 +1,46 @@
+import { whenVisible } from './whenVisible';
+import { whenIdle } from './whenIdle';
+import { doHydration } from './doHydration';
+import { getName } from './getName';
+import { getProps } from './getProps';
+
+export const initHydration = (elements: NodeListOf<Element>) => {
+	/**
+	 * Partial Hydration / React Islands
+	 *
+	 * The code here looks for parts of the dom that have been marked using the `gu-island`
+	 * marker, hydrating/rendering each one using the following properties:
+	 *
+	 * deferUntil - Used to optionally defer execution
+	 * name - The name of the component. Used to dynamically import the code
+	 * props - The data for the component that has been serialised in the dom
+	 * element - The `gu-island` custom element which is wrapping the content
+	 */
+	elements.forEach((element) => {
+		if (element instanceof HTMLElement) {
+			const name = getName(element);
+			const props = getProps(element);
+
+			if (!name) return;
+
+			const deferUntil = element.getAttribute('deferuntil');
+			switch (deferUntil) {
+				case 'idle': {
+					whenIdle(() => {
+						doHydration(name, props, element);
+					});
+					break;
+				}
+				case 'visible': {
+					whenVisible(element, () => {
+						doHydration(name, props, element);
+					});
+					break;
+				}
+				default: {
+					doHydration(name, props, element);
+				}
+			}
+		}
+	});
+};

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
+import { initHydration } from '../browser/islands/initHydration';
 import { useApi } from '../lib/useApi';
 
 type Props = {
@@ -36,23 +37,36 @@ const Toast = ({
 
 const isServer = typeof window === 'undefined';
 
-function hydrateBlocks() {
-	console.log('hydrateBlocks');
-	// TODO Call existing hydration solution targetted to these elements
-	// Maybe we can make doHydration work for all gu-islands things
-	// where the gu-hydrated data attribute isn't set?
-}
-
 /**
- * insertNewBlocks takes html and inserts it at the top of the liveblog
+ * insert
+ *
+ * Takes html, parses and hydrates it, and then inserts the resulting blocks
+ * at the top of the liveblog
  *
  * @param {string} html The block html to be inserted
  * @returns void
  */
-function insertNewBlocks(html: string) {
+function insert(html: string) {
+	// Create
+	// ------
+	const template = document.createElement('template');
+	template.innerHTML = html;
+	const fragment = template.content;
+
+	// Hydrate
+	// -------
+	const islands = fragment.querySelectorAll('gu-island');
+	initHydration(islands);
+
+	// Insert
+	// ------
+	// Shouldn't we snaitise this html?
+	// We're being sent this string by our own backend, not reader input, so we
+	// trust that the tags and attributes it contains are safe and intentional
+	const maincontent = document.querySelector('#maincontent');
 	const latestBlock = document.querySelector('#maincontent :first-child');
-	if (!latestBlock) return;
-	latestBlock.insertAdjacentHTML('beforebegin', html);
+	if (!latestBlock || !maincontent) return;
+	maincontent.insertBefore(fragment, latestBlock);
 }
 
 /**
@@ -141,8 +155,7 @@ export const Liveness = ({
 		}) => {
 			if (data && data.numNewBlocks && data.numNewBlocks > 0) {
 				// Always insert the new blocks in the dom (but hidden)
-				insertNewBlocks(data.html);
-				hydrateBlocks();
+				insert(data.html);
 
 				if (topOfBlogVisible()) {
 					revealNewBlocks();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We now hydrate new live blog blocks as part of inserting them into the dom

## Why?
So that we can have interactive (uses javascript) content dynamically appear in live blogs

