### PR TITLE
Revert single front door test

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -32,6 +32,7 @@ import { buildAdTargeting } from '../../lib/ad-targeting';
 import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 import { GetMatchTabs } from './GetMatchTabs';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';
+import { Lazy } from './Lazy';
 
 type Props = {
 	CAPI: CAPIBrowserType;
@@ -301,6 +302,20 @@ export const App = ({ CAPI }: Props) => {
 					idUrl={CAPI.config.idUrl}
 					pageViewId={pageViewId}
 				/>
+			</Portal>
+			<Portal rootId="reader-revenue-links-footer">
+				<Lazy margin={300}>
+					<ReaderRevenueLinks
+						urls={CAPI.nav.readerRevenueLinks.footer}
+						edition={CAPI.editionId}
+						dataLinkNamePrefix="footer : "
+						inHeader={false}
+						remoteHeaderEnabled={false}
+						pageViewId={pageViewId}
+						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						ophanRecord={ophanRecord}
+					/>
+				</Lazy>
 			</Portal>
 			<Portal rootId="bottom-banner">
 				<StickyBottomBanner

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -232,20 +232,27 @@ export const Links = ({
 
 	const isServer = typeof window === 'undefined';
 
+	const showSupporterCTA =
+		!isServer &&
+		getCookie({
+			name: 'gu_hide_support_messaging',
+			shouldMemoize: true,
+		}) === 'true';
+
 	const isSignedIn =
 		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
 
 	return (
 		<div data-print-layout="hide" css={linksStyles}>
-			{supporterCTA !== '' && (
+			{showSupporterCTA && supporterCTA !== '' && (
 				<>
 					<div css={seperatorStyles} />
 					<a
-						href="https://support.theguardian.com/subscribe/weekly?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_supporter_cta%22%7D"
+						href={supporterCTA}
 						css={[linkTablet({ showAtTablet: false }), linkStyles]}
 						data-link-name="nav2 : supporter-cta"
 					>
-						Print subscriptions
+						Subscriptions
 					</a>
 				</>
 			)}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -73,7 +73,7 @@ export const ReaderRevenueLinks: React.FC<{
 			longTitle: 'Subscribe',
 			title: 'Subscribe',
 			mobileOnly: true,
-			url: 'https://support.theguardian.com/subscribe/weekly?INTCMP=side_menu_support_subscribe&acquisitionData=%7B"source"%3A"GUARDIAN_WEB"%2C"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"side_menu_support_subscribe"%7D',
+			url: readerRevenueLinks.sideMenu.subscribe,
 		},
 	];
 


### PR DESCRIPTION
We're now ready to end the Single Front Door test so we can revert these changes.

Reverts guardian/dotcom-rendering#3832