### PR TITLE
Don't wait for hydration in Cypress commercial test

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-6/commercial.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/commercial.spec.js
@@ -30,10 +30,6 @@ describe('Commercial E2E tests', function () {
 		cy.get(`[data-name="right"]`).should('have.length', 1);
 		cy.scrollTo('bottom');
 		cy.get(`[data-name="merchandising-high"]`).should('have.length', 1);
-		// Wait for hydration
-		cy.get('gu-island[name=MostViewedFooter]')
-			.first()
-			.should('have.attr', 'data-gu-ready', 'true');
 		cy.get(`[data-name="mostpop"]`).should('have.length', 1);
 		cy.get(`[data-name="merchandising"]`).should('have.length', 1);
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

In the commercial Cypress test, remove the step where we wait for the `MostViewedFooter` island to be hydrated before proceeding.

## Why?

Now that the `mostpop` ad slot is not in an island (#3978), there is no need to wait for this hydration step.

It also should fix the test, as this should really wait for `MostViewedFooterData` (I'm not sure why this didn't get caught in the #3978's branch Cypress run 🤔 )