### PR TITLE
`Toast`

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -1,38 +1,14 @@
-import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { initHydration } from '../browser/islands/initHydration';
 import { useApi } from '../lib/useApi';
+import { Toast } from './Toast';
 
 type Props = {
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
 	filterKeyEvents: boolean;
-};
-
-// TODO: Break this out into its own component
-const Toast = ({
-	onClick,
-	numHiddenBlocks,
-}: {
-	onClick: () => void;
-	numHiddenBlocks: number;
-}) => {
-	// TODO: Style and absolute position this component
-	return (
-		<nav
-			css={css`
-				position: fixed;
-				top: 20px;
-				left: 50px;
-				display: flex;
-				width: 100%;
-				align-items: center;
-			`}
-		>
-			<button onClick={onClick}>{`${numHiddenBlocks} blah`}</button>
-		</nav>
-	);
+	format: ArticleFormat;
 };
 
 const isServer = typeof window === 'undefined';
@@ -133,6 +109,7 @@ export const Liveness = ({
 	webTitle,
 	ajaxUrl,
 	filterKeyEvents,
+	format,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
 	const [numHiddenBlocks, setNumHiddenBlocks] = useState(0);
@@ -204,7 +181,10 @@ export const Liveness = ({
 
 	const handleToastClick = () => {
 		setShowToast(false);
-		topOfBlog?.scrollIntoView();
+		document.getElementById('maincontent')?.scrollIntoView({
+			behavior: 'smooth',
+		});
+		window.location.href = '#maincontent';
 		revealNewBlocks();
 		setNumHiddenBlocks(0);
 	};
@@ -213,7 +193,8 @@ export const Liveness = ({
 		return (
 			<Toast
 				onClick={handleToastClick}
-				numHiddenBlocks={numHiddenBlocks}
+				count={numHiddenBlocks}
+				format={format}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/web/components/Toast.stories.tsx
+++ b/dotcom-rendering/src/web/components/Toast.stories.tsx
@@ -1,0 +1,137 @@
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
+
+import { Toast } from './Toast';
+
+export default {
+	component: Toast,
+	title: 'Components/Toast',
+};
+
+export const Default = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticlePillar.News,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={3}
+			onClick={() => {}}
+		/>
+	);
+};
+Default.story = {
+	name: 'with 3 updates',
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+	},
+};
+
+export const Sport = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticlePillar.Sport,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={3}
+			onClick={() => {}}
+		/>
+	);
+};
+Sport.story = {
+	name: 'with sport theme',
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+	},
+};
+
+export const Special = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticleSpecial.SpecialReport,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={17}
+			onClick={() => {}}
+		/>
+	);
+};
+Special.story = {
+	name: 'with special report theme',
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+	},
+};
+
+export const One = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticlePillar.Culture,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={1}
+			onClick={() => {}}
+		/>
+	);
+};
+One.story = {
+	name: 'with only one update',
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+	},
+};
+
+export const Lots = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticlePillar.Lifestyle,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={239}
+			onClick={() => {}}
+		/>
+	);
+};
+Lots.story = {
+	name: 'with many updates',
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+	},
+};
+
+export const Mobile = () => {
+	return (
+		<Toast
+			format={{
+				theme: ArticlePillar.News,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			count={3}
+			onClick={() => {}}
+		/>
+	);
+};
+Mobile.story = {
+	name: 'with mobile viewport',
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+	},
+};

--- a/dotcom-rendering/src/web/components/Toast.tsx
+++ b/dotcom-rendering/src/web/components/Toast.tsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react';
+import { EditorialButton } from '@guardian/source-react-components-development-kitchen';
+import { Hide, SvgArrowUpStraight } from '@guardian/source-react-components';
+import { getZIndex } from '../lib/getZIndex';
+
+type Props = {
+	count: number;
+	onClick: () => void;
+	format: ArticleFormat;
+};
+
+export const Toast = ({ count, onClick, format }: Props) => {
+	return (
+		<div
+			css={css`
+				position: fixed;
+				top: 20px;
+				display: flex;
+				${getZIndex('toast')};
+				width: 100%;
+				justify-content: center;
+			`}
+		>
+			<Hide above="phablet">
+				<EditorialButton
+					size="xsmall" // <-- Mobile version is xsmall
+					onClick={onClick}
+					format={format}
+					icon={<SvgArrowUpStraight />}
+				>{`${count} new update${
+					count === 1 ? '' : 's'
+				}`}</EditorialButton>
+			</Hide>
+			<Hide below="phablet">
+				<EditorialButton
+					size="small" // <-- Desktop version is small
+					onClick={onClick}
+					format={format}
+					icon={<SvgArrowUpStraight />}
+				>{`${count} new update${
+					count === 1 ? '' : 's'
+				}`}</EditorialButton>
+			</Hide>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -400,6 +400,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						webTitle={CAPI.webTitle}
 						ajaxUrl={CAPI.config.ajaxUrl}
 						filterKeyEvents={CAPI.filterKeyEvents}
+						format={format}
 					/>
 				</Island>
 			)}

--- a/dotcom-rendering/src/web/lib/getZIndex.test.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.test.tsx
@@ -2,15 +2,16 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 18;');
-		expect(getZIndex('dropdown')).toBe('z-index: 17;');
-		expect(getZIndex('burger')).toBe('z-index: 16;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 15;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 14;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 13;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 12;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 11;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 10;');
+		expect(getZIndex('banner')).toBe('z-index: 19;');
+		expect(getZIndex('dropdown')).toBe('z-index: 18;');
+		expect(getZIndex('burger')).toBe('z-index: 17;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 16;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 15;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 14;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 13;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 12;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 11;');
+		expect(getZIndex('toast')).toBe('z-index: 10;');
 		expect(getZIndex('onwardsCarousel')).toBe('z-index: 9;');
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -38,6 +38,9 @@ const indices = [
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 
+	// Liveblog toast
+	'toast',
+
 	// Onwards Carousel (Related content etc)
 	'onwardsCarousel',
 

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -295,5 +295,6 @@ export const document = ({ data }: Props): string => {
 		openGraphData,
 		twitterData,
 		keywords,
+		format,
 	});
 };

--- a/dotcom-rendering/src/web/server/htmlTemplate.ts
+++ b/dotcom-rendering/src/web/server/htmlTemplate.ts
@@ -1,5 +1,6 @@
 import { resets, brandBackground } from '@guardian/source-foundations';
 import he from 'he';
+import { ArticleDesign } from '@guardian/libs';
 import { getFontsCss } from '../../lib/fonts-css';
 import { ASSET_ORIGIN } from '../../lib/assets';
 
@@ -19,6 +20,7 @@ export const htmlTemplate = ({
 	openGraphData,
 	twitterData,
 	keywords,
+	format,
 }: {
 	title?: string;
 	description: string;
@@ -35,6 +37,7 @@ export const htmlTemplate = ({
 	openGraphData: { [key: string]: string };
 	twitterData: { [key: string]: string };
 	keywords: string;
+	format: ArticleFormat;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -111,6 +114,8 @@ export const htmlTemplate = ({
 		(src) => `<link rel="dns-prefetch" href="${src}">`,
 	);
 
+	const smoothScrolling = `style="scroll-behavior: smooth;"`;
+
 	const weAreHiringMessage = `
 <!--
 
@@ -156,7 +161,10 @@ https://workforus.theguardian.com/careers/product-engineering/
 --->`;
 
 	return `<!doctype html>
-        <html lang="en">
+        <html lang="en" ${
+			// Used when taking the reader to the top of the blog on toast click
+			format.design === ArticleDesign.LiveBlog && smoothScrolling
+		}>
             <head>
 			    ${weAreHiringMessage}
                 <title>${title}</title>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `Toast` component.

<img width="229" alt="Screenshot 2022-02-15 at 08 40 18" src="https://user-images.githubusercontent.com/1336821/154024450-645bd6e4-bffd-441b-84cb-24cceed6efa7.png">

This component appears on liveblogs when the reader is scrolled down the page and new updates become available

![2022-02-15 08 38 47](https://user-images.githubusercontent.com/1336821/154024275-dea3ec92-60c9-41c4-b774-16d22e50cae8.gif)

### Smooth scrolling and accessibility
We want to use smooth scrolling but not at the price of accessibility. To prevent the action of of clicking the toast from setting the reader's focus to a confusing place, we're also using the `#maincontent` hash to ensure focus is set at the new location (the top of the blog). After clicking the toast, keyboard navigation will continue from the point of the new content, with no interruption.
