### PR TITLE
Create new hook and wrapper component

### DIFF
--- a/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+import { useStickyVideo } from '../lib/useStickyVideo';
+
+interface Props {
+	children: React.ReactNode;
+}
+
+const stuckStyles = css`
+	@keyframes fade-in-up {
+		0% {
+			opacity: 0;
+		}
+		100% {
+			transform: translateY(0);
+			opacity: 1;
+		}
+	}
+
+	height: 500px;
+	position: fixed;
+	bottom: 50px;
+	right: 20px;
+	width: 260px;
+	height: 145px;
+	z-index: 9999999;
+	transform: translateY(100%);
+	animation: fade-in-up 0.25s ease forwards;
+
+	figcaption {
+		display: none;
+	}
+`;
+
+const unstuckStyles = css``;
+
+export const StickyVideo = ({ children }: Props) => {
+	const [stickyVideo, setStickyVideo] = useState(false);
+	const [hasBeenSeen, setRef] = useStickyVideo({
+		threshold: 0,
+		debounce: true,
+	});
+
+	useEffect(() => {
+		setStickyVideo(hasBeenSeen);
+	}, [hasBeenSeen]);
+
+	return (
+		<div css={stickyVideo ? stuckStyles : unstuckStyles} ref={setRef}>
+			{stickyVideo && (
+				<button onClick={() => setStickyVideo(false)}>Unstick</button>
+			)}
+			{children}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.tsx
@@ -14,6 +14,7 @@ import { record } from '../browser/ophan/ophan';
 
 import { Caption } from './Caption';
 import { decidePalette } from '../lib/decidePalette';
+import { StickyVideo } from './StickyVideo.importable';
 
 type Props = {
 	id: string;
@@ -112,6 +113,10 @@ export const YoutubeBlockComponent = ({
 			});
 	}, []);
 
+	useEffect(() => {
+		console.log('here');
+	});
+
 	const palette = decidePalette(format);
 	const shouldLimitWidth =
 		!isMainMedia &&
@@ -175,57 +180,61 @@ export const YoutubeBlockComponent = ({
 	};
 
 	return (
-		<div data-chromatic="ignore" data-component="youtube-atom">
-			<YoutubeAtom
-				assetId={assetId}
-				overrideImage={
-					overrideImage
-						? [
-								{
-									srcSet: [
-										{
-											src: overrideImage,
-											width: 500, // we do not have width for overlayImage so set a random number
-										},
-									],
-								},
-						  ]
-						: undefined
-				}
-				posterImage={
-					posterImage
-						? [
-								{
-									srcSet: posterImage.map((img) => ({
-										src: img.url,
-										width: img.width,
-									})),
-								},
-						  ]
-						: undefined
-				}
-				role={role}
-				alt={altText || mediaTitle || ''}
-				adTargeting={adTargeting}
-				consentState={consentState}
-				height={height}
-				width={width}
-				title={mediaTitle}
-				duration={duration}
-				eventEmitters={[ophanTracking, gaTracking]}
-				pillar={format.theme}
-				origin={process.env.NODE_ENV === 'development' ? '' : origin}
-			/>
-			{!hideCaption && (
-				<Caption
-					palette={palette}
-					captionText={mediaTitle || ''}
-					format={format}
-					displayCredit={false}
-					shouldLimitWidth={shouldLimitWidth}
-					mediaType="Video"
+		<StickyVideo>
+			<div data-chromatic="ignore" data-component="youtube-atom">
+				<YoutubeAtom
+					assetId={assetId}
+					overrideImage={
+						overrideImage
+							? [
+									{
+										srcSet: [
+											{
+												src: overrideImage,
+												width: 500, // we do not have width for overlayImage so set a random number
+											},
+										],
+									},
+							  ]
+							: undefined
+					}
+					posterImage={
+						posterImage
+							? [
+									{
+										srcSet: posterImage.map((img) => ({
+											src: img.url,
+											width: img.width,
+										})),
+									},
+							  ]
+							: undefined
+					}
+					role={role}
+					alt={altText || mediaTitle || ''}
+					adTargeting={adTargeting}
+					consentState={consentState}
+					height={height}
+					width={width}
+					title={mediaTitle}
+					duration={duration}
+					eventEmitters={[ophanTracking, gaTracking]}
+					pillar={format.theme}
+					origin={
+						process.env.NODE_ENV === 'development' ? '' : origin
+					}
 				/>
-			)}
-		</div>
+				{!hideCaption && (
+					<Caption
+						palette={palette}
+						captionText={mediaTitle || ''}
+						format={format}
+						displayCredit={false}
+						shouldLimitWidth={shouldLimitWidth}
+						mediaType="Video"
+					/>
+				)}
+			</div>
+		</StickyVideo>
 	);
 };

--- a/dotcom-rendering/src/web/lib/useStickyVideo.ts
+++ b/dotcom-rendering/src/web/lib/useStickyVideo.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState, useRef } from 'react';
+import libDebounce from 'lodash.debounce';
+
+const useStickyVideo = (
+	options: IntersectionObserverInit & { debounce?: boolean },
+): [boolean, React.Dispatch<React.SetStateAction<HTMLElement | null>>] => {
+	const [isIntersecting, setIsIntersecting] = useState<boolean>(false);
+	const [node, setNode] = useState<HTMLElement | null>(null);
+
+	const observer = useRef<IntersectionObserver | null>(null);
+
+	// Enabling debouncing ensures the target element intersects for at least
+	// 200ms before the callback is executed
+	const intersectionFn: IntersectionObserverCallback = ([entry]) => {
+		if (entry.isIntersecting) {
+			setIsIntersecting(true);
+		} else {
+			setIsIntersecting(false);
+		}
+	};
+	const intersectionCallback = options.debounce
+		? libDebounce(intersectionFn, 200)
+		: intersectionFn;
+
+	useEffect((): any => {
+		if (observer.current) {
+			observer.current.disconnect();
+		}
+
+		if (window.IntersectionObserver) {
+			observer.current = new window.IntersectionObserver(
+				intersectionCallback,
+				options,
+			);
+
+			const { current: currentObserver } = observer;
+
+			if (node) {
+				currentObserver.observe(node);
+			}
+
+			return () => currentObserver.disconnect();
+		}
+	}, [node, options, intersectionCallback]);
+
+	return [isIntersecting, setNode];
+};
+
+export { useStickyVideo };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Draft PR to for sticky video work to share code with @mxdvl. The design work is not complete currently so this is more about creating a working sticky video, that only sticks when the video is playing.

So far we have a `StickyVideo` wrapper component, and a `useStickyVideo` hook (based on the `useHasBeenSeen` hook) which creates an `IntersectionObserver`.

To do still:
- access video atom playing state (youtube iframe api?)
- refine threshold for sticking

## Why?

### Before

### After
