### PR TITLE
Remove filters from Webpack configs

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -38,15 +38,16 @@ module.exports = ({ isLegacyJS, sessionId }) => ({
 	optimization: {
 		splitChunks: { cacheGroups: { default: false } },
 	},
-	plugins: [
-		DEV &&
-			new GuStatsReportPlugin({
-				buildName: isLegacyJS ? 'legacy-client' : 'client',
-				project: 'dotcom-rendering',
-				team: 'dotcom',
-				sessionId,
-			}),
-	].filter(Boolean),
+	plugins: DEV
+		? [
+				new GuStatsReportPlugin({
+					buildName: isLegacyJS ? 'legacy-client' : 'client',
+					project: 'dotcom-rendering',
+					team: 'dotcom',
+					sessionId,
+				}),
+		  ]
+		: undefined,
 	module: {
 		rules: [
 			{

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -53,30 +53,41 @@ const commonConfigs = ({ platform }) => ({
 		new webpack.IgnorePlugin({
 			resourceRegExp: /^(canvas|bufferutil|utf-8-validate)$/,
 		}),
-		PROD &&
-			new BundleAnalyzerPlugin({
-				reportFilename: path.join(dist, `${platform}-bundles.html`),
-				analyzerMode: 'static',
-				openAnalyzer: false,
-				logLevel: 'warn',
-			}),
-		DEV &&
-			new WebpackMessages({
-				name: platform,
-				logger: (message) => {
-					// distinguish between initial and subsequent (re)builds in console output
-					if (builds < module.exports.length * 2) {
-						message = message
-							.replace('Building', 'Building initial')
-							.replace('Completed', 'Completed initial');
-					} else {
-						message = message.replace('Building', 'Rebuilding');
-					}
-					console.log(message);
-					builds += 1;
-				},
-			}),
-	].filter(Boolean),
+		...(DEV
+			? // DEV plugins
+			  [
+					new WebpackMessages({
+						name: platform,
+						logger: (message) => {
+							// distinguish between initial and subsequent (re)builds in console output
+							if (builds < module.exports.length * 2) {
+								message = message
+									.replace('Building', 'Building initial')
+									.replace('Completed', 'Completed initial');
+							} else {
+								message = message.replace(
+									'Building',
+									'Rebuilding',
+								);
+							}
+							console.log(message);
+							builds += 1;
+						},
+					}),
+			  ]
+			: // PROD plugins
+			  [
+					new BundleAnalyzerPlugin({
+						reportFilename: path.join(
+							dist,
+							`${platform}-bundles.html`,
+						),
+						analyzerMode: 'static',
+						openAnalyzer: false,
+						logLevel: 'warn',
+					}),
+			  ]),
+	],
 	infrastructureLogging: {
 		level: PROD ? 'info' : 'warn',
 	},
@@ -92,17 +103,20 @@ module.exports = [
 		DEV ? require(`./dev/webpack.config.dev-server`) : {},
 	),
 	// browser bundle configs
-	// TODO: ignore static files for legacy compliation
-	INCLUDE_LEGACY &&
-		merge(
-			commonConfigs({
-				platform: 'browser.legacy',
-			}),
-			require(`./webpack.config.browser`)({
-				isLegacyJS: true,
-				sessionId,
-			}),
-		),
+	// TODO: ignore static files for legacy compilation
+	...(INCLUDE_LEGACY
+		? [
+				merge(
+					commonConfigs({
+						platform: 'browser.legacy',
+					}),
+					require(`./webpack.config.browser`)({
+						isLegacyJS: true,
+						sessionId,
+					}),
+				),
+		  ]
+		: []),
 	merge(
 		commonConfigs({
 			platform: 'browser',
@@ -112,4 +126,4 @@ module.exports = [
 			sessionId,
 		}),
 	),
-].filter(Boolean);
+];

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -50,16 +50,18 @@ module.exports = ({ sessionId }) => ({
 				: callback();
 		},
 	],
-	plugins: [
-		DEV &&
-			new GuStatsReportPlugin({
-				displayDisclaimer: true,
-				buildName: 'server',
-				project: 'dotcom-rendering',
-				team: 'dotcom',
-				sessionId,
-			}),
-	].filter(Boolean),
+	plugins: DEV
+		? [
+				new GuStatsReportPlugin({
+					displayDisclaimer: true,
+					buildName: 'server',
+					project: 'dotcom-rendering',
+					team: 'dotcom',
+					sessionId,
+					// TODO: convert the plugin to TS
+				}),
+		  ]
+		: undefined,
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
## What does this change?

Removes the strange `.filter(Boolean)` used in the Webpack configs for a more idiomatic ternary.

## Why?

Preps the changes coming in #3967, and ensures git history is kept.
