### PR TITLE
Render caption on email signup embeds

### DIFF
--- a/apps-rendering/src/components/emailSignup.tsx
+++ b/apps-rendering/src/components/emailSignup.tsx
@@ -32,8 +32,8 @@ const EmailSignupEmbed: FC<Props> = ({ embed }) => (
 			height="52"
 			title={withDefault('Email newsletter signup embed')(embed.alt)}
 		></iframe>
-		{maybeRender(embed.alt, (alt) => (
-			<figcaption css={captionStyles}>{alt}</figcaption>
+		{maybeRender(embed.caption, (caption) => (
+			<figcaption css={captionStyles}>{caption}</figcaption>
 		))}
 	</figure>
 );


### PR DESCRIPTION
## What does this change?

* Renders the `caption` field on Email Signup embeds, instead of the `alt` field

## Why?

* Now that the npm package `@guardian/apps-rendering-api-models` has been updated to use the latest `@guardian/content-api-models`, the `caption` field is available to render

Related PRs:

* https://github.com/guardian/dotcom-rendering/pull/3973
* https://github.com/guardian/dotcom-rendering/pull/3930
