### PR TITLE
Convert GuStatsPlugin to Typescript

### DIFF
--- a/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.ts
+++ b/dotcom-rendering/scripts/webpack/plugins/gu-stats-report-plugin.ts
@@ -21,9 +21,9 @@ class GuStatsReportPlugin implements WebpackPluginInstance {
 		log: (...args: unknown[]) => void;
 	} = console;
 
-	protected gitBranch?: string;
+	protected gitBranch: string = 'unknown';
 
-	protected gitHash?: string;
+	protected gitHash: string = 'unknown';
 
 	constructor(config?: {
 		team: string;
@@ -79,13 +79,6 @@ class GuStatsReportPlugin implements WebpackPluginInstance {
 					'Unable to report stats - invalid config',
 				);
 
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars -- it will be used later
-			type Payload = {
-				label: string;
-				properties: Array<{ name: string; value: string }>;
-				metrics: Array<{ name: string; value: number }>;
-			};
-
 			const URL = 'https://logs.guardianapis.com/log';
 			fetch(URL, {
 				method: 'POST',
@@ -110,11 +103,11 @@ class GuStatsReportPlugin implements WebpackPluginInstance {
 						},
 						{
 							name: 'gitHash',
-							value: this.gitHash || 'unknown',
+							value: this.gitHash,
 						},
 						{
 							name: 'gitBranch',
-							value: this.gitBranch || 'unknown',
+							value: this.gitBranch,
 						},
 						{
 							name: 'sessionId',

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.ts
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.ts
@@ -1,5 +1,4 @@
-import type { Configuration, WebpackPluginInstance } from 'webpack';
-// @ts-ignore -- TODO: Convert to Typescript
+import type { Configuration} from 'webpack';
 import GuStatsReportPlugin from './plugins/gu-stats-report-plugin';
 
 const PROD = process.env.NODE_ENV === 'production';
@@ -62,8 +61,7 @@ export default ({
 					project: 'dotcom-rendering',
 					team: 'dotcom',
 					sessionId,
-					// TODO: remove assertion
-				}) as WebpackPluginInstance,
+				}),
 		  ]
 		: undefined,
 	module: {

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.ts
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.ts
@@ -1,4 +1,4 @@
-import type { Configuration, WebpackPluginInstance } from 'webpack';
+import type { Configuration } from 'webpack';
 import WebpackNodeExternals from 'webpack-node-externals';
 import GuStatsReportPlugin from './plugins/gu-stats-report-plugin';
 
@@ -60,8 +60,7 @@ export default ({ sessionId }: { sessionId: string }): Configuration => ({
 					project: 'dotcom-rendering',
 					team: 'dotcom',
 					sessionId,
-					// TODO: convert the plugin to TS
-				}) as WebpackPluginInstance,
+				}),
 		  ]
 		: undefined,
 	module: {


### PR DESCRIPTION
## What does this change?

Convert GuStatsReportPlugin to Typescript.

## Why?

We’re converting the Webpack config to typescript in #3967.