### PR TITLE
Handle backgrounded liveblogs

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -200,17 +200,12 @@ export const Liveness = ({
 			}
 		};
 
-		window.addEventListener(
-			'visibilitychange',
-			handleVisibilityChange,
-			false,
-		);
+		window.addEventListener('visibilitychange', handleVisibilityChange);
 
 		return () => {
 			window.removeEventListener(
 				'visibilitychange',
 				handleVisibilityChange,
-				false,
 			);
 		};
 	}, [numHiddenBlocks]);

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -134,7 +134,7 @@ export const Liveness = ({
 				// Always insert the new blocks in the dom (but hidden)
 				insert(data.html);
 
-				if (topOfBlogVisible()) {
+				if (topOfBlogVisible() && document.hasFocus()) {
 					revealNewBlocks();
 					setNumHiddenBlocks(0);
 				} else {
@@ -178,6 +178,42 @@ export const Liveness = ({
 
 		observer.observe(topOfBlog);
 	}
+
+	/**
+	 * This useEffect sets up a listener for when the page is backgrounded or restored. We
+	 * do this so that any new blocks that were fetched while the blog was in the
+	 * background are animated in at the point when focus is restored
+	 */
+	useEffect(() => {
+		const handleVisibilityChange = () => {
+			// The blog was either hiiden or has become visible
+			if (
+				// If we're returning to a blog that has pending blocks and the reader
+				// is at the top of the page then...
+				document.visibilityState === 'visible' &&
+				numHiddenBlocks > 0 &&
+				topOfBlogVisible()
+			) {
+				revealNewBlocks();
+				setNumHiddenBlocks(0);
+				setShowToast(false);
+			}
+		};
+
+		window.addEventListener(
+			'visibilitychange',
+			handleVisibilityChange,
+			false,
+		);
+
+		return () => {
+			window.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange,
+				false,
+			);
+		};
+	}, [numHiddenBlocks]);
 
 	const handleToastClick = () => {
 		setShowToast(false);

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -186,7 +186,7 @@ export const Liveness = ({
 	 */
 	useEffect(() => {
 		const handleVisibilityChange = () => {
-			// The blog was either hiiden or has become visible
+			// The blog was either hidden or has become visible
 			if (
 				// If we're returning to a blog that has pending blocks and the reader
 				// is at the top of the page then...


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces logic to handle when any new blocks are revealed to the reader

## Why?
If a blog is on a page or tab that does not have focus then it will continue to poll but we don't want any updates to be inserted into the top of the blog while the page is backgrounded. Once the page becomes visible again then, at that point, the new blocks are revealed.
