### PR TITLE
Set a min height for email embed iframes

### DIFF
--- a/apps-rendering/src/components/emailSignup.tsx
+++ b/apps-rendering/src/components/emailSignup.tsx
@@ -13,6 +13,10 @@ interface Props {
 const styles = css`
 	margin: ${remSpace[4]} 0;
 
+	iframe {
+		min-height: 60px;
+	}
+
 	${darkModeCss`
         background: white;
         padding: ${remSpace[3]};
@@ -29,7 +33,7 @@ const EmailSignupEmbed: FC<Props> = ({ embed }) => (
 		<iframe
 			src={embed.src}
 			className="js-email-signup"
-			height="52"
+			height="60"
 			title={withDefault('Email newsletter signup embed')(embed.alt)}
 		></iframe>
 		{maybeRender(embed.caption, (caption) => (

--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -19,11 +19,12 @@ const emailCaptionStyle = css`
 	color: ${text.supporting};
 `;
 
-const embedContainer = css`
+const embedContainerStyles = (isEmailEmbed: boolean) => css`
 	iframe {
 		/* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
 		/* stylelint-disable-next-line declaration-no-important */
 		width: 100% !important;
+		${isEmailEmbed && `min-height: 60px;`}
 	}
 `;
 
@@ -46,7 +47,7 @@ export const EmbedBlockComponent = ({
 			source={source}
 			sourceDomain={sourceDomain}
 		>
-			<div data-cy="embed-block" css={embedContainer}>
+			<div data-cy="embed-block" css={embedContainerStyles(isEmailEmbed)}>
 				<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
 				{isEmailEmbed && caption && (
 					<div css={emailCaptionStyle}>{caption}</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Sets a `min-height` for email embed iframes to `60px`

## Why?

* Prevents the reCAPTCHA message getting clipped

### Before

In some, but not all cases:
<img width="680" alt="Screenshot 2022-02-17 at 12 43 31" src="https://user-images.githubusercontent.com/705427/154484248-acbe6090-69c6-40f3-8b48-9c915bc5c68e.png">

### After

<img width="694" alt="Screenshot 2022-02-17 at 12 44 18" src="https://user-images.githubusercontent.com/705427/154484400-e487c364-cc5a-4aad-82b1-c77ccd50f7f8.png">