### PR TITLE
Add LiveDateline component for liveblogs/deadblogs

### DIFF
--- a/apps-rendering/src/components/liveDateline.tsx
+++ b/apps-rendering/src/components/liveDateline.tsx
@@ -1,12 +1,13 @@
 // ----- Imports ----- //
 
 import { css, keyframes } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { neutral, pxToRem, textSans } from '@guardian/source-foundations';
-import type { FC } from 'react';
-import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import { maybeRender } from 'lib';
 import { makeRelativeDate } from 'date';
+import { maybeRender } from 'lib';
+import type { FC } from 'react';
 
 // ----- Component ----- //
 
@@ -17,7 +18,7 @@ const livePulse = keyframes`
     100% {opacity: 1;}
 `;
 
-const timestampStyles = (isDeadBlog: boolean = false) => css`
+const timestampStyles = (isDeadBlog = false): ReturnType<typeof css> => css`
 	color: ${isDeadBlog ? neutral[7] : neutral[100]};
 	${textSans.xxsmall({ lineHeight: 'tight' })}
 `;

--- a/apps-rendering/src/components/liveDateline.tsx
+++ b/apps-rendering/src/components/liveDateline.tsx
@@ -1,0 +1,61 @@
+// ----- Imports ----- //
+
+import { css, keyframes } from '@emotion/react';
+import { neutral, pxToRem, textSans } from '@guardian/source-foundations';
+import type { FC } from 'react';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+import type { Option } from '@guardian/types';
+import { maybeRender } from 'lib';
+import { makeRelativeDate } from 'date';
+
+// ----- Component ----- //
+
+const livePulse = keyframes`
+    0% {opacity: 1;}
+    10% {opacity: .25;}
+    40% {opacity: 1;}
+    100% {opacity: 1;}
+`;
+
+const timestampStyles = (isDeadBlog: boolean = false) => css`
+	color: ${isDeadBlog ? neutral[7] : neutral[100]};
+	${textSans.xxsmall({ lineHeight: 'tight' })}
+`;
+
+const liveSpanStyles = css`
+	font-weight: bold;
+
+	&::before {
+		content: '';
+		display: inline-block;
+		border-radius: 100%;
+		background-color: ${neutral[100]};
+		width: ${pxToRem(9)}rem;
+		height: ${pxToRem(9)}rem;
+		margin-right: ${pxToRem(2)}rem;
+		animation: ${livePulse} 1s infinite;
+
+		@media (prefers-reduced-motion) {
+			animation: none;
+		}
+	}
+`;
+
+interface Props {
+	date: Option<Date>;
+	format: ArticleFormat;
+}
+
+const RelativeDateline: FC<Props> = ({ date, format }) =>
+	maybeRender(date, (d) => (
+		<time css={timestampStyles(format.design === ArticleDesign.DeadBlog)}>
+			{format.design === ArticleDesign.LiveBlog && (
+				<span css={liveSpanStyles}>LIVE </span>
+			)}
+			Updated {makeRelativeDate(d)}
+		</time>
+	));
+
+// ----- Exports ----- //
+
+export default RelativeDateline;

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -1,8 +1,6 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
 import { background } from '@guardian/common-rendering/src/editorialPalette';
-import { neutral, textSans } from '@guardian/source-foundations';
 import { Column, Columns, Container } from '@guardian/source-react-components';
 import Headline from 'components/headline';
 import Standfirst from 'components/standfirst';
@@ -10,13 +8,9 @@ import type { DeadBlog, LiveBlog } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
 import Series from './series';
+import LiveDateline from './liveDateline';
 
 // ----- Component ----- //
-
-const timestampStyles = css`
-	color: ${neutral[100]};
-	${textSans.xxsmall({ lineHeight: 'tight' })}
-`;
 
 interface Props {
 	item: LiveBlog | DeadBlog;
@@ -46,9 +40,7 @@ const LiveblogHeader: FC<Props> = ({ item }) => {
 			>
 				<Columns collapseUntil="desktop">
 					<Column span={3}>
-						<time css={timestampStyles}>
-							TODO: Updated timestamp
-						</time>
+						<LiveDateline date={item.publishDate} format={format} />
 					</Column>
 					<Column span={8}>
 						<Standfirst item={item} />

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -7,8 +7,8 @@ import Standfirst from 'components/standfirst';
 import type { DeadBlog, LiveBlog } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
-import Series from './series';
 import LiveDateline from './liveDateline';
+import Series from './series';
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -1,7 +1,12 @@
 // ----- Imports ----- //
 
 import { background } from '@guardian/common-rendering/src/editorialPalette';
-import { Column, Columns, Container } from '@guardian/source-react-components';
+import {
+	Column,
+	Columns,
+	Container,
+	Hide,
+} from '@guardian/source-react-components';
 import Headline from 'components/headline';
 import Standfirst from 'components/standfirst';
 import type { DeadBlog, LiveBlog } from 'item';
@@ -40,7 +45,12 @@ const LiveblogHeader: FC<Props> = ({ item }) => {
 			>
 				<Columns collapseUntil="desktop">
 					<Column span={3}>
-						<LiveDateline date={item.publishDate} format={format} />
+						<Hide below="desktop">
+							<LiveDateline
+								date={item.publishDate}
+								format={format}
+							/>
+						</Hide>
 					</Column>
 					<Column span={8}>
 						<Standfirst item={item} />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a relative time to the header of liveblogs or deadblogs, showing time since last update

## Why?

### Before
<img width="387" alt="image" src="https://user-images.githubusercontent.com/99400613/154546516-80e2d252-09c7-408c-a6f6-a849e3c6c47e.png">

### After
<img width="490" alt="image" src="https://user-images.githubusercontent.com/99400613/154546402-4f9cef5a-ab1f-4ef4-9c3d-cdf8f4d22a83.png">
