### PR TITLE
Update Quote icon alignment

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -1,6 +1,7 @@
-import { css, ClassNames } from '@emotion/react';
+import { ClassNames } from '@emotion/react';
 
 import { body } from '@guardian/source-foundations';
+import { renderToString } from 'react-dom/server';
 import { unwrapHtml } from '../../model/unwrapHtml';
 import { RewrappedComponent } from './RewrappedComponent';
 import { QuoteIcon } from './QuoteIcon';
@@ -11,42 +12,31 @@ type Props = {
 	quoted?: boolean;
 };
 
-const BlockquoteRow = ({ children }: { children: React.ReactNode }) => (
-	<blockquote
-		css={css`
-			display: flex;
-			flex-direction: row;
-		`}
-	>
-		{children}
-	</blockquote>
-);
-
 export const BlockquoteBlockComponent: React.FC<Props> = ({
 	html,
 	palette,
 	quoted,
 }: Props) => (
 	<ClassNames>
-		{({ css: _css }) => {
-			const baseBlockquoteStyles = _css`
-			margin-bottom: 16px;
-			${body.medium()};
-			font-style: italic;
-		`;
+		{({ css }) => {
+			const baseBlockquoteStyles = css`
+				margin-bottom: 16px;
+				${body.medium()};
+				font-style: italic;
+			`;
 
-			const simpleBlockquoteStyles = _css`
-			${baseBlockquoteStyles}
-			margin-top: 16px;
-			margin-right: 0;
-			margin-bottom: 16px;
-			margin-left: 33px;
-		`;
+			const simpleBlockquoteStyles = css`
+				${baseBlockquoteStyles}
+				margin-top: 16px;
+				margin-right: 0;
+				margin-bottom: 16px;
+				margin-left: 33px;
+			`;
 
-			const quotedBlockquoteStyles = _css`
-			${baseBlockquoteStyles}
-			color: ${palette.text.blockquote};
-		`;
+			const quotedBlockquoteStyles = css`
+				${baseBlockquoteStyles}
+				color: ${palette.text.blockquote};
+			`;
 
 			const {
 				willUnwrap: isUnwrapped,
@@ -70,19 +60,21 @@ export const BlockquoteBlockComponent: React.FC<Props> = ({
 			});
 
 			if (quoted) {
+				const htmlWithIcon = unwrappedHtml
+					.trim()
+					.replace(
+						'<p>',
+						`<p>${renderToString(
+							<QuoteIcon colour={palette.fill.blockquoteIcon} />,
+						)}`,
+					);
 				return (
-					<BlockquoteRow>
-						<QuoteIcon
-							colour={palette.fill.blockquoteIcon}
-							size="medium"
-						/>
-						<RewrappedComponent
-							isUnwrapped={isUnwrapped}
-							html={unwrappedHtml}
-							elCss={quotedBlockquoteStyles}
-							tagName={unwrappedElement}
-						/>
-					</BlockquoteRow>
+					<RewrappedComponent
+						isUnwrapped={isUnwrapped}
+						html={htmlWithIcon}
+						tagName="blockquote"
+						elCss={quotedBlockquoteStyles}
+					/>
 				);
 			}
 			return (

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -166,10 +166,7 @@ export const CardHeadline = ({
 						/>
 					)}
 					{showQuotes && (
-						<QuoteIcon
-							colour={palette.text.cardKicker}
-							size={size}
-						/>
+						<QuoteIcon colour={palette.text.cardKicker} />
 					)}
 
 					<span

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -85,9 +85,7 @@ export const LinkHeadline = ({
 					showSlash={showSlash}
 				/>
 			)}
-			{showQuotes && (
-				<QuoteIcon colour={palette.text.linkKicker} size={size} />
-			)}
+			{showQuotes && <QuoteIcon colour={palette.text.linkKicker} />}
 			{link ? (
 				// We were passed a link object so headline should be a link, with link styling
 				<>

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -156,7 +156,7 @@ export const PullQuoteBlockComponent: React.FC<{
 						`,
 					]}
 				>
-					<QuoteIcon colour={palette.fill.quoteIcon} size="medium" />
+					<QuoteIcon colour={palette.fill.quoteIcon} />
 					<blockquote
 						css={css`
 							display: inline;
@@ -189,7 +189,7 @@ export const PullQuoteBlockComponent: React.FC<{
 						`,
 					]}
 				>
-					<QuoteIcon colour={palette.fill.quoteIcon} size="large" />
+					<QuoteIcon colour={palette.fill.quoteIcon} />
 					<blockquote
 						// eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={{
@@ -235,7 +235,7 @@ export const PullQuoteBlockComponent: React.FC<{
 						`,
 					]}
 				>
-					<QuoteIcon colour={palette.fill.quoteIcon} size="medium" />
+					<QuoteIcon colour={palette.fill.quoteIcon} />
 					<blockquote
 						css={css`
 							display: inline;

--- a/dotcom-rendering/src/web/components/QuoteIcon.tsx
+++ b/dotcom-rendering/src/web/components/QuoteIcon.tsx
@@ -1,84 +1,23 @@
 import { css } from '@emotion/react';
 
-import { until } from '@guardian/source-foundations';
-
-const quoteStyles = (colour?: string) => css`
-	height: 17px;
-	width: 9px;
-	margin-right: 12px;
-	transform: translateY(-1px);
-	overflow: visible;
-	fill: ${colour && colour};
+const quoteStyles = (colour: string) => css`
+	height: 1em;
+	width: 1.5em;
+	margin-right: 3px;
+	vertical-align: baseline;
+	fill: ${colour};
 `;
-
-const sizeStyles = (size: SmallHeadlineSize) => {
-	const tinySvg = css`
-		svg {
-			height: 13px;
-			width: 7px;
-		}
-	`;
-	const smallSvg = css`
-		svg {
-			height: 16px;
-			width: 8px;
-		}
-	`;
-	const mediumSvg = css`
-		margin-right: 4px;
-		svg {
-			height: 20px;
-			width: 11px;
-		}
-	`;
-	const largeSvg = css`
-		margin-right: 8px;
-		svg {
-			height: 24px;
-			width: 13px;
-		}
-	`;
-	switch (size) {
-		case 'tiny':
-			return css`
-				${tinySvg}
-			`;
-		case 'small':
-			return css`
-				${smallSvg}
-			`;
-		case 'medium':
-			return css`
-				${mediumSvg}
-				${until.desktop} {
-					${smallSvg}
-				}
-			`;
-		case 'large':
-			return css`
-				${largeSvg}
-				${until.desktop} {
-					${mediumSvg}
-				}
-			`;
-	}
-};
 
 type Props = {
 	colour: string;
-	size: SmallHeadlineSize;
 };
 
-export const QuoteIcon = ({ colour, size }: Props) => (
-	<span css={sizeStyles(size)}>
-		<svg
-			width="70"
-			height="49"
-			viewBox="0 0 35 25"
-			css={quoteStyles(colour)}
-			data-testid="quote-icon"
-		>
-			<path d="M69.587.9c-1.842 15.556-3.89 31.316-4.708 48.1H37.043c3.07-16.784 8.391-32.544 17.602-48.1h14.942zM32.949.9c-2.047 15.556-4.094 31.316-4.912 48.1H.2C3.066 32.216 8.592 16.456 17.598.9h15.35z" />
-		</svg>
-	</span>
+/**
+ * An inline quote icon (“) sized to match the font size.
+ */
+export const QuoteIcon = ({ colour }: Props) => (
+	/* This viewBox is narrower than Source’s SvgQuote */
+	<svg viewBox="4 4 24 16" css={quoteStyles(colour)}>
+		<path d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z" />
+	</svg>
 );

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -261,13 +261,11 @@ export const RichLink = ({
 										<Hide when="above" breakpoint="wide">
 											<QuoteIcon
 												colour={palette.fill.quoteIcon}
-												size="small"
 											/>
 										</Hide>
 										<Hide when="below" breakpoint="wide">
 											<QuoteIcon
 												colour={palette.fill.quoteIcon}
-												size="medium"
 											/>
 										</Hide>
 									</>


### PR DESCRIPTION
## Why?

It’s not tight enough.

### Before

<img width="694" alt="image" src="https://user-images.githubusercontent.com/76776/155110250-74a468ce-b969-44f3-bc19-e3db10a1390c.png">

### After

<img width="696" alt="image" src="https://user-images.githubusercontent.com/76776/155110760-65fd6993-c7d5-4a6a-a8b4-1b4ea05b96e3.png">
