### PR TITLE
Wrong folder for dev server

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
@@ -63,7 +63,6 @@ module.exports = {
 						__dirname,
 						'..',
 						'..',
-						'..',
 						'src',
 						'server',
 						'dev-index.html',


### PR DESCRIPTION
## What does this change?

Includes the `dev-index.html` from the right folder.

## Why?

I probably mixed-up the merge conflicts from #4017 