### PR TITLE
`Span` Module - Calculating Widths By Guardian Grid Columns

### DIFF
--- a/common-rendering/src/span.test.ts
+++ b/common-rendering/src/span.test.ts
@@ -1,0 +1,55 @@
+// ----- Imports ----- //
+
+import {
+    Grid,
+    span,
+    spanTablet,
+    spanDesktop,
+    spanLeftCol,
+    spanWide,
+} from "./span";
+
+// ----- Tests ----- //
+
+describe("span", () => {
+    describe("spanTablet", () => {
+        it("calculates the width of 5 columns for a tablet grid", () => {
+            expect(spanTablet(5)).toBe(280);
+        });
+    });
+
+    describe("spanDesktop", () => {
+        it("calculates the width of 6 columns for a desktop grid", () => {
+            expect(spanDesktop(6)).toBe(460);
+        });
+    });
+
+    describe("spanLeftCol", () => {
+        it("calculates the width of 7 columns for a leftCol grid", () => {
+            expect(spanLeftCol(7)).toBe(540);
+        });
+    });
+
+    describe("spanWide", () => {
+        it("calculates the width of 8 columns for a wide grid", () => {
+            expect(spanWide(8)).toBe(620);
+        });
+    });
+
+    describe("span", () => {
+        it("calculates the width of 8 columns for a tablet grid", () => {
+            expect(span(Grid.Tablet)(8)).toBe(460);
+        });
+        it("calculates the width of 7 columns for a desktop grid", () => {
+            expect(span(Grid.Desktop)(7)).toBe(540);
+        });
+        it("calculates the width of 6 columns for a leftCol grid", () => {
+            expect(span(Grid.LeftCol)(6)).toBe(460);
+        });
+        it("calculates the width of 5 columns for a wide grid", () => {
+            expect(span(Grid.Wide)(5)).toBe(380);
+        });
+    });
+});
+
+

--- a/common-rendering/src/span.ts
+++ b/common-rendering/src/span.ts
@@ -1,0 +1,48 @@
+// ----- Definitions ----- //
+
+enum Grid {
+    Tablet,
+    Desktop,
+    LeftCol,
+    Wide,
+}
+
+const tabletColumnSize = 40;
+const desktopColumnSize = 60;
+const gutterSize = 20;
+
+// ----- Functions ----- //
+
+const calcSpan = (columnSize: number) => (numColumns: number): number =>
+    (numColumns * columnSize) + ((numColumns - 1) * gutterSize);
+
+function span(grid: Grid.Tablet): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12) => number;
+function span(grid: Grid.Desktop): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12) => number;
+function span(grid: Grid.LeftCol): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14) => number;
+function span(grid: Grid.Wide): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16) => number;
+function span(grid: Grid): (numColumns: number) => number {
+    switch (grid) {
+        case Grid.Tablet:
+            return calcSpan(tabletColumnSize);
+        case Grid.Desktop:
+        case Grid.LeftCol:
+        case Grid.Wide:
+            return calcSpan(desktopColumnSize);
+    }
+}
+
+const spanTablet = span(Grid.Tablet);
+const spanDesktop = span(Grid.Desktop);
+const spanLeftCol = span(Grid.LeftCol);
+const spanWide = span(Grid.Wide);
+
+// ----- Exports ----- //
+
+export {
+    Grid,
+    span,
+    spanTablet,
+    spanDesktop,
+    spanLeftCol,
+    spanWide,
+}

--- a/common-rendering/src/span.ts
+++ b/common-rendering/src/span.ts
@@ -1,5 +1,10 @@
 // ----- Definitions ----- //
 
+/**
+ * The Guardian Grid sizes, used for structuring page designs. For more
+ * information see https://theguardian.design/2a1e5182b/p/41be19-grids or
+ * the documentation for the `span` function in this module.
+ */
 enum Grid {
     Tablet,
     Desktop,
@@ -16,6 +21,54 @@ const gutterSize = 20;
 const calcSpan = (columnSize: number) => (numColumns: number): number =>
     (numColumns * columnSize) + ((numColumns - 1) * gutterSize);
 
+/**
+ * Takes a grid size and a number of columns, and returns the width
+ * corresponding to that number of columns at that grid size.
+ * 
+ * The grid sizes are as follows:
+ * - Tablet: 12 columns of 40px, 20px gutters between
+ * - Desktop: 12 columns of 60px, 20px gutters between
+ * - LeftCol: 14 columns of 60px, 20px gutters between
+ * - Wide: 16 columns of 60px, 20px gutters between
+ * 
+ * See https://theguardian.design/2a1e5182b/p/41be19-grids for documentation
+ * on our grids.
+ * 
+ * The function is curried - you can set it up with the grid size you're
+ * working with and provide the number of columns later. This module also
+ * provides convenience functions that already do this for each grid size:
+ * `spanTablet`, `spanDesktop`, `spanLeftCol` and `spanWide`.
+ * 
+ * @param grid One of the breakpoint-based Guardian grid sizes: Tablet, Desktop,
+ * LeftCol or Wide
+ * @param numColumns The number of columns
+ * @returns {number} The width in pixels
+ * @example
+ * const tabletWidth = span(Grid.Tablet)(5) // 280
+ * const desktopWidth = span(Grid.Desktop)(5) // 380
+ * const leftColWidth = span(Grid.LeftCol)(6) // 460
+ * const wideWidth = span(Grid.Wide)(7) // 540
+ * 
+ * const styles = css`
+ *   width: 100%;
+ * 
+ *   ${from.tablet} {
+ *     width: ${tabletWidth}px;
+ *   }
+ * 
+ *   ${from.desktop} {
+ *     width: ${desktopWidth}px;
+ *   }
+ * 
+ *   ${from.leftCol} {
+ *     width: ${leftColWidth}px;
+ *   }
+ * 
+ *   ${from.wide} {
+ *     width: ${wideWidth}px;
+ *   }
+ * `;
+ */
 function span(grid: Grid.Tablet): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12) => number;
 function span(grid: Grid.Desktop): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12) => number;
 function span(grid: Grid.LeftCol): (numColumns: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14) => number;
@@ -31,9 +84,52 @@ function span(grid: Grid): (numColumns: number) => number {
     }
 }
 
+/**
+ * Takes a number of columns and returns the width corresponding to that number
+ * of columns for the Guardian Tablet grid size.
+ * 
+ * See the documentation for the `span` function in this module for more
+ * information about Guardian grid sizes.
+ * 
+ * @param numColumns The number of columns, from 1-12
+ * @returns {number} The width in pixels
+ */
 const spanTablet = span(Grid.Tablet);
+
+/**
+ * Takes a number of columns and returns the width corresponding to that number
+ * of columns for the Guardian Desktop grid size.
+ * 
+ * See the documentation for the `span` function in this module for more
+ * information about Guardian grid sizes.
+ * 
+ * @param numColumns The number of columns, from 1-12
+ * @returns {number} The width in pixels
+ */
 const spanDesktop = span(Grid.Desktop);
+
+/**
+ * Takes a number of columns and returns the width corresponding to that number
+ * of columns for the Guardian LeftCol grid size.
+ * 
+ * See the documentation for the `span` function in this module for more
+ * information about Guardian grid sizes.
+ * 
+ * @param numColumns The number of columns, from 1-14
+ * @returns {number} The width in pixels
+ */
 const spanLeftCol = span(Grid.LeftCol);
+
+/**
+ * Takes a number of columns and returns the width corresponding to that number
+ * of columns for the Guardian Wide grid size.
+ * 
+ * See the documentation for the `span` function in this module for more
+ * information about Guardian grid sizes.
+ * 
+ * @param numColumns The number of columns, from 1-16
+ * @returns {number} The width in pixels
+ */
 const spanWide = span(Grid.Wide);
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why?

We have a series of design grids based on the concept of columns and gutters: https://theguardian.design/2a1e5182b/p/41be19-grids

I thought it might be convenient to have some functions that take a number of columns and return the width in pixels for a given grid size. I know that Source does this under the hood for the `Columns` component, but I couldn't find anywhere that we were exposing the base calculations in an API (I may have missed it though).

This is just a draft as I don't know how useful people might find it. It's just something that occurred to me because I was working on something where it would have been handy. All feedback welcome 🙂, particularly from @SiAdcock @sndrs regarding crossover with Source.

### IntelliSense and Type Safety

For all functions in this API the number of columns allowed for a given grid size is constrained at the type level. Passing a number of columns outside of the accepted range will result in a type error, and TS-based IntelliSense is available.

#### IntelliSense On Hover

![intellisense-desktop](https://user-images.githubusercontent.com/53781962/154730081-cdd85c68-3557-406d-bdaa-80702aaa0d36.jpg)
![intellisense-leftcol](https://user-images.githubusercontent.com/53781962/154730087-4ac796d4-7b5f-4375-814e-a720bab7dec6.jpg)

#### IntelliSense For Parameters

![intellisense-parameters](https://user-images.githubusercontent.com/53781962/154730077-ff3ef1eb-4b7c-4542-bcca-f3d61b5d22b4.jpg)

#### Type Safety

![type-safety-desktop](https://user-images.githubusercontent.com/53781962/154730076-22500e92-b420-48b3-b3fb-b4f0340e8d55.jpg)
![type-safety-span](https://user-images.githubusercontent.com/53781962/154730074-51c1f7a0-d8ed-4c10-b762-286eb3fafd0c.jpg)

### API

#### `Grid`

An `enum` specifying the Grid sizes: Tablet, Desktop, LeftCol and Wide. There's also a Mobile grid size, but it's fluid based on screen width and therefore calculating exact widths isn't possible. It might be interesting to consider percentage-or-viewport-based widths in this case... I haven't thought about it enough.

#### `span`

The core function. Takes a grid size and a number of columns, and returns the width corresponding to that number of columns at that grid size (in pixels). I've exported this directly, but in practice it might be preferable to use the convenience functions in most cases.

#### `spanTablet`, `spanDesktop`, `spanLeftCol` and `spanWide`

Convenience functions that calculate the width for a given grid size. Each of these take a number of columns and return the width in pixels.

## Changes

- Added `span` function to calculate width according to number of columns in the Guardian grid
- Added `spanTablet`, `spanDesktop`, `spanLeftCol` and `spanWide` convenience functions
