### PR TITLE
Increase timeout in Cypress click to view embed test

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-1/article.elements.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-1/article.elements.spec.js
@@ -109,7 +109,7 @@ describe('Elements', function () {
 			cy.scrollTo(0, 4500);
 
 			// Wait for hydration
-			cy.get('gu-island[name=EmbedBlockComponent]')
+			cy.get('gu-island[name=EmbedBlockComponent]', { timeout: 30000 })
 				.first()
 				.should('have.attr', 'data-gu-ready', 'true');
 


### PR DESCRIPTION
## What does this change?

Increase the timeout when waiting for the embed element to 30 seconds.

## Why?

This can sometimes take longer than the default 4 seconds, causing the test to fail.
