### PR TITLE
Animate new posts

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 
 import { headline, body, between, space } from '@guardian/source-foundations';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
@@ -72,6 +72,20 @@ const globalLinkStyles = (palette: Palette) => css`
 	}
 `;
 
+const revealStyles = css`
+	/* We're using classnames here because we add and remove these classes
+	   using plain javascript */
+	.reveal {
+		animation: ${keyframes`
+			0% { opacity: 0; }
+			100% { opacity: 1; }
+		`} 4s ease-out;
+	}
+	.pending {
+		display: none;
+	}
+`;
+
 export const ArticleBody = ({
 	format,
 	palette,
@@ -99,7 +113,13 @@ export const ArticleBody = ({
 					id="maincontent"
 					// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
 					className="js-liveblog-body"
-					css={[globalStrongStyles, globalLinkStyles(palette)]}
+					css={[
+						globalStrongStyles,
+						globalLinkStyles(palette),
+						// revealStyles is used to animate the reveal of new blocks
+						format.design === ArticleDesign.LiveBlog &&
+							revealStyles,
+					]}
 				>
 					<LiveBlogRenderer
 						format={format}

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -48,8 +48,9 @@ function insert(html: string, switches: Switches) {
 	// Enhance
 	// -----------
 	if (switches.enhanceTweets) {
-		const pendingBlocks =
-			maincontent.querySelectorAll<HTMLElement>('.pending');
+		const pendingBlocks = maincontent.querySelectorAll<HTMLElement>(
+			'article .pending.block',
+		);
 		// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
 		twttr.ready((twitter) => {
 			twitter.widgets.load(Array.from(pendingBlocks));
@@ -58,11 +59,17 @@ function insert(html: string, switches: Switches) {
 }
 
 /**
- * revealNewBlocks - style any blocks that have been inserted but are hidden such that
- * they are revealed
+ * reveal any blocks that have been inserted but are still hidden
  */
-	console.log('revealNewBlocks');
 function revealPendingBlocks() {
+	const maincontent = document.querySelector<HTMLElement>('#maincontent');
+	const pendingBlocks = maincontent?.querySelectorAll<HTMLElement>(
+		'article .pending.block',
+	);
+	pendingBlocks?.forEach((block) => {
+		block.classList.add('reveal');
+		block.classList.remove('pending');
+	});
 }
 
 /**

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -47,9 +47,9 @@ function insert(html: string, switches: Switches) {
 
 	// Enhance
 	// -----------
-	if (switches.enhaceTweets) {
 		const pandingBlocks =
 			maincontent.querySelectorAll<HTMLElement>('.pending');
+	if (switches.enhanceTweets) {
 		// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
 		twttr.ready((twitter) => {
 			twitter.widgets.load(Array.from(pandingBlocks));

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -37,7 +37,7 @@ function insert(html: string, switches: Switches) {
 
 	// Insert
 	// ------
-	// Shouldn't we snaitise this html?
+	// Shouldn't we sanitise this html?
 	// We're being sent this string by our own backend, not reader input, so we
 	// trust that the tags and attributes it contains are safe and intentional
 	const maincontent = document.querySelector<HTMLElement>('#maincontent');

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -47,12 +47,12 @@ function insert(html: string, switches: Switches) {
 
 	// Enhance
 	// -----------
-		const pandingBlocks =
-			maincontent.querySelectorAll<HTMLElement>('.pending');
 	if (switches.enhanceTweets) {
+		const pendingBlocks =
+			maincontent.querySelectorAll<HTMLElement>('.pending');
 		// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
 		twttr.ready((twitter) => {
-			twitter.widgets.load(Array.from(pandingBlocks));
+			twitter.widgets.load(Array.from(pendingBlocks));
 		});
 	}
 }

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -61,8 +61,8 @@ function insert(html: string, switches: Switches) {
  * revealNewBlocks - style any blocks that have been inserted but are hidden such that
  * they are revealed
  */
-function revealNewBlocks() {
 	console.log('revealNewBlocks');
+function revealPendingBlocks() {
 }
 
 /**
@@ -148,7 +148,7 @@ export const Liveness = ({
 				insert(data.html, switches);
 
 				if (topOfBlogVisible() && document.hasFocus()) {
-					revealNewBlocks();
+					revealPendingBlocks();
 					setNumHiddenBlocks(0);
 				} else {
 					setShowToast(true);
@@ -174,7 +174,7 @@ export const Liveness = ({
 			([entry]) => {
 				if (entry.isIntersecting) {
 					entry.target.classList.add('in-viewport');
-					revealNewBlocks();
+					revealPendingBlocks();
 					setNumHiddenBlocks(0);
 					setShowToast(false);
 					return;
@@ -207,7 +207,7 @@ export const Liveness = ({
 				numHiddenBlocks > 0 &&
 				topOfBlogVisible()
 			) {
-				revealNewBlocks();
+				revealPendingBlocks();
 				setNumHiddenBlocks(0);
 				setShowToast(false);
 			}
@@ -229,7 +229,7 @@ export const Liveness = ({
 			behavior: 'smooth',
 		});
 		window.location.href = '#maincontent';
-		revealNewBlocks();
+		revealPendingBlocks();
 		setNumHiddenBlocks(0);
 	};
 

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -17,8 +17,8 @@ const isServer = typeof window === 'undefined';
 /**
  * insert
  *
- * Takes html, parses and hydrates it, and then inserts the resulting blocks
- * at the top of the liveblog
+ * Takes html, parses and hydrates it, inserts the resulting blocks
+ * at the top of the liveblog, and then enhances any tweets
  *
  * @param {string} html The block html to be inserted
  * @returns void


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds animation when a new blog post is revealed

## Why?
To make it clear to readers what is happening

## Should we change how we announce new content?
We could, I've implemented the same styling here as we have in Frontend but we can still change this later

### Before
![2022-02-21 10 03 56](https://user-images.githubusercontent.com/1336821/154933023-e11ced49-b784-41e5-aa31-702661b4a34f.gif)


### After
![2022-02-21 10 00 26](https://user-images.githubusercontent.com/1336821/154932646-dad9fa2b-3615-44b9-9455-b960c25b7936.gif)
