### PR TITLE
`onFirstPage`

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -402,6 +402,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						filterKeyEvents={CAPI.filterKeyEvents}
 						format={format}
 						switches={CAPI.config.switches}
+						onFirstPage={pagination.currentPage === 1}
+						webURL={CAPI.webURL}
 					/>
 				</Island>
 			)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces the `onFirstPage` prop and builds logic using it to vary what we do depending on if the reader is on the first page of the blog or not

## Why?
We don't want to try and insert content at the top of the second page so instead we now use the Toast more and navigate readers to the first page of the blog if they click it on any subsequent page

### But polling is broken outside the first page
I noticed that polling is returning the wrong results if you're not on the first page. This is because it is using the wrong `latestBlockId`. But this bug is unrelated to this PR.