### PR TITLE
Narrower types for `unwrapHtml`

### DIFF
--- a/dotcom-rendering/src/model/unwrapHtml.test.ts
+++ b/dotcom-rendering/src/model/unwrapHtml.test.ts
@@ -1,9 +1,11 @@
 import { unwrapHtml } from './unwrapHtml';
 
+type Params = Parameters<typeof unwrapHtml>[0];
+
 describe('unwrapHtml', () => {
 	it('Returns unwrapped HTML if prefix and suffix match', () => {
 		// Blockquote, elements inside
-		const bqUnwrap = {
+		const bqUnwrap: Params = {
 			html: '<blockquote class="quote"><p>inner</p></blockquote>',
 			fixes: [
 				{
@@ -17,7 +19,7 @@ describe('unwrapHtml', () => {
 			unwrapHtml(bqUnwrap);
 
 		// Paragraph, no elements inside
-		const pUnwrap = {
+		const pUnwrap: Params = {
 			html: '<p>inner</p>',
 			fixes: [
 				{
@@ -37,7 +39,7 @@ describe('unwrapHtml', () => {
 	});
 
 	it('Returns non-unwrapped HTML if prefix and suffix do not match', () => {
-		const bqUnwrap = {
+		const bqUnwrap: Params = {
 			html: '<blockquote><p>inner</p></blockquote>',
 			fixes: [
 				{
@@ -53,7 +55,7 @@ describe('unwrapHtml', () => {
 	});
 
 	it('Returns wrapped HTML if prefix and suffix of one "fix" match from multiple options', () => {
-		const bqUnwrap = {
+		const bqUnwrap: Params = {
 			html: '<blockquote><p>inner</p></blockquote>',
 			fixes: [
 				{
@@ -75,7 +77,7 @@ describe('unwrapHtml', () => {
 			unwrappedElement: bqUnwrappedElement,
 		} = unwrapHtml(bqUnwrap);
 
-		const pUnwrap = {
+		const pUnwrap: Params = {
 			html: '<p>inner</p>',
 			fixes: [
 				{
@@ -96,7 +98,7 @@ describe('unwrapHtml', () => {
 			unwrappedElement: pUnwrappedElement,
 		} = unwrapHtml(pUnwrap);
 
-		const ulUnwrap = {
+		const ulUnwrap: Params = {
 			html: '<ul><li>Test</li><li>test2</li></ul>',
 			fixes: [
 				{

--- a/dotcom-rendering/src/model/unwrapHtml.ts
+++ b/dotcom-rendering/src/model/unwrapHtml.ts
@@ -1,48 +1,55 @@
-const stripTags = (html: string, prefix: string, suffix: string) => {
-	return html.slice(prefix.length, html.length - suffix.length);
-};
+type HTMLTag = keyof HTMLElementTagNameMap;
+
+type Prefix = `<${HTMLTag}${'' | ` ${string}`}>`;
+type Suffix = `</${HTMLTag}>`;
+
+const stripTags = (html: string, prefix: Prefix, suffix: Suffix) =>
+	html.slice(prefix.length, html.length - suffix.length);
 
 /**
-unwrapHtml will check whether the html passed in starts with any of the prefixes
-and ends with the suffixes and will then return the html with the prefix and
-suffix stripped off, as well as the matching element that we want to 'rewrap'
-the html in
+ * This method unwraps a string of HTML from an enclosing tag.
+ *
+ * If the HTML passed in matches any of the fixes, in order, we will unwrap.
+ * A fix matches if it starts with the prefix and ends with the suffix provided.
+ *
+ * - `willUnwrap === true`:
+ * 	Return the html with the prefix and suffix stripped off,
+ * 	as well as the matching element that we want to rewrap the HTML in.
+ *
+ * - `willUnwrap === false`:
+ * 	Return the original HTML string and the `p` unwrappedElement.
  */
 export const unwrapHtml = ({
 	fixes,
 	html,
 }: {
-	fixes: { prefix: string; suffix: string; unwrappedElement?: string }[];
+	fixes: {
+		prefix: Prefix;
+		suffix: Suffix;
+		unwrappedElement?: HTMLTag;
+	}[];
 	html: string;
 }): {
 	unwrappedHtml: string;
 	willUnwrap: boolean;
-	unwrappedElement: string;
+	unwrappedElement: HTMLTag;
 } => {
-	const fixFilteredToMatchingHtmlTags = fixes.filter(
+	const matchingFix = fixes.find(
 		({ prefix, suffix }) =>
 			html.startsWith(prefix) && html.endsWith(suffix),
 	);
 
-	// We only unwrap if we have a match on the start and end html tags to one of the passed 'fixes'
-	const willUnwrap = fixFilteredToMatchingHtmlTags.length === 1;
-	const matchingFix =
-		fixFilteredToMatchingHtmlTags && fixFilteredToMatchingHtmlTags[0];
+	const unwrappedHtml = matchingFix
+		? // Chop off the start and end tags if we have matches to unwrap the html
+		  stripTags(html, matchingFix.prefix, matchingFix.suffix)
+		: html;
 
-	const unwrappedHtml =
-		(willUnwrap &&
-			matchingFix &&
-			// Chop off the start and end tags if we have matches to unwrap the html
-			stripTags(html, matchingFix.prefix, matchingFix.suffix)) ||
-		html;
-
-	// span is the default unwrappedElement
-	const unwrappedElement =
-		(willUnwrap && matchingFix && matchingFix.unwrappedElement) || 'p';
+	/** `p` is the default unwrappedElement */
+	const unwrappedElement = matchingFix?.unwrappedElement || 'p';
 
 	return {
 		unwrappedHtml,
-		willUnwrap,
+		willUnwrap: !!matchingFix,
 		unwrappedElement,
 	};
 };

--- a/dotcom-rendering/src/model/unwrapHtml.ts
+++ b/dotcom-rendering/src/model/unwrapHtml.ts
@@ -53,3 +53,5 @@ export const unwrapHtml = ({
 		unwrappedElement,
 	};
 };
+
+export type { HTMLTag };

--- a/dotcom-rendering/src/web/components/RewrappedComponent.tsx
+++ b/dotcom-rendering/src/web/components/RewrappedComponent.tsx
@@ -1,21 +1,22 @@
-// @ts-ignore
+// @ts-ignore -- we’re actually using preact
 import { jsx as _jsx } from 'react/jsx-runtime';
 import { ClassNames } from '@emotion/react';
 
 import { unescapeData } from '../../lib/escapeData';
 
-// Ideally we want to want to avoid an unnecessary 'span' wrapper,
-// which also will cause issues with ads (spacefinder rules). React
-// requires a wrapping element for dangerouslySetInnerHTML so we
-// strip the original element markup and rewrap. The fallback case is
-// added for safety but should never happen. If it does happen
-// though it will cause issues with commercial JS which expects
-// paras to be top-level.
-
+/**
+ * React requires a wrapping element for `dangerouslySetInnerHTML` so we
+ * strip the original element markup and rewrap.
+ *
+ * The fallback case (`isUnwrapped == false`) is added for safety,
+ * but should _never_ happen. We want to avoid an unnecessary `<span>` wrapper,
+ * which can cause issues with ads and commercial JS (`spacefinder` rules).
+ * Commercial expects `<p>` tags at the top level of the rewrapped element.
+ */
 export const RewrappedComponent = ({
 	isUnwrapped,
 	html,
-	elCss = '',
+	elCss,
 	tagName,
 }: {
 	isUnwrapped: boolean;
@@ -25,7 +26,7 @@ export const RewrappedComponent = ({
 }) => (
 	<ClassNames>
 		{({ css }) => {
-			const element = isUnwrapped ? tagName : 'span';
+			const element: string = isUnwrapped ? tagName : 'span';
 
 			// If we implement a span, we want to apply the CSS to the inner element
 			// to ensure we still style correctly
@@ -39,7 +40,8 @@ export const RewrappedComponent = ({
 
 			// Create a react element from the tagName passed in OR
 			// default to <span> if we've not been able to unwrap based on prefix & suffix
-			return _jsx(`${element}`, {
+			return _jsx(element, {
+				// if style is `undefined`, it will be omitted
 				className: style,
 				dangerouslySetInnerHTML: {
 					__html: unescapeData(html),

--- a/dotcom-rendering/src/web/components/RewrappedComponent.tsx
+++ b/dotcom-rendering/src/web/components/RewrappedComponent.tsx
@@ -2,6 +2,7 @@
 import { jsx as _jsx } from 'react/jsx-runtime';
 import { ClassNames } from '@emotion/react';
 
+import type { HTMLTag } from 'src/model/unwrapHtml';
 import { unescapeData } from '../../lib/escapeData';
 
 /**
@@ -22,11 +23,11 @@ export const RewrappedComponent = ({
 	isUnwrapped: boolean;
 	html: string;
 	elCss?: string;
-	tagName: string;
+	tagName: HTMLTag;
 }) => (
 	<ClassNames>
 		{({ css }) => {
-			const element: string = isUnwrapped ? tagName : 'span';
+			const element: HTMLTag = isUnwrapped ? tagName : 'span';
 
 			// If we implement a span, we want to apply the CSS to the inner element
 			// to ensure we still style correctly


### PR DESCRIPTION
## What does this change?

Create a new `HTMLTag`, which matches standard HTML Tag names (e.g. `p`, `aside`, `main`, `table`, …)

Use this `HTMLTag` to add type safety to `unwrapHtml` and `RewrappedComponent`.

Add comments to explain more thoroughly the workings of these components using JSDoc.

Simplify some of the inner logic to rely on [`find`][] instead of `filter` then `[0]`.

[`find`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

## Why?

It’s easier to understand the shape of the function with string literals.

The existing method was notoriously hard to reason about.
This changes makes the public API more narrowly typed.
When specifying a prefix or suffix, the compiler will complain if the
strings do not match opening and closing HTML tag names.