### PR TITLE
DCR: Add /KeyEvents endpoint to render key events individually

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -571,6 +571,15 @@ interface BlocksRequest {
 	videoDuration?: number;
 }
 
+/**
+ * KeyEventsRequest is the expected body format for POST requests made to /keyEvents
+ */
+interface KeyEventsRequest {
+	keyEvents: Block[];
+	format: CAPIFormat;
+	filterKeyEvents: boolean;
+}
+
 interface BadgeType {
 	seriesTag: string;
 	imageUrl: string;

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -5,6 +5,7 @@ import {
 	renderArticleJson,
 	renderBlocks,
 	renderInteractive,
+	renderKeyEvents,
 } from '../web/server';
 
 // see https://www.npmjs.com/package/webpack-hot-server-Middleware
@@ -24,6 +25,8 @@ export const devServer = () => {
 				return renderAMPArticle(req, res);
 			case '/Blocks':
 				return renderBlocks(req, res);
+			case '/KeyEvents':
+				return renderKeyEvents(req, res);
 			default:
 				next();
 		}

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -7,6 +7,7 @@ import {
 	renderArticleJson,
 	renderBlocks,
 	renderInteractive,
+	renderKeyEvents,
 	renderPerfTest as renderArticlePerfTest,
 } from '../web/server';
 import {
@@ -83,6 +84,7 @@ export const prodServer = () => {
 	app.post('/Interactive', logRenderTime, renderInteractive);
 	app.post('/AMPInteractive', logRenderTime, renderAMPArticle);
 	app.post('/Blocks', logRenderTime, renderBlocks);
+	app.post('/KeyEvents', logRenderTime, renderKeyEvents);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get('/Article', logRenderTime, async (req: Request, res: Response) => {

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -7,6 +7,7 @@ import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { validateAsCAPIType } from '../../model/validate';
 import { extract as extractGA } from '../../model/extract-ga';
 import { blocksToHtml } from './blocksToHtml';
+import { keyEventsToHtml } from './keyEventsToHtml';
 
 export const renderArticle = (
 	{ body }: express.Request,
@@ -143,6 +144,27 @@ export const renderBlocks = (
 			section,
 			sharedAdTargeting,
 			adUnit,
+		});
+
+		res.status(200).send(html);
+	} catch (e) {
+		// @ts-expect-error
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		res.status(500).send(`<pre>${e.stack}</pre>`);
+	}
+};
+
+export const renderKeyEvents = (
+	{ body }: { body: KeyEventsRequest },
+	res: express.Response,
+): void => {
+	try {
+		const { keyEvents, format, filterKeyEvents } = body;
+
+		const html = keyEventsToHtml({
+			keyEvents,
+			format,
+			filterKeyEvents,
 		});
 
 		res.status(200).send(html);

--- a/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
@@ -1,0 +1,33 @@
+import { renderToString } from 'react-dom/server';
+import { KeyEventsContainer } from '../components/KeyEventsContainer';
+import { decideDesign } from '../lib/decideDesign';
+import { decideDisplay } from '../lib/decideDisplay';
+import { decideTheme } from '../lib/decideTheme';
+
+/**
+ * keyEventsToHtml is used by the /keyEvents endpoint as part of keeping liveblogs live
+ * It takes an array of json key-event blocks and returns the resulting html string
+ *
+ * @returns string (the html)
+ */
+export const keyEventsToHtml = ({
+	keyEvents,
+	format: CAPIFormat,
+	filterKeyEvents,
+}: KeyEventsRequest): string => {
+	const format: ArticleFormat = {
+		display: decideDisplay(CAPIFormat),
+		design: decideDesign(CAPIFormat),
+		theme: decideTheme(CAPIFormat),
+	};
+
+	const html = renderToString(
+		<KeyEventsContainer
+			keyEvents={keyEvents}
+			format={format}
+			filterKeyEvents={filterKeyEvents}
+		/>,
+	);
+
+	return html;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds an endpoint to DCR for rendering key-events (for liveblogs) on their own, which can be used as part liveness to update the key-events in situ on DCR liveblogs

This follows the same pattern used to add the `/Blocks` endpoint in #3881

## Why?

Frontend already provides fresh key-events in the live api, however it does not currently render/update them on the page. This brings us closes to parity of functionality

### After
(styling abnormalities in screenshot due to lack of css-reset in individual responses)
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/9575458/154955188-3bb8a87d-343e-404e-a8dd-a8020a1a0dbd.png">

