### PR TITLE
Split dev url manually

### DIFF
--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -29,7 +29,29 @@ exports.default = getContentFromURL;
 
 exports.getContentFromURLMiddleware = async (req, res, next) => {
 	if (req.query.url) {
-		let { url } = req.query;
+		/**
+		 * We use string manipulation on the raw value of req.url
+		 * here instead of the url property of the req.query object
+		 * because we want to capture any *other* query params that
+		 * might be being used. Eg.
+		 *
+		 * If my original url is:
+		 *
+		 * http://localhost:3030/Article?url=https://www.theguardian.com/my/article?filterKeyEvents=true
+		 *
+		 * then req.query.url is:
+		 *
+		 * https://www.theguardian.com/my/article
+		 *
+		 * and req.query.filterKeyEvents is:
+		 *
+		 * true
+		 *
+		 * This happens because the url query param isn't serialised. But we actually want everything
+		 * after 'url=' including '?filterKeyEvents=true' and we'd rather not serialise so we just
+		 * split the string instead
+		 */
+		let url = req.url.split('url=')[1];
 		if (req.path.startsWith('/AMP')) {
 			url = url.replace('www', 'amp');
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Refactor the way we get the `url` param value for making the call to Frontend.

### Before
We used the `req.query.url` property

### After
We now take the whole `req.url` string and split it manually

## Why?
Like this we can also pass through any additional query params that might have been passed. This is especially useful for blogs where we use the url for pagination and state like `filterKeyEvents`
