### PR TITLE
Poll more frequently

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -140,7 +140,7 @@ export const Liveness = ({
 
 	// useApi returns { data, loading, error } but we're not using them here
 	useApi(getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents), {
-		refreshInterval: 5_000,
+		refreshInterval: 10_000,
 		refreshWhenHidden: true,
 		// onSuccess runs (once) after every successful api call. This is useful because it
 		// allows us to avoid the problems of imperative code being executed multiple times

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -140,7 +140,7 @@ export const Liveness = ({
 
 	// useApi returns { data, loading, error } but we're not using them here
 	useApi(getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents), {
-		refreshInterval: 15_000,
+		refreshInterval: 5_000,
 		refreshWhenHidden: true,
 		// onSuccess runs (once) after every successful api call. This is useful because it
 		// allows us to avoid the problems of imperative code being executed multiple times


### PR DESCRIPTION
## What?
Decreases the time between polls from 15 seconds to 10

## Why?
More frequent polling has limited impact as these calls are well cached but greatly improves the reader experience