### PR TITLE
Split live and dead blogs in `LinkHeadline`

### DIFF
--- a/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
@@ -311,7 +311,7 @@ export const LiveBlogSizes = () => (
 		/>
 	</ElementContainer>
 );
-LiveBlogSizes.story = { name: 'with various sizes' };
+LiveBlogSizes.story = { name: 'with various sizes (live)' };
 
 export const DeadBlogSizes = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
@@ -328,9 +328,9 @@ export const DeadBlogSizes = () => (
 				theme: ArticlePillar.News,
 			}}
 			showQuotes={true}
-			kickerText="Large live"
+			kickerText="Large dead"
 			showSlash={true}
-			showPulsingDot={true}
+			showPulsingDot={false}
 			size="large"
 		/>
 		<br />
@@ -347,9 +347,9 @@ export const DeadBlogSizes = () => (
 				theme: ArticlePillar.News,
 			}}
 			showQuotes={true}
-			kickerText="Medium live"
+			kickerText="Medium dead"
 			showSlash={true}
-			showPulsingDot={true}
+			showPulsingDot={false}
 			size="medium"
 		/>
 		<br />
@@ -366,9 +366,9 @@ export const DeadBlogSizes = () => (
 				theme: ArticlePillar.News,
 			}}
 			showQuotes={true}
-			kickerText="Small live"
+			kickerText="Small dead"
 			showSlash={true}
-			showPulsingDot={true}
+			showPulsingDot={false}
 			size="small"
 		/>
 		<br />
@@ -387,12 +387,12 @@ export const DeadBlogSizes = () => (
 			showQuotes={true}
 			kickerText="Tiny live"
 			showSlash={true}
-			showPulsingDot={true}
+			showPulsingDot={false}
 			size="tiny"
 		/>
 	</ElementContainer>
 );
-DeadBlogSizes.story = { name: 'with various sizes' };
+DeadBlogSizes.story = { name: 'with various sizes (dead)' };
 
 export const Updated = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
@@ -311,7 +311,7 @@ export const LiveBlogSizes = () => (
 		/>
 	</ElementContainer>
 );
-LiveBlogSizes.story = { name: 'with various sizes (live)' };
+LiveBlogSizes.story = { name: 'With various sizes (live)' };
 
 export const DeadBlogSizes = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
@@ -385,14 +385,14 @@ export const DeadBlogSizes = () => (
 				theme: ArticlePillar.News,
 			}}
 			showQuotes={true}
-			kickerText="Tiny live"
+			kickerText="Tiny dead"
 			showSlash={true}
 			showPulsingDot={false}
 			size="tiny"
 		/>
 	</ElementContainer>
 );
-DeadBlogSizes.story = { name: 'with various sizes (dead)' };
+DeadBlogSizes.story = { name: 'With various sizes (dead)' };
 
 export const Updated = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>


### PR DESCRIPTION
## What does this change?

Update storybook to properly reflect `LinkHeadline` for DeadBlogs.

## Why?

As it stands, the stories are identical in storybook so we get no visibility on changes. Introduced in #2665.

### Before

<img width="474" alt="image" src="https://user-images.githubusercontent.com/76776/155108775-051c8816-276f-460c-b01e-208656516fbe.png">

### After

<img width="472" alt="image" src="https://user-images.githubusercontent.com/76776/155108824-031bdd22-9c17-4dcd-b2f6-5c8a5cf2598a.png">
