### PR TITLE
Fix special reports cards text colour

### DIFF
--- a/dotcom-rendering/src/web/components/OnwardsData.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsData.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 type OnwardsResponse = {
-	trails: [];
+	trails: CAPITrailType[];
 	heading: string;
 	displayname: string;
 	description: string;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -311,8 +311,8 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 };
 
 const textCardHeadline = (format: ArticleFormat): string => {
-	if (format.display === ArticleDisplay.Immersive) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport) return WHITE;
+	if (format.display === ArticleDisplay.Immersive) return BLACK;
 	switch (format.design) {
 		case ArticleDesign.Feature:
 		case ArticleDesign.Interview:


### PR DESCRIPTION
## What does this change?

Fix Onward card styles in Suisse Secret special report by making `ArticleSpecial.SpecialReport` take precedence over `ArticleDisplay.Immersive`.

## Why?

The text is hard to read and unnaccessible. Fixes #4045 

### Before

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/76776/155132140-dc5866a6-1e6c-4b5f-a402-69f6fa3a46e1.png">

### After

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/76776/155132093-96dac241-e9e7-49cd-848b-bf8f9401681c.png">

