### PR TITLE
Update YoutubeAtom

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -22,7 +22,7 @@ const interceptPlayEvent = (id) => {
 };
 
 const getOverlaySelector = (videoId) =>
-	`[data-cy="youtube-overlay-${videoId}"]`
+	`[data-cy="youtube-overlay-${videoId}"]`;
 
 describe('YouTube Atom', function () {
 	beforeEach(function () {
@@ -128,37 +128,6 @@ describe('YouTube Atom', function () {
 
 		// Play video
 		cy.get(overlaySelector).click();
-
-		cy.wait('@ophanCall', { timeout: 30000 });
-
-		// Video is playing, overlay is gone
-		cy.get(overlaySelector).should('not.exist');
-	});
-
-	it('still plays the video even if it was not preloaded', function () {
-		cy.visit(
-			'/Article?url=https://www.theguardian.com/uk-news/2020/dec/04/edinburgh-hit-by-thundersnow-as-sonic-boom-wakes-residents',
-		);
-		cmpIframe().contains("It's your choice");
-		cmpIframe().find("[title='Manage my cookies']").click();
-		privacySettingsIframe().contains('Privacy settings');
-		privacySettingsIframe()
-			.find("[title='Accept all']", { timeout: 12000 })
-			.click();
-
-		// Wait for hydration
-		cy.get('[data-component=youtube-atom]')
-			.parent()
-			.should('have.attr', 'data-gu-ready', 'true');
-
-		// Listen for the ophan call made when the video is played
-		interceptPlayEvent(
-			'gu-video-youtube-2b33a7b7-e639-4232-9ecd-0fb920fa8147',
-		).as('ophanCall');
-
-		// Play video (without triggering any pre load events)
-		const overlaySelector = getOverlaySelector('S0CE1n-R3OY');
-		cy.get(overlaySelector).trigger('click');
 
 		cy.wait('@ophanCall', { timeout: 30000 });
 

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -21,9 +21,6 @@ const interceptPlayEvent = (id) => {
 	);
 };
 
-const getOverlaySelector = (videoId) =>
-	`[data-cy="youtube-overlay-${videoId}"]`;
-
 describe('YouTube Atom', function () {
 	beforeEach(function () {
 		storage.local.set('gu.geo.override', 'GB');
@@ -46,7 +43,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = getOverlaySelector('S0CE1n-R3OY');
+		const overlaySelector = `[data-cy="youtube-overlay-S0CE1n-R3OY"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// YouTube has not initialised
@@ -84,7 +81,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = getOverlaySelector('NtN-a6inr1E');
+		const overlaySelector = `[data-cy="youtube-overlay-NtN-a6inr1E"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
@@ -118,7 +115,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = getOverlaySelector('NtN-a6inr1E');
+		const overlaySelector = `[data-cy="youtube-overlay-NtN-a6inr1E"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -20,6 +20,10 @@ const interceptPlayEvent = (id) => {
 		},
 	);
 };
+
+const getOverlaySelector = (videoId) =>
+	`[data-cy="youtube-overlay-${videoId}"]`
+
 describe('YouTube Atom', function () {
 	beforeEach(function () {
 		storage.local.set('gu.geo.override', 'GB');
@@ -42,20 +46,11 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
+		const overlaySelector = getOverlaySelector('S0CE1n-R3OY');
+		cy.get(overlaySelector).should('be.visible');
 
-		// Trigger mouseenter event
+		// YouTube has not initialised
 		cy.window().its('onYouTubeIframeAPIReady').should('not.exist');
-
-		cy.get(`[data-cy="youtube-overlay"]`).trigger('mouseenter');
-
-		// Wait for youtube to be initialised
-		cy.window()
-			.its('onYouTubeIframeAPIReady', { timeout: 30000 })
-			.should('exist');
-
-		// YouTube was initialised but the overlay is still showing
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent(
@@ -63,12 +58,12 @@ describe('YouTube Atom', function () {
 		).as('ophanCall');
 
 		// Play video
-		cy.get(`[data-cy="youtube-overlay"]`).click();
+		cy.get(overlaySelector).click();
 
 		cy.wait('@ophanCall', { timeout: 30000 });
 
 		// Video is playing, overlay is gone
-		cy.get(`[data-cy="youtube-overlay"]`).should('not.exist');
+		cy.get(overlaySelector).should('not.exist');
 	});
 
 	it('plays in body videos', function () {
@@ -89,14 +84,8 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
-
-		// Trigger mouseenter event
-		cy.get(`[data-cy="youtube-overlay"]`).trigger('touchstart');
-		// cy.wait('@callToYouTube');
-
-		// The youtube files were loaded by the overlay is still showing
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
+		const overlaySelector = getOverlaySelector('NtN-a6inr1E');
+		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent(
@@ -104,12 +93,12 @@ describe('YouTube Atom', function () {
 		).as('ophanCall');
 
 		// Play video
-		cy.get(`[data-cy="youtube-overlay"]`).click();
+		cy.get(overlaySelector).click();
 
 		cy.wait('@ophanCall', { timeout: 30000 });
 
 		// // Video is playing, overlay is gone
-		cy.get(`[data-cy="youtube-overlay"]`).should('not.exist');
+		cy.get(overlaySelector).should('not.exist');
 	});
 
 	it('still plays the video if the reader rejects consent', function () {
@@ -129,13 +118,8 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
-
-		// Trigger mouseenter event
-		cy.get(`[data-cy="youtube-overlay"]`).trigger('mouseenter');
-
-		// The youtube files were loaded by the overlay is still showing
-		cy.get(`[data-cy="youtube-overlay"]`).should('be.visible');
+		const overlaySelector = getOverlaySelector('NtN-a6inr1E');
+		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent(
@@ -143,12 +127,12 @@ describe('YouTube Atom', function () {
 		).as('ophanCall');
 
 		// Play video
-		cy.get(`[data-cy="youtube-overlay"]`).click();
+		cy.get(overlaySelector).click();
 
 		cy.wait('@ophanCall', { timeout: 30000 });
 
 		// Video is playing, overlay is gone
-		cy.get(`[data-cy="youtube-overlay"]`).should('not.exist');
+		cy.get(overlaySelector).should('not.exist');
 	});
 
 	it('still plays the video even if it was not preloaded', function () {
@@ -173,11 +157,12 @@ describe('YouTube Atom', function () {
 		).as('ophanCall');
 
 		// Play video (without triggering any pre load events)
-		cy.get(`[data-cy="youtube-overlay"]`).trigger('click');
+		const overlaySelector = getOverlaySelector('S0CE1n-R3OY');
+		cy.get(overlaySelector).trigger('click');
 
 		cy.wait('@ophanCall', { timeout: 30000 });
 
 		// Video is playing, overlay is gone
-		cy.get(`[data-cy="youtube-overlay"]`).should('not.exist');
+		cy.get(overlaySelector).should('not.exist');
 	});
 });

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -46,7 +46,7 @@
     "@cypress/skip-test": "^2.6.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^22.2.0",
+    "@guardian/atoms-rendering": "^22.3.0",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.32.0",
     "@guardian/consent-management-platform": "^10.1.1",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -106,8 +106,7 @@
     "sanitize-html": "^2.3.2",
     "stylelint": "^13.13.1",
     "swr": "^1.1.2",
-    "web-vitals": "^2.1.0",
-    "youtube-player": "^5.5.2"
+    "web-vitals": "^2.1.0"
   },
   "devDependencies": {
     "@babel/helper-create-regexp-features-plugin": "^7.12.17",
@@ -280,8 +279,7 @@
     "webpack-merge": "^5.7.3",
     "webpack-messages": "^2.0.4",
     "webpack-node-externals": "^3.0.0",
-    "webpack-sources": "^3.2.3",
-    "youtube-player": "^5.5.2"
+    "webpack-sources": "^3.2.3"
   },
   "resolutions": {
     "@types/serve-static": "^1.13.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,10 +2802,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^22.2.0":
-  version "22.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.2.0.tgz#ee2549bb57893bdddf87feccf2c4317e7ddb9db0"
-  integrity sha512-p4h19meQlZfC5X1ra1zuOF5J75Upe0Gipe5l9K0uo/L1LoWgXNxj+D8zIb5c3y4USh1fZ+Gmkg97uy3DVdbPjA==
+"@guardian/atoms-rendering@^22.3.0":
+  version "22.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.3.0.tgz#9472f7ed8bfbd791b4afd1aa239e6f06852b2a49"
+  integrity sha512-LMmNXATyxVxUtD2jYcJ6meJCqjTbAv4N+kG537igv0OwjpFF2W1URy+w9Jp2XJ0ukBcTOQuCRk3EQFzrwzlMqw==
   dependencies:
     youtube-player "^5.5.2"
 
@@ -5247,7 +5247,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*":
+"@types/serve-static@*", "@types/serve-static@^1.13.9":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -5272,6 +5272,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -5282,7 +5287,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/tapable@^1.0.5":
+"@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
@@ -5341,14 +5346,26 @@
     "@types/node" "*"
     webpack "^5"
 
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8", "@types/webpack@^5.0.0":
-  version "5.28.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
-  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
+"@types/webpack-sources@*":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
+  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
   dependencies:
     "@types/node" "*"
-    tapable "^2.2.0"
-    webpack "^5"
+    "@types/source-list-map" "*"
+    source-map "^0.7.3"
+
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
+  version "4.41.32"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.32.tgz#a7bab03b72904070162b2f169415492209e94212"
+  integrity sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -6207,7 +6224,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5247,7 +5247,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.9":
+"@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -5272,11 +5272,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/source-list-map@*":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
-  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -5287,7 +5282,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/tapable@^1", "@types/tapable@^1.0.5":
+"@types/tapable@^1.0.5":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
@@ -5346,26 +5341,14 @@
     "@types/node" "*"
     webpack "^5"
 
-"@types/webpack-sources@*":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
-  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.8", "@types/webpack@^5.0.0":
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
+  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
   dependencies:
     "@types/node" "*"
-    "@types/source-list-map" "*"
-    source-map "^0.7.3"
-
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
-  version "4.41.32"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.32.tgz#a7bab03b72904070162b2f169415492209e94212"
-  integrity sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==
-  dependencies:
-    "@types/node" "*"
-    "@types/tapable" "^1"
-    "@types/uglify-js" "*"
-    "@types/webpack-sources" "*"
-    anymatch "^3.0.0"
-    source-map "^0.6.0"
+    tapable "^2.2.0"
+    webpack "^5"
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -6224,7 +6207,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==


### PR DESCRIPTION
## What does this change?

- Updates `atoms-rendering` to `v22.3.0` to bring in the refactor and fixes to `YoutubeAtom` from the PR:

  https://github.com/guardian/atoms-rendering/pull/334

- Updates the `atom.video.spec` cypress test to reflect new behaviour of the player:
    - removal of the intermediate `mouseenter` step that would load the player
    - no need to wait for `onYouTubeIframeAPIReady`
  
- Remove `youtube-player` dependency as this is a dependency in `atoms-rendering`

## Why?

Incorporate bugfixes and refactors to `YoutubeAtom`