### PR TITLE
feat: add colourful underline for `CardHeadline` & `ArticleHeadline`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -141,7 +141,7 @@ type Palette = {
 		headlineTag: Colour;
 		mostViewedTab: Colour;
 		matchNav: Colour;
-		underline: Colour;
+		analysisUnderline: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -141,6 +141,7 @@ type Palette = {
 		headlineTag: Colour;
 		mostViewedTab: Colour;
 		matchNav: Colour;
+		underline: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -323,7 +323,7 @@ export const Analysis = () => {
 							</LeftColumn>
 							<ArticleContainer format={format(theme)}>
 								<ArticleHeadline
-									headlineString={`This is an Analysis headline, it's underlined. ${themeName} Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor`}
+									headlineString={`This is an Analysis headline in ${themeName}, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor`}
 									format={format(theme)}
 									tags={[]}
 								/>

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -299,26 +299,41 @@ export const Comment = () => {
 Comment.story = { name: 'Comment' };
 
 export const Analysis = () => {
-	const format = {
+	const themes: [string, ArticleTheme][] = [
+		['News', ArticlePillar.News],
+		['Opinion', ArticlePillar.Opinion],
+		['Sport', ArticlePillar.Sport],
+		['Culture', ArticlePillar.Culture],
+		['Lifestyle', ArticlePillar.Lifestyle],
+	];
+	const format = (theme: ArticleTheme): ArticleFormat => ({
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Analysis,
-		theme: ArticlePillar.News,
-	};
+		theme,
+	});
+
 	return (
-		<ElementContainer>
-			<Flex>
-				<LeftColumn borderType="full">
-					<></>
-				</LeftColumn>
-				<ArticleContainer format={format}>
-					<ArticleHeadline
-						headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
-						format={format}
-						tags={[]}
-					/>
-				</ArticleContainer>
-			</Flex>
-		</ElementContainer>
+		<>
+			{themes.map(([themeName, theme]) => (
+				<>
+					<ElementContainer>
+						<Flex>
+							<LeftColumn borderType="full">
+								<></>
+							</LeftColumn>
+							<ArticleContainer format={format(theme)}>
+								<ArticleHeadline
+									headlineString={`This is an Analysis headline, it's underlined. ${themeName} Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor`}
+									format={format(theme)}
+									tags={[]}
+								/>
+							</ArticleContainer>
+						</Flex>
+					</ElementContainer>
+					<br />
+				</>
+			))}
+		</>
 	);
 };
 Analysis.story = { name: 'Analysis' };

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -381,7 +381,9 @@ export const ArticleHeadline = ({
 							css={[
 								standardFont,
 								topPadding,
-								underlinedStyles(palette.background.underline),
+								underlinedStyles(
+									palette.background.analysisUnderline,
+								),
 								css`
 									color: ${palette.text.headline};
 								`,

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -95,12 +95,12 @@ const lightFont = css`
 	}
 `;
 
-const underlinedStyles = css`
+const underlinedStyles = (colour: string) => css`
 	background-image: repeating-linear-gradient(
 		to bottom,
 		transparent,
 		transparent 47px,
-		rgba(171, 6, 19, 0.5)
+		${colour}
 	);
 	line-height: 48px;
 	background-size: 1rem 48px;
@@ -109,7 +109,7 @@ const underlinedStyles = css`
 			to bottom,
 			transparent,
 			transparent 39px,
-			rgba(171, 6, 19, 0.5)
+			${colour}
 		);
 		line-height: 40px;
 		background-size: 1px 40px;
@@ -381,7 +381,7 @@ export const ArticleHeadline = ({
 							css={[
 								standardFont,
 								topPadding,
-								underlinedStyles,
+								underlinedStyles(palette.background.underline),
 								css`
 									color: ${palette.text.headline};
 								`,

--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -11,6 +11,7 @@ export const HeadlineWrapper = ({ children, isFullCardImage }: Props) => (
 			padding-bottom: ${isFullCardImage ? 0 : 8}px;
 			padding-left: ${isFullCardImage ? 0 : 5}px;
 			padding-right: 5px;
+			flex-grow: 1;
 		`}
 	>
 		{children}

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -37,18 +37,97 @@ export const Article = () => (
 Article.story = { name: 'Article' };
 
 export const Analysis = () => (
-	<ElementContainer showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how an Analysis card headline looks"
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Analysis,
-				theme: ArticlePillar.News,
-			}}
-		/>
-	</ElementContainer>
+	<>
+		{smallHeadlineSizes.map((size) => (
+			<div key={size}>
+				<ElementContainer showTopBorder={false} showSideBorders={false}>
+					<CardHeadline
+						headlineText={`This is how a ${size} Analysis card headline looks`}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Analysis,
+							theme: ArticlePillar.News,
+						}}
+						size={size}
+					/>
+				</ElementContainer>
+				<br />
+			</div>
+		))}
+		<br />
+		<ElementContainer
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<CardHeadline
+				headlineText="This is how an Sport Analysis card headline looks"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Analysis,
+					theme: ArticlePillar.Sport,
+				}}
+			/>
+		</ElementContainer>
+		<br />
+		<ElementContainer
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<CardHeadline
+				headlineText="This is how an Culture Analysis card headline looks"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Analysis,
+					theme: ArticlePillar.Culture,
+				}}
+			/>
+		</ElementContainer>
+		<br />
+		<ElementContainer
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<CardHeadline
+				headlineText="This is how an Opinion Analysis card headline looks"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Analysis,
+					theme: ArticlePillar.Opinion,
+				}}
+			/>
+		</ElementContainer>
+		<br />
+		<ElementContainer
+			showTopBorder={false}
+			showSideBorders={false}
+		>
+			<CardHeadline
+				headlineText="This is how an Lifestyle Analysis card headline looks"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Analysis,
+					theme: ArticlePillar.Lifestyle,
+				}}
+			/>
+		</ElementContainer>
+		<br />
+		<ElementContainer
+			showTopBorder={false}
+			showSideBorders={false}
+			backgroundColour={specialReport[300]}
+		>
+			<CardHeadline
+				headlineText="This is how an Special Report Analysis card headline looks"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Analysis,
+					theme: ArticleSpecial.SpecialReport,
+				}}
+			/>
+		</ElementContainer>
+	</>
 );
-Analysis.story = { name: 'Analysis' };
+Analysis.story = { name: 'Analysis (Underline)' };
 
 export const Feature = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
@@ -148,22 +227,7 @@ export const cultureVariant = () => (
 );
 cultureVariant.story = { name: 'With a culture kicker' };
 
-export const AnalysisXSmall = () => (
-	<ElementContainer showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="Xsmall card headline for an Analysis article"
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Analysis,
-				theme: ArticlePillar.Lifestyle,
-			}}
-			size="large"
-		/>
-	</ElementContainer>
-);
-AnalysisXSmall.story = { name: 'Underlined | large' };
-
-export const opinionxxxsmall = () => (
+export const Opinion = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how small card headline for opinion articles look"
@@ -177,7 +241,7 @@ export const opinionxxxsmall = () => (
 		/>
 	</ElementContainer>
 );
-opinionxxxsmall.story = { name: 'Quotes | small' };
+Opinion.story = { name: 'Opinion (Quotes)' };
 
 export const OpinionKicker = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
@@ -215,7 +279,7 @@ export const SpecialReport = () => (
 		/>
 	</ElementContainer>
 );
-SpecialReport.story = { name: 'with theme SpecialReport' };
+SpecialReport.story = { name: 'With theme SpecialReport' };
 
 export const Busy = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -55,10 +55,7 @@ export const Analysis = () => (
 			</div>
 		))}
 		<br />
-		<ElementContainer
-			showTopBorder={false}
-			showSideBorders={false}
-		>
+		<ElementContainer showTopBorder={false} showSideBorders={false}>
 			<CardHeadline
 				headlineText="This is how an Sport Analysis card headline looks"
 				format={{
@@ -69,10 +66,7 @@ export const Analysis = () => (
 			/>
 		</ElementContainer>
 		<br />
-		<ElementContainer
-			showTopBorder={false}
-			showSideBorders={false}
-		>
+		<ElementContainer showTopBorder={false} showSideBorders={false}>
 			<CardHeadline
 				headlineText="This is how an Culture Analysis card headline looks"
 				format={{
@@ -83,10 +77,7 @@ export const Analysis = () => (
 			/>
 		</ElementContainer>
 		<br />
-		<ElementContainer
-			showTopBorder={false}
-			showSideBorders={false}
-		>
+		<ElementContainer showTopBorder={false} showSideBorders={false}>
 			<CardHeadline
 				headlineText="This is how an Opinion Analysis card headline looks"
 				format={{
@@ -97,10 +88,7 @@ export const Analysis = () => (
 			/>
 		</ElementContainer>
 		<br />
-		<ElementContainer
-			showTopBorder={false}
-			showSideBorders={false}
-		>
+		<ElementContainer showTopBorder={false} showSideBorders={false}>
 			<CardHeadline
 				headlineText="This is how an Lifestyle Analysis card headline looks"
 				format={{

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -148,7 +148,10 @@ export const CardHeadline = ({
 						? labTextStyles(size)
 						: fontStyles(size),
 					format.design === ArticleDesign.Analysis &&
-						underlinedStyles(size, palette.background.underline),
+						underlinedStyles(
+							size,
+							palette.background.analysisUnderline,
+						),
 					isFullCardImage &&
 						css`
 							line-height: 1; /* Reset line height in full image carousel */

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -13,7 +13,6 @@ import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
 import { Byline } from './Byline';
 import { decidePalette } from '../lib/decidePalette';
-import { transparentColour } from '../lib/transparentColour';
 
 type Props = {
 	headlineText: string; // The text shown
@@ -92,7 +91,7 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 				to bottom,
 				transparent,
 				transparent ${baseSize - 1}px,
-				${transparentColour(colour)}
+				${colour}
 			);
 			line-height: ${baseSize}px;
 			background-size: 1px ${baseSize}px;
@@ -150,7 +149,7 @@ export const CardHeadline = ({
 						: fontStyles(size),
 					format.design === ArticleDesign.Analysis &&
 						// TODO: are we overloading the cardKicker colour?
-						underlinedStyles(size, palette.text.cardKicker),
+						underlinedStyles(size, palette.background.underline),
 					isFullCardImage &&
 						css`
 							line-height: 1; /* Reset line height in full image carousel */

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -148,7 +148,6 @@ export const CardHeadline = ({
 						? labTextStyles(size)
 						: fontStyles(size),
 					format.design === ArticleDesign.Analysis &&
-						// TODO: are we overloading the cardKicker colour?
 						underlinedStyles(size, palette.background.underline),
 					isFullCardImage &&
 						css`

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -84,16 +84,18 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 	}
 };
 
-const underlinedStyles = (size: SmallHeadlineSize) => {
+const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
+	const transparentColour = `${colour}88`;
+
 	function generateUnderlinedCss(baseSize: number) {
 		return css`
 			background-image: linear-gradient(
 				to bottom,
 				transparent,
 				transparent ${baseSize - 1}px,
-				rgba(199, 0, 0, 0.5)
+				${transparentColour}
 			);
-			line-height: ${baseSize - 1}px;
+			line-height: ${baseSize}px;
 			background-size: 1px ${baseSize}px;
 			background-origin: content-box;
 			background-clip: content-box;
@@ -148,7 +150,8 @@ export const CardHeadline = ({
 						? labTextStyles(size)
 						: fontStyles(size),
 					format.design === ArticleDesign.Analysis &&
-						underlinedStyles(size),
+						// TODO: are we overloading the cardKicker colour?
+						underlinedStyles(size, palette.text.cardKicker),
 					isFullCardImage &&
 						css`
 							line-height: 1; /* Reset line height in full image carousel */

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -102,13 +102,13 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 	}
 	switch (size) {
 		case 'small':
-			return generateUnderlinedCss(21);
+			return generateUnderlinedCss(22);
 		case 'medium':
-			return generateUnderlinedCss(24);
+			return generateUnderlinedCss(25);
 		case 'large':
-			return generateUnderlinedCss(28);
+			return generateUnderlinedCss(29);
 		default:
-			return generateUnderlinedCss(23);
+			return generateUnderlinedCss(24);
 	}
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -13,6 +13,7 @@ import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
 import { Byline } from './Byline';
 import { decidePalette } from '../lib/decidePalette';
+import { transparentColour } from '../lib/transparentColour';
 
 type Props = {
 	headlineText: string; // The text shown
@@ -85,15 +86,13 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 };
 
 const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
-	const transparentColour = `${colour}88`;
-
 	function generateUnderlinedCss(baseSize: number) {
 		return css`
 			background-image: linear-gradient(
 				to bottom,
 				transparent,
 				transparent ${baseSize - 1}px,
-				${transparentColour}
+				${transparentColour(colour)}
 			);
 			line-height: ${baseSize}px;
 			background-size: 1px ${baseSize}px;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1088,7 +1088,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			headlineTag: backgroundHeadlineTag(format),
 			mostViewedTab: backgroundMostViewedTab(format),
 			matchNav: backgroundMatchNav(),
-			underline: backgroundUnderline(format),
+			analysisUnderline: backgroundUnderline(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -23,6 +23,7 @@ import {
 
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../../lib/pillars';
+import { transparentColour } from './transparentColour';
 
 const WHITE = neutral[100];
 const BLACK = neutral[7];
@@ -805,6 +806,9 @@ const backgroundMatchNav = (): string => {
 	return '#FFE500';
 };
 
+const backgroundUnderline = (format: ArticleFormat): string =>
+	transparentColour(textCardKicker(format));
+
 const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -1084,6 +1088,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			headlineTag: backgroundHeadlineTag(format),
 			mostViewedTab: backgroundMostViewedTab(format),
 			matchNav: backgroundMatchNav(),
+			underline: backgroundUnderline(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/web/lib/transparentColour.test.ts
+++ b/dotcom-rendering/src/web/lib/transparentColour.test.ts
@@ -1,0 +1,28 @@
+import { transparentColour } from './transparentColour';
+
+describe('transparentColour', () => {
+	test.each([
+		['#000000', 'rgba(0, 0, 0, 0.5)'],
+		['#C70000', 'rgba(199, 0, 0, 0.5)'],
+		['#aabbcc', 'rgba(170, 187, 204, 0.5)'],
+		['#ffffff', 'rgba(255, 255, 255, 0.5)'],
+	])('For valid hex %s, return %s', (hex, output) => {
+		expect(transparentColour(hex)).toEqual(output);
+	});
+
+	test.each([
+		['#000', 'rgba(0, 0, 0, 0.5)'],
+		['#c00', 'rgba(204, 0, 0, 0.5)'],
+		['#abc', 'rgba(170, 187, 204, 0.5)'],
+		['#fff', 'rgba(255, 255, 255, 0.5)'],
+	])('For short hex %s, return %s', (hex, output) => {
+		expect(transparentColour(hex)).toEqual(output);
+	});
+
+	test.each(['---', '#ab', '#abcd', '#gggggg', '-ffffff', 'rgb(0,0,0)'])(
+		'For invalid hex %s, return rgba(127, 127, 127, 0.5)',
+		(hex) => {
+			expect(transparentColour(hex)).toEqual('rgba(127, 127, 127, 0.5)');
+		},
+	);
+});

--- a/dotcom-rendering/src/web/lib/transparentColour.ts
+++ b/dotcom-rendering/src/web/lib/transparentColour.ts
@@ -37,7 +37,7 @@ export const transparentColour = (
 	const g = getColour(colour.slice(1 + hex, 1 + hex * 2));
 	const b = getColour(colour.slice(1 + hex * 2, 1 + hex * 3));
 
-	if([r,g,b].some(Number.isNaN)) return fallback;
+	if ([r, g, b].some(Number.isNaN)) return fallback;
 
 	return `rgba(${r}, ${g}, ${b}, ${opacity})`;
 };

--- a/dotcom-rendering/src/web/lib/transparentColour.ts
+++ b/dotcom-rendering/src/web/lib/transparentColour.ts
@@ -1,0 +1,23 @@
+/**
+ * Transforms a hex colour to a transparent one of the same colour.
+ *
+ * The alternative [#RRGGBBAA notation is not well supported][caniuse],
+ * so we used the more widely supported rgba() notation.
+ *
+ * [caniuse]: https://caniuse.com/css-rrggbbaa
+ *
+ * @param colour the hex string, e.g. #C70000
+ * @param opacity optional opacity 0-1. Defaults to 0.5 (50%)
+ * @returns an functional colour string, e.g. rgba(199, 0, 0, 0.5)
+ */
+export const transparentColour = (
+	colour: string,
+	opacity = 0.5,
+): `rgba(${number}, ${number}, ${number}, ${number})` => {
+	// extract hex colours as numbers
+	const r = parseInt(colour.slice(1, 3), 16);
+	const g = parseInt(colour.slice(3, 5), 16);
+	const b = parseInt(colour.slice(5, 7), 16);
+
+	return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};

--- a/dotcom-rendering/src/web/lib/transparentColour.ts
+++ b/dotcom-rendering/src/web/lib/transparentColour.ts
@@ -1,3 +1,16 @@
+const getColour = (string: string) => {
+	switch (string.length) {
+		case 2:
+			return parseInt(string, 16);
+		case 1:
+			return parseInt(string + string, 16);
+		default:
+			return 127;
+	}
+};
+
+const fallback = 'rgba(127, 127, 127, 0.5)';
+
 /**
  * Transforms a hex colour to a transparent one of the same colour.
  *
@@ -14,10 +27,17 @@ export const transparentColour = (
 	colour: string,
 	opacity = 0.5,
 ): `rgba(${number}, ${number}, ${number}, ${number})` => {
-	// extract hex colours as numbers
-	const r = parseInt(colour.slice(1, 3), 16);
-	const g = parseInt(colour.slice(3, 5), 16);
-	const b = parseInt(colour.slice(5, 7), 16);
+	// if we have an invalid string,
+	if (colour.charAt(0) !== '#' || ![4, 7].includes(colour.length))
+		return fallback;
+
+	const hex = colour.length === 7 ? 2 : 1;
+
+	const r = getColour(colour.slice(1, 1 + hex));
+	const g = getColour(colour.slice(1 + hex, 1 + hex * 2));
+	const b = getColour(colour.slice(1 + hex * 2, 1 + hex * 3));
+
+	if([r,g,b].some(Number.isNaN)) return fallback;
 
 	return `rgba(${r}, ${g}, ${b}, ${opacity})`;
 };


### PR DESCRIPTION
## What does this change?

Introduces a colour variation for the underline of analysis pieces. Transforms a hex string to a transparent colour, and uses that to underline. The underline is meant to reach the far right of its container. We also increased the line-height by 1px so it looks more visually pleasing.

Introduces a new `background.analysisUnderline` property to `decidePalette`.

Updates stories to capture this visually.

## Why?

In #4046 we fixed the colour of cards, but the red underline against a black background is not very nice.

We made the underline disappear in https://github.com/guardian/dotcom-rendering/pull/1003/files#r811988546

Examples of Analysis outside of news:
- **Sport:** [Australian stars shine to erase off-court drama and create ‘dream’ grand slam](https://www.theguardian.com/sport/2022/jan/31/australian-stars-shine-to-erase-off-court-drama-and-create-dream-grand-slam)
- **Culture:** [After the Whoopi Goldberg controversy has America’s daytime TV show lost its way?](https://www.theguardian.com/tv-and-radio/2022/feb/06/the-view-whoopi-goldberg-abc-daytime)
- **Lifestyle:** (couldn’t find one, but this one’s close &rarr; [Over-the-counter HRT is a promising start but deeper change is needed](https://www.theguardian.com/lifeandstyle/2022/feb/02/uk-womens-health-review-set-to-launch-in-spring) )
- **Opinion:** couldn’t find one

## Cards comparison

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

## Analysis article comparison

<img width="1524" alt="image" src="https://user-images.githubusercontent.com/76776/155174854-b2314d8c-21ef-49d2-9af0-c24220c59dfb.png">


[before]: https://user-images.githubusercontent.com/76776/155150124-dfc16e7b-cd44-4f32-80db-6e011e219ba8.png
[after]: https://user-images.githubusercontent.com/76776/155150752-48fd5e4e-4333-4438-837f-94b8f6dddced.png