### PR TITLE
Fix `KeyEvents` width

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -65,10 +65,6 @@ const keyEventWrapperStyles = (
 `;
 
 const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	${from.desktop} {
-		width: 13.75rem;
-	}
-
 	li::before {
 		content: "";
 		display: block;

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -2,14 +2,25 @@
 
 import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
-import { textSans, headline, sport, culture, lifestyle, opinion, news } from "@guardian/source-foundations";
-import { remSpace } from "@guardian/source-foundations";
 import {
+	textSans,
+	headline,
+	sport,
+	culture,
+	lifestyle,
+	opinion,
+	news,
 	neutral,
+	remSpace,
+	from,
 } from "@guardian/source-foundations";
 import { Link } from "@guardian/source-react-components";
-import { ArticleFormat, ArticlePillar, ArticleTheme, timeAgo } from "@guardian/libs";
-import { from } from "@guardian/source-foundations";
+import {
+	ArticleFormat,
+	ArticlePillar,
+	ArticleTheme,
+	timeAgo,
+} from "@guardian/libs";
 import { darkModeCss } from "../lib";
 import Accordion from "./accordion";
 import { text } from "../editorialPalette";
@@ -104,7 +115,6 @@ const timeTextWrapperStyles: SerializedStyles = css`
 	margin-left: 0.5rem;
 `;
 
-
 const textStyles = (
 	format: ArticleFormat,
 	supportsDarkMode: boolean
@@ -112,7 +122,7 @@ const textStyles = (
 	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
 	/* TODO update with Source value when it's added */
 	${from.desktop} {
-		font-size:15px;
+		font-size: 15px;
 	}
 	color: ${text.keyEventsInline(format)};
 	display: block;
@@ -138,7 +148,6 @@ const textStyles = (
 			color: ${getColor(format.theme, 500)};
 		}
 	`}
-
 `;
 
 const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes a fixed width property from `KeyEvents`

## Why?
It was causing this element to overflow it's container

### Before
<img width="291" alt="Screenshot 2022-02-21 at 21 22 21" src="https://user-images.githubusercontent.com/1336821/155190023-42252dd9-cdb0-45d5-b0a3-5dad5ee37ca7.png">

### After
<img width="291" alt="Screenshot 2022-02-21 at 21 22 54" src="https://user-images.githubusercontent.com/1336821/155190017-898d84cb-343a-4d13-bf04-ffc45604d363.png">
