### PR TITLE
Infer palette from format

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -900,7 +900,7 @@ interface BaseTrailType {
 	branding?: Branding;
 }
 interface TrailType extends BaseTrailType {
-	palette: Palette;
+	palette?: never;
 	format: ArticleFormat;
 }
 

--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import loadable from '@loadable/component';
 
-import { ArticleDisplay, ArticleDesign, storage, log } from '@guardian/libs';
+import { storage, log } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
 import {
@@ -19,8 +19,7 @@ import { AudioAtomWrapper } from './AudioAtomWrapper';
 import { Portal } from './Portal';
 import { HydrateOnce, HydrateInteractiveOnce } from './HydrateOnce';
 import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 import { useOnce } from '../lib/useOnce';
 
 import { incrementAlreadyVisited } from '../lib/alreadyVisited';
@@ -117,15 +116,9 @@ export const App = ({ CAPI }: Props) => {
 		setBrazeMessages(buildBrazeMessages(CAPI.config.idApiUrl));
 	}, [CAPI.config.idApiUrl]);
 
-	const display: ArticleDisplay = decideDisplay(CAPI.format);
-	const design: ArticleDesign = decideDesign(CAPI.format);
 	const pillar: ArticleTheme = decideTheme(CAPI.format);
 
-	const format: ArticleFormat = {
-		display,
-		design,
-		theme: pillar,
-	};
+	const format: ArticleFormat = decideFormat(CAPI.format);
 
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPI.isAdFreeUser,

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -151,7 +151,6 @@ export const ArticleBody = ({
 		>
 			<ArticleRenderer
 				format={format}
-				palette={palette}
 				elements={blocks[0] ? blocks[0].elements : []}
 				adTargeting={adTargeting}
 				host={host}

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -39,7 +39,6 @@ export const ArticleStory = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is how the default headline looks"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -65,7 +64,6 @@ export const Feature = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is a Feature headline, it has colour applied based on pillar"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -96,7 +94,6 @@ export const ShowcaseInterview = () => {
 					>
 						<ArticleHeadline
 							headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-							palette={decidePalette(format)}
 							format={format}
 							tags={[]}
 							byline="Byline text"
@@ -138,7 +135,6 @@ export const ShowcaseInterviewNobyline = () => {
 					>
 						<ArticleHeadline
 							headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-							palette={decidePalette(format)}
 							format={format}
 							tags={[]}
 							byline=""
@@ -177,7 +173,6 @@ export const Interview = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 						byline="Byline text"
@@ -217,7 +212,6 @@ export const InterviewSpecialReport = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 						byline="Byline text"
@@ -259,7 +253,6 @@ export const InterviewNoByline = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 						byline=""
@@ -301,7 +294,6 @@ export const Comment = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="Yes, the billionaire club is one we really need to shut down"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -327,7 +319,6 @@ export const Analysis = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -353,7 +344,6 @@ export const Media = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is Media"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -379,7 +369,6 @@ export const Review = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is Review"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -405,7 +394,6 @@ export const PhotoEssay = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is PhotoEssay"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -431,7 +419,6 @@ export const Quiz = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is Quiz"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -457,7 +444,6 @@ export const Recipe = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is Recipe"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -483,7 +469,6 @@ export const Immersive = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when display type is Immersive"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -509,7 +494,6 @@ export const ImmersiveNoMainMedia = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is PrintShop, which has no main media"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -539,7 +523,6 @@ export const ImmersiveComment = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when display type is Immersive and design Comment"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -565,7 +548,6 @@ export const Editorial = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is Editorial"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -591,7 +573,6 @@ export const MatchReport = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is MatchReport"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -617,7 +598,6 @@ export const SpecialReport = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when pillar is SpecialReport"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -643,7 +623,6 @@ export const LiveBlog = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is LiveBlog"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -682,7 +661,6 @@ export const DeadBlog = () => {
 				<ArticleContainer format={format}>
 					<ArticleHeadline
 						headlineString="This is the headline you see when design type is DeadBlog"
-						palette={decidePalette(format)}
 						format={format}
 						tags={[]}
 					/>
@@ -712,7 +690,6 @@ export const ReviewWithoutStars = () => {
 					>
 						<ArticleHeadline
 							headlineString="This is a Review headline."
-							palette={decidePalette(format)}
 							format={format}
 							tags={[]}
 							byline="Byline text"

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -16,7 +16,6 @@ import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
 import { Standfirst } from './Standfirst';
 import { mainMediaElements } from './ArticleHeadline.mocks';
-import { decidePalette } from '../lib/decidePalette';
 import { ArticleHeadlinePadding } from './ArticleHeadlinePadding';
 
 export default {
@@ -101,7 +100,6 @@ export const ShowcaseInterview = () => {
 					</div>
 					<MainMedia
 						format={format}
-						palette={decidePalette(format)}
 						hideCaption={true}
 						elements={mainMediaElements}
 						pageId="testID"
@@ -142,7 +140,6 @@ export const ShowcaseInterviewNobyline = () => {
 					</div>
 					<MainMedia
 						format={format}
-						palette={decidePalette(format)}
 						hideCaption={true}
 						elements={mainMediaElements}
 						pageId="testID"
@@ -183,7 +180,6 @@ export const Interview = () => {
 					/>
 					<MainMedia
 						format={format}
-						palette={decidePalette(format)}
 						hideCaption={true}
 						elements={mainMediaElements}
 						pageId="testID"
@@ -222,7 +218,6 @@ export const InterviewSpecialReport = () => {
 					/>
 					<MainMedia
 						format={format}
-						palette={decidePalette(format)}
 						hideCaption={true}
 						elements={mainMediaElements}
 						pageId="testID"
@@ -263,7 +258,6 @@ export const InterviewNoByline = () => {
 					/>
 					<MainMedia
 						format={format}
-						palette={decidePalette(format)}
 						hideCaption={true}
 						elements={mainMediaElements}
 						pageId="testID"

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -18,13 +18,13 @@ import { HeadlineByline } from './HeadlineByline';
 
 import { getZIndex } from '../lib/getZIndex';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	headlineString: string;
 	format: ArticleFormat;
 	byline?: string;
 	tags: TagType[];
-	palette: Palette;
 };
 
 const curly = (x: any) => x;
@@ -225,8 +225,8 @@ export const ArticleHeadline = ({
 	format,
 	tags,
 	byline,
-	palette,
 }: Props) => {
+	const palette = decidePalette(format);
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {

--- a/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
@@ -7,7 +7,6 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import { ArticleMeta } from './ArticleMeta';
-import { decidePalette } from '../lib/decidePalette';
 import {
 	getAllThemes,
 	getThemeNameAsString,
@@ -65,11 +64,6 @@ export const ArticleStory = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -115,11 +109,6 @@ export const BrandingStory = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -150,11 +139,6 @@ export const FeatureStory = () => {
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Culture,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Culture,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -184,11 +168,6 @@ export const SpecialReportStory = () => {
 					design: ArticleDesign.Feature,
 					theme: ArticleSpecial.SpecialReport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticleSpecial.SpecialReport,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -218,11 +197,6 @@ export const CommentStory = () => {
 					design: ArticleDesign.Comment,
 					theme: ArticlePillar.Opinion,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Comment,
-					theme: ArticlePillar.Opinion,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -252,11 +226,6 @@ export const InterviewStory = () => {
 					design: ArticleDesign.Interview,
 					theme: ArticlePillar.Lifestyle,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Interview,
-					theme: ArticlePillar.Lifestyle,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -286,11 +255,6 @@ export const ImmersiveStory = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -320,11 +284,6 @@ export const TwoContributorsStory = () => {
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Sport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Sport,
-				})}
 				pageId=""
 				webTitle=""
 				author={{
@@ -356,7 +315,6 @@ export const DeadBlogStory = () => {
 					<p>{getThemeNameAsString(format)}</p>
 					<ArticleMeta
 						format={format}
-						palette={decidePalette(format)}
 						pageId=""
 						webTitle=""
 						author={{

--- a/dotcom-rendering/src/web/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.test.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 
 import { ArticleMeta } from './ArticleMeta';
-import { decidePalette } from '../lib/decidePalette';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 
 describe('ArticleMeta', () => {
@@ -17,7 +16,6 @@ describe('ArticleMeta', () => {
 		const { container } = render(
 			<ArticleMeta
 				format={format}
-				palette={decidePalette(format)}
 				pageId="1234"
 				webTitle="A title"
 				author={{ byline: 'Observer writers' }}
@@ -58,7 +56,6 @@ describe('ArticleMeta', () => {
 		const { container } = render(
 			<ArticleMeta
 				format={format}
-				palette={decidePalette(format)}
 				pageId="1234"
 				webTitle="A title"
 				author={{ byline: 'Observer writers' }}

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -364,7 +364,6 @@ export const ArticleMeta = ({
 									author={author}
 									tags={tags}
 									format={format}
-									palette={palette}
 								/>
 							)}
 							<Dateline

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -20,10 +20,10 @@ import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStylin
 import { CommentCount } from './CommentCount.importable';
 import { Island } from './Island';
 import { ShareCount } from './ShareCount.importable';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	pageId: string;
 	webTitle: string;
 	author: AuthorType;
@@ -284,7 +284,6 @@ const metaNumbersExtrasLiveBlog = css`
 export const ArticleMeta = ({
 	branding,
 	format,
-	palette,
 	pageId,
 	webTitle,
 	author,
@@ -319,6 +318,9 @@ export const ArticleMeta = ({
 		showAvatarFromAuthor() &&
 		shouldShowAvatar(format);
 	const isInteractive = format.design === ArticleDesign.Interactive;
+
+	const palette = decidePalette(format);
+
 	return (
 		<div
 			className={

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -10,7 +10,6 @@ import {
 	getAllThemes,
 	getThemeNameAsString,
 } from '../../../../common-rendering/src/fixtures/article';
-import { decidePalette } from '../lib/decidePalette';
 
 import { ArticleTitle } from './ArticleTitle';
 
@@ -74,11 +73,6 @@ export const defaultStory = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Standard,
-				})}
 			/>
 		</Container>
 	);
@@ -96,11 +90,6 @@ export const beyondTheBlade = () => {
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.News,
-					design: ArticleDesign.Standard,
-				})}
 			/>
 		</Container>
 	);
@@ -123,11 +112,6 @@ export const immersiveComment = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Comment,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Comment,
-				})}
 			/>
 		</div>
 	);
@@ -150,11 +134,6 @@ export const immersiveCommentTag = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Comment,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Comment,
-				})}
 				tags={[
 					{
 						id: '',
@@ -179,11 +158,6 @@ export const ImmersiveSeriesTag = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Review,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Review,
-				})}
 				tags={[
 					{
 						id: '',
@@ -208,11 +182,6 @@ export const ArticleBlogTag = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -237,11 +206,6 @@ export const ArticleOpinionTag = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -266,11 +230,6 @@ export const ArticleSeriesTag = () => {
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.Sport,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -295,11 +254,6 @@ export const SpecialReportTitle = () => {
 					theme: ArticleSpecial.SpecialReport,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticleSpecial.SpecialReport,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -324,11 +278,6 @@ export const ArticleNoTags = () => {
 					theme: ArticlePillar.Culture,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.Culture,
-					design: ArticleDesign.Standard,
-				})}
 			/>
 		</Container>
 	);
@@ -346,11 +295,6 @@ export const LabsStory = () => {
 					theme: ArticleSpecial.Labs,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticleSpecial.Labs,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -375,11 +319,6 @@ export const LongStory = () => {
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.News,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -404,11 +343,6 @@ export const LongWord = () => {
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					theme: ArticlePillar.News,
-					design: ArticleDesign.Standard,
-				})}
 				tags={[
 					{
 						id: '',
@@ -435,7 +369,6 @@ export const ArticleDeadBlogTitle = () => {
 						// eslint-disable-next-line react/jsx-props-no-spreading
 						{...CAPI}
 						format={format}
-						palette={decidePalette(format)}
 						tags={[
 							{
 								id: '',

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -7,7 +7,6 @@ import { SeriesSectionLink } from './SeriesSectionLink';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	tags: TagType[];
 	sectionLabel: string;
 	sectionUrl: string;
@@ -59,7 +58,6 @@ const immersiveMargins = css`
 
 export const ArticleTitle = ({
 	format,
-	palette,
 	tags,
 	sectionLabel,
 	sectionUrl,
@@ -82,7 +80,6 @@ export const ArticleTitle = ({
 		>
 			<SeriesSectionLink
 				format={format}
-				palette={palette}
 				tags={tags}
 				sectionLabel={sectionLabel}
 				sectionUrl={sectionUrl}

--- a/dotcom-rendering/src/web/components/Byline.tsx
+++ b/dotcom-rendering/src/web/components/Byline.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/react';
 
 import { headline, textSans, until } from '@guardian/source-foundations';
 import { ArticleSpecial } from '@guardian/libs';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	text: string;
-	palette: Palette;
 	format: ArticleFormat;
 	size: SmallHeadlineSize;
 };
@@ -82,8 +82,10 @@ const colourStyles = (palette: Palette) => {
 	`;
 };
 
-export const Byline = ({ text, palette, format, size }: Props) => (
-	<span css={[bylineStyles(size, format), colourStyles(palette)]}>
+export const Byline = ({ text, format, size }: Props) => (
+	<span
+		css={[bylineStyles(size, format), colourStyles(decidePalette(format))]}
+	>
 		{text}
 	</span>
 );

--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -9,7 +9,6 @@ import { breakpoints } from '@guardian/source-foundations';
 import { ElementContainer } from './ElementContainer';
 import { Caption } from './Caption';
 import { StarRating } from './StarRating/StarRating';
-import { decidePalette } from '../lib/decidePalette';
 
 export default {
 	component: Caption,
@@ -37,11 +36,6 @@ export const Article = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -56,11 +50,6 @@ export const Analysis = () => (
 				design: ArticleDesign.Analysis,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Analysis,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -75,11 +64,6 @@ export const PhotoEssay = () => (
 				design: ArticleDesign.PhotoEssay,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Immersive,
-				design: ArticleDesign.PhotoEssay,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -94,11 +78,6 @@ export const SpecialReport = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticleSpecial.SpecialReport,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticleSpecial.SpecialReport,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -113,11 +92,6 @@ export const PhotoEssayLimitedWidth = () => (
 				design: ArticleDesign.PhotoEssay,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Immersive,
-				design: ArticleDesign.PhotoEssay,
-				theme: ArticlePillar.News,
-			})}
 			shouldLimitWidth={true}
 		/>
 	</ElementContainer>
@@ -133,11 +107,6 @@ export const Credit = () => (
 				design: ArticleDesign.Feature,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Feature,
-				theme: ArticlePillar.News,
-			})}
 			credit="Credited to Able Jones"
 			displayCredit={true}
 		/>
@@ -154,11 +123,6 @@ export const WidthLimited = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			shouldLimitWidth={true}
 		/>
 	</ElementContainer>
@@ -174,11 +138,6 @@ export const Padded = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			padCaption={true}
 		/>
 	</ElementContainer>
@@ -212,11 +171,6 @@ export const Overlayed = () => (
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				padCaption={true}
 			/>
 		</div>
@@ -251,11 +205,6 @@ export const OverlayedWithStars = () => (
 					design: ArticleDesign.Review,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Showcase,
-					design: ArticleDesign.Review,
-					theme: ArticlePillar.News,
-				})}
 				padCaption={true}
 			/>
 			<div
@@ -281,11 +230,6 @@ export const VideoCaption = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			mediaType="Video"
 		/>
 	</ElementContainer>

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -16,11 +16,11 @@ import {
 
 import CameraSvg from '../../static/icons/camera.svg';
 import VideoSvg from '../../static/icons/video-icon.svg';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	captionText?: string;
 	format: ArticleFormat;
-	palette: Palette;
 	padCaption?: boolean;
 	credit?: string;
 	displayCredit?: boolean;
@@ -224,7 +224,6 @@ const VideoIcon = ({ palette, format }: IconProps) => {
 export const Caption = ({
 	captionText,
 	format,
-	palette,
 	padCaption = false,
 	credit,
 	displayCredit = true,
@@ -238,6 +237,8 @@ export const Caption = ({
 	const noCredit = !credit;
 	const hideCredit = !displayCredit;
 	if (noCaption && (noCredit || hideCredit)) return null;
+
+	const palette = decidePalette(format);
 
 	const defaultCaption = (
 		<figcaption

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '../lib/decidePalette';
 import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
@@ -60,11 +59,6 @@ export const StandardArticle = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 		</Container>
 	);
@@ -83,11 +77,6 @@ export const PhotoEssay = () => {
 					design: ArticleDesign.PhotoEssay,
 					theme: ArticlePillar.Lifestyle,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					design: ArticleDesign.PhotoEssay,
-					theme: ArticlePillar.Lifestyle,
-				})}
 				padCaption={false}
 				credit="Credit text"
 				displayCredit={false}
@@ -111,11 +100,6 @@ export const PhotoEssayHTML = () => {
 					design: ArticleDesign.PhotoEssay,
 					theme: ArticlePillar.Sport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Immersive,
-					design: ArticleDesign.PhotoEssay,
-					theme: ArticlePillar.Sport,
-				})}
 				padCaption={false}
 				credit="Credit text"
 				displayCredit={false}
@@ -139,11 +123,6 @@ export const Padded = () => {
 					design: ArticleDesign.Analysis,
 					theme: ArticlePillar.Culture,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Analysis,
-					theme: ArticlePillar.Culture,
-				})}
 				padCaption={true}
 				credit="Credit text"
 				displayCredit={false}
@@ -167,11 +146,6 @@ export const WidthLimited = () => {
 					design: ArticleDesign.Review,
 					theme: ArticlePillar.Culture,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Review,
-					theme: ArticlePillar.Culture,
-				})}
 				padCaption={false}
 				credit="Credit text"
 				displayCredit={false}
@@ -195,11 +169,6 @@ export const Credited = () => {
 					design: ArticleDesign.MatchReport,
 					theme: ArticlePillar.Culture,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.MatchReport,
-					theme: ArticlePillar.Culture,
-				})}
 				padCaption={false}
 				credit="Credit text"
 				displayCredit={true}
@@ -223,11 +192,6 @@ export const Overlayed = () => {
 					design: ArticleDesign.Comment,
 					theme: ArticlePillar.Sport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Showcase,
-					design: ArticleDesign.Comment,
-					theme: ArticlePillar.Sport,
-				})}
 				padCaption={false}
 				credit="Credit text"
 				displayCredit={false}

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
@@ -3,7 +3,6 @@ import { Caption } from './Caption';
 type Props = {
 	captionText?: string;
 	format: ArticleFormat;
-	palette: Palette;
 	padCaption?: boolean;
 	credit?: string;
 	displayCredit?: boolean;
@@ -14,7 +13,6 @@ type Props = {
 export const CaptionBlockComponent = ({
 	captionText,
 	format,
-	palette,
 	padCaption = false,
 	credit,
 	displayCredit = true,
@@ -23,7 +21,6 @@ export const CaptionBlockComponent = ({
 }: Props) => (
 	<Caption
 		format={format}
-		palette={palette}
 		captionText={captionText}
 		padCaption={padCaption}
 		credit={credit}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -223,7 +223,6 @@ export const Card = ({
 									<CardHeadline
 										headlineText={headlineText}
 										format={format}
-										palette={cardPalette}
 										size={headlineSize}
 										showQuotes={showQuotes}
 										kickerText={

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -7,7 +7,6 @@ import {
 
 import { specialReport } from '@guardian/source-foundations';
 import { ElementContainer } from './ElementContainer';
-import { decidePalette } from '../lib/decidePalette';
 
 import { CardHeadline } from './CardHeadline';
 
@@ -25,11 +24,6 @@ export const Article = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -44,11 +38,6 @@ export const Analysis = () => (
 				design: ArticleDesign.Analysis,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Analysis,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -63,11 +52,6 @@ export const Feature = () => (
 				design: ArticleDesign.Feature,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Feature,
-				theme: ArticlePillar.News,
-			})}
 		/>
 	</ElementContainer>
 );
@@ -82,11 +66,6 @@ export const xsmallStory = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			size="large"
 		/>
 	</ElementContainer>
@@ -102,11 +81,6 @@ export const liveStory = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			kickerText="Live"
 		/>
 	</ElementContainer>
@@ -122,11 +96,6 @@ export const noSlash = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			kickerText="Live"
 			showSlash={false}
 		/>
@@ -143,11 +112,6 @@ export const pulsingDot = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.News,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			kickerText="Live"
 			showPulsingDot={true}
 		/>
@@ -164,11 +128,6 @@ export const cultureVariant = () => (
 				design: ArticleDesign.Feature,
 				theme: ArticlePillar.Culture,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Feature,
-				theme: ArticlePillar.Culture,
-			})}
 			kickerText="Art and stuff"
 		/>
 	</ElementContainer>
@@ -184,11 +143,6 @@ export const AnalysisXSmall = () => (
 				design: ArticleDesign.Analysis,
 				theme: ArticlePillar.Lifestyle,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Analysis,
-				theme: ArticlePillar.Lifestyle,
-			})}
 			size="large"
 		/>
 	</ElementContainer>
@@ -204,11 +158,6 @@ export const opinionxxxsmall = () => (
 				design: ArticleDesign.Comment,
 				theme: ArticlePillar.Opinion,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Comment,
-				theme: ArticlePillar.Opinion,
-			})}
 			showQuotes={true}
 			size="small"
 		/>
@@ -225,11 +174,6 @@ export const OpinionKicker = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticlePillar.Opinion,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.Opinion,
-			})}
 			showQuotes={true}
 			kickerText="George Monbiot"
 			showSlash={true}
@@ -251,11 +195,6 @@ export const SpecialReport = () => (
 				design: ArticleDesign.Standard,
 				theme: ArticleSpecial.SpecialReport,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticleSpecial.SpecialReport,
-			})}
 			showQuotes={true}
 			kickerText="Special Report"
 			showSlash={true}
@@ -273,11 +212,6 @@ export const Busy = () => (
 				design: ArticleDesign.Feature,
 				theme: ArticlePillar.Lifestyle,
 			}}
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Feature,
-				theme: ArticlePillar.Lifestyle,
-			})}
 			showQuotes={true}
 			kickerText="Aerial Yoga"
 			showSlash={true}
@@ -296,11 +230,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticleSpecial.Labs,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticleSpecial.Labs,
-				})}
 				byline="Labs byline"
 				showByline={true}
 			/>
@@ -314,11 +243,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.News,
-				})}
 				byline="News byline"
 				showByline={true}
 			/>
@@ -332,11 +256,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Sport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Sport,
-				})}
 				byline="Sport byline"
 				showByline={true}
 			/>
@@ -350,11 +269,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Culture,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Culture,
-				})}
 				byline="Culture byline"
 				showByline={true}
 			/>
@@ -368,11 +282,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Lifestyle,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Lifestyle,
-				})}
 				byline="Lifestyle byline"
 				showByline={true}
 			/>
@@ -386,11 +295,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticlePillar.Opinion,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticlePillar.Opinion,
-				})}
 				byline="Opinion byline"
 				showByline={true}
 			/>
@@ -408,11 +312,6 @@ export const Byline = () => (
 					design: ArticleDesign.Feature,
 					theme: ArticleSpecial.SpecialReport,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Feature,
-					theme: ArticleSpecial.SpecialReport,
-				})}
 				byline="SpecialReport byline"
 				showByline={true}
 			/>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -182,11 +182,7 @@ export const CardHeadline = ({
 				</span>
 			</h4>
 			{byline && showByline && (
-				<Byline
-					text={byline}
-					format={format}
-					size={size}
-				/>
+				<Byline text={byline} format={format} size={size} />
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -12,11 +12,11 @@ import {
 import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
 import { Byline } from './Byline';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	headlineText: string; // The text shown
 	format: ArticleFormat; // Used to decide when to add type specific styles
-	palette: Palette; // Used to colour the headline and the kicker
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	showSlash?: boolean;
@@ -130,7 +130,6 @@ const fullCardImageTextStyles = css`
 export const CardHeadline = ({
 	headlineText,
 	format,
-	palette,
 	showQuotes,
 	kickerText,
 	showPulsingDot,
@@ -139,51 +138,57 @@ export const CardHeadline = ({
 	byline,
 	showByline,
 	isFullCardImage,
-}: Props) => (
-	<>
-		<h4
-			css={[
-				format.theme === ArticleSpecial.Labs
-					? labTextStyles(size)
-					: fontStyles(size),
-				format.design === ArticleDesign.Analysis &&
-					underlinedStyles(size),
-				isFullCardImage &&
-					css`
-						line-height: 1; /* Reset line height in full image carousel */
-					`,
-			]}
-		>
-			<span css={isFullCardImage && fullCardImageTextStyles}>
-				{kickerText && (
-					<Kicker
-						text={kickerText}
-						palette={palette}
-						showPulsingDot={showPulsingDot}
-						showSlash={showSlash}
-						inCard={true}
-					/>
-				)}
-				{showQuotes && (
-					<QuoteIcon colour={palette.text.cardKicker} size={size} />
-				)}
+}: Props) => {
+	const palette = decidePalette(format);
+	return (
+		<>
+			<h4
+				css={[
+					format.theme === ArticleSpecial.Labs
+						? labTextStyles(size)
+						: fontStyles(size),
+					format.design === ArticleDesign.Analysis &&
+						underlinedStyles(size),
+					isFullCardImage &&
+						css`
+							line-height: 1; /* Reset line height in full image carousel */
+						`,
+				]}
+			>
+				<span css={isFullCardImage && fullCardImageTextStyles}>
+					{kickerText && (
+						<Kicker
+							text={kickerText}
+							palette={palette}
+							showPulsingDot={showPulsingDot}
+							showSlash={showSlash}
+							inCard={true}
+						/>
+					)}
+					{showQuotes && (
+						<QuoteIcon
+							colour={palette.text.cardKicker}
+							size={size}
+						/>
+					)}
 
-				<span
-					css={css`
-						color: ${palette.text.cardHeadline};
-					`}
-				>
-					{headlineText}
+					<span
+						css={css`
+							color: ${palette.text.cardHeadline};
+						`}
+					>
+						{headlineText}
+					</span>
 				</span>
-			</span>
-		</h4>
-		{byline && showByline && (
-			<Byline
-				text={byline}
-				palette={palette}
-				format={format}
-				size={size}
-			/>
-		)}
-	</>
-);
+			</h4>
+			{byline && showByline && (
+				<Byline
+					text={byline}
+					palette={palette}
+					format={format}
+					size={size}
+				/>
+			)}
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -184,7 +184,6 @@ export const CardHeadline = ({
 			{byline && showByline && (
 				<Byline
 					text={byline}
-					palette={palette}
 					format={format}
 					size={size}
 				/>

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -2,8 +2,6 @@ import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { ElementContainer } from './ElementContainer';
 
-import { decidePalette } from '../lib/decidePalette';
-
 import { Carousel } from './Carousel';
 
 export default {
@@ -29,7 +27,6 @@ const convertToImmersive = (trails: TrailType[]): TrailType[] => {
 		return {
 			...trail,
 			format,
-			palette: decidePalette(format),
 		};
 	});
 };
@@ -52,11 +49,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.LiveBlog,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.LiveBlog,
-		}),
 		webPublicationDate: '2021-02-17T12:45:05.000Z',
 		headline:
 			'UK Covid live: England lockdown to be eased in stages, says PM, amid reports of nationwide mass testing',
@@ -79,11 +71,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Standard,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Standard,
-		}),
 		webPublicationDate: '2021-02-17T10:03:02.000Z',
 		headline:
 			'UK to infect up to 90 healthy volunteers with Covid in world first trial',
@@ -106,11 +93,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Standard,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Standard,
-		}),
 		webPublicationDate: '2021-02-17T11:11:43.000Z',
 		headline:
 			'Scottish government inadequately prepared for Covid, says watchdog',
@@ -133,11 +115,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Standard,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Standard,
-		}),
 		webPublicationDate: '2021-02-16T16:00:55.000Z',
 		headline:
 			'‘Encouraging’ signs for Covid vaccine as over-80s deaths fall in England',
@@ -160,11 +137,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Standard,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Standard,
-		}),
 		webPublicationDate: '2021-02-16T18:22:53.000Z',
 		headline:
 			'Contact tracing alone has little impact on curbing Covid spread, report finds',
@@ -187,11 +159,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Standard,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Standard,
-		}),
 		webPublicationDate: '2021-02-16T16:35:45.000Z',
 		headline:
 			'Ethnicity and poverty are Covid risk factors, new Oxford modelling tool shows',
@@ -214,11 +181,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.LiveBlog,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.LiveBlog,
-		}),
 		webPublicationDate: '2021-02-16T17:00:15.000Z',
 		headline:
 			'UK Covid: 799 more deaths and 10,625 new cases reported; Scottish schools in phased return from Monday – as it happened',
@@ -241,11 +203,6 @@ const trails: TrailType[] = [
 			theme: ArticlePillar.News,
 			design: ArticleDesign.Analysis,
 		},
-		palette: decidePalette({
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-			design: ArticleDesign.Analysis,
-		}),
 		webPublicationDate: '2021-02-16T18:42:44.000Z',
 		headline:
 			'QCovid: how improved algorithm can identify more higher-risk adults',

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -363,7 +363,6 @@ const convertToImmersive = (trails: TrailType[]): TrailType[] => {
 		return {
 			...trail,
 			format,
-			palette: decidePalette(format),
 		};
 	});
 };

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -4,8 +4,6 @@ import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
 
-import { decidePalette } from '../lib/decidePalette';
-
 import { ContainerLayout } from './ContainerLayout';
 import { Figure } from './Figure';
 import { EmbedBlockComponent } from './EmbedBlockComponent.importable';
@@ -765,11 +763,6 @@ export const VimeoBlockComponentStory = () => {
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
 							}}
-							palette={decidePalette({
-								theme: ArticlePillar.News,
-								display: ArticleDisplay.Standard,
-								design: ArticleDesign.Standard,
-							})}
 							embedUrl={vimeoVideoEmbed.embedUrl}
 							height={vimeoVideoEmbed.height}
 							width={vimeoVideoEmbed.width}

--- a/dotcom-rendering/src/web/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.test.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 
 import { Contributor } from './Contributor';
-import { decidePalette } from '../lib/decidePalette';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 
 describe('Contributor', () => {
@@ -17,7 +16,6 @@ describe('Contributor', () => {
 		const { container } = render(
 			<Contributor
 				format={format}
-				palette={decidePalette(format)}
 				author={{ byline: 'Observer writers' }}
 				tags={[
 					{
@@ -44,7 +42,6 @@ describe('Contributor', () => {
 		const { container } = render(
 			<Contributor
 				format={format}
-				palette={decidePalette(format)}
 				author={{ byline: 'Observer writers' }}
 				tags={[
 					{

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -13,6 +13,7 @@ import { BylineLink } from './BylineLink';
 import TwitterIcon from '../../static/icons/twitter.svg';
 
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
+import { decidePalette } from '../lib/decidePalette';
 
 const twitterHandleStyles = (palette: Palette) => css`
 	${textSans.xxsmall()};
@@ -87,11 +88,12 @@ export const Contributor: React.FC<{
 	author: AuthorType;
 	tags: TagType[];
 	format: ArticleFormat;
-	palette: Palette;
-}> = ({ author, tags, format, palette }) => {
+}> = ({ author, tags, format }) => {
 	if (!author.byline) {
 		return null;
 	}
+
+	const palette = decidePalette(format);
 
 	const onlyOneContributor: boolean =
 		tags.filter((tag) => tag.type === 'Contributor').length === 1;

--- a/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
@@ -7,10 +7,9 @@ import { Caption } from './Caption';
 export const GuVideoBlockComponent: React.FC<{
 	html: string;
 	format: ArticleFormat;
-	palette: Palette;
 	credit: string;
 	caption?: string;
-}> = ({ html, format, palette, credit, caption }) => {
+}> = ({ html, format, credit, caption }) => {
 	const embedContainer = css`
 		width: 100%;
 		margin-bottom: ${caption ? `0px` : `6px`};
@@ -27,7 +26,6 @@ export const GuVideoBlockComponent: React.FC<{
 				<Caption
 					captionText={caption}
 					format={format}
-					palette={palette}
 					credit={credit}
 					mediaType="Video"
 				/>

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -3,7 +3,6 @@
 import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '../lib/decidePalette';
 import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
@@ -65,11 +64,6 @@ export const StandardArticle = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 		</Container>
@@ -90,11 +84,6 @@ export const Immersive = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 		</Container>
@@ -115,11 +104,6 @@ export const Showcase = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 		</Container>
@@ -140,11 +124,6 @@ export const Thumbnail = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 		</Container>
@@ -165,11 +144,6 @@ export const Supporting = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 		</Container>
@@ -190,11 +164,6 @@ export const HideCaption = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 					hideCaption={true}
 				/>
 			</Figure>
@@ -216,11 +185,6 @@ export const InlineTitle = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 					title="This is the title text"
 					hideCaption={true}
 				/>
@@ -247,11 +211,6 @@ export const InlineTitleMobile = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 					title="This is the title text"
 					hideCaption={true}
 				/>
@@ -278,11 +237,6 @@ export const ImmersiveTitle = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 					title="This is the title text"
 					hideCaption={true}
 				/>
@@ -305,11 +259,6 @@ export const ShowcaseTitle = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 					title="This is the title text"
 					hideCaption={true}
 				/>
@@ -356,11 +305,6 @@ export const HalfWidth = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<p>
@@ -421,11 +365,6 @@ export const HalfWidthMobile = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<p>
@@ -486,11 +425,6 @@ export const HalfWidthWide = () => {
 						design: ArticleDesign.Standard,
 						theme: ArticlePillar.News,
 					}}
-					palette={decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: ArticlePillar.News,
-					})}
 				/>
 			</Figure>
 			<p>

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.tsx
@@ -2,7 +2,6 @@ import { ImageComponent } from './ImageComponent';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	element: ImageBlockElement;
 	hideCaption?: boolean;
 	title?: string;
@@ -13,7 +12,6 @@ type Props = {
 
 export const ImageBlockComponent = ({
 	format,
-	palette,
 	element,
 	hideCaption,
 	title,
@@ -26,7 +24,6 @@ export const ImageBlockComponent = ({
 		<ImageComponent
 			element={element}
 			format={format}
-			palette={palette}
 			hideCaption={hideCaption}
 			isMainMedia={isMainMedia}
 			starRating={starRating}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -363,7 +363,6 @@ export const ImageComponent = ({
 									<Caption
 										captionText={element.data.caption || ''}
 										format={format}
-										palette={palette}
 										credit={element.data.credit}
 										displayCredit={element.displayCredit}
 										shouldLimitWidth={shouldLimitWidth}
@@ -384,7 +383,6 @@ export const ImageComponent = ({
 					<Caption
 						captionText={element.data.caption || ''}
 						format={format}
-						palette={palette}
 						credit={element.data.credit}
 						displayCredit={element.displayCredit}
 						shouldLimitWidth={shouldLimitWidth}
@@ -394,7 +392,6 @@ export const ImageComponent = ({
 				<Caption
 					captionText={element.data.caption || ''}
 					format={format}
-					palette={palette}
 					credit={element.data.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={shouldLimitWidth}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -14,12 +14,12 @@ import { Picture } from './Picture';
 import { Caption } from './Caption';
 import { Hide } from './Hide';
 import { StarRating } from './StarRating/StarRating';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	element: ImageBlockElement;
 	role: RoleType;
 	format: ArticleFormat;
-	palette: Palette;
 	hideCaption?: boolean;
 	isMainMedia?: boolean;
 	starRating?: number;
@@ -212,7 +212,6 @@ const CaptionToggle = () => (
 export const ImageComponent = ({
 	element,
 	format,
-	palette,
 	hideCaption,
 	role,
 	isMainMedia,
@@ -242,6 +241,8 @@ export const ImageComponent = ({
 			element.media.allImages[0] &&
 			element.media.allImages[0].fields.height) ||
 		'372';
+
+	const palette = decidePalette(format);
 
 	if (
 		isMainMedia &&

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.tsx
@@ -312,12 +312,7 @@ export const InteractiveBlockComponent = ({
 					</>
 				)}
 			</figure>
-			{caption && (
-				<Caption
-					captionText={caption}
-					format={format}
-				/>
-			)}
+			{caption && <Caption captionText={caption} format={format} />}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.tsx
@@ -316,7 +316,6 @@ export const InteractiveBlockComponent = ({
 				<Caption
 					captionText={caption}
 					format={format}
-					palette={palette}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
@@ -7,7 +7,6 @@ import {
 import { ElementContainer } from './ElementContainer';
 
 import { LinkHeadline } from './LinkHeadline';
-import { decidePalette } from '../lib/decidePalette';
 
 export default {
 	component: LinkHeadline,
@@ -18,11 +17,6 @@ export const xsmallStory = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a large headline link looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -38,11 +32,6 @@ export const liveStory = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a live kicker looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -58,11 +47,6 @@ export const noSlash = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with no kicker slash looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -79,11 +63,6 @@ export const pulsingDot = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a pulsing dot looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -100,11 +79,6 @@ export const cultureVariant = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with the culture pillar looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.Culture,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -120,11 +94,6 @@ export const opinionxxxsmall = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how small links to opinion articles look"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Comment,
-				theme: ArticlePillar.Opinion,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Comment,
@@ -142,11 +111,6 @@ export const OpinionKicker = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how an opinion headline with a kicker looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Comment,
-				theme: ArticlePillar.Opinion,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Comment,
@@ -164,11 +128,6 @@ export const SpecialReport = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a Special Report headline with a kicker looks"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Comment,
-				theme: ArticleSpecial.SpecialReport,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Comment,
@@ -186,11 +145,6 @@ export const InUnderlinedState = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is the underlined state when showUnderline is true"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -212,11 +166,6 @@ export const linkStory = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline looks as a link"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.Sport,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -236,11 +185,6 @@ export const LiveBlogSizes = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.LiveBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.LiveBlog,
@@ -255,11 +199,6 @@ export const LiveBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.LiveBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.LiveBlog,
@@ -274,11 +213,6 @@ export const LiveBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.LiveBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.LiveBlog,
@@ -293,11 +227,6 @@ export const LiveBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.LiveBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.LiveBlog,
@@ -317,11 +246,6 @@ export const DeadBlogSizes = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.DeadBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.DeadBlog,
@@ -336,11 +260,6 @@ export const DeadBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.DeadBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.DeadBlog,
@@ -355,11 +274,6 @@ export const DeadBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.DeadBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.DeadBlog,
@@ -374,11 +288,6 @@ export const DeadBlogSizes = () => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.DeadBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.DeadBlog,
@@ -398,11 +307,6 @@ export const Updated = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText=""
-			palette={decidePalette({
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.LiveBlog,
-				theme: ArticlePillar.News,
-			})}
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.LiveBlog,

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -5,10 +5,10 @@ import { headline } from '@guardian/source-foundations';
 import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
 import { Byline } from './Byline';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	headlineText: string; // The text shown
-	palette: Palette; // Used to colour the headline and the kicker
 	format: ArticleFormat;
 	showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
 	kickerText?: string;
@@ -63,7 +63,6 @@ const visitedStyles = (visitedColour: string) => css`
 
 export const LinkHeadline = ({
 	headlineText,
-	palette,
 	format,
 	showUnderline = false,
 	kickerText,
@@ -73,45 +72,54 @@ export const LinkHeadline = ({
 	size = 'medium',
 	link,
 	byline,
-}: Props) => (
-	<h4 css={fontStyles(size)}>
-		{kickerText && (
-			<Kicker
-				text={kickerText}
-				palette={palette}
-				showPulsingDot={showPulsingDot}
-				showSlash={showSlash}
-			/>
-		)}
-		{showQuotes && (
-			<QuoteIcon colour={palette.text.linkKicker} size={size} />
-		)}
-		{link ? (
-			// We were passed a link object so headline should be a link, with link styling
-			<>
-				<a
-					css={[
-						// Composed styles - order matters for colours
-						linkStyles,
-						showUnderline && textDecorationUnderline,
-						link.visitedColour && visitedStyles(link.visitedColour),
-					]}
-					href={link.to}
-					// If link.preventFocus is true, set tabIndex to -1 to ensure this
-					// link is not tabbed to. Useful if there is an outer link to the same
-					// place, such as with MostViewed
-					tabIndex={link.preventFocus ? -1 : undefined}
-				>
-					{headlineText}
-				</a>
-				{byline && <Byline text={byline} format={format} size={size} />}
-			</>
-		) : (
-			// We don't have a link so simply use a span here
-			<>
-				<span>{headlineText}</span>
-				{byline && <Byline text={byline} size={size} format={format} />}
-			</>
-		)}
-	</h4>
-);
+}: Props) => {
+	const palette = decidePalette(format);
+
+	return (
+		<h4 css={fontStyles(size)}>
+			{kickerText && (
+				<Kicker
+					text={kickerText}
+					palette={palette}
+					showPulsingDot={showPulsingDot}
+					showSlash={showSlash}
+				/>
+			)}
+			{showQuotes && (
+				<QuoteIcon colour={palette.text.linkKicker} size={size} />
+			)}
+			{link ? (
+				// We were passed a link object so headline should be a link, with link styling
+				<>
+					<a
+						css={[
+							// Composed styles - order matters for colours
+							linkStyles,
+							showUnderline && textDecorationUnderline,
+							link.visitedColour &&
+								visitedStyles(link.visitedColour),
+						]}
+						href={link.to}
+						// If link.preventFocus is true, set tabIndex to -1 to ensure this
+						// link is not tabbed to. Useful if there is an outer link to the same
+						// place, such as with MostViewed
+						tabIndex={link.preventFocus ? -1 : undefined}
+					>
+						{headlineText}
+					</a>
+					{byline && (
+						<Byline text={byline} format={format} size={size} />
+					)}
+				</>
+			) : (
+				// We don't have a link so simply use a span here
+				<>
+					<span>{headlineText}</span>
+					{byline && (
+						<Byline text={byline} size={size} format={format} />
+					)}
+				</>
+			)}
+		</h4>
+	);
+};

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -104,27 +104,13 @@ export const LinkHeadline = ({
 				>
 					{headlineText}
 				</a>
-				{byline && (
-					<Byline
-						text={byline}
-						palette={palette}
-						format={format}
-						size={size}
-					/>
-				)}
+				{byline && <Byline text={byline} format={format} size={size} />}
 			</>
 		) : (
 			// We don't have a link so simply use a span here
 			<>
 				<span>{headlineText}</span>
-				{byline && (
-					<Byline
-						text={byline}
-						size={size}
-						palette={palette}
-						format={format}
-					/>
-				)}
+				{byline && <Byline text={byline} size={size} format={format} />}
 			</>
 		)}
 	</h4>

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -51,7 +51,6 @@ export const LiveBlock = ({
 			{block.elements.map((element, index) =>
 				renderArticleElement({
 					format,
-					palette,
 					element,
 					isMainMedia: false,
 					host,

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -70,7 +70,6 @@ const chooseWrapper = (format: ArticleFormat) => {
 
 export const MainMedia: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	elements: CAPIElement[];
 	hideCaption?: boolean;
 	adTargeting?: AdTargeting;
@@ -82,7 +81,6 @@ export const MainMedia: React.FC<{
 }> = ({
 	elements,
 	format,
-	palette,
 	hideCaption,
 	adTargeting,
 	starRating,
@@ -96,7 +94,6 @@ export const MainMedia: React.FC<{
 			{elements.map((element, index) =>
 				renderArticleElement({
 					format,
-					palette,
 					element,
 					adTargeting,
 					ajaxUrl,

--- a/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 import { Caption } from './Caption';
-import { decidePalette } from '../lib/decidePalette';
 import { ClickToView } from './ClickToView';
 
 type Props = {
@@ -51,8 +50,6 @@ export const MapEmbedBlockComponent = ({
 		margin-bottom: ${hasCaption ? `0px` : `6px`};
 	`;
 
-	const palette = decidePalette(format);
-
 	return (
 		<ClickToView
 			role={role}
@@ -75,7 +72,6 @@ export const MapEmbedBlockComponent = ({
 					<Caption
 						captionText={caption}
 						format={format}
-						palette={palette}
 						credit={credit}
 					/>
 				)}

--- a/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
@@ -83,7 +83,6 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 				{trail.format.design === ArticleDesign.LiveBlog ? (
 					<LinkHeadline
 						headlineText={trail.headline}
-						palette={trail.palette}
 						format={trail.format}
 						size="small"
 						kickerText="Live"
@@ -94,7 +93,6 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 				) : (
 					<LinkHeadline
 						headlineText={trail.headline}
-						palette={trail.palette}
 						format={trail.format}
 						size="small"
 						showQuotes={

--- a/dotcom-rendering/src/web/components/MostViewedFooterSecondTierItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterSecondTierItem.tsx
@@ -94,7 +94,6 @@ export const MostViewedFooterSecondTierItem = ({
 		avatarUrl,
 		image,
 		format,
-		palette,
 		byline,
 		showByline,
 		ageWarning,
@@ -111,7 +110,6 @@ export const MostViewedFooterSecondTierItem = ({
 						<div css={titleStyles}>{title}</div>
 						<LinkHeadline
 							headlineText={headlineText}
-							palette={palette}
 							format={format}
 							size="small"
 							byline={showByline ? byline : undefined}

--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -94,7 +94,6 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 						{trail.format.design === ArticleDesign.LiveBlog ? (
 							<LinkHeadline
 								headlineText={trail.headline}
-								palette={trail.palette}
 								format={trail.format}
 								size="small"
 								showUnderline={isHovered}
@@ -108,7 +107,6 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 						) : (
 							<LinkHeadline
 								headlineText={trail.headline}
-								palette={trail.palette}
 								format={trail.format}
 								size="small"
 								showUnderline={isHovered}

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.stories.tsx
@@ -1,6 +1,5 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { ContainerLayout } from './ContainerLayout';
-import { decidePalette } from '../lib/decidePalette';
 
 import { MultiImageBlockComponent } from './MultiImageBlockComponent';
 import { fourImages } from './MultiImageBlockComponent.mocks';
@@ -24,11 +23,6 @@ export const SingleImage = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={oneImage}
 			/>
 		</ContainerLayout>
@@ -47,11 +41,6 @@ export const SingleImageWithCaption = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={oneImage}
 				caption="This is the caption for a single image"
 			/>
@@ -71,11 +60,6 @@ export const SideBySide = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={twoImages}
 			/>
 		</ContainerLayout>
@@ -94,11 +78,6 @@ export const SideBySideWithCaption = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={twoImages}
 				caption="This is the caption for side by side"
 			/>
@@ -118,11 +97,6 @@ export const OneAboveTwo = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={threeImages}
 			/>
 		</ContainerLayout>
@@ -141,11 +115,6 @@ export const OneAboveTwoWithCaption = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={threeImages}
 				caption="This is the caption for one above two"
 			/>
@@ -165,11 +134,6 @@ export const GridOfFour = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={fourImages}
 			/>
 		</ContainerLayout>
@@ -188,11 +152,6 @@ export const GridOfFourWithCaption = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				images={fourImages}
 				caption="This is the caption for grid of four"
 			/>

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
@@ -121,7 +121,6 @@ export const MultiImageBlockComponent = ({
 					/>
 					{caption && (
 						<Caption
-							palette={palette}
 							format={format}
 							captionText={caption}
 							shouldLimitWidth={false}
@@ -164,7 +163,6 @@ export const MultiImageBlockComponent = ({
 					</SideBySideGrid>
 					{caption && (
 						<Caption
-							palette={palette}
 							captionText={caption}
 							format={format}
 							shouldLimitWidth={false}
@@ -216,7 +214,6 @@ export const MultiImageBlockComponent = ({
 					</OneAboveTwoGrid>
 					{caption && (
 						<Caption
-							palette={palette}
 							captionText={caption}
 							format={format}
 							shouldLimitWidth={false}
@@ -276,7 +273,6 @@ export const MultiImageBlockComponent = ({
 					</GridOfFour>
 					{caption && (
 						<Caption
-							palette={palette}
 							captionText={caption}
 							format={format}
 							shouldLimitWidth={false}

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
@@ -9,7 +9,6 @@ import { GridItem } from './GridItem';
 type Props = {
 	images: ImageBlockElement[];
 	format: ArticleFormat;
-	palette: Palette;
 	caption?: string;
 };
 
@@ -94,7 +93,6 @@ const GridOfFour = ({ children }: { children: React.ReactNode }) => (
 export const MultiImageBlockComponent = ({
 	images,
 	format,
-	palette,
 	caption,
 }: Props) => {
 	const imageCount = images.length;
@@ -113,7 +111,6 @@ export const MultiImageBlockComponent = ({
 					`}
 				>
 					<ImageComponent
-						palette={palette}
 						format={format}
 						element={images[0]}
 						hideCaption={true}
@@ -144,7 +141,6 @@ export const MultiImageBlockComponent = ({
 					<SideBySideGrid>
 						<GridItem area="first">
 							<ImageComponent
-								palette={palette}
 								element={images[0]}
 								format={format}
 								hideCaption={true}
@@ -153,7 +149,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="second">
 							<ImageComponent
-								palette={palette}
 								element={images[1]}
 								format={format}
 								hideCaption={true}
@@ -186,7 +181,6 @@ export const MultiImageBlockComponent = ({
 					<OneAboveTwoGrid>
 						<GridItem area="first">
 							<ImageComponent
-								palette={palette}
 								element={images[0]}
 								format={format}
 								hideCaption={true}
@@ -195,7 +189,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="second">
 							<ImageComponent
-								palette={palette}
 								element={images[1]}
 								format={format}
 								hideCaption={true}
@@ -204,7 +197,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="third">
 							<ImageComponent
-								palette={palette}
 								element={images[2]}
 								format={format}
 								hideCaption={true}
@@ -236,7 +228,6 @@ export const MultiImageBlockComponent = ({
 					<GridOfFour>
 						<GridItem area="first">
 							<ImageComponent
-								palette={palette}
 								element={images[0]}
 								format={format}
 								hideCaption={true}
@@ -245,7 +236,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="second">
 							<ImageComponent
-								palette={palette}
 								element={images[1]}
 								format={format}
 								hideCaption={true}
@@ -254,7 +244,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="third">
 							<ImageComponent
-								palette={palette}
 								element={images[2]}
 								format={format}
 								hideCaption={true}
@@ -263,7 +252,6 @@ export const MultiImageBlockComponent = ({
 						</GridItem>
 						<GridItem area="forth">
 							<ImageComponent
-								palette={palette}
 								element={images[3]}
 								format={format}
 								hideCaption={true}

--- a/dotcom-rendering/src/web/components/NumberedTitleBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/NumberedTitleBlockComponent.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
-import { decideTheme } from '../lib/decideTheme';
+import { decideFormat } from '../lib/decideFormat';
 
 type Props = {
 	position: number;
@@ -34,12 +32,7 @@ export const NumberedTitleBlockComponent = ({
 	html,
 	format,
 }: Props) => {
-	const dcrFormat = {
-		display: decideDisplay(format),
-		design: decideDesign(format),
-		theme: decideTheme(format),
-	};
-	const palette = decidePalette(dcrFormat);
+	const palette = decidePalette(decideFormat(format));
 	return (
 		<div
 			css={css`

--- a/dotcom-rendering/src/web/components/Onwards.mocks.ts
+++ b/dotcom-rendering/src/web/components/Onwards.mocks.ts
@@ -5,9 +5,7 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 
-import { decideDesign } from '../lib/decideDesign';
-import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
+import { decideFormat } from '../lib/decideFormat';
 
 const CAPITrails: CAPITrailType[] = [
 	{
@@ -148,9 +146,7 @@ const CAPITrails: CAPITrailType[] = [
 ];
 
 const trails: TrailType[] = CAPITrails.map((thisTrail) => {
-	const display = decideDisplay(thisTrail.format);
-	const design = decideDesign(thisTrail.format);
-	const theme = decideTheme(thisTrail.format);
+	const format = decideFormat(thisTrail.format);
 	return {
 		url: thisTrail.url,
 		headline: thisTrail.headline,
@@ -161,11 +157,7 @@ const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 		webPublicationDate: thisTrail.webPublicationDate,
 		mediaType: thisTrail.mediaType,
 		mediaDuration: thisTrail.mediaDuration,
-		format: {
-			display,
-			theme,
-			design,
-		}
+		format,
 	};
 });
 

--- a/dotcom-rendering/src/web/components/Onwards.mocks.ts
+++ b/dotcom-rendering/src/web/components/Onwards.mocks.ts
@@ -7,7 +7,6 @@ import {
 
 import { decideDesign } from '../lib/decideDesign';
 import { decideTheme } from '../lib/decideTheme';
-import { decidePalette } from '../lib/decidePalette';
 import { decideDisplay } from '../lib/decideDisplay';
 
 const CAPITrails: CAPITrailType[] = [
@@ -166,12 +165,7 @@ const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 			display,
 			theme,
 			design,
-		},
-		palette: decidePalette({
-			display,
-			theme,
-			design,
-		}),
+		}
 	};
 });
 

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -2,9 +2,7 @@ import { RichLink, RichLinkImageData } from './RichLink';
 import { DefaultRichLink } from './DefaultRichLink';
 
 import { useApi } from '../lib/useApi';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
-import { decideTheme } from '../lib/decideTheme';
+import { decideFormat } from '../lib/decideFormat';
 
 type Props = {
 	element: RichLinkBlockElement;
@@ -90,11 +88,7 @@ export const RichLinkComponent = ({
 			contentType={data.contentType}
 			url={data.url}
 			starRating={data.starRating}
-			format={{
-				display: decideDisplay(data.format),
-				design: decideDesign(data.format),
-				theme: decideTheme(data.format),
-			}}
+			format={decideFormat(data.format)}
 			tags={data.tags}
 			sponsorName={data.sponsorName}
 			contributorImage={data.contributorImage}

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -12,10 +12,10 @@ import { ArticleDisplay, ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { Hide } from './Hide';
 import { Badge } from './Badge';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	tags: TagType[];
 	sectionLabel: string;
 	sectionUrl: string;
@@ -166,7 +166,6 @@ const immersiveTitleBadgeStyle = (palette: Palette) => css`
 
 export const SeriesSectionLink = ({
 	format,
-	palette,
 	tags,
 	sectionLabel,
 	sectionUrl,
@@ -185,6 +184,8 @@ export const SeriesSectionLink = ({
 	const hasSeriesTag = tag && tag.type === 'Series';
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
+
+	const palette = decidePalette(format);
 
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {

--- a/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { Caption } from './Caption';
-import { decidePalette } from '../lib/decidePalette';
 import { ClickToView } from './ClickToView';
 
 /**
@@ -46,8 +45,6 @@ export const SpotifyBlockComponent = ({
 		margin-bottom: 16px;
 	`;
 
-	const palette = decidePalette(format);
-
 	return (
 		<ClickToView
 			role={role}
@@ -68,7 +65,6 @@ export const SpotifyBlockComponent = ({
 					<Caption
 						captionText={caption}
 						format={format}
-						palette={palette}
 						credit={credit}
 					/>
 				)}

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 
 import { Caption } from './Caption';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
-import { decidePalette } from '../lib/decidePalette';
 import { ClickToView } from './ClickToView';
 
 type Props = {
@@ -49,8 +48,6 @@ export const VideoFacebookBlockComponent = ({
 		margin-bottom: ${caption ? `0px` : `6px`};
 	`;
 
-	const palette = decidePalette(format);
-
 	return (
 		<ClickToView
 			role={role}
@@ -73,7 +70,6 @@ export const VideoFacebookBlockComponent = ({
 					<Caption
 						captionText={caption}
 						format={format}
-						palette={palette}
 						credit={credit}
 						mediaType="Video"
 					/>

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '../lib/decidePalette';
 import { VimeoBlockComponent } from './VimeoBlockComponent';
 
 export default {
@@ -36,11 +35,6 @@ export const smallAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 			<p>abc</p>
 		</Container>
@@ -64,11 +58,6 @@ export const largeAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 			<p>abc</p>
 		</Container>
@@ -92,11 +81,6 @@ export const verticalAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 			/>
 			<p>abc</p>
 		</Container>

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
@@ -15,14 +15,13 @@ const responsiveAspectRatio = (height: number, width: number) => css`
 `;
 export const VimeoBlockComponent: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	embedUrl?: string;
 	height: number;
 	width: number;
 	caption?: string;
 	credit?: string;
 	title?: string;
-}> = ({ embedUrl, caption, title, format, palette, width, height, credit }) => {
+}> = ({ embedUrl, caption, title, format, width, height, credit }) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -53,7 +52,6 @@ export const VimeoBlockComponent: React.FC<{
 				<Caption
 					captionText={caption}
 					format={format}
-					palette={palette}
 					credit={credit}
 					mediaType="Video"
 				/>

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.tsx
@@ -13,7 +13,6 @@ import { trackVideoInteraction } from '../browser/ga/ga';
 import { record } from '../browser/ophan/ophan';
 
 import { Caption } from './Caption';
-import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	id: string;
@@ -112,7 +111,6 @@ export const YoutubeBlockComponent = ({
 			});
 	}, []);
 
-	const palette = decidePalette(format);
 	const shouldLimitWidth =
 		!isMainMedia &&
 		(role === 'showcase' || role === 'supporting' || role === 'immersive');
@@ -145,7 +143,6 @@ export const YoutubeBlockComponent = ({
 				</div>
 				{!hideCaption && (
 					<Caption
-						palette={palette}
 						captionText={mediaTitle || ''}
 						format={format}
 						displayCredit={false}
@@ -218,7 +215,6 @@ export const YoutubeBlockComponent = ({
 			/>
 			{!hideCaption && (
 				<Caption
-					palette={palette}
 					captionText={mediaTitle || ''}
 					format={format}
 					displayCredit={false}

--- a/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
@@ -43,7 +43,6 @@ export const YoutubeEmbedBlockComponent: React.FC<{
 				<Caption
 					captionText={caption}
 					format={format}
-					palette={palette}
 					credit={credit}
 					mediaType="Video"
 				/>

--- a/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
@@ -12,7 +12,7 @@ export const YoutubeEmbedBlockComponent: React.FC<{
 	caption?: string;
 	credit?: string;
 	title?: string;
-}> = ({ embedUrl, caption, title, format, palette, width, height, credit }) => {
+}> = ({ embedUrl, caption, title, format, width, height, credit }) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -518,7 +518,6 @@ export const CommentLayout = ({
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									palette={palette}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 									author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -421,7 +421,6 @@ export const CommentLayout = ({
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								palette={palette}
 								tags={CAPI.tags}
 								sectionLabel={CAPI.sectionLabel}
 								sectionUrl={CAPI.sectionUrl}
@@ -450,7 +449,6 @@ export const CommentLayout = ({
 										<ArticleHeadline
 											format={format}
 											headlineString={CAPI.headline}
-											palette={palette}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
 										/>
@@ -499,7 +497,6 @@ export const CommentLayout = ({
 							>
 								<MainMedia
 									format={format}
-									palette={palette}
 									elements={CAPI.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -43,13 +43,12 @@ interface Props {
 
 const Renderer: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	elements: CAPIElement[];
 	host?: string;
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
-}> = ({ format, palette, elements, host, pageId, webTitle, ajaxUrl }) => {
+}> = ({ format, elements, host, pageId, webTitle, ajaxUrl }) => {
 	// const cleanedElements = elements.map(element =>
 	//     'html' in element ? { ...element, html: clean(element.html) } : element,
 	// );
@@ -58,7 +57,7 @@ const Renderer: React.FC<{
 	const output = elements.map((element, index) => {
 		const [ok, el] = renderElement({
 			format,
-			palette,
+
 			element,
 			adTargeting: undefined,
 			host,
@@ -295,7 +294,6 @@ export const FullPageInteractiveLayout = ({
 				<article>
 					<Renderer
 						format={format}
-						palette={palette}
 						elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
 						host={host}
 						pageId={CAPI.pageId}

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -4,9 +4,7 @@ import { breakpoints } from '@guardian/source-foundations';
 
 import { makeGuardianBrowserCAPI } from '../../model/window-guardian';
 
-import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 
 import { Article } from '../../../fixtures/generated/articles/Article';
 import { PhotoEssay } from '../../../fixtures/generated/articles/PhotoEssay';
@@ -74,11 +72,7 @@ const convertToImmersive = (CAPI: CAPIType) => ({
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
-	const format: ArticleFormat = {
-		display: decideDisplay(ServerCAPI.format),
-		design: decideDesign(ServerCAPI.format),
-		theme: decideTheme(ServerCAPI.format),
-	};
+	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		BootReact({ CAPI });

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -276,7 +276,6 @@ export const ImmersiveLayout = ({
 									>
 										<ArticleTitle
 											format={format}
-											palette={palette}
 											tags={CAPI.tags}
 											sectionLabel={CAPI.sectionLabel}
 											sectionUrl={CAPI.sectionUrl}
@@ -296,7 +295,6 @@ export const ImmersiveLayout = ({
 										<ArticleHeadline
 											format={format}
 											headlineString={CAPI.headline}
-											palette={palette}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
 										/>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -347,7 +347,6 @@ export const ImmersiveLayout = ({
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									palette={palette}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 									author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -246,7 +246,6 @@ export const ImmersiveLayout = ({
 						<GridItem area="caption">
 							<Hide when="above" breakpoint="leftCol">
 								<Caption
-									palette={palette}
 									captionText={captionText}
 									format={format}
 									shouldLimitWidth={false}

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -2,9 +2,7 @@ import { useEffect } from 'react';
 
 import { makeGuardianBrowserCAPI } from '../../model/window-guardian';
 
-import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 
 import { Article } from '../../../fixtures/generated/articles/Article';
 
@@ -44,11 +42,7 @@ const convertToInteractiveImmersive = (CAPI: CAPIType) => {
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
-	const format: ArticleFormat = {
-		display: decideDisplay(ServerCAPI.format),
-		design: decideDesign(ServerCAPI.format),
-		theme: decideTheme(ServerCAPI.format),
-	};
+	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -296,7 +296,6 @@ export const InteractiveImmersiveLayout = ({
 						<GridItem area="caption">
 							<Hide when="above" breakpoint="leftCol">
 								<Caption
-									palette={palette}
 									captionText={captionText}
 									format={format}
 									shouldLimitWidth={false}

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -148,13 +148,12 @@ const InteractiveImmersiveGrid = ({
 
 const Renderer: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	elements: CAPIElement[];
 	host?: string;
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
-}> = ({ format, palette, elements, host, pageId, webTitle, ajaxUrl }) => {
+}> = ({ format, elements, host, pageId, webTitle, ajaxUrl }) => {
 	// const cleanedElements = elements.map(element =>
 	//     'html' in element ? { ...element, html: clean(element.html) } : element,
 	// );
@@ -163,7 +162,6 @@ const Renderer: React.FC<{
 	const output = elements.map((element, index) => {
 		const [ok, el] = renderElement({
 			format,
-			palette,
 			element,
 			adTargeting: undefined,
 			host,
@@ -328,7 +326,6 @@ export const InteractiveImmersiveLayout = ({
 									>
 										<ArticleTitle
 											format={format}
-											palette={palette}
 											tags={CAPI.tags}
 											sectionLabel={CAPI.sectionLabel}
 											sectionUrl={CAPI.sectionUrl}
@@ -348,7 +345,6 @@ export const InteractiveImmersiveLayout = ({
 										<ArticleHeadline
 											format={format}
 											headlineString={CAPI.headline}
-											palette={palette}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
 										/>
@@ -437,7 +433,6 @@ export const InteractiveImmersiveLayout = ({
 					<article>
 						<Renderer
 							format={format}
-							palette={palette}
 							elements={
 								CAPI.blocks[0] ? CAPI.blocks[0].elements : []
 							}

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -397,7 +397,6 @@ export const InteractiveImmersiveLayout = ({
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									palette={palette}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 									author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -491,7 +491,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									<ArticleMeta
 										branding={branding}
 										format={format}
-										palette={palette}
 										pageId={CAPI.pageId}
 										webTitle={CAPI.webTitle}
 										author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -398,7 +398,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								>
 									<ArticleTitle
 										format={format}
-										palette={palette}
 										tags={CAPI.tags}
 										sectionLabel={CAPI.sectionLabel}
 										sectionUrl={CAPI.sectionUrl}
@@ -433,7 +432,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											headlineString={CAPI.headline}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
-											palette={palette}
 										/>
 										{age && (
 											<AgeWarning
@@ -464,7 +462,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<div css={maxWidth}>
 									<MainMedia
 										format={format}
-										palette={palette}
 										elements={CAPI.mainMediaElements}
 										adTargeting={adTargeting}
 										host={host}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -504,7 +504,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							leftContent={
 								<ArticleTitle
 									format={format}
-									palette={palette}
 									tags={CAPI.tags}
 									sectionLabel={CAPI.sectionLabel}
 									sectionUrl={CAPI.sectionUrl}
@@ -520,7 +519,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<Hide above="leftCol">
 								<ArticleTitle
 									format={format}
-									palette={palette}
 									tags={CAPI.tags}
 									sectionLabel={CAPI.sectionLabel}
 									sectionUrl={CAPI.sectionUrl}
@@ -547,7 +545,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<GridItem area="title">
 									<ArticleTitle
 										format={format}
-										palette={palette}
 										tags={CAPI.tags}
 										sectionLabel={CAPI.sectionLabel}
 										sectionUrl={CAPI.sectionUrl}
@@ -573,7 +570,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 													}
 													tags={CAPI.tags}
 													byline={CAPI.author.byline}
-													palette={palette}
 												/>
 											)}
 											{age && (
@@ -716,7 +712,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									<div css={maxWidth}>
 										<MainMedia
 											format={format}
-											palette={palette}
 											elements={CAPI.mainMediaElements}
 											adTargeting={adTargeting}
 											host={host}
@@ -933,7 +928,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									<div css={maxWidth}>
 										<MainMedia
 											format={format}
-											palette={palette}
 											elements={CAPI.mainMediaElements}
 											adTargeting={adTargeting}
 											host={host}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -638,7 +638,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										<ArticleMeta
 											branding={branding}
 											format={format}
-											palette={palette}
 											pageId={CAPI.pageId}
 											webTitle={CAPI.webTitle}
 											author={CAPI.author}
@@ -746,7 +745,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											<ArticleMeta
 												branding={branding}
 												format={format}
-												palette={palette}
 												pageId={CAPI.pageId}
 												webTitle={CAPI.webTitle}
 												author={CAPI.author}
@@ -960,7 +958,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											<ArticleMeta
 												branding={branding}
 												format={format}
-												palette={palette}
 												pageId={CAPI.pageId}
 												webTitle={CAPI.webTitle}
 												author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -3,9 +3,7 @@ import { useEffect } from 'react';
 import { breakpoints } from '@guardian/source-foundations';
 import { makeGuardianBrowserCAPI } from '../../model/window-guardian';
 
-import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 
 import { Article } from '../../../fixtures/generated/articles/Article';
 import { PhotoEssay } from '../../../fixtures/generated/articles/PhotoEssay';
@@ -59,11 +57,7 @@ const convertToShowcase = (CAPI: CAPIType) => {
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
-	const format: ArticleFormat = {
-		display: decideDisplay(ServerCAPI.format),
-		design: decideDesign(ServerCAPI.format),
-		theme: decideTheme(ServerCAPI.format),
-	};
+	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -423,7 +423,6 @@ export const ShowcaseLayout = ({
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								palette={palette}
 								tags={CAPI.tags}
 								sectionLabel={CAPI.sectionLabel}
 								sectionUrl={CAPI.sectionUrl}
@@ -449,7 +448,6 @@ export const ShowcaseLayout = ({
 									<ArticleHeadline
 										format={format}
 										headlineString={CAPI.headline}
-										palette={palette}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
 									/>
@@ -466,7 +464,6 @@ export const ShowcaseLayout = ({
 							<div css={mainMediaWrapper}>
 								<MainMedia
 									format={format}
-									palette={palette}
 									elements={CAPI.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -504,7 +504,6 @@ export const ShowcaseLayout = ({
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									palette={palette}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 									author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -4,9 +4,7 @@ import { breakpoints } from '@guardian/source-foundations';
 
 import { makeGuardianBrowserCAPI } from '../../model/window-guardian';
 
-import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 
 import { Article } from '../../../fixtures/generated/articles/Article';
 import { PhotoEssay } from '../../../fixtures/generated/articles/PhotoEssay';
@@ -71,11 +69,7 @@ const HydratedLayout = ({
 }) => {
 	fireAndResetHydrationState();
 	const NAV = extractNAV(ServerCAPI.nav);
-	const format: ArticleFormat = {
-		display: decideDisplay(ServerCAPI.format),
-		design: decideDesign(ServerCAPI.format),
-		theme: decideTheme(ServerCAPI.format),
-	};
+	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -606,7 +606,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									palette={palette}
 									pageId={CAPI.pageId}
 									webTitle={CAPI.webTitle}
 									author={CAPI.author}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -478,7 +478,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								palette={palette}
 								tags={CAPI.tags}
 								sectionLabel={CAPI.sectionLabel}
 								sectionUrl={CAPI.sectionUrl}
@@ -544,7 +543,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										headlineString={CAPI.headline}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
-										palette={palette}
 									/>
 									{age && (
 										<AgeWarning
@@ -575,7 +573,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<div css={maxWidth}>
 								<MainMedia
 									format={format}
-									palette={palette}
 									elements={CAPI.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -136,7 +136,6 @@ export const ImmersiveHeader = ({
 			`}
 		>
 			<Caption
-				palette={palette}
 				captionText={captionText}
 				format={format}
 				shouldLimitWidth={true}

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -206,7 +206,6 @@ export const ImmersiveHeader = ({
 
 					<MainMedia
 						format={format}
-						palette={palette}
 						elements={CAPI.mainMediaElements}
 						adTargeting={adTargeting}
 						starRating={
@@ -244,7 +243,6 @@ export const ImmersiveHeader = ({
 							>
 								<ArticleTitle
 									format={format}
-									palette={palette}
 									tags={CAPI.tags}
 									sectionLabel={CAPI.sectionLabel}
 									sectionUrl={CAPI.sectionUrl}
@@ -261,7 +259,6 @@ export const ImmersiveHeader = ({
 									<ArticleHeadline
 										format={format}
 										headlineString={CAPI.headline}
-										palette={palette}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
 									/>

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -48,27 +48,16 @@ const adStylesDynamic = css`
 
 export const ArticleRenderer: React.FC<{
 	format: ArticleFormat;
-	palette: Palette;
 	elements: CAPIElement[];
 	adTargeting?: AdTargeting;
 	host?: string;
 	pageId: string;
 	webTitle: string;
 	ajaxUrl: string;
-}> = ({
-	format,
-	palette,
-	elements,
-	adTargeting,
-	host,
-	pageId,
-	webTitle,
-	ajaxUrl,
-}) => {
+}> = ({ format, elements, adTargeting, host, pageId, webTitle, ajaxUrl }) => {
 	const output = elements.map((element, index) => {
 		return renderArticleElement({
 			format,
-			palette,
 			element,
 			adTargeting,
 			ajaxUrl,

--- a/dotcom-rendering/src/web/lib/decideDesign.ts
+++ b/dotcom-rendering/src/web/lib/decideDesign.ts
@@ -1,8 +1,14 @@
 import { ArticleDesign } from '@guardian/libs';
 
-export const decideDesign = (format: CAPIFormat): ArticleDesign => {
-	const designType: CAPIDesign = format.design;
-	switch (designType) {
+/**
+ * NOTE: Immersive Opinion pieces are not supported,
+ * i.e. when `CommentDesign` and `ImmersiveDisplay` are used jointly.
+ */
+export const decideDesign = ({
+	design,
+	display,
+}: Partial<CAPIFormat>): ArticleDesign => {
+	switch (design) {
 		case 'ArticleDesign':
 			return ArticleDesign.Standard;
 		case 'MediaDesign':
@@ -13,7 +19,7 @@ export const decideDesign = (format: CAPIFormat): ArticleDesign => {
 			return ArticleDesign.Analysis;
 		case 'CommentDesign':
 			// Temporary hack until we can handle Immersive Opinion pieces
-			return format.display === 'ImmersiveDisplay'
+			return display === 'ImmersiveDisplay'
 				? ArticleDesign.Standard
 				: ArticleDesign.Comment;
 		case 'LetterDesign':

--- a/dotcom-rendering/src/web/lib/decideDisplay.ts
+++ b/dotcom-rendering/src/web/lib/decideDisplay.ts
@@ -1,7 +1,8 @@
 import { ArticleDisplay } from '@guardian/libs';
 
-export const decideDisplay = (format: CAPIFormat): ArticleDisplay => {
-	const { display } = format;
+export const decideDisplay = ({
+	display,
+}: Partial<CAPIFormat>): ArticleDisplay => {
 	switch (display) {
 		case 'StandardDisplay':
 			return ArticleDisplay.Standard;

--- a/dotcom-rendering/src/web/lib/decideFormat.ts
+++ b/dotcom-rendering/src/web/lib/decideFormat.ts
@@ -1,0 +1,9 @@
+import { decideDesign } from './decideDesign';
+import { decideDisplay } from './decideDisplay';
+import { decideTheme } from './decideTheme';
+
+export const decideFormat = (format: Partial<CAPIFormat>): ArticleFormat => ({
+	display: decideDisplay(format),
+	theme: decideTheme(format),
+	design: decideDesign(format),
+});

--- a/dotcom-rendering/src/web/lib/decideTheme.ts
+++ b/dotcom-rendering/src/web/lib/decideTheme.ts
@@ -1,7 +1,6 @@
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 
-export const decideTheme = (format: CAPIFormat): ArticleTheme => {
-	const { theme } = format;
+export const decideTheme = ({ theme }: Partial<CAPIFormat>): ArticleTheme => {
 	switch (theme) {
 		case 'NewsPillar':
 			return ArticlePillar.News;

--- a/dotcom-rendering/src/web/lib/decideTrail.ts
+++ b/dotcom-rendering/src/web/lib/decideTrail.ts
@@ -1,20 +1,7 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { decideDesign } from './decideDesign';
-import { decideTheme } from './decideTheme';
-import { decideDisplay } from './decideDisplay';
+import { decideFormat } from './decideFormat';
 
 export const decideTrail = (trail: CAPITrailType): TrailType => {
-	const format: ArticleFormat = trail.format
-		? {
-				display: decideDisplay(trail.format),
-				theme: decideTheme(trail.format),
-				design: decideDesign(trail.format),
-		  }
-		: {
-				display: ArticleDisplay.Standard,
-				theme: ArticlePillar.News,
-				design: ArticleDesign.Standard,
-		  };
+	const format: ArticleFormat = decideFormat(trail.format);
 
 	return {
 		...trail,

--- a/dotcom-rendering/src/web/lib/decideTrail.ts
+++ b/dotcom-rendering/src/web/lib/decideTrail.ts
@@ -2,7 +2,6 @@ import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { decideDesign } from './decideDesign';
 import { decideTheme } from './decideTheme';
 import { decideDisplay } from './decideDisplay';
-import { decidePalette } from './decidePalette';
 
 export const decideTrail = (trail: CAPITrailType): TrailType => {
 	const format: ArticleFormat = trail.format
@@ -17,11 +16,8 @@ export const decideTrail = (trail: CAPITrailType): TrailType => {
 				design: ArticleDesign.Standard,
 		  };
 
-	const palette = decidePalette(format);
-
 	return {
 		...trail,
 		format,
-		palette,
 	};
 };

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -63,10 +63,10 @@ import {
 } from '../layouts/lib/interactiveLegacyStyling';
 
 import { Island } from '../components/Island';
+import { decidePalette } from './decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	element: CAPIElement;
 	adTargeting?: AdTargeting;
 	host?: string;
@@ -117,7 +117,6 @@ const updateRole = (el: CAPIElement, format: ArticleFormat): CAPIElement => {
 // inspection.
 export const renderElement = ({
 	format,
-	palette,
 	element,
 	adTargeting,
 	host,
@@ -129,6 +128,7 @@ export const renderElement = ({
 	webTitle,
 	ajaxUrl,
 }: Props): [boolean, JSX.Element] => {
+	const palette = decidePalette(format);
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return [
@@ -751,7 +751,6 @@ const bareElements = new Set([
 // types.
 export const renderArticleElement = ({
 	format,
-	palette,
 	element,
 	adTargeting,
 	ajaxUrl,
@@ -767,7 +766,6 @@ export const renderArticleElement = ({
 
 	const [ok, el] = renderElement({
 		format,
-		palette,
 		element: withUpdatedRole,
 		adTargeting,
 		ajaxUrl,

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -166,7 +166,6 @@ export const renderElement = ({
 				<CaptionBlockComponent
 					key={index}
 					format={format}
-					palette={palette}
 					captionText={element.captionText}
 					padCaption={element.padCaption}
 					credit={element.credit}
@@ -304,7 +303,6 @@ export const renderElement = ({
 				<GuVideoBlockComponent
 					html={element.html}
 					format={format}
-					palette={palette}
 					credit={element.source}
 					caption={element.caption}
 				/>,
@@ -609,7 +607,6 @@ export const renderElement = ({
 				true,
 				<VimeoBlockComponent
 					format={format}
-					palette={palette}
 					embedUrl={element.embedUrl}
 					height={element.height}
 					width={element.width}

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -317,7 +317,6 @@ export const renderElement = ({
 				true,
 				<ImageBlockComponent
 					format={format}
-					palette={palette}
 					key={index}
 					element={element}
 					hideCaption={hideCaption}
@@ -421,7 +420,6 @@ export const renderElement = ({
 				true,
 				<MultiImageBlockComponent
 					format={format}
-					palette={palette}
 					key={index}
 					images={element.images}
 					caption={element.caption}

--- a/dotcom-rendering/src/web/lib/useComments.test.tsx
+++ b/dotcom-rendering/src/web/lib/useComments.test.tsx
@@ -1,5 +1,4 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from './decidePalette';
 
 import { findCount, buildUrl } from './useComments';
 
@@ -86,11 +85,6 @@ describe('buildUrl', () => {
 							theme: ArticlePillar.Opinion,
 							design: ArticleDesign.Comment,
 						},
-						palette: decidePalette({
-							display: ArticleDisplay.Standard,
-							theme: ArticlePillar.Opinion,
-							design: ArticleDesign.Comment,
-						}),
 						webPublicationDate: '2020-11-03T11:00:02.000Z',
 						headline:
 							"There's no point railing against Farage. You have to present an alternative",
@@ -109,11 +103,6 @@ describe('buildUrl', () => {
 							theme: ArticlePillar.Opinion,
 							design: ArticleDesign.Comment,
 						},
-						palette: decidePalette({
-							display: ArticleDisplay.Standard,
-							theme: ArticlePillar.Opinion,
-							design: ArticleDesign.Comment,
-						}),
 						webPublicationDate: '2020-11-03T10:26:01.000Z',
 						headline:
 							"This election isn't about the next four years. It's about the next four millennia",
@@ -151,11 +140,6 @@ describe('buildUrl', () => {
 							theme: ArticlePillar.Opinion,
 							design: ArticleDesign.Comment,
 						},
-						palette: decidePalette({
-							display: ArticleDisplay.Standard,
-							theme: ArticlePillar.Opinion,
-							design: ArticleDesign.Comment,
-						}),
 						webPublicationDate: '2020-11-03T15:33:04.000Z',
 						headline:
 							'The EHRC report shows how difficult building real anti-racist politics will be',
@@ -174,11 +158,6 @@ describe('buildUrl', () => {
 							theme: ArticlePillar.Opinion,
 							design: ArticleDesign.Comment,
 						},
-						palette: decidePalette({
-							display: ArticleDisplay.Standard,
-							theme: ArticlePillar.Opinion,
-							design: ArticleDesign.Comment,
-						}),
 						webPublicationDate: '2020-11-03T13:50:06.000Z',
 						headline:
 							"Macron wants to fix France's social ills – but he won't do it by 'reforming' Islam",

--- a/dotcom-rendering/src/web/server/blocksToHtml.tsx
+++ b/dotcom-rendering/src/web/server/blocksToHtml.tsx
@@ -1,8 +1,6 @@
 import { renderToString } from 'react-dom/server';
 import { buildAdTargeting } from '../../lib/ad-targeting';
-import { decideDesign } from '../lib/decideDesign';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideTheme } from '../lib/decideTheme';
+import { decideFormat } from '../lib/decideFormat';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
 
 /**
@@ -26,11 +24,7 @@ export const blocksToHtml = ({
 	sharedAdTargeting,
 	adUnit,
 }: BlocksRequest): string => {
-	const format: ArticleFormat = {
-		display: decideDisplay(CAPIFormat),
-		design: decideDesign(CAPIFormat),
-		theme: decideTheme(CAPIFormat),
-	};
+	const format: ArticleFormat = decideFormat(CAPIFormat);
 
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser,

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -6,8 +6,7 @@ import createCache from '@emotion/cache';
 import { ChunkExtractor } from '@loadable/server';
 import { ArticlePillar } from '@guardian/libs';
 import { decideTheme } from '../lib/decideTheme';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideDesign } from '../lib/decideDesign';
+import { decideFormat } from '../lib/decideFormat';
 
 import { Page } from '../components/Page';
 
@@ -62,11 +61,7 @@ export const document = ({ data }: Props): string => {
 	const { extractCriticalToChunks, constructStyleTagsFromChunks } =
 		createEmotionServer(cache);
 
-	const format: ArticleFormat = {
-		display: decideDisplay(CAPI.format),
-		design: decideDesign(CAPI.format),
-		theme: decideTheme(CAPI.format),
-	};
+	const format: ArticleFormat = decideFormat(CAPI.format);
 
 	const html = renderToString(
 		<CacheProvider value={cache}>

--- a/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/keyEventsToHtml.tsx
@@ -1,8 +1,6 @@
 import { renderToString } from 'react-dom/server';
 import { KeyEventsContainer } from '../components/KeyEventsContainer';
-import { decideDesign } from '../lib/decideDesign';
-import { decideDisplay } from '../lib/decideDisplay';
-import { decideTheme } from '../lib/decideTheme';
+import { decideFormat } from '../lib/decideFormat';
 
 /**
  * keyEventsToHtml is used by the /KeyEvents endpoint as part of keeping liveblogs live
@@ -15,16 +13,10 @@ export const keyEventsToHtml = ({
 	format: CAPIFormat,
 	filterKeyEvents,
 }: KeyEventsRequest): string => {
-	const format: ArticleFormat = {
-		display: decideDisplay(CAPIFormat),
-		design: decideDesign(CAPIFormat),
-		theme: decideTheme(CAPIFormat),
-	};
-
 	const html = renderToString(
 		<KeyEventsContainer
 			keyEvents={keyEvents}
-			format={format}
+			format={decideFormat(CAPIFormat)}
 			filterKeyEvents={filterKeyEvents}
 		/>,
 	);


### PR DESCRIPTION
## What does this change?

If we have `format`, we can forgo `palette`. The consumer can do `decidePalette` – or even the fancier `editorialPalette`.

Added a `decideFormat` method to replace a common pattern:

```ts
// before
const format: ArticleFormat = {
	display: decideDisplay(CAPIformat),
	theme: decideTheme(CAPIformat),
	design: decideDesign(CAPIformat),
}

// after
const format: ArticleFormat = decideFormat(CAPIformat)
```

## Why?

There’s loads of duplicated code. Passing props that contain the same information makes refactors harder.