### PR TITLE
Vimeo element url

### DIFF
--- a/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
@@ -10,9 +10,8 @@ export const VideoVimeoBlockComponent: React.FC<{
 	// which is used in composer.
 	// see: https://github.com/guardian/dotcom-rendering/issues/4057
 	// We should remove this once ☝️ is fixed.
-	const url = element.url === '' ? (element.originalUrl ?? '') : element.url;
+	const url = element.url === '' ? element.originalUrl ?? '' : element.url;
 	const vimeoId = getIdFromUrl(url, '(\\d+)($|\\/)', true);
-
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
@@ -26,4 +25,3 @@ export const VideoVimeoBlockComponent: React.FC<{
 		</Caption>
 	);
 };
-

--- a/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
@@ -6,7 +6,13 @@ export const VideoVimeoBlockComponent: React.FC<{
 	element: VideoVimeoBlockElement;
 	pillar: ArticleTheme;
 }> = ({ element, pillar }) => {
-	const vimeoId = getIdFromUrl(element.url, '(\\d+)($|\\/)', true);
+	// This is a hack as `url` is coming through as `""` from the embed.ly oembed endpoint
+	// which is used in composer.
+	// see: https://github.com/guardian/dotcom-rendering/issues/4057
+	// We should remove this once ☝️ is fixed.
+	const url = element.url === '' ? (element.originalUrl ?? '') : element.url;
+	const vimeoId = getIdFromUrl(url, '(\\d+)($|\\/)', true);
+
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
@@ -20,3 +26,4 @@ export const VideoVimeoBlockComponent: React.FC<{
 		</Caption>
 	);
 };
+


### PR DESCRIPTION
part of https://github.com/guardian/dotcom-rendering/issues/4057
## What does this change?
Checks if the `url === ''` then falls back to the `originalUrl`. This seems to be a bug that has been caused by the new way composer / flexible content are no longer omitting the `url` if embed.ly returns an emopty string. Which it does. See the issue for more details.

This is a hack and should be removed once we get to the bottom of that issue, but we're clogging up our errors which is a dangerous place to be.

## Why?
Less of these errors = more visibility into actual errors

### Before
<img width="1001" alt="Screenshot 2022-02-23 at 09 46 10" src="https://user-images.githubusercontent.com/31692/155297272-c9c8fb46-6f1d-4f06-9362-afde9e15c631.png">


### After
<img width="708" alt="Screenshot 2022-02-23 at 09 46 04" src="https://user-images.githubusercontent.com/31692/155297286-3512bce2-5791-493c-9872-ce432e9ab797.png">

