### PR TITLE
Remove Redundant `max-width` In `Standfirst`

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -98,9 +98,6 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 
 						max-width: 280px;
 						${from.tablet} {
-							max-width: 400px;
-						}
-						${from.tablet} {
 							max-width: 460px;
 						}
 						color: ${palette.text.standfirst};


### PR DESCRIPTION
## Why?

It's immediately overwritten by the next `max-width`.

## Changes

- Removed redundant `max-width` in `Standfirst`
