### PR TITLE
Add `cardTextByline` to palette

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -93,6 +93,7 @@ type Palette = {
 		articleLink: Colour;
 		articleLinkHover: Colour;
 		cardHeadline: Colour;
+		cardByline: Colour;
 		cardKicker: Colour;
 		linkKicker: Colour;
 		cardStandfirst: Colour;

--- a/dotcom-rendering/src/web/components/Byline.tsx
+++ b/dotcom-rendering/src/web/components/Byline.tsx
@@ -8,6 +8,7 @@ type Props = {
 	text: string;
 	format: ArticleFormat;
 	size: SmallHeadlineSize;
+	isCard?: boolean;
 };
 
 const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
@@ -76,15 +77,18 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 	}
 };
 
-const colourStyles = (palette: Palette) => {
+const colourStyles = (palette: Palette, isCard: Props['isCard']) => {
 	return css`
-		color: ${palette.text.cardByline};
+		color: ${isCard ? palette.text.cardByline : palette.text.byline};
 	`;
 };
 
-export const Byline = ({ text, format, size }: Props) => (
+export const Byline = ({ text, format, size, isCard }: Props) => (
 	<span
-		css={[bylineStyles(size, format), colourStyles(decidePalette(format))]}
+		css={[
+			bylineStyles(size, format),
+			colourStyles(decidePalette(format), isCard),
+		]}
 	>
 		{text}
 	</span>

--- a/dotcom-rendering/src/web/components/Byline.tsx
+++ b/dotcom-rendering/src/web/components/Byline.tsx
@@ -78,7 +78,7 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 
 const colourStyles = (palette: Palette) => {
 	return css`
-		color: ${palette.text.byline};
+		color: ${palette.text.cardByline};
 	`;
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -15,6 +15,13 @@ export default {
 	title: 'Components/CardHeadline',
 };
 
+const smallHeadlineSizes: SmallHeadlineSize[] = [
+	'large',
+	'medium',
+	'small',
+	'tiny',
+];
+
 export const Article = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
@@ -57,20 +64,27 @@ export const Feature = () => (
 );
 Feature.story = { name: 'Feature' };
 
-export const xsmallStory = () => (
-	<ElementContainer showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a large card headline looks"
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			}}
-			size="large"
-		/>
-	</ElementContainer>
+export const Size = () => (
+	<>
+		{smallHeadlineSizes.map((size) => (
+			<div key={size}>
+				<ElementContainer showTopBorder={false} showSideBorders={false}>
+					<CardHeadline
+						headlineText={`This is how a ${size} card headline looks`}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						size={size}
+					/>
+				</ElementContainer>
+				<br />
+			</div>
+		))}
+	</>
 );
-xsmallStory.story = { name: 'Size | large' };
+Size.story = { name: 'Size' };
 
 export const liveStory = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -179,7 +179,12 @@ export const CardHeadline = ({
 				</span>
 			</h4>
 			{byline && showByline && (
-				<Byline text={byline} format={format} size={size} />
+				<Byline
+					text={byline}
+					format={format}
+					size={size}
+					isCard={true}
+				/>
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -338,6 +338,14 @@ const textCardHeadline = (format: ArticleFormat): string => {
 
 const textCardStandfirst = textCardHeadline;
 
+/** same as textByline except for SpecialReport */
+const textCardByline = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return specialReport[700];
+
+	return textByline(format);
+};
+
 const textCardKicker = (format: ArticleFormat): string => {
 	if (
 		format.theme === ArticleSpecial.SpecialReport &&
@@ -1028,6 +1036,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			articleLink: textArticleLink(format),
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline: textCardHeadline(format),
+			cardByline: textCardByline(format),
 			cardKicker: textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardStandfirst: textCardStandfirst(format),


### PR DESCRIPTION
## What does this change?

Add a new palette key: `cardTextByline`. Follows a similar logic to `cardTextHeadline`.

## Why?

Currently, we use the `textByline` colour for cards, but this breaks for Special Reports, where the background is the same colour as the byline.

### Before

<a href="https://5dfcbf3012392c0020e7140b-qgngtexhes.chromatic.com/?path=/story/components-cardheadline--byline">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/76776/155315598-7d43b70d-84c0-4bc8-a4fc-db9d57cafe34.png">
</a>

### After

<img width="519" alt="image" src="https://user-images.githubusercontent.com/76776/155315407-249e5529-6d32-4af7-8cfd-c1bab4fc5549.png">
