### PR TITLE
Add AR Standard layout to Storybook

### DIFF
--- a/apps-rendering/src/components/layout/live.stories.tsx
+++ b/apps-rendering/src/components/layout/live.stories.tsx
@@ -15,7 +15,7 @@ const DeadBlog = (): ReactElement => <Live item={{ ...deadBlog }} />;
 
 export default {
 	component: Live,
-	title: 'AR/LiveBlog Prototype',
+	title: 'AR/Layouts/LiveBlog',
 	decorators: [withKnobs],
 	parameters: {
 		layout: 'fullscreen',

--- a/apps-rendering/src/components/layout/standard.stories.tsx
+++ b/apps-rendering/src/components/layout/standard.stories.tsx
@@ -1,0 +1,77 @@
+// ----- Imports ----- //
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
+import { partition } from '@guardian/types';
+import { withKnobs } from '@storybook/addon-knobs';
+import Standard from 'components/layout/standard';
+import { article, matchReport, review } from 'fixtures/item';
+import { renderAll } from 'renderer';
+
+// ----- Stories ----- //
+
+const display = ArticleDisplay.Standard;
+
+export const Article = (): React.ReactNode => {
+	return (
+		<Standard item={article}>
+			{renderAll(
+				{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.Standard,
+					display,
+				},
+				partition(article.body).oks,
+			)}
+		</Standard>
+	);
+};
+Article.story = { name: 'Article' };
+
+export const Review = (): React.ReactNode => {
+	return (
+		<Standard item={review}>
+			{renderAll(
+				{
+					theme: ArticlePillar.Culture,
+					design: ArticleDesign.Standard,
+					display,
+				},
+				partition(review.body).oks,
+			)}
+		</Standard>
+	);
+};
+Review.story = { name: 'Review' };
+
+export const MatchReport = (): React.ReactNode => {
+	return (
+		<Standard item={matchReport}>
+			{renderAll(
+				{
+					theme: ArticlePillar.Sport,
+					design: ArticleDesign.MatchReport,
+					display,
+				},
+				partition(matchReport.body).oks,
+			)}
+		</Standard>
+	);
+};
+MatchReport.story = { name: 'Match Report' };
+
+export default {
+	title: 'AR/Layouts/Standard',
+	decorators: [withKnobs],
+	parameters: {
+		layout: 'fullscreen',
+		chromatic: {
+			diffThreshold: 0.4,
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+};

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
 
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -17,7 +19,7 @@ import type { MatchScores } from 'football';
 import type { MainMedia } from 'headerMedia';
 import { MainMediaKind } from 'headerMedia';
 import type { Image } from 'image';
-import type { Item, Review } from 'item';
+import type { Item, MatchReport, Review, Standard } from 'item';
 import { pipe } from 'lib';
 import { galleryBody } from './galleryBody';
 import { relatedContent } from './relatedContent';
@@ -243,6 +245,65 @@ const matchScores: MatchScores = {
 	},
 };
 
+const tags: Tag[] = [
+	{
+		id: 'world/refugees',
+		type: TagType.SERIES,
+		webTitle: 'Refugees',
+		webUrl: 'https://www.theguardian.com/world/refugees',
+		apiUrl: 'https://content.guardianapis.com/world/refugees',
+		references: [],
+	},
+	{
+		id: 'uk/immigration',
+		type: TagType.KEYWORD,
+		webTitle: 'Immigration and asylum',
+		webUrl: 'https://www.theguardian.com/uk/immigration',
+		apiUrl: 'https://content.guardianapis.com/uk/immigration',
+		references: [],
+	},
+	{
+		id: 'uk/uk',
+		type: TagType.KEYWORD,
+		webTitle: 'UK news',
+		webUrl: 'https://www.theguardian.com/uk/uk',
+		apiUrl: 'https://content.guardianapis.com/uk/uk',
+		references: [],
+	},
+	{
+		id: 'world/world',
+		type: TagType.KEYWORD,
+		webTitle: 'World news',
+		webUrl: 'https://www.theguardian.com/world/world',
+		apiUrl: 'https://content.guardianapis.com/world/world',
+		references: [],
+	},
+	{
+		id: 'society/youngpeople',
+		type: TagType.KEYWORD,
+		webTitle: 'Young people',
+		webUrl: 'https://www.theguardian.com/society/youngpeople',
+		apiUrl: 'https://content.guardianapis.com/society/youngpeople"',
+		references: [],
+	},
+	{
+		id: 'profile/lukeharding',
+		type: TagType.CONTRIBUTOR,
+		webTitle: 'Luke Harding',
+		webUrl: 'https://www.theguardian.com/profile/lukeharding',
+		apiUrl: 'https://content.guardianapis.com/profile/lukeharding',
+		references: [],
+	},
+	{
+		id: 'tracking/commissioningdesk/saturday-magazine',
+		type: TagType.TRACKING,
+		webTitle: 'Saturday Magazine',
+		webUrl: 'https://www.theguardian.com/tracking/commissioningdesk/saturday-magazine',
+		apiUrl: 'https://content.guardianapis.com/tracking/commissioningdesk/saturday-magazine',
+		references: [],
+	},
+];
+
 const fields = {
 	theme: ArticlePillar.News,
 	display: ArticleDisplay.Standard,
@@ -263,7 +324,7 @@ const fields = {
 		references: [],
 	}),
 	commentable: false,
-	tags: [],
+	tags: tags,
 	shouldHideReaderRevenue: false,
 	branding: none,
 	internalShortId: none,
@@ -274,7 +335,7 @@ const fields = {
 	webUrl: '',
 };
 
-const article: Item = {
+const article: Standard = {
 	design: ArticleDesign.Standard,
 	...fields,
 };
@@ -299,6 +360,7 @@ const review: Review = {
 	design: ArticleDesign.Review,
 	starRating: 4,
 	...fields,
+	theme: ArticlePillar.Culture,
 };
 
 const labs: Item = {
@@ -339,10 +401,11 @@ const cartoon: Item = {
 	body: [],
 };
 
-const matchReport: Item = {
+const matchReport: MatchReport = {
 	design: ArticleDesign.MatchReport,
 	football: some(matchScores),
 	...fields,
+	theme: ArticlePillar.Sport,
 	body: galleryBody,
 };
 


### PR DESCRIPTION
## Why?
Because it doesn't currently exist.

I have also:
- slightly refactored the structure of the layout stories for AR so they match DCR.  

![image](https://user-images.githubusercontent.com/57295823/155316023-31d1ca79-d146-46e6-8089-9c6f285e4ab7.png)

- created tag fixtures

### Before
N/A

### After
#### Standard Article
![image](https://user-images.githubusercontent.com/57295823/155316393-ae162008-6926-4e44-a5c8-c2c96e1a1d83.png)
#### Review
![image](https://user-images.githubusercontent.com/57295823/155316534-149f2b6f-a37e-4186-b044-5bd66c2d0cc6.png)
#### Match Report
![image](https://user-images.githubusercontent.com/57295823/155316575-52a79233-cf00-4c16-888a-786a917b2de2.png)

As mentioned above, I have also added tags to better mimic what articles currently look like in AR.

![image](https://user-images.githubusercontent.com/57295823/155316657-c8f6a505-9ccf-4bd1-9cf2-69795ab27f6f.png)


