### PR TITLE
GridItem `info`

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -231,25 +231,20 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'lines		 matchtabs'
-						'meta		 media'
-						'meta		 media'
-						'keyevents	 media'
-						'keyevents   filter'
-						'matchstats	 body'
-						'. 			 .';
+						'info		matchtabs'
+						'info		media'
+						'info		filter'
+						'info		body';
 				}
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'lines 		 matchtabs right-column'
-						'meta  		 media     right-column'
-						'keyevents   media 	   right-column'
-						'matchstats  body      right-column'
-						'keyevents   filter    right-column'
-						'.			 .         right-column';
+						'info  		 matchtabs right-column'
+						'info  		 media     right-column'
+						'info		 filter    right-column'
+						'info		 body      right-column';
 				}
 				/* until desktop define fixed body width */
 				${until.desktop} {
@@ -257,10 +252,7 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'matchtabs'
 						'media'
-						'lines'
-						'meta'
-						'keyevents'
-						'matchstats'
+						'info'
 						'filter'
 						'body';
 				}
@@ -270,10 +262,7 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'matchtabs'
 						'media'
-						'lines'
-						'meta'
-						'keyevents'
-						'matchstats'
+						'info'
 						'filter'
 						'body';
 				}
@@ -720,7 +709,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										/>
 									</div>
 								</GridItem>
-								<GridItem area="lines">
+								<GridItem area="info" element="aside">
+									{/* Lines */}
 									<Hide until="desktop">
 										<div
 											css={[maxWidth, sidePaddingDesktop]}
@@ -736,8 +726,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											/>
 										</div>
 									</Hide>
-								</GridItem>
-								<GridItem area="meta" element="aside">
+									{/* Meta */}
 									<Hide until="desktop">
 										<div
 											css={[maxWidth, sidePaddingDesktop]}
@@ -772,8 +761,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											/>
 										</div>
 									</Hide>
-								</GridItem>
-								<GridItem area="keyevents">
+									{/* Key events */}
 									<div
 										css={[
 											!CAPI.matchUrl && sticky,
@@ -790,8 +778,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											}
 										/>
 									</div>
-								</GridItem>
-								<GridItem area="matchstats">
+									{/* Match stats */}
 									{CAPI.matchUrl && (
 										<Island
 											deferUntil="visible"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This creates the `info` grid area, which contains `lines`, `meta`, `keyevents` & `matchstats`

## Why?
Because this allows us to keep all this content together in the left column without creating space in the main column

### Before
<img width="386" alt="Screenshot 2022-02-23 at 13 04 33" src="https://user-images.githubusercontent.com/1336821/155324871-8a5a5d2b-4b00-4e01-b6d9-edb994e4597c.png">


### After
<img width="386" alt="Screenshot 2022-02-23 at 13 04 01" src="https://user-images.githubusercontent.com/1336821/155324807-6a114b73-0e80-45da-89cb-af19b3bd887e.png">

