### PR TITLE
Repurpose `data-spacefinder-ignore` attribute

### DIFF
--- a/dotcom-rendering/docs/contracts/001-commercial-selectors.md
+++ b/dotcom-rendering/docs/contracts/001-commercial-selectors.md
@@ -7,6 +7,17 @@ We place the following classes on the container element of the article body:
 -   `article-body-commercial-selector` on the ArticleRenderer
 -   `js-liveblog-body` on the ArticleBody when rendering a Liveblog/Deadblog
 
+Furthermore, within the article body, we add the following attribute to certain elements:
+
+- `data-spacefinder-component`
+
+It currently supports two values:
+
+- `numbered-list-title`
+- `rich-link`
+
+These are elements spacefinder needs to know about when positioning adverts.
+
 ## Where is it relied upon?
 
 It is relied upon in the commercial DCR bundle from frontend.

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -175,13 +175,20 @@ export const Figure = ({
 			</figure>
 		);
 	}
+
+	// See 001-commercial-selectors.md for details on `data-spacefinder-component`
+	let spacefinderComponent: 'rich-link' | 'numbered-list-title' | undefined;
+	if (role === 'richLink') {
+		spacefinderComponent = 'rich-link';
+	} else if (isNumberedListTitle) {
+		spacefinderComponent = 'numbered-list-title';
+	}
+
 	return (
 		<figure
 			id={id}
 			css={defaultRoleStyles(role)}
-			data-spacefinder-ignore={
-				isNumberedListTitle ? 'numbered-list-title' : null
-			}
+			data-spacefinder-component={spacefinderComponent}
 			className={className}
 		>
 			{children}


### PR DESCRIPTION
## What does this change?

Rename `data-spacefinder-ignore` to `data-spacefinder-component`. Furthermore, add support for the value `rich-link`.

## Why?

It will allow spacefinder to identify rich links in this PR: https://github.com/guardian/frontend/pull/24690