### PR TITLE
Fix padding on immersive article series section link

### DIFF
--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -84,13 +84,6 @@ const invertedStyle = css`
 	padding-right: ${space[1]}px;
 	padding-top: ${space[1]}px;
 	padding-bottom: ${space[3]}px;
-	padding-left: ${space[3]}px;
-	${from.mobileLandscape} {
-		padding-left: ${space[5]}px;
-	}
-	${from.tablet} {
-		padding-left: ${space[1]}px;
-	}
 `;
 
 const fontStyles = (format: ArticleFormat) => {
@@ -148,6 +141,16 @@ const titleBadgeWrapper = css`
 	margin-bottom: ${space[1]}px;
 	margin-top: ${space[1]}px;
 	margin-right: ${space[2]}px;
+`;
+
+const sectionPadding = css`
+	padding-left: 10px;
+	${from.mobileLandscape} {
+		padding-left: 18px;
+	}
+	${from.tablet} {
+		padding-left: ${space[1]}px;
+	}
 `;
 
 const immersiveTitleBadgeStyle = (palette: Palette) => css`
@@ -291,7 +294,12 @@ export const SeriesSectionLink = ({
 								css={badge && immersiveTitleBadgeStyle(palette)}
 							>
 								{badge && (
-									<div css={titleBadgeWrapper}>
+									<div
+										css={[
+											titleBadgeWrapper,
+											sectionPadding,
+										]}
+									>
 										<Badge
 											imageUrl={badge.imageUrl}
 											seriesTag={badge.seriesTag}
@@ -305,6 +313,7 @@ export const SeriesSectionLink = ({
 										fontStyles(format),
 										invertedStyle,
 										breakWord,
+										!badge && sectionPadding,
 										css`
 											color: ${palette.text.seriesTitle};
 											background-color: ${palette

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -171,7 +171,15 @@ SpecialReportStory.story = {
 };
 SpecialReportStory.parameters = {
 	// Wait for the interactives to load
-	chromatic: { delay: 1000 },
+	chromatic: {
+		delay: 1000,
+		viewports: [
+			breakpoints.mobile,
+			breakpoints.mobileLandscape,
+			breakpoints.phablet,
+			breakpoints.wide,
+		],
+	},
 };
 
 export const FeatureStory = (): React.ReactNode => {


### PR DESCRIPTION
## What does this change?
There were alignment issues on the badge & series link on immersive layouts (where the immersive article included an immersive header). This change ensures the badge (or just the series link) is always aligned with the headline directly below.

Note that this will result in 2 different types of visual diff:
- At lower breakpoints immersive headers with a badge will have additional left padding. New stories have been added to capture these requirements at lower breakpoints.
- At higher breakers immersive headers without a badge will also have additional left padding. We already have stories to cover this scenario so can expect to see chromatic diffs.

## Why?
To ensure immersive articles with an immersive header more closely meet the intended design.

### Without badge

https://www.theguardian.com//travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton

#### Mobile:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/155347344-263f084b-998c-40ff-871d-235ef3dc6170.png
[after]: https://user-images.githubusercontent.com/45561419/155347422-ff32d9be-f8ae-462c-bf07-475f2c7229bf.png

#### Tablet

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
<img width="1159" alt="Screenshot 2022-02-23 at 15 12 39" src="https://user-images.githubusercontent.com/45561419/155347755-abed6d3d-ea1d-45a4-9724-c2bb1337c434.png">

[after]: 

### With badge
