### PR TITLE
Delete `LiveGridSport`

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -231,7 +231,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
-						'info		matchtabs'
 						'info		media'
 						'info		filter'
 						'info		body';
@@ -241,7 +240,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
-						'info  		 matchtabs right-column'
 						'info  		 media     right-column'
 						'info		 filter    right-column'
 						'info		 body      right-column';
@@ -250,7 +248,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 				${until.desktop} {
 					grid-template-columns: 700px; /* Main content */
 					grid-template-areas:
-						'matchtabs'
 						'media'
 						'info'
 						'filter'
@@ -260,7 +257,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 				${until.tablet} {
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'matchtabs'
 						'media'
 						'info'
 						'filter'
@@ -683,21 +679,19 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										/>
 									</Island>
 								</GridItem>
-								<GridItem area="matchtabs" element="aside">
-									<div css={maxWidth}>
-										<Island
-											clientOnly={true}
-											placeholderHeight={40}
-										>
-											<GetMatchTabs
-												matchUrl={CAPI.matchUrl}
-												format={format}
-											/>
-										</Island>
-									</div>
-								</GridItem>
 								<GridItem area="media">
 									<div css={maxWidth}>
+										{CAPI.matchUrl && (
+											<Island
+												clientOnly={true}
+												placeholderHeight={40}
+											>
+												<GetMatchTabs
+													matchUrl={CAPI.matchUrl}
+													format={format}
+												/>
+											</Island>
+										)}
 										<MainMedia
 											format={format}
 											elements={CAPI.mainMediaElements}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -162,77 +162,9 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 				/* from desktop define fixed body width */
 				${from.desktop} {
 					grid-column-gap: 20px;
-					grid-template-columns: 240px 700px;
-					grid-template-areas:
-						'lines		 media'
-						'meta		 media'
-						'keyevents	 media'
-						'keyevents   filter'
-						'keyevents	 body'
-						'keyevents	 body'
-						'. 			 .';
-				}
-				/* from wide define fixed body width */
-				${from.wide} {
-					grid-column-gap: 20px;
-					grid-template-columns: 240px 700px 1fr;
-					grid-template-areas:
-						'lines 		 media	   right-column'
-						'meta  		 media     right-column'
-						'keyevents   media 	   right-column'
-						'keyevents   filter    right-column'
-						'keyevents   body      right-column'
-						'keyevents   body      right-column'
-						'.			 .         right-column';
-				}
-				/* until desktop define fixed body width */
-				${until.desktop} {
-					grid-template-columns: 1fr; /* Main content */
-					grid-template-areas:
-						'media'
-						'lines'
-						'meta'
-						'keyevents'
-						'filter'
-						'body';
-				}
-			}
-		`}
-	>
-		{children}
-	</div>
-);
-
-const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			/* IE Fallback */
-			display: flex;
-			flex-direction: column;
-			${until.desktop} {
-				margin-left: 0px;
-			}
-			${from.desktop} {
-				margin-left: 320px;
-			}
-			@supports (display: grid) {
-				display: grid;
-				width: 100%;
-				margin-left: 0;
-				grid-column-gap: 0px;
-
-				/*
-					Explanation of each unit of grid-template-columns
-					Main content
-					Right Column
-				*/
-				/* from desktop define fixed body width */
-				${from.desktop} {
-					grid-column-gap: 20px;
 					grid-template-columns: 220px 700px;
 					grid-template-areas:
 						'info		media'
-						'info		filter'
 						'info		body';
 				}
 				/* from wide define fixed body width */
@@ -241,7 +173,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 220px 700px 1fr;
 					grid-template-areas:
 						'info  		 media     right-column'
-						'info		 filter    right-column'
 						'info		 body      right-column';
 				}
 				/* until desktop define fixed body width */
@@ -250,7 +181,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'media'
 						'info'
-						'filter'
 						'body';
 				}
 				/* fluid until tablet */
@@ -259,7 +189,6 @@ const LiveGridSport = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'media'
 						'info'
-						'filter'
 						'body';
 				}
 			}
@@ -668,231 +597,106 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						borderColour={palette.border.article}
 						padded={false}
 					>
-						{CAPI.matchUrl ? (
-							<LiveGridSport>
-								<GridItem area="filter">
-									<Island deferUntil="visible">
-										<FilterKeyEventsToggle
-											filterKeyEvents={
-												CAPI.filterKeyEvents
-											}
-										/>
-									</Island>
-								</GridItem>
-								<GridItem area="media">
-									<div css={maxWidth}>
-										{CAPI.matchUrl && (
-											<Island
-												clientOnly={true}
-												placeholderHeight={40}
-											>
-												<GetMatchTabs
-													matchUrl={CAPI.matchUrl}
-													format={format}
-												/>
-											</Island>
-										)}
-										<MainMedia
-											format={format}
-											elements={CAPI.mainMediaElements}
-											adTargeting={adTargeting}
-											host={host}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-											ajaxUrl={CAPI.config.ajaxUrl}
-										/>
-									</div>
-								</GridItem>
-								<GridItem area="info" element="aside">
-									{/* Lines */}
-									<Hide until="desktop">
-										<div
-											css={[maxWidth, sidePaddingDesktop]}
-										>
-											<Lines
-												count={decideLineCount(
-													format.design,
-												)}
-												effect={decideLineEffect(
-													format.design,
-													format.theme,
-												)}
-											/>
-										</div>
-									</Hide>
-									{/* Meta */}
-									<Hide until="desktop">
-										<div
-											css={[maxWidth, sidePaddingDesktop]}
-										>
-											<ArticleMeta
-												branding={branding}
-												format={format}
-												pageId={CAPI.pageId}
-												webTitle={CAPI.webTitle}
-												author={CAPI.author}
-												tags={CAPI.tags}
-												primaryDateline={
-													CAPI.webPublicationDateDisplay
-												}
-												secondaryDateline={
-													CAPI.webPublicationSecondaryDateDisplay
-												}
-												isCommentable={
-													CAPI.isCommentable
-												}
-												discussionApiUrl={
-													CAPI.config.discussionApiUrl
-												}
-												shortUrlId={
-													CAPI.config.shortUrlId
-												}
-												ajaxUrl={CAPI.config.ajaxUrl}
-												showShareCount={
-													CAPI.config.switches
-														.serverShareCounts
-												}
-											/>
-										</div>
-									</Hide>
-									{/* Key events */}
-									<div
-										css={[
-											!CAPI.matchUrl && sticky,
-											keyEventsTopMargin,
-											sidePaddingDesktop,
-											accordionBottomMargin,
-										]}
-									>
-										<KeyEventsContainer
-											format={format}
-											keyEvents={CAPI.keyEvents}
-											filterKeyEvents={
-												CAPI.filterKeyEvents
-											}
-										/>
-									</div>
-									{/* Match stats */}
+						<LiveGrid>
+							<GridItem area="media">
+								<div css={maxWidth}>
 									{CAPI.matchUrl && (
 										<Island
-											deferUntil="visible"
 											clientOnly={true}
-											placeholderHeight={800}
+											placeholderHeight={40}
 										>
-											<GetMatchStats
+											<GetMatchTabs
 												matchUrl={CAPI.matchUrl}
 												format={format}
 											/>
 										</Island>
 									)}
-								</GridItem>
-								<GridItem area="body">
-									<ArticleContainer format={format}>
-										{pagination.currentPage !== 1 && (
-											<Pagination
-												currentPage={
-													pagination.currentPage
-												}
-												totalPages={
-													pagination.totalPages
-												}
-												newest={pagination.newest}
-												oldest={pagination.oldest}
-												newer={pagination.newer}
-												older={pagination.older}
-												format={format}
-											/>
-										)}
-										<ArticleBody
-											format={format}
-											palette={palette}
-											blocks={CAPI.blocks}
-											adTargeting={adTargeting}
-											host={host}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-											ajaxUrl={CAPI.config.ajaxUrl}
-										/>
-										{pagination.totalPages > 1 && (
-											<Pagination
-												currentPage={
-													pagination.currentPage
-												}
-												totalPages={
-													pagination.totalPages
-												}
-												newest={pagination.newest}
-												oldest={pagination.oldest}
-												newer={pagination.newer}
-												older={pagination.older}
-												format={format}
-											/>
-										)}
-										{showBodyEndSlot && (
-											<div id="slot-body-end" />
-										)}
+									<MainMedia
+										format={format}
+										elements={CAPI.mainMediaElements}
+										adTargeting={adTargeting}
+										host={host}
+										pageId={CAPI.pageId}
+										webTitle={CAPI.webTitle}
+										ajaxUrl={CAPI.config.ajaxUrl}
+									/>
+								</div>
+							</GridItem>
+							<GridItem area="info" element="aside">
+								{/* Lines */}
+								<Hide until="desktop">
+									<div css={[maxWidth, sidePaddingDesktop]}>
 										<Lines
-											data-print-layout="hide"
-											count={4}
-											effect="straight"
+											count={decideLineCount(
+												format.design,
+											)}
+											effect={decideLineEffect(
+												format.design,
+												format.theme,
+											)}
 										/>
-										<SubMeta
-											palette={palette}
-											format={format}
-											subMetaKeywordLinks={
-												CAPI.subMetaKeywordLinks
-											}
-											subMetaSectionLinks={
-												CAPI.subMetaSectionLinks
-											}
-											pageId={CAPI.pageId}
-											webUrl={CAPI.webURL}
-											webTitle={CAPI.webTitle}
-											showBottomSocialButtons={
-												CAPI.showBottomSocialButtons
-											}
-											badge={CAPI.badge}
-										/>
-									</ArticleContainer>
-								</GridItem>
-								<GridItem area="right-column">
-									<div
-										css={css`
-											height: 100%;
-											${from.desktop} {
-												/* above 980 */
-												margin-left: 20px;
-												margin-right: -20px;
-												display: none;
-											}
-											${from.leftCol} {
-												/* above 1140 */
-												margin-left: 0px;
-												margin-right: 0px;
-											}
-											${from.wide} {
-												display: block;
-											}
-										`}
-									>
-										<RightColumn>
-											<AdSlot
-												position="right"
-												display={format.display}
-												shouldHideReaderRevenue={
-													CAPI.shouldHideReaderRevenue
-												}
-												isPaidContent={
-													CAPI.pageType.isPaidContent
-												}
-											/>
-										</RightColumn>
 									</div>
-								</GridItem>
-							</LiveGridSport>
-						) : (
-							<LiveGrid>
-								<GridItem area="filter">
+								</Hide>
+								{/* Meta */}
+								<Hide until="desktop">
+									<div css={[maxWidth, sidePaddingDesktop]}>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={CAPI.pageId}
+											webTitle={CAPI.webTitle}
+											author={CAPI.author}
+											tags={CAPI.tags}
+											primaryDateline={
+												CAPI.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												CAPI.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={CAPI.isCommentable}
+											discussionApiUrl={
+												CAPI.config.discussionApiUrl
+											}
+											shortUrlId={CAPI.config.shortUrlId}
+											ajaxUrl={CAPI.config.ajaxUrl}
+											showShareCount={
+												CAPI.config.switches
+													.serverShareCounts
+											}
+										/>
+									</div>
+								</Hide>
+								{/* Key events */}
+								<div
+									css={[
+										!CAPI.matchUrl && sticky,
+										keyEventsTopMargin,
+										sidePaddingDesktop,
+										accordionBottomMargin,
+									]}
+								>
+									<KeyEventsContainer
+										format={format}
+										keyEvents={CAPI.keyEvents}
+										filterKeyEvents={CAPI.filterKeyEvents}
+									/>
+								</div>
+								{/* Match stats */}
+								{CAPI.matchUrl && (
+									<Island
+										deferUntil="visible"
+										clientOnly={true}
+										placeholderHeight={800}
+									>
+										<GetMatchStats
+											matchUrl={CAPI.matchUrl}
+											format={format}
+										/>
+									</Island>
+								)}
+							</GridItem>
+							<GridItem area="body">
+								<div css={accordionBottomMargin}>
 									<Hide below="desktop">
 										<Island deferUntil="visible">
 											<FilterKeyEventsToggle
@@ -902,224 +706,125 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											/>
 										</Island>
 									</Hide>
-								</GridItem>
-								<GridItem area="media">
-									<div css={maxWidth}>
-										<MainMedia
-											format={format}
-											elements={CAPI.mainMediaElements}
-											adTargeting={adTargeting}
-											host={host}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-											ajaxUrl={CAPI.config.ajaxUrl}
-										/>
-									</div>
-								</GridItem>
-								<GridItem area="lines">
-									<Hide until="desktop">
-										<div
-											css={[maxWidth, sidePaddingDesktop]}
-										>
-											<Lines
-												count={decideLineCount(
-													format.design,
-												)}
-												effect={decideLineEffect(
-													format.design,
-													format.theme,
-												)}
-											/>
-										</div>
-									</Hide>
-								</GridItem>
-								<GridItem area="meta" element="aside">
-									<Hide until="desktop">
-										<div css={sidePaddingDesktop}>
-											<ArticleMeta
-												branding={branding}
+									<Accordion
+										supportsDarkMode={false}
+										accordionTitle="Live feed"
+										context="liveFeed"
+									>
+										<Hide above="desktop">
+											<Island deferUntil="visible">
+												<FilterKeyEventsToggle
+													filterKeyEvents={
+														CAPI.filterKeyEvents
+													}
+												/>
+											</Island>
+										</Hide>
+										<ArticleContainer format={format}>
+											{pagination.currentPage !== 1 && (
+												<Pagination
+													currentPage={
+														pagination.currentPage
+													}
+													totalPages={
+														pagination.totalPages
+													}
+													newest={pagination.newest}
+													oldest={pagination.oldest}
+													newer={pagination.newer}
+													older={pagination.older}
+													format={format}
+												/>
+											)}
+											<ArticleBody
 												format={format}
+												palette={palette}
+												blocks={CAPI.blocks}
+												adTargeting={adTargeting}
+												host={host}
 												pageId={CAPI.pageId}
 												webTitle={CAPI.webTitle}
-												author={CAPI.author}
-												tags={CAPI.tags}
-												primaryDateline={
-													CAPI.webPublicationDateDisplay
-												}
-												secondaryDateline={
-													CAPI.webPublicationSecondaryDateDisplay
-												}
-												isCommentable={
-													CAPI.isCommentable
-												}
-												discussionApiUrl={
-													CAPI.config.discussionApiUrl
-												}
-												shortUrlId={
-													CAPI.config.shortUrlId
-												}
 												ajaxUrl={CAPI.config.ajaxUrl}
-												showShareCount={
-													CAPI.config.switches
-														.serverShareCounts
-												}
 											/>
-										</div>
-									</Hide>
-								</GridItem>
-								<GridItem area="keyevents">
-									<div
-										css={[
-											sticky,
-											keyEventsTopMargin,
-											sidePaddingDesktop,
-											accordionBottomMargin,
-										]}
-									>
-										<KeyEventsContainer
-											format={format}
-											keyEvents={CAPI.keyEvents}
-											filterKeyEvents={
-												CAPI.filterKeyEvents
+											{pagination.totalPages > 1 && (
+												<Pagination
+													currentPage={
+														pagination.currentPage
+													}
+													totalPages={
+														pagination.totalPages
+													}
+													newest={pagination.newest}
+													oldest={pagination.oldest}
+													newer={pagination.newer}
+													older={pagination.older}
+													format={format}
+												/>
+											)}
+											{showBodyEndSlot && (
+												<div id="slot-body-end" />
+											)}
+											<Lines
+												data-print-layout="hide"
+												count={4}
+												effect="straight"
+											/>
+											<SubMeta
+												palette={palette}
+												format={format}
+												subMetaKeywordLinks={
+													CAPI.subMetaKeywordLinks
+												}
+												subMetaSectionLinks={
+													CAPI.subMetaSectionLinks
+												}
+												pageId={CAPI.pageId}
+												webUrl={CAPI.webURL}
+												webTitle={CAPI.webTitle}
+												showBottomSocialButtons={
+													CAPI.showBottomSocialButtons
+												}
+												badge={CAPI.badge}
+											/>
+										</ArticleContainer>
+									</Accordion>
+								</div>
+							</GridItem>
+							<GridItem area="right-column">
+								<div
+									css={css`
+										height: 100%;
+										${from.desktop} {
+											/* above 980 */
+											margin-left: 20px;
+											margin-right: -20px;
+											display: none;
+										}
+										${from.leftCol} {
+											/* above 1140 */
+											margin-left: 0px;
+											margin-right: 0px;
+										}
+										${from.wide} {
+											display: block;
+										}
+									`}
+								>
+									<RightColumn>
+										<AdSlot
+											position="right"
+											display={format.display}
+											shouldHideReaderRevenue={
+												CAPI.shouldHideReaderRevenue
+											}
+											isPaidContent={
+												CAPI.pageType.isPaidContent
 											}
 										/>
-									</div>
-								</GridItem>
-								<GridItem area="body">
-									<div css={accordionBottomMargin}>
-										<Accordion
-											supportsDarkMode={false}
-											accordionTitle="Live feed"
-											context="liveFeed"
-										>
-											<GridItem area="filter">
-												<Hide above="desktop">
-													<Island deferUntil="visible">
-														<FilterKeyEventsToggle
-															filterKeyEvents={
-																CAPI.filterKeyEvents
-															}
-														/>
-													</Island>
-												</Hide>
-											</GridItem>
-											<ArticleContainer format={format}>
-												{pagination.currentPage !==
-													1 && (
-													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
-														newer={pagination.newer}
-														older={pagination.older}
-														format={format}
-													/>
-												)}
-												<ArticleBody
-													format={format}
-													palette={palette}
-													blocks={CAPI.blocks}
-													adTargeting={adTargeting}
-													host={host}
-													pageId={CAPI.pageId}
-													webTitle={CAPI.webTitle}
-													ajaxUrl={
-														CAPI.config.ajaxUrl
-													}
-												/>
-												{pagination.totalPages > 1 && (
-													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
-														newer={pagination.newer}
-														older={pagination.older}
-														format={format}
-													/>
-												)}
-												{showBodyEndSlot && (
-													<div id="slot-body-end" />
-												)}
-												<Lines
-													data-print-layout="hide"
-													count={4}
-													effect="straight"
-												/>
-												<SubMeta
-													palette={palette}
-													format={format}
-													subMetaKeywordLinks={
-														CAPI.subMetaKeywordLinks
-													}
-													subMetaSectionLinks={
-														CAPI.subMetaSectionLinks
-													}
-													pageId={CAPI.pageId}
-													webUrl={CAPI.webURL}
-													webTitle={CAPI.webTitle}
-													showBottomSocialButtons={
-														CAPI.showBottomSocialButtons
-													}
-													badge={CAPI.badge}
-												/>
-											</ArticleContainer>
-										</Accordion>
-									</div>
-								</GridItem>
-								<GridItem area="right-column">
-									<div
-										css={css`
-											height: 100%;
-											${from.desktop} {
-												/* above 980 */
-												margin-left: 20px;
-												margin-right: -20px;
-												display: none;
-											}
-											${from.leftCol} {
-												/* above 1140 */
-												margin-left: 0px;
-												margin-right: 0px;
-											}
-											${from.wide} {
-												display: block;
-											}
-										`}
-									>
-										<RightColumn>
-											<AdSlot
-												position="right"
-												display={format.display}
-												shouldHideReaderRevenue={
-													CAPI.shouldHideReaderRevenue
-												}
-												isPaidContent={
-													CAPI.pageType.isPaidContent
-												}
-											/>
-										</RightColumn>
-									</div>
-								</GridItem>
-							</LiveGrid>
-						)}
+									</RightColumn>
+								</div>
+							</GridItem>
+						</LiveGrid>
 					</ElementContainer>
 				</article>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This repo removes `LiveGridSport` by moving away from depending on the grid for layout features

## Why?
Having two grids was a lot of extra code

### Where has `filter` gone?
There used to be a grid item called `filter` which was used to position this toggle based on breakpoint. But at some point we also had to support the fact this toggle should be placed inside the Accordion on smaller breakpoints, which meant we had to move away from using the grid. I've now completed that move and dropped the `filter` grid item completely