### PR TITLE
Add darkmode styles to Liveblog/Deadblog

### DIFF
--- a/apps-rendering/src/components/blockquote.tsx
+++ b/apps-rendering/src/components/blockquote.tsx
@@ -4,7 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { fill } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import { neutral, remSpace } from '@guardian/source-foundations';
+import { remSpace } from '@guardian/source-foundations';
 import { SvgQuote } from '@guardian/source-react-components';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
@@ -16,29 +16,24 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const styles = (format: ArticleFormat): SerializedStyles => {
-	const blockquoteFill = fill.blockquoteIcon(format);
+const styles = (format: ArticleFormat): SerializedStyles => css`
+	font-style: italic;
+	position: relative;
+	margin: ${remSpace[4]} 0 ${remSpace[9]} 0;
+	padding: 0 ${remSpace[6]};
 
-	return css`
-		font-style: italic;
-		position: relative;
-		margin: ${remSpace[4]} 0 ${remSpace[9]} 0;
-		padding: 0 ${remSpace[6]};
-		svg {
-			height: 62.4px;
-			margin-left: -9.2625px;
-			margin-bottom: -12px;
-			margin-top: 4.4px;
-			fill: ${blockquoteFill};
-		}
+	svg {
+		height: 62.4px;
+		margin-left: -9.2625px;
+		margin-bottom: -12px;
+		margin-top: 4.4px;
+		fill: ${fill.blockquoteIcon(format)};
 
 		${darkModeCss`
-            svg {
-                fill: ${neutral[86]};
-            }
-        `}
-	`;
-};
+			fill: ${fill.blockquoteIconDark(format)};
+		`}
+	}
+`;
 
 const Blockquote: FC<Props> = ({ children, format }: Props) => (
 	<blockquote css={styles(format)}>

--- a/apps-rendering/src/components/byline.tsx
+++ b/apps-rendering/src/components/byline.tsx
@@ -129,11 +129,14 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 			return css(
 				blogStyles,
 				blogColor(neutral[100], bylineLeftColumn, bylineDark),
+				darkModeCss`
+					color: ${neutral[86]};
+				`,
 			);
 		case ArticleDesign.DeadBlog:
 			return css(
 				blogStyles,
-				blogColor(bylineInline, bylineLeftColumn, neutral[93]),
+				blogColor(bylineInline, bylineLeftColumn, neutral[86]),
 			);
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:

--- a/apps-rendering/src/components/commentCount.tsx
+++ b/apps-rendering/src/components/commentCount.tsx
@@ -55,6 +55,10 @@ const blogStyles = (color: string): SerializedStyles => css`
 	${from.desktop} {
 		color: ${neutral[46]};
 		border-left: 1px solid ${neutral[86]};
+
+		${darkModeCss`
+			border-left-color: ${neutral[20]}
+		`}
 	}
 	padding-top: ${remSpace[2]};
 	margin-bottom: ${remSpace[2]};

--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -18,32 +18,27 @@ interface Props extends ArticleFormat {
 	contributors: Contributor[];
 }
 
-const styles = (format: ArticleFormat): SerializedStyles => {
-	const follow = text.follow(format);
-	const followDark = text.followDark(format);
+const styles = (format: ArticleFormat): SerializedStyles => css`
+	${textSans.small()}
+	color: ${text.follow(format)};
+	display: block;
+	padding: 0;
+	border: none;
+	background: none;
+	margin-left: 0;
+	margin-top: ${remSpace[1]};
+	min-height: ${remSpace[6]};
 
-	return css`
-		${textSans.small()}
-		color: ${follow};
-		display: block;
-		padding: 0;
-		border: none;
-		background: none;
-		margin-left: 0;
-		margin-top: ${remSpace[1]};
-		min-height: ${remSpace[6]};
+	svg {
+		width: ${remSpace[6]};
+		height: ${remSpace[6]};
+		fill: currentColor;
+	}
 
-		svg {
-			width: ${remSpace[6]};
-			height: ${remSpace[6]};
-			fill: currentColor;
-		}
-
-		${darkModeCss`
-			color: ${followDark};
-		`}
-	`;
-};
+	${darkModeCss`
+		color: ${text.followDark(format)};
+	`}
+`;
 
 const followStatusStyles = css`
 	display: flex;

--- a/apps-rendering/src/components/footer.stories.tsx
+++ b/apps-rendering/src/components/footer.stories.tsx
@@ -2,13 +2,14 @@
 
 import { withKnobs } from '@storybook/addon-knobs';
 import Footer from 'components/footer';
+import { article } from 'fixtures/item';
 import type { FC } from 'react';
 
 // ----- Stories ----- //
 
-const WithCcpa: FC = () => <Footer isCcpa={true} />;
+const WithCcpa: FC = () => <Footer isCcpa={true} format={article} />;
 
-const Default: FC = () => <Footer isCcpa={false} />;
+const Default: FC = () => <Footer isCcpa={false} format={article} />;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/footer.tsx
+++ b/apps-rendering/src/components/footer.tsx
@@ -1,6 +1,9 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	breakpoints,
 	from,
@@ -14,7 +17,7 @@ import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	border-width: 0 1px;
 	${textSans.small({ lineHeight: 'regular' })};
 	margin-left: 0;
@@ -37,7 +40,7 @@ const styles = css`
 
 	${darkModeCss`
         color: ${neutral[60]};
-		background: ${neutral[0]};
+		background-color: ${background.articleContentDark(format)};
 
         a {
             color: ${neutral[60]};
@@ -47,10 +50,11 @@ const styles = css`
 
 interface Props {
 	isCcpa: boolean;
+	format: ArticleFormat;
 }
 
-const Footer: FC<Props> = ({ isCcpa }) => (
-	<footer css={styles}>
+const Footer: FC<Props> = ({ isCcpa, format }) => (
+	<footer css={styles(format)}>
 		<FooterContent isCcpa={isCcpa} />
 	</footer>
 );

--- a/apps-rendering/src/components/lastUpdated.tsx
+++ b/apps-rendering/src/components/lastUpdated.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 interface Props {
 	lastUpdatedDisplay: string;
@@ -14,6 +15,10 @@ const LastUpdated: FC<Props> = ({ lastUpdatedDisplay, lastUpdated }: Props) => (
 			align-items: flex-end;
 			${textSans.xxsmall()};
 			color: ${neutral[46]};
+
+			${darkModeCss`
+				color: ${neutral[60]};
+			`}
 		`}
 	>
 		<time

--- a/apps-rendering/src/components/layout/comment.tsx
+++ b/apps-rendering/src/components/layout/comment.tsx
@@ -112,7 +112,7 @@ const Comment: FC<Props> = ({ item, children }) => (
 		<section css={onwardStyles}>
 			<RelatedContent content={item.relatedContent} />
 		</section>
-		<Footer isCcpa={false} />
+		<Footer isCcpa={false} format={item} />
 	</main>
 );
 

--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -61,7 +61,11 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 		item.design === ArticleDesign.Interactive &&
 		item.display === ArticleDisplay.Immersive
 	) {
-		return <Interactive>{renderAllWithoutStyles(item, body)}</Interactive>;
+		return (
+			<Interactive item={item}>
+				{renderAllWithoutStyles(item, body)}
+			</Interactive>
+		);
 	}
 
 	if (

--- a/apps-rendering/src/components/layout/interactive.tsx
+++ b/apps-rendering/src/components/layout/interactive.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import type { ArticleFormat } from '@guardian/libs';
 import Footer from 'components/footer';
 import type { FC, ReactNode } from 'react';
 
@@ -7,12 +8,13 @@ import type { FC, ReactNode } from 'react';
 
 interface Props {
 	children: ReactNode[];
+	item: ArticleFormat;
 }
 
-const Interactive: FC<Props> = ({ children }) => (
+const Interactive: FC<Props> = ({ children, item }) => (
 	<main>
 		<article>{children}</article>
-		<Footer isCcpa={false} />
+		<Footer isCcpa={false} format={item} />
 	</main>
 );
 

--- a/apps-rendering/src/components/layout/interactiveimmersive.tsx
+++ b/apps-rendering/src/components/layout/interactiveimmersive.tsx
@@ -94,7 +94,7 @@ const InteractiveImmersive: FC<Props> = ({ item, children }) => {
 			<section css={onwardStyles}>
 				<RelatedContent content={item.relatedContent} />
 			</section>
-			<Footer isCcpa={false} />
+			<Footer isCcpa={false} format={item} />
 		</main>
 	);
 };

--- a/apps-rendering/src/components/layout/labs.tsx
+++ b/apps-rendering/src/components/layout/labs.tsx
@@ -87,7 +87,7 @@ const Labs: FC<Props> = ({ item, children }) => {
 			<section css={onwardStyles}>
 				<RelatedContent content={item.relatedContent} />
 			</section>
-			<Footer isCcpa={false} />
+			<Footer isCcpa={false} format={item} />
 		</main>
 	);
 };

--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
 import type { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
 import KeyEvents from '@guardian/common-rendering/src/components/keyEvents';
 import { Pagination } from '@guardian/common-rendering/src/components/Pagination';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, news, remSpace } from '@guardian/source-foundations';
@@ -21,11 +22,11 @@ import type { DeadBlog, LiveBlog } from 'item';
 import { toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
-import { articleWidthStyles, onwardStyles } from 'styles';
+import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
 
 // ----- Component ----- //
 
-const mainStyles = css`
+const mainStyles = (format: ArticleFormat): SerializedStyles => css`
 	display: grid;
 	background-color: ${neutral[97]};
 	grid-template-columns: 1fr;
@@ -34,6 +35,10 @@ const mainStyles = css`
 		'main-media'
 		'key-events'
 		'live-blocks';
+
+	${darkModeCss`
+		background-color: ${background.articleContentDark(format)};
+	`}
 
 	${from.tablet} {
 		column-gap: 20px;
@@ -117,9 +122,14 @@ const Live: FC<Props> = ({ item }) => {
 		/>
 	);
 	return (
-		<article className="js-article">
+		<article
+			className="js-article"
+			css={darkModeCss`
+					background-color: ${background.articleContentDark(item)};
+				`}
+		>
 			<LiveblogHeader item={item} />
-			<main css={mainStyles}>
+			<main css={mainStyles(item)}>
 				<GridItem area="metadata">
 					<div css={metadataWrapperStyles(item)}>
 						<Metadata item={item} />
@@ -153,7 +163,7 @@ const Live: FC<Props> = ({ item }) => {
 				<RelatedContent content={item.relatedContent} />
 			</section>
 			<section css={articleWidthStyles}>
-				<Footer isCcpa={false} />
+				<Footer format={item} isCcpa={false} />
 			</section>
 		</article>
 	);

--- a/apps-rendering/src/components/layout/media.tsx
+++ b/apps-rendering/src/components/layout/media.tsx
@@ -70,7 +70,7 @@ const Media: FC<Props> = ({ item, children }) => (
 		<section css={onwardStyles}>
 			<RelatedContent content={item.relatedContent} />
 		</section>
-		<Footer isCcpa={false} />
+		<Footer isCcpa={false} format={item} />
 	</main>
 );
 

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -166,7 +166,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 				<RelatedContent content={item.relatedContent} />
 			</section>
 			{commentContainer}
-			<Footer isCcpa={false} />
+			<Footer isCcpa={false} format={item} />
 		</main>
 	);
 };

--- a/apps-rendering/src/components/list.stories.tsx
+++ b/apps-rendering/src/components/list.stories.tsx
@@ -7,21 +7,21 @@ import ListItem from './listItem';
 
 // ----- Setup ----- //
 
-const listItem = (
-	<ListItem
-		format={{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-		}}
-	>
-		A bullet point
-	</ListItem>
-);
+const format = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticlePillar.News,
+};
+
+const listItem = <ListItem format={format}>A bullet point</ListItem>;
 
 // ----- Stories ----- //
 
-const Default: FC = () => <List>{[listItem, listItem, listItem]}</List>;
+const Default: FC = () => (
+	<List usePillarColour={false} format={format}>
+		{[listItem, listItem, listItem]}
+	</List>
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/list.tsx
+++ b/apps-rendering/src/components/list.tsx
@@ -2,12 +2,18 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const styles: SerializedStyles = css`
+const styles = (
+	usePillarColour: boolean,
+	format: ArticleFormat,
+): SerializedStyles => css`
 	list-style: none;
 	margin: ${remSpace[3]} 0;
 	padding-left: 0;
@@ -23,14 +29,22 @@ const styles: SerializedStyles = css`
 		background-color: ${neutral[86]};
 		margin-left: -${remSpace[6]};
 		vertical-align: middle;
+
+		${darkModeCss`
+			background-color: ${background.bulletDark(format, usePillarColour)};
+		`}
 	}
 `;
 
 interface Props {
 	children: ReactNode;
+	usePillarColour: boolean;
+	format: ArticleFormat;
 }
 
-const List: FC<Props> = ({ children }) => <ul css={styles}>{children}</ul>;
+const List: FC<Props> = ({ children, usePillarColour, format }) => (
+	<ul css={styles(usePillarColour, format)}>{children}</ul>
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -2,7 +2,6 @@
 
 import { css } from '@emotion/react';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
-import { border } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { map, OptionKind, partition } from '@guardian/types';
 import { LastUpdated } from 'components/lastUpdated';
@@ -23,8 +22,8 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 		<>
 			{/* Accordion? */}
 			{blocks.map((block) => {
-				const blockLink = `#block-${block.id}`;
-				const borderLiveBlock = border.liveBlock(format);
+				// TODO: get page number
+				const blockLink = `${1}#block-${block.id}`;
 				const blockFirstPublished = pipe(
 					block.firstPublished,
 					map(Number),
@@ -35,10 +34,11 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 					<LiveBlockContainer
 						key={block.id}
 						id={block.id}
-						borderColour={borderLiveBlock}
+						format={format}
 						blockTitle={block.title}
 						blockFirstPublished={blockFirstPublished}
 						blockLink={blockLink}
+						supportsDarkMode={true}
 					>
 						{renderAll(format, partition(block.body).oks)}
 

--- a/apps-rendering/src/components/liveblogHeader.tsx
+++ b/apps-rendering/src/components/liveblogHeader.tsx
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import { background } from '@guardian/common-rendering/src/editorialPalette';
 import {
 	Column,
 	Columns,
@@ -9,6 +8,10 @@ import {
 } from '@guardian/source-react-components';
 import Headline from 'components/headline';
 import Standfirst from 'components/standfirst';
+import {
+	headlineBackgroundColour,
+	standfirstBackgroundColour,
+} from 'editorialStyles';
 import type { DeadBlog, LiveBlog } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
@@ -26,10 +29,7 @@ const LiveblogHeader: FC<Props> = ({ item }) => {
 
 	return (
 		<header>
-			<Container
-				element="div"
-				backgroundColor={background.headline(format)}
-			>
+			<Container element="div" css={headlineBackgroundColour(format)}>
 				<Columns collapseUntil="desktop">
 					<Column span={3}>
 						<Series item={item} />
@@ -39,10 +39,7 @@ const LiveblogHeader: FC<Props> = ({ item }) => {
 					</Column>
 				</Columns>
 			</Container>
-			<Container
-				element="div"
-				backgroundColor={background.standfirst(format)}
-			>
+			<Container element="div" css={standfirstBackgroundColour(format)}>
 				<Columns collapseUntil="desktop">
 					<Column span={3}>
 						<Hide below="desktop">

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -2,6 +2,7 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
@@ -78,6 +79,10 @@ const metaBottomStyles = (isLive: boolean): SerializedStyles => css`
 	}
 
 	${!isLive && `border-top: 1px solid rgba(153, 153, 153, 0.4);`}
+
+	${darkModeCss`
+		border-top-color: ${neutral[20]};
+	`}
 `;
 
 const toggleStyles = css`
@@ -110,6 +115,10 @@ const toggleOverrideStyles = css`
 			background-color: rgba(255, 255, 255, 0.5);
 		}
 	}
+
+	${darkModeCss`
+		color: ${neutral[93]};
+	`}
 `;
 
 const liveBylineStyles = css`
@@ -154,22 +163,22 @@ const tempraryBackgroundStyle = (format: ArticleFormat): SerializedStyles => {
 				${from.desktop} {
 					background-color: ${neutral[97]};
 				}
-				@media (prefers-color-scheme: dark) {
-					background-color: ${neutral[10]};
-				}
+
+				${darkModeCss`
+					background-color: ${background.articleContentDark(format)};
+				`}
 			`;
 		default:
 			return css`
 				background-color: ${themeStyles.liveblogBackground};
+
 				${from.desktop} {
 					background-color: ${neutral[97]};
 				}
-				@media (prefers-color-scheme: dark) {
-					background-color: ${themeStyles.liveblogDarkBackground};
-					${from.desktop} {
-						background-color: ${neutral[10]};
-					}
-				}
+
+				${darkModeCss`
+					background-color: ${background.articleContentDark(format)};
+				`}
 			`;
 	}
 };

--- a/apps-rendering/src/components/series.tsx
+++ b/apps-rendering/src/components/series.tsx
@@ -63,10 +63,12 @@ const immersiveLabsLinkStyles = css`
 
 const blogLinkStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.xxxsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
-	color: ${format.design === ArticleDesign.LiveBlog
-		? getThemeStyles(format.theme).liveblogKicker
-		: text.seriesTitle(format)};
+	color: ${text.seriesTitle(format)};
 	text-decoration: none;
+
+	${darkModeCss`
+		color: ${text.seriesTitleDark(format)};
+	`}
 `;
 
 const getLinkStyles = ({

--- a/apps-rendering/src/components/standfirst.tsx
+++ b/apps-rendering/src/components/standfirst.tsx
@@ -16,12 +16,13 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
+import { standfirstBackgroundColour } from 'editorialStyles';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactElement, ReactNode } from 'react';
 import { renderStandfirstText } from 'renderer';
-import { darkModeCss as darkMode } from 'styles';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -29,12 +30,12 @@ interface Props {
 	item: Item;
 }
 
-const darkStyles = (format: ArticleFormat): SerializedStyles => darkMode`
+const darkStyles = (format: ArticleFormat): SerializedStyles => darkModeCss`
     background: ${background.standfirstDark(format)};
     color: ${text.standfirstDark(format)};
 
     a {
-        color: ${text.standfirstDark(format)};
+        color: ${text.standfirstLinkDark(format)};
 		border-bottom: 0.0625rem solid ${border.standfirstLinkDark(format)};
     }
 `;
@@ -46,7 +47,8 @@ const isNotBlog = (format: ArticleFormat): boolean =>
 const styles = (format: ArticleFormat): SerializedStyles => css`
 	margin-bottom: ${remSpace[3]};
 	color: ${text.standfirst(format)};
-	background-color: ${background.standfirst(format)};
+
+	${standfirstBackgroundColour(format)}
 
 	p,
 	ul {
@@ -92,6 +94,8 @@ const liveblogStyles: SerializedStyles = css`
 	p {
 		margin: 0;
 		padding: 0.75rem 0;
+
+		${darkModeCss`color: ${neutral[93]};`}
 	}
 
 	ul {
@@ -118,6 +122,13 @@ const deadblogStyles = (format: ArticleFormat): SerializedStyles => {
 			color: ${colour};
 			border-bottom: 1px solid ${colour};
 		}
+
+		${darkModeCss`
+			a:link, a:hover {
+				color: ${text.standfirstLinkDark(format)};
+				border-bottom-color: ${border.standfirstLinkDark(format)};
+			}
+		`}
 	`;
 };
 

--- a/apps-rendering/src/components/tags.tsx
+++ b/apps-rendering/src/components/tags.tsx
@@ -2,14 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	background,
-	neutral,
-	remSpace,
-	textSans,
-} from '@guardian/source-foundations';
+import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
@@ -28,7 +24,7 @@ const backgroundColour = (format: ArticleFormat): string => {
 	}
 };
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	margin-top: 0;
 	margin-bottom: 0;
 	display: flex;
@@ -38,7 +34,7 @@ const styles = css`
 	${textSans.medium()}
 
 	${darkModeCss`
-		background: ${background.inverse};
+		background-color: ${background.articleContentDark(format)};
 		color: ${neutral[86]};
 	`}
 `;
@@ -64,7 +60,7 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	line-height: 1;
 
 	${darkModeCss`
-		color: ${neutral[60]};
+		color: ${neutral[86]};
 		background-color: ${neutral[20]};
 	`};
 `;
@@ -79,7 +75,7 @@ interface Props {
 }
 
 const Tags: FC<Props> = ({ tags, format }) => (
-	<ul css={styles}>
+	<ul css={styles(format)}>
 		{tags.map((tag, index) => {
 			return (
 				<li key={index} css={tagStyles}>

--- a/apps-rendering/src/editorialStyles.ts
+++ b/apps-rendering/src/editorialStyles.ts
@@ -42,10 +42,17 @@ const headlineBackgroundColour = (format: ArticleFormat): SerializedStyles =>
 		background.headlineDark(format),
 	);
 
+const standfirstBackgroundColour = (format: ArticleFormat): SerializedStyles =>
+	backgroundColour(
+		background.standfirst(format),
+		background.standfirstDark(format),
+	);
+
 // ----- Exports ----- //
 
 export {
 	headlineTextColour,
 	headlineBackgroundColour,
+	standfirstBackgroundColour,
 	editionsHeadlineTextColour,
 };

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -256,7 +256,7 @@ const textElement =
 			case 'BR':
 				return h('br', { key }, null);
 			case 'UL':
-				return h(List, { children });
+				return h(List, { children, format, usePillarColour: false });
 			case 'OL':
 				return h(OrderedList, { children });
 			case 'LI':
@@ -303,13 +303,21 @@ const standfirstTextElement =
 					children,
 				);
 			case 'UL':
-				return h(List, { children });
+				return styledH(List, {
+					children,
+					format,
+					usePillarColour: true,
+				});
 			case 'LI':
 				return h(ListItem, { format, children });
 			case 'A': {
 				const styles = css`
 					color: ${text.standfirstLink(format)};
 					${borderFromFormat(format)};
+
+					${darkModeCss`
+						color: ${text.standfirstLinkDark(format)};
+					`}
 				`;
 				const url = withDefault('')(getHref(node));
 				const href = url.startsWith('profile/')

--- a/common-rendering/src/__snapshots__/sizes.test.tsx.snap
+++ b/common-rendering/src/__snapshots__/sizes.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`sizesAttribute returns a list of media queries 1`] = `"(min-width: 980p
 
 exports[`styles returns dimensions for each media query 1`] = `
 <div
-  className="css-9i4kf7"
+  className="css-1mcn5oz"
 />
 `;
 
 exports[`styles returns the default dimensions when there are no media queries 1`] = `
 <div
-  className="css-1xhyoy7"
+  className="css-1w67tw9"
 />
 `;

--- a/common-rendering/src/components/FirstPublished.stories.tsx
+++ b/common-rendering/src/components/FirstPublished.stories.tsx
@@ -1,15 +1,16 @@
 // ----- Imports ----- //
 
-import type { FC } from "react";
+import type { FC } from 'react';
 
-import { FirstPublished } from "./FirstPublished";
+import { FirstPublished } from './FirstPublished';
 
 // ----- Stories ----- //
 
 const Default: FC = () => (
 	<FirstPublished
+		supportsDarkMode={true}
 		firstPublished={1613763003000}
-		blockLink={"#block-60300f5f8f08ad21ea60071e"}
+		blockLink={'#block-60300f5f8f08ad21ea60071e'}
 	/>
 );
 
@@ -17,7 +18,7 @@ const Default: FC = () => (
 
 export default {
 	component: FirstPublished,
-	title: "Common/Components/FirstPublished",
+	title: 'Common/Components/FirstPublished',
 };
 
 export { Default };

--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import { timeAgo } from "@guardian/libs";
 import { neutral, space, textSans } from "@guardian/source-foundations";
+import { darkModeCss } from "../lib";
 
 // TODO: update this code to use shared version when it is available
 const padString = (time: number) => (time < 10 ? `0${time}` : time);
@@ -8,9 +9,11 @@ const padString = (time: number) => (time < 10 ? `0${time}` : time);
 const FirstPublished = ({
 	firstPublished,
 	blockLink,
+	supportsDarkMode,
 }: {
 	firstPublished: number;
 	blockLink: string;
+	supportsDarkMode: boolean;
 }) => {
 	const publishedDate = new Date(firstPublished);
 	return (
@@ -37,6 +40,10 @@ const FirstPublished = ({
 					color: ${neutral[46]};
 					font-weight: bold;
 					margin-right: ${space[2]}px;
+
+					${darkModeCss(supportsDarkMode)`
+						color: ${neutral[60]};
+					`}
 				`}
 			>
 				{timeAgo(firstPublished)}
@@ -45,6 +52,10 @@ const FirstPublished = ({
 				css={css`
 					${textSans.xxsmall()};
 					color: ${neutral[46]};
+
+					${darkModeCss(supportsDarkMode)`
+						color: ${neutral[60]};
+					`}
 				`}
 			>
 				{`${padString(publishedDate.getHours())}:${padString(

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -23,7 +23,7 @@ import {
 } from '@guardian/libs';
 import { darkModeCss } from '../lib';
 import Accordion from './accordion';
-import { text } from '../editorialPalette';
+import { background, text } from '../editorialPalette';
 
 // ----- Component ----- //
 type paletteId = 300 | 400 | 500;
@@ -61,6 +61,7 @@ const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
 };
 
 const keyEventWrapperStyles = (
+	format: ArticleFormat,
 	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	width: 100%;
@@ -71,11 +72,15 @@ const keyEventWrapperStyles = (
 	}
 
 	${darkModeCss(supportsDarkMode)`
-		background-color: ${neutral[10]};
+		border-top-color: ${neutral[20]};
+		background-color: ${background.articleContentDark(format)};
 	`}
 `;
 
-const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const listStyles = (
+	format: ArticleFormat,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
 	li::before {
 		content: '';
 		display: block;
@@ -89,9 +94,11 @@ const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	}
 
 	${darkModeCss(supportsDarkMode)`
+	background-color: ${background.articleContentDark(format)};
+
 		li::before {
 			border-color: transparent ${neutral[60]};
-			background-color: neutral[60];
+
 		}
 	`}
 `;
@@ -191,7 +198,7 @@ const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
 			tabIndex={0}
 			id="keyevents"
-			css={keyEventWrapperStyles(supportsDarkMode)}
+			css={keyEventWrapperStyles(format, supportsDarkMode)}
 			aria-label="Key Events"
 		>
 			<Accordion
@@ -199,7 +206,7 @@ const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
 				accordionTitle="Key events"
 				context="keyEvents"
 			>
-				<ul css={listStyles(supportsDarkMode)}>
+				<ul css={listStyles(format, supportsDarkMode)}>
 					{keyEvents.slice(0, 7).map((event, index) => (
 						<ListItem
 							key={`${event.url}${index}`}

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,12 +1,15 @@
-import { css } from "@emotion/react";
+import { css } from '@emotion/react';
 import {
 	neutral,
 	from,
 	space,
 	headline,
 	body,
-} from "@guardian/source-foundations";
-import { FirstPublished } from "./FirstPublished";
+} from '@guardian/source-foundations';
+import { darkModeCss } from '../lib';
+import { FirstPublished } from './FirstPublished';
+import { border } from '../editorialPalette';
+import { ArticleFormat } from '@guardian/libs';
 
 type BlockContributor = {
 	name: string;
@@ -16,13 +19,14 @@ type BlockContributor = {
 type Props = {
 	id: string;
 	children: React.ReactNode;
-	borderColour: string;
+	format: ArticleFormat;
 	blockTitle?: string;
 	blockFirstPublished?: number;
 	blockLink: string;
 	isLiveUpdate?: boolean;
 	contributors?: BlockContributor[];
 	avatarBackgroundColor?: string;
+	supportsDarkMode: boolean;
 };
 
 const LEFT_MARGIN_DESKTOP = 60;
@@ -47,7 +51,7 @@ const BlockTitle = ({ title }: { title: string }) => {
 	return (
 		<h2
 			css={css`
-				${headline.xxsmall({ fontWeight: "bold" })}
+				${headline.xxsmall({ fontWeight: 'bold' })}
 				margin-bottom: ${space[2]}px;
 			`}
 		>
@@ -74,7 +78,7 @@ const BlockByline = ({
 			`}
 		>
 			{imageUrl && (
-				<div style={{ width: "36px", height: "36px" }}>
+				<div style={{ width: '36px', height: '36px' }}>
 					<img
 						src={imageUrl}
 						alt={name}
@@ -105,13 +109,14 @@ const BlockByline = ({
 const LiveBlockContainer = ({
 	id,
 	children,
-	borderColour,
+	format,
 	blockTitle,
 	blockFirstPublished,
 	blockLink,
 	isLiveUpdate,
 	contributors,
 	avatarBackgroundColor,
+	supportsDarkMode,
 }: Props) => {
 	return (
 		<article
@@ -124,17 +129,24 @@ const LiveBlockContainer = ({
 			 * - 'pending' is used to mark blocks that have been inserted as part of a live update. We use this
 			 *    to animate the reveal as well as for enhancing twitter embeds
 			 */
-			className={`block ${isLiveUpdate && "pending"}`}
+			className={`block ${isLiveUpdate && 'pending'}`}
 			css={css`
 				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
 				margin-bottom: ${space[3]}px;
 				background: ${neutral[100]};
-				border-top: 1px solid ${borderColour};
+				border-top: 1px solid ${border.liveBlock(format)};
 				${from.tablet} {
 					padding: ${space[2]}px ${SIDE_MARGIN}px;
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
 				border-bottom: 1px solid ${neutral[86]};
+
+				${darkModeCss(supportsDarkMode)`
+					border-top: 1px solid ${border.liveBlockDark(format)};
+					background-color: ${neutral[10]};
+					color: ${neutral[100]};
+					border-bottom: 0;
+				`}
 			`}
 		>
 			<Header>
@@ -142,6 +154,7 @@ const LiveBlockContainer = ({
 					<FirstPublished
 						firstPublished={blockFirstPublished}
 						blockLink={blockLink}
+						supportsDarkMode={supportsDarkMode}
 					/>
 				)}
 				{blockTitle ? <BlockTitle title={blockTitle} /> : null}

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -52,10 +52,9 @@ const headline = (format: ArticleFormat): Colour => {
 };
 
 const headlineDark = (format: ArticleFormat): Colour => {
-	if (
-		format.design === ArticleDesign.LiveBlog ||
-		format.design === ArticleDesign.DeadBlog
-	) {
+	if (format.design === ArticleDesign.DeadBlog) {
+		return neutral[7];
+	} else if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case ArticlePillar.Culture:
 				return culture[200];
@@ -125,6 +124,46 @@ const standfirstDark = ({ design, theme }: ArticleFormat): Colour => {
 	}
 };
 
+const bulletDark = (
+	{ design, theme }: ArticleFormat,
+	returnPillarColour: boolean,
+): Colour => {
+	if (returnPillarColour) {
+		switch (design) {
+			case ArticleDesign.DeadBlog:
+				return neutral[46];
+			case ArticleDesign.LiveBlog:
+				switch (theme) {
+					case ArticlePillar.Opinion:
+						return opinion[550];
+					case ArticlePillar.Sport:
+						return sport[500];
+					case ArticlePillar.Culture:
+						return culture[500];
+					case ArticlePillar.Lifestyle:
+						return lifestyle[500];
+					case ArticlePillar.News:
+						return news[550];
+					default:
+						return neutral[46];
+				}
+			default:
+				return neutral[46];
+		}
+	}
+
+	return neutral[46];
+};
+
+const articleContentDark = ({ design }: ArticleFormat): Colour => {
+	switch (design) {
+		case ArticleDesign.DeadBlog:
+			return neutral[7];
+		default:
+			return neutral[0];
+	}
+};
+
 // ----- API ----- //
 
 const background = {
@@ -132,6 +171,8 @@ const background = {
 	headlineDark,
 	standfirst,
 	standfirstDark,
+	articleContentDark,
+	bulletDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -45,7 +45,7 @@ const liveBlock = (format: ArticleFormat): Colour => {
 		case ArticlePillar.Lifestyle:
 			return lifestyle[300];
 		case ArticlePillar.Sport:
-			return sport[300];
+			return sport[400];
 		case ArticlePillar.Culture:
 			return culture[300];
 		case ArticlePillar.Opinion:
@@ -54,6 +54,25 @@ const liveBlock = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+	}
+};
+
+const liveBlockDark = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
 	}
 };
 
@@ -81,6 +100,7 @@ const border = {
 	articleLink,
 	articleLinkDark,
 	liveBlock,
+	liveBlockDark,
 	standfirstLink,
 	standfirstLinkDark,
 	pagination,

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -14,6 +14,7 @@ import {
 	opinion,
 	labs,
 	specialReport,
+	neutral,
 } from '@guardian/source-foundations';
 import { Colour } from '.';
 
@@ -113,6 +114,16 @@ const blockquoteIcon = (format: ArticleFormat): Colour => {
 	}
 };
 
+const blockquoteIconDark = (format: ArticleFormat): Colour => {
+	switch (format.design) {
+		case ArticleDesign.DeadBlog:
+		case ArticleDesign.LiveBlog:
+			return neutral[60];
+		default:
+			return blockquoteIcon(format);
+	}
+};
+
 // ----- API ----- //
 
 const fill = {
@@ -120,6 +131,7 @@ const fill = {
 	icon,
 	iconDark,
 	blockquoteIcon,
+	blockquoteIconDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -171,26 +171,11 @@ const follow = (format: ArticleFormat): Colour => {
 	}
 };
 
-const bylineDark = (format: ArticleFormat): Colour => {
-	switch (format.theme) {
-		case ArticlePillar.News:
-			return news[500];
-		case ArticlePillar.Lifestyle:
-			return lifestyle[500];
-		case ArticlePillar.Sport:
-			return sport[500];
-		case ArticlePillar.Culture:
-			return culture[500];
-		case ArticlePillar.Opinion:
-			return opinion[500];
-		case ArticleSpecial.Labs:
-			return specialReport[500];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[500];
-	}
+const followDark = (format: ArticleFormat): Colour => {
+	return neutral[100];
 };
 
-const followDark = (format: ArticleFormat): Colour => {
+const bylineDark = (format: ArticleFormat): Colour => {
 	switch (format.theme) {
 		case ArticlePillar.News:
 			return news[500];
@@ -386,6 +371,49 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 	}
 };
 
+const standfirstLinkDark = (format: ArticleFormat): Colour => {
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return neutral[100];
+		case ArticleDesign.Media:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+			}
+		default: {
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[300];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+			}
+		}
+	}
+};
+
 const kicker = (format: ArticleFormat): Colour => {
 	if (
 		format.theme === ArticleSpecial.SpecialReport &&
@@ -453,21 +481,77 @@ const kicker = (format: ArticleFormat): Colour => {
 };
 
 const seriesTitle = (format: ArticleFormat): Colour => {
+	switch (format.design) {
+		case ArticleDesign.DeadBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[400];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[400];
+				case ArticlePillar.Sport:
+					return sport[400];
+				case ArticlePillar.Culture:
+					return culture[400];
+				case ArticlePillar.Opinion:
+					return opinion[400];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[400];
+			}
+
+		case ArticleDesign.LiveBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[600];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[600];
+				case ArticlePillar.Culture:
+					return culture[600];
+				case ArticlePillar.Opinion:
+					return opinion[600];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+			}
+	}
 	switch (format.theme) {
 		case ArticlePillar.News:
-			return news[400];
+			return news[600];
 		case ArticlePillar.Lifestyle:
-			return lifestyle[400];
+			return lifestyle[500];
 		case ArticlePillar.Sport:
-			return sport[400];
+			return sport[600];
 		case ArticlePillar.Culture:
-			return culture[300];
+			return culture[600];
 		case ArticlePillar.Opinion:
-			return opinion[300];
+			return opinion[600];
 		case ArticleSpecial.Labs:
-			return labs[300];
+			return labs[400];
 		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
+			return specialReport[500];
+	}
+};
+
+const seriesTitleDark = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
 	}
 };
 
@@ -510,7 +594,9 @@ const text = {
 	standfirst,
 	standfirstDark,
 	standfirstLink,
+	standfirstLinkDark,
 	seriesTitle,
+	seriesTitleDark,
 	pagination,
 };
 

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -49,13 +49,14 @@ export const LiveBlock = ({
 	return (
 		<LiveBlockContainer
 			id={block.id}
-			borderColour={palette.border.liveBlock}
 			blockTitle={block.title}
 			blockFirstPublished={block.blockFirstPublished}
 			blockLink={blockLink}
 			isLiveUpdate={isLiveUpdate}
 			contributors={block.contributors}
 			avatarBackgroundColor={palette.background.avatar}
+			supportsDarkMode={false}
+			format={format}
 		>
 			{block.elements.map((element, index) =>
 				renderArticleElement({

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -570,15 +570,13 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.TextBlockElement':
 			return [
 				true,
-				<>
-					<TextBlockComponent
-						key={index}
-						isFirstParagraph={index === 0}
-						html={element.html}
-						format={format}
-						forceDropCap={element.dropCap}
-					/>
-				</>,
+				<TextBlockComponent
+					key={index}
+					isFirstParagraph={index === 0}
+					html={element.html}
+					format={format}
+					forceDropCap={element.dropCap}
+				/>,
 			];
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 			return [


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes styles available for darkmode for both Liveblogs and Deadblogs

| Before |  After |
| ---- | ---- |
| <img width="1084" alt="image" src="https://user-images.githubusercontent.com/99400613/157500258-f8818cc6-31e4-4668-9b62-08a5aa38a614.png"> | <img width="1085" alt="image" src="https://user-images.githubusercontent.com/99400613/157499820-89185905-4a97-4583-afd8-2a527b18a92a.png"> |




