### PR TITLE
remove true value from data-block-on-consent

### DIFF
--- a/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -15,7 +15,7 @@ export const VideoYoutubeBlockComponent: React.FC<{
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
 			<amp-youtube
-				data-block-on-consent={true} // Block player until consent is obtained
+				data-block-on-consent=""
 				data-videoid={youtubeId}
 				layout="responsive"
 				width={element.width}

--- a/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -53,15 +53,15 @@ export const YoutubeBlockComponent: React.FC<{
 		layout: 'responsive',
 		width: '16',
 		height: '9',
-		'data-block-on-consent': true, // Block player until consent is obtained
+		'data-block-on-consent': '', // Block player until consent is obtained
 		'data-param-modestbranding': true, // Remove YouTube logo
 		credentials: 'omit',
 	};
 
 	if (adTargeting) {
-		attributes['data-param-embed_config'] = JSON.stringify(
-			buildEmbedConfig(adTargeting),
-		);
+		attributes['data-param-embed_config'] = attributes[
+			'data-param-embed_config'
+		] = JSON.stringify(buildEmbedConfig(adTargeting));
 	}
 
 	if (element.channelId) {

--- a/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -59,9 +59,9 @@ export const YoutubeBlockComponent: React.FC<{
 	};
 
 	if (adTargeting) {
-		attributes['data-param-embed_config'] = attributes[
-			'data-param-embed_config'
-		] = JSON.stringify(buildEmbedConfig(adTargeting));
+		attributes['data-param-embed_config'] = JSON.stringify(
+			buildEmbedConfig(adTargeting),
+		);
 	}
 
 	if (element.channelId) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This sets the value for `data-block-on-consent=""`. If set to true, it renders out as `data-block-on-consent="true"` which is an invalid value, and breaks consent on Amp.

I would like to set the value to just `data-block-on-consent` but linting doesn't let me.
`
