### PR TITLE
Add `SpacefinderOkr3RichLinks` test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -9,6 +9,7 @@ import { useOnce } from '../lib/useOnce';
 import { tests } from '../experiments/ab-tests';
 import { spacefinderOkr1FilterNearby } from '../experiments/tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from '../experiments/tests/spacefinder-okr-2-images-loaded';
+import { spacefinderOkr3RichLinks } from '../experiments/tests/spacefinder-okr-3-rich-links';
 
 type Props = {
 	enabled: boolean;
@@ -35,6 +36,7 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 			/* keep array multi-line */
 			spacefinderOkr1FilterNearby,
 			spacefinderOkr2ImagesLoaded,
+			spacefinderOkr3RichLinks,
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -8,6 +8,7 @@ import {
 } from './tests/newsletter-merch-unit-test';
 import { spacefinderOkr1FilterNearby } from './tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from './tests/spacefinder-okr-2-images-loaded';
+import { spacefinderOkr3RichLinks } from './tests/spacefinder-okr-3-rich-links';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseVariants,
 	spacefinderOkr1FilterNearby,
 	spacefinderOkr2ImagesLoaded,
+	spacefinderOkr3RichLinks,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-3-rich-links.ts
+++ b/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-3-rich-links.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const spacefinderOkr3RichLinks: ABTest = {
+	id: 'SpacefinderOkr3RichLinks',
+	author: 'Simon Byford (@simonbyford)',
+	start: '2022-02-28',
+	expiry: '2022-03-21',
+	audience: 10 / 100,
+	audienceOffset: 30 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Fixing the bug leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Check whether ignoring rich links in spacefinder on desktop leads to an increase in inline programmatic revenue per 1000 pageviews',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Introduces an A/B test in DCR which can be used to measure the impact of this change: https://github.com/guardian/frontend/pull/24690

## Why?

The test definition must exist in both frontend and DCR