### PR TITLE
Change `sign-in-gate` placeholder to `div`

### DIFF
--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -1,7 +1,7 @@
-// This placeholder p is used by the SignInGate component to insert the sign in gate into the appropriate location within body of an article,
+// This placeholder div is used by the SignInGate component to insert the sign in gate into the appropriate location within body of an article,
 // if the SignInGateSelector determines a gate should be rendered.
 
-const SignInGateSlot = <p id="sign-in-gate" />;
+const SignInGateSlot = <div id="sign-in-gate" />;
 
 export const withSignInGateSlot = (
 	articleElements: (JSX.Element | null | undefined)[],


### PR DESCRIPTION
## What does this change?

Change `sign-in-gate` placeholder to `div`

## Why?

Spacefinder was incorrectly considering it when getting candidates for ad insertion

Tested on code, still works fine:

![Screenshot 2022-02-24 at 13 22 14](https://user-images.githubusercontent.com/7423751/155532029-b57c9e42-34b1-413b-a0ed-3817f4483895.png)
