### PR TITLE
Epic click handling support for `@guardian/braze-components`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.3.0",
-    "@guardian/braze-components": "^5.3.0",
+    "@guardian/braze-components": "6.0.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.1.2",
     "@guardian/discussion-rendering": "^9.1.1",

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -44,7 +44,7 @@ const containerStyles = css`
 export const canShowBrazeBanner = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 	brazeArticleContext: BrazeArticleContext,
-): Promise<CanShowResult<any>> => {
+): Promise<CanShowResult<Meta>> => {
 	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
 		return {
@@ -68,13 +68,17 @@ export const canShowBrazeBanner = async (
 			message.logImpression();
 		};
 
-		const meta = {
-			dataFromBraze: message.extras,
-			logImpressionWithBraze,
-			logButtonClickWithBraze,
-		};
+		if (message.extras) {
+			const meta = {
+				dataFromBraze: message.extras,
+				logImpressionWithBraze,
+				logButtonClickWithBraze,
+			};
 
-		return { show: true, meta };
+			return { show: true, meta };
+		}
+
+		return { show: false };
 	} catch (e) {
 		return { show: false };
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.3.0.tgz#abe79666e5636ad2a0064cb2f227a64239231d2f"
-  integrity sha512-3tljnI79cIR2e3RrnXMc0liSPAuFjezDZ50MCpXw9Y3KX8jD92AqWDAfjsC0XrpGj946ZB149Z/EarhrSRQ/hg==
+"@guardian/braze-components@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-6.0.0.tgz#031515e7ee5db8c96e42ace0b9a89bb8b1020219"
+  integrity sha512-oQf1TqrQM1DomUI1LwzWYlgj029vTgLYjIFAANgOoOJ6v5bDB71kAR0b3IGPCiZmmUR+dePWzYye4fwBXW8uUA==
 
 "@guardian/commercial-core@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?

We'd like to support tracking button click actions in the epic components in `@guardian/braze-components`, so, for example, we could vary a user's journey through a Braze canvas based on their interactions with messages on the website.

We already support passing through click tracking functions for banners. In guardian/braze-components#297 we're adding `submitComponentEvent` and `logButtonClickWithBraze` as required props to the epic entry point component `BrazeEndOfArticleComponent`. This PR passes those props through from the platform.

This PR also includes some improvements to the types we're specifying, going from `Promise<CanShowResult<any>>`
to `Promise<CanShowResult<Meta>>` for the return value of the `canShow` method for both epics and banners.

*Note: I'll merge guardian/braze-components#297 and do a proper v6.0.0 release before updating and merging this PR.*