### PR TITLE
`useIsInView`

### DIFF
--- a/dotcom-rendering/src/web/components/Lazy.tsx
+++ b/dotcom-rendering/src/web/components/Lazy.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { useHasBeenSeen } from '../lib/useHasBeenSeen';
+import { useIsInView } from '../lib/useIsInView';
 
 type Props = {
 	children: JSX.Element;
@@ -16,7 +16,7 @@ const flexGrowStyles = css`
 `;
 
 export const Lazy = ({ children, margin, disableFlexStyles }: Props) => {
-	const [hasBeenSeen, setRef] = useHasBeenSeen({
+	const [hasBeenSeen, setRef] = useIsInView({
 		rootMargin: `${margin}px`,
 	});
 

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.tsx
@@ -32,7 +32,7 @@ import {
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
 import { setAutomat } from '../lib/setAutomat';
-import { useHasBeenSeen } from '../lib/useHasBeenSeen';
+import { useIsInView } from '../lib/useIsInView';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {
 	OphanRecordFunction,
@@ -275,7 +275,7 @@ const ReaderRevenueLinksNative: React.FC<{
 		campaignCode,
 	};
 
-	const [hasBeenSeen, setNode] = useHasBeenSeen({
+	const [hasBeenSeen, setNode] = useIsInView({
 		threshold: 0,
 		debounce: true,
 	});

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -10,7 +10,7 @@ import type { CommonEndOfArticleComponentProps } from '@guardian/braze-component
 import { getBrazeMetaFromUrlFragment } from '../../lib/braze/forceBrazeMessage';
 import { CanShowResult } from '../../lib/messagePicker';
 import { useOnce } from '../../lib/useOnce';
-import { useHasBeenSeen } from '../../lib/useHasBeenSeen';
+import { useIsInView } from '../../lib/useIsInView';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 
 const wrapperMargins = css`
@@ -75,7 +75,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 	countryCode,
 	idApiUrl,
 }: InnerProps) => {
-	const [hasBeenSeen, setNode] = useHasBeenSeen({
+	const [hasBeenSeen, setNode] = useIsInView({
 		rootMargin: '-18px',
 		threshold: 0,
 		debounce: true,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -12,7 +12,7 @@ import {
 	BannerPayload,
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import { useHasBeenSeen } from '../../lib/useHasBeenSeen';
+import { useIsInView } from '../../lib/useIsInView';
 import {
 	shouldHideSupportMessaging,
 	withinLocalNoBannerCachePeriod,
@@ -270,7 +270,7 @@ const RemoteBanner = ({
 }: RemoteBannerProps) => {
 	const [Banner, setBanner] = useState<React.FC>();
 
-	const [hasBeenSeen, setNode] = useHasBeenSeen({
+	const [hasBeenSeen, setNode] = useIsInView({
 		threshold: 0,
 		debounce: true,
 	});

--- a/dotcom-rendering/src/web/lib/useIsInView.ts
+++ b/dotcom-rendering/src/web/lib/useIsInView.ts
@@ -2,7 +2,10 @@ import { useEffect, useState, useRef } from 'react';
 import libDebounce from 'lodash.debounce';
 
 const useIsInView = (
-	options: IntersectionObserverInit & { debounce?: boolean },
+	options: IntersectionObserverInit & {
+		debounce?: boolean;
+		repeat?: boolean;
+	},
 ): [boolean, React.Dispatch<React.SetStateAction<HTMLElement | null>>] => {
 	const [isInView, setIsInView] = useState<boolean>(false);
 	const [node, setNode] = useState<HTMLElement | null>(null);
@@ -14,6 +17,9 @@ const useIsInView = (
 	const intersectionFn: IntersectionObserverCallback = ([entry]) => {
 		if (entry.isIntersecting) {
 			setIsInView(true);
+		}
+		if (options.repeat && !entry.isIntersecting) {
+			setIsInView(false);
 		}
 	};
 	const intersectionCallback = options.debounce

--- a/dotcom-rendering/src/web/lib/useIsInView.ts
+++ b/dotcom-rendering/src/web/lib/useIsInView.ts
@@ -17,8 +17,7 @@ const useIsInView = (
 	const intersectionFn: IntersectionObserverCallback = ([entry]) => {
 		if (entry.isIntersecting) {
 			setIsInView(true);
-		}
-		if (options.repeat && !entry.isIntersecting) {
+		} else if (options.repeat) {
 			setIsInView(false);
 		}
 	};

--- a/dotcom-rendering/src/web/lib/useIsInView.ts
+++ b/dotcom-rendering/src/web/lib/useIsInView.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState, useRef } from 'react';
 import libDebounce from 'lodash.debounce';
 
-const useHasBeenSeen = (
+const useIsInView = (
 	options: IntersectionObserverInit & { debounce?: boolean },
 ): [boolean, React.Dispatch<React.SetStateAction<HTMLElement | null>>] => {
-	const [hasBeenSeen, setHasBeenSeen] = useState<boolean>(false);
+	const [isInView, setIsInView] = useState<boolean>(false);
 	const [node, setNode] = useState<HTMLElement | null>(null);
 
 	const observer = useRef<IntersectionObserver | null>(null);
@@ -13,7 +13,7 @@ const useHasBeenSeen = (
 	// 200ms before the callback is executed
 	const intersectionFn: IntersectionObserverCallback = ([entry]) => {
 		if (entry.isIntersecting) {
-			setHasBeenSeen(true);
+			setIsInView(true);
 		}
 	};
 	const intersectionCallback = options.debounce
@@ -41,7 +41,7 @@ const useHasBeenSeen = (
 		}
 	}, [node, options, intersectionCallback]);
 
-	return [hasBeenSeen, setNode];
+	return [isInView, setNode];
 };
 
-export { useHasBeenSeen };
+export { useIsInView };


### PR DESCRIPTION
## What?
This PR renames `useHasBeenSeen` to `useIsInView` and adds the `repeat` prop

## Why?
Previously, useHasBeenSeen fired once and was an indication that an element had appeared. But now we've added the `repeat` prop so that we can tell when elements scroll into view, are scrolled away, and appear again.

This is useful for things like sticking videos.