### PR TITLE
Use correct standfirst background colour for comment design

### DIFF
--- a/common-rendering/src/editorialPalette.ts
+++ b/common-rendering/src/editorialPalette.ts
@@ -633,6 +633,10 @@ const backgroundStandfirst = ({
 		}
 	}
 
+	if (design === ArticleDesign.Comment) {
+		return opinion[800];
+	}
+
 	return neutral[100];
 };
 


### PR DESCRIPTION
## Why?
Standfirsts in AR-rendered pieces using the comment layout default to a white background, as the current `standfirstBackground` logic only supports deadblogs and liveblogs.

This PR fixes fixes the problem by setting the background colour to peach if the design is `ArticleDesign.Comment`.

### Before
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/57295823/155553797-e0d90938-80f0-49b9-8804-47a3cd7394d9.png">

### After
<img width="1565" alt="image" src="https://user-images.githubusercontent.com/57295823/155554319-fb81ec05-6150-4501-9694-ecf8f3c34362.png">

