### PR TITLE
Smaller click area for `FirstPublishedDate`

### DIFF
--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -22,6 +22,7 @@ const FirstPublished = ({
 				margin-bottom: ${space[1]}px;
 				padding-top: ${space[1]}px;
 				display: flex;
+				width: fit-content;
 				flex-direction: row;
 				text-decoration: none;
 				:hover {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Creates smaller click area for `FirstPublishedDate`

## Why?
So it is smaller

### Before
![2022-02-24 17 39 18](https://user-images.githubusercontent.com/1336821/155577893-d7028989-b3df-4df3-be0f-49f1769a44b1.gif)


### After
![2022-02-24 17 34 12](https://user-images.githubusercontent.com/1336821/155577702-41fd5a3c-f0cf-4d55-adb6-50f95c0d7fdc.gif)

