### PR TITLE
`mostRecentBlockId`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -500,6 +500,9 @@ interface CAPIType {
 	// https://github.com/guardian/frontend/blob/main/common/app/model/dotcomrendering/InteractiveSwitchOver.scala#L7.
 	isLegacyInteractive?: boolean;
 	filterKeyEvents: boolean;
+
+	// Included on live and dead blogs. Used when polling
+	mostRecentBlockId?: string;
 }
 
 // Browser data models. Note the CAPI prefix here means something different to
@@ -542,6 +545,7 @@ type CAPIBrowserType = {
 	isPreview?: boolean;
 	webTitle: string;
 	stage: string;
+	mostRecentBlockId?: string;
 };
 
 interface TagType {

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -213,6 +213,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 			.concat(CAPI.mainMediaElements)
 			// Filter for elements that need hydrating -> [h,h]
 			.filter((element) => needsHydrating(element)),
+		mostRecentBlockId: CAPI.mostRecentBlockId,
 	};
 };
 

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -13,6 +13,7 @@ type Props = {
 	switches: Switches;
 	onFirstPage: boolean;
 	webURL: string;
+	mostRecentBlockId: string;
 };
 
 const isServer = typeof window === 'undefined';
@@ -139,13 +140,11 @@ export const Liveness = ({
 	switches,
 	onFirstPage,
 	webURL,
+	mostRecentBlockId,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
 	const [numHiddenBlocks, setNumHiddenBlocks] = useState(0);
-	const [latestBlockId, setLatestBlockId] = useState(
-		// By default we use the first (latest) block id on the page
-		document.querySelector('#maincontent :first-child')?.id || '',
-	);
+	const [latestBlockId, setLatestBlockId] = useState(mostRecentBlockId);
 
 	/**
 	 * This function runs (once) after every successful useApi call. This is useful because it

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -311,6 +311,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						switches={CAPI.config.switches}
 						onFirstPage={pagination.currentPage === 1}
 						webURL={CAPI.webURL}
+						// We default to string here because the property is optional but we
+						// know it will exist for all blogs
+						mostRecentBlockId={CAPI.mostRecentBlockId || ''}
 					/>
 				</Island>
 			)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This changes the way we get the most recent block id. Instead of using a document lookup (reading `first-child` of the list of blocks), we now use `CAPI.mostRecentBlockId` 

## Why?
This is both more resilient and it will also work when we're not on the first page of a blog (where reading the list of elements in the dom won't actually give us the latest block id)
