### PR TITLE
docs(stale): improve documentation around `stale` PR action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,4 +26,6 @@ jobs:
           days-before-close: 3
           close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
           
+          delete-branch: true
+          
           exempt-pr-labels: "dependencies,DCR Dependency,AR Dependency"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,17 @@ jobs:
     steps:
       - uses: actions/stale@v4.1.0
         id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
         with:
-          stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 3 days"
+          # never automatically mark issues as stale
           days-before-issue-stale: -1
+          
           days-before-stale: 30
+          stale-pr-message: >
+            "This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days"
+          
           days-before-close: 3
+          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
+          
           exempt-pr-labels: "dependencies,DCR Dependency,AR Dependency"


### PR DESCRIPTION
## What does this change?

Add more documentation around the stale PR action, including link to the options docs.

Enforce deleting of branches when the PR is closed.

_Built on top of @AshCorr’s excellent #3895_

## Why?

We have many stale branches, and many of them had an associated PR, before I deleted them. [It’s trivial to restore them](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/deleting-and-restoring-branches-in-a-pull-request#restoring-a-deleted-branch).