### PR TITLE
`BlockByline`

### DIFF
--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -2,6 +2,23 @@ import { css } from "@emotion/react";
 import { neutral, from, space, headline } from "@guardian/source-foundations";
 import { FirstPublished } from "./FirstPublished";
 
+type BlockContributor = {
+	name: string;
+	imageUrl?: string;
+};
+
+type Props = {
+	id: string;
+	children: React.ReactNode;
+	borderColour: string;
+	blockTitle?: string;
+	blockFirstPublished?: number;
+	blockLink: string;
+	isLiveUpdate?: boolean;
+	contributors?: BlockContributor[];
+	avatarBackgroundColor?: string;
+};
+
 const LEFT_MARGIN_DESKTOP = 60;
 const SIDE_MARGIN = space[5];
 const SIDE_MARGIN_MOBILE = 10;
@@ -33,6 +50,52 @@ const BlockTitle = ({ title }: { title: string }) => {
 	);
 };
 
+const BlockByline = ({
+	name,
+	imageUrl,
+	avatarBackgroundColor,
+}: {
+	name: string;
+	imageUrl?: string;
+	avatarBackgroundColor?: string;
+}) => {
+	return (
+		<div
+			css={css`
+				display: flex;
+				flex-direction: row;
+				padding-bottom: ${space[1]}px;
+			`}
+		>
+			{imageUrl && (
+				<div style={{ width: "36px", height: "36px" }}>
+					<img
+						src={imageUrl}
+						alt={name}
+						css={css`
+							border-radius: 100%;
+							object-fit: cover;
+							height: 100%;
+							width: 100%;
+							background-color: ${avatarBackgroundColor};
+						`}
+					/>
+				</div>
+			)}
+			<span
+				css={css`
+					display: flex;
+					align-items: center;
+					padding-left: ${imageUrl ? space[1] : 0}px;
+					font-size: 19px;
+				`}
+			>
+				{name}
+			</span>
+		</div>
+	);
+};
+
 const LiveBlockContainer = ({
 	id,
 	children,
@@ -41,15 +104,9 @@ const LiveBlockContainer = ({
 	blockFirstPublished,
 	blockLink,
 	isLiveUpdate,
-}: {
-	id: string;
-	children: React.ReactNode;
-	borderColour: string;
-	blockTitle?: string;
-	blockFirstPublished?: number;
-	blockLink: string;
-	isLiveUpdate?: boolean;
-}) => {
+	contributors,
+	avatarBackgroundColor,
+}: Props) => {
 	return (
 		<article
 			id={`block-${id}`}
@@ -82,6 +139,14 @@ const LiveBlockContainer = ({
 					/>
 				)}
 				{blockTitle ? <BlockTitle title={blockTitle} /> : null}
+				{contributors &&
+					contributors.map((contributor) => (
+						<BlockByline
+							name={contributor.name}
+							imageUrl={contributor.imageUrl}
+							avatarBackgroundColor={avatarBackgroundColor}
+						/>
+					))}
 			</Header>
 			{children}
 		</article>

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -1,5 +1,11 @@
 import { css } from "@emotion/react";
-import { neutral, from, space, headline } from "@guardian/source-foundations";
+import {
+	neutral,
+	from,
+	space,
+	headline,
+	body,
+} from "@guardian/source-foundations";
 import { FirstPublished } from "./FirstPublished";
 
 type BlockContributor = {
@@ -84,10 +90,10 @@ const BlockByline = ({
 			)}
 			<span
 				css={css`
+					${body.medium()}
 					display: flex;
 					align-items: center;
 					padding-left: ${imageUrl ? space[1] : 0}px;
-					font-size: 19px;
 				`}
 			>
 				{name}

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -322,6 +322,11 @@ interface AuthorType {
 	email?: string;
 }
 
+interface BlockContributor {
+	name: string;
+	imageUrl?: string;
+}
+
 interface Block {
 	id: string;
 	elements: CAPIElement[];
@@ -340,6 +345,7 @@ interface Block {
 	lastUpdatedDisplay?: string;
 	firstPublished?: number;
 	firstPublishedDisplay?: string;
+	contributors?: BlockContributor[];
 }
 
 interface Pagination {

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -293,7 +293,7 @@ export const FirstImage = () => {
 };
 FirstImage.story = { name: 'with an image as the first element' };
 
-export const ImaheAndTitle = () => {
+export const ImageAndTitle = () => {
 	const block: Block = {
 		...baseBlock,
 		title: 'Afternoon summary',
@@ -324,7 +324,7 @@ export const ImaheAndTitle = () => {
 		</Wrapper>
 	);
 };
-ImaheAndTitle.story = { name: 'with only a title and an image' };
+ImageAndTitle.story = { name: 'with only a title and an image' };
 
 export const Updated = () => {
 	const publishedDate: number = baseBlock.blockFirstPublished || 999999;
@@ -356,3 +356,101 @@ export const Updated = () => {
 Updated.story = {
 	name: 'with updated time showing',
 };
+
+export const Contributor = () => {
+	const block: Block = {
+		...baseBlock,
+		contributors: [
+			{
+				name: 'Andrew Roth',
+				imageUrl:
+					'https://i.guim.co.uk/img/uploads/2019/06/07/Andrew_Roth,_L.png?width=300&quality=85&auto=format&fit=max&s=b43b83c4998787fd8c68631b800cb8f7',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
+				format={{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.LiveBlog,
+					display: ArticleDisplay.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				ajaxUrl=""
+			/>
+		</Wrapper>
+	);
+};
+Contributor.story = { name: 'with a contributor' };
+
+export const NoAvatar = () => {
+	const block: Block = {
+		...baseBlock,
+		contributors: [
+			{
+				name: 'Andrew Roth',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
+				format={{
+					theme: ArticlePillar.Opinion,
+					design: ArticleDesign.LiveBlog,
+					display: ArticleDisplay.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				ajaxUrl=""
+			/>
+		</Wrapper>
+	);
+};
+NoAvatar.story = { name: 'with a contributor but no avatar' };
+
+export const TitleAndContributor = () => {
+	const block: Block = {
+		...baseBlock,
+		title: 'Afternoon summary',
+		contributors: [
+			{
+				name: 'Andrew Roth',
+				imageUrl:
+					'https://i.guim.co.uk/img/uploads/2019/06/07/Andrew_Roth,_L.png?width=300&quality=85&auto=format&fit=max&s=b43b83c4998787fd8c68631b800cb8f7',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
+				format={{
+					theme: ArticlePillar.Sport,
+					design: ArticleDesign.LiveBlog,
+					display: ArticleDisplay.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				ajaxUrl=""
+			/>
+		</Wrapper>
+	);
+};
+TitleAndContributor.story = { name: 'with a contributor and a title' };

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -47,6 +47,8 @@ export const LiveBlock = ({
 			blockFirstPublished={block.blockFirstPublished}
 			blockLink={blockLink}
 			isLiveUpdate={isLiveUpdate}
+			contributors={block.contributors}
+			avatarBackgroundColor={palette.background.avatar}
 		>
 			{block.elements.map((element, index) =>
 				renderArticleElement({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `BlockByline` component 

![2022-02-25 17 39 24](https://user-images.githubusercontent.com/1336821/155761709-4068d33c-d718-41e3-9666-3a4a878e7aaf.gif)



## Why?
These were missing from the data model before but now that [this PR](https://github.com/guardian/frontend/pull/24707) is merged we're ready to add them
