### PR TITLE
Observe `topOfBlog` when not on first page

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -121,16 +121,6 @@ const lastUpdated: Element | null = !isServer
 	? window.document.querySelector('[data-gu-marker=liveblog-last-updated]')
 	: null;
 
-/**
- * This allows us to make decisions in javascript based on if the reader
- * has the top of the blog in view or not
- *
- * @returns boolean
- */
-function topOfBlogVisible(): boolean {
-	return topOfBlog ? topOfBlog.classList.contains('in-viewport') : false;
-}
-
 export const Liveness = ({
 	pageId,
 	webTitle,
@@ -143,6 +133,9 @@ export const Liveness = ({
 	mostRecentBlockId,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
+	const [topOfBlogVisible, setTopOfBlogVisible] = useState<
+		boolean | undefined
+	>();
 	const [numHiddenBlocks, setNumHiddenBlocks] = useState(0);
 	const [latestBlockId, setLatestBlockId] = useState(mostRecentBlockId);
 
@@ -161,7 +154,7 @@ export const Liveness = ({
 				updateTimeElement(lastUpdated);
 			}
 
-			if (onFirstPage && topOfBlogVisible() && document.hasFocus()) {
+			if (onFirstPage && topOfBlogVisible && document.hasFocus()) {
 				revealPendingBlocks();
 				setNumHiddenBlocks(0);
 			} else {
@@ -207,9 +200,9 @@ export const Liveness = ({
 				const topOfBlogShowing = entry.isIntersecting;
 
 				if (topOfBlogShowing) {
-					entry.target.classList.add('in-viewport');
+					setTopOfBlogVisible(true);
 				} else {
-					entry.target.classList.remove('in-viewport');
+					setTopOfBlogVisible(false);
 				}
 
 				if (topOfBlogShowing && onFirstPage) {
@@ -246,7 +239,7 @@ export const Liveness = ({
 				// is at the top of the first page then...
 				document.visibilityState === 'visible' &&
 				numHiddenBlocks > 0 &&
-				topOfBlogVisible() &&
+				topOfBlogVisible &&
 				onFirstPage
 			) {
 				revealPendingBlocks();

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -250,7 +250,7 @@ export const Liveness = ({
 				handleVisibilityChange,
 			);
 		};
-	}, [numHiddenBlocks, onFirstPage]);
+	}, [numHiddenBlocks, onFirstPage, topOfBlogVisible]);
 
 	const handleToastClick = () => {
 		if (onFirstPage) {

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -199,28 +199,35 @@ export const Liveness = ({
 			numHiddenBlocks > 0 ? `(${numHiddenBlocks}) ${webTitle}` : webTitle;
 	}, [numHiddenBlocks, webTitle]);
 
-	if (onFirstPage && topOfBlog) {
-		const observer = new window.IntersectionObserver(
-			([entry]) => {
-				if (entry.isIntersecting) {
-					entry.target.classList.add('in-viewport');
-					revealPendingBlocks();
-					setNumHiddenBlocks(0);
-					setShowToast(false);
-					return;
-				}
-				entry.target.classList.remove('in-viewport');
-			},
-			{
-				root: null,
-				// A margin makes more sense because the element we're
-				// observing (topOfBlog) has no height
-				rootMargin: '100px',
-			},
-		);
+	useEffect(() => {
+		if (topOfBlog) {
+			const observer = new window.IntersectionObserver(
+				([entry]) => {
+					const topOfBlogShowing = entry.isIntersecting;
 
-		observer.observe(topOfBlog);
-	}
+					if (topOfBlogShowing) {
+						entry.target.classList.add('in-viewport');
+					} else {
+						entry.target.classList.remove('in-viewport');
+					}
+
+					if (topOfBlogShowing && onFirstPage) {
+						revealPendingBlocks();
+						setNumHiddenBlocks(0);
+						setShowToast(false);
+					}
+				},
+				{
+					root: null,
+					// A margin makes more sense because the element we're
+					// observing (topOfBlog) has no height
+					rootMargin: '100px',
+				},
+			);
+
+			observer.observe(topOfBlog);
+		}
+	}, [onFirstPage]);
 
 	/**
 	 * This useEffect sets up a listener for when the page is backgrounded or restored. We

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -197,15 +197,9 @@ export const Liveness = ({
 
 		const observer = new window.IntersectionObserver(
 			([entry]) => {
-				const topOfBlogShowing = entry.isIntersecting;
+				setTopOfBlogVisible(entry.isIntersecting);
 
-				if (topOfBlogShowing) {
-					setTopOfBlogVisible(true);
-				} else {
-					setTopOfBlogVisible(false);
-				}
-
-				if (topOfBlogShowing && onFirstPage) {
+				if (entry.isIntersecting && onFirstPage) {
 					revealPendingBlocks();
 					setNumHiddenBlocks(0);
 					setShowToast(false);

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -200,33 +200,37 @@ export const Liveness = ({
 	}, [numHiddenBlocks, webTitle]);
 
 	useEffect(() => {
-		if (topOfBlog) {
-			const observer = new window.IntersectionObserver(
-				([entry]) => {
-					const topOfBlogShowing = entry.isIntersecting;
+		if (!topOfBlog) return () => {};
 
-					if (topOfBlogShowing) {
-						entry.target.classList.add('in-viewport');
-					} else {
-						entry.target.classList.remove('in-viewport');
-					}
+		const observer = new window.IntersectionObserver(
+			([entry]) => {
+				const topOfBlogShowing = entry.isIntersecting;
 
-					if (topOfBlogShowing && onFirstPage) {
-						revealPendingBlocks();
-						setNumHiddenBlocks(0);
-						setShowToast(false);
-					}
-				},
-				{
-					root: null,
-					// A margin makes more sense because the element we're
-					// observing (topOfBlog) has no height
-					rootMargin: '100px',
-				},
-			);
+				if (topOfBlogShowing) {
+					entry.target.classList.add('in-viewport');
+				} else {
+					entry.target.classList.remove('in-viewport');
+				}
 
-			observer.observe(topOfBlog);
-		}
+				if (topOfBlogShowing && onFirstPage) {
+					revealPendingBlocks();
+					setNumHiddenBlocks(0);
+					setShowToast(false);
+				}
+			},
+			{
+				root: null,
+				// A margin makes more sense because the element we're
+				// observing (topOfBlog) has no height
+				rootMargin: '100px',
+			},
+		);
+
+		observer.observe(topOfBlog);
+
+		return () => {
+			observer.disconnect();
+		};
 	}, [onFirstPage]);
 
 	/**


### PR DESCRIPTION
## What does this change?
Previously, we only set the observer for the topOfBlog when on the first page. In this PR we allow some features of this observer on all pages

## Why?
Because we had a bug where the toast was being removed when it should have been kept on the page but also because this allows us to use this logic in other situations, such as if we wanted to stick the toast and needed a way to dynamically set some state based on scroll position (this is a pending feature)