### PR TITLE
Only insert new blocks when on the first page

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -153,8 +153,8 @@ export const Liveness = ({
 	 */
 	function onSuccess(data: LiveUpdateType) {
 		if (data && data.numNewBlocks && data.numNewBlocks > 0) {
-			// Always insert the new blocks in the dom (but hidden)
-			insert(data.html, switches);
+			// Insert the new blocks in the dom (but hidden)
+			if (onFirstPage) insert(data.html, switches);
 
 			if (lastUpdated) {
 				lastUpdated.setAttribute('dateTime', new Date().toString());


### PR DESCRIPTION
## What?
Here we restrict when new blog updates are inserted into the dom to when the reader is on the first page


## Why?
We should only be inserting new blocks at the start of the blog, not half way through