### PR TITLE
Upgrade commercial core v3.0.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.3.0",
     "@guardian/braze-components": "^5.3.0",
-    "@guardian/commercial-core": "^1.0.0",
+    "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.1.2",
     "@guardian/discussion-rendering": "^9.1.1",
     "@guardian/libs": "^3.4.1",

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -45,12 +45,12 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 			window.guardian.config.page.isDev ||
 			window.location.hostname.includes('localhost');
 
-		initCommercialMetrics(
+		initCommercialMetrics({
 			pageViewId,
-			browserId || undefined,
+			browserId: browserId || undefined,
 			isDev,
 			adBlockerInUse,
-		);
+		});
 		// TODO: capture CWV also, to ensure commercial performance
 		// doesn’t come at the expense of user experience.
 		// See https://git.io/JP68Q in `frontend`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,10 +2814,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.3.0.tgz#abe79666e5636ad2a0064cb2f227a64239231d2f"
   integrity sha512-3tljnI79cIR2e3RrnXMc0liSPAuFjezDZ50MCpXw9Y3KX8jD92AqWDAfjsC0XrpGj946ZB149Z/EarhrSRQ/hg==
 
-"@guardian/commercial-core@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-1.0.0.tgz#4f0aa9a56fa0a614a175738593608010147904c9"
-  integrity sha512-GlsHxvbi+fQQWtUShZHOW7xczwgrJdL79F8KTfTY9h1Z23n3i5aM0H6SP4JcIv1wZQ63lx7ypmH5gB23okvqJQ==
+"@guardian/commercial-core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.0.0.tgz#8b2040e89b4dd8e317563938552776da4ced5bee"
+  integrity sha512-wB3y5p6eyuuekEK27S4OZ8vnVRMJ1tcHwi1SwmfIsYNEZLwYJRv3UxsLlTEeUmH8YAnYNgIEzJ390GfQ8iaVeA==
 
 "@guardian/consent-management-platform@^10.1.2":
   version "10.1.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Upgrades version of commercial core from 1.0.0 to [3.0.0](https://github.com/guardian/commercial-core/releases/tag/v3.0.0)

## Why?
To keep DCR's version of commercial core up-to-date and in line with frontend's
