### PR TITLE
feat(cmp): add a dummy for the server bundle

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
@@ -145,7 +145,7 @@ describe('Liveblogs', function () {
 			},
 			(req) => {
 				expect(req.query.lastUpdate).to.equal(
-					'62148e2d8f081f9e465d1bb7',
+					'block-62148e2d8f081f9e465d1bb7',
 				);
 			},
 		).as('updateCall');

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -20,6 +20,12 @@ module.exports = ({ sessionId }) => ({
 		minimize: false,
 		runtimeChunk: false,
 	},
+	resolve: {
+		alias: {
+			'@guardian/consent-management-platform':
+				'../../../src/server/cmp-dummy',
+		},
+	},
 	externals: [
 		'@loadable/component',
 		require('webpack-node-externals')({

--- a/dotcom-rendering/src/server/cmp-dummy.ts
+++ b/dotcom-rendering/src/server/cmp-dummy.ts
@@ -1,0 +1,28 @@
+import type { CMP } from '@guardian/consent-management-platform/dist/types';
+
+const warn = (): void => {
+	console.warn(
+		'This is a dummy version of the @guardian/consent-management-platform',
+		'No consent signals will be received.',
+	);
+};
+
+const warnAndReturn = <T extends unknown>(arg: T): (() => T) => {
+	warn();
+	return () => arg;
+};
+
+export const cmp: CMP = {
+	__disable: warn,
+	__enable: warnAndReturn(false),
+	__isDisabled: warnAndReturn(false),
+	hasInitialised: warnAndReturn(false),
+	init: warn,
+	showPrivacyManager: warn,
+	version: 'n/a',
+	willShowPrivacyMessage: warnAndReturn(Promise.resolve(false)),
+	willShowPrivacyMessageSync: warnAndReturn(false),
+};
+
+export const onConsentChange: typeof window.guCmpHotFix.onConsentChange = warn;
+export const getConsentFor: typeof window.guCmpHotFix.onConsentChange = warn;


### PR DESCRIPTION
## What does this change?

Create a dummy CMP that is used in the server bundle via Webpack’s `resolve`/`alias`. 

## Why?

The CMP lib code is not server-safe, as it relies on `window`.

We need a way to make sure this code does not run on the server,
so this aliases to a dummy CMP that does nothing. This approach can be
pushed upstream so the CMP exports this dummy directly.