### PR TITLE
fix card icon colour in Special Reports

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -285,7 +285,6 @@ export const Card = ({
 										webPublicationDate ? (
 											<CardAge
 												format={format}
-												palette={cardPalette}
 												webPublicationDate={
 													webPublicationDate
 												}

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -3,16 +3,17 @@ import { css } from '@emotion/react';
 import { textSans, until } from '@guardian/source-foundations';
 import { ArticleDesign, timeAgo } from '@guardian/libs';
 
+import { decidePalette } from '../../../lib/decidePalette';
 import ClockIcon from '../../../../static/icons/clock.svg';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	webPublicationDate: string;
 	showClock?: boolean;
 };
 
-const ageStyles = (format: ArticleFormat, palette: Palette) => {
+const ageStyles = (format: ArticleFormat) => {
+	const palette = decidePalette(format);
 	return css`
 		${textSans.xxsmall()};
 		color: ${palette.text.cardFooter};
@@ -42,12 +43,7 @@ const ageStyles = (format: ArticleFormat, palette: Palette) => {
 	`;
 };
 
-export const CardAge = ({
-	format,
-	palette,
-	webPublicationDate,
-	showClock,
-}: Props) => {
+export const CardAge = ({ format, webPublicationDate, showClock }: Props) => {
 	const displayString = timeAgo(new Date(webPublicationDate).getTime());
 
 	if (!displayString) {
@@ -55,7 +51,7 @@ export const CardAge = ({
 	}
 
 	return (
-		<span css={ageStyles(format, palette)}>
+		<span css={ageStyles(format)}>
 			<span>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate} data-relativeformat="med">

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -678,7 +678,13 @@ const fillBlockquoteIcon = (format: ArticleFormat): string =>
 
 const fillCardIcon = (format: ArticleFormat): string => {
 	// Setting Card clock colour for immersive cards to all be dark grey
-	if (format.display === ArticleDisplay.Immersive) return neutral[60];
+	// Except ArticleSpecial.SpecialReport
+	if (
+		format.display === ArticleDisplay.Immersive &&
+		format.theme !== ArticleSpecial.SpecialReport
+	) {
+		return neutral[60];
+	}
 	switch (format.design) {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -690,7 +690,6 @@ const fillCardIcon = (format: ArticleFormat): string => {
 				default:
 					return neutral[46];
 			}
-			return lifestyle[500];
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
 				case ArticlePillar.News:
@@ -729,7 +728,7 @@ const fillCardIcon = (format: ArticleFormat): string => {
 		default:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:
-					return brandAltBackground.primary;
+					return brandAlt[400];
 				default:
 					return neutral[46];
 			}


### PR DESCRIPTION
## What does this change?

Keep colouring Special Reports yellow. This fixes #4072.

- refactor: infer palette from format – follow up from #4053 
- refactor(decidePalette): make code consistent

## Why?

The icon doesn’t match the text, currently.

### Before (left) / After (right)

<img width="489" alt="image" src="https://user-images.githubusercontent.com/76776/155999099-5e816157-7ff6-46cb-8847-39b4f3376614.png">
