### PR TITLE
Remove palette.fill.cardIcon in favour of explicit colours

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -151,7 +151,6 @@ type Palette = {
 		shareIcon: Colour;
 		shareIconGrayBackground: Colour;
 		cameraCaptionIcon: Colour;
-		cardIcon: Colour;
 		richLink: Colour;
 		quoteIcon: Colour;
 		blockquoteIcon: Colour;

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -179,11 +179,7 @@ export const Card = ({
 	const cardPalette = decidePalette(format);
 
 	return (
-		<CardLink
-			linkTo={linkTo}
-			format={format}
-			dataLinkName={dataLinkName}
-		>
+		<CardLink linkTo={linkTo} format={format} dataLinkName={dataLinkName}>
 			<TopBar palette={cardPalette} isFullCardImage={isFullCardImage}>
 				<CardLayout
 					imagePosition={imagePosition}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -182,7 +182,6 @@ export const Card = ({
 		<CardLink
 			linkTo={linkTo}
 			format={format}
-			palette={cardPalette}
 			dataLinkName={dataLinkName}
 		>
 			<TopBar palette={cardPalette} isFullCardImage={isFullCardImage}>
@@ -318,7 +317,6 @@ export const Card = ({
 										branding ? (
 											<CardBranding
 												branding={branding}
-												palette={cardPalette}
 												format={format}
 											/>
 										) : undefined

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -27,7 +27,7 @@ const ageStyles = (format: ArticleFormat) => {
 		}
 
 		svg {
-			fill: ${palette.fill.cardIcon};
+			fill: ${palette.text.cardFooter};
 			margin-bottom: -1px;
 			height: 11px;
 			width: 11px;

--- a/dotcom-rendering/src/web/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardBranding.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { space, textSans, visuallyHidden } from '@guardian/source-foundations';
+import { decidePalette } from '../../../lib/decidePalette';
 import { decideLogo } from '../../../lib/decideLogo';
 
 type Props = {
 	branding: Branding;
 	format: ArticleFormat;
-	palette: Palette;
 };
 
 const logoImageStyle = css`
@@ -30,8 +30,9 @@ const labelStyle = (palette: Palette) => {
 	`;
 };
 
-export const CardBranding = ({ branding, format, palette }: Props) => {
+export const CardBranding = ({ branding, format }: Props) => {
 	const logo = decideLogo(format, branding);
+	const palette = decidePalette(format);
 	return (
 		<div css={brandingWrapperStyle}>
 			<div css={labelStyle(palette)}>{logo.label}</div>

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -5,7 +5,7 @@ import { neutral } from '@guardian/source-foundations';
 import { decidePalette } from '../../../lib/decidePalette';
 
 const linkStyles = (format: ArticleFormat) => {
-	const palette = decidePalette(format)
+	const palette = decidePalette(format);
 	const baseLinkStyles = css`
 		display: flex;
 		/* a tag specific styles */
@@ -93,11 +93,7 @@ export const CardLink = ({
 	format,
 	dataLinkName = 'article',
 }: Props) => (
-	<a
-		href={linkTo}
-		css={linkStyles(format)}
-		data-link-name={dataLinkName}
-	>
+	<a href={linkTo} css={linkStyles(format)} data-link-name={dataLinkName}>
 		{children}
 	</a>
 );

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -2,8 +2,10 @@ import { css } from '@emotion/react';
 
 import { ArticleDesign, ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
+import { decidePalette } from '../../../lib/decidePalette';
 
-const linkStyles = (format: ArticleFormat, palette: Palette) => {
+const linkStyles = (format: ArticleFormat) => {
+	const palette = decidePalette(format)
 	const baseLinkStyles = css`
 		display: flex;
 		/* a tag specific styles */
@@ -82,7 +84,6 @@ type Props = {
 	children: React.ReactNode;
 	linkTo: string;
 	format: ArticleFormat;
-	palette: Palette;
 	dataLinkName?: string;
 };
 
@@ -90,12 +91,11 @@ export const CardLink = ({
 	children,
 	linkTo,
 	format,
-	palette,
 	dataLinkName = 'article',
 }: Props) => (
 	<a
 		href={linkTo}
-		css={linkStyles(format, palette)}
+		css={linkStyles(format)}
 		data-link-name={dataLinkName}
 	>
 		{children}

--- a/dotcom-rendering/src/web/components/CardCommentCount.tsx
+++ b/dotcom-rendering/src/web/components/CardCommentCount.tsx
@@ -25,7 +25,7 @@ const svgStyles = (palette: Palette) => css`
 		height: 14px;
 		width: 14px;
 		margin-right: 2px;
-		fill: ${palette.fill.cardIcon};
+		fill: ${palette.text.cardFooter};
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -15,7 +15,7 @@ type Props = {
 const iconWrapperStyles = (mediaType: MediaType, palette: Palette) => css`
 	width: 24px;
 	height: 23px;
-	background-color: ${palette.fill.cardIcon};
+	background-color: ${palette.text.cardFooter};
 	border-radius: 50%;
 	display: inline-block;
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -404,7 +404,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
 					return '#ff9941';
 				default:
-					return neutral[60];
+					return neutral[46];
 			}
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -676,71 +676,6 @@ const fillCaptionCamera = (format: ArticleFormat): string =>
 const fillBlockquoteIcon = (format: ArticleFormat): string =>
 	pillarPalette[format.theme].main;
 
-const fillCardIcon = (format: ArticleFormat): string => {
-	// Setting Card clock colour for immersive cards to all be dark grey
-	// Except ArticleSpecial.SpecialReport
-	if (
-		format.display === ArticleDisplay.Immersive &&
-		format.theme !== ArticleSpecial.SpecialReport
-	) {
-		return neutral[60];
-	}
-	switch (format.design) {
-		case ArticleDesign.Comment:
-		case ArticleDesign.Letter:
-			switch (format.theme) {
-				case ArticleSpecial.SpecialReport:
-					// TODO: Pull this in from source once we see it here:
-					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-					return '#ff9941';
-				default:
-					return neutral[46];
-			}
-		case ArticleDesign.LiveBlog:
-			switch (format.theme) {
-				case ArticlePillar.News:
-					return news[600];
-				case ArticlePillar.Sport:
-					return sport[600];
-				case ArticlePillar.Opinion:
-					return WHITE;
-				case ArticlePillar.Culture:
-					return culture[600];
-				case ArticlePillar.Lifestyle:
-					return lifestyle[500];
-				case ArticleSpecial.SpecialReport:
-					return brandAlt[400];
-				case ArticleSpecial.Labs:
-				default:
-					return BLACK;
-			}
-		case ArticleDesign.Media:
-			switch (format.theme) {
-				case ArticleSpecial.SpecialReport:
-					return brandAlt[400];
-				case ArticlePillar.News:
-					return news[600];
-				case ArticlePillar.Sport:
-					return sport[600];
-				case ArticlePillar.Opinion:
-					// TODO: Pull this in from source as opinion[550]
-					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-					return '#ff9941';
-				case ArticlePillar.Lifestyle:
-				case ArticlePillar.Culture:
-				default:
-					return pillarPalette[format.theme][500];
-			}
-		default:
-			switch (format.theme) {
-				case ArticleSpecial.SpecialReport:
-					return brandAlt[400];
-				default:
-					return neutral[46];
-			}
-	}
-};
-
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;
@@ -1103,7 +1038,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			shareCountIconUntilDesktop: fillShareCountIconUntilDesktop(format),
 			shareIconGrayBackground: fillShareIconGrayBackground(format),
 			cameraCaptionIcon: fillCaptionCamera(format),
-			cardIcon: fillCardIcon(format),
 			richLink: fillRichLink(format),
 			quoteIcon: fillQuoteIcon(format),
 			blockquoteIcon: fillBlockquoteIcon(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -446,7 +446,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 				case ArticleSpecial.SpecialReport:
 					return brandAltBackground.primary;
 				default:
-					return neutral[60];
+					return neutral[46];
 			}
 	}
 };


### PR DESCRIPTION
## What does this change?

Remove `palette.fill.cardIcon`, as we always want to use the current text colour. ~No visual changes.~ The text and icons are made darker to meet WCAG 2.1 standard AA.

Small side notes:
- keep inferring `palette` from `format`, as started in #4053.
- ~use icons from Source in `MediaMeta`.~ moved to own PR: #4119 

## Why?

Smaller bundle, easier to reason about, less decisions required in palette, which can lead to inconsistencies like in #4072 

