### PR TITLE
More information for `spacefinder`

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
@@ -145,7 +145,7 @@ describe('Liveblogs', function () {
 			},
 			(req) => {
 				expect(req.query.lastUpdate).to.equal(
-					'62148e2d8f081f9e465d1bb7',
+					'block-62148e2d8f081f9e465d1bb7',
 				);
 			},
 		).as('updateCall');

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -178,6 +178,9 @@ export const Figure = ({
 		);
 	}
 
+	// TODO: isNumberedListTitle is not used
+	// TODO: Any usage of data-spacefinder-component can be replaced with data-spacefinder-type
+	//       Once this has been done we can remove this attribute
 	// See 001-commercial-selectors.md for details on `data-spacefinder-component`
 	let spacefinderComponent: 'rich-link' | 'numbered-list-title' | undefined;
 	if (role === 'richLink') {
@@ -191,9 +194,9 @@ export const Figure = ({
 			id={id}
 			css={defaultRoleStyles(role)}
 			data-spacefinder-component={spacefinderComponent}
-			className={className}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}
+			className={className}
 		>
 			{children}
 		</figure>

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -190,6 +190,7 @@ export const Figure = ({
 			css={defaultRoleStyles(role)}
 			data-spacefinder-component={spacefinderComponent}
 			className={className}
+			data-spacefinder-role={role}
 		>
 			{children}
 		</figure>

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -149,6 +149,7 @@ type Props = {
 	id?: string;
 	isNumberedListTitle?: boolean;
 	className?: string;
+	type?: CAPIElement['_type'];
 };
 
 const mainMediaFigureStyles = css`
@@ -162,6 +163,7 @@ export const Figure = ({
 	isMainMedia,
 	isNumberedListTitle = false,
 	className = '',
+	type,
 }: Props) => {
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
@@ -191,6 +193,7 @@ export const Figure = ({
 			data-spacefinder-component={spacefinderComponent}
 			className={className}
 			data-spacefinder-role={role}
+			data-spacefinder-type={type}
 		>
 			{children}
 		</figure>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -792,6 +792,7 @@ export const renderArticleElement = ({
 					? interactiveLegacyFigureClasses(element._type, role)
 					: ''
 			}
+			type={element._type}
 		>
 			{el}
 		</Figure>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds two two attributes for spacefinder to use as it needs

`role: RoleType` - Also know as `weighting`, this is how the element is positioned
`type: CAPIElement._type` - This is the type of element, richlink, image, embed, etc.

## Why?
Because we want to be more declarative, giving situational information to spacefinder to help it best make decisions. By providing the same values that DCR itself uses to make decisions we are also aligning contracts between the platforms (rather than establishing new ones).

### Should we share the types for these things?
If we hoist the type definitions for `role` and `_type` to, say, libs then we can control changes, making sure that the different platforms are not left behind. The con to this is the extra work involved but I think this is justified given these couplings between the codebases are real and need respecting.

### `isNumberedListTitle`
This prop [was added](https://github.com/guardian/dotcom-rendering/pull/2976) to fix a bug where ads were exploding the elements on the page but a [later change](https://github.com/guardian/dotcom-rendering/commit/4b422040e81dd080454175cd5983f97ad0bd8a25) removed the code that implemented it so it is now unused. I've made a note about this and I think if we complete the refactor on the commercial side of things using the `type` value in place of `component` then we can remove this prop entirely.

