### PR TITLE
Use `getContentFromURLMiddleware` everywhere

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -75,7 +75,8 @@ export const prodServer = () => {
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
 		'/Article',
-		[logRenderTime, getContentFromURLMiddleware],
+		logRenderTime,
+		getContentFromURLMiddleware,
 		async (req: Request, res: Response) => {
 			// Eg. http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/...
 			try {
@@ -89,7 +90,8 @@ export const prodServer = () => {
 
 	app.get(
 		'/AMPArticle',
-		[logRenderTime, getContentFromURLMiddleware],
+		logRenderTime,
+		getContentFromURLMiddleware,
 		async (req: Request, res: Response) => {
 			// Eg. http://localhost:9000/AMPArticle?url=https://www.theguardian.com/commentisfree/...
 			try {


### PR DESCRIPTION
## What?
Replaces the similar but different logic that was being used on the `GET /Article` route for the prod build with the new `getContentFromURLMiddleware` middleware that [was added to](https://github.com/guardian/dotcom-rendering/pull/3957) the same route for the dev build.

## Why?
Because [we improved](https://github.com/guardian/dotcom-rendering/pull/4037) `getContentFromURLMiddleware` to handle query params better and we want that same improved goodness when we run `make run-ci`
