### PR TITLE
Fix `StickyVideo` isSticky conditional

### DIFF
--- a/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
@@ -59,7 +59,7 @@ export const StickyVideo = ({ isPlaying, children }: Props) => {
 	});
 
 	useEffect(() => {
-		if (isPlaying) setIsSticky(!isIntersecting);
+		setIsSticky(isPlaying && !isIntersecting);
 	}, [isIntersecting, isPlaying]);
 
 	return (

--- a/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
@@ -27,7 +27,6 @@ const stickyStyles = css`
 	position: fixed;
 	bottom: 20px;
 	width: 300px;
-	height: 169px;
 	${getZIndex('sticky-video')};
 	animation: fade-in-up 1s ease both;
 
@@ -55,12 +54,12 @@ interface Props {
 export const StickyVideo = ({ isPlaying, children }: Props) => {
 	const [isSticky, setIsSticky] = useState(false);
 	const [isIntersecting, setRef] = useIsInView({
-		threshold: 0.1,
+		threshold: 0.5,
 		repeat: true,
 	});
 
 	useEffect(() => {
-		setIsSticky(isIntersecting && isPlaying);
+		if (isPlaying) setIsSticky(!isIntersecting);
 	}, [isIntersecting, isPlaying]);
 
 	return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Reverses the `setIsSticky` conditional so that the video is stuck when the video container is **not** intersecting.
- Moves the intersecting threshold so the IO is triggered when the video is 50% out of the viewport
- removes unnecessary height value from the sticky video styles 

## Why?

Previously the video would only be stuck when the video container was intersecting, for obvious reasons this wasn't the behaviour we wanted. See [this PR](https://github.com/guardian/dotcom-rendering/pull/3992) for context.

### Before

https://user-images.githubusercontent.com/77005274/156212950-45c44afd-c73f-4f50-96a0-acda1156a9ac.mov

### After

https://user-images.githubusercontent.com/77005274/156213009-1094c450-a4e8-4f57-8a3d-b63ad02304c3.mov


