### PR TITLE
Update `StickyVideo` button styles

### DIFF
--- a/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
@@ -35,10 +35,10 @@ const buttonStyles = css`
 // to click the close video button more easily
 const hoverAreaStyles = css`
 	position: absolute;
-	top: 0;
+	top: -4px;
 	bottom: 0;
-	left: -36px;
-	width: 36px;
+	left: -${32 * 1.15}px;
+	width: ${32 * 1.15}px;
 
 	&:hover button {
 		display: flex;

--- a/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyVideo.importable.tsx
@@ -1,14 +1,48 @@
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from, neutral } from '@guardian/source-foundations';
+import { SvgCross } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import { getZIndex } from '../lib/getZIndex';
 import { useIsInView } from '../lib/useIsInView';
 
 const buttonStyles = css`
 	position: absolute;
-	left: 0;
+	left: -36px;
 	top: 0;
 	${getZIndex('sticky-video-button')};
+	background-color: ${neutral[7]};
+	height: 32px;
+	width: 32px;
+	border-radius: 50%;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	display: none;
+	justify-content: center;
+	align-items: center;
+	transition: transform 0.2s;
+
+	&:hover {
+		transform: scale(1.15);
+	}
+
+	svg {
+		fill: ${neutral[100]};
+	}
+`;
+
+// This extended hover area allows users
+// to click the close video button more easily
+const hoverAreaStyles = css`
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: -36px;
+	width: 36px;
+
+	&:hover button {
+		display: flex;
+	}
 `;
 
 const stickyStyles = css`
@@ -26,9 +60,17 @@ const stickyStyles = css`
 
 	position: fixed;
 	bottom: 20px;
-	width: 300px;
+	width: 216px;
 	${getZIndex('sticky-video')};
 	animation: fade-in-up 1s ease both;
+
+	&:hover button {
+		display: flex;
+	}
+
+	${from.tablet} {
+		width: 300px;
+	}
 
 	figcaption {
 		display: none;
@@ -65,12 +107,13 @@ export const StickyVideo = ({ isPlaying, children }: Props) => {
 	return (
 		<div ref={setRef} css={isSticky && stickyContainerStyles(192)}>
 			<div css={isSticky && stickyStyles}>
+				<span css={hoverAreaStyles} />
 				{isSticky && (
 					<button
 						css={buttonStyles}
 						onClick={() => setIsSticky(false)}
 					>
-						Unstick
+						<SvgCross size="medium" />
 					</button>
 				)}
 				{children}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Expanding on the `<StickyVideo />` component created [here](https://github.com/guardian/dotcom-rendering/pull/3992), this PR styles the close video button correctly, adding a `<SvgCross />` from Source and adding a hover state which zooms the button to 115% in keeping with the play button on the `YoutubeAtom`.

On @benwuersching 's recommendation we've also added an additional `<span />` to the left of the video component when it is sticking to provide an extra hover area, this makes it easier for users to click the button without the hover state reseting. See below.

<img width="300" alt="Screenshot 2022-02-23 at 13 12 53" src="https://user-images.githubusercontent.com/77005274/155337999-2aa4feb5-d495-46ca-b8c7-869ca0762de5.png">



### Before

<img width="300" alt="Screenshot 2022-02-23 at 14 22 35" src="https://user-images.githubusercontent.com/77005274/155338051-4b44838c-680e-4f0b-bd77-a53d46c91a74.png">


### After
<img width="300" alt="Screenshot 2022-02-23 at 14 20 21" src="https://user-images.githubusercontent.com/77005274/155338040-1619ed6b-d509-4622-83cf-072cc78bf4c3.png">

### Video

https://user-images.githubusercontent.com/77005274/155339473-c63539dd-ec38-41ac-85f7-20aaef9dd536.mov

