### PR TITLE
Remove Babel From AR Jest Config

### DIFF
--- a/apps-rendering/config/jest.config.js
+++ b/apps-rendering/config/jest.config.js
@@ -27,14 +27,6 @@ module.exports = {
 	globalSetup: './config/jestglobalSetup.js',
 	globals: {
 		'ts-jest': {
-			babelConfig: {
-				presets: [
-					[
-						'@babel/preset-env',
-						{ targets: { node: '12' }, modules: 'cjs' },
-					],
-				],
-			},
 			tsconfig: 'config/tsconfig.test.json',
 		},
 	},

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -70,7 +70,6 @@
     "@typescript-eslint/parser": "^4.31.2",
     "aws-cdk": "1.132.0",
     "aws-sdk": "^2.995.0",
-    "babel-jest": "^26.6.2",
     "babel-loader": "^8.2.2",
     "buffer": "^6.0.3",
     "clean-css": "^5.2.0",


### PR DESCRIPTION
## Why?

I think Babel existed in our Jest config solely to transpile ES modules for Node. Now that we're on Node 14, which has support for ES modules, this is no longer needed.

## Changes

- Removed the babel-specific parts of our Jest config
- Removed `babel-jest` from our direct dependencies
