### PR TITLE
Add `SpacefinderOkr4ListItems` test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -12,6 +12,7 @@ import { tests } from '../experiments/ab-tests';
 import { spacefinderOkr1FilterNearby } from '../experiments/tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from '../experiments/tests/spacefinder-okr-2-images-loaded';
 import { spacefinderOkr3RichLinks } from '../experiments/tests/spacefinder-okr-3-rich-links';
+import { spacefinderOkr4ListItems } from '../experiments/tests/spacefinder-okr-4-list-items';
 
 type Props = {
 	enabled: boolean;
@@ -36,6 +37,7 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 			spacefinderOkr1FilterNearby,
 			spacefinderOkr2ImagesLoaded,
 			spacefinderOkr3RichLinks,
+			spacefinderOkr4ListItems,
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -9,6 +9,7 @@ import {
 import { spacefinderOkr1FilterNearby } from './tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from './tests/spacefinder-okr-2-images-loaded';
 import { spacefinderOkr3RichLinks } from './tests/spacefinder-okr-3-rich-links';
+import { spacefinderOkr4ListItems } from './tests/spacefinder-okr-4-list-items';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	spacefinderOkr1FilterNearby,
 	spacefinderOkr2ImagesLoaded,
 	spacefinderOkr3RichLinks,
+	spacefinderOkr4ListItems,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-4-list-items.ts
+++ b/dotcom-rendering/src/web/experiments/tests/spacefinder-okr-4-list-items.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const spacefinderOkr4ListItems: ABTest = {
+	id: 'SpacefinderOkr4ListItems',
+	author: 'Simon Byford (@simonbyford)',
+	start: '2022-03-07',
+	expiry: '2022-04-01',
+	audience: 10 / 100,
+	audienceOffset: 50 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Fixing the bug leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Check whether considering list items as candidates in spacefinder leads to an increase in inline programmatic revenue per 1000 pageviews',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Introduces an A/B test in DCR which can be used to measure the impact of this change: https://github.com/guardian/frontend/pull/24712

## Why?

The test definition must exist in both frontend and DCR