### PR TITLE
Add more stories to the Standard Display section in Storybook (AR Layouts)

### DIFF
--- a/apps-rendering/src/components/layout/standard.stories.tsx
+++ b/apps-rendering/src/components/layout/standard.stories.tsx
@@ -11,8 +11,14 @@ import {
 	article,
 	comment,
 	editorial,
+	feature,
+	interview,
 	letter,
 	matchReport,
+	photoEssay,
+	printShop,
+	quiz,
+	recipe,
 	review,
 } from 'fixtures/item';
 import { deadBlog, live } from 'fixtures/live';
@@ -69,6 +75,78 @@ export const MatchReport = (): React.ReactNode => {
 	);
 };
 MatchReport.story = { name: 'Match Report' };
+
+export const PrintShop = (): React.ReactNode => {
+	return (
+		<Standard item={printShop}>
+			{renderAll(
+				formatFromItem(printShop, some(ArticleDisplay.Standard)),
+				partition(printShop.body).oks,
+			)}
+		</Standard>
+	);
+};
+PrintShop.story = { name: 'PrintShop' };
+
+export const PhotoEssay = (): React.ReactNode => {
+	return (
+		<Standard item={photoEssay}>
+			{renderAll(
+				formatFromItem(photoEssay, some(ArticleDisplay.Standard)),
+				partition(photoEssay.body).oks,
+			)}
+		</Standard>
+	);
+};
+PhotoEssay.story = { name: 'Photo Essay' };
+
+export const Feature = (): React.ReactNode => {
+	return (
+		<Standard item={feature}>
+			{renderAll(
+				formatFromItem(feature, some(ArticleDisplay.Standard)),
+				partition(feature.body).oks,
+			)}
+		</Standard>
+	);
+};
+Feature.story = { name: 'Feature' };
+
+export const Interview = (): React.ReactNode => {
+	return (
+		<Standard item={interview}>
+			{renderAll(
+				formatFromItem(interview, some(ArticleDisplay.Standard)),
+				partition(interview.body).oks,
+			)}
+		</Standard>
+	);
+};
+Interview.story = { name: 'Interview' };
+
+export const Quiz = (): React.ReactNode => {
+	return (
+		<Standard item={quiz}>
+			{renderAll(
+				formatFromItem(quiz, some(ArticleDisplay.Standard)),
+				partition(quiz.body).oks,
+			)}
+		</Standard>
+	);
+};
+Quiz.story = { name: 'Quiz' };
+
+export const Recipe = (): React.ReactNode => {
+	return (
+		<Standard item={recipe}>
+			{renderAll(
+				formatFromItem(recipe, some(ArticleDisplay.Standard)),
+				partition(recipe.body).oks,
+			)}
+		</Standard>
+	);
+};
+Recipe.story = { name: 'Recipe' };
 
 export const CommentItem = (): React.ReactNode => {
 	return (

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -22,6 +22,7 @@ import type { Image } from 'image';
 import type {
 	Comment,
 	Editorial,
+	Feature,
 	Interview,
 	Item,
 	Letter,
@@ -364,7 +365,7 @@ const analysis: Standard = {
 	...fields,
 };
 
-const feature: Standard = {
+const feature: Feature = {
 	design: ArticleDesign.Feature,
 	...fields,
 };

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -22,9 +22,14 @@ import type { Image } from 'image';
 import type {
 	Comment,
 	Editorial,
+	Interview,
 	Item,
 	Letter,
 	MatchReport,
+	PhotoEssay,
+	PrintShop,
+	Quiz,
+	Recipe,
 	Review,
 	Standard,
 } from 'item';
@@ -359,7 +364,7 @@ const analysis: Standard = {
 	...fields,
 };
 
-const feature: Item = {
+const feature: Standard = {
 	design: ArticleDesign.Feature,
 	...fields,
 };
@@ -395,7 +400,7 @@ const editorial: Editorial = {
 	theme: ArticlePillar.Opinion,
 };
 
-const interview: Item = {
+const interview: Interview = {
 	design: ArticleDesign.Interview,
 	...fields,
 };
@@ -424,6 +429,29 @@ const correction: Item = {
 	design: ArticleDesign.Correction,
 	...fields,
 };
+
+const printShop: PrintShop = {
+	design: ArticleDesign.PrintShop,
+	...fields,
+};
+
+const photoEssay: PhotoEssay = {
+	design: ArticleDesign.PhotoEssay,
+	...fields,
+};
+
+const recipe: Recipe = {
+	design: ArticleDesign.Recipe,
+	...fields,
+	theme: ArticlePillar.Lifestyle,
+};
+
+const quiz: Quiz = {
+	design: ArticleDesign.Quiz,
+	...fields,
+	theme: ArticlePillar.Sport,
+};
+
 // ----- Exports ----- //
 
 export {
@@ -441,4 +469,8 @@ export {
 	matchReport,
 	cartoon,
 	correction,
+	printShop,
+	photoEssay,
+	recipe,
+	quiz,
 };

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -126,7 +126,33 @@ interface Correction extends Fields {
 	design: ArticleDesign.Correction;
 	body: Body;
 }
+interface Interview extends Fields {
+	design: ArticleDesign.Interview;
+	body: Body;
+}
 
+interface Quiz extends Fields {
+	design: ArticleDesign.Quiz;
+	body: Body;
+}
+interface Recipe extends Fields {
+	design: ArticleDesign.Recipe;
+	body: Body;
+}
+
+interface Feature extends Fields {
+	design: ArticleDesign.Feature;
+	body: Body;
+}
+interface PhotoEssay extends Fields {
+	design: ArticleDesign.PhotoEssay;
+	body: Body;
+}
+
+interface PrintShop extends Fields {
+	design: ArticleDesign.PrintShop;
+	body: Body;
+}
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each ArticleDesign type.
 interface Standard extends Fields {
@@ -467,6 +493,12 @@ export {
 	ResizedRelatedContent,
 	Letter,
 	Editorial,
+	Interview,
+	Recipe,
+	Quiz,
+	PhotoEssay,
+	Feature,
+	PrintShop,
 	fromCapi,
 	fromCapiLiveBlog,
 	getFormat,


### PR DESCRIPTION
## Why?

More stories to capture Standard display options.
DCR stories include `NumberedList`, `Labs` and `SpecialReport` which I didn't include in this PR because `NumberedList` is a Display type separate from Standard, and `Labs` and `SpecialReports` are special themes.

A note on the possibly redundant interfaces that I defined in `item.ts`.
I'm aware that this interface is supposed to capture all the Design types  not included in the `Exclude` type:
```typescript
interface Standard extends Fields {
	design: Exclude<
		ArticleDesign,
		| ArticleDesign.LiveBlog
		| ArticleDesign.DeadBlog
		| ArticleDesign.Review
		| ArticleDesign.Comment
		| ArticleDesign.Letter
		| ArticleDesign.Editorial
	>;
	body: Body;
}
```

**However**, fixtures are defined as being of type `Item`, which is a union type of the following:

```typescript
type Item =
	| LiveBlog
	| DeadBlog
	| Review
	| Comment
	| Standard  // <----- this is the interface above
	| Interactive
	| MatchReport
	| Letter
	| Obituary
	| Editorial
	| Correction;
```

This isn't a problem per se, but the `<Standard>` layout component (which I used to render most of these stories) accepts an `item` of type `Standard | Review | MatchReport`, which throws a bunch of TypeScript errors. For instance, passing the `quiz` fixture to `Standard`  causes the following errors: `Type 'LiveBlog' is not assignable to type 'Review | Standard | MatchReport'`, `Argument of type 'unknown[]' is not assignable to parameter of type 'BodyElement[]'`.

The workaround is to define a `Quiz` interface explicitly instead of falling back to `Standard`. This isn't a new idea and there are more example of this in `item.ts` so I just followed that example. 

### Screenshot

![image](https://user-images.githubusercontent.com/57295823/156385117-8688eb8a-3a28-453e-872b-60a31dfd28e8.png)

