### PR TITLE
Identity | Sign In Gate | Make dismiss button accessible through keyboard

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { LinkButton, Link } from '@guardian/source-react-components';
+import { LinkButton, Link, Button } from '@guardian/source-react-components';
 import { cmp } from '@guardian/consent-management-platform';
 import {
 	headline,
@@ -338,7 +338,7 @@ export const SignInGateFakeSocial = ({
 					Register for free
 				</LinkButton>
 
-				<LinkButton
+				<Button
 					data-cy="sign-in-gate-fake-social_dismiss"
 					data-ignore="global-link-styling"
 					css={laterButton}
@@ -350,7 +350,7 @@ export const SignInGateFakeSocial = ({
 					}}
 				>
 					I’ll do it later
-				</LinkButton>
+				</Button>
 			</div>
 
 			<p css={[bodySeparator, bodyBold, signInHeader, bodyPadding]}>

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -1,4 +1,4 @@
-import { LinkButton, Link } from '@guardian/source-react-components';
+import { LinkButton, Link, Button } from '@guardian/source-react-components';
 import { cmp } from '@guardian/consent-management-platform';
 
 import { trackLink } from '../componentEventTracking';
@@ -70,7 +70,7 @@ export const SignInGateMain = ({
 					Register for free
 				</LinkButton>
 				{!isMandatory && (
-					<LinkButton
+					<Button
 						data-cy="sign-in-gate-main_dismiss"
 						data-ignore="global-link-styling"
 						css={laterButton}
@@ -82,7 +82,7 @@ export const SignInGateMain = ({
 						}}
 					>
 						I’ll do it later
-					</LinkButton>
+					</Button>
 				)}
 			</div>
 


### PR DESCRIPTION
## Why?
Within the sign in gate, the "I'll do it later" button link was not accessible through keyboard commands. This is frustrating for keyboard only users as they do not have the ability to interact with the link, dismiss the gate, and the sign in gate will remain present.

We solve this by changing the component from a `LinkButton` to a `Button`, which makes it focusable and interactable via keyboard.

### Before
https://user-images.githubusercontent.com/13315440/156404096-ffacd475-d774-4aa2-817d-ca2b81780fa1.mov

### After
https://user-images.githubusercontent.com/13315440/156403145-4fc2ca76-dca4-4045-8eda-78bf39ac2cf7.mov
