### PR TITLE
Move `vm2` Into `aws-cdk` Transitive Deps

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -7818,6 +7818,16 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b",
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
         "agent-base": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
@@ -9730,6 +9740,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "vm2": {
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
+          "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
+          "requires": {
+            "acorn": "^8.7.0",
+            "acorn-walk": "^8.2.0"
+          }
         },
         "word-wrap": {
           "version": "1.2.3",
@@ -19312,27 +19331,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "vm2": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
-      "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
-        },
-        "acorn-walk": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
-        }
-      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",


### PR DESCRIPTION
## Why?

Running `npm i` on local machines seems to cause our `package-lock.json` to revert to an older version of `vm2`. It's essentially reverting #4124.

My theory is that `aws-cdk` uses a `npm-shrinkwrap.json` file to specify exact versions of its dependencies. `vm2` is a transitive dependency of `aws-cdk` a few levels deep. It's actually specified using a `^`, so in theory a more recent version should be allowed, but the shrinkwrap is pinned to an older version as mentioned.

Usage of shrinkwrap files in published packages is quite rare (I think this is the only instance of one across all our top-level dependencies). The docs state that (https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json):

> The recommended use-case for npm-shrinkwrap.json is applications deployed through the publishing process on the registry: for example, daemons and command-line tools intended as global installs or devDependencies. It's strongly discouraged for library authors to publish this file, since that would prevent end users from having control over transitive dependency updates.

This transitive dependency issue is what we're seeing here.

### The Workaround

I believe I've managed to get a more recent version of `vm2` pinned without `npm i` reverting it in this PR. I'm not sure this is intended behaviour; my understanding of shrinkwraps is that they're meant to _prevent_ this from happening. However, it does work on at least two different local machines.

**Note:** I achieved this by running the following commands:

```sh
npm upgrade --depth=5 degenerator
npm i
```

### Longer Term Solution

All that said, I think the long-term solution would be to update `aws-cdk` to a more recent version that has updated dependencies specified in its shrinkwrap file. Or possibly even to a version that doesn't use shrinkwrap any more - I can't see one being used in version `1.147.0` (the latest version in the 1.x series) for example.

As @akash1810 mentioned in https://github.com/guardian/dotcom-rendering/pull/4123#pullrequestreview-896590217 this isn't something we're able to do on our own in this project. We'll need GuCDK to update first before we make the changes here, so that the versions remain in sync.

cc @guardian/devx-operations 

### A Note On Yarn

It's possible that the behaviour will be different in Yarn-based projects, as it seems Yarn doesn't support shrinkwraps: https://classic.yarnpkg.com/lang/en/docs/migrating-from-npm/

## Changes

- Used `npm` to pull `vm2` into `aws-cdk`'s transitive deps in the lockfile
