### PR TITLE
chore(deps): bump @guardian/consent-management-platform from 10.1.2 to 10.2.2

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@guardian/atoms-rendering": "^22.3.0",
     "@guardian/braze-components": "6.0.0",
     "@guardian/commercial-core": "^3.0.0",
-    "@guardian/consent-management-platform": "^10.1.2",
+    "@guardian/consent-management-platform": "^10.2.2",
     "@guardian/discussion-rendering": "^9.1.1",
     "@guardian/libs": "^3.4.1",
     "@guardian/prettier": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,10 +2819,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.0.0.tgz#8b2040e89b4dd8e317563938552776da4ced5bee"
   integrity sha512-wB3y5p6eyuuekEK27S4OZ8vnVRMJ1tcHwi1SwmfIsYNEZLwYJRv3UxsLlTEeUmH8YAnYNgIEzJ390GfQ8iaVeA==
 
-"@guardian/consent-management-platform@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.2.tgz#f7ea2ce14c1ee9c5822c8f0fe34aec006adfda89"
-  integrity sha512-2rJxMIqAekwWxerxscWai4pbEnOnmf1rrPO5kawLlkppv9AKMS+KpK+9/C8vqqHBC2Niat5JpT845IJJUYv4CA==
+"@guardian/consent-management-platform@^10.2.2":
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.2.2.tgz#bffa22192c68b308574d6c6abfb22277058d3e32"
+  integrity sha512-lLdVTrDhxtf9BC3S2PNLMJf7/cR0Zo5RnfstWaynGerwOILwM8Ppl5xdHX/i6RdZrt2O4Z7GuB6mxhNAeAw27A==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

Bumps the CMP to 10.122 to incorporate changes from:
- https://github.com/guardian/consent-management-platform/pull/560
- https://github.com/guardian/consent-management-platform/pull/559

## Why?

Stays up to date with the most current version of the CMP. 

10.2.2 makes using the CMP server-safe, hopefully removing the need for:
- https://github.com/guardian/dotcom-rendering/pull/4106
- https://github.com/guardian/dotcom-rendering/pull/3925
