### PR TITLE
Bump @guardian/braze-components to v6.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.3.0",
-    "@guardian/braze-components": "6.0.0",
+    "@guardian/braze-components": "^6.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.1.2",
     "@guardian/discussion-rendering": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-6.0.0.tgz#031515e7ee5db8c96e42ace0b9a89bb8b1020219"
-  integrity sha512-oQf1TqrQM1DomUI1LwzWYlgj029vTgLYjIFAANgOoOJ6v5bDB71kAR0b3IGPCiZmmUR+dePWzYye4fwBXW8uUA==
+"@guardian/braze-components@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-6.1.0.tgz#11e4414ed15fbd16ac005dab60c42383b913dbec"
+  integrity sha512-26dRs/zXoYXz9Ov54GRhhEB1wiB2+iAnxc+HYRmsb/tOjcyxu/YkyhFnPgHgZUX8F7y2IuB7TBx7nNGONjWYgQ==
 
 "@guardian/commercial-core@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps `@guardian/braze-components` to v6.1.0.

## Why?

This release contains an icon change and the wiring up of click tracking for the newsletter epic components.