### PR TITLE
Simplify `getZIndex`

### DIFF
--- a/dotcom-rendering/src/web/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/web/layouts/lib/stickiness.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import { getZIndex, getZIndexImportant } from '../../lib/getZIndex';
+import { getZIndex, getZIndexImportant, ZIndex } from '../../lib/getZIndex';
 
 type Props = {
 	children?: React.ReactNode;
@@ -8,7 +8,7 @@ type Props = {
 
 type StuckProps = {
 	children?: React.ReactNode;
-	zIndex?: string;
+	zIndex?: ZIndex;
 };
 
 const stickyStyles = css`
@@ -16,7 +16,7 @@ const stickyStyles = css`
 	top: 0;
 `;
 
-const addZindex = (zIndex = 'stickyAdWrapper') => css`
+const addZindex = (zIndex: ZIndex = 'stickyAdWrapper') => css`
 	${getZIndex(zIndex)}
 `;
 

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -69,16 +69,10 @@ const indices = [
 // Implementation code - you don't need to change this to get a new index
 export type ZIndex = typeof indices[number];
 
-function reverseArray(array: any[]) {
-	return array.map((item, index) => array[array.length - 1 - index]);
-}
-
-const decideIndex = (name: string): number | null => {
-	let decided;
-	reverseArray(indices).forEach((item, index) => {
-		if (item === name) decided = index + 1;
-	});
-	return decided || null;
+const decideIndex = (name: ZIndex): number | null => {
+	const index = indices.indexOf(name);
+	if (index === -1) return null; // indexOf returns -1 if there is no match
+	return indices.length - index; // reverse the indices: last item gets 1
 };
 
 export const getZIndex = (zIndex: ZIndex): string =>

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -64,11 +64,10 @@ const indices = [
 
 	// Main media
 	'mainMedia',
-];
+] as const;
 
-//
-// Implementation code  - you don't need to change this to get a new index
-type ZIndex = typeof indices[number];
+// Implementation code - you don't need to change this to get a new index
+export type ZIndex = typeof indices[number];
 
 function reverseArray(array: any[]) {
 	return array.map((item, index) => array[array.length - 1 - index]);


### PR DESCRIPTION
## What does this change?

Refactor and simplify `getZIndex`.

Use the `test.each` pattern in Jest, to get more precise errors when something fails.

## Why?

Less code, no array mutation & pure maths!

### Before

![before](https://user-images.githubusercontent.com/76776/156804273-568c2195-0e73-419c-bb51-d6625d52186f.png)

### After

![fater](https://user-images.githubusercontent.com/76776/156804240-7d38d3a5-e163-485f-b87c-e647ab58f0f9.png)
