### PR TITLE
Add pagination component to LiveBlogs on AR

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -4,6 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
 import KeyEvents from '@guardian/common-rendering/src/components/keyEvents';
+import { Pagination } from '@guardian/common-rendering/src/components/Pagination';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, news, remSpace } from '@guardian/source-foundations';
@@ -17,6 +18,7 @@ import RelatedContent from 'components/relatedContent';
 import Tags from 'components/tags';
 import HeaderMedia from 'headerMedia';
 import type { DeadBlog, LiveBlog } from 'item';
+import { toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { articleWidthStyles, onwardStyles } from 'styles';
@@ -102,42 +104,60 @@ interface Props {
 	item: LiveBlog | DeadBlog;
 }
 
-const Live: FC<Props> = ({ item }) => (
-	<article className="js-article">
-		<LiveblogHeader item={item} />
-		<main css={mainStyles}>
-			<GridItem area="metadata">
-				<div css={metadataWrapperStyles(item)}>
-					<Metadata item={item} />
-				</div>
-			</GridItem>
-			<GridItem area="key-events">
-				<div css={keyEventsWrapperStyles}>
-					<KeyEvents
-						keyEvents={keyEvents(item.blocks)}
+const Live: FC<Props> = ({ item }) => {
+	const pagination = (
+		<Pagination
+			format={item}
+			currentPage={item.pagedBlocks.currentPage.pageNumber}
+			totalPages={item.pagedBlocks.pagination.numberOfPages}
+			newest={toNullable(item.pagedBlocks.pagination.newest)}
+			newer={toNullable(item.pagedBlocks.pagination.newer)}
+			oldest={toNullable(item.pagedBlocks.pagination.oldest)}
+			older={toNullable(item.pagedBlocks.pagination.older)}
+		/>
+	);
+	return (
+		<article className="js-article">
+			<LiveblogHeader item={item} />
+			<main css={mainStyles}>
+				<GridItem area="metadata">
+					<div css={metadataWrapperStyles(item)}>
+						<Metadata item={item} />
+					</div>
+				</GridItem>
+				<GridItem area="key-events">
+					<div css={keyEventsWrapperStyles}>
+						<KeyEvents
+							keyEvents={keyEvents(item.blocks)}
+							format={item}
+							supportsDarkMode
+						/>
+					</div>
+				</GridItem>
+				<GridItem area="main-media">
+					<HeaderMedia item={item} />
+				</GridItem>
+				<GridItem area="live-blocks">
+					{item.pagedBlocks.currentPage.pageNumber > 1 && pagination}
+					<LiveBlocks
+						blocks={item.pagedBlocks.currentPage.blocks}
 						format={item}
-						supportsDarkMode
 					/>
-				</div>
-			</GridItem>
-			<GridItem area="main-media">
-				<HeaderMedia item={item} />
-			</GridItem>
-			<GridItem area="live-blocks">
-				<LiveBlocks blocks={item.blocks} format={item} />
-			</GridItem>
-		</main>
-		<section css={articleWidthStyles}>
-			<Tags tags={item.tags} format={item} />
-		</section>
-		<section css={onwardStyles}>
-			<RelatedContent content={item.relatedContent} />
-		</section>
-		<section css={articleWidthStyles}>
-			<Footer isCcpa={false} />
-		</section>
-	</article>
-);
+					{pagination}
+				</GridItem>
+			</main>
+			<section css={articleWidthStyles}>
+				<Tags tags={item.tags} format={item} />
+			</section>
+			<section css={onwardStyles}>
+				<RelatedContent content={item.relatedContent} />
+			</section>
+			<section css={articleWidthStyles}>
+				<Footer isCcpa={false} />
+			</section>
+		</article>
+	);
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/pagination.test.ts
+++ b/apps-rendering/src/pagination.test.ts
@@ -209,8 +209,8 @@ describe('pagination', () => {
 
 			it('should return expected pagination object', () => {
 				const expectedPagination: Pagination = {
-					newer: some(''),
-					newest: some(''),
+					newer: some('?page=with:block-0'),
+					newest: some('?page=with:block-0'),
 					older: none,
 					oldest: none,
 					numberOfPages: 2,
@@ -237,8 +237,8 @@ describe('pagination', () => {
 
 			it('should return expected pagination object', () => {
 				const expectedPagination: Pagination = {
-					newer: some(''),
-					newest: some(''),
+					newer: some('?page=with:block-0'),
+					newest: some('?page=with:block-0'),
 					older: some(`?page=with:block-24`),
 					oldest: some(`?page=with:block-34`),
 					numberOfPages: 4,
@@ -267,7 +267,7 @@ describe('pagination', () => {
 		it('should return expected pagination object', () => {
 			const expectedPagination: Pagination = {
 				newer: some(`?page=with:block-14`),
-				newest: some(''),
+				newest: some('?page=with:block-0'),
 				older: some(`?page=with:block-34`),
 				oldest: some(`?page=with:block-44`),
 				numberOfPages: 5,
@@ -295,7 +295,7 @@ describe('pagination', () => {
 		it('should return expected pagination object', () => {
 			const expectedPagination: Pagination = {
 				newer: some(`?page=with:block-24`),
-				newest: some(''),
+				newest: some('?page=with:block-0'),
 				older: some(`?page=with:block-44`),
 				oldest: some(`?page=with:block-44`),
 				numberOfPages: 5,
@@ -325,7 +325,7 @@ describe('pagination', () => {
 				older: none,
 				oldest: none,
 				newer: some(`?page=with:block-34`),
-				newest: some(''),
+				newest: some('?page=with:block-0'),
 				numberOfPages: 5,
 			};
 

--- a/apps-rendering/src/pagination.ts
+++ b/apps-rendering/src/pagination.ts
@@ -98,20 +98,19 @@ const getNewerPage = (
 	pages: LiveBlock[][],
 	pageNumber: number,
 ): Option<string> => {
-	if (pageNumber > 2) {
+	if (pageNumber > 1) {
 		return maybePageRef(pageNumber - 2, pages);
-	}
-
-	if (pageNumber === 2) {
-		return some('');
 	}
 
 	return none;
 };
 
-const getNewestPage = (pageNumber: number): Option<string> => {
+const getNewestPage = (
+	pages: LiveBlock[][],
+	pageNumber: number,
+): Option<string> => {
 	if (pageNumber > 1) {
-		return some('');
+		return maybePageRef(0, pages);
 	}
 
 	return none;
@@ -183,7 +182,7 @@ export const getPagedBlocks = (
 		currentPage,
 		pagination: {
 			newer: getNewerPage(pages, currentPage.pageNumber),
-			newest: getNewestPage(currentPage.pageNumber),
+			newest: getNewestPage(pages, currentPage.pageNumber),
 			older: getOlderPage(pages, currentPage.pageNumber),
 			oldest: getOldestPage(pages, currentPage.pageNumber),
 			numberOfPages: pages.length,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the pagination component in `common-rendering` to Live layout in `apps-rendering` and switches the live blocks to the paginated list. Also fixed bug with links not redirecting to first page (a blank `href` on the link was not removing the query string params).

| **Before** | **After** |
|-----------|-----------|
|<img width="837" alt="image" src="https://user-images.githubusercontent.com/99400613/156604592-4b93dc8e-d3bc-40be-a716-59b9f071c08a.png"> | <img width="754" alt="image" src="https://user-images.githubusercontent.com/99400613/156604533-c0102121-0f0f-4084-9c03-3685d9ddf307.png"> |
| <img width="820" alt="image" src="https://user-images.githubusercontent.com/99400613/156602556-5283bc50-b4c5-485a-ae69-0b0b4e6316b8.png"> | <img width="757" alt="image" src="https://user-images.githubusercontent.com/99400613/156602442-1008c643-4798-4711-b6e2-56ad02d995d1.png"> |

