### PR TITLE
Ensure the block link is valid

### DIFF
--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import { joinUrl } from '@guardian/libs';
 import { renderArticleElement } from '../lib/renderElement';
 import { decidePalette } from '../lib/decidePalette';
 
@@ -24,13 +25,13 @@ export const LiveBlock = ({
 	pageId,
 	webTitle,
 	adTargeting,
-	host,
+	host = 'https://www.theguardian.com',
 	ajaxUrl,
 	isLiveUpdate,
 }: Props) => {
 	if (block.elements.length === 0) return null;
 	const palette = decidePalette(format);
-	const blockLink = `${pageId}#block-${block.id}`;
+	const blockLink = `${joinUrl(host, pageId)}#block-${block.id}`;
 
 	// Decide if the block has been updated or not
 	const showLastUpdated: boolean =


### PR DESCRIPTION
We were missing the leading slash before

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes an issue where the block timestamp was returning an incorrect permalink

### Before
<img width="389" alt="Screenshot 2022-03-03 at 16 47 40" src="https://user-images.githubusercontent.com/1336821/156611517-273def75-f23d-442c-a1f8-5270db7547c2.png">


### After
<img width="388" alt="Screenshot 2022-03-03 at 16 44 56" src="https://user-images.githubusercontent.com/1336821/156611521-3d56901c-8ee9-4284-a47b-90f5379d8211.png">

Closes #4166 