### PR TITLE
Use the same relative time format everywhere

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import { css } from "@emotion/react";
-import type { SerializedStyles } from "@emotion/react";
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
 import {
 	textSans,
 	headline,
@@ -13,17 +13,17 @@ import {
 	neutral,
 	remSpace,
 	from,
-} from "@guardian/source-foundations";
-import { Link } from "@guardian/source-react-components";
+} from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
 import {
 	ArticleFormat,
 	ArticlePillar,
 	ArticleTheme,
 	timeAgo,
-} from "@guardian/libs";
-import { darkModeCss } from "../lib";
-import Accordion from "./accordion";
-import { text } from "../editorialPalette";
+} from '@guardian/libs';
+import { darkModeCss } from '../lib';
+import Accordion from './accordion';
+import { text } from '../editorialPalette';
 
 // ----- Component ----- //
 type paletteId = 300 | 400 | 500;
@@ -61,7 +61,7 @@ const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
 };
 
 const keyEventWrapperStyles = (
-	supportsDarkMode: boolean
+	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	width: 100%;
 
@@ -77,7 +77,7 @@ const keyEventWrapperStyles = (
 
 const listStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	li::before {
-		content: "";
+		content: '';
 		display: block;
 		position: absolute;
 		top: 0;
@@ -117,9 +117,9 @@ const timeTextWrapperStyles: SerializedStyles = css`
 
 const textStyles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean
+	supportsDarkMode: boolean,
 ): SerializedStyles => css`
-	${headline.xxxsmall({ fontWeight: "regular", lineHeight: "regular" })};
+	${headline.xxxsmall({ fontWeight: 'regular', lineHeight: 'regular' })};
 	/* TODO update with Source value when it's added */
 	${from.desktop} {
 		font-size: 15px;
@@ -151,7 +151,7 @@ const textStyles = (
 `;
 
 const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	${textSans.xxsmall({ fontWeight: "bold", lineHeight: "tight" })};
+	${textSans.xxsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
 	display: block;
 	transform: translateY(-2.5px);

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -171,7 +171,7 @@ const ListItem = ({ keyEvent, format, supportsDarkMode }: ListItemProps) => {
 					title={keyEvent.date.toLocaleTimeString()}
 					css={timeStyles(supportsDarkMode)}
 				>
-					{timeAgo(keyEvent.date.getTime(), { verbose: true })}
+					{timeAgo(keyEvent.date.getTime())}
 				</time>
 				<Link
 					priority="secondary"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes an issue where we were using `verbose` format on the server but not on the client

## Why?
Because it was causing the content to flash with the wrong value on page load

### Before
![2022-03-04 09 23 08](https://user-images.githubusercontent.com/1336821/156736040-1654dc3c-ab94-4724-b0e8-48485762e7be.gif)


### After
![2022-03-04 09 18 34](https://user-images.githubusercontent.com/1336821/156735319-0e746fb2-13e2-47f2-bed3-0fa0a44c9c47.gif)

Closes #4157 