### PR TITLE
Pass through gu headers when fetching content

### DIFF
--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 
-async function getContentFromURL(_url) {
+async function getContentFromURL(_url, _headers) {
 	try {
 		if (!_url) {
 			throw new Error('The url query parameter is mandatory');
@@ -14,9 +14,20 @@ async function getContentFromURL(_url) {
 		// Reconstruct the parsed url adding .json?dcr which we need to force dcr to return json
 		const jsonUrl = `${url.origin}${url.pathname}.json?dcr=true&${searchparams}`;
 
-		const { html, ...config } = await fetch(jsonUrl).then((article) =>
-			article.json(),
-		);
+		// Explicitly pass through GU headers - this enables us to override properties such as region in CI
+		let guHeaders = {};
+		if (_headers) {
+			guHeaders = Object.keys(_headers)
+				.filter((key) => key.toLowerCase().startsWith('x-gu-'))
+				.reduce((result, key) => {
+					result[key] = _headers[key];
+					return result;
+				}, {});
+		}
+
+		const { html, ...config } = await fetch(jsonUrl, {
+			headers: guHeaders,
+		}).then((article) => article.json());
 
 		return config;
 	} catch (error) {
@@ -55,7 +66,7 @@ exports.getContentFromURLMiddleware = async (req, res, next) => {
 		if (req.path.startsWith('/AMP')) {
 			url = url.replace('www', 'amp');
 		}
-		req.body = await getContentFromURL(url);
+		req.body = await getContentFromURL(url, req.headers);
 	}
 	next();
 };


### PR DESCRIPTION
## What does this change?
For CI we may want to override the edition (e.g. force a specific edition of an article to load regardless of server location). We previously couldn't do this because only the url was being extracted from the request. This change extracts and forwards GU headers.

## Why?
We were testing click events in labs articles (https://github.com/guardian/dotcom-rendering/pull/4098) and needed to guarantee a specific article edition. When testing locally the cypress tests passed (edition = UK, so tests passed), but on CI they failed (edition != UK, tests failed). We couldn't find a way to force CI to load articles for a given edition.

To force articles to render for a specific edition you can set a header:
`'x-gu-geolocation': 'ip.dummytext,country:UK'` 

However, this had no effect in CI because only the URL is extracted from the request.

### Before
On `cy.visit(url, { headers :  { 'x-gu-geolocation': 'ip.dummytext,country:UK' } })` the article edition defaults to the server geo location (header is ignored).

### After
On `cy.visit(url, { headers :  { 'x-gu-geolocation': 'ip.dummytext,country:UK' } })` the article edition defaults to the value in the header.
