### PR TITLE
Less props passed to ABProvider

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -6,7 +6,7 @@ import {
 import { getCookie } from '@guardian/libs';
 import { useAB } from '@guardian/ab-react';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
-import { WithABProvider } from './WithABProvider';
+import { ABProps, WithABProvider } from './WithABProvider';
 import { useOnce } from '../lib/useOnce';
 import { tests } from '../experiments/ab-tests';
 import { spacefinderOkr3RichLinks } from '../experiments/tests/spacefinder-okr-3-rich-links';
@@ -14,9 +14,6 @@ import { spacefinderOkrMegaTest } from '../experiments/tests/spacefinder-okr-meg
 
 type Props = {
 	enabled: boolean;
-	switches: Switches;
-	isSensitive: boolean;
-	isDev?: boolean;
 };
 
 const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
@@ -67,13 +64,13 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 
 export const CommercialMetrics = ({
 	enabled,
-	switches,
-	isSensitive,
+	abTestSwitches,
+	pageIsSensitive,
 	isDev,
-}: Props) => (
+}: Props & ABProps) => (
 	<WithABProvider
-		abTestSwitches={switches}
-		pageIsSensitive={isSensitive}
+		abTestSwitches={abTestSwitches}
+		pageIsSensitive={pageIsSensitive}
 		isDev={!!isDev}
 	>
 		<CommercialMetricsWithAB enabled={enabled} />

--- a/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
@@ -35,7 +35,7 @@ describe('MostViewedFooterData', () => {
 					display: ArticleDisplay.Standard,
 				})}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 			/>,
@@ -74,7 +74,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				})}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 			/>,
@@ -109,7 +109,7 @@ describe('MostViewedFooterData', () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				})}
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
@@ -155,7 +155,7 @@ describe('MostViewedFooterData', () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				})}
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
@@ -200,7 +200,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				})}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 			/>,
@@ -221,7 +221,7 @@ describe('MostViewedFooterData', () => {
 					theme: ArticlePillar.News,
 				})}
 				ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-				switches={{}}
+				abTestSwitches={{}}
 				pageIsSensitive={false}
 				isDev={false}
 			/>,

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -10,18 +10,12 @@ import { decideTrail } from '../lib/decideTrail';
 import { MostViewedFooterGrid } from './MostViewedFooterGrid';
 import { MostViewedFooterSecondTierItem } from './MostViewedFooterSecondTierItem';
 import { abTestTest } from '../experiments/tests/ab-test-test';
-import { WithABProvider } from './WithABProvider';
+import { ABProps, WithABProvider } from './WithABProvider';
 
-interface WithABProps {
+interface Props {
 	sectionName?: string;
 	palette: Palette;
 	ajaxUrl: string;
-}
-
-interface Props extends WithABProps {
-	switches: Switches;
-	pageIsSensitive: boolean;
-	isDev?: boolean;
 }
 
 const stackBelow = (breakpoint: Breakpoint) => css`
@@ -63,7 +57,7 @@ const MostViewedFooterDataWithAB = ({
 	sectionName,
 	palette,
 	ajaxUrl,
-}: WithABProps) => {
+}: Props) => {
 	// Example usage of AB Tests
 	// Used in the Cypress tests as smoke test of the AB tests framework integration
 	const ABTestAPI = useAB();
@@ -131,12 +125,12 @@ export const MostViewedFooterData = ({
 	sectionName,
 	palette,
 	ajaxUrl,
-	switches,
+	abTestSwitches,
 	pageIsSensitive,
 	isDev,
-}: Props) => (
+}: Props & ABProps) => (
 	<WithABProvider
-		abTestSwitches={switches}
+		abTestSwitches={abTestSwitches}
 		pageIsSensitive={pageIsSensitive}
 		isDev={!!isDev}
 	>

--- a/dotcom-rendering/src/web/components/MostViewedFooterLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterLayout.stories.tsx
@@ -61,7 +61,7 @@ export const withTwoTabs = () => {
 						}}
 						sectionName="politics"
 						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-						switches={{}}
+						abTestSwitches={{}}
 						pageIsSensitive={false}
 						isDev={false}
 					/>
@@ -89,7 +89,7 @@ export const withOneTabs = () => {
 							theme: ArticlePillar.News,
 						}}
 						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-						switches={{}}
+						abTestSwitches={{}}
 						pageIsSensitive={false}
 						isDev={false}
 					/>
@@ -117,7 +117,7 @@ export const withNoMostSharedImage = () => {
 							theme: ArticlePillar.News,
 						}}
 						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-						switches={{}}
+						abTestSwitches={{}}
 						pageIsSensitive={false}
 						isDev={false}
 					/>

--- a/dotcom-rendering/src/web/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterLayout.tsx
@@ -7,6 +7,7 @@ import { MostViewedFooterData } from './MostViewedFooterData.importable';
 import { AdSlot, labelStyles } from './AdSlot';
 import { decidePalette } from '../lib/decidePalette';
 import { Island } from './Island';
+import { ABProps } from './WithABProvider';
 
 const stackBelow = (breakpoint: Breakpoint) => css`
 	display: flex;
@@ -63,19 +64,16 @@ interface Props {
 	sectionName?: string;
 	format: ArticleFormat;
 	ajaxUrl: string;
-	switches: Switches;
-	pageIsSensitive: boolean;
-	isDev?: boolean;
 }
 
 export const MostViewedFooterLayout = ({
 	sectionName,
 	format,
 	ajaxUrl,
-	switches,
+	abTestSwitches,
 	pageIsSensitive,
 	isDev,
-}: Props) => {
+}: Props & ABProps) => {
 	const palette = decidePalette(format);
 
 	return (
@@ -113,9 +111,9 @@ export const MostViewedFooterLayout = ({
 								sectionName={sectionName}
 								palette={palette}
 								ajaxUrl={ajaxUrl}
-								switches={switches}
+								abTestSwitches={abTestSwitches}
 								pageIsSensitive={pageIsSensitive}
-								isDev={isDev}
+								isDev={!!isDev}
 							/>
 						</Island>
 					</div>

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -7,6 +7,7 @@ import { DecideLayout } from '../layouts/DecideLayout';
 import { CommercialMetrics } from './CommercialMetrics.importable';
 import { Island } from './Island';
 import { FocusStyles } from './FocusStyles.importable';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 type Props = {
 	CAPI: CAPIType;
@@ -46,9 +47,9 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 			<Island clientOnly={true} deferUntil="idle">
 				<CommercialMetrics
 					enabled={CAPI.config.switches.commercialMetrics}
-					switches={CAPI.config.switches}
-					isSensitive={CAPI.config.isSensitive}
-					isDev={CAPI.config.isDev}
+					abTestSwitches={filterABTestSwitches(CAPI.config.switches)}
+					pageIsSensitive={CAPI.config.isSensitive}
+					isDev={!!CAPI.config.isDev}
 				/>
 			</Island>
 			<div id="react-root" />

--- a/dotcom-rendering/src/web/components/WithABProvider.tsx
+++ b/dotcom-rendering/src/web/components/WithABProvider.tsx
@@ -6,9 +6,10 @@ import { tests } from '../experiments/ab-tests';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';
 import { getCypressSwitches } from '../experiments/cypress-switches';
 import { getForcedParticipationsFromUrl } from '../lib/getAbUrlHash';
+import type { ABTestSwitches } from '../lib/filterSwitches';
 
 type Props = {
-	abTestSwitches: CoreAPIConfig['abTestSwitches'];
+	abTestSwitches: ABTestSwitches;
 	pageIsSensitive: CoreAPIConfig['pageIsSensitive'];
 	isDev: boolean;
 	children: JSX.Element;
@@ -68,3 +69,5 @@ export const WithABProvider = ({
 		</ABProvider>
 	);
 };
+
+export type ABProps = Omit<Props, 'children'>;

--- a/dotcom-rendering/src/web/components/WithABProvider.tsx
+++ b/dotcom-rendering/src/web/components/WithABProvider.tsx
@@ -47,6 +47,12 @@ export const WithABProvider = ({
 		// eslint-disable-next-line no-console
 		console.log('There is no MVT ID set, see WithABProvider.tsx');
 	}
+	if (Object.keys(abTestSwitches).some((key) => !key.startsWith('ab'))) {
+		console.warn(
+			'Unused switches passed. Make sure you use filterABTestSwitches',
+		);
+	}
+
 	const ophanRecord = getOphanRecordFunction();
 	const windowHash = window?.location.hash;
 	// Get the forced switches to use for when running within cypress

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -45,6 +45,7 @@ import { MostViewedRightWrapper } from '../components/MostViewedRightWrapper.imp
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const StandardGrid = ({
 	children,
@@ -696,9 +697,11 @@ export const CommentLayout = ({
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -42,6 +42,7 @@ import { Island } from '../components/Island';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -519,9 +520,11 @@ export const ImmersiveLayout = ({
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -56,6 +56,7 @@ import { Island } from '../components/Island';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -636,9 +637,11 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -59,6 +59,7 @@ import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { ArticleLastUpdated } from '../components/ArticleLastUpdated';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -927,9 +928,11 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -50,6 +50,7 @@ import { MostViewedRightWrapper } from '../components/MostViewedRightWrapper.imp
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -678,9 +679,11 @@ export const ShowcaseLayout = ({
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -57,6 +57,7 @@ import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
+import { filterABTestSwitches } from '../lib/filterSwitches';
 
 const StandardGrid = ({
 	children,
@@ -804,9 +805,11 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							format={format}
 							sectionName={CAPI.sectionName}
 							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
+							abTestSwitches={filterABTestSwitches(
+								CAPI.config.switches,
+							)}
 							pageIsSensitive={CAPI.config.isSensitive}
-							isDev={CAPI.config.isDev}
+							isDev={!!CAPI.config.isDev}
 						/>
 					</ElementContainer>
 				)}

--- a/dotcom-rendering/src/web/lib/filterSwitches.ts
+++ b/dotcom-rendering/src/web/lib/filterSwitches.ts
@@ -1,0 +1,6 @@
+export type ABTestSwitches = Record<`ab${string}`, boolean>;
+
+export const filterABTestSwitches = (switches: Switches): ABTestSwitches =>
+	Object.fromEntries(
+		Object.entries(switches).filter(([key]) => key.startsWith('ab')),
+	);


### PR DESCRIPTION
## What does this change?

Add a method to filter out unused switches.

## Why?

We should only pass required props to `Island` children.

### Before

> `{"sectionName":"uk-news","palette":{"text":{"headline":"#121212","seriesTitle":"#C70000","sectionTitle":"#C70000","byline":"#C70000","twitterHandle":"#707070","caption":"#707070","captionLink":"#C70000","subMeta":"#C70000","subMetaLabel":"#707070","subMetaLink":"#707070","syndicationButton":"#707070","articleLink":"#C70000","articleLinkHover":"#C70000","cardHeadline":"#121212","cardByline":"#C70000","cardKicker":"#C70000","linkKicker":"#C70000","cardStandfirst":"#121212","cardFooter":"#707070","headlineByline":"#C70000","standfirst":"#121212","standfirstLink":"#C70000","branding":"#C70000","disclaimerLink":"#AB0613","signInLink":"#AB0613","richLink":"#C70000","pullQuote":"#AB0613","pullQuoteAttribution":"#C70000","witnessIcon":"#C70000","witnessAuthor":"#C70000","witnessTitle":"#C70000","carouselTitle":"#C70000","calloutHeading":"#007ABC","dropCap":"#AB0613","blockquote":"#707070","numberedTitle":"#C70000","numberedPosition":"#707070","overlayedCaption":"#FFFFFF","shareCount":"#707070","shareCountUntilDesktop":"#707070"},"background":{"article":"transparent","seriesTitle":"transparent","sectionTitle":"transparent","avatar":"#FF5943","card":"#F6F6F6","headline":"transparent","headlineByline":"transparent","bullet":"#C70000","bulletStandfirst":"#DCDCDC","header":"transparent","standfirst":"transparent","richLink":"#C70000","imageTitle":"#C70000","speechBubble":"#C70000","carouselDot":"#C70000","carouselDotFocus":"#C70000","headlineTag":"#AB0613","mostViewedTab":"#AB0613","matchNav":"#FFE500","analysisUnderline":"rgba(199, 0, 0, 0.5)"},"fill":{"commentCount":"#C70000","commentCountUntilDesktop":"#C70000","shareIcon":"#C70000","shareCountIcon":"#707070","shareCountIconUntilDesktop":"#707070","shareIconGrayBackground":"#AB0613","cameraCaptionIcon":"#707070","richLink":"#C70000","quoteIcon":"#C70000","blockquoteIcon":"#C70000"},"border":{"syndicationButton":"#DCDCDC","subNav":"#C70000","articleLink":"#DCDCDC","articleLinkHover":"#C70000","liveBlock":"#C70000","standfirstLink":"#DCDCDC","headline":"#DCDCDC","standfirst":"#DCDCDC","richLink":"#C70000","navPillar":"#FF5943","article":"#DCDCDC","lines":"#DCDCDC","matchTab":"#DCDCDC","activeMatchTab":"#005689"},"topBar":{"card":"#C70000"},"hover":{"headlineByline":"#AB0613","standfirstLink":"#DCDCDC"}},"ajaxUrl":"https://api.nextgen.guardianapps.co.uk","switches":{"anniversaryHeaderSvg":true,"abSpacefinderOkr3RichLinks":true,"prebidAppnexusUkRow":true,"commercialMetrics":true,"prebidTrustx":true,"scAdFreeBanner":false,"abSpacefinderOkr2ImagesLoaded":false,"prebidPermutiveAudience":true,"compareVariantDecision":false,"enableSentryReporting":true,"lazyLoadContainers":true,"adFreeStrictExpiryEnforcement":false,"liveblogRendering":true,"remarketing":true,"fetchNonRefreshableLineItems":true,"registerWithPhone":false,"targeting":true,"remoteHeader":true,"extendedMostPopularFronts":true,"slotBodyEnd":true,"prebidImproveDigitalSkins":true,"emailInlineInFooter":true,"showNewPrivacyWordingOnEmailSignupEmbeds":true,"facebookTrackingPixel":true,"iasAdTargeting":true,"extendedMostPopular":true,"prebidAnalytics":true,"prebidCriteo":true,"puzzlesBanner":true,"imrWorldwide":true,"acast":true,"twitterUwt":true,"prebidAppnexusInvcode":true,"a9HeaderBidding":true,"prebidAppnexus":true,"enableDiscussionSwitch":true,"standaloneCommercialBundle":true,"prebidXaxis":true,"abSpacefinderOkr1FilterNearby":false,"stickyVideos":true,"interactiveFullHeaderSwitch":true,"discussionAllPageSize":true,"prebidUserSync":true,"audioOnwardJourneySwitch":true,"mobileStickyPrebid":true,"externalVideoEmbeds":true,"simpleReach":true,"carrotTrafficDriver":true,"sentinelLogger":true,"geoMostPopular":true,"weAreHiring":true,"relatedContent":true,"thirdPartyEmbedTracking":true,"prebidOzone":true,"ampAmazon":true,"prebidAdYouLike":true,"mostViewedFronts":true,"abSignInGateMainControl":true,"ampPrebid":true,"googleSearch":true,"brazeSwitch":true,"consentManagement":true,"commercial":true,"redplanetForAus":true,"prebidSonobi":true,"idProfileNavigation":true,"confiantAdVerification":true,"discussionAllowAnonymousRecommendsSwitch":false,"scrollDepth":true,"permutive":true,"comscore":true,"webFonts":true,"prebidImproveDigital":true,"ophan":true,"crosswordSvgThumbnails":true,"prebidTriplelift":true,"weather":true,"commercialOutbrainNewids":true,"abSignInGateMainVariant":true,"abAdblockAsk":true,"prebidPubmatic":true,"serverShareCounts":false,"autoRefresh":true,"enhanceTweets":true,"prebidIndexExchange":true,"prebidOpenx":true,"prebidHeaderBidding":true,"idCookieRefresh":true,"sharingComments":true,"discussionPageSize":true,"smartAppBanner":false,"boostGaUserTimingFidelity":false,"historyTags":true,"mobileStickyLeaderboard":true,"surveys":true,"remoteBanner":true,"emailSignupRecaptcha":true,"prebidSmart":true,"inizio":true},"pageIsSensitive":false,"isDev":false}`

### After


> `{"sectionName":"uk-news","palette":{"text":{"headline":"#121212","seriesTitle":"#C70000","sectionTitle":"#C70000","byline":"#C70000","twitterHandle":"#707070","caption":"#707070","captionLink":"#C70000","subMeta":"#C70000","subMetaLabel":"#707070","subMetaLink":"#707070","syndicationButton":"#707070","articleLink":"#C70000","articleLinkHover":"#C70000","cardHeadline":"#121212","cardByline":"#C70000","cardKicker":"#C70000","linkKicker":"#C70000","cardStandfirst":"#121212","cardFooter":"#707070","headlineByline":"#C70000","standfirst":"#121212","standfirstLink":"#C70000","branding":"#C70000","disclaimerLink":"#AB0613","signInLink":"#AB0613","richLink":"#C70000","pullQuote":"#AB0613","pullQuoteAttribution":"#C70000","witnessIcon":"#C70000","witnessAuthor":"#C70000","witnessTitle":"#C70000","carouselTitle":"#C70000","calloutHeading":"#007ABC","dropCap":"#AB0613","blockquote":"#707070","numberedTitle":"#C70000","numberedPosition":"#707070","overlayedCaption":"#FFFFFF","shareCount":"#707070","shareCountUntilDesktop":"#707070"},"background":{"article":"transparent","seriesTitle":"transparent","sectionTitle":"transparent","avatar":"#FF5943","card":"#F6F6F6","headline":"transparent","headlineByline":"transparent","bullet":"#C70000","bulletStandfirst":"#DCDCDC","header":"transparent","standfirst":"transparent","richLink":"#C70000","imageTitle":"#C70000","speechBubble":"#C70000","carouselDot":"#C70000","carouselDotFocus":"#C70000","headlineTag":"#AB0613","mostViewedTab":"#AB0613","matchNav":"#FFE500","analysisUnderline":"rgba(199, 0, 0, 0.5)"},"fill":{"commentCount":"#C70000","commentCountUntilDesktop":"#C70000","shareIcon":"#C70000","shareCountIcon":"#707070","shareCountIconUntilDesktop":"#707070","shareIconGrayBackground":"#AB0613","cameraCaptionIcon":"#707070","richLink":"#C70000","quoteIcon":"#C70000","blockquoteIcon":"#C70000"},"border":{"syndicationButton":"#DCDCDC","subNav":"#C70000","articleLink":"#DCDCDC","articleLinkHover":"#C70000","liveBlock":"#C70000","standfirstLink":"#DCDCDC","headline":"#DCDCDC","standfirst":"#DCDCDC","richLink":"#C70000","navPillar":"#FF5943","article":"#DCDCDC","lines":"#DCDCDC","matchTab":"#DCDCDC","activeMatchTab":"#005689"},"topBar":{"card":"#C70000"},"hover":{"headlineByline":"#AB0613","standfirstLink":"#DCDCDC"}},"ajaxUrl":"https://api.nextgen.guardianapps.co.uk","abTestSwitches":{"abSpacefinderOkr3RichLinks":true,"abSpacefinderOkrMegaTest":false,"abSignInGateMainControl":true,"abSignInGateMainVariant":true,"abAdblockAsk":true},"pageIsSensitive":false,"isDev":false}`
```
