### PR TITLE
Darker backgrounds

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -581,7 +581,7 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 const backgroundHeader = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
-			return pillarPalette[format.theme][400];
+			return pillarPalette[format.theme][300];
 		default:
 			return backgroundArticle(format);
 	}
@@ -590,7 +590,23 @@ const backgroundHeader = (format: ArticleFormat): string => {
 const backgroundStandfirst = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
-			return pillarPalette[format.theme][300];
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[200];
+				case ArticlePillar.Culture:
+					return culture[200];
+				case ArticlePillar.Sport:
+					return sport[200];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[200];
+				case ArticlePillar.Opinion:
+					return opinion[200];
+				case ArticleSpecial.Labs:
+					return labs[200];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[200];
+			}
+			break;
 		case ArticleDesign.DeadBlog:
 			return neutral[93];
 		default:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -581,7 +581,15 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 const backgroundHeader = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
-			return pillarPalette[format.theme][300];
+			switch (format.theme) {
+				case ArticleSpecial.Labs:
+				case ArticleSpecial.SpecialReport:
+					// We don't have designs for Special Report or Labs liveblogs yet
+					// so we default to news
+					return news[200];
+				default:
+					return pillarPalette[format.theme][300];
+			}
 		default:
 			return backgroundArticle(format);
 	}
@@ -602,9 +610,10 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 				case ArticlePillar.Opinion:
 					return opinion[200];
 				case ArticleSpecial.Labs:
-					return labs[200];
 				case ArticleSpecial.SpecialReport:
-					return specialReport[200];
+					// We don't have designs for Special Report or Labs liveblogs yet
+					// so we default to news
+					return news[200];
 			}
 			break;
 		case ArticleDesign.DeadBlog:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -596,7 +596,7 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 				case ArticlePillar.Culture:
 					return culture[200];
 				case ArticlePillar.Sport:
-					return sport[200];
+					return sport[100];
 				case ArticlePillar.Lifestyle:
 					return lifestyle[200];
 				case ArticlePillar.Opinion:


### PR DESCRIPTION
Fixes #4154

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR darkens the background used for a liveblog headline and standfirst

## Why?
To match the designs

### Before
<img width="738" alt="Screenshot 2022-03-07 at 11 57 06" src="https://user-images.githubusercontent.com/1336821/157030151-1b28cba3-c8df-4faa-ac6f-a4a85473f58c.png">


### After
<img width="738" alt="Screenshot 2022-03-07 at 11 56 31" src="https://user-images.githubusercontent.com/1336821/157030074-40bed273-d8dd-44b5-9043-3d5e8427eb8f.png">
