### PR TITLE
Compute realtime config within AMP `Ad` component

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -46,7 +46,7 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	return adTargetingMapped;
 };
 
-export const realTimeConfig = (
+const realTimeConfig = (
 	usePrebid: boolean,
 	usePermutive: boolean,
 	useAmazon: boolean,
@@ -86,7 +86,7 @@ export const realTimeConfig = (
 	return JSON.stringify(data);
 };
 
-export interface CommercialConfig {
+interface CommercialConfig {
 	usePrebid: boolean;
 	usePermutive: boolean;
 	useAmazon: boolean;
@@ -98,11 +98,12 @@ export interface BaseAdProps {
 	contentType: string;
 	commercialProperties: CommercialProperties;
 	adTargeting: AdTargeting;
+	config: CommercialConfig;
 }
 
 interface AdProps extends BaseAdProps {
 	isSticky?: boolean;
-	rtcConfig: string;
+	placementId: number;
 }
 
 export const Ad = ({
@@ -111,8 +112,9 @@ export const Ad = ({
 	section,
 	contentType,
 	commercialProperties,
-	rtcConfig,
 	adTargeting,
+	config: { useAmazon, usePrebid, usePermutive },
+	placementId,
 }: AdProps) => {
 	const adSizes = isSticky ? stickySizes : inlineSizes;
 	// Set Primary ad size as first element (should be the largest)
@@ -143,7 +145,12 @@ export const Ad = ({
 				]),
 			)}
 			data-slot={ampData(section, contentType)}
-			rtc-config={rtcConfig}
+			rtc-config={realTimeConfig(
+				usePrebid,
+				usePermutive,
+				useAmazon,
+				placementId,
+			)}
 		/>
 	);
 };

--- a/dotcom-rendering/src/amp/components/RegionalAd.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.tsx
@@ -1,15 +1,11 @@
 import { ClassNames } from '@emotion/react';
 import { regionClasses } from '../lib/region-classes';
-import { realTimeConfig, BaseAdProps, CommercialConfig, Ad } from './Ad';
+import { BaseAdProps, Ad } from './Ad';
 
 type AdRegion = 'US' | 'AU' | 'ROW';
 
 // Array of possible ad regions
 const adRegions: AdRegion[] = ['US', 'AU', 'ROW'];
-
-interface RegionalAdProps extends BaseAdProps {
-	config: CommercialConfig;
-}
 
 /**
  * Determine the Placement ID that is used to look up a given stored bid request
@@ -47,7 +43,7 @@ export const RegionalAd = ({
 	commercialProperties,
 	config,
 	adTargeting,
-}: RegionalAdProps) => (
+}: BaseAdProps) => (
 	<>
 		{adRegions.map((adRegion) => (
 			<ClassNames key={adRegion}>
@@ -65,12 +61,8 @@ export const RegionalAd = ({
 							section={section}
 							contentType={contentType}
 							commercialProperties={commercialProperties}
-							rtcConfig={realTimeConfig(
-								config.usePrebid,
-								config.usePermutive,
-								config.useAmazon,
-								getPlacementIdByAdRegion(adRegion),
-							)}
+							config={config}
+							placementId={getPlacementIdByAdRegion(adRegion)}
 							adTargeting={adTargeting}
 						/>
 					</div>

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -1,5 +1,5 @@
 import { text, textSans } from '@guardian/source-foundations';
-import { realTimeConfig, BaseAdProps, CommercialConfig, Ad } from './Ad';
+import { BaseAdProps, Ad } from './Ad';
 
 // This CSS should be imported and added to global styles in amp/server/document.tsx to add the Advertisement label to the sticky
 export const stickyAdLabelCss = `
@@ -17,10 +17,6 @@ amp-sticky-ad:before {
 
 const mobileStickyPlacementId = 9;
 
-interface StickyAdProps extends BaseAdProps {
-	config: CommercialConfig;
-}
-
 export const StickyAd = ({
 	edition,
 	section,
@@ -28,7 +24,7 @@ export const StickyAd = ({
 	config,
 	commercialProperties,
 	adTargeting,
-}: StickyAdProps) => {
+}: BaseAdProps) => {
 	return (
 		<amp-sticky-ad layout="nodisplay">
 			<Ad
@@ -37,12 +33,8 @@ export const StickyAd = ({
 				section={section}
 				contentType={contentType}
 				commercialProperties={commercialProperties}
-				rtcConfig={realTimeConfig(
-					config.usePrebid,
-					config.usePermutive,
-					config.useAmazon,
-					mobileStickyPlacementId,
-				)}
+				config={config}
+				placementId={mobileStickyPlacementId}
 				adTargeting={adTargeting}
 			/>
 		</amp-sticky-ad>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Currently we compute the [Real Time Config](https://github.com/ampproject/amphtml/blob/main/extensions/amp-a4a/rtc-documentation.md) for AMP `Ad` components and pass this in as a prop (either from `StickyAd` or `RegionalAd`).

In this PR, instead we pass the commercial `config` and `placementId` as props, and compute the RTC within the ad component.

## Why?

This leaves us with only one call site where `realTimeConfig` is called. This will simplify subsequent work where we want to run an AB test, with different variants computing different RTC strings.