### PR TITLE
Thumbnail images in blogs

### DIFF
--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -61,7 +61,15 @@ const RoleStory = ({
 					level. Truffaut street art edison bulb, banh mi cliche
 					post-ironic mixtape
 				</p>
-				<Figure isMainMedia={false} role={role}>
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role={role}
+				>
 					<ClickToView
 						role={role}
 						isTracking={true}
@@ -481,7 +489,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={facebookEmbed.html}
@@ -499,7 +515,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={vimeoEmbedEmbed.html}
@@ -517,7 +541,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={youtubeEmbedEmbed.html}
@@ -535,7 +567,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={spotifyEmbedEmbed.html}
@@ -553,7 +593,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={bandcampEmbedEmbed.html}
@@ -571,7 +619,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={ourworldindataEmbedEmbed.html}
@@ -589,7 +645,15 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<EmbedBlockComponent
 						key={1}
 						html={bbcEmbedEmbed.html}
@@ -631,7 +695,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<UnsafeEmbedBlockComponent
 						key="1"
 						html={instagramEmbedEmbed.html}
@@ -649,7 +721,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<UnsafeEmbedBlockComponent
 						key="2"
 						html={formStackEmbed.html}
@@ -668,7 +748,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<UnsafeEmbedBlockComponent
 						key="3"
 						html={scribdEmbedEmbed.html}
@@ -687,7 +775,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<UnsafeEmbedBlockComponent
 						key="4"
 						html={tiktokEmbedEmbed.html}
@@ -706,7 +802,15 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<UnsafeEmbedBlockComponent
 						key="5"
 						html={twitterEmbedEmbed.html}
@@ -750,7 +854,15 @@ export const VimeoBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={vimeoVideoEmbed.source}
@@ -804,7 +916,15 @@ export const DocumentBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={scribdDocumentEmbed.source}
@@ -853,7 +973,15 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={soundcloudAudioEmbed.source}
@@ -872,7 +1000,15 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={soundcloudEmbedEmbed.source}
@@ -916,7 +1052,15 @@ export const SpotifyBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={spotifyAudioEmbed.source}
@@ -974,7 +1118,15 @@ export const TweetBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={twitterTweetEmbed.source}
@@ -1015,7 +1167,15 @@ export const InstagramBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<InstagramBlockComponent
 						key={1}
 						element={instagramInstramEmbed}
@@ -1053,7 +1213,15 @@ export const MapBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={mapEmbedEmbed.source}
@@ -1108,7 +1276,15 @@ export const VineBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure isMainMedia={false} role="inline">
+				<Figure
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
+					isMainMedia={false}
+					role="inline"
+				>
 					<ClickToView
 						isTracking={true}
 						source={vineEmbedEmbed.source}

--- a/dotcom-rendering/src/web/components/Figure.stories.tsx
+++ b/dotcom-rendering/src/web/components/Figure.stories.tsx
@@ -72,7 +72,14 @@ export const InlineStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false}>
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+					>
 						<Grey />
 					</Figure>
 					<SomeText />
@@ -102,7 +109,15 @@ export const SupportingStory = () => {
 				>
 					<SomeText />
 					<SomeText />
-					<Figure isMainMedia={false} role="supporting">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="supporting"
+					>
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -135,7 +150,15 @@ export const ImmersiveStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="immersive">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="immersive"
+					>
 						<Grey heightInPixels={700} />
 					</Figure>
 					<SomeText />
@@ -164,7 +187,15 @@ export const ThumbnailStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="thumbnail">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="thumbnail"
+					>
 						<Grey heightInPixels={200} />
 					</Figure>
 					<SomeText />
@@ -194,7 +225,15 @@ export const ShowcaseStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="showcase">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="showcase"
+					>
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -223,7 +262,15 @@ export const HalfWidthStory = () => {
 					}}
 				>
 					<SomeText />
-					<Figure isMainMedia={false} role="halfWidth">
+					<Figure
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						isMainMedia={false}
+						role="halfWidth"
+					>
 						<Grey />
 					</Figure>
 					<SomeText />

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -4,6 +4,7 @@ import { from, until, space } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
+	format: ArticleFormat;
 	isMainMedia: boolean;
 	role?: RoleType | 'richLink';
 	id?: string;
@@ -158,6 +159,7 @@ const mainMediaFigureStyles = css`
 
 export const Figure = ({
 	role = 'inline',
+	format,
 	children,
 	id,
 	isMainMedia,

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 
 import { from, until, space } from '@guardian/source-foundations';
 
@@ -132,7 +133,10 @@ const roleCss = {
 };
 
 // Used for vast majority of layouts.
-export const defaultRoleStyles = (role: RoleType | 'richLink') => {
+export const defaultRoleStyles = (
+	role: RoleType | 'richLink',
+	format: ArticleFormat,
+) => {
 	switch (role) {
 		case 'inline':
 			return roleCss.inline;
@@ -143,7 +147,20 @@ export const defaultRoleStyles = (role: RoleType | 'richLink') => {
 		case 'showcase':
 			return roleCss.showcase;
 		case 'thumbnail':
-			return roleCss.thumbnail;
+			switch (format.design) {
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					// In blogs we don't want to use negative left margins
+					return css`
+						${roleCss.thumbnail}
+						/* It's important we use the media query here to ensure we override the default values */
+						${from.leftCol} {
+							margin-left: 0px;
+						}
+					`;
+				default:
+					return roleCss.thumbnail;
+			}
 		case 'richLink':
 			return roleCss.richLink;
 		case 'halfWidth':
@@ -194,7 +211,7 @@ export const Figure = ({
 	return (
 		<figure
 			id={id}
-			css={defaultRoleStyles(role)}
+			css={defaultRoleStyles(role, format)}
 			data-spacefinder-component={spacefinderComponent}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -2,6 +2,16 @@ import { css } from '@emotion/react';
 
 import { from, until, space } from '@guardian/source-foundations';
 
+type Props = {
+	children: React.ReactNode;
+	isMainMedia: boolean;
+	role?: RoleType | 'richLink';
+	id?: string;
+	isNumberedListTitle?: boolean;
+	className?: string;
+	type?: CAPIElement['_type'];
+};
+
 const roleCss = {
 	inline: css`
 		margin-top: ${space[3]}px;
@@ -140,16 +150,6 @@ export const defaultRoleStyles = (role: RoleType | 'richLink') => {
 		default:
 			return roleCss.inline;
 	}
-};
-
-type Props = {
-	children: React.ReactNode;
-	isMainMedia: boolean;
-	role?: RoleType | 'richLink';
-	id?: string;
-	isNumberedListTitle?: boolean;
-	className?: string;
-	type?: CAPIElement['_type'];
 };
 
 const mainMediaFigureStyles = css`

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.stories.tsx
@@ -56,7 +56,15 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 export const StandardArticle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -76,7 +84,15 @@ StandardArticle.story = {
 export const Immersive = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="immersive">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="immersive"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -96,7 +112,15 @@ Immersive.story = {
 export const Showcase = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -116,7 +140,15 @@ Showcase.story = {
 export const Thumbnail = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="thumbnail">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="thumbnail"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'thumbnail' }}
 					format={{
@@ -136,7 +168,15 @@ Thumbnail.story = {
 export const Supporting = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="supporting">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="supporting"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'supporting' }}
 					format={{
@@ -156,7 +196,15 @@ Supporting.story = {
 export const HideCaption = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -177,7 +225,15 @@ HideCaption.story = {
 export const InlineTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -203,7 +259,15 @@ InlineTitle.story = {
 export const InlineTitleMobile = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -229,7 +293,15 @@ InlineTitleMobile.story = {
 export const ImmersiveTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="immersive">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="immersive"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -251,7 +323,15 @@ ImmersiveTitle.story = {
 export const ShowcaseTitle = () => {
 	return (
 		<Container>
-			<Figure isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -297,7 +377,15 @@ export const HalfWidth = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -357,7 +445,15 @@ export const HalfWidthMobile = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -417,7 +513,15 @@ export const HalfWidthWide = () => {
 				sint occaecat cupidatat non proident, sunt in culpa qui officia
 				deserunt mollit anim id est laborum.
 			</p>
-			<Figure isMainMedia={false} role="halfWidth">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="halfWidth"
+			>
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
@@ -42,7 +42,15 @@ export const Default = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="supporting">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="supporting"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2018/01/archive-zip/giv-3902O7VEVpcWiCO7/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -68,7 +76,15 @@ export const InlineMap = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -93,7 +109,15 @@ export const Showcase = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="showcase">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="showcase"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/embed/from-tool/photo-collage/index.html?vertical=News&opinion-tint=false&left-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F84bd48ec5962601f8550286bfb5c2093fa0a3ffe%3Fcrop%3D0_70_3500_2100&left-caption=A%20woman%20stands%20during%20a%20song%20ahead%20of%20Trump’s%20remarks%20at%20the%20King%20Jesus%20International%20Ministry%20in%20Miami.%20Photo%3A%20Tom%20Brenner%2FReuters&right-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F9eb6381555963f1dc58c637adf2f3dc08f283e58%3Fcrop%3D0_26_3000_1800&right-caption=People%20give%20thumbs%20down%20to%20media%20covering%20the%20Trump%20campaign%20event%20held%20at%20the%20King%20Jesus%20International%20Ministry.%20Photo%3A%20Joe%20Raedle%2FGetty&always-place-captions-below=false"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -119,7 +143,15 @@ export const WithCaption = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -146,7 +178,15 @@ export const NonBootJs = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<InteractiveBlockComponent
 					url="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					scriptUrl="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -298,58 +298,34 @@ export const ImageRoles = () => {
 		...baseBlock,
 		elements: [
 			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Inline</p>',
-			},
-			{
 				...images[0],
 				role: 'inline',
-			},
-			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Thumbnail</p>',
+				title: 'Inline',
 			},
 			{
 				...images[0],
 				role: 'thumbnail',
-			},
-			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Immersive</p>',
+				title: 'Thumbnail',
 			},
 			{
 				...images[0],
 				role: 'immersive',
-			},
-			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Supporting</p>',
+				title: 'Immersive',
 			},
 			{
 				...images[0],
 				role: 'supporting',
-			},
-			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Showcase</p>',
+				title: 'Supporting',
 			},
 			{
 				...images[0],
 				role: 'showcase',
-			},
-			{
-				elementId: '1',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>Half width</p>',
+				title: 'Showcase',
 			},
 			{
 				...images[0],
 				role: 'halfWidth',
+				title: 'Half width',
 			},
 		],
 	};

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -375,6 +375,53 @@ export const ImageRoles = () => {
 };
 ImageRoles.story = { name: 'with images at different roles' };
 
+export const Thumbnail = () => {
+	const block: Block = {
+		...baseBlock,
+		elements: [
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>eos his vis cetero dicta usu eu duo officiis ei eleifend sed repudiandae consequat vitae splendide pretium est partiendo semper ne uonsetetur ipsum aliquam per leo odio inimicus eam his tincidunt et ne semper amet et voluptua mauris qui eum nec inimicus sed aenean eu mea odio vitae at.</p>',
+			},
+			{
+				...images[0],
+				role: 'thumbnail',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>eos his vis cetero dicta usu eu duo officiis ei eleifend sed repudiandae consequat vitae splendide pretium est partiendo semper ne uonsetetur ipsum aliquam per leo odio inimicus eam his tincidunt et ne semper amet et voluptua mauris qui eum nec inimicus sed aenean eu mea odio vitae at.</p>',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>eos his vis cetero dicta usu eu duo officiis ei eleifend sed repudiandae consequat vitae splendide pretium est partiendo semper ne uonsetetur ipsum aliquam per leo odio inimicus eam his tincidunt et ne semper amet et voluptua mauris qui eum nec inimicus sed aenean eu mea odio vitae at.</p>',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
+				format={{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.LiveBlog,
+					display: ArticleDisplay.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				ajaxUrl=""
+			/>
+		</Wrapper>
+	);
+};
+Thumbnail.story = { name: 'with a thumbnail image surrounded by text' };
+
 export const ImageAndTitle = () => {
 	const block: Block = {
 		...baseBlock,

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -293,6 +293,88 @@ export const FirstImage = () => {
 };
 FirstImage.story = { name: 'with an image as the first element' };
 
+export const ImageRoles = () => {
+	const block: Block = {
+		...baseBlock,
+		elements: [
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Inline</p>',
+			},
+			{
+				...images[0],
+				role: 'inline',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Thumbnail</p>',
+			},
+			{
+				...images[0],
+				role: 'thumbnail',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Immersive</p>',
+			},
+			{
+				...images[0],
+				role: 'immersive',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Supporting</p>',
+			},
+			{
+				...images[0],
+				role: 'supporting',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Showcase</p>',
+			},
+			{
+				...images[0],
+				role: 'showcase',
+			},
+			{
+				elementId: '1',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html: '<p>Half width</p>',
+			},
+			{
+				...images[0],
+				role: 'halfWidth',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{
+					customParams: { sens: 'f', urlkw: [] },
+					adUnit: '',
+				}}
+				format={{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.LiveBlog,
+					display: ArticleDisplay.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				ajaxUrl=""
+			/>
+		</Wrapper>
+	);
+};
+ImageRoles.story = { name: 'with images at different roles' };
+
 export const ImageAndTitle = () => {
 	const block: Block = {
 		...baseBlock,

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -31,7 +31,15 @@ export default {
 export const Article = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
@@ -55,7 +63,15 @@ export const Article = () => {
 export const Network = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="special-report"
@@ -85,7 +101,15 @@ Network.story = {
 export const SectionStory = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="live"
@@ -112,7 +136,15 @@ SectionStory.story = {
 export const Inline = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="inline">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="inline"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -139,7 +171,15 @@ Inline.story = {
 export const ImageContent = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="dead"
@@ -169,7 +209,15 @@ ImageContent.story = {
 export const Interactive = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="feature"
@@ -198,7 +246,15 @@ Interactive.story = {
 export const Gallery = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -228,7 +284,15 @@ Gallery.story = {
 export const Video = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -259,7 +323,15 @@ Video.story = {
 export const Audio = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="podcast"
@@ -283,7 +355,15 @@ export const Audio = () => {
 export const LiveBlog = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="media"
@@ -313,7 +393,15 @@ LiveBlog.story = {
 export const Tag = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="analysis"
@@ -337,7 +425,15 @@ export const Tag = () => {
 export const Index = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="review"
@@ -368,7 +464,15 @@ export const Index = () => {
 export const Crossword = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="letters"
@@ -392,7 +496,15 @@ export const Crossword = () => {
 export const Survey = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -416,7 +528,15 @@ export const Survey = () => {
 export const Signup = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -441,7 +561,15 @@ export const Signup = () => {
 export const Userid = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="editorial"
@@ -465,7 +593,15 @@ export const Userid = () => {
 export const PaidFor = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure isMainMedia={false} role="richLink">
+			<Figure
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				isMainMedia={false}
+				role="richLink"
+			>
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -793,6 +793,7 @@ export const renderArticleElement = ({
 					: ''
 			}
 			type={element._type}
+			format={format}
 		>
 			{el}
 		</Figure>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds support for `thumbnail` images in blogs

## Why?
They were appearing off to the left outside the block 😨 

### Before
<img width="689" alt="Screenshot 2022-03-07 at 17 42 48" src="https://user-images.githubusercontent.com/1336821/157088552-fd77f51e-4564-490a-83cc-0aad6781783c.png">


### After
<img width="689" alt="Screenshot 2022-03-07 at 17 41 08" src="https://user-images.githubusercontent.com/1336821/157088532-6be1ae99-012f-4662-9375-47d0a21dad8b.png">


Fixes #4194