### PR TITLE
Refactor `MatchStats`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -141,6 +141,7 @@ type Palette = {
 		mostViewedTab: Colour;
 		matchNav: Colour;
 		analysisUnderline: Colour;
+		matchStats: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/components/GoalAttempts.stories.tsx
+++ b/dotcom-rendering/src/web/components/GoalAttempts.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 
 import { GoalAttempts } from './GoalAttempts';
 
@@ -33,7 +34,11 @@ export const Default = () => {
 					offTarget: 4,
 					color: '#e3f45a',
 				}}
-				backgroundColour="lightgray"
+				format={{
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.Sport,
+					display: ArticleDisplay.Standard,
+				}}
 			/>
 		</Container>
 	);

--- a/dotcom-rendering/src/web/components/GoalAttempts.tsx
+++ b/dotcom-rendering/src/web/components/GoalAttempts.tsx
@@ -7,7 +7,7 @@ import { isLight } from '../lib/isLight';
 type Props = {
 	left: Section;
 	right: Section;
-	backgroundColour: string;
+	palette: Palette;
 };
 
 type Section = {
@@ -36,13 +36,13 @@ const Side = ({
 	onTarget,
 	teamColours,
 	position,
-	backgroundColour,
+	palette,
 }: {
 	offTarget: number;
 	onTarget: number;
 	teamColours: string;
 	position: 'left' | 'right';
-	backgroundColour: string;
+	palette: Palette;
 }) => (
 	<div
 		css={css`
@@ -96,11 +96,11 @@ const Side = ({
 				height: 70px;
 				width: 92px;
 
-				border-top: 8px solid ${backgroundColour};
+				border-top: 8px solid ${palette.background.matchStats};
 				border-left: ${position === 'left' &&
-				`8px solid ${backgroundColour}`};
+				`8px solid ${palette.background.matchStats}`};
 				border-right: ${position === 'right' &&
-				`8px solid ${backgroundColour}`};
+				`8px solid ${palette.background.matchStats}`};
 			`}
 		>
 			{onTarget}
@@ -116,7 +116,7 @@ const Side = ({
 	</div>
 );
 
-export const GoalAttempts = ({ left, right, backgroundColour }: Props) => {
+export const GoalAttempts = ({ left, right, palette }: Props) => {
 	return (
 		<Row>
 			<Side
@@ -124,14 +124,14 @@ export const GoalAttempts = ({ left, right, backgroundColour }: Props) => {
 				offTarget={left.offTarget}
 				onTarget={left.onTarget}
 				teamColours={left.color}
-				backgroundColour={backgroundColour}
+				palette={palette}
 			/>
 			<Side
 				position="right"
 				offTarget={right.offTarget}
 				onTarget={right.onTarget}
 				teamColours={right.color}
-				backgroundColour={backgroundColour}
+				palette={palette}
 			/>
 		</Row>
 	);

--- a/dotcom-rendering/src/web/components/GoalAttempts.tsx
+++ b/dotcom-rendering/src/web/components/GoalAttempts.tsx
@@ -1,13 +1,14 @@
 import { css } from '@emotion/react';
 
 import { headline, textSans, text } from '@guardian/source-foundations';
+import { decidePalette } from '../lib/decidePalette';
 
 import { isLight } from '../lib/isLight';
 
 type Props = {
 	left: Section;
 	right: Section;
-	palette: Palette;
+	format: ArticleFormat;
 };
 
 type Section = {
@@ -36,87 +37,90 @@ const Side = ({
 	onTarget,
 	teamColours,
 	position,
-	palette,
+	format,
 }: {
 	offTarget: number;
 	onTarget: number;
 	teamColours: string;
 	position: 'left' | 'right';
-	palette: Palette;
-}) => (
-	<div
-		css={css`
-			position: relative;
-			${headline.medium({ fontWeight: 'bold' })}
-			color: ${isLight(teamColours)
-				? text.ctaSecondary
-				: text.ctaPrimary};
-			background: ${teamColours};
-			flex-basis: 50%;
-			line-height: 0.8;
-
-			height: 132px;
-
-			background-image: url('data:image/svg+xml;utf-8,${svgBackground}');
-			background-repeat: repeat;
-			background-size: 3px;
-			background-position-x: 0;
-
-			padding-top: 1px;
-			padding-left: 6px;
-			padding-right: 6px;
-			padding-bottom: 9px;
-
-			text-align: ${position === 'left' ? 'left' : 'right'};
-		`}
-	>
-		{offTarget}
+	format: ArticleFormat;
+}) => {
+	const palette = decidePalette(format);
+	return (
 		<div
 			css={css`
-				${textSans.small()}
-				padding-top: 4px;
-			`}
-		>
-			{position === 'left' && 'Off target'}
-		</div>
-		<div
-			css={css`
-				position: absolute;
-				bottom: 0;
-				left: ${position === 'right' && 0};
-				right: ${position === 'left' && 0};
-
+				position: relative;
+				${headline.medium({ fontWeight: 'bold' })}
+				color: ${isLight(teamColours)
+					? text.ctaSecondary
+					: text.ctaPrimary};
 				background: ${teamColours};
+				flex-basis: 50%;
+				line-height: 0.8;
+
+				height: 132px;
+
+				background-image: url('data:image/svg+xml;utf-8,${svgBackground}');
+				background-repeat: repeat;
+				background-size: 3px;
+				background-position-x: 0;
+
+				padding-top: 1px;
+				padding-left: 6px;
+				padding-right: 6px;
+				padding-bottom: 9px;
 
 				text-align: ${position === 'left' ? 'left' : 'right'};
-
-				padding-left: 4px;
-				padding-right: 4px;
-
-				height: 70px;
-				width: 92px;
-
-				border-top: 8px solid ${palette.background.matchStats};
-				border-left: ${position === 'left' &&
-				`8px solid ${palette.background.matchStats}`};
-				border-right: ${position === 'right' &&
-				`8px solid ${palette.background.matchStats}`};
 			`}
 		>
-			{onTarget}
+			{offTarget}
 			<div
 				css={css`
 					${textSans.small()}
 					padding-top: 4px;
 				`}
 			>
-				{position === 'left' && 'On target'}
+				{position === 'left' && 'Off target'}
+			</div>
+			<div
+				css={css`
+					position: absolute;
+					bottom: 0;
+					left: ${position === 'right' && 0};
+					right: ${position === 'left' && 0};
+
+					background: ${teamColours};
+
+					text-align: ${position === 'left' ? 'left' : 'right'};
+
+					padding-left: 4px;
+					padding-right: 4px;
+
+					height: 70px;
+					width: 92px;
+
+					border-top: 8px solid ${palette.background.matchStats};
+					border-left: ${position === 'left' &&
+					`8px solid ${palette.background.matchStats}`};
+					border-right: ${position === 'right' &&
+					`8px solid ${palette.background.matchStats}`};
+				`}
+			>
+				{onTarget}
+				<div
+					css={css`
+						${textSans.small()}
+						padding-top: 4px;
+					`}
+				>
+					{position === 'left' && 'On target'}
+				</div>
 			</div>
 		</div>
-	</div>
-);
+	);
+};
 
-export const GoalAttempts = ({ left, right, palette }: Props) => {
+export const GoalAttempts = ({ left, right, format }: Props) => {
 	return (
 		<Row>
 			<Side
@@ -124,14 +128,14 @@ export const GoalAttempts = ({ left, right, palette }: Props) => {
 				offTarget={left.offTarget}
 				onTarget={left.onTarget}
 				teamColours={left.color}
-				palette={palette}
+				format={format}
 			/>
 			<Side
 				position="right"
 				offTarget={right.offTarget}
 				onTarget={right.onTarget}
 				teamColours={right.color}
-				palette={palette}
+				format={format}
 			/>
 		</Row>
 	);

--- a/dotcom-rendering/src/web/components/MatchStats.tsx
+++ b/dotcom-rendering/src/web/components/MatchStats.tsx
@@ -18,14 +18,13 @@ import { Doughnut } from './Doughnut';
 import { Distribution } from './Distribution';
 import { GoalAttempts } from './GoalAttempts';
 import { Lineup } from './Lineup';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	home: TeamType;
 	away: TeamType;
 	format: ArticleFormat;
 };
-
-const BACKGROUND_COLOUR = '#d9edf6';
 
 const StatsGrid = ({
 	children,
@@ -34,6 +33,8 @@ const StatsGrid = ({
 	children: React.ReactNode;
 	format: ArticleFormat;
 }) => {
+
+	const palette = decidePalette(format);
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog: {
@@ -44,6 +45,7 @@ const StatsGrid = ({
 						display: flex;
 						flex-direction: column;
 
+						background-color: ${palette.background.matchStats};
 						@supports (display: grid) {
 							display: grid;
 
@@ -96,6 +98,7 @@ const StatsGrid = ({
 						display: flex;
 						flex-direction: column;
 
+						background-color: ${palette.background.matchStats};
 						@supports (display: grid) {
 							display: grid;
 
@@ -143,7 +146,13 @@ const StatsGrid = ({
 	}
 };
 
-const StretchBackground = ({ children }: { children: React.ReactNode }) => (
+const StretchBackground = ({
+	palette,
+	children,
+}: {
+	palette: Palette;
+	children: React.ReactNode;
+}) => (
 	<div
 		css={css`
 			clear: left;
@@ -152,7 +161,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
 			padding: ${space[2]}px 10px;
 			/* We use min-height to help reduce our CLS value */
 			min-height: 800px;
-			background-color: ${BACKGROUND_COLOUR};
+			background-color: ${palette.background.matchStats};
 
 			${from.leftCol} {
 				:before {
@@ -163,7 +172,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
 					/* stretch left */
 					left: -100vw;
 					right: 0;
-					background-color: ${BACKGROUND_COLOUR};
+					background-color: ${palette.background.matchStats};
 					z-index: -1;
 				}
 			}
@@ -332,125 +341,131 @@ const DecideDoughnut = ({
 	}
 };
 
-export const MatchStats = ({ home, away, format }: Props) => (
-	<StretchBackground>
-		<StatsGrid format={format}>
-			<GridItem area="title" element="aside">
-				<ShiftLeft format={format}>
-					{/* Don't show the right border if this text was
+export const MatchStats = ({ home, away, format }: Props) => {
+	const palette = decidePalette(format);
+
+	return (
+		<StretchBackground palette={palette}>
+			<StatsGrid format={format}>
+				<GridItem area="title" element="aside">
+					<ShiftLeft format={format}>
+						{/* Don't show the right border if this text was
                         shifted into the left column */}
-					<Hide when="above" breakpoint="desktop">
-						<RightBorder>
+						<Hide when="above" breakpoint="desktop">
+							<RightBorder>
+								<H3>Match Stats</H3>
+							</RightBorder>
+						</Hide>
+						<Hide when="below" breakpoint="desktop">
 							<H3>Match Stats</H3>
-						</RightBorder>
-					</Hide>
-					<Hide when="below" breakpoint="desktop">
-						<H3>Match Stats</H3>
-					</Hide>
-				</ShiftLeft>
-			</GridItem>
-			<GridItem area="possession">
-				<RightBorder>
-					<H4>Possession</H4>
-					<Center>
-						<DecideDoughnut
-							home={home}
-							away={away}
-							format={format}
-						/>
-					</Center>
-				</RightBorder>
-				<br />
-			</GridItem>
-			<GridItem area="attempts">
-				<H4>Attempts</H4>
-				<GoalAttempts
-					left={{
-						onTarget: home.shotsOn,
-						offTarget: home.shotsOff,
-						color: home.colours,
-					}}
-					right={{
-						onTarget: away.shotsOn,
-						offTarget: away.shotsOff,
-						color: away.colours,
-					}}
-					backgroundColour={BACKGROUND_COLOUR}
-				/>
-			</GridItem>
-			<GridItem area="corners">
-				<H4>Corners</H4>
-				<Distribution
-					left={{
-						value: home.corners,
-						color: home.colours,
-					}}
-					right={{
-						value: away.corners,
-						color: away.colours,
-					}}
-				/>
-			</GridItem>
-			<GridItem area="fouls">
-				<H4>Fouls</H4>
-				<Distribution
-					left={{
-						value: home.fouls,
-						color: home.colours,
-					}}
-					right={{
-						value: away.fouls,
-						color: away.colours,
-					}}
-				/>
-				<br />
-			</GridItem>
-			<GridItem area="subtitle">
-				<ShiftLeft format={format}>
-					{/* Don't show the right border if this text was
+						</Hide>
+					</ShiftLeft>
+				</GridItem>
+				<GridItem area="possession">
+					<RightBorder>
+						<H4>Possession</H4>
+						<Center>
+							<DecideDoughnut
+								home={home}
+								away={away}
+								format={format}
+							/>
+						</Center>
+					</RightBorder>
+					<br />
+				</GridItem>
+				<GridItem area="attempts">
+					<H4>Attempts</H4>
+					<GoalAttempts
+						left={{
+							onTarget: home.shotsOn,
+							offTarget: home.shotsOff,
+							color: home.colours,
+						}}
+						right={{
+							onTarget: away.shotsOn,
+							offTarget: away.shotsOff,
+							color: away.colours,
+						}}
+						palette={palette}
+					/>
+				</GridItem>
+				<GridItem area="corners">
+					<H4>Corners</H4>
+					<Distribution
+						left={{
+							value: home.corners,
+							color: home.colours,
+						}}
+						right={{
+							value: away.corners,
+							color: away.colours,
+						}}
+					/>
+				</GridItem>
+				<GridItem area="fouls">
+					<H4>Fouls</H4>
+					<Distribution
+						left={{
+							value: home.fouls,
+							color: home.colours,
+						}}
+						right={{
+							value: away.fouls,
+							color: away.colours,
+						}}
+					/>
+					<br />
+				</GridItem>
+				<GridItem area="subtitle">
+					<ShiftLeft format={format}>
+						{/* Don't show the right border if this text was
                         shifted into the left column */}
-					<Hide when="above" breakpoint="desktop">
-						<RightBorder>
+						<Hide when="above" breakpoint="desktop">
+							<RightBorder>
+								<H3>Lineups</H3>
+							</RightBorder>
+						</Hide>
+						<Hide when="below" breakpoint="desktop">
 							<H3>Lineups</H3>
-						</RightBorder>
-					</Hide>
-					<Hide when="below" breakpoint="desktop">
-						<H3>Lineups</H3>
-					</Hide>
-				</ShiftLeft>
-			</GridItem>
-			<GridItem area="home">
-				<RightBorder>
-					<H4>{home.name}</H4>
+						</Hide>
+					</ShiftLeft>
+				</GridItem>
+				<GridItem area="home">
+					<RightBorder>
+						<H4>{home.name}</H4>
+						<Lineup
+							players={home.players.filter(
+								(player) => !player.substitute,
+							)}
+						/>
+						<br />
+						<H4>Substitutes</H4>
+						<Lineup
+							players={home.players.filter(
+								(player) => player.substitute,
+							)}
+						/>
+						<br />
+					</RightBorder>
+				</GridItem>
+				<GridItem area="away">
+					<H4>{away.name}</H4>
 					<Lineup
-						players={home.players.filter(
+						players={away.players.filter(
 							(player) => !player.substitute,
 						)}
 					/>
 					<br />
 					<H4>Substitutes</H4>
 					<Lineup
-						players={home.players.filter(
+						players={away.players.filter(
 							(player) => player.substitute,
 						)}
 					/>
 					<br />
-				</RightBorder>
-			</GridItem>
-			<GridItem area="away">
-				<H4>{away.name}</H4>
-				<Lineup
-					players={away.players.filter(
-						(player) => !player.substitute,
-					)}
-				/>
-				<br />
-				<H4>Substitutes</H4>
-				<Lineup
-					players={away.players.filter((player) => player.substitute)}
-				/>
-				<br />
-			</GridItem>
-		</StatsGrid>
-	</StretchBackground>
-);
+				</GridItem>
+			</StatsGrid>
+		</StretchBackground>
+	);
+};

--- a/dotcom-rendering/src/web/components/MatchStats.tsx
+++ b/dotcom-rendering/src/web/components/MatchStats.tsx
@@ -33,7 +33,6 @@ const StatsGrid = ({
 	children: React.ReactNode;
 	format: ArticleFormat;
 }) => {
-
 	const palette = decidePalette(format);
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:

--- a/dotcom-rendering/src/web/components/MatchStats.tsx
+++ b/dotcom-rendering/src/web/components/MatchStats.tsx
@@ -146,40 +146,44 @@ const StatsGrid = ({
 };
 
 const StretchBackground = ({
-	palette,
+	format,
 	children,
 }: {
-	palette: Palette;
+	format: ArticleFormat;
 	children: React.ReactNode;
-}) => (
-	<div
-		css={css`
-			clear: left;
-			position: relative;
-			flex-grow: 1;
-			padding: ${space[2]}px 10px;
-			/* We use min-height to help reduce our CLS value */
-			min-height: 800px;
-			background-color: ${palette.background.matchStats};
+}) => {
+	const palette = decidePalette(format);
 
-			${from.leftCol} {
-				:before {
-					content: '';
-					position: absolute;
-					top: 0;
-					bottom: 0;
-					/* stretch left */
-					left: -100vw;
-					right: 0;
-					background-color: ${palette.background.matchStats};
-					z-index: -1;
+	return (
+		<div
+			css={css`
+				clear: left;
+				position: relative;
+				flex-grow: 1;
+				padding: ${space[2]}px 10px;
+				/* We use min-height to help reduce our CLS value */
+				min-height: 800px;
+				background-color: ${palette.background.matchStats};
+
+				${from.leftCol} {
+					:before {
+						content: '';
+						position: absolute;
+						top: 0;
+						bottom: 0;
+						/* stretch left */
+						left: -100vw;
+						right: 0;
+						background-color: ${palette.background.matchStats};
+						z-index: -1;
+					}
 				}
-			}
-		`}
-	>
-		{children}
-	</div>
-);
+			`}
+		>
+			{children}
+		</div>
+	);
+};
 
 const ShiftLeft = ({
 	children,
@@ -341,10 +345,8 @@ const DecideDoughnut = ({
 };
 
 export const MatchStats = ({ home, away, format }: Props) => {
-	const palette = decidePalette(format);
-
 	return (
-		<StretchBackground palette={palette}>
+		<StretchBackground format={format}>
 			<StatsGrid format={format}>
 				<GridItem area="title" element="aside">
 					<ShiftLeft format={format}>
@@ -386,7 +388,7 @@ export const MatchStats = ({ home, away, format }: Props) => {
 							offTarget: away.shotsOff,
 							color: away.colours,
 						}}
-						palette={palette}
+						format={format}
 					/>
 				</GridItem>
 				<GridItem area="corners">

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -951,6 +951,16 @@ const textShareCountUntilDesktop = (format: ArticleFormat): string => {
 	return text.supporting;
 };
 
+const backgroundMatchStats = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return neutral[97];
+		default:
+			return "#d9edf6";
+	}
+};
+
 export const decidePalette = (format: ArticleFormat): Palette => {
 	return {
 		text: {
@@ -1016,6 +1026,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			mostViewedTab: backgroundMostViewedTab(format),
 			matchNav: backgroundMatchNav(),
 			analysisUnderline: backgroundUnderline(format),
+			matchStats: backgroundMatchStats(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -957,7 +957,7 @@ const backgroundMatchStats = (format: ArticleFormat): string => {
 		case ArticleDesign.DeadBlog:
 			return neutral[97];
 		default:
-			return "#d9edf6";
+			return '#d9edf6';
 	}
 };
 


### PR DESCRIPTION
## What does this change?
This PR refactors the `MatchStats` component so it now uses `decidePalette` to handle styling.
The diff looks atrocious, sorry, but it's a result of running `yarn prettier:fix` - you can review it with hidden whitespace [here](https://github.com/guardian/dotcom-rendering/pull/4204/files?diff=unified&w=1), which is much better.

The bulk of the PR is around changing the props of `MatchStats`, `StretchBackground`, `GoalAttempts`, `Side` to take `format` as one of the props, which allows the use of `decidePalette`. 

## Why?
This was needed because the component used to take a fixed background colour, which looked incorrect on liveblogs and deadblogs (where it needed to be transparent instead).

## Screenshots
| **Before** | **After** |
|------------|-----------|
| <img width="987" alt="image" src="https://user-images.githubusercontent.com/57295823/157273654-2f1abca5-8139-4dce-b3d3-b7d819047d8f.png"> | <img width="981" alt="image" src="https://user-images.githubusercontent.com/57295823/157273811-ef5bc9f8-913f-4468-9adb-78f71e83b3ab.png"> |
| <img width="1136" alt="image" src="https://user-images.githubusercontent.com/57295823/157274089-0af427a5-4987-4410-803c-811fe522cdab.png"> | <img width="1132" alt="image" src="https://user-images.githubusercontent.com/57295823/157273985-1fe7edb9-7dc4-4c10-b103-2737987241f6.png"> |

The changes introduced by this PR do not introduce a visual difference in standard articles - only in live / deadblogs.