### PR TITLE
Show before/after screenshots side by side in PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
 
 ## Why?
 
-### Before
+## Screenshots
 
-### After
+| **Before** | **After** |
+|------------|-----------|
+| Image      | Image     |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,20 @@
 
 ## Screenshots
 
-| **Before** | **After** |
-|------------|-----------|
-| Image      | Image     |
+| Before      | After      |
+|-------------|------------|
+| ![before][] | ![after][] |
+
+[before]: https://example.com/before.png
+[after]: https://example.com/after.png
+
+<!--
+You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.
+
+| ![before2][] | ![after2][] |
+
+You can then reference the labels and map them to corresponding links.
+
+[before2]: https://example.com/before2.png
+[after2]: https://example.com/after2.png
+-->


### PR DESCRIPTION
## What does this change?
This PR changes the PR template (how very meta).

I think it makes sense to have the before and after screenshots side by side as opposed to one below the either, as I find it much easier to spot differences.
I'd be interested in hearing your thoughts on this.

There are a couple of examples where I've tried this out and it's not too bad, e.g.:

- #4204 
- #4175 
- #4198 