### PR TITLE
AB test for Prebid server on AMP

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -1,4 +1,5 @@
 import { adJson, stringify } from '../lib/ad-json';
+import { RTCParameters } from '../lib/real-time-config';
 
 // Largest size first
 const inlineSizes = [
@@ -103,7 +104,7 @@ export interface BaseAdProps {
 
 interface AdProps extends BaseAdProps {
 	isSticky?: boolean;
-	placementId: number;
+	rtcParameters: RTCParameters;
 }
 
 export const Ad = ({
@@ -114,7 +115,7 @@ export const Ad = ({
 	commercialProperties,
 	adTargeting,
 	config: { useAmazon, usePrebid, usePermutive },
-	placementId,
+	rtcParameters,
 }: AdProps) => {
 	const adSizes = isSticky ? stickySizes : inlineSizes;
 	// Set Primary ad size as first element (should be the largest)
@@ -149,7 +150,7 @@ export const Ad = ({
 				usePrebid,
 				usePermutive,
 				useAmazon,
-				placementId,
+				rtcParameters.placementId,
 			)}
 		/>
 	);

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -28,6 +28,21 @@ const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
 
 const relevantYieldURLPrefix = 'https://pbs.relevant-digital.com/openrtb2/amp';
 
+const commonPrebidUrlParams = [
+	'w=ATTR(width)',
+	'h=ATTR(height)',
+	'ow=ATTR(data-override-width)',
+	'oh=ATTR(data-override-height)',
+	'ms=ATTR(data-multi-size)',
+	'slot=ATTR(data-slot)',
+	'targeting=TGT',
+	'curl=CANONICAL_URL',
+	'timeout=TIMEOUT',
+	'adcid=ADCID',
+	'purl=HREF',
+	'gdpr_consent=CONSENT_STRING',
+];
+
 const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	const adTargetingMapped: AdTargetParam[] = [];
 
@@ -72,8 +87,8 @@ const useRealTimeConfig = (
 	if (isInVariant('relevant-yield', group)) {
 		const relevantYieldURL = [
 			`${relevantYieldURLPrefix}?tag_id=${tagId}`,
+			...commonPrebidUrlParams,
 			'tgt_pfx=rv',
-			'gdpr_consent=CONSENT_STRING',
 			'dummy_param=ATTR(data-amp-slot-index)',
 		].join('&');
 
@@ -108,18 +123,7 @@ const useRealTimeConfig = (
 		// In this case it corresponds to the placement ID of the bid requests
 		// on the prebid server
 		`${preBidServerPrefix}?tag_id=${placementId}`,
-		'w=ATTR(width)',
-		'h=ATTR(height)',
-		'ow=ATTR(data-override-width)',
-		'oh=ATTR(data-override-height)',
-		'ms=ATTR(data-multi-size)',
-		'slot=ATTR(data-slot)',
-		'targeting=TGT',
-		'curl=CANONICAL_URL',
-		'timeout=TIMEOUT',
-		'adcid=ADCID',
-		'purl=HREF',
-		'gdpr_consent=CONSENT_STRING',
+		...commonPrebidUrlParams,
 	].join('&');
 
 	return realTimeConfig({

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -74,6 +74,7 @@ const useRealTimeConfig = (
 			`${relevantYieldURLPrefix}?tag_id=${tagId}`,
 			'tgt_pfx=rv',
 			'gdpr_consent=CONSENT_STRING',
+			'dummy_param=ATTR(data-amp-slot-index)',
 		].join('&');
 
 		return realTimeConfig({

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -16,13 +16,13 @@ describe('RegionalAd', () => {
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 
 	const ukRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
 	const usRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
 	const auRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
 	const intRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
 
 	const apsVendorObj = {
 		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -12,8 +12,8 @@ describe('RegionalAd', () => {
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=7&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const auPrebidURL =
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
-	// UK and International have same tag_id
-	const intPrebidURL = ukPrebidURL;
+	const intPrebidURL =
+		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 
 	const ukRelevantYieldURL =
 		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
@@ -34,9 +34,24 @@ describe('RegionalAd', () => {
 			PUB_ID: '157207',
 		},
 	};
-	const usPubmaticVendorObj = ukPubmaticVendorObj;
-	const auPubmaticVendorObj = usPubmaticVendorObj;
-	const intPubmaticVendorObj = auPubmaticVendorObj;
+	const usPubmaticVendorObj = {
+		openwrap: {
+			PROFILE_ID: '6696',
+			PUB_ID: '157206',
+		},
+	};
+	const auPubmaticVendorObj = {
+		openwrap: {
+			PROFILE_ID: '6697',
+			PUB_ID: '157203',
+		},
+	};
+	const intPubmaticVendorObj = {
+		openwrap: {
+			PROFILE_ID: '6611',
+			PUB_ID: '157207',
+		},
+	};
 
 	it('with no ab test running rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -5,6 +5,7 @@ import { RegionalAd } from './RegionalAd';
 describe('RegionalAd', () => {
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+
 	const ukPrebidURL =
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const usPrebidURL =
@@ -13,6 +14,29 @@ describe('RegionalAd', () => {
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	// UK and International have same tag_id
 	const intPrebidURL = ukPrebidURL;
+
+	const ukRelevantYieldURL =
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+	const usRelevantYieldURL =
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+	const auRelevantYieldURL =
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+	const intRelevantYieldURL =
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&tgt_pfx=rv&gdpr_consent=CONSENT_STRING';
+
+	const apsVendorObj = {
+		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
+	};
+
+	const ukPubmaticVendorObj = {
+		openwrap: {
+			PROFILE_ID: '6611',
+			PUB_ID: '157207',
+		},
+	};
+	const usPubmaticVendorObj = ukPubmaticVendorObj;
+	const auPubmaticVendorObj = usPubmaticVendorObj;
+	const intPubmaticVendorObj = auPubmaticVendorObj;
 
 	it('with no ab test running rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
@@ -57,13 +81,10 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		expect(ukRtcAttribute.urls).toMatchObject([ukPrebidURL, permutiveURL]);
-		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL, permutiveURL]);
-		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL, permutiveURL]);
-		expect(intRtcAttribute.urls).toMatchObject([
-			intPrebidURL,
-			permutiveURL,
-		]);
+		expect(ukRtcAttribute.urls).toEqual([ukPrebidURL, permutiveURL]);
+		expect(usRtcAttribute.urls).toEqual([usPrebidURL, permutiveURL]);
+		expect(auRtcAttribute.urls).toEqual([auPrebidURL, permutiveURL]);
+		expect(intRtcAttribute.urls).toEqual([intPrebidURL, permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains just the prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
@@ -109,10 +130,10 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		expect(ukRtcAttribute.urls).toMatchObject([ukPrebidURL]);
-		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL]);
-		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL]);
-		expect(intRtcAttribute.urls).toMatchObject([intPrebidURL]);
+		expect(ukRtcAttribute.urls).toEqual([ukPrebidURL]);
+		expect(usRtcAttribute.urls).toEqual([usPrebidURL]);
+		expect(auRtcAttribute.urls).toEqual([auPrebidURL]);
+		expect(intRtcAttribute.urls).toEqual([intPrebidURL]);
 	});
 
 	it('with no ab test running rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
@@ -158,10 +179,10 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		expect(ukRtcAttribute.urls).toMatchObject([permutiveURL]);
-		expect(usRtcAttribute.urls).toMatchObject([permutiveURL]);
-		expect(auRtcAttribute.urls).toMatchObject([permutiveURL]);
-		expect(intRtcAttribute.urls).toMatchObject([permutiveURL]);
+		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
@@ -256,14 +277,10 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		const apsVendorObj = {
-			aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
-		};
-
-		expect(ukRtcAttribute.vendors).toMatchObject(apsVendorObj);
-		expect(usRtcAttribute.vendors).toMatchObject(apsVendorObj);
-		expect(auRtcAttribute.vendors).toMatchObject(apsVendorObj);
-		expect(intRtcAttribute.vendors).toMatchObject(apsVendorObj);
+		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
 	it('with no ab test running rtc-config contains no vendor config when `useAmazon` is set to false', () => {
@@ -309,9 +326,195 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		expect(ukRtcAttribute.vendors).toMatchObject({});
-		expect(usRtcAttribute.vendors).toMatchObject({});
-		expect(auRtcAttribute.vendors).toMatchObject({});
-		expect(intRtcAttribute.vendors).toMatchObject({});
+		expect(ukRtcAttribute.vendors).toEqual({});
+		expect(usRtcAttribute.vendors).toEqual({});
+		expect(auRtcAttribute.vendors).toEqual({});
+		expect(intRtcAttribute.vendors).toEqual({});
+	});
+
+	it('with ab test running and in control group, rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
+		const { container } = render(
+			<ContentABTestProvider
+				pageId="world/2021/jun/24/hong-kong-apple-daily-queue-final-edition-newspaper"
+				switches={{ ampContentAbTesting: true }}
+			>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: true,
+						usePermutive: true,
+						useAmazon: true,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
+		);
+
+		const ampAdElement = container.querySelectorAll('amp-ad');
+
+		expect(ampAdElement).not.toBeNull();
+
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
+
+		expect(ukRtcAttribute.urls).toEqual([ukPrebidURL, permutiveURL]);
+		expect(usRtcAttribute.urls).toEqual([usPrebidURL, permutiveURL]);
+		expect(auRtcAttribute.urls).toEqual([auPrebidURL, permutiveURL]);
+		expect(intRtcAttribute.urls).toEqual([intPrebidURL, permutiveURL]);
+
+		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
+	});
+
+	it('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
+		const { container } = render(
+			<ContentABTestProvider
+				pageId="food/2022/feb/15/air-fryers-miraculous-kitchen-must-have-or-just-a-load-of-hot-air"
+				switches={{ ampContentAbTesting: true }}
+			>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: true,
+						usePermutive: true,
+						useAmazon: true,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
+		);
+
+		const ampAdElement = container.querySelectorAll('amp-ad');
+
+		expect(ampAdElement).not.toBeNull();
+
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
+
+		expect(ukRtcAttribute.urls).toEqual([ukRelevantYieldURL, permutiveURL]);
+		expect(usRtcAttribute.urls).toEqual([usRelevantYieldURL, permutiveURL]);
+		expect(auRtcAttribute.urls).toEqual([auRelevantYieldURL, permutiveURL]);
+		expect(intRtcAttribute.urls).toEqual([
+			intRelevantYieldURL,
+			permutiveURL,
+		]);
+
+		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
+	});
+
+	it('with ab test running and in Pubmatic variant, rtc-config contains Permutive UR and Pubmatic vendor when `usePermutive` and `usePrebid` flags are set to true', () => {
+		const { container } = render(
+			<ContentABTestProvider
+				pageId="money/2004/may/13/homeimprovements"
+				switches={{ ampContentAbTesting: true }}
+			>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: true,
+						usePermutive: true,
+						useAmazon: true,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
+		);
+
+		const ampAdElement = container.querySelectorAll('amp-ad');
+
+		expect(ampAdElement).not.toBeNull();
+
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[0].getAttribute('rtc-config') || '{}',
+		);
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[1].getAttribute('rtc-config') || '{}',
+		);
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
+
+		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
+
+		expect(ukRtcAttribute.vendors).toEqual({
+			...ukPubmaticVendorObj,
+			...apsVendorObj,
+		});
+		expect(usRtcAttribute.vendors).toEqual({
+			...usPubmaticVendorObj,
+			...apsVendorObj,
+		});
+		expect(auRtcAttribute.vendors).toEqual({
+			...auPubmaticVendorObj,
+			...apsVendorObj,
+		});
+		expect(intRtcAttribute.vendors).toEqual({
+			...intPubmaticVendorObj,
+			...apsVendorObj,
+		});
 	});
 });

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -16,13 +16,13 @@ describe('RegionalAd', () => {
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 
 	const ukRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const usRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const auRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const intRelevantYieldURL =
-		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&tgt_pfx=rv&gdpr_consent=CONSENT_STRING&dummy_param=ATTR(data-amp-slot-index)';
+		'https://pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 
 	const apsVendorObj = {
 		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -1,278 +1,317 @@
 import { render } from '@testing-library/react';
+import { ContentABTestProvider } from './ContentABTest';
 import { RegionalAd } from './RegionalAd';
 
 describe('RegionalAd', () => {
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+	const ukPrebidURL =
+		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const usPrebidURL =
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=7&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const auPrebidURL =
 		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
-	const rowPrebidURL =
-		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
+	// UK and International have same tag_id
+	const intPrebidURL = ukPrebidURL;
 
-	it('rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
+	it('with no ab test running rtc-config contains permutive and prebid URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: true,
-					usePermutive: true,
-					useAmazon: false,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: true,
+						usePermutive: true,
+						useAmazon: false,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
 		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
+		expect(ukRtcAttribute.urls).toMatchObject([ukPrebidURL, permutiveURL]);
 		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL, permutiveURL]);
 		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL, permutiveURL]);
-		expect(rowRtcAttribute.urls).toMatchObject([
-			rowPrebidURL,
+		expect(intRtcAttribute.urls).toMatchObject([
+			intPrebidURL,
 			permutiveURL,
 		]);
 	});
 
-	it('rtc-config contains just the prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
+	it('with no ab test running rtc-config contains just the prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: true,
-					usePermutive: false,
-					useAmazon: false,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: true,
+						usePermutive: false,
+						useAmazon: false,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
 		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
+		expect(ukRtcAttribute.urls).toMatchObject([ukPrebidURL]);
 		expect(usRtcAttribute.urls).toMatchObject([usPrebidURL]);
 		expect(auRtcAttribute.urls).toMatchObject([auPrebidURL]);
-		expect(rowRtcAttribute.urls).toMatchObject([rowPrebidURL]);
+		expect(intRtcAttribute.urls).toMatchObject([intPrebidURL]);
 	});
 
-	it('rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
+	it('with no ab test running rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: false,
-					usePermutive: true,
-					useAmazon: false,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: false,
+						usePermutive: true,
+						useAmazon: false,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
 		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
+		expect(ukRtcAttribute.urls).toMatchObject([permutiveURL]);
 		expect(usRtcAttribute.urls).toMatchObject([permutiveURL]);
 		expect(auRtcAttribute.urls).toMatchObject([permutiveURL]);
-		expect(rowRtcAttribute.urls).toMatchObject([permutiveURL]);
+		expect(intRtcAttribute.urls).toMatchObject([permutiveURL]);
 	});
 
-	it('rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
+	it('with no ab test running rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: false,
-					usePermutive: false,
-					useAmazon: false,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: false,
+						usePermutive: false,
+						useAmazon: false,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
 		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
+		expect(ukRtcAttribute.urls).toHaveLength(0);
 		expect(usRtcAttribute.urls).toHaveLength(0);
 		expect(auRtcAttribute.urls).toHaveLength(0);
-		expect(rowRtcAttribute.urls).toHaveLength(0);
+		expect(intRtcAttribute.urls).toHaveLength(0);
 	});
 
-	it('rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
+	it('with no ab test running rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: false,
-					usePermutive: false,
-					useAmazon: true,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: false,
+						usePermutive: false,
+						useAmazon: true,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
+		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
 		const apsVendorObj = {
 			aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
 		};
 
+		expect(ukRtcAttribute.vendors).toMatchObject(apsVendorObj);
 		expect(usRtcAttribute.vendors).toMatchObject(apsVendorObj);
 		expect(auRtcAttribute.vendors).toMatchObject(apsVendorObj);
-		expect(rowRtcAttribute.vendors).toMatchObject(apsVendorObj);
+		expect(intRtcAttribute.vendors).toMatchObject(apsVendorObj);
 	});
 
-	it('rtc-config contains no vendor config when `useAmazon` is set to false', () => {
+	it('with no ab test running rtc-config contains no vendor config when `useAmazon` is set to false', () => {
 		const { container } = render(
-			<RegionalAd
-				edition="UK"
-				section=""
-				contentType=""
-				config={{
-					usePrebid: false,
-					usePermutive: false,
-					useAmazon: false,
-				}}
-				commercialProperties={{
-					UK: { adTargeting: [] },
-					US: { adTargeting: [] },
-					AU: { adTargeting: [] },
-					INT: { adTargeting: [] },
-				}}
-				adTargeting={{
-					customParams: { sens: 'f', urlkw: [] },
-					adUnit: '',
-				}}
-			/>,
+			<ContentABTestProvider pageId="" switches={{}}>
+				<RegionalAd
+					edition="UK"
+					section=""
+					contentType=""
+					config={{
+						usePrebid: false,
+						usePermutive: false,
+						useAmazon: false,
+					}}
+					commercialProperties={{
+						UK: { adTargeting: [] },
+						US: { adTargeting: [] },
+						AU: { adTargeting: [] },
+						INT: { adTargeting: [] },
+					}}
+					adTargeting={{
+						customParams: { sens: 'f', urlkw: [] },
+						adUnit: '',
+					}}
+				/>
+			</ContentABTestProvider>,
 		);
 
 		const ampAdElement = container.querySelectorAll('amp-ad');
 
 		expect(ampAdElement).not.toBeNull();
 
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
+		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[0].getAttribute('rtc-config') || '{}',
 		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
+		const usRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[1].getAttribute('rtc-config') || '{}',
 		);
-		const rowRtcAttribute: Record<string, unknown> = JSON.parse(
+		const auRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[2].getAttribute('rtc-config') || '{}',
 		);
+		const intRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
+		expect(ukRtcAttribute.vendors).toMatchObject({});
 		expect(usRtcAttribute.vendors).toMatchObject({});
 		expect(auRtcAttribute.vendors).toMatchObject({});
-		expect(rowRtcAttribute.vendors).toMatchObject({});
+		expect(intRtcAttribute.vendors).toMatchObject({});
 	});
 });

--- a/dotcom-rendering/src/amp/components/RegionalAd.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.tsx
@@ -1,33 +1,7 @@
 import { ClassNames } from '@emotion/react';
-import { regionClasses } from '../lib/region-classes';
+import { getRTCParameters } from '../lib/real-time-config';
+import { adRegions, regionClasses } from '../lib/region-classes';
 import { BaseAdProps, Ad } from './Ad';
-
-type AdRegion = 'US' | 'AU' | 'ROW';
-
-// Array of possible ad regions
-const adRegions: AdRegion[] = ['US', 'AU', 'ROW'];
-
-/**
- * Determine the Placement ID that is used to look up a given stored bid request
- *
- * Stored bid requests are stored by the prebid server instance and each is
- * keyed by a placement ID. This placement ID corresponds to the tag id parameter
- * provided on the client
- *
- * @param adRegion The advertising region - different regions are covered by different
- * stored bid requests
- * @returns The placement id for an ad, depending on its ad region
- */
-const getPlacementIdByAdRegion = (adRegion: AdRegion): number => {
-	switch (adRegion) {
-		case 'US':
-			return 7;
-		case 'AU':
-			return 6;
-		default:
-			return 4;
-	}
-};
 
 /**
  * Ad slot component whose config differs based on region.
@@ -62,7 +36,7 @@ export const RegionalAd = ({
 							contentType={contentType}
 							commercialProperties={commercialProperties}
 							config={config}
-							placementId={getPlacementIdByAdRegion(adRegion)}
+							rtcParameters={getRTCParameters({ adRegion })}
 							adTargeting={adTargeting}
 						/>
 					</div>

--- a/dotcom-rendering/src/amp/components/StickyAd.tsx
+++ b/dotcom-rendering/src/amp/components/StickyAd.tsx
@@ -1,4 +1,5 @@
 import { text, textSans } from '@guardian/source-foundations';
+import { getRTCParameters } from '../lib/real-time-config';
 import { BaseAdProps, Ad } from './Ad';
 
 // This CSS should be imported and added to global styles in amp/server/document.tsx to add the Advertisement label to the sticky
@@ -14,8 +15,6 @@ amp-sticky-ad:before {
 	line-height: 1;
 	font-size: 0.75rem;
 }`;
-
-const mobileStickyPlacementId = 9;
 
 export const StickyAd = ({
 	edition,
@@ -34,8 +33,8 @@ export const StickyAd = ({
 				contentType={contentType}
 				commercialProperties={commercialProperties}
 				config={config}
-				placementId={mobileStickyPlacementId}
 				adTargeting={adTargeting}
+				rtcParameters={getRTCParameters({ isSticky: true })}
 			/>
 		</amp-sticky-ad>
 	);

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -50,20 +50,20 @@ const getPlacementId = (adType: AdType): number => {
  * Determine the Relevant Yield tag id that is used to look up a given stored bid request
  */
 const getTagId = (adType: AdType): string => {
-	if (!adType.isSticky) {
-		switch (adType.adRegion) {
-			case 'UK':
-				return '6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f';
-			case 'US':
-				return '6214cb381a577cd525aeef3f_6214caacb52b565527aeef39';
-			case 'AU':
-				return '6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40';
-			// 'INT' same as sticky
-			default:
-				break;
-		}
+	if (adType.isSticky || adType.adRegion === 'INT') {
+		return '6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2';
 	}
-	return '6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2';
+
+	if (adType.adRegion === 'UK') {
+		return '6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f';
+	}
+
+	if (adType.adRegion === 'US') {
+		return '6214cb381a577cd525aeef3f_6214caacb52b565527aeef39';
+	}
+
+	// ad region is AU
+	return '6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40';
 };
 
 /**
@@ -76,19 +76,23 @@ const getPubAndProfileIds = (
 	pubId: string;
 	profileId: string;
 } => {
-	if (!adType.isSticky) {
-		switch (adType.adRegion) {
-			case 'AU':
-				return { profileId: '6697', pubId: '157203' };
-			case 'US':
-				return { profileId: '6696', pubId: '157206' };
-		}
+	if (
+		adType.isSticky ||
+		adType.adRegion === 'UK' ||
+		adType.adRegion === 'INT'
+	) {
+		return {
+			profileId: '6611',
+			pubId: '157207',
+		};
 	}
-	// Sticky, International and UK
-	return {
-		profileId: '6611',
-		pubId: '157207',
-	};
+
+	if (adType.adRegion === 'AU') {
+		return { profileId: '6697', pubId: '157203' };
+	}
+
+	// ad region is US
+	return { profileId: '6696', pubId: '157206' };
 };
 
 /**

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -39,3 +39,34 @@ const getPlacementId = (config: Config): number => {
 export const getRTCParameters = (config: Config): RTCParameters => ({
 	placementId: getPlacementId(config),
 });
+
+const permutiveURL = 'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+
+const amazonConfig = {
+	aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
+};
+
+const notUndefined = <T>(x: T | undefined): x is T => x !== undefined;
+
+export const realTimeConfig = ({
+	vendors = {},
+	url = undefined,
+	usePermutive = false,
+	useAmazon = false,
+}: {
+	vendors?: Record<string, unknown>;
+	url?: string;
+	usePermutive?: boolean;
+	useAmazon?: boolean;
+}): string => {
+	const data = {
+		urls: [url, usePermutive ? permutiveURL : undefined].filter(
+			notUndefined,
+		),
+		vendors: {
+			...vendors,
+			...(useAmazon ? amazonConfig : {}),
+		},
+	};
+	return JSON.stringify(data);
+};

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -69,15 +69,27 @@ const getTagId = (adType: AdType): string => {
 /**
  * Determine the pub id and profile id required by Pubmatic to construct an RTC vendor
  *
- * TODO in the future these values will depend up `AdType`
  */
-const getPubAndProfileIds = (): {
+const getPubAndProfileIds = (
+	adType: AdType,
+): {
 	pubId: string;
 	profileId: string;
-} => ({
-	profileId: '6611',
-	pubId: '157207',
-});
+} => {
+	if (!adType.isSticky) {
+		switch (adType.adRegion) {
+			case 'AU':
+				return { profileId: '6697', pubId: '157203' };
+			case 'US':
+				return { profileId: '6696', pubId: '157206' };
+		}
+	}
+	// Sticky, International and UK
+	return {
+		profileId: '6611',
+		pubId: '157207',
+	};
+};
 
 /**
  * Compute the full set of RTC parameters from a given ad type
@@ -85,7 +97,7 @@ const getPubAndProfileIds = (): {
 export const getRTCParameters = (adType: AdType): RTCParameters => ({
 	placementId: getPlacementId(adType),
 	tagId: getTagId(adType),
-	...getPubAndProfileIds(),
+	...getPubAndProfileIds(adType),
 });
 
 const permutiveURL = 'https://guardian.amp.permutive.com/rtc?type=doubleclick';

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -9,6 +9,9 @@ type Config =
 
 export type RTCParameters = {
 	placementId: number;
+	tagId: string;
+	profileId: string;
+	pubId: string;
 };
 
 /**
@@ -36,8 +39,37 @@ const getPlacementId = (config: Config): number => {
 	}
 };
 
+const getTagId = (config: Config): string => {
+	if (!config.isSticky) {
+		switch (config.adRegion) {
+			case 'UK':
+				return '6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f';
+			case 'US':
+				return '6214cb381a577cd525aeef3f_6214caacb52b565527aeef39';
+			case 'AU':
+				return '6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40';
+			// Do the same as for sticky
+			default:
+				break;
+		}
+	}
+	return '6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2';
+};
+
+const getPubAndProfileIds = ({}: Config): {
+	pubId: string;
+	profileId: string;
+} => {
+	return {
+		profileId: '6611',
+		pubId: '157207',
+	};
+};
+
 export const getRTCParameters = (config: Config): RTCParameters => ({
 	placementId: getPlacementId(config),
+	tagId: getTagId(config),
+	...getPubAndProfileIds(config),
 });
 
 const permutiveURL = 'https://guardian.amp.permutive.com/rtc?type=doubleclick';
@@ -53,11 +85,13 @@ export const realTimeConfig = ({
 	url = undefined,
 	usePermutive = false,
 	useAmazon = false,
+	timeoutMillis,
 }: {
 	vendors?: Record<string, unknown>;
 	url?: string;
 	usePermutive?: boolean;
 	useAmazon?: boolean;
+	timeoutMillis?: number;
 }): string => {
 	const data = {
 		urls: [url, usePermutive ? permutiveURL : undefined].filter(
@@ -67,6 +101,7 @@ export const realTimeConfig = ({
 			...vendors,
 			...(useAmazon ? amazonConfig : {}),
 		},
+		...(timeoutMillis ? { timeoutMillis: 1000 } : {}),
 	};
 	return JSON.stringify(data);
 };

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -1,0 +1,41 @@
+import { AdRegion } from './region-classes';
+
+type Config =
+	| { isSticky: true }
+	| {
+			isSticky?: false;
+			adRegion: AdRegion;
+	  };
+
+export type RTCParameters = {
+	placementId: number;
+};
+
+/**
+ * Determine the Placement ID that is used to look up a given stored bid request
+ *
+ * Stored bid requests are stored by the prebid server instance and each is
+ * keyed by a placement ID. This placement ID corresponds to the tag id parameter
+ * provided on the client
+ *
+ * @param adRegion The advertising region - different regions are covered by different
+ * stored bid requests
+ * @returns The placement id for an ad, depending on its ad region
+ */
+const getPlacementId = (config: Config): number => {
+	if (config.isSticky) {
+		return 9;
+	}
+	switch (config.adRegion) {
+		case 'US':
+			return 7;
+		case 'AU':
+			return 6;
+		default:
+			return 4;
+	}
+};
+
+export const getRTCParameters = (config: Config): RTCParameters => ({
+	placementId: getPlacementId(config),
+});

--- a/dotcom-rendering/src/amp/lib/region-classes.ts
+++ b/dotcom-rendering/src/amp/lib/region-classes.ts
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
 
+// Array of possible ad regions
+export const adRegions = ['UK', 'US', 'AU', 'INT'] as const;
+
+export type AdRegion = typeof adRegions[number];
+
 /**
  * Class that will display an element if the user accesses the AMP page
  * from Great Britain


### PR DESCRIPTION
## What does this change?

This PR introduces a test to assign different AMP pages to use different Prebid servers when filling ad slots.

We use a lightweight content testing AB test framework introduced in #4110 to partition AMP content into three variants. Each of the three groups will fire Prebid requests to a different partner. We have a total of 12 groups available and split them evenly between the three variants. The test plan is summarised in the table below:

| Prebid Server    | Variant          | Groups          |
|------------------|------------------|-----------------|
| Xander (current) | `control`        | 0,1,2,3 (33.3%) |
| Relevant Yield   | `relevant-yield` | 4,5,6,7 (33.3%)         |
| Pubmatic         | `pubmatic`       | 8,9,10,11 (33.3%)       |

In order to support this setup we make the following changes:

- Create a generic `realTimeConfig` function that produces an RTC string for an arbitrary Prebid partner. We optionally allow Permutive and Amazon by passing flags to this function (these will both be enabled in parallel with the partner under test). 
- This RTC string is passed to the `amp-ad` component and used by the AMP runtime to fire requests to the Prebid server.
- Create a `useRealTimeConfig` hook which uses the content AB test API to retrieve the test group and allocate a variant based off that value. Depending on participation in a given variant, a different RTC string is constructed for each of the given partners.
- We add functions for computing parameters required by the different Prebid partners. We abstract over the current `placementId` parameter required by Xandr to also include `tagId` (required by Relevant Yield) and `profileId` / `pubId` (required by Pubmatic).

## Why?

This test will also us to compare the revenue generated by the different Prebid servers, and make an informed decision about which to use in the future.