### PR TITLE
Bump TypeScript In AR To 4.5.5

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -17719,9 +17719,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -102,7 +102,7 @@
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.6",
     "ts-node": "^9.1.1",
-    "typescript": "^4.4.3",
+    "typescript": "^4.5.5",
     "webpack": "^5.54.0",
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.7.3",


### PR DESCRIPTION
## Why?

We'd like to keep it up-to-date, and some issues with `aws-cdk` seem to be preventing us from going to 4.6.2 for now (see the failing tests on #4210).

## Changes

- Bumps TypeScript to 4.5.5 in AR
