### PR TITLE
Don't skip this test anymore

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/liveblog.interactivity.spec.js
@@ -155,7 +155,7 @@ describe('Liveblogs', function () {
 		cy.wait('@updateCall');
 	});
 
-	it.skip('should handle when the toast is clicked from the second page', function () {
+	it('should handle when the toast is clicked from the second page', function () {
 		stubUpdates();
 		cy.visit(
 			`/Article?url=${blogUrl}?live=true&page=with:block-6214732b8f08f86d89ef68d6&filterKeyEvents=false#liveblog-navigation`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Enables the test to verify that when clicking on the toast from the second page we are correctly routed

## Why?
Because we merged [this PR](https://github.com/guardian/dotcom-rendering/pull/4099) which is what we were [waiting on](https://github.com/guardian/dotcom-rendering/pull/4105)
