### PR TITLE
Single front door test v2

### DIFF
--- a/dotcom-rendering/src/web/components/App.tsx
+++ b/dotcom-rendering/src/web/components/App.tsx
@@ -22,7 +22,6 @@ import { ReaderRevenueDevUtils } from '../lib/readerRevenueDevUtils';
 
 import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';
-import { Lazy } from './Lazy';
 
 type Props = {
 	CAPI: CAPIBrowserType;
@@ -204,20 +203,6 @@ export const App = ({ CAPI }: Props) => {
 					idUrl={CAPI.config.idUrl}
 					pageViewId={pageViewId}
 				/>
-			</Portal>
-			<Portal rootId="reader-revenue-links-footer">
-				<Lazy margin={300}>
-					<ReaderRevenueLinks
-						urls={CAPI.nav.readerRevenueLinks.footer}
-						edition={CAPI.editionId}
-						dataLinkNamePrefix="footer : "
-						inHeader={false}
-						remoteHeaderEnabled={false}
-						pageViewId={pageViewId}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
-						ophanRecord={ophanRecord}
-					/>
-				</Lazy>
 			</Portal>
 			<Portal rootId="bottom-banner">
 				<StickyBottomBanner

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -232,27 +232,20 @@ export const Links = ({
 
 	const isServer = typeof window === 'undefined';
 
-	const showSupporterCTA =
-		!isServer &&
-		getCookie({
-			name: 'gu_hide_support_messaging',
-			shouldMemoize: true,
-		}) === 'true';
-
 	const isSignedIn =
 		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
 
 	return (
 		<div data-print-layout="hide" css={linksStyles}>
-			{showSupporterCTA && supporterCTA !== '' && (
+			{supporterCTA !== '' && (
 				<>
 					<div css={seperatorStyles} />
 					<a
-						href={supporterCTA}
+						href="https://support.theguardian.com/subscribe/weekly?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_supporter_cta%22%7D"
 						css={[linkTablet({ showAtTablet: false }), linkStyles]}
 						data-link-name="nav2 : supporter-cta"
 					>
-						Subscriptions
+						Print subscriptions
 					</a>
 				</>
 			)}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -73,7 +73,7 @@ export const ReaderRevenueLinks: React.FC<{
 			longTitle: 'Subscribe',
 			title: 'Subscribe',
 			mobileOnly: true,
-			url: readerRevenueLinks.sideMenu.subscribe,
+			url: 'https://support.theguardian.com/subscribe/weekly?INTCMP=side_menu_support_subscribe&acquisitionData=%7B"source"%3A"GUARDIAN_WEB"%2C"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"side_menu_support_subscribe"%7D',
 		},
 	];
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Currently we only show the the "Subscriptions" link in the main navigation to supporters. For the duration of the Single Front Door AB Test we will display a "Print Subscriptions" link which isn't dependant on the user's supporter status and whether they're in the AB test. 

We will also hide the Supporter Revenue links in the footer for all users.

## Changes
- Hide Supporter Revenue links in the footer
- Update "Subscriptions" link in desktop navigation
- Update "Subscriptions" link in mobile navigation

These changes have been reproduced in frontend here: https://github.com/guardian/frontend/pull/24742

## Screenshots
| Before | After |
|-- | -- |
| <img width="587" alt="Screenshot 2022-01-14 at 13 05 20" src="https://user-images.githubusercontent.com/44685872/149520117-e69e17c8-52d4-4c1e-999d-9d5c01bde0d6.png"> | <img width="587" alt="Screenshot 2022-01-14 at 12 57 39" src="https://user-images.githubusercontent.com/44685872/149520132-d97b0290-4bfe-4b1b-bec9-ced757e17434.png"> |
| <img width="829" alt="Screenshot 2022-01-14 at 13 16 49" src="https://user-images.githubusercontent.com/44685872/149521375-474d35ab-c561-4621-baf0-c754a24a82d2.png"> | <img width="829" alt="Screenshot 2022-01-14 at 13 16 36" src="https://user-images.githubusercontent.com/44685872/149521355-525cda32-d2bc-4d3e-b1de-28680afb2ae2.png"> |

## Why
To support the new product proposition work we are going to run an ABC test to measure the effect of the current contribute/subscribe split messaging vs a single 'support the guardian' call to action. This will be done in combination with bringing forward the existing ‘Supporter Newsletter’ & reduced support asks benefits to contributors on the support site.
