### PR TITLE
Ignore elements causing false positives

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -126,7 +126,7 @@ const Live: FC<Props> = ({ item }) => {
 					</div>
 				</GridItem>
 				<GridItem area="key-events">
-					<div css={keyEventsWrapperStyles}>
+					<div css={keyEventsWrapperStyles} data-chromatic="ignore">
 						<KeyEvents
 							keyEvents={keyEvents(item.blocks)}
 							format={item}

--- a/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
@@ -147,6 +147,7 @@ export const MostViewedFooterGrid = ({ data, sectionName, palette }: Props) => {
 								data-cy={`tab-heading-${i}`}
 								key={`tabs-popular-${i}-tab`}
 								data-link-name={tab.heading}
+								data-chromatic="ignore"
 							>
 								<button
 									css={tabButton}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a couple of `data-chromatic="ignore"` attributes to tell Chromatic to not create diffs for these things

## Why?
Because we've been getting false positives on these for a while now and people are getting antsy

## Why not fix the root issue?
Fair. This is a stopgap to calm the masses but we would ideally look deeper into why these were happening. Will that really happen? Maybe, maybe not. It's all about trades offs in the end.
