### PR TITLE
No RichLink images in blogs

### DIFF
--- a/dotcom-rendering/src/web/components/DefaultRichLink.tsx
+++ b/dotcom-rendering/src/web/components/DefaultRichLink.tsx
@@ -22,6 +22,13 @@ export const DefaultRichLink: React.FC<DefaultProps> = ({
 	url,
 	isPlaceholder,
 }) => {
+	const defaultFormat = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		// We default to SpecialReport here purely because the greys of this theme
+		// look better as the defaults
+		theme: ArticleSpecial.SpecialReport,
+	};
 	return (
 		<RichLink
 			richLinkIndex={index}
@@ -30,13 +37,8 @@ export const DefaultRichLink: React.FC<DefaultProps> = ({
 			headlineText={headlineText}
 			contentType="article"
 			url={url}
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				// We default to SpecialReport here purely because the greys of this theme
-				// look better as the defaults
-				theme: ArticleSpecial.SpecialReport,
-			}}
+			linkFormat={defaultFormat}
+			format={defaultFormat}
 			tags={[]}
 			sponsorName=""
 			isPlaceholder={isPlaceholder}

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -47,6 +47,11 @@ export const Article = () => {
 					headlineText="Rich link headline"
 					contentType="article"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -79,6 +84,11 @@ export const Network = () => {
 					headlineText="Rich link headline"
 					contentType="network"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -117,6 +127,11 @@ export const SectionStory = () => {
 					headlineText="Rich link headline"
 					contentType="section"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Sport,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -152,6 +167,11 @@ export const Inline = () => {
 					headlineText="Rich link when inline"
 					contentType="section"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Lifestyle,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -187,6 +207,11 @@ export const ImageContent = () => {
 					headlineText="Rich link headline"
 					contentType="imageContent"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -225,6 +250,11 @@ export const Interactive = () => {
 					headlineText="Rich link headline"
 					contentType="interactive"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Lifestyle,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -262,6 +292,11 @@ export const Gallery = () => {
 					headlineText="Rich link headline"
 					contentType="gallery"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticleSpecial.Labs,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -300,6 +335,11 @@ export const Video = () => {
 					headlineText="Rich link headline"
 					contentType="video"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.News,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -339,6 +379,11 @@ export const Audio = () => {
 					headlineText="Rich link headline"
 					contentType="audio"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -371,6 +416,11 @@ export const LiveBlog = () => {
 					headlineText="Rich link headline"
 					contentType="liveBlog"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Sport,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -409,6 +459,11 @@ export const Tag = () => {
 					headlineText="Rich link headline"
 					contentType="tag"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -441,6 +496,11 @@ export const Index = () => {
 					headlineText="Rich link headline"
 					contentType="index"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -480,6 +540,11 @@ export const Crossword = () => {
 					headlineText="Rich link headline"
 					contentType="crossword"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Opinion,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -512,6 +577,11 @@ export const Survey = () => {
 					headlineText="Rich link headline"
 					contentType="survey"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -544,6 +614,11 @@ export const Signup = () => {
 					headlineText="Rich link headline"
 					contentType="signup"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -577,6 +652,11 @@ export const Userid = () => {
 					headlineText="Rich link headline"
 					contentType="userid"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,
@@ -609,6 +689,11 @@ export const PaidFor = () => {
 					headlineText="Rich link headline"
 					contentType="userid"
 					url=""
+					linkFormat={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: ArticlePillar.Culture,
+					}}
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/web/components/RichLink.stories.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.stories.tsx
@@ -403,7 +403,7 @@ export const LiveBlog = () => {
 			<Figure
 				format={{
 					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
+					design: ArticleDesign.LiveBlog,
 					theme: ArticlePillar.News,
 				}}
 				isMainMedia={false}
@@ -418,12 +418,12 @@ export const LiveBlog = () => {
 					url=""
 					linkFormat={{
 						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
+						design: ArticleDesign.LiveBlog,
 						theme: ArticlePillar.Sport,
 					}}
 					format={{
 						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
+						design: ArticleDesign.LiveBlog,
 						theme: ArticlePillar.Sport,
 					}}
 					tags={[]}

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -303,7 +303,7 @@ export const RichLink = ({
 								<Avatar
 									imageSrc={contributorImage}
 									imageAlt={mainContributor}
-									palette={decidePalette(linkFormat)}
+									palette={palette}
 								/>
 							</div>
 						)}

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -8,7 +8,7 @@ import {
 	textSans,
 	from,
 } from '@guardian/source-foundations';
-import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticleFormat, ArticleSpecial } from '@guardian/libs';
 
 import ArrowInCircle from '../../static/icons/arrow-in-circle.svg';
 
@@ -26,6 +26,7 @@ interface Props {
 	contentType: ContentType;
 	url: string;
 	starRating?: number;
+	linkFormat: ArticleFormat;
 	format: ArticleFormat;
 	tags: TagType[];
 	sponsorName: string;
@@ -207,27 +208,33 @@ export const RichLink = ({
 	contentType,
 	url,
 	starRating,
+	linkFormat,
 	format,
 	tags,
 	sponsorName,
 	contributorImage,
 	isPlaceholder,
 }: Props) => {
-	const palette = decidePalette(format);
+	const palette = decidePalette(linkFormat);
 	const linkText =
 		cardStyle === 'letters' ? `${headlineText} | Letters ` : headlineText;
 
 	const imageCardStyles = ['news', 'letters', 'media', 'feature'];
+	const parentIsBlog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
+
 	const showImage =
 		imageData &&
 		imageData.thumbnailUrl &&
-		imageCardStyles.includes(cardStyle);
+		imageCardStyles.includes(cardStyle) &&
+		!parentIsBlog;
 	const isPaidContent = tags
 		? tags.filter((t) => t.id === 'tone/advertisement-features').length > 0
 		: false;
 	const isOpinion = cardStyle === 'comment';
 	const mainContributor = getMainContributor(tags);
-	const isLabs = format.theme === ArticleSpecial.Labs;
+	const isLabs = linkFormat.theme === ArticleSpecial.Labs;
 
 	return (
 		<div
@@ -296,7 +303,7 @@ export const RichLink = ({
 								<Avatar
 									imageSrc={contributorImage}
 									imageAlt={mainContributor}
-									palette={decidePalette(format)}
+									palette={decidePalette(linkFormat)}
 								/>
 							</div>
 						)}

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -8,6 +8,7 @@ type Props = {
 	element: RichLinkBlockElement;
 	ajaxUrl: string;
 	richLinkIndex: number;
+	format: ArticleFormat;
 };
 
 interface CAPIRichLinkType {
@@ -53,6 +54,7 @@ export const RichLinkComponent = ({
 	element,
 	ajaxUrl,
 	richLinkIndex,
+	format,
 }: Props) => {
 	const url = buildUrl(element, ajaxUrl);
 	const { data, error } = useApi<CAPIRichLinkType>(url);
@@ -88,7 +90,8 @@ export const RichLinkComponent = ({
 			contentType={data.contentType}
 			url={data.url}
 			starRating={data.starRating}
-			format={decideFormat(data.format)}
+			linkFormat={decideFormat(data.format)}
+			format={format}
 			tags={data.tags}
 			sponsorName={data.sponsorName}
 			contributorImage={data.contributorImage}

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -512,6 +512,7 @@ export const renderElement = ({
 						richLinkIndex={index}
 						element={element}
 						ajaxUrl={ajaxUrl}
+						format={format}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This prevents images from being dynamically inserted into rich links when in live or dead blogs.

## Why?
Richlinks get their image data client side so any image is inserted after the page has already loaded. On normal articles this is not such a problem as the richlinks sit in the left column. But in blogs they are inline with the main content and so dynamically inserting them causes a lot of content layout shift.

Another issue with rich ink images in blogs is their size. In articles the images are small, typically a little larger than a thumbnail, but in blogs the same image is stretched to 700px wide - a size it was not scaled for - and they appear pixelated

### Before
<img width="720" alt="Screenshot 2022-03-11 at 10 32 34" src="https://user-images.githubusercontent.com/1336821/157850609-8b617b9d-f5f8-4f1b-b2f2-3e7fae394ea7.png">


### After
<img width="720" alt="Screenshot 2022-03-11 at 10 32 14" src="https://user-images.githubusercontent.com/1336821/157850624-a964db0c-179e-4cd2-a646-b5abb4fe140f.png">

Fixes #4172 