### PR TITLE
feat: Change cursor to indicate that the acordions are clickable

### DIFF
--- a/common-rendering/src/components/accordion.tsx
+++ b/common-rendering/src/components/accordion.tsx
@@ -37,6 +37,7 @@ const detailsStyles: SerializedStyles = css`
 `;
 
 const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	cursor: pointer;
 	position: relative;
 	display: block;
 	align-items: center;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates the cursor item to show that the summary and chevron of acordions are clickable.

Fixes #4162 

## Accessibility

Part of #4162 was to address the accessibility concerns of acordions where we wanted to wrap the chevrons in a link or button, however, doing this breaks the collapse and expand behaviour of the accordion. I think the `<summary>` and `<details>` tags are pretty accessible now days and don't need anything extra for accessibility.

I've tested the accordions with NVDA and it seems to announce that our accordions are clickable and announces when they collapse and expand.

### Before

![chrome_fIriEHepIp](https://user-images.githubusercontent.com/21217225/157852960-c6534ee8-9031-4d0a-ac1c-0bd3f46970a6.gif)


### After
![chrome_PlsreHrj0Z](https://user-images.githubusercontent.com/21217225/157851738-321640a1-bc64-4126-a162-503d3f860541.gif)

