### PR TITLE
`CustomEvent('liveblog:blocks-updated')`

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -74,6 +74,8 @@ function revealPendingBlocks() {
 		block.classList.add('reveal');
 		block.classList.remove('pending');
 	});
+	// Notify commercial that new blocks are available and they can re-run spacefinder
+	document.dispatchEvent(new CustomEvent('liveblog:blocks-updated'));
 }
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
DCR now sends a custom event when new blocks are revealed on the page

## Why?
We need a way to notify commercial that they should re-run spacefinder

Closes #4178 