### PR TITLE
Signed in subscribers get the wrong header links

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -38,6 +38,46 @@ describe('Signed in readers', function () {
 		cy.contains('My account');
 	});
 
+	it('should have the correct urls for the header links', function () {
+		cy.setCookie('GU_U', 'true', {
+			log: true,
+		});
+		cy.setCookie('gu_hide_support_messaging', 'true', {
+			log: true,
+		});
+		cy.on('uncaught:exception', (err, runnable) => {
+			// When we set the `GU_U` cookie this is causing the commercial bundle to try and do
+			// something with the url which is failing in Cypress with a malformed URI error
+			expect(err.message).to.include('URI malformed');
+			// This error is unrelated to the test in question so return  false to prevent
+			// this commercial error from failing this test
+			return false;
+		});
+		// Mock call to 'profile/me'
+		cy.intercept(
+			'GET',
+			'**/profile/me?strict_sanctions_check=false',
+			profileResponse,
+		);
+		cy.visit(`Article?url=${articleUrl}`);
+
+		cy.get('a[data-link-name="nav2 : supporter-cta"]')
+			.should('have.attr', 'href')
+			.and('contain', 'support.theguardian.com');
+
+		cy.get('a[data-link-name="nav2 : job-cta"]').should(
+			'have.attr',
+			'href',
+			'https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader',
+		);
+		cy.get('button[data-link-name="nav2 : topbar: my account"]');
+		cy.get('a[data-link-name="nav2 : search"]').should(
+			'have.attr',
+			'href',
+			'https://www.google.co.uk/advanced_search?q=site:www.theguardian.com',
+		);
+	});
+
 	it('should not display signed in texts when users are not signed in', function () {
 		cy.visit(`Article?url=${articleUrl}`);
 		cy.scrollTo('bottom', { duration: 300 });

--- a/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-4/signedin.spec.js
@@ -45,14 +45,6 @@ describe('Signed in readers', function () {
 		cy.setCookie('gu_hide_support_messaging', 'true', {
 			log: true,
 		});
-		cy.on('uncaught:exception', (err, runnable) => {
-			// When we set the `GU_U` cookie this is causing the commercial bundle to try and do
-			// something with the url which is failing in Cypress with a malformed URI error
-			expect(err.message).to.include('URI malformed');
-			// This error is unrelated to the test in question so return  false to prevent
-			// this commercial error from failing this test
-			return false;
-		});
 		// Mock call to 'profile/me'
 		cy.intercept(
 			'GET',

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -110,6 +110,10 @@ const Search = ({
 	</a>
 );
 
+const linkWrapperStyles = css`
+	display: inline;
+`;
+
 const linksStyles = css`
 	position: absolute;
 	left: 10px;
@@ -244,18 +248,25 @@ export const Links = ({
 
 	return (
 		<div data-print-layout="hide" css={linksStyles}>
-			{showSupporterCTA && supporterCTA !== '' && (
-				<>
-					<div css={seperatorStyles} />
-					<a
-						href={supporterCTA}
-						css={[linkTablet({ showAtTablet: false }), linkStyles]}
-						data-link-name="nav2 : supporter-cta"
-					>
-						Subscriptions
-					</a>
-				</>
-			)}
+			{/* Since 'subscriptions' is only rendered on the client, rendering it within
+				a div is required to prevent DOM elements getting mis-matched during hydration  */}
+			<div css={linkWrapperStyles}>
+				{showSupporterCTA && supporterCTA !== '' && (
+					<>
+						<div css={seperatorStyles} id="supporter" />
+						<a
+							href={supporterCTA}
+							css={[
+								linkTablet({ showAtTablet: false }),
+								linkStyles,
+							]}
+							data-link-name="nav2 : supporter-cta"
+						>
+							Subscriptions
+						</a>
+					</>
+				)}
+			</div>
 
 			<div css={seperatorStyles} />
 			<a
@@ -267,15 +278,19 @@ export const Links = ({
 			</a>
 			<div css={seperatorHideStyles} />
 
-			{isSignedIn ? (
-				<MyAccount
-					mmaUrl={mmaUrl}
-					idUrl={idUrl}
-					discussionApiUrl={discussionApiUrl}
-				/>
-			) : (
-				<SignIn idUrl={idUrl} />
-			)}
+			{/* Since we switch from SignIn to MyAccount between SSR & hydration (if the user is logged in), we need to wrap
+				the conditional in a div so preact knows where the old component was & is able to swap it out. */}
+			<div css={linkWrapperStyles}>
+				{isSignedIn ? (
+					<MyAccount
+						mmaUrl={mmaUrl}
+						idUrl={idUrl}
+						discussionApiUrl={discussionApiUrl}
+					/>
+				) : (
+					<SignIn idUrl={idUrl} />
+				)}
+			</div>
 
 			<Search
 				href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"


### PR DESCRIPTION
Regression of https://github.com/guardian/dotcom-rendering/pull/2341
## What does this change?
<img width="488" alt="image" src="https://user-images.githubusercontent.com/9575458/157881349-0f2be06b-5da4-4984-880a-85f87ae888d4.png">
If you were a signed in subscriber, the header links would link to the wrong place

- Subscriptions -> jobs
- Jobs -> Sign in link
- My Account -> Dropdown (correct)
- Search -> Search (correct)

This happened because we were updating the DOM content on the initial hydration of the `links.importable` component. This meant that where the server-side-rendered content had only 2 links, 'Sign in' and 'Search', the client side hydrated version had 4 links, 'Subscription', 'Jobs', 'My Account' and 'Search'. 

This confused preact, and it was unable to correctly identify what content to keep and what to replace (more info in https://github.com/guardian/dotcom-rendering/pull/2341)

We fix this by wrapping the two conditionals in `<div>`s we essentially assign them a position in the DOM, for when/if they're added during hydration. This gives preact enough information to perform hydration correctly.

## Why?
Links taking you to the wrong place is probably confusing
