### PR TITLE
Amp: Lines going through byline

### DIFF
--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -76,9 +76,17 @@ const BylineMeta: React.FunctionComponent<{
 		? contributorTag.bylineImageUrl
 		: null;
 
+	const shouldShowBylineImage =
+		contributorTag && bylineImageUrl && contributorCount === 1;
+
 	return (
 		<div css={bylineWrapper}>
-			<div css={[bylineStyle(pillar), !bylineImageUrl && bottomPadding]}>
+			<div
+				css={[
+					bylineStyle(pillar),
+					!shouldShowBylineImage && bottomPadding,
+				]}
+			>
 				<Byline
 					byline={articleData.author.byline}
 					tags={articleData.tags}
@@ -86,7 +94,7 @@ const BylineMeta: React.FunctionComponent<{
 				/>
 			</div>
 
-			{contributorTag && bylineImageUrl && contributorCount === 1 && (
+			{shouldShowBylineImage && (
 				<amp-img
 					class={bylineImageStyle}
 					src={bylineImageUrl}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Handle edge-case where there is a bylineImage but multiple contributors ~ padding should have been applied to compensate for the image not being rendered.

### Before

<img width="362" alt="image" src="https://user-images.githubusercontent.com/9575458/158210776-dbd9a9a3-ed2f-4bab-baf6-258815eaaabc.png">


### After

<img width="360" alt="image" src="https://user-images.githubusercontent.com/9575458/158210687-781159fe-476e-44a3-bc7a-cffa812da664.png">

