### PR TITLE
Hide gap between main image and header until tablet screen size on Liveblogs

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -577,11 +577,13 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						borderColour={palette.border.article}
 						backgroundColour={palette.background.article}
 					>
-						<div
-							css={css`
-								height: ${space[4]}px;
-							`}
-						/>
+						<Hide until="tablet">
+							<div
+								css={css`
+									height: ${space[4]}px;
+								`}
+							/>
+						</Hide>
 					</ElementContainer>
 
 					<ElementContainer


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Hides the gap between the main image and the header if on a display smaller than a tablet.

## Why?

The gap doesn't look very nice on a mobile display.

Fixes #4151 

### Before

![image](https://user-images.githubusercontent.com/21217225/158214454-b20ff4ff-fedb-4a4b-9040-97a89c66601b.png)

### After

![image](https://user-images.githubusercontent.com/21217225/158214973-9bea3a9d-dfc6-4322-9af4-e60f1d589972.png)