### PR TITLE
fix: Force twitter embed to respect container size

### DIFF
--- a/dotcom-rendering/src/web/components/TweetBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TweetBlockComponent.tsx
@@ -13,6 +13,10 @@ const noJSStyling = css`
 		${body.small()};
 	}
 
+	.twitter-tweet iframe {
+		width: 100% !important;
+	}
+
 	.twitter-tweet p {
 		padding-bottom: 10px;
 	}

--- a/dotcom-rendering/src/web/components/TweetBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TweetBlockComponent.tsx
@@ -14,6 +14,8 @@ const noJSStyling = css`
 	}
 
 	.twitter-tweet iframe {
+		/* Unfortunately due to how Twitter embeds work setting !important is the only way to overwrite tweet CSS */
+		/* stylelint-disable-next-line declaration-no-important */
 		width: 100% !important;
 	}
 


### PR DESCRIPTION
## What does this change?

Overrides twitters fixed width on Tweets and instead sets it to be 100% of the containers width. This allows the page to be resized without breaking.

## Why?

Fixes #4158 

### Before

![chrome_VJYUSdkiAJ](https://user-images.githubusercontent.com/21217225/158392349-898cb49f-a0fe-4959-856f-ed80f89a6ca3.gif)

### After

![chrome_yWCui5ODx0](https://user-images.githubusercontent.com/21217225/158392083-21881efa-e113-4bb8-b16e-83400293093d.gif)

