### PR TITLE
Show long time format on hover

### DIFF
--- a/dotcom-rendering/src/web/components/LastUpdated.tsx
+++ b/dotcom-rendering/src/web/components/LastUpdated.tsx
@@ -17,7 +17,21 @@ const LastUpdated = ({
 				color: ${neutral[46]};
 			`}
 		>
-			<time dateTime={new Date(lastUpdated).toISOString()}>
+			<time
+				dateTime={new Date(lastUpdated).toISOString()}
+				title={`Last updated ${new Date(lastUpdated).toLocaleDateString(
+					'en-GB',
+					{
+						hour: '2-digit',
+						minute: '2-digit',
+						weekday: 'long',
+						year: 'numeric',
+						month: 'long',
+						day: 'numeric',
+						timeZoneName: 'long',
+					},
+				)}`}
+			>
 				{`Updated at ${lastUpdatedDisplay}`}
 			</time>
 		</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR closes #4159 by implementing the `title` attribute on the `LastUpdated` component for live blocks

## Why?
To better communicate things

<img width="384" alt="Screenshot 2022-03-15 at 16 17 24" src="https://user-images.githubusercontent.com/1336821/158427655-6a38a2c7-cb9b-4239-974b-d972a16c8f2d.png">

