### PR TITLE
Better Function Definition For Liveblocks Parser

### DIFF
--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -363,7 +363,7 @@ const fromCapiLiveBlog =
 			? 30
 			: 10;
 
-		const parsedBlocks = parseLiveBlocks(body)(context);
+		const parsedBlocks = parseLiveBlocks(context)(body);
 		const pagedBlocks = getPagedBlocks(pageSize, parsedBlocks, blockId);
 		return {
 			design:

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -32,8 +32,8 @@ const parse =
 	});
 
 const parseMany =
-	(blocks: Block[]): ((context: Context) => LiveBlock[]) =>
-	(context: Context): LiveBlock[] =>
+	(context: Context) =>
+	(blocks: Block[]): LiveBlock[] =>
 		blocks.map(parse(context));
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why?

I noticed that this could be improved a little bit.

The intermediate return type was unnecessary; arrow functions allow you to provide a nice, clean way to write curried function definitions.

I've also swapped the order of the arguments. With curried functions it's common to set up the argument order to aid later partial application and composition. In this case I think it's more likely that you'll want to create a partially applied function with the context and then pass the blocks later, possibly as part of a chain of operations.

## Change

- Removed unnecessary intermediate type annotation
- Swapped the arguments to aid composition
