### PR TITLE
Bump @guardian/braze-components to v7.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.6.1",
-    "@guardian/braze-components": "^7.0.0",
+    "@guardian/braze-components": "^7.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",
     "@guardian/discussion-rendering": "^9.2.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^22.6.1",
-    "@guardian/braze-components": "^6.1.0",
+    "@guardian/braze-components": "^7.0.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",
     "@guardian/discussion-rendering": "^9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-6.1.0.tgz#11e4414ed15fbd16ac005dab60c42383b913dbec"
-  integrity sha512-26dRs/zXoYXz9Ov54GRhhEB1wiB2+iAnxc+HYRmsb/tOjcyxu/YkyhFnPgHgZUX8F7y2IuB7TBx7nNGONjWYgQ==
+"@guardian/braze-components@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.0.0.tgz#d92482c652d93c82272d8bb350ca8320e08a87dc"
+  integrity sha512-33qYKl7YaF2dCfgznLrCV6REOwc7LfiMAbqHYtbeqg+cRFPUYIXc17iiI1tGkFESjQ0hFqIBQ0Q/B8Fga1J1zA==
 
 "@guardian/commercial-core@^3.0.0":
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.0.0.tgz#d92482c652d93c82272d8bb350ca8320e08a87dc"
-  integrity sha512-33qYKl7YaF2dCfgznLrCV6REOwc7LfiMAbqHYtbeqg+cRFPUYIXc17iiI1tGkFESjQ0hFqIBQ0Q/B8Fga1J1zA==
+"@guardian/braze-components@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.1.0.tgz#b8812002cc77f5c65a091ebf0f5b78d6fc1403f4"
+  integrity sha512-6X+CKHfElQQj7k8JELFuiUW0JyMJArY8XEum2RpnNs1qelPSwtmtibo4bh5LKtKVXf83zYs9PwUXd3AJwp3x1g==
 
 "@guardian/commercial-core@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/braze-components` to v7.1.0.

## Why?

This release contains new epic remind me button functionality.

![Screenshot 2022-03-16 at 09 44 52](https://user-images.githubusercontent.com/379839/158562578-cd597647-3a9d-4e97-b7f3-c9785a4637ff.png)

- [x] Tested on CODE