### PR TITLE
Add back captions to interactive block element

### DIFF
--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -383,6 +383,7 @@ export const renderElement = ({
 						role={element.role}
 						format={format}
 						elementId={element.elementId}
+						caption={element.caption}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds back captions to InteractiveBlockElements

## Why?

They went missing in #4077

### Before
<img width="657" alt="image" src="https://user-images.githubusercontent.com/9575458/158574783-64f6f53a-765c-417d-bba8-c20cc5c6a922.png">

### After

<img width="656" alt="image" src="https://user-images.githubusercontent.com/9575458/158574865-32892bea-cbae-4584-a672-602f6f00e09a.png">

