### PR TITLE
Add top margin to `Upgrade to Premium` button

### DIFF
--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -132,9 +132,9 @@ export const adStyles = (format: ArticleFormat): SerializedStyles => {
 		.ad-placeholder {
 			margin: ${remSpace[4]} 0;
 
-			&.hidden {
-				display: none;
-			}
+			// &.hidden {
+			// 	display: none;
+			// }
 
 			color: ${neutral[20]};
 			background: ${backgroundColor(format)};
@@ -183,6 +183,10 @@ export const adStyles = (format: ArticleFormat): SerializedStyles => {
 				h1 {
 					${headline.xxxsmall()};
 					margin-top: 0;
+				}
+
+				button {
+					margin-top: ${remSpace[3]};
 				}
 
 				${darkModeCss`

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -132,9 +132,9 @@ export const adStyles = (format: ArticleFormat): SerializedStyles => {
 		.ad-placeholder {
 			margin: ${remSpace[4]} 0;
 
-			// &.hidden {
-			// 	display: none;
-			// }
+			&.hidden {
+				display: none;
+			}
 
 			color: ${neutral[20]};
 			background: ${backgroundColor(format)};


### PR DESCRIPTION
## Why?
Just a tiny PR to make this button's margin more consistent with the old template.
Addresses issue #4076 

| **Before**      | **After**      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
https://user-images.githubusercontent.com/57295823/158630804-e4396e91-f84c-441b-99d2-37a233d78dc0.png
[after]: https://user-images.githubusercontent.com/57295823/158630447-599df98e-ac9a-4575-b210-ba55472890d3.png
