### PR TITLE
bring back the yellow highlight

### DIFF
--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { Global, css } from '@emotion/react';
-import { focusHalo } from '@guardian/source-foundations';
+import { focusHalo, brandAlt, neutral } from '@guardian/source-foundations';
 import { ArticleDesign } from '@guardian/libs';
 import { SkipTo } from './SkipTo';
 import { DecideLayout } from '../layouts/DecideLayout';
@@ -34,6 +34,10 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
 					*:focus {
 						${focusHalo}
+					}
+					::selection {
+						background: ${brandAlt[400]};
+						color: ${neutral[7]};
 					}
 				`}
 			/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
text highlight back to yellow

### Before
<img width="745" alt="image" src="https://user-images.githubusercontent.com/20658471/158662014-1f4f45b6-d826-4431-a0f7-5e400d4a20b9.png">

### After
<img width="780" alt="image" src="https://user-images.githubusercontent.com/20658471/158661856-d6d566f3-7cfd-4af4-bd09-d153627a3064.png">
