### PR TITLE
Add Branding Logo To Blogs

### DIFF
--- a/apps-rendering/src/components/logo.tsx
+++ b/apps-rendering/src/components/logo.tsx
@@ -4,11 +4,7 @@ import type { Branding } from '@guardian/apps-rendering-api-models/branding';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import {
-	remSpace,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { remSpace, textSans, until } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import Anchor from 'components/anchor';
 import { getFormat } from 'item';
@@ -84,11 +80,14 @@ const getStyles = (
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
-			return css(styles(format, lightModeImage, darkModeImage), blogStyles);
+			return css(
+				styles(format, lightModeImage, darkModeImage),
+				blogStyles,
+			);
 		default:
 			return styles(format, lightModeImage, darkModeImage);
 	}
-}
+};
 
 const OptionalLogo = (item: Item): JSX.Element =>
 	pipe(

--- a/apps-rendering/src/components/logo.tsx
+++ b/apps-rendering/src/components/logo.tsx
@@ -1,12 +1,13 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Branding } from '@guardian/apps-rendering-api-models/branding';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
+import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
-	neutral,
 	remSpace,
-	text,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import Anchor from 'components/anchor';
@@ -15,7 +16,6 @@ import type { Item } from 'item';
 import { pipe } from 'lib';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
-import { getThemeStyles } from 'themeStyles';
 
 interface Props {
 	branding: Branding;
@@ -27,10 +27,10 @@ const styles = (
 	lightModeImage: string,
 	darkModeImage?: string,
 ): SerializedStyles => {
-	const { kicker, inverted } = getThemeStyles(format.theme);
 	return css`
 		margin: ${remSpace[9]} 0;
 		${textSans.small()}
+		background-color: transparent;
 
 		img {
 			content: url('${lightModeImage}');
@@ -40,11 +40,11 @@ const styles = (
 		}
 
 		label {
-			color: ${text.supporting};
+			color: ${text.branding(format)};
 		}
 
 		a {
-			color: ${kicker};
+			color: ${text.articleLink(format)};
 		}
 
 		${darkModeCss`
@@ -53,15 +53,42 @@ const styles = (
             }
 
             label {
-                color: ${neutral[86]};
+                color: ${text.brandingDark(format)};
             }
 
             a {
-                color: ${inverted};
+                color: ${text.linkDark(format)};
             }
         `}
 	`;
 };
+
+const blogStyles = css`
+	margin: 0 0 ${remSpace[4]};
+
+	${until.mobileLandscape} {
+		padding-left: ${remSpace[3]};
+		padding-right: ${remSpace[3]};
+	}
+
+	img {
+		max-height: unset;
+	}
+`;
+
+const getStyles = (
+	format: ArticleFormat,
+	lightModeImage: string,
+	darkModeImage?: string,
+): SerializedStyles => {
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return css(styles(format, lightModeImage, darkModeImage), blogStyles);
+		default:
+			return styles(format, lightModeImage, darkModeImage);
+	}
+}
 
 const OptionalLogo = (item: Item): JSX.Element =>
 	pipe(
@@ -80,7 +107,7 @@ const Logo: FC<Props> = ({ branding, format }: Props) => {
 	const darkLogo = cleanImageUrl(branding.altLogo ?? branding.logo);
 
 	return (
-		<section css={styles(format, lightLogo, darkLogo)}>
+		<section css={getStyles(format, lightLogo, darkLogo)}>
 			<label>{branding.label}</label>
 			<a href={branding.sponsorUri}>
 				<img alt={branding.sponsorName} />

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -20,6 +20,7 @@ import Byline from 'components/byline';
 import CommentCount from 'components/commentCount';
 import Dateline from 'components/dateline';
 import Follow from 'components/follow';
+import OptionalLogo from 'components/logo';
 import type { Item } from 'item';
 import type { FC } from 'react';
 import { useState } from 'react';
@@ -228,6 +229,7 @@ const MetadataWithAlertSwitch: FC<Props> = ({ item }: Props) => {
 			)}
 		>
 			<BlogLines {...item} />
+			{OptionalLogo(item)}
 			<Avatar {...item} />
 			<div css={css(textStyles, withBylineTextStyles, liveBlogPadding)}>
 				<div css={liveBylineStyles}>

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -25,6 +25,7 @@ import { Colour } from '.';
 const branding = (_format: ArticleFormat): Colour => {
 	return neutral[20];
 }
+
 const brandingDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
 }

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -22,6 +22,13 @@ import { Colour } from '.';
 
 // ----- Functions ----- //
 
+const branding = (_format: ArticleFormat): Colour => {
+	return neutral[20];
+}
+const brandingDark = (_format: ArticleFormat): Colour => {
+	return neutral[86];
+}
+
 const headline = (format: ArticleFormat): Colour => {
 	if (
 		format.display === ArticleDisplay.Immersive ||
@@ -486,6 +493,8 @@ const pagination = (format: ArticleFormat): Colour => {
 
 const text = {
 	articleLink,
+	branding,
+	brandingDark,
 	bylineLeftColumn,
 	bylineInline,
 	bylineDark,


### PR DESCRIPTION
## Why?

Sometimes we have branding logos on sponsored content. For example: https://www.theguardian.com/world/series/the-pacific-project

If a liveblog/deadblog is branded then we need to show the logo there too.

**Note:** It's difficult to find examples of this so I've inferred the designs from how normal (non-blog) articles handle it on dotcom and the apps. @HarryFischer let me know what you think.

## Changes

- Added `branding` to `text` palette
- Added logo to liveblog metadata
- Refactored logo to use `editorialPalette` colours
- Added blog styles to logo

## Screenshots

| Wide | Tablet | Mobile | Dark |
| - | - | - | - |
| ![logo-wide][] | ![logo-tablet][] | ![logo-mobile][] | ![logo-dark][] |

[logo-wide]: https://user-images.githubusercontent.com/53781962/158665887-3795c9c1-ab53-4e5b-8555-3fc12725d758.jpg
[logo-tablet]: https://user-images.githubusercontent.com/53781962/158665892-cd29a1a3-3f99-49f7-90cf-c8d874072cf4.jpg
[logo-mobile]: https://user-images.githubusercontent.com/53781962/158665896-ede07ab2-c143-4718-8a43-e0d8d6b675e0.jpg
[logo-dark]: https://user-images.githubusercontent.com/53781962/158665898-cfbd0442-2c7a-4bd6-940c-a73cd30c13bc.jpg
