### PR TITLE
change padding to margin – geo popular images

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -52,7 +52,7 @@ const headlineWrapperStyles = css`
 const imageWrapperStyles = css`
 	width: 72px;
 	height: 72px;
-	padding-top: 3px;
+	margin-top: 3px;
 	margin-right: 10px;
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes most viewed images proper circles
### Before
<img width="384" alt="Screenshot 2022-03-16 at 19 02 02" src="https://user-images.githubusercontent.com/20658471/158667443-a526af73-7b01-4b60-b513-d62fa106ae7d.png">

### After
<img width="430" alt="Screenshot 2022-03-16 at 19 02 09" src="https://user-images.githubusercontent.com/20658471/158667457-5721f648-a2f0-4f1b-a264-0c51d0b57cc1.png">

