### PR TITLE
Border colours

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -749,45 +749,16 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 
 const borderHeadline = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) {
-		switch (format.theme) {
-			case ArticlePillar.Culture:
-				return '#716960';
-			case ArticlePillar.Opinion:
-				return '#ae4017';
-			case ArticlePillar.Lifestyle:
-				return '#713b68';
-			case ArticlePillar.Sport:
-				return '#3e657b';
-			case ArticleSpecial.SpecialReport:
-				return specialReport[200];
-			case ArticleSpecial.Labs:
-				return labs[200];
-			case ArticlePillar.News:
-				return '#914b4a';
-		}
+		return 'rgba(255,255,255, 0.2)';
 	}
 	if (format.design === ArticleDesign.DeadBlog) return '#CDCDCD';
 	return border.secondary;
 };
 
 const borderStandfirst = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.LiveBlog)
-		switch (format.theme) {
-			case ArticlePillar.Culture:
-				return '#615b53';
-			case ArticlePillar.Opinion:
-				return '#9b3801';
-			case ArticlePillar.Lifestyle:
-				return '#6f3d67';
-			case ArticlePillar.Sport:
-				return '#295873';
-			case ArticleSpecial.SpecialReport:
-				return specialReport[300];
-			case ArticleSpecial.Labs:
-				return labs[300];
-			case ArticlePillar.News:
-				return '#7f3a3a';
-		}
+	if (format.design === ArticleDesign.LiveBlog) {
+		return 'rgba(255,255,255, 0.2)';
+	}
 	if (format.design === ArticleDesign.DeadBlog) return '#BDBDBD';
 	return border.secondary;
 };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -786,7 +786,7 @@ const borderStandfirst = (format: ArticleFormat): string => {
 			case ArticleSpecial.Labs:
 				return labs[300];
 			case ArticlePillar.News:
-				return '#874444';
+				return '#7f3a3a';
 		}
 	if (format.design === ArticleDesign.DeadBlog) return '#BDBDBD';
 	return border.secondary;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -748,13 +748,46 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 };
 
 const borderHeadline = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.LiveBlog) return '#9F2423';
+	if (format.design === ArticleDesign.LiveBlog) {
+		switch (format.theme) {
+			case ArticlePillar.Culture:
+				return '#716960';
+			case ArticlePillar.Opinion:
+				return '#ae4017';
+			case ArticlePillar.Lifestyle:
+				return '#713b68';
+			case ArticlePillar.Sport:
+				return '#3e657b';
+			case ArticleSpecial.SpecialReport:
+				return specialReport[200];
+			case ArticleSpecial.Labs:
+				return labs[200];
+			case ArticlePillar.News:
+				return '#914b4a';
+		}
+	}
 	if (format.design === ArticleDesign.DeadBlog) return '#CDCDCD';
 	return border.secondary;
 };
 
 const borderStandfirst = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.LiveBlog) return '#8C2222';
+	if (format.design === ArticleDesign.LiveBlog)
+		switch (format.theme) {
+			case ArticlePillar.Culture:
+				return '#615b53';
+			case ArticlePillar.Opinion:
+				return '#9b3801';
+			case ArticlePillar.Lifestyle:
+				return '#6f3d67';
+			case ArticlePillar.Sport:
+				return '#295873';
+			case ArticleSpecial.SpecialReport:
+				return specialReport[300];
+			case ArticleSpecial.Labs:
+				return labs[300];
+			case ArticlePillar.News:
+				return '#874444';
+		}
 	if (format.design === ArticleDesign.DeadBlog) return '#BDBDBD';
 	return border.secondary;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4152 by setting different border colours for different themes

|           | BEFORE | AFTER |
|-----------|--------|-------|
| `News`      |    <img width="242" alt="Screenshot 2022-03-17 at 09 04 24" src="https://user-images.githubusercontent.com/1336821/158774868-7e2b879a-91b0-45f3-b047-3da6daae5903.png">    |   ![Screenshot 2022-03-17 at 11 27 11](https://user-images.githubusercontent.com/1336821/158799374-6ea57930-e615-444a-9ad3-83128a2797c6.png)  |
| `Opinion`   |   <img width="242" alt="Screenshot 2022-03-17 at 09 09 09" src="https://user-images.githubusercontent.com/1336821/158775800-a114974b-20df-4604-822f-4f285bf76e88.png">  |   <img width="235" alt="Screenshot 2022-03-17 at 11 58 03" src="https://user-images.githubusercontent.com/1336821/158803894-3e2d8322-ca32-4da6-bd92-04a724f6859b.png">    |
| `Sport`     |   <img width="242" alt="Screenshot 2022-03-17 at 09 10 03" src="https://user-images.githubusercontent.com/1336821/158775957-c60993a5-92b4-429f-a953-a1d274398b09.png">    |    <img width="235" alt="Screenshot 2022-03-17 at 11 55 34" src="https://user-images.githubusercontent.com/1336821/158803480-07be3a5c-70a7-4ba6-8970-f35ede8060ed.png">   |
| `Lifestyle` |  <img width="242" alt="Screenshot 2022-03-17 at 09 09 39" src="https://user-images.githubusercontent.com/1336821/158775878-9a8d8154-564a-48cd-ab38-3f72913316ca.png">    |   <img width="235" alt="Screenshot 2022-03-17 at 11 54 04" src="https://user-images.githubusercontent.com/1336821/158803215-14a77114-d571-4842-89d4-9054ad2ac1d2.png">   |
| `Culture`   |   <img width="242" alt="Screenshot 2022-03-17 at 09 10 34" src="https://user-images.githubusercontent.com/1336821/158775997-e74626a0-7e57-4625-841a-28da325c451e.png">    |   <img width="235" alt="Screenshot 2022-03-17 at 11 52 11" src="https://user-images.githubusercontent.com/1336821/158802962-5477e87c-0a99-45b7-8260-7e93146a9be2.png">    |



