### PR TITLE
replace more dropdown box with chevron icon from source

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -8,6 +8,8 @@ import {
 	brandAlt,
 } from '@guardian/source-foundations';
 
+import { SvgChevronDownSingle } from '@guardian/source-react-components';
+
 import { ArticleDisplay } from '@guardian/libs';
 import { navInputCheckboxId, showMoreButtonId } from '../config';
 
@@ -18,37 +20,25 @@ const screenReadable = css`
 const showMoreTextStyles = css`
 	display: block;
 	height: 100%;
-	:after {
-		content: '';
-		border: 1px solid currentColor;
-		border-left: transparent;
-		border-top: transparent;
-		display: inline-block;
-		height: 8px;
-		margin-left: 6px;
 
-		/*
-            IMPORTANT NOTE:
-            we need to specify the adjacent path to the a (current) tag
-            to apply styles to the nested tabs due to the fact we use ~
-            to support NoJS
-        */
-		transform: translateY(-3px) rotate(45deg);
-		/* stylelint-disable-next-line selector-type-no-unknown */
-		${`#${navInputCheckboxId}`}:checked ~ div label & {
-			transform: translateY(1px) rotate(-135deg);
+	${`#${navInputCheckboxId}`}:checked ~ div label & svg {
+		transform: translateY(-2px) rotate(-180deg);
+		:hover {
+			transform: translateY(-4px) rotate(-180deg);
 		}
-
-		transition: transform 250ms ease-out;
-		vertical-align: middle;
-		width: 8px;
 	}
-	:hover:after {
-		transform: translateY(0) rotate(45deg);
-		/* refer to comment above */
-		/* stylelint-disable-next-line selector-type-no-unknown */
-		${`#${navInputCheckboxId}`}:checked ~ div label & {
-			transform: translateY(-2px) rotate(-135deg);
+
+	svg {
+		position: absolute;
+		right: 2px;
+		top: 14px;
+		fill: currentColor;
+		height: 16px;
+		width: 16px;
+		transition: transform 250ms ease-out;
+
+		:hover {
+			transform: translateY(2px);
 		}
 	}
 `;
@@ -95,7 +85,10 @@ export const ShowMoreMenu = ({ display }: { display: ArticleDisplay }) => (
 			data-cy="nav-show-more-button"
 		>
 			<span css={screenReadable}>Show</span>
-			<span css={showMoreTextStyles}>More</span>
+			<span css={showMoreTextStyles}>
+				More
+				<SvgChevronDownSingle />
+			</span>
 		</label>
 		{/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */}
 	</>

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -21,13 +21,16 @@ const showMoreTextStyles = css`
 	display: block;
 	height: 100%;
 
-	/* stylelint-disable-next-line selector-type-no-unknown */
+	/* stylelint-disable selector-type-no-unknown */
 	${`#${navInputCheckboxId}`}:checked ~ div label & svg {
 		transform: translateY(-2px) rotate(-180deg);
-		:hover {
-			transform: translateY(-4px) rotate(-180deg);
-		}
 	}
+
+	${`#${navInputCheckboxId}`}:checked ~ div label:hover & svg,
+	${`#${navInputCheckboxId}`}:checked ~ div label:focus & svg {
+		transform: translateY(-4px) rotate(-180deg);
+	}
+	/* stylelint-enable selector-type-no-unknown */
 
 	svg {
 		position: absolute;
@@ -37,10 +40,6 @@ const showMoreTextStyles = css`
 		height: 16px;
 		width: 16px;
 		transition: transform 250ms ease-out;
-
-		:hover {
-			transform: translateY(2px);
-		}
 	}
 `;
 
@@ -62,9 +61,13 @@ const openExpandedMenuStyles = (display: ArticleDisplay) => css`
 		padding-top: ${display === ArticleDisplay.Immersive ? '9px' : '5px'};
 		height: 42px;
 	}
+
 	:hover,
 	:focus {
 		color: ${brandAlt[400]};
+		svg {
+			transform: translateY(2px);
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -21,6 +21,7 @@ const showMoreTextStyles = css`
 	display: block;
 	height: 100%;
 
+	/* stylelint-disable-next-line selector-type-no-unknown */
 	${`#${navInputCheckboxId}`}:checked ~ div label & svg {
 		transform: translateY(-2px) rotate(-180deg);
 		:hover {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Use the chevron icon from Source for the 'more' dropdown link.

## Why?
Fixes a bug raised by Design.

### Before
I think before the 'icon' next to `More` was a rotated box with some borders applied.

<img width="131" alt="Screenshot 2022-03-17 at 11 23 59" src="https://user-images.githubusercontent.com/45561419/158798863-55b544bf-6319-4a66-9db0-1fbc2ec02942.png">


### After
Now the icon next to `More` is the chevron icon from Source

<img width="119" alt="Screenshot 2022-03-17 at 11 24 06" src="https://user-images.githubusercontent.com/45561419/158798879-051ab783-4231-4557-925c-265bc18f4423.png">
