### PR TITLE
Run less tests when not on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,9 @@ jobs:
       - uses: guardian/actions-setup-node@main
         with:
           cache: "yarn"
+      - run: make install
       - name: Lint
-        run: yarn lint
+        run: make lint
         working-directory: dotcom-rendering
       - name: Stylelint
         run: make stylelint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           cache: "yarn"
       - run: make install
+        working-directory: dotcom-rendering
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,21 @@
 name: DCR lint 🔎
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
+  push:
+    paths-ignore:
+      - "apps-rendering/**"
 
 jobs:
-    lint:
-        name: DCR Lint
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: guardian/actions-setup-node@main
-						  with:
-							  cache: 'yarn'
-            - name: Lint
-              run: yarn lint
-              working-directory: dotcom-rendering
-						-	name: Stylelint
-						  run: make stylelint
-							working-directory: dotcom-rendering
+  lint:
+    name: DCR Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: guardian/actions-setup-node@main
+        with:
+          cache: "yarn"
+      - name: Lint
+        run: yarn lint
+        working-directory: dotcom-rendering
+      - name: Stylelint
+        run: make stylelint
+        working-directory: dotcom-rendering

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,11 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: guardian/actions-setup-node@main
-
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
-
-            - name: Install
-              run: yarn
-
+						  with:
+							  cache: 'yarn'
             - name: Lint
               run: yarn lint
               working-directory: dotcom-rendering
+						-	name: Stylelint
+						  run: make stylelint
+							working-directory: dotcom-rendering

--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -37,14 +37,21 @@ else
 
     cd dotcom-rendering
 
-    #Code Validation
-    echo bundlesize token $BUNDLESIZE_GITHUB_TOKEN
-    make validate-ci
+	if [ $currentBranch == "main" ]
+	then
+		#Code Validation
+		make validate-ci
 
-    #Cypress Tests
-    # see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
-    # apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
-    make cypress
+		#Cypress Tests
+		# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
+		# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+		make cypress
+	else
+		#Run bundle size?
+		make bundlesize
+
+		printf "Skipping code checks when not on main"
+	fi
 
     #RiffRaff publish
     make riffraff-publish


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Make PR checks less annoying & inefficient by removing redundant checks that were being run in github actions from our teamcity builds

We keep these checks for `main` branch builds to ensure that in no case a weird merge on githubs part could accidentally publish a broken build to the main site.

## Why?

Faster teamcity builds + less flakyness

### Before

10 minutes 🤬😤😡
<img width="881" alt="image" src="https://user-images.githubusercontent.com/9575458/158834895-a1ad76d4-a278-4286-97cb-d7d55b5b2547.png">

### After
4 minutes 😇😍🥰
<img width="867" alt="image" src="https://user-images.githubusercontent.com/9575458/158834941-e1c72b3c-244e-48a3-a613-f74648492f9f.png">

