### PR TITLE
feat: Explicit Island chunk names

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -24,6 +24,7 @@ export const doHydration = (name: string, data: any, element: HTMLElement) => {
 	start();
 	import(
 		/* webpackInclude: /\.importable\.tsx$/ */
+		/* webpackChunkName: "[request]" */
 		`../../components/${name}.importable`
 	)
 		.then((module) => {

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -23,7 +23,7 @@ export const doHydration = (name: string, data: any, element: HTMLElement) => {
 	const { start, end } = initPerf(`hydrate-${name}`);
 	start();
 	import(
-		/* webpackInclude: /\.importable\.(tsx|jsx)$/ */
+		/* webpackInclude: /\.importable\.tsx$/ */
 		`../../components/${name}.importable`
 	)
 		.then((module) => {

--- a/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
+++ b/dotcom-rendering/src/web/browser/islands/doStorybookHydration.js
@@ -26,7 +26,8 @@ export const doStorybookHydration = () => {
 
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			import(
-				/* webpackInclude: /\.importable\.(tsx|jsx)$/ */
+				/* webpackInclude: /\.importable\.tsx$/ */
+				/* webpackChunkName: "[request]" */
 				`../../components/${name}.importable`
 			).then((module) => {
 				ReactDOM.hydrate(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Previously, island chunks generated by Webpack were numeric IDs like `8873`. Now they reflect the actual filenames.

## Why?

Easier to understand the impact of changes are reported by the compress action.

### Before

```sh
ls dist/**.js

dist/1189.9b78234a9be174bcb95f.js
dist/1214.0c3439950f252b3450f3.js
dist/1376.e09de2b0edfb5b7663fb.js
dist/1451.8f29eca0e0395fb89cf0.js
dist/1578.bbbaf25c73420bfce5d8.js
dist/1828.aaabd9914f2832062f6d.js
dist/1924.8dbea87ab294d577cff0.js
dist/1956.af85a4429398e3e6a127.js
```

### After

```sh
ls dist/**.js

dist/AlreadyVisited-importable.dd6db9d38cd8b7efda3f.js
dist/AudioAtomWrapper-importable.898a1bc9bdefdd656c63.js
dist/Branding-importable.6f67ab9266fc97b4d7d3.js
dist/BrazeMessaging-importable.67b10c92553cac70d24b.js
dist/CalloutBlockComponent-importable.6c42df120ac2da56e508.js
dist/ChartAtomWrapper-importable.7a8ea5381c29db6c9088.js
dist/CommentCount-importable.5210ae6d30fe4b42eb46.js
dist/CommercialMetrics-importable.fb68b72be920cdff5150.js
# etc.
```