### PR TITLE
Fix broken date links in individual blocks

### DIFF
--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -22,9 +22,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 	return (
 		<>
 			{/* Accordion? */}
-			{/* Pagination? */}
 			{blocks.map((block) => {
-				// TODO: get page number
 				const blockLink = `#block-${block.id}`;
 				const borderLiveBlock = border.liveBlock(format);
 				const blockFirstPublished = pipe(

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -25,7 +25,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 			{/* Pagination? */}
 			{blocks.map((block) => {
 				// TODO: get page number
-				const blockLink = `${1}#block-${block.id}`;
+				const blockLink = `#block-${block.id}`;
 				const borderLiveBlock = border.liveBlock(format);
 				const blockFirstPublished = pipe(
 					block.firstPublished,

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -134,9 +134,14 @@ const buildHtml = (
 	head: string,
 	body: string,
 	scripts: ReactElement,
-): string => `
-    <!DOCTYPE html>
-    <html lang="en">
+	isBlog: boolean,
+): string => {
+	// Used when taking the reader to the top of the blog on toast click
+	// or when linking to a specific block
+	const smoothScrolling = isBlog ? `style="scroll-behavior: smooth;"` : '';
+
+	return `<!DOCTYPE html>
+    <html lang="en" ${smoothScrolling}>
         <head>
             ${head}
         </head>
@@ -146,6 +151,7 @@ const buildHtml = (
         </body>
     </html>
 `;
+};
 
 function render(
 	imageSalt: string,
@@ -173,7 +179,11 @@ function render(
 		/>
 	);
 
-	return { html: buildHtml(head, body.html, scripts), clientScript };
+	const isBlog =
+		item.design === ArticleDesign.LiveBlog ||
+		item.design === ArticleDesign.DeadBlog;
+
+	return { html: buildHtml(head, body.html, scripts, isBlog), clientScript };
 }
 
 // ----- Export ----- //

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -138,7 +138,7 @@ const buildHtml = (
 ): string => {
 	// Used when taking the reader to the top of the blog on toast click
 	// or when linking to a specific block
-	const smoothScrolling = isBlog ? `style="scroll-behavior: smooth;"` : '';
+	const smoothScrolling = isBlog ? 'style="scroll-behavior: smooth;"' : '';
 
 	return `<!DOCTYPE html>
     <html lang="en" ${smoothScrolling}>


### PR DESCRIPTION
## Why?
Date links on top of each block in AR blogs were broken.
This PR fixes the problem by using the correct anchor hash (there used to be a rogue `${1}` before the hash for some reason, which would break the link. Update: @DavidLawes says this is a leftover from before pagination was implemented).

It also adds smooth scrolling to blogs to [mirror DCR's behaviour ](https://github.com/guardian/dotcom-rendering/blob/52befb48891e12880e8baf55bc83e44034cce2e7/dotcom-rendering/src/web/server/htmlTemplate.ts#L162-L165)

This PR addresses issue #4292.

## Before
https://user-images.githubusercontent.com/57295823/158857194-09f342e4-d49c-44b5-8413-e12d5fa71183.mov

## After

https://user-images.githubusercontent.com/57295823/158857310-3b751caf-e7f3-4d30-ab4a-3a5aef68ad6e.mov