### PR TITLE
Remove Unnecessary Fragment

### DIFF
--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -570,15 +570,13 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.TextBlockElement':
 			return [
 				true,
-				<>
-					<TextBlockComponent
-						key={index}
-						isFirstParagraph={index === 0}
-						html={element.html}
-						format={format}
-						forceDropCap={element.dropCap}
-					/>
-				</>,
+				<TextBlockComponent
+					key={index}
+					isFirstParagraph={index === 0}
+					html={element.html}
+					format={format}
+					forceDropCap={element.dropCap}
+				/>,
 			];
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 			return [


### PR DESCRIPTION
## Why?

I don't think it's necessary to wrap this component in a fragment. I think the fragment was introduced in #1740 to put a sign-in gate placeholder alongside (back when this code was in `ArticleRenderer`), but this placeholder was removed in #1819.

## Changes

- Removed enclosing fragment
