### PR TITLE
Refactor Action: Preact compressed size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,4 @@ indent_style = tab
 
 [*.yml]
 indent_size = 2
+indent_style = space

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -17,3 +17,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           build-script: build:dcr
+
+          # https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
+          minimum-change-threshold: 100

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -20,3 +20,7 @@ jobs:
 
           # https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
           minimum-change-threshold: 100
+
+          # https://github.com/preactjs/compressed-size-action#dealing-with-hashed-filenames
+          # The default hash digest is set to 20 chars in Webpack
+          strip-hash: "\\.(\\w{20})\\.js$"

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -2,9 +2,7 @@
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
-const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
-const GITHUB = process.env.CI_ENV === 'github';
 
 /**
  * @param {boolean} isLegacyJS
@@ -12,8 +10,7 @@ const GITHUB = process.env.CI_ENV === 'github';
  */
 const generateName = (isLegacyJS) => {
 	const legacyString = isLegacyJS ? '.legacy' : '';
-	const chunkhashString = PROD && !GITHUB ? '.[chunkhash]' : '';
-	return `[name]${legacyString}${chunkhashString}.js`;
+	return `[name]${legacyString}.[chunkhash].js`;
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Set a threshold for compressed size change for a file to qualify as different–100 bytes.
Strip the file hash directly in the action, allowing the same build in GHA as we do in TeamCity.

The action will report a change wrong in this PR, because the file names are changing:

`dist/Branding-importable.js` &rarr; `dist/Branding-importable.********************.js`

## Why?

There can be a lot of noise for minuscule changes with this action, and since #4287, we have gained more visibility on what has actually changed.

Helps pave the way for a full GHA delivery, as the build is identical.