### PR TITLE
Fix getArticleCountToday

### DIFF
--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -27,6 +27,7 @@ import { CanShowResult } from '../../lib/messagePicker';
 import { setAutomat } from '../../lib/setAutomat';
 import { useOnce } from '../../lib/useOnce';
 import { ArticleCounts } from '../../../lib/article-count';
+import { getToday } from '../../lib/dailyArticleCount';
 
 type BaseProps = {
 	isSignedIn: boolean;
@@ -70,11 +71,13 @@ export type CanShowFunctionType<T> = (
 const getArticleCountToday = (
 	articleCounts: ArticleCounts | undefined,
 ): number | undefined => {
-	if (articleCounts) {
-		return (
-			articleCounts.dailyArticleHistory[0] &&
-			articleCounts.dailyArticleHistory[0].count
-		);
+	const latest = articleCounts?.dailyArticleHistory[0];
+	if (latest) {
+		if (latest.day === getToday()) {
+			return articleCounts?.dailyArticleHistory[0].count;
+		}
+		// article counting is enabled, but none so far today
+		return 0;
 	}
 	return undefined;
 };

--- a/dotcom-rendering/src/web/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/web/lib/dailyArticleCount.ts
@@ -36,7 +36,7 @@ export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
 	}
 };
 
-export const getToday = (): number => Math.floor(Date.now() / 86400000);
+export const getToday = (): number => Math.floor(Date.now() / 86_400_000);
 
 export const incrementDailyArticleCount = (): void => {
 	// get the daily article count from local storage

--- a/dotcom-rendering/src/web/lib/dailyArticleCount.ts
+++ b/dotcom-rendering/src/web/lib/dailyArticleCount.ts
@@ -36,12 +36,14 @@ export const getDailyArticleCount = (): DailyArticleHistory | undefined => {
 	}
 };
 
+export const getToday = (): number => Math.floor(Date.now() / 86400000);
+
 export const incrementDailyArticleCount = (): void => {
 	// get the daily article count from local storage
 	const dailyArticleCount = getDailyArticleCount() || [];
 
 	// calculate days since unix epoch for today date
-	const today = Math.floor(Date.now() / 86400000);
+	const today = getToday();
 
 	// check if latest day is today and increment if so
 	if (


### PR DESCRIPTION
Currently this function might return e.g. yesterday's count if the browser hasn't yet landed on an article

[frontend change](https://github.com/guardian/frontend/pull/24784)