### PR TITLE
Rename `dcr:page:article:redisplayed`

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -182,7 +182,7 @@ const SignInGateSelectorWithAB = ({
 		// this only happens within the dismissGate method
 		if (isGateDismissed) {
 			document.dispatchEvent(
-				new CustomEvent('dcr:page:article:redisplayed'),
+				new CustomEvent('article:sign-in-gate-dismissed'),
 			);
 		}
 	}, [isGateDismissed]);


### PR DESCRIPTION
## What does this change?

Renames the event `dcr:page:article:redisplayed` to `article:sign-in-gate-dismissed`

## Why?

`dcr:page:article:redisplayed` didn't capture what was actually happening. It was a hangover from the old `mediator` event name