### PR TITLE
Correct path string for `run-if-changed`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -251,7 +251,7 @@
     ]
   },
   "run-if-changed": {
-    "src/lib/content.d.ts": "make gen-schema && make gen-fixtures",
-    "src/lib/index.d.ts": "make gen-schema && make gen-fixtures"
+    "dotcom-rendering/src/lib/content.d.ts": "make gen-schema && make gen-fixtures",
+    "dotcom-rendering/src/lib/index.d.ts": "make gen-schema && make gen-fixtures"
   }
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This corrects the path string used to watch files for changes by the `rub-if-changed` lib

## Why?
I _think_ that as part of the move to the monorepo this didn't get updated so we've not been updating the schema we check Frontend data against
