### PR TITLE
refactor: extract island name as const

### DIFF
--- a/dotcom-rendering/src/web/browser/initDiscussion/init.ts
+++ b/dotcom-rendering/src/web/browser/initDiscussion/init.ts
@@ -2,22 +2,19 @@ import '../webpackPublicPath';
 import { startup } from '../startup';
 import { getProps } from '../islands/getProps';
 import { doHydration } from '../islands/doHydration';
-import { getName } from '../islands/getName';
 
 function forceHydration() {
 	try {
+		const name = 'DiscussionContainer';
+
 		// Select the Discussion island element
 		const guElement = document.querySelector<HTMLElement>(
-			'gu-island[name=DiscussionContainer]',
+			`gu-island[name=${name}]`,
 		);
 		if (!guElement) return;
 
 		// Read the props from where they have been serialised in the dom using an Island
 		const props = getProps(guElement);
-		const name = getName(guElement);
-
-		// Ensure we have name
-		if (!name) return;
 
 		// Now that we have the props as an object, tell Discussion we want it to expand itself
 		props.expanded = true;


### PR DESCRIPTION
## What does this change?

Explicitly set the name we expect for this Island.

## Why?

We want an island with a specific name, `DiscussionContainer`. There’s no point parsing the `gu-island` element to check if it has this name, as that’s how it’s selected in the first place.