### PR TITLE
Some Small Dark Mode Fixes On Standard Articles

### DIFF
--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -159,8 +159,10 @@ const articleContentDark = ({ design }: ArticleFormat): Colour => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return neutral[7];
-		default:
+		case ArticleDesign.LiveBlog:
 			return neutral[0];
+		default:
+			return neutral[10];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -172,7 +172,28 @@ const follow = (format: ArticleFormat): Colour => {
 };
 
 const followDark = (format: ArticleFormat): Colour => {
-	return neutral[100];
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return neutral[100];
+		default:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[500];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticlePillar.Sport:
+					return sport[500];
+				case ArticlePillar.Culture:
+					return culture[500];
+				case ArticlePillar.Opinion:
+					return opinion[500];
+				case ArticleSpecial.Labs:
+					return specialReport[500];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[500];
+			}
+	}
 };
 
 const bylineDark = (format: ArticleFormat): Colour => {
@@ -394,22 +415,7 @@ const standfirstLinkDark = (format: ArticleFormat): Colour => {
 					return specialReport[500];
 			}
 		default: {
-			switch (format.theme) {
-				case ArticlePillar.News:
-					return news[400];
-				case ArticlePillar.Culture:
-					return culture[400];
-				case ArticlePillar.Lifestyle:
-					return lifestyle[400];
-				case ArticlePillar.Sport:
-					return sport[400];
-				case ArticlePillar.Opinion:
-					return opinion[400];
-				case ArticleSpecial.Labs:
-					return labs[300];
-				case ArticleSpecial.SpecialReport:
-					return specialReport[400];
-			}
+			return neutral[60];
 		}
 	}
 };


### PR DESCRIPTION
## Why?

Couple of quick fixes to dark mode styles on standard articles.

## Changes

- Background on normal articles is `neutral[10]`
- Follow text should follow theme colour
- Standfirst links are normally grey

## Screenshots

|  | Before | After |
| - | - | - |
| Follow Text | ![follow-before][] | ![follow-after][] |
| Standfirst Links | ![standfirst-before][] | ![standfirst-after][] |
| Tags | ![tags-before][] | ![tags-after][] |

[tags-after]: https://user-images.githubusercontent.com/53781962/159043823-dc1827b6-2094-42b1-82e8-b7bb742f463a.jpg
[follow-before]: https://user-images.githubusercontent.com/53781962/159043830-a6412daa-330c-4e5d-b880-0aa9439eae6a.jpg
[follow-after]: https://user-images.githubusercontent.com/53781962/159043832-7d197a0c-86cd-41c0-8114-ab11644bc836.jpg
[standfirst-before]: https://user-images.githubusercontent.com/53781962/159043834-1fa1a8bc-c1e0-448e-a539-d002eed7053b.jpg
[tags-before]: https://user-images.githubusercontent.com/53781962/159043836-9c27c06b-6bc6-4519-899c-3c0bec20d12a.jpg
[standfirst-after]: https://user-images.githubusercontent.com/53781962/159044431-3b5785d8-bb57-40e4-be1f-ae914eab924c.jpg
