### PR TITLE
Fix wide ads served as square

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -140,11 +140,6 @@ const articleAdStyles = css`
 				}
 			}
 		}
-
-		&.ad-slot--fluid {
-			background-color: green;
-			width: 100%;
-		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -134,7 +134,7 @@ const articleAdStyles = css`
 				padding-bottom: ${space[6]}px;
 
 				& > div:not(.ad-slot__label) {
-					width: 300px;
+					width: auto;
 					margin-left: auto;
 					margin-right: auto;
 				}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- fix: let ads be the width they want
- fix: remove deprecated css

## Why?

Fixes #4041. See https://github.com/guardian/dotcom-rendering/pull/3773/files#r817880039

### Before

TODO

### After

TODO