### PR TITLE
Fix padding of liveblocks on mobile

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -8,7 +8,13 @@ import { Pagination } from '@guardian/common-rendering/src/components/Pagination
 import { background } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { from, neutral, news, remSpace } from '@guardian/source-foundations';
+import {
+	from,
+	neutral,
+	news,
+	pxToRem,
+	remSpace,
+} from '@guardian/source-foundations';
 import { OptionKind } from '@guardian/types';
 import Footer from 'components/footer';
 import GridItem from 'components/gridItem';
@@ -148,12 +154,35 @@ const Live: FC<Props> = ({ item }) => {
 					<HeaderMedia item={item} />
 				</GridItem>
 				<GridItem area="live-blocks">
-					{item.pagedBlocks.currentPage.pageNumber > 1 && pagination}
-					<LiveBlocks
-						blocks={item.pagedBlocks.currentPage.blocks}
-						format={item}
-					/>
-					{pagination}
+					<div
+						css={css`
+							padding-left: ${pxToRem(10)}rem;
+							padding-right: ${pxToRem(10)}rem;
+							padding-top: ${remSpace[3]};
+
+							${from.mobileLandscape} {
+								padding-left: ${remSpace[5]};
+								padding-right: ${remSpace[5]};
+							}
+
+							${from.tablet} {
+								padding-left: 0;
+								padding-right: 0;
+							}
+
+							${from.desktop} {
+								padding: 0;
+							}
+						`}
+					>
+						{item.pagedBlocks.currentPage.pageNumber > 1 &&
+							pagination}
+						<LiveBlocks
+							blocks={item.pagedBlocks.currentPage.blocks}
+							format={item}
+						/>
+						{pagination}
+					</div>
 				</GridItem>
 			</main>
 			<section css={articleWidthStyles}>

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -134,6 +134,7 @@ const LiveBlockContainer = ({
 			className={`block ${isLiveUpdate && 'pending'}`}
 			css={css`
 				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
+				box-sizing: border-box;
 				margin-bottom: ${space[3]}px;
 				background: ${neutral[100]};
 				${!isPinnedPost &&


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a container around the liveblocks on the live layout for AR.

## Why?
The padding on liveblocks was causing an overflow and the pagination was not padded at all so it was flush with the screen edge.

| Before |  After |
| -------|-------|
| <img width="421" alt="image" src="https://user-images.githubusercontent.com/99400613/159261674-deef9946-df73-4ad6-9e1b-fa1925792b5e.png"> | <img width="471" alt="image" src="https://user-images.githubusercontent.com/99400613/159261494-cdc47da6-eaf5-45c5-8858-47d9d9e65b6b.png"> |




