### PR TITLE
AB test margin values for lazily-loaded ads

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -33,7 +33,7 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 		const testsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
 			spacefinderOkrMegaTest,
-			commercialLazyLoadMargin
+			commercialLazyLoadMargin,
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -10,6 +10,7 @@ import { WithABProvider } from './WithABProvider';
 import { useOnce } from '../lib/useOnce';
 import { tests } from '../experiments/ab-tests';
 import { spacefinderOkrMegaTest } from '../experiments/tests/spacefinder-okr-mega-test';
+import { commercialLazyLoadMargin } from '../experiments/tests/commercial-lazy-load-margin';
 
 type Props = {
 	enabled: boolean;
@@ -32,6 +33,7 @@ const CommercialMetricsWithAB = ({ enabled }: { enabled: boolean }) => {
 		const testsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
 			spacefinderOkrMegaTest,
+			commercialLazyLoadMargin
 		];
 		const shouldForceMetrics = ABTestAPI.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -7,6 +7,7 @@ import {
 	newsletterMerchUnitLighthouseVariants,
 } from './tests/newsletter-merch-unit-test';
 import { spacefinderOkrMegaTest } from './tests/spacefinder-okr-mega-test';
+import { commercialLazyLoadMargin } from './tests/commercial-lazy-load-margin';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	spacefinderOkrMegaTest,
+	commercialLazyLoadMargin,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
@@ -5,9 +5,9 @@ export const commercialLazyLoadMargin: ABTest = {
 	author: 'Zeke Hunter-Green (@zekehuntergreen)',
 	description:
 		'Test various margins at which ads are lazily-loaded in order to find the optimal one',
-	start: '2022-03-22',
+	start: '2022-03-24',
 	// test should be in place for a minimum of 14 days
-	expiry: '2022-04-06',
+	expiry: '2022-04-14',
 	audience: 5 / 100,
 	audienceOffset: 11 / 100,
 	audienceCriteria: 'All pageviews',

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const commercialLazyLoadMargin: ABTest = {
+	id: 'CommercialLazyLoadMargin',
+	author: 'Zeke Hunter-Green (@zekehuntergreen)',
+	description:
+		'Test various margins at which ads are lazily-loaded in order to find the optimal one',
+	start: '2022-03-22',
+	// test should be in place for a minimum of 14 days
+	expiry: '2022-04-06',
+	audience: 5 / 100,
+	audienceOffset: 11 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
+	idealOutcome:
+		'One of the variants shows a marked improvement in all of the metrics that we are considering',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Introduces an AB test to compare different lazy load margins for ad slots.
- Full description in the corresponding frontend PR: [#24770](https://github.com/guardian/frontend/pull/24770)
