### PR TITLE
Add bylines to blocks

### DIFF
--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -1,15 +1,27 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import LiveBlockContainer, { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { map, OptionKind, partition } from '@guardian/types';
+import { map, OptionKind, partition, withDefault } from '@guardian/types';
 import { LastUpdated } from 'components/lastUpdated';
+import { Contributor } from 'contributor';
 import { formatUTCTimeDateTz } from 'date';
 import { pipe, toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { renderAll } from 'renderer';
+
+// ----- Functions ----- //
+
+const contributorToBlockContributor = (contributor: Contributor): BlockContributor => ({
+	name: contributor.name,
+	imageUrl: pipe(
+		contributor.image,
+		map((i) => i.src),
+		withDefault<string | undefined>(undefined),
+	),
+});
 
 // ----- Component ----- //
 interface LiveBlocksProps {
@@ -41,6 +53,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 						// TODO pass this value in when available
 						isPinnedPost={false}
 						supportsDarkMode={true}
+						contributors={block.contributors.map(contributorToBlockContributor)}
 					>
 						{renderAll(format, partition(block.body).oks)}
 

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -1,11 +1,12 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import LiveBlockContainer, { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
+import type { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
+import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
 import { map, OptionKind, partition, withDefault } from '@guardian/types';
 import { LastUpdated } from 'components/lastUpdated';
-import { Contributor } from 'contributor';
+import type { Contributor } from 'contributor';
 import { formatUTCTimeDateTz } from 'date';
 import { pipe, toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
@@ -14,7 +15,9 @@ import { renderAll } from 'renderer';
 
 // ----- Functions ----- //
 
-const contributorToBlockContributor = (contributor: Contributor): BlockContributor => ({
+const contributorToBlockContributor = (
+	contributor: Contributor,
+): BlockContributor => ({
 	name: contributor.name,
 	imageUrl: pipe(
 		contributor.image,
@@ -53,7 +56,9 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 						// TODO pass this value in when available
 						isPinnedPost={false}
 						supportsDarkMode={true}
-						contributors={block.contributors.map(contributorToBlockContributor)}
+						contributors={block.contributors.map(
+							contributorToBlockContributor,
+						)}
 					>
 						{renderAll(format, partition(block.body).oks)}
 

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -281,12 +281,8 @@ const blocks: LiveBlock[] = [
 					width: 36,
 					height: 36,
 					caption: captionDocFragment,
-					credit: {
-						kind: OptionKind.None,
-					},
-					nativeCaption: {
-						kind: OptionKind.None,
-					},
+					credit: none,
+					nativeCaption: none,
 					role: ArticleElementRole.Standard,
 				}),
 			},

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -267,6 +267,30 @@ const blocks: LiveBlock[] = [
 		firstPublished: some(new Date('2021-11-02T12:00:00Z')),
 		lastModified: some(new Date('2021-11-02T13:13:13Z')),
 		body: [],
+		contributors: [
+			{
+				id: '',
+				apiUrl: '',
+				name: 'Alex Hern',
+				image: some({
+					src: 'https://i.guim.co.uk/img/uploads/2021/02/18/Alex_Hern.png?width=64&quality=85&fit=bounds&s=23a43b779a5093807af839a51836919a',
+					srcset: 'https://i.guim.co.uk/img/uploads/2021/02/18/Alex_Hern.png?width=64&quality=85&fit=bounds&s=23a43b779a5093807af839a51836919a',
+					dpr2Srcset:
+						'https://i.guim.co.uk/img/uploads/2021/02/18/Alex_Hern.png?width=64&quality=85&fit=bounds&s=23a43b779a5093807af839a51836919a',
+					alt: some('image'),
+					width: 36,
+					height: 36,
+					caption: captionDocFragment,
+					credit: {
+						kind: OptionKind.None,
+					},
+					nativeCaption: {
+						kind: OptionKind.None,
+					},
+					role: ArticleElementRole.Standard,
+				}),
+			},
+		],
 	},
 	{
 		id: '2',
@@ -275,6 +299,7 @@ const blocks: LiveBlock[] = [
 		firstPublished: some(new Date('2021-11-02T11:20:00Z')),
 		lastModified: some(new Date('2021-11-02T13:03:13Z')),
 		body: [],
+		contributors: [],
 	},
 	{
 		id: '3',
@@ -283,6 +308,7 @@ const blocks: LiveBlock[] = [
 		firstPublished: some(new Date('2021-11-02T11:05:12Z')),
 		lastModified: some(new Date('2021-11-02T12:13:13Z')),
 		body: [],
+		contributors: [],
 	},
 	{
 		id: '4',
@@ -291,6 +317,7 @@ const blocks: LiveBlock[] = [
 		firstPublished: some(new Date('2021-11-02T10:55:03Z')),
 		lastModified: some(new Date('2021-11-02T11:13:13Z')),
 		body: [],
+		contributors: [],
 	},
 	{
 		id: '5',
@@ -299,6 +326,7 @@ const blocks: LiveBlock[] = [
 		firstPublished: some(new Date('2021-11-02T10:20:20Z')),
 		lastModified: some(new Date('2021-11-02T11:13:13Z')),
 		body: [],
+		contributors: [],
 	},
 ];
 

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -363,7 +363,7 @@ const fromCapiLiveBlog =
 			? 30
 			: 10;
 
-		const parsedBlocks = parseLiveBlocks(body)(context);
+		const parsedBlocks = parseLiveBlocks(context)(body, content.tags);
 		const pagedBlocks = getPagedBlocks(pageSize, parsedBlocks, blockId);
 		return {
 			design:

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -1,12 +1,13 @@
 // ----- Imports ----- //
 
 import type { Block } from '@guardian/content-api-models/v1/block';
-import { Tag } from '@guardian/content-api-models/v1/tag';
+import type { Tag } from '@guardian/content-api-models/v1/tag';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
-import { Contributor, tagToContributor } from 'contributor';
+import type { Contributor } from 'contributor';
+import { tagToContributor } from 'contributor';
 import type { Context } from 'parserContext';
 
 // ----- Types ----- //
@@ -25,10 +26,15 @@ type LiveBlock = {
 
 const contributorTags = (contributors: string[], tags: Tag[]): Tag[] => {
 	const isTag = (tag: Tag | undefined): tag is Tag => tag !== undefined;
-	return contributors.map(contributor => tags.find(tag => tag.id === `profile/${contributor}`)).filter(isTag);
-}
+	return contributors
+		.map((contributor) =>
+			tags.find((tag) => tag.id === `profile/${contributor}`),
+		)
+		.filter(isTag);
+};
 
-const tagsToContributors = (tags: Tag[], context: Context): Contributor[] => tags.map(tagToContributor(context.salt))
+const tagsToContributors = (tags: Tag[], context: Context): Contributor[] =>
+	tags.map(tagToContributor(context.salt));
 
 const parse =
 	(context: Context, tags: Tag[]) =>
@@ -39,7 +45,10 @@ const parse =
 		firstPublished: maybeCapiDate(block.firstPublishedDate),
 		lastModified: maybeCapiDate(block.lastModifiedDate),
 		body: parseElements(context)(block.elements),
-		contributors: tagsToContributors(contributorTags(block.contributors, tags), context),
+		contributors: tagsToContributors(
+			contributorTags(block.contributors, tags),
+			context,
+		),
 	});
 
 const parseMany =

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -1,10 +1,12 @@
 // ----- Imports ----- //
 
 import type { Block } from '@guardian/content-api-models/v1/block';
+import { Tag } from '@guardian/content-api-models/v1/tag';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
+import { Contributor, tagToContributor } from 'contributor';
 import type { Context } from 'parserContext';
 
 // ----- Types ----- //
@@ -16,12 +18,20 @@ type LiveBlock = {
 	firstPublished: Option<Date>;
 	lastModified: Option<Date>;
 	body: Body;
+	contributors: Contributor[];
 };
 
 // ----- Functions ----- //
 
+const contributorTags = (contributors: string[], tags: Tag[]): Tag[] => {
+	const isTag = (tag: Tag | undefined): tag is Tag => tag !== undefined;
+	return contributors.map(contributor => tags.find(tag => tag.id === `profile/${contributor}`)).filter(isTag);
+}
+
+const tagsToContributors = (tags: Tag[], context: Context): Contributor[] => tags.map(tagToContributor(context.salt))
+
 const parse =
-	(context: Context) =>
+	(context: Context, tags: Tag[]) =>
 	(block: Block): LiveBlock => ({
 		id: block.id,
 		isKeyEvent: block.attributes.keyEvent ?? false,
@@ -29,12 +39,13 @@ const parse =
 		firstPublished: maybeCapiDate(block.firstPublishedDate),
 		lastModified: maybeCapiDate(block.lastModifiedDate),
 		body: parseElements(context)(block.elements),
+		contributors: tagsToContributors(contributorTags(block.contributors, tags), context),
 	});
 
 const parseMany =
-	(blocks: Block[]): ((context: Context) => LiveBlock[]) =>
-	(context: Context): LiveBlock[] =>
-		blocks.map(parse(context));
+	(context: Context) =>
+	(blocks: Block[], tags: Tag[]): LiveBlock[] =>
+		blocks.map(parse(context, tags));
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/pagination.test.ts
+++ b/apps-rendering/src/pagination.test.ts
@@ -10,6 +10,7 @@ const generateBlocks = (numberOfBlocks: number): LiveBlock[] => {
 		firstPublished: some(new Date('2021-11-02T12:00:00Z')),
 		lastModified: some(new Date('2021-11-02T13:13:13Z')),
 		body: [],
+		contributors: [],
 	};
 
 	const liveBlocks = [];

--- a/common-rendering/src/components/liveBlockContainer.tsx
+++ b/common-rendering/src/components/liveBlockContainer.tsx
@@ -177,3 +177,4 @@ const LiveBlockContainer = ({
 };
 
 export default LiveBlockContainer;
+export type { BlockContributor };


### PR DESCRIPTION
## Why?
Bylines weren't being rendered in blocks in AR. This PR addresses the issue by adding an array of `contributors` to `LiveBlock`. Figuring this out wasn't straightforward and involved some digging in the `frontend` codebase - thanks @JamieB-gu for pairing on this.

| **Before** | **After** |
|-----------|----------|
| ![image](https://user-images.githubusercontent.com/57295823/159330697-a270aab9-eb9c-4cfc-b469-07bc39e57b31.png) | ![image](https://user-images.githubusercontent.com/57295823/159330649-cedd2bda-87f5-41b7-b564-dc217071142b.png) |

## Follow-up work
1) Bylines appear to be larger than `36x36`, despite using the same component as DCR. We need to investigate why this is.
2) Byline images currently do not display a background colour, unlike DCR. This needs to be fixed.