### PR TITLE
Remove `data-spacefinder-component` attribute

### DIFF
--- a/dotcom-rendering/docs/contracts/001-commercial-selectors.md
+++ b/dotcom-rendering/docs/contracts/001-commercial-selectors.md
@@ -7,14 +7,10 @@ We place the following classes on the container element of the article body:
 -   `article-body-commercial-selector` on the ArticleRenderer
 -   `js-liveblog-body` on the ArticleBody when rendering a Liveblog/Deadblog
 
-Furthermore, within the article body, we add the following attribute to certain elements:
+Furthermore, within the article body, we add the following attributes to certain elements:
 
-- `data-spacefinder-component`
-
-It currently supports two values:
-
-- `numbered-list-title`
-- `rich-link`
+- `data-spacefinder-role` which denotes the role of figures (e.g. rich-links)
+- `data-spacefinder-type` the underlying element `_type`
 
 These are elements spacefinder needs to know about when positioning adverts.
 

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -9,7 +9,6 @@ type Props = {
 	isMainMedia: boolean;
 	role?: RoleType | 'richLink';
 	id?: string;
-	isNumberedListTitle?: boolean;
 	className?: string;
 	type?: CAPIElement['_type'];
 };
@@ -180,7 +179,6 @@ export const Figure = ({
 	children,
 	id,
 	isMainMedia,
-	isNumberedListTitle = false,
 	className = '',
 	type,
 }: Props) => {
@@ -197,22 +195,10 @@ export const Figure = ({
 		);
 	}
 
-	// TODO: isNumberedListTitle is not used
-	// TODO: Any usage of data-spacefinder-component can be replaced with data-spacefinder-type
-	//       Once this has been done we can remove this attribute
-	// See 001-commercial-selectors.md for details on `data-spacefinder-component`
-	let spacefinderComponent: 'rich-link' | 'numbered-list-title' | undefined;
-	if (role === 'richLink') {
-		spacefinderComponent = 'rich-link';
-	} else if (isNumberedListTitle) {
-		spacefinderComponent = 'numbered-list-title';
-	}
-
 	return (
 		<figure
 			id={id}
 			css={defaultRoleStyles(role, format)}
-			data-spacefinder-component={spacefinderComponent}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}
 			className={className}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR removes the `data-spacefinder-component` attribute from figures. In doing this we can also remove the `isNumberedList` prop (which is optional and never passed in anywhere anyway).

This PR is dependent on [Frontend #24776](https://github.com/guardian/frontend/pull/24776) being merged first.

## Why?

This has been deprecated in favour of using `data-spacefinder-role` and `data-spacefinder-type`. See #4113 for the basis of this change.
