### PR TITLE
Refactor expansion in `Discussion`

### DIFF
--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -71,21 +71,6 @@ export const Discussion = ({
 		return false;
 	};
 
-	const handleExpanded = (value: number): void => {
-		const { ga } = window;
-
-		if (!ga) {
-			return;
-		}
-
-		ga('allEditorialPropertyTracker.send', 'event', {
-			eventCategory: 'Performance',
-			eventAction: 'DiscussionExpanded',
-			eventValue: Math.round(value),
-			nonInteraction: true,
-		});
-	};
-
 	// Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120
 	// If so, make a call to get the context of this comment so we know what page it is
 	// on.
@@ -145,9 +130,6 @@ export const Discussion = ({
 				commentToScrollTo={hashCommentId}
 				onPermalinkClick={handlePermalink}
 				apiKey="dotcom-rendering"
-				onExpanded={(value) => {
-					handleExpanded(value);
-				}}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -62,11 +62,9 @@ export const Discussion = ({
 	const handlePermalink = (commentId: number) => {
 		if (typeof window === 'undefined') return false;
 		window.location.hash = `#comment-${commentId}`;
-		const comment = window.document.getElementById(`comment-${commentId}`);
-		if (comment) {
-			// The comment was already on the page so just scroll to it.
-			comment.scrollIntoView();
-		}
+		// Put this comment id into the hashCommentId state which will
+		// trigger an api call to get the comment context and then expand
+		// and reload the discussion based on the resuts
 		setHashCommentId(commentId);
 		return false;
 	};

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -18,7 +18,6 @@ export type Props = {
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
 	user?: UserProfile;
-	expanded?: boolean;
 };
 
 const commentIdFromUrl = () => {
@@ -38,14 +37,13 @@ export const Discussion = ({
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
 	user,
-	expanded,
 }: Props) => {
 	const [commentPage, setCommentPage] = useState<number>();
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
 		'newest' | 'oldest' | 'recommendations'
 	>();
-	const [isExpanded, setIsExpanded] = useState<boolean>(!!expanded);
+	const [isExpanded, setIsExpanded] = useState<boolean>(false);
 	const [hashCommentId, setHashCommentId] = useState<number | undefined>(
 		commentIdFromUrl(),
 	);

--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -8,7 +8,7 @@ import { Island } from './Island';
 import { DiscussionContainer } from './DiscussionContainer.importable';
 import { DiscussionMeta } from './DiscussionMeta.importable';
 
-interface DiscussionLayoutProps {
+type Props = {
 	format: ArticleFormat;
 	discussionApiUrl: string;
 	shortUrlId: string;
@@ -18,7 +18,7 @@ interface DiscussionLayoutProps {
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
 	expanded?: boolean;
-}
+};
 
 export const DiscussionLayout = ({
 	format,
@@ -30,7 +30,7 @@ export const DiscussionLayout = ({
 	isAdFreeUser,
 	shouldHideAds,
 	expanded,
-}: DiscussionLayoutProps) => {
+}: Props) => {
 	const hideAd = isAdFreeUser || shouldHideAds;
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -17,7 +17,6 @@ type Props = {
 	enableDiscussionSwitch: boolean;
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
-	expanded?: boolean;
 };
 
 export const DiscussionLayout = ({
@@ -29,7 +28,6 @@ export const DiscussionLayout = ({
 	enableDiscussionSwitch,
 	isAdFreeUser,
 	shouldHideAds,
-	expanded,
 }: Props) => {
 	const hideAd = isAdFreeUser || shouldHideAds;
 	return (
@@ -70,7 +68,6 @@ export const DiscussionLayout = ({
 									discussionApiClientHeader
 								}
 								enableDiscussionSwitch={enableDiscussionSwitch}
-								expanded={expanded}
 							/>
 						</Island>
 					</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR helps with https://github.com/guardian/dotcom-rendering/issues/4297 and is related to https://github.com/guardian/discussion-rendering/pull/559 but does not fix or depend on either

Here we refactor expansion in `Discussion`.

1) Use `type Props` to match convention
2) Remove unused `expanded` prop
3) Stop logging unused metrics to GA (we have completed the Emotion 11 migration)
4) Always reload the `Discussion` component when a permalink is clicked (for more reliability)
