### PR TITLE
Bump @guardian/discussion-rendering to `v9.2.0`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
     "@guardian/braze-components": "^6.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",
-    "@guardian/discussion-rendering": "^9.1.1",
+    "@guardian/discussion-rendering": "^9.2.0",
     "@guardian/libs": "^3.8.1",
     "@guardian/prettier": "^0.5.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,10 +2826,10 @@
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 
-"@guardian/discussion-rendering@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-9.1.1.tgz#5c7598f308388dffd5372919282cdcbb38b763bc"
-  integrity sha512-nxY7ZTOYroMQOhJP1OqtXUa29S4cwLBWlhygPg0pX7Sq4Gw1bivqgjhOvJOvew4/kUxlpCjfKyXbvu3PoDUwJQ==
+"@guardian/discussion-rendering@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-9.2.0.tgz#27791ae13f8f03c4f0725166f6d79666a86af34e"
+  integrity sha512-YiPEcXWDtpQ0IbE3gAhbGdbDvx0hH8RYrKahBLz4mAMZWdE/zt0qypJwOe2zv8iHHRik8AaPnCQ+qZZK71rWZA==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps @guardian/discussion-rendering to `v9.2.0`

## Why?
[This release](https://github.com/guardian/discussion-rendering/releases/tag/v9.2.0) has improvements to comment permalinks
