### PR TITLE
Fix broken date link in blocks

### DIFF
--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -37,7 +37,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 		<>
 			{/* Accordion? */}
 			{blocks.map((block) => {
-				const blockLink = `#block-${block.id}`;
+				const blockLink = `?page=with:block-${block.id}#block-${block.id}`;
 				const blockFirstPublished = pipe(
 					block.firstPublished,
 					map(Number),

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -37,8 +37,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 		<>
 			{/* Accordion? */}
 			{blocks.map((block) => {
-				// TODO: get page number
-				const blockLink = `${1}#block-${block.id}`;
+				const blockLink = `#block-${block.id}`;
 				const blockFirstPublished = pipe(
 					block.firstPublished,
 					map(Number),


### PR DESCRIPTION
- #4298 was overwritten by a merge conflict. 
This PR reinstates the line that was changed by mistake. 