### PR TITLE
BUGFIX: Interactive articles using iframes when not required

### DIFF
--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -350,7 +350,10 @@ export const renderElement = ({
 				</Island>,
 			];
 		case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
-			if (format.design === ArticleDesign.Interactive) {
+			if (
+				format.design === ArticleDesign.Interactive ||
+				format.design === ArticleDesign.FullPageInteractive
+			) {
 				return [
 					true,
 					<InteractiveLayoutAtom


### PR DESCRIPTION
## What does this change & why?

co-authored-by: @OllysCoding @mxdvl 

Articles of both design type 'interactive' and design type 'fullpageinteractive' should use the non-iframed interactive renderer code. Because of recent changes in CAPI and DCR, we are now actively using the 'fullpageinteractive' design type and therefore needed to make this change so that interactive articles of this type are rendered correctly

### Before
<img width="1530" alt="Screenshot 2022-03-23 at 09 41 39" src="https://user-images.githubusercontent.com/3300789/159670167-d78adb73-a980-4dcd-80f0-9f6d1b3e0373.png">

### After
<img width="1530" alt="Screenshot 2022-03-23 at 09 42 10" src="https://user-images.githubusercontent.com/3300789/159670005-25848bf3-a060-49f9-bb41-98603fdf72de.png">