### PR TITLE
Add support for SDC_URL back in

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -47,6 +47,7 @@ import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 
 const StandardGrid = ({
 	children,
@@ -325,6 +326,8 @@ export const CommentLayout = ({
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+
 	return (
 		<>
 			<div id="bannerandheader">
@@ -362,7 +365,7 @@ export const CommentLayout = ({
 								urls={CAPI.nav.readerRevenueLinks.header}
 								remoteHeader={CAPI.config.switches.remoteHeader}
 								contributionsServiceUrl={
-									CAPI.contributionsServiceUrl
+									contributionsServiceUrl
 								}
 							/>
 						</ElementContainer>
@@ -571,7 +574,7 @@ export const CommentLayout = ({
 											!!CAPI.config.isPaidContent
 										}
 										contributionsServiceUrl={
-											CAPI.contributionsServiceUrl
+											contributionsServiceUrl
 										}
 										contentType={CAPI.contentType}
 										sectionName={CAPI.sectionName || ''}
@@ -587,7 +590,7 @@ export const CommentLayout = ({
 												}
 												contentType={CAPI.contentType}
 												contributionsServiceUrl={
-													CAPI.contributionsServiceUrl
+													contributionsServiceUrl
 												}
 												idApiUrl={CAPI.config.idApiUrl}
 												isDev={
@@ -806,7 +809,7 @@ export const CommentLayout = ({
 					<StickyBottomBanner
 						abTestSwitches={CAPI.config.switches}
 						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPI.config.idApiUrl}
 						isDev={CAPI.config.isDev ?? false}
 						isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -44,6 +44,7 @@ import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -228,6 +229,8 @@ export const ImmersiveLayout = ({
 	const captionText = decideCaption(mainMedia);
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+
 	return (
 		<>
 			<ImmersiveHeader
@@ -391,7 +394,7 @@ export const ImmersiveLayout = ({
 									tags={CAPI.tags}
 									isPaidContent={!!CAPI.config.isPaidContent}
 									contributionsServiceUrl={
-										CAPI.contributionsServiceUrl
+										contributionsServiceUrl
 									}
 									contentType={CAPI.contentType}
 									sectionName={CAPI.sectionName || ''}
@@ -407,7 +410,7 @@ export const ImmersiveLayout = ({
 											}
 											contentType={CAPI.contentType}
 											contributionsServiceUrl={
-												CAPI.contributionsServiceUrl
+												contributionsServiceUrl
 											}
 											idApiUrl={CAPI.config.idApiUrl}
 											isDev={CAPI.config.isDev ?? false}
@@ -619,7 +622,7 @@ export const ImmersiveLayout = ({
 					<StickyBottomBanner
 						abTestSwitches={CAPI.config.switches}
 						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPI.config.idApiUrl}
 						isDev={CAPI.config.isDev ?? false}
 						isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -61,6 +61,7 @@ import { ArticleLastUpdated } from '../components/ArticleLastUpdated';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -302,6 +303,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 		totalPages: 1,
 	};
 
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 	return (
 		<>
@@ -339,9 +342,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							}
 							urls={CAPI.nav.readerRevenueLinks.header}
 							remoteHeader={CAPI.config.switches.remoteHeader}
-							contributionsServiceUrl={
-								CAPI.contributionsServiceUrl
-							}
+							contributionsServiceUrl={contributionsServiceUrl}
 						/>
 					</ElementContainer>
 
@@ -791,7 +792,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 													!!CAPI.config.isPaidContent
 												}
 												contributionsServiceUrl={
-													CAPI.contributionsServiceUrl
+													contributionsServiceUrl
 												}
 												contentType={CAPI.contentType}
 												sectionName={
@@ -831,7 +832,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 															CAPI.contentType
 														}
 														contributionsServiceUrl={
-															CAPI.contributionsServiceUrl
+															contributionsServiceUrl
 														}
 														idApiUrl={
 															CAPI.config.idApiUrl
@@ -1071,7 +1072,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<StickyBottomBanner
 						abTestSwitches={CAPI.config.switches}
 						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPI.config.idApiUrl}
 						isDev={CAPI.config.isDev ?? false}
 						isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -52,6 +52,7 @@ import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -264,6 +265,8 @@ export const ShowcaseLayout = ({
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+
 	return (
 		<>
 			{format.theme !== ArticleSpecial.Labs ? (
@@ -307,7 +310,7 @@ export const ShowcaseLayout = ({
 										CAPI.config.switches.remoteHeader
 									}
 									contributionsServiceUrl={
-										CAPI.contributionsServiceUrl
+										contributionsServiceUrl
 									}
 								/>
 							</ElementContainer>
@@ -555,7 +558,7 @@ export const ShowcaseLayout = ({
 									tags={CAPI.tags}
 									isPaidContent={!!CAPI.config.isPaidContent}
 									contributionsServiceUrl={
-										CAPI.contributionsServiceUrl
+										contributionsServiceUrl
 									}
 									contentType={CAPI.contentType}
 									sectionName={CAPI.sectionName || ''}
@@ -571,7 +574,7 @@ export const ShowcaseLayout = ({
 											}
 											contentType={CAPI.contentType}
 											contributionsServiceUrl={
-												CAPI.contributionsServiceUrl
+												contributionsServiceUrl
 											}
 											idApiUrl={CAPI.config.idApiUrl}
 											isDev={CAPI.config.isDev ?? false}
@@ -784,7 +787,7 @@ export const ShowcaseLayout = ({
 					<StickyBottomBanner
 						abTestSwitches={CAPI.config.switches}
 						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPI.config.idApiUrl}
 						isDev={CAPI.config.isDev ?? false}
 						isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -358,6 +358,9 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					theme: getCurrentPillar(CAPI),
 			  };
 
+	const contributionsServiceUrl =
+		process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -395,7 +398,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								urls={CAPI.nav.readerRevenueLinks.header}
 								remoteHeader={CAPI.config.switches.remoteHeader}
 								contributionsServiceUrl={
-									CAPI.contributionsServiceUrl
+									contributionsServiceUrl
 								}
 							/>
 						</ElementContainer>
@@ -657,7 +660,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									tags={CAPI.tags}
 									isPaidContent={!!CAPI.config.isPaidContent}
 									contributionsServiceUrl={
-										CAPI.contributionsServiceUrl
+										contributionsServiceUrl
 									}
 									contentType={CAPI.contentType}
 									sectionName={CAPI.sectionName || ''}
@@ -687,7 +690,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											}
 											contentType={CAPI.contentType}
 											contributionsServiceUrl={
-												CAPI.contributionsServiceUrl
+												contributionsServiceUrl
 											}
 											idApiUrl={CAPI.config.idApiUrl}
 											isDev={CAPI.config.isDev ?? false}
@@ -916,7 +919,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<StickyBottomBanner
 						abTestSwitches={CAPI.config.switches}
 						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPI.config.idApiUrl}
 						isDev={CAPI.config.isDev ?? false}
 						isMinuteArticle={CAPI.pageType.isMinuteArticle}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -59,6 +59,7 @@ import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 
 const StandardGrid = ({
 	children,
@@ -358,8 +359,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					theme: getCurrentPillar(CAPI),
 			  };
 
-	const contributionsServiceUrl =
-		process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -241,3 +241,6 @@ export const lazyFetchEmailWithTimeout =
 			});
 		});
 	};
+
+export const getContributionsServiceUrl = (CAPI: CAPIType): string =>
+	process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;


### PR DESCRIPTION
For running support-dotcom-components locally
this was lost [here](https://github.com/guardian/dotcom-rendering/pull/4262)