### PR TITLE
refactor: infer palette from format

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -5,10 +5,10 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	blocks: Block[];
 	pinnedPost?: Block;
 	adTargeting: AdTargeting;
@@ -103,7 +103,6 @@ const revealStyles = css`
 
 export const ArticleBody = ({
 	format,
-	palette,
 	blocks,
 	pinnedPost,
 	adTargeting,
@@ -127,6 +126,7 @@ export const ArticleBody = ({
 	onFirstPage,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
+	const palette = decidePalette(format);
 
 	if (
 		format.design === ArticleDesign.LiveBlog ||

--- a/dotcom-rendering/src/web/components/Border.tsx
+++ b/dotcom-rendering/src/web/components/Border.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/react';
 
 import { from } from '@guardian/source-foundations';
+import { decidePalette } from '../lib/decidePalette';
 
-export const Border = ({ palette }: { palette: Palette }) => (
+export const Border = ({ format }: { format: ArticleFormat }) => (
 	<div
 		css={css`
 			${from.leftCol} {
-				border-left: 1px solid ${palette.border.article};
+				border-left: 1px solid ${decidePalette(format).border.article};
 				height: 100%;
 			}
 		`}

--- a/dotcom-rendering/src/web/components/SubMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.stories.tsx
@@ -7,7 +7,6 @@ import {
 } from '@guardian/libs';
 
 import { css } from '@emotion/react';
-import { decidePalette } from '../lib/decidePalette';
 import {
 	getAllThemes,
 	getThemeNameAsString,
@@ -69,11 +68,6 @@ export const News = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -95,11 +89,6 @@ export const Sport = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Sport,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -121,11 +110,6 @@ export const Culture = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Culture,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -147,11 +131,6 @@ export const Lifestyle = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Lifestyle,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -173,11 +152,6 @@ export const Opinion = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Opinion,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -199,11 +173,6 @@ export const Labs = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.Labs,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -225,11 +194,6 @@ export const SpecialReport = () => {
 	return (
 		<Container>
 			<SubMeta
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.SpecialReport,
-				})}
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -257,7 +221,6 @@ export const DeadBlogStory = () => {
 				<Container>
 					<p>{getThemeNameAsString(format)}</p>
 					<SubMeta
-						palette={decidePalette(format)}
 						format={format}
 						subMetaKeywordLinks={subMetaKeywordLinks}
 						subMetaSectionLinks={subMetaSectionLinks}

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -12,6 +12,7 @@ import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 
 import { ShareIcons } from './ShareIcons';
 import { Badge } from './Badge';
+import { decidePalette } from '../lib/decidePalette';
 
 const labelStyles = (palette: Palette) => css`
 	${textSans.xxsmall()};
@@ -121,7 +122,6 @@ const hideSlash = css`
 `;
 
 type Props = {
-	palette: Palette;
 	format: ArticleFormat;
 	subMetaSectionLinks: SimpleLinkType[];
 	subMetaKeywordLinks: SimpleLinkType[];
@@ -141,7 +141,6 @@ const syndicationButtonOverrides = (palette: Palette) => css`
 `;
 
 export const SubMeta = ({
-	palette,
 	format,
 	subMetaKeywordLinks,
 	subMetaSectionLinks,
@@ -151,6 +150,7 @@ export const SubMeta = ({
 	showBottomSocialButtons,
 	badge,
 }: Props) => {
+	const palette = decidePalette(format);
 	const hasSectionLinks = subMetaSectionLinks.length > 0;
 	const hasKeywordLinks = subMetaKeywordLinks.length > 0;
 	return (

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -48,6 +48,7 @@ import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
 
 const StandardGrid = ({
 	children,
@@ -277,15 +278,9 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
-export const CommentLayout = ({
-	CAPI,
-	NAV,
-	format,
-	palette,
-}: Props): JSX.Element => {
+export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -325,6 +320,8 @@ export const CommentLayout = ({
 	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const palette = decidePalette(format);
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
 
@@ -436,7 +433,7 @@ export const CommentLayout = ({
 							/>
 						</GridItem>
 						<GridItem area="border">
-							<Border palette={palette} />
+							<Border format={format} />
 						</GridItem>
 						<GridItem area="headline">
 							<div css={maxWidth}>
@@ -555,7 +552,6 @@ export const CommentLayout = ({
 								<div css={maxWidth}>
 									<ArticleBody
 										format={format}
-										palette={palette}
 										blocks={CAPI.blocks}
 										adTargeting={adTargeting}
 										host={host}
@@ -622,7 +618,6 @@ export const CommentLayout = ({
 									)}
 									<Lines count={4} effect="straight" />
 									<SubMeta
-										palette={palette}
 										format={format}
 										subMetaKeywordLinks={
 											CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -1,8 +1,6 @@
 import { ArticleDisplay, ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { decidePalette } from '../lib/decidePalette';
-
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
@@ -18,8 +16,6 @@ type Props = {
 };
 
 export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
-	const palette = decidePalette(format);
-
 	// TODO we can probably better express this as data
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
@@ -42,7 +38,6 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						<ImmersiveLayout
 							CAPI={CAPI}
 							NAV={NAV}
-							palette={palette}
 							format={format}
 						/>
 					);
@@ -54,33 +49,16 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
-					return (
-						<LiveLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
-					);
+					return <LiveLayout CAPI={CAPI} NAV={NAV} format={format} />;
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 					return (
-						<CommentLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
+						<CommentLayout CAPI={CAPI} NAV={NAV} format={format} />
 					);
 				default:
 					return (
-						<ShowcaseLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
+						<ShowcaseLayout CAPI={CAPI} NAV={NAV} format={format} />
 					);
 			}
 		}
@@ -93,7 +71,6 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							CAPI={CAPI}
 							NAV={NAV}
 							format={format}
-							palette={palette}
 						/>
 					);
 				case ArticleDesign.FullPageInteractive: {
@@ -107,33 +84,16 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				}
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
-					return (
-						<LiveLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
-					);
+					return <LiveLayout CAPI={CAPI} NAV={NAV} format={format} />;
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 					return (
-						<CommentLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
+						<CommentLayout CAPI={CAPI} NAV={NAV} format={format} />
 					);
 				default:
 					return (
-						<StandardLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							format={format}
-							palette={palette}
-						/>
+						<StandardLayout CAPI={CAPI} NAV={NAV} format={format} />
 					);
 			}
 		}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -45,6 +45,7 @@ import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -173,7 +174,6 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
@@ -190,12 +190,7 @@ const decideCaption = (mainMedia: ImageBlockElement): string => {
 	return caption.join(' ');
 };
 
-export const ImmersiveLayout = ({
-	CAPI,
-	NAV,
-	format,
-	palette,
-}: Props): JSX.Element => {
+export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -233,17 +228,12 @@ export const ImmersiveLayout = ({
 
 	return (
 		<>
-			<ImmersiveHeader
-				CAPI={CAPI}
-				NAV={NAV}
-				format={format}
-				palette={palette}
-			/>
+			<ImmersiveHeader CAPI={CAPI} NAV={NAV} format={format} />
 			<main>
 				<ElementContainer
 					showTopBorder={false}
 					showSideBorders={false}
-					backgroundColour={palette.background.article}
+					backgroundColour={decidePalette(format).background.article}
 					element="article"
 				>
 					<ImmersiveGrid>
@@ -261,7 +251,7 @@ export const ImmersiveLayout = ({
 							{format.design === ArticleDesign.PhotoEssay ? (
 								<></>
 							) : (
-								<Border palette={palette} />
+								<Border format={format} />
 							)}
 						</GridItem>
 						<GridItem area="title" element="aside">
@@ -377,7 +367,6 @@ export const ImmersiveLayout = ({
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									palette={palette}
 									blocks={CAPI.blocks}
 									adTargeting={adTargeting}
 									host={host}
@@ -437,7 +426,6 @@ export const ImmersiveLayout = ({
 								)}
 								<Lines count={4} effect="straight" />
 								<SubMeta
-									palette={palette}
 									format={format}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -295,12 +295,7 @@ export const InteractiveImmersiveLayout = ({
 				<AdSlot position="survey" display={format.display} />
 			)}
 
-			<ImmersiveHeader
-				CAPI={CAPI}
-				NAV={NAV}
-				format={format}
-				palette={palette}
-			/>
+			<ImmersiveHeader CAPI={CAPI} NAV={NAV} format={format} />
 			<main>
 				<ElementContainer
 					showTopBorder={false}
@@ -323,7 +318,7 @@ export const InteractiveImmersiveLayout = ({
 							{format.design === ArticleDesign.PhotoEssay ? (
 								<></>
 							) : (
-								<Border palette={palette} />
+								<Border format={format} />
 							)}
 						</GridItem>
 						<GridItem area="title" element="aside">

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -57,6 +57,7 @@ import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { decidePalette } from '../lib/decidePalette';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -235,10 +236,9 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
-export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
+export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -264,6 +264,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const palette = decidePalette(format);
+
 	return (
 		<>
 			{CAPI.isLegacyInteractive && (
@@ -413,7 +416,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								{format.theme === ArticleSpecial.Labs ? (
 									<></>
 								) : (
-									<Border palette={palette} />
+									<Border format={format} />
 								)}
 							</GridItem>
 							<GridItem area="headline">
@@ -524,7 +527,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								<ArticleContainer format={format}>
 									<ArticleBody
 										format={format}
-										palette={palette}
 										blocks={CAPI.blocks}
 										adTargeting={adTargeting}
 										host={host}
@@ -560,7 +562,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										/>
 									</div>
 									<SubMeta
-										palette={palette}
 										format={format}
 										subMetaKeywordLinks={
 											CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -62,6 +62,7 @@ import { GetMatchTabs } from '../components/GetMatchTabs.importable';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -263,10 +264,9 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
-export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
+export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -306,6 +306,9 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const palette = decidePalette(format);
+
 	return (
 		<>
 			<div data-print-layout="hide">
@@ -770,7 +773,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 											)}
 											<ArticleBody
 												format={format}
-												palette={palette}
 												blocks={CAPI.blocks}
 												pinnedPost={CAPI.pinnedPost}
 												adTargeting={adTargeting}
@@ -880,7 +882,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 												effect="straight"
 											/>
 											<SubMeta
-												palette={palette}
 												format={format}
 												subMetaKeywordLinks={
 													CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -53,6 +53,7 @@ import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -223,15 +224,9 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
-export const ShowcaseLayout = ({
-	CAPI,
-	NAV,
-	format,
-	palette,
-}: Props): JSX.Element => {
+export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -264,6 +259,8 @@ export const ShowcaseLayout = ({
 	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const palette = decidePalette(format);
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
 
@@ -439,7 +436,7 @@ export const ShowcaseLayout = ({
 							/>
 						</GridItem>
 						<GridItem area="border">
-							<Border palette={palette} />
+							<Border format={format} />
 						</GridItem>
 						<GridItem area="headline">
 							<PositionHeadline design={format.design}>
@@ -541,7 +538,6 @@ export const ShowcaseLayout = ({
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									palette={palette}
 									blocks={CAPI.blocks}
 									adTargeting={adTargeting}
 									host={host}
@@ -601,7 +597,6 @@ export const ShowcaseLayout = ({
 								)}
 								<Lines count={4} effect="straight" />
 								<SubMeta
-									palette={palette}
 									format={format}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -60,6 +60,7 @@ import { GetMatchTabs } from '../components/GetMatchTabs.importable';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
+import { decidePalette } from '../lib/decidePalette';
 
 const StandardGrid = ({
 	children,
@@ -310,10 +311,9 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
-export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
+export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
 	} = CAPI;
@@ -350,6 +350,8 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+	const palette = decidePalette(format);
 
 	const formatForNav =
 		format.theme === ArticleSpecial.Labs
@@ -496,7 +498,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							{format.theme === ArticleSpecial.Labs ? (
 								<></>
 							) : (
-								<Border palette={palette} />
+								<Border format={format} />
 							)}
 						</GridItem>
 						<GridItem area="matchNav" element="aside">
@@ -642,7 +644,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									palette={palette}
 									blocks={CAPI.blocks}
 									pinnedPost={CAPI.pinnedPost}
 									adTargeting={adTargeting}
@@ -721,7 +722,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									effect="straight"
 								/>
 								<SubMeta
-									palette={palette}
 									format={format}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -24,6 +24,7 @@ import { getZIndex } from '../../lib/getZIndex';
 import { Stuck } from '../lib/stickiness';
 import { getCurrentPillar } from '../../lib/layoutHelpers';
 import { Island } from '../../components/Island';
+import { decidePalette } from '../../lib/decidePalette';
 
 const hasMainMediaStyles = css`
 	height: 100vh;
@@ -44,7 +45,6 @@ interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
 	format: ArticleFormat;
-	palette: Palette;
 }
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
@@ -98,12 +98,7 @@ const Box = ({
 	</div>
 );
 
-export const ImmersiveHeader = ({
-	CAPI,
-	NAV,
-	format,
-	palette,
-}: Props): JSX.Element => {
+export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const {
 		config: { host },
 	} = CAPI;
@@ -143,6 +138,8 @@ export const ImmersiveHeader = ({
 			/>
 		</div>
 	);
+
+	const palette = decidePalette(format);
 
 	return (
 		<>


### PR DESCRIPTION
## What does this change?

Infer `palette` from `format` in the following layouts:
- CommentLayout
- ImmersiveLayout
- InteractiveLayout
- LiveLayout
- ShowcaseLayout
- StandardLayout

By changing the props of components `ArticleBody`, `Border` and `SubMeta`.

## Why?

Having both is redundant.

Follow-up on #4053