### PR TITLE
Add Spacefinder attribute to interactive blocks

### DIFF
--- a/dotcom-rendering/docs/contracts/001-commercial-selectors.md
+++ b/dotcom-rendering/docs/contracts/001-commercial-selectors.md
@@ -9,7 +9,7 @@ We place the following classes on the container element of the article body:
 
 Furthermore, within the article body, we add the following attributes to certain elements:
 
-- `data-spacefinder-role` which denotes the role of figures (e.g. rich-links)
+- `data-spacefinder-role` which denotes the role of figures (e.g. rich-links). We add this to elements belonging to `Figure` and `InteractiveBlockComponent` components.
 - `data-spacefinder-type` the underlying element `_type`
 
 These are elements spacefinder needs to know about when positioning adverts.

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
@@ -302,6 +302,7 @@ export const InteractiveBlockComponent = ({
 				)}
 				data-alt={alt} // for compatibility with custom boot scripts
 				data-cypress={`interactive-element-${encodeURI(alt || '')}`}
+				data-spacefinder-role={role}
 			>
 				{!loaded && (
 					<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add the `data-spacefinder-role` attribute to interactive block `figure` elements.

## Why?

See #4113 and #4354 for the historical basis for this change.

Currently Spacefinder is selecting for these elements via a legacy `figure.element-immersive` selector. We'd like to be more declarative in our approach, and use the role for the interactive block itself.

#### Do we really need another Spacefinder selector?

Yes, if this helps us to avoid using classes or attributes that incidentally allow Spacefinder to avoid certain elements. Here, we're being much more explicit about why we're adding the attribute and what we want to avoid.

#### Follow-up

[This PR](https://github.com/guardian/frontend/pull/24806) will allow us to deprecate the `figure.element-immersive` selector in Spacefinder.js.


