### PR TITLE
Allow GetMatchStats and GetMatchNav to fail & hide the placeholder

### DIFF
--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -17,12 +17,12 @@ export const GetMatchNav = ({ matchUrl }: Props) => {
 		comments?: string;
 		minByMinUrl?: string;
 		venue?: string;
-	}>(matchUrl);
+	}>(matchUrl, { errorRetryCount: 1 });
 
 	if (loading) return <Loading />;
 	if (error) {
 		// Send the error to Sentry and then prevent the element from rendering
-		window.guardian.modules.sentry.reportError(error, 'match-nav');
+		window.guardian?.modules?.sentry?.reportError?.(error, 'match-nav');
 
 		return null;
 	}

--- a/dotcom-rendering/src/web/components/GetMatchTabs.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchTabs.importable.tsx
@@ -15,11 +15,12 @@ export const GetMatchTabs = ({ matchUrl, format }: Props) => {
 	const { data, error, loading } = useApi<{
 		reportUrl?: string;
 		minByMinUrl?: string;
-	}>(matchUrl);
+	}>(matchUrl, { errorRetryCount: 1 });
+
 	if (loading) return <Loading />;
 	if (error) {
 		// Send the error to Sentry and then prevent the element from rendering
-		window.guardian.modules.sentry.reportError(error, 'match-tabs');
+		window.guardian?.modules?.sentry?.reportError?.(error, 'match-tabs');
 
 		return null;
 	}


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Max retries on GetMatchStats & GetMatchNav set to 1; This means if for some reason we can't get match stats (For example we don't have the Women's FA Cup 2022), we won't infinitely show the placeholder on the page.

### Before

<img width="975" alt="image" src="https://user-images.githubusercontent.com/9575458/159741812-4d930642-8fe7-46f2-878e-28416299b23f.png">

### After

<img width="994" alt="image" src="https://user-images.githubusercontent.com/9575458/159741870-72fe199a-c569-4147-a7c6-b03b7ad1075c.png">

(Placeholder is removed after less than 1 second)
