### PR TITLE
Ab/fix pinned post scroll

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -23,12 +23,15 @@ function hideShowMore() {
 }
 
 /**
- * Scroll to the top of the main content when the pinned post is collapsed
+ * Scroll to the top of the main content when the pinned post is collapsed if the top of the post is out of view
  */
 function scrollOnCollapse() {
-	document.getElementById('maincontent')?.scrollIntoView({
-		behavior: 'smooth',
-	});
+	const position = pinnedPost?.getBoundingClientRect();
+	if (position && position.top < 0) {
+		document.getElementById('maincontent')?.scrollIntoView({
+			behavior: 'smooth',
+		});
+	}
 }
 
 export const EnhancePinnedPost = () => {

--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -28,7 +28,7 @@ function hideShowMore() {
 function scrollOnCollapse() {
 	const position = pinnedPost?.getBoundingClientRect();
 	if (position && position.top < 0) {
-		document.getElementById('maincontent')?.scrollIntoView({
+		pinnedPost?.scrollIntoView({
 			behavior: 'smooth',
 		});
 	}

--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -22,6 +22,15 @@ function hideShowMore() {
 	if (pinnedPostButton) pinnedPostButton.style.display = 'none';
 }
 
+/**
+ * Scroll to the top of the main content when the pinned post is collapsed
+ */
+function scrollOnCollapse() {
+	document.getElementById('maincontent')?.scrollIntoView({
+		behavior: 'smooth',
+	});
+}
+
 export const EnhancePinnedPost = () => {
 	const contentFitsContainer =
 		pinnedPost && pinnedPost.scrollHeight <= pinnedPost.clientHeight;
@@ -49,6 +58,7 @@ export const EnhancePinnedPost = () => {
 					action: 'CLICK',
 					value: 'show-less',
 				});
+				scrollOnCollapse();
 			}
 		}
 	};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a function that scrolls the user to the top of the pinned post when the `see less` button is clicked if the top of the pinned post is out of view. If the full pinned post is within the viewport there is no scroll. 

NB - this is part of the pinned post enhanced JS so users without JS enabled will not be scrolled to the top of the pinned post.

## Why?
This fixes a bug where users were scrolled to the top of the main media instead of the top of the pinned post.

### Before
https://user-images.githubusercontent.com/20416599/159755971-f97ba928-5dc1-430e-aa69-c85a9d5b28e0.mov


### After
https://user-images.githubusercontent.com/20416599/159756328-3973149b-2cdb-4189-b28d-fd010fd0bf28.mov


