### PR TITLE
Fix key events dark mode at narrow breakpoints

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -13,6 +13,7 @@ import {
 	neutral,
 	remSpace,
 	from,
+	until,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import {
@@ -82,6 +83,10 @@ const listStyles = (
 	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	${darkModeCss(supportsDarkMode)`
+		${until.desktop} {
+			background-color: ${neutral[10]};
+		}
+
 		background-color: ${background.articleContentDark(format)};
 	`}
 `;


### PR DESCRIPTION
## Why?
Key events are wrapped in an accordion component at narrow breakpoints (which always has the same background colour regardless of whether it's a liveblog or a deadblog), and we were not considering this previously.

| **Before** | **After** |
|------------|----------|
| <img width="740" alt="image" src="https://user-images.githubusercontent.com/57295823/159760969-8e5aa946-7219-47d5-87bd-6b0bbdcf15c7.png"> | <img width="729" alt="image" src="https://user-images.githubusercontent.com/57295823/159761025-c927475f-1286-44d7-83ce-372902e4addc.png"> |

No changes at wider breakpoints:

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/57295823/159761237-8eda66a9-a147-44ff-a6f0-502b7b67e151.png">

