### PR TITLE
Allow a single Doughnut section

### DIFF
--- a/dotcom-rendering/src/web/components/Doughnut.stories.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.stories.tsx
@@ -20,6 +20,14 @@ const ninetyNineToOne = [
 	},
 ];
 
+const oneSection = [
+	{
+		value: 100,
+		label: 'All',
+		color: '#FFE500',
+	},
+];
+
 const twoSections = [
 	{
 		value: 29,
@@ -70,6 +78,15 @@ export const NinetyNineToOne = () => {
 	);
 };
 NinetyNineToOne.story = { name: 'with one section at 99 and the other at 1' };
+
+export const One = () => {
+	return (
+		<Container>
+			<Doughnut sections={oneSection} />
+		</Container>
+	);
+};
+One.story = { name: 'with one section' };
 
 export const Two = () => {
 	return (

--- a/dotcom-rendering/src/web/components/Doughnut.stories.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.stories.tsx
@@ -109,12 +109,7 @@ Three.story = { name: 'with three sections' };
 export const Smaller = () => {
 	return (
 		<Container>
-			<Doughnut
-				sections={twoSections}
-				percentCutout={20}
-				width={200}
-				height={200}
-			/>
+			<Doughnut sections={twoSections} percentCutout={20} size={200} />
 		</Container>
 	);
 };

--- a/dotcom-rendering/src/web/components/Doughnut.test.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.test.tsx
@@ -24,12 +24,7 @@ describe('Doughnut', () => {
 
 	it('should display the given labels when sizing is customised', () => {
 		const { getByText } = render(
-			<Doughnut
-				sections={mockSections}
-				percentCutout={20}
-				width={200}
-				height={200}
-			/>,
+			<Doughnut sections={mockSections} percentCutout={20} size={200} />,
 		);
 
 		expect(getByText(mockSections[0].label)).toBeInTheDocument();

--- a/dotcom-rendering/src/web/components/Doughnut.test.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.test.tsx
@@ -31,10 +31,10 @@ describe('Doughnut', () => {
 		expect(getByText(mockSections[1].label)).toBeInTheDocument();
 	});
 
-	it('should return null if only one section is passed', () => {
+	it('should return a circle if only one section is passed', () => {
 		const { container } = render(<Doughnut sections={[mockSections[0]]} />);
 
-		expect(container.firstChild).toBeNull();
+		expect(container.firstChild).not.toBeNull();
 	});
 
 	it('should handle if a section has a zero value', () => {

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -16,6 +16,9 @@ type Section = {
 	color: string;
 };
 
+/** three decimal places are plenty */
+const PRECISION = 3;
+
 const unitStyles = css`
 	${headline.medium({ fontWeight: 'bold' })}
 	text-anchor: middle;
@@ -75,20 +78,23 @@ export const Doughnut = ({
 		const angleEnd = angleStart + angleLength;
 		const angleMid = angleStart + angleLength / 2;
 
-		const dasharray = [
-			angleLength * radius,
-			(tau - angleLength) * radius,
-		].join(',');
-		const dashoffset = (-angleStart * radius).toString();
+		const dasharray = [angleLength * radius, (tau - angleLength) * radius]
+			.map((dash) => dash.toFixed(PRECISION))
+			.join(',');
+		const dashoffset = (-angleStart * radius).toFixed(PRECISION);
 
 		segments.push({
 			dasharray,
 			dashoffset,
 			label,
 			value,
-			transform: `translate(${Math.cos(angleMid) * radius + center}, ${
-				Math.sin(angleMid) * radius + center
-			})`,
+			transform: [
+				'translate(',
+				(Math.cos(angleMid) * radius + center).toFixed(PRECISION),
+				', ',
+				(Math.sin(angleMid) * radius + center).toFixed(PRECISION),
+				')',
+			].join(''),
 			color,
 		});
 

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -16,8 +16,8 @@ type Section = {
 	color: string;
 };
 
-/** three decimal places are plenty */
-const PRECISION = 3;
+/** set decimal places */
+const PRECISION = 6;
 
 const unitStyles = css`
 	${headline.medium({ fontWeight: 'bold' })}

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -67,35 +67,33 @@ export const Doughnut = ({
 		value: number;
 	}[] = [];
 
-	withoutZeroSections(sections).reduce<number>(
-		(angleStart, { color, label, value }) => {
-			const angleLength = (value / totalValue) * tau;
+	/** start from the top of the circle and keep going */
+	let angleStart = -Math.PI / 2;
+	for (const { color, label, value } of withoutZeroSections(sections)) {
+		const angleLength = (value / totalValue) * tau;
 
-			const angleEnd = angleStart + angleLength;
-			const angleMid = (angleStart + angleEnd) / 2;
+		const angleEnd = angleStart + angleLength;
+		const angleMid = angleStart + angleLength / 2;
 
-			const dasharray = [
-				angleLength * radius,
-				(tau - angleLength) * radius,
-			].join(',');
-			const dashoffset = (-angleStart * radius).toString();
+		const dasharray = [
+			angleLength * radius,
+			(tau - angleLength) * radius,
+		].join(',');
+		const dashoffset = (-angleStart * radius).toString();
 
-			segments.push({
-				dasharray,
-				dashoffset,
-				label,
-				value,
-				transform: `translate(${
-					Math.cos(angleMid) * radius + center
-				}, ${Math.sin(angleMid) * radius + center})`,
-				color,
-			});
+		segments.push({
+			dasharray,
+			dashoffset,
+			label,
+			value,
+			transform: `translate(${Math.cos(angleMid) * radius + center}, ${
+				Math.sin(angleMid) * radius + center
+			})`,
+			color,
+		});
 
-			return angleEnd;
-		},
-		// start at the top of the circle
-		-Math.PI / 2,
-	);
+		angleStart = angleEnd;
+	}
 
 	return (
 		<svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -7,8 +7,7 @@ import { isLight } from '../lib/isLight';
 type Props = {
 	sections: Section[];
 	percentCutout?: number;
-	width?: number;
-	height?: number;
+	size?: number;
 };
 
 type Section = {
@@ -40,13 +39,12 @@ const withoutZeroSections = (sections: Section[]) =>
 export const Doughnut = ({
 	sections,
 	percentCutout = 35,
-	width = 300,
-	height = 300,
+	size = 300,
 }: Props) => {
 	// TODO: Support displaying 0% for sections where value is zero
 	// We handle these at the moment by filtering them out using withoutZeroSections()
 
-	const outerRadius = Math.min(height / 2, width / 2);
+	const outerRadius = size / 2;
 	const innerRadius = outerRadius * (percentCutout / 100);
 	const radius = (innerRadius + outerRadius) / 2;
 
@@ -58,8 +56,8 @@ export const Doughnut = ({
 	const tau = Math.PI * 2;
 
 	const center = {
-		x: width / 2,
-		y: height / 2,
+		x: size / 2,
+		y: size / 2,
 	};
 
 	const getPosition = (angle: number) =>
@@ -140,9 +138,9 @@ export const Doughnut = ({
 	return (
 		<svg
 			preserveAspectRatio="xMinYMin"
-			width={width}
-			height={height}
-			viewBox={`0 0 ${width} ${height}`}
+			width={size}
+			height={size}
+			viewBox={`0 0 ${size} ${size}`}
 		>
 			{segments.map((segment) => (
 				<g>

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -37,8 +37,6 @@ const labelStyles = (background: string) => css`
 const withoutZeroSections = (sections: Section[]) =>
 	sections.filter((section) => section.value !== 0);
 
-type Point = { x: number; y: number };
-
 export const Doughnut = ({
 	sections,
 	percentCutout = 35,
@@ -59,7 +57,7 @@ export const Doughnut = ({
 	/** τ = 2π https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals */
 	const tau = Math.PI * 2;
 
-	const center: Point = {
+	const center = {
 		x: width / 2,
 		y: height / 2,
 	};
@@ -88,7 +86,6 @@ export const Doughnut = ({
 
 			const sweepFlag = (angleEnd - angleStart) % tau > Math.PI ? 1 : 0;
 
-
 			/**
 			 * Get the SVG path commands string
 			 *
@@ -96,6 +93,7 @@ export const Doughnut = ({
 			 *
 			 * M: move https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#line_commands
 			 * A: arc https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs
+			 * Z: close the circle
 			 *
 			 * We cannot draw a circle with the arc command, so we split it
 			 * in two if there’s
@@ -118,9 +116,9 @@ export const Doughnut = ({
 							`M ${getPosition(angleStart)}`,
 							`A ${radius} ${radius} 0 0 1`,
 							getPosition(angleMid),
-							`M ${getPosition(angleMid)}`,
 							`A ${radius} ${radius} 0 0 1`,
 							getPosition(angleEnd),
+							'Z',
 					  ].join(' ');
 
 			segments.push({

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -57,6 +57,7 @@ export const Doughnut = ({
 
 	/** τ = 2π https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals */
 	const tau = Math.PI * 2;
+	const quarterTurn = Math.PI / 2;
 
 	const center = size / 2;
 
@@ -70,8 +71,7 @@ export const Doughnut = ({
 		value: number;
 	}[] = [];
 
-	/** start from the top of the circle and keep going */
-	let angleStart = -Math.PI / 2;
+	let angleStart = -quarterTurn;
 	for (const { color, label, value } of withoutZeroSections(sections)) {
 		const angleLength = (value / totalValue) * tau;
 
@@ -81,7 +81,14 @@ export const Doughnut = ({
 		const dasharray = [angleLength * radius, (tau - angleLength) * radius]
 			.map((dash) => dash.toFixed(PRECISION))
 			.join(',');
-		const dashoffset = (-angleStart * radius).toFixed(PRECISION);
+		/**
+		 * The offset is turned one quarter and rotated
+		 * with a transform to keep the top join as crisp
+		 * as possible.
+		 */
+		const dashoffset = (-(quarterTurn + angleStart) * radius).toFixed(
+			PRECISION,
+		);
 
 		segments.push({
 			dasharray,
@@ -114,6 +121,8 @@ export const Doughnut = ({
 						strokeWidth={outerRadius - innerRadius}
 						strokeDasharray={segment.dasharray}
 						strokeDashoffset={segment.dashoffset}
+						// rotate back a quarter turn
+						transform={`rotate(-90 ${center} ${center})`}
 					/>
 					<text transform={segment.transform}>
 						<tspan css={labelStyles(segment.color)} x="0" dy="0">

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -136,12 +136,7 @@ export const Doughnut = ({
 	);
 
 	return (
-		<svg
-			preserveAspectRatio="xMinYMin"
-			width={size}
-			height={size}
-			viewBox={`0 0 ${size} ${size}`}
-		>
+		<svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
 			{segments.map((segment) => (
 				<g>
 					<path

--- a/dotcom-rendering/src/web/components/Doughnut.tsx
+++ b/dotcom-rendering/src/web/components/Doughnut.tsx
@@ -55,15 +55,12 @@ export const Doughnut = ({
 	/** τ = 2π https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals */
 	const tau = Math.PI * 2;
 
-	const center = {
-		x: size / 2,
-		y: size / 2,
-	};
+	const center = size / 2;
 
 	const getPosition = (angle: number) =>
 		[
-			center.x + Math.cos(angle) * radius,
-			center.y + Math.sin(angle) * radius,
+			center + Math.cos(angle) * radius,
+			center + Math.sin(angle) * radius,
 		].join(' ');
 
 	// Segments
@@ -124,8 +121,8 @@ export const Doughnut = ({
 				label,
 				value,
 				transform: `translate(${
-					Math.cos(angleMid) * radius + center.x
-				}, ${Math.sin(angleMid) * radius + center.y})`,
+					Math.cos(angleMid) * radius + center
+				}, ${Math.sin(angleMid) * radius + center})`,
 				color,
 			});
 
@@ -157,7 +154,7 @@ export const Doughnut = ({
 			))}
 			<text
 				css={unitStyles}
-				transform={`translate(${center.x}, ${center.y})`}
+				transform={`translate(${center}, ${center})`}
 				dy="0.4em"
 			>
 				%

--- a/dotcom-rendering/src/web/components/MatchStats.tsx
+++ b/dotcom-rendering/src/web/components/MatchStats.tsx
@@ -302,11 +302,7 @@ const DecideDoughnut = ({
 							}
 						`}
 					>
-						<Doughnut
-							sections={sections}
-							width={200}
-							height={200}
-						/>
+						<Doughnut sections={sections} size={200} />
 					</div>
 					<div
 						css={css`
@@ -316,11 +312,7 @@ const DecideDoughnut = ({
 							}
 						`}
 					>
-						<Doughnut
-							sections={sections}
-							width={300}
-							height={300}
-						/>
+						<Doughnut sections={sections} size={300} />
 					</div>
 					{/* This represents the stats component being within the left column on a liveblog */}
 					<div
@@ -330,11 +322,7 @@ const DecideDoughnut = ({
 							}
 						`}
 					>
-						<Doughnut
-							sections={sections}
-							width={200}
-							height={200}
-						/>
+						<Doughnut sections={sections} size={200} />
 					</div>
 				</>
 			);


### PR DESCRIPTION
## What does this change?

Allow a single Doughnut section and refactors the SVG code. Doughnut now only takes a `size` prop instead of `width` and `height`.

Instead of using [`path`][] and drawing arcs, leverage the [`circle`][] element, and use stroke dash to draw the arcs.


[`path`]: https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement
[`circle`]: https://developer.mozilla.org/en-US/docs/Web/API/SVGCircleElement

## Why?

This was a long-standing missing feature. I took this as an opportunity to refactor some of the doughnut code to simplify it.

## Screenshot

<img width="359" alt="image" src="https://user-images.githubusercontent.com/76776/159886309-d3771dc6-f218-40e2-b0f6-5af7fb582248.png">
