### PR TITLE
Remove top padding on liveblog timestamp

### DIFF
--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -25,7 +25,6 @@ const FirstPublished = ({
 			css={css`
 				${textSans.xxsmall({ fontWeight: 'bold' })}
 				margin-bottom: ${space[1]}px;
-				padding-top: ${space[1]}px;
 				display: flex;
 				width: fit-content;
 				flex-direction: row;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Removes the 4px top padding on liveblog timestamps.

## Why?

Closes #4148 

### Before
![image](https://user-images.githubusercontent.com/21217225/159891644-a25bb3c6-33d9-4739-852d-e4d801dcee87.png)

### After
![image](https://user-images.githubusercontent.com/21217225/159891580-82f9c375-086f-4711-a07f-5ddd550b596c.png)

