### PR TITLE
`position: sticky` in Safari

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -291,15 +291,20 @@ export const Liveness = ({
 
 	if (toastRoot && showToast) {
 		/**
-		 * createPortal?
+		 * Why `createPortal`?
 		 *
-		 * We're using a portal here because of a the way Safari implements position: sticky. If
-		 * the element is rendered directly here as a child of the Island (its parent) then stickiness
-		 * won't work in Safari because this browser positions the element relative to the immediate
-		 * parent, whereas Chrome et al are more forgiving.
+		 * We use a Portal because of a the way different browsers implement `position: sticky`.
+		 * A [stickily positioned element][] depends on its [containing block][] to determine
+		 * when to become stuck.
+		 *
+		 * In Safari the containing block is set to the immediate parent
+		 * whereas Chrome, Firefox and other browser are more forgiving.
 		 *
 		 * By using a Portal we can insert the Toast as a sibling to the Island, which works around
 		 * Safari's behaviour.
+		 *
+		 * [stickily positioned element]: https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning
+		 * [containing block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
 		 */
 		return ReactDOM.createPortal(
 			<Toast

--- a/dotcom-rendering/src/web/components/Toast.stories.tsx
+++ b/dotcom-rendering/src/web/components/Toast.stories.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -8,6 +9,19 @@ import { breakpoints } from '@guardian/source-foundations';
 
 import { Toast } from './Toast';
 
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			position: sticky;
+			top: 0;
+			display: flex;
+			justify-content: center;
+		`}
+	>
+		{children}
+	</div>
+);
+
 export default {
 	component: Toast,
 	title: 'Components/Toast',
@@ -15,15 +29,17 @@ export default {
 
 export const Default = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticlePillar.News,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={3}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={3}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 Default.story = {
@@ -35,15 +51,17 @@ Default.story = {
 
 export const Sport = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticlePillar.Sport,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={3}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticlePillar.Sport,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={3}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 Sport.story = {
@@ -55,15 +73,17 @@ Sport.story = {
 
 export const Special = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticleSpecial.SpecialReport,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={17}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticleSpecial.SpecialReport,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={17}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 Special.story = {
@@ -75,15 +95,17 @@ Special.story = {
 
 export const One = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticlePillar.Culture,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={1}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticlePillar.Culture,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={1}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 One.story = {
@@ -95,15 +117,17 @@ One.story = {
 
 export const Lots = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticlePillar.Lifestyle,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={239}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticlePillar.Lifestyle,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={239}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 Lots.story = {
@@ -115,15 +139,17 @@ Lots.story = {
 
 export const Mobile = () => {
 	return (
-		<Toast
-			format={{
-				theme: ArticlePillar.News,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}}
-			count={3}
-			onClick={() => {}}
-		/>
+		<Wrapper>
+			<Toast
+				format={{
+					theme: ArticlePillar.News,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				count={3}
+				onClick={() => {}}
+			/>
+		</Wrapper>
 	);
 };
 Mobile.story = {

--- a/dotcom-rendering/src/web/components/Toast.tsx
+++ b/dotcom-rendering/src/web/components/Toast.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { EditorialButton } from '@guardian/source-react-components-development-kitchen';
 import { Hide } from '@guardian/source-react-components';
 import { space } from '@guardian/source-foundations';
-import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
 	count: number;
@@ -29,46 +28,39 @@ const SvgReload = ({ size }: { size: 12 | 16 | 18 | 24 | 26 | 28 | 30 }) => {
 
 /**
  * A button to scroll to the top when new content exists.
+ *
+ * This element is rendered using a Portal into the `toast-root` div. This
+ * root div has position: sticky
  */
 export const Toast = ({ count, onClick, format }: Props) => {
 	return (
 		<div
 			css={css`
-				position: sticky;
-				top: 0;
-				${getZIndex('toast')};
-				display: flex;
-				justify-content: center;
+				position: absolute;
+				top: ${space[2]}px;
 			`}
 			data-cy="toast"
 		>
-			<div
-				css={css`
-					position: absolute;
-					top: ${space[2]}px;
-				`}
-			>
-				<Hide above="phablet">
-					<EditorialButton
-						size="xsmall" // <-- Mobile version is xsmall
-						onClick={onClick}
-						format={format}
-						icon={<SvgReload size={30} />}
-					>{`${count} new update${
-						count === 1 ? '' : 's'
-					}`}</EditorialButton>
-				</Hide>
-				<Hide below="phablet">
-					<EditorialButton
-						size="small" // <-- Desktop version is small
-						onClick={onClick}
-						format={format}
-						icon={<SvgReload size={30} />}
-					>{`${count} new update${
-						count === 1 ? '' : 's'
-					}`}</EditorialButton>
-				</Hide>
-			</div>
+			<Hide above="phablet">
+				<EditorialButton
+					size="xsmall" // <-- Mobile version is xsmall
+					onClick={onClick}
+					format={format}
+					icon={<SvgReload size={30} />}
+				>{`${count} new update${
+					count === 1 ? '' : 's'
+				}`}</EditorialButton>
+			</Hide>
+			<Hide below="phablet">
+				<EditorialButton
+					size="small" // <-- Desktop version is small
+					onClick={onClick}
+					format={format}
+					icon={<SvgReload size={30} />}
+				>{`${count} new update${
+					count === 1 ? '' : 's'
+				}`}</EditorialButton>
+			</Hide>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -63,6 +63,7 @@ import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
+import { getZIndex } from '../lib/getZIndex';
 
 const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -704,33 +705,52 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 								<div id="maincontent" css={bodyWrapper}>
 									{format.design ===
 										ArticleDesign.LiveBlog && (
-										<Island
-											clientOnly={true}
-											deferUntil="idle"
-										>
-											<Liveness
-												pageId={CAPI.pageId}
-												webTitle={CAPI.webTitle}
-												ajaxUrl={CAPI.config.ajaxUrl}
-												filterKeyEvents={
-													CAPI.filterKeyEvents
-												}
-												format={format}
-												switches={CAPI.config.switches}
-												onFirstPage={
-													pagination.currentPage === 1
-												}
-												webURL={CAPI.webURL}
-												// We default to string here because the property is optional but we
-												// know it will exist for all blogs
-												mostRecentBlockId={
-													CAPI.mostRecentBlockId || ''
-												}
-												hasPinnedPost={
-													!!CAPI.pinnedPost
-												}
+										<>
+											{/* The Toast component is inserted into this div using a Portal */}
+											<div
+												id="toast-root"
+												css={css`
+													position: sticky;
+													top: 0;
+													${getZIndex('toast')};
+													display: flex;
+													justify-content: center;
+												`}
 											/>
-										</Island>
+											<Island
+												clientOnly={true}
+												deferUntil="idle"
+											>
+												<Liveness
+													pageId={CAPI.pageId}
+													webTitle={CAPI.webTitle}
+													ajaxUrl={
+														CAPI.config.ajaxUrl
+													}
+													filterKeyEvents={
+														CAPI.filterKeyEvents
+													}
+													format={format}
+													switches={
+														CAPI.config.switches
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+													webURL={CAPI.webURL}
+													// We default to string here because the property is optional but we
+													// know it will exist for all blogs
+													mostRecentBlockId={
+														CAPI.mostRecentBlockId ||
+														''
+													}
+													hasPinnedPost={
+														!!CAPI.pinnedPost
+													}
+												/>
+											</Island>
+										</>
 									)}
 									<Hide below="desktop">
 										<Island deferUntil="visible">


### PR DESCRIPTION
## What?
This PR fixes #4372  a bug where when in Safari the `Toast` was not sticking. 

Safari treats position: sticky differently to Chrome et al; it uses the immediate parent when deciding where to stick things but in this case the immediate parent is the `Island` and this element has no height so nothing is stuck.

To get around this I considered various options:

1) Move the Toast out of the Island. If we rendered it by itself we could put it anywhere which would solve this issue but the problem with this approach is the component has props and state which are linked to the code inside the `Liveness` island. Rejected ❌

2) Add css to the `Island`. It would be nice to solve this css problem using css but this neither works (if I give the island height it pushes other content around) and would introduce undesired coupling. Rejected ❌

3) Use a [React Portal](https://reactjs.org/docs/portals.html). Portals in React are a way to render content outside the classic DOM hierarchy that you would normally expect using React. By doing a portal we can continue to benefit from shared state and props but still render the element as a sibling to the Island and not as a child of it. Chosen ✅

