### PR TITLE
 Auto accept any chromatic diffs on main builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          autoAcceptChanges: main


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Sets the automic action to auto approve any diffs on the main branch.

## Why?

Looking at [this build](https://www.chromatic.com/test?appId=5dfcbf3012392c0020e7140b&id=623c46322ac802003a41bc30) I noticed there was some diffs that were completely unrelated to the thing being changed. Checking the "Baseline history" that chromatic provided I could see that there was a [main build](https://www.chromatic.com/test?appId=5dfcbf3012392c0020e7140b&id=623c46322ac802003a41bc30) with the exact same diff that had not been accepted 

I'm not sure how a diff ended up being on main, my guess is that a branch a few commits behind main was merged and caused diffs once it was mixed with the newer main code.

Maybe this'll decrease how many false positives we get?
