### PR TITLE
Remove blank space in standfirst lists

### DIFF
--- a/apps-rendering/src/components/standfirst.tsx
+++ b/apps-rendering/src/components/standfirst.tsx
@@ -52,7 +52,7 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 
 	p,
 	ul {
-		padding: ${remSpace[3]} 0;
+		padding: ${remSpace[3]} 0 0;
 		margin: 0;
 	}
 

--- a/apps-rendering/src/components/standfirst.tsx
+++ b/apps-rendering/src/components/standfirst.tsx
@@ -52,7 +52,8 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 
 	p,
 	ul {
-		margin: ${remSpace[3]} 0;
+		padding: ${remSpace[3]} 0;
+		margin: 0;
 	}
 
 	address {


### PR DESCRIPTION
## What does this change?

Uses padding instead of margin for the gaps around standfirst’s paragraphs and unordered lists.

## Why?

Margins bleed outside of components so it can be hard to reason about how they will look. This fixes #4378 : a white gap in standfirst with lists.

### Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/159935712-2084c707-61ff-4b64-86d4-8086afca31da.png
[after]: https://user-images.githubusercontent.com/76776/159935710-c57123b4-d5ee-49a4-8180-9a9b0139a293.png