### PR TITLE
[DO NOT MERGE] Testing a GitHub branch of the CMP in code

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@guardian/atoms-rendering": "^22.6.1",
     "@guardian/braze-components": "^6.1.0",
     "@guardian/commercial-core": "^3.0.0",
-    "@guardian/consent-management-platform": "^10.3.1",
+    "@guardian/consent-management-platform": "guardian/consent-management-platform#unified-cmp-2",
     "@guardian/discussion-rendering": "^9.2.0",
     "@guardian/libs": "^3.8.1",
     "@guardian/prettier": "^0.5.0",


### PR DESCRIPTION
## What does this change?

This change depends on a branched version of the CMP here:

https://github.com/guardian/consent-management-platform/pull/561 

That PR attempts to resolve an issue with loading Ads in Canada where we hand off control of ad-loading to a third party script that I suspect of preventing local testing of ad-loading behaviour.

**This change should only ever be deployed to CODE, it should not be merged and will be closed after testing.**
