### PR TITLE
Check if new blocks were added to the page before notifying spacefinder

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -90,8 +90,10 @@ function revealPendingBlocks() {
 		block.classList.add('reveal');
 		block.classList.remove('pending');
 	});
-	// Notify commercial that new blocks are available and they can re-run spacefinder
-	document.dispatchEvent(new CustomEvent('liveblog:blocks-updated'));
+
+	if (pendingBlocks?.length)
+		// Notify commercial that new blocks are available and they can re-run spacefinder
+		document.dispatchEvent(new CustomEvent('liveblog:blocks-updated'));
 }
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Check if new blocks were added before notifying spacefinder

## Why?

Removes dependency on spacefinder trying to figure out if new blocks were added or not when event is called


