### PR TITLE
Fix show more button not hiding when content fits container

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -12,14 +12,24 @@ const pinnedPostCheckBox: Element | null = !isServer
 	? window.document.querySelector('input[name=pinned-post-checkbox]')
 	: null;
 
+const pinnedPostContent: Element | null = !isServer
+	? window.document.querySelector('#collapsible-body')
+	: null;
+
 /**
- * hide show more button on pinned post
+ * hide show more button and overlay on pinned post
  */
 function hideShowMore() {
 	const pinnedPostButton = document.querySelector<HTMLElement>(
 		'#pinned-post-button',
 	);
-	if (pinnedPostButton) pinnedPostButton.style.display = 'none';
+	const pinnedPostOverlay = document.querySelector<HTMLElement>(
+		'#pinned-post-overlay',
+	);
+	if (pinnedPostButton && pinnedPostOverlay) {
+		pinnedPostButton.style.display = 'none';
+		pinnedPostOverlay.style.display = 'none';
+	}
 }
 
 /**
@@ -36,7 +46,9 @@ function scrollOnCollapse() {
 
 export const EnhancePinnedPost = () => {
 	const contentFitsContainer =
-		pinnedPost && pinnedPost.scrollHeight <= pinnedPost.clientHeight;
+		pinnedPostContent &&
+		pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
+
 	if (contentFitsContainer) hideShowMore();
 
 	const hasBeenSeen = useRef(false);

--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -26,10 +26,8 @@ function hideShowMore() {
 	const pinnedPostOverlay = document.querySelector<HTMLElement>(
 		'#pinned-post-overlay',
 	);
-	if (pinnedPostButton && pinnedPostOverlay) {
-		pinnedPostButton.style.display = 'none';
-		pinnedPostOverlay.style.display = 'none';
-	}
+	if (pinnedPostButton) pinnedPostButton.style.display = 'none';
+	if (pinnedPostOverlay) pinnedPostOverlay.style.display = 'none';
 }
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Measures and compares the inner content scrollheight and clientheight rather than the outer container.

## Why?
The pinned post has a max height of 40vh with additional content revealed as an accordian. If content height is less than or equal to 40vh then the show more button and overlay should disappear.  This is achieved by measuring the element scrollheight and client height and checking to see if scrollheight is less than or equal to the clientheight. However, was measuring this using the container rather than the inner content and so the show more button was never being hidden. This PR fixes this logic to measure the pinned post body instead.

This PR also adds hides the show more overlay if the body fits the container.

### Before
<img width="723" alt="Screenshot 2022-03-24 at 16 12 49" src="https://user-images.githubusercontent.com/20416599/159961389-e02e9f54-5a2d-40ef-ab07-8fedbf420e6a.png">

### After
<img width="723" alt="Screenshot 2022-03-24 at 16 07 31" src="https://user-images.githubusercontent.com/20416599/159961409-5dd26bcd-dceb-4479-8fe0-012f03cb81d7.png">

