### PR TITLE
Filter AB Tests Props

### DIFF
--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -10,7 +10,7 @@ Ideally, these transformations would not be required. A better solution would be
 ## Examples
 
 ### DropCaps
-Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, `dropcap: true`, so instead a convention was invented where if the preceding element was a h2 tag containing '* * *' then that was the trigger to give the following paragraph drop cap styling.
+Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, `dropcap: true`, so instead a convention was invented where, if the preceding element was an `h2` tag containing '* * *', then that was the trigger to give the following paragraph drop cap styling.
 
 In DCR we replicate this using [enhance-dividers.ts](/dotcom-rendering/src/model/enhance-dividers.ts)
 

--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -2,7 +2,7 @@
 The enhance CAPI pattern is one where the CAPI object is transformed into a different, more useable, format. In particular, it relates to the `blocks` array. Each enhancement function, takes the `CAPIType` and returns the `CAPIType`.
 
 ## Lexicon
-An 'enhancement' could also be termed a 'transformation' and in other places similar functions are refereed to as 'cleaners'.
+An 'enhancement' could also be termed a 'transformation' and in other places similar functions are referred to as 'cleaners'.
 
 ## Why?
 Ideally, these transformations would not be required. A better solution would be to construct the array at source, in Composer or CAPI, with the ideal structure. But for - probably very good - reasons the decision was taken to use [cleaners in frontend](https://github.com/guardian/frontend/blob/aa0013a6f9c247be36d29b9716e0ccc80cc8b218/common/app/views/support/HtmlCleaner.scala) to solve design problems. So now, in order to support the same designs, we need to replicate these cleaners in DCR. The enhancements are applied in the [server/index.ts](/dotcom-rendering/src/web/server/index.ts).

--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -2,7 +2,7 @@
 The enhance CAPI pattern is one where the CAPI object is transformed into a different, more useable, format. In particular, it relates to the `blocks` array. Each enhancement function, takes the `CAPIType` and returns the `CAPIType`.
 
 ## Lexicon
-An 'enhancement' could also be termed a 'transformation' and in other places similar functions are refrered to as 'cleaners'.
+An 'enhancement' could also be termed a 'transformation' and in other places similar functions are refereed to as 'cleaners'.
 
 ## Why?
 Ideally, these transformations would not be required. A better solution would be to construct the array at source, in Composer or CAPI, with the ideal structure. But for - probably very good - reasons the decision was taken to use [cleaners in frontend](https://github.com/guardian/frontend/blob/aa0013a6f9c247be36d29b9716e0ccc80cc8b218/common/app/views/support/HtmlCleaner.scala) to solve design problems. So now, in order to support the same designs, we need to replicate these cleaners in DCR. The enhancements are applied in the [server/index.ts](/dotcom-rendering/src/web/server/index.ts).
@@ -10,7 +10,7 @@ Ideally, these transformations would not be required. A better solution would be
 ## Examples
 
 ### DropCaps
-Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, dropcap: true, so instead a convention was invented where if the preceeding element was a h2 tag containing '* * *' then that was the trigger to give the following paragraph drop cap styling.
+Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, `dropcap: true`, so instead a convention was invented where if the preceding element was a h2 tag containing '* * *' then that was the trigger to give the following paragraph drop cap styling.
 
 In DCR we replicate this using [enhance-dividers.ts](/dotcom-rendering/src/model/enhance-dividers.ts)
 
@@ -18,7 +18,7 @@ In DCR we replicate this using [enhance-dividers.ts](/dotcom-rendering/src/model
 There are some conventions that can result in images appearing differently, we need a cleaner to support these while we wait for support for them to be added natively to Composer.
 
 Multi images. Consecutive sequences of two halfWidth images will be merged into a MultiImageBlockElement and shown side by side
-Captions. A ul/li tag directly after an image will replace the preoceeding image's caption
+Captions. A ul/li tag directly after an image will replace the proceeding image's caption
 
 In particular, Photo essay articles needs a lot of cleaning to achieve the intended designs. They use special caption styles and can sometimes have titles overlaying images.
 

--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -18,7 +18,7 @@ In DCR we replicate this using [enhance-dividers.ts](/dotcom-rendering/src/model
 There are some conventions that can result in images appearing differently, we need a cleaner to support these while we wait for support for them to be added natively to Composer.
 
 Multi images. Consecutive sequences of two halfWidth images will be merged into a MultiImageBlockElement and shown side by side
-Captions. A ul/li tag directly after an image will replace the proceeding image's caption
+Captions. A `ul`/`li` tag directly after an image will replace the preceding image's caption
 
 In particular, Photo essay articles needs a lot of cleaning to achieve the intended designs. They use special caption styles and can sometimes have titles overlaying images.
 

--- a/dotcom-rendering/src/model/enhance-switches.ts
+++ b/dotcom-rendering/src/model/enhance-switches.ts
@@ -1,0 +1,21 @@
+export type ABTestSwitches = { [key: `ab${string}`]: boolean };
+
+/**
+ * Switches that start with "ab" are used for AB tests.
+ *
+ * We strip those out of the list of switches to reduce
+ * the amount of prop data that needs to be serialised
+ * for the SetABTests Island.
+ *
+ * Ref: [`frontend`][] Switches & [`ab-testing`][] filter.
+ *
+ * [`frontend`]: https://github.com/guardian/frontend/blob/016e9e26/common/app/conf/switches/ABTestSwitches.scala
+ * [`ab-testing`]: https://github.com/guardian/ab-testing/blob/b5de0e09/packages/ab-core/src/core.ts#L29-L30
+ *
+ * @param {Switches} switches
+ * @returns {ABTestSwitches} an object containing only AB switches
+ */
+export const filterABTestSwitches = (switches: Switches): ABTestSwitches =>
+	Object.fromEntries(
+		Object.entries(switches).filter(([key]) => key.startsWith('ab')),
+	);

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { Global, css } from '@emotion/react';
 import { focusHalo, brandAlt, neutral } from '@guardian/source-foundations';
 import { ArticleDesign } from '@guardian/libs';
+import { filterABTestSwitches } from '../../model/enhance-switches';
 import { SkipTo } from './SkipTo';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { CommercialMetrics } from './CommercialMetrics.importable';
@@ -73,7 +74,7 @@ export const Page = ({ CAPI, NAV, format }: Props) => {
 			</Island>
 			<Island clientOnly={true}>
 				<SetABTests
-					abTestSwitches={CAPI.config.switches}
+					abTestSwitches={filterABTestSwitches(CAPI.config.switches)}
 					pageIsSensitive={CAPI.config.isSensitive}
 					isDev={!!CAPI.config.isDev}
 				/>

--- a/dotcom-rendering/src/web/components/Page.tsx
+++ b/dotcom-rendering/src/web/components/Page.tsx
@@ -24,9 +24,10 @@ type Props = {
  * @description
  * Page is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
- * @param {CAPIType} CAPI - The article JSON data
- * @param {NAVType} NAV - The article JSON data
- * @param {ArticleFormat} format - The format model for the article
+ * @param {Props} props
+ * @param {CAPIType} props.CAPI - The article JSON data
+ * @param {NAVType} props.NAV - The article JSON data
+ * @param {ArticleFormat} props.format - The format model for the article
  * */
 export const Page = ({ CAPI, NAV, format }: Props) => {
 	return (


### PR DESCRIPTION
## What does this change?

Filter out AB Test Props

## Why?

Because we can limit the amout of props passed.
Closes #4190

### Before

```json
{
  "abTestSwitches": {
    "anniversaryHeaderSvg": true,
    "prebidAppnexusUkRow": true,
    "commercialMetrics": true,
    "prebidTrustx": true,
    "scAdFreeBanner": false,
    "prebidPermutiveAudience": true,
    "compareVariantDecision": false,
    "enableSentryReporting": true,
    "lazyLoadContainers": true,
    "adFreeStrictExpiryEnforcement": false,
    "liveblogRendering": true,
    "remarketing": true,
    "fetchNonRefreshableLineItems": true,
    "registerWithPhone": false,
    "targeting": true,
    "remoteHeader": true,
    "extendedMostPopularFronts": true,
    "slotBodyEnd": true,
    "prebidImproveDigitalSkins": true,
    "emailInlineInFooter": true,
    "showNewPrivacyWordingOnEmailSignupEmbeds": true,
    "facebookTrackingPixel": true,
    "iasAdTargeting": true,
    "extendedMostPopular": true,
    "ampContentAbTesting": true,
    "prebidAnalytics": true,
    "prebidCriteo": true,
    "puzzlesBanner": true,
    "abSpacefinderOkrMegaTest": false,
    "imrWorldwide": true,
    "acast": true,
    "twitterUwt": true,
    "prebidAppnexusInvcode": true,
    "a9HeaderBidding": true,
    "prebidAppnexus": true,
    "enableDiscussionSwitch": true,
    "standaloneCommercialBundle": true,
    "prebidXaxis": true,
    "stickyVideos": true,
    "interactiveFullHeaderSwitch": true,
    "discussionAllPageSize": true,
    "prebidUserSync": true,
    "audioOnwardJourneySwitch": true,
    "mobileStickyPrebid": true,
    "externalVideoEmbeds": true,
    "simpleReach": true,
    "carrotTrafficDriver": true,
    "sentinelLogger": true,
    "geoMostPopular": true,
    "weAreHiring": true,
    "relatedContent": true,
    "thirdPartyEmbedTracking": true,
    "prebidOzone": true,
    "ampAmazon": true,
    "abCommercialLazyLoadMargin": true,
    "prebidAdYouLike": true,
    "mostViewedFronts": true,
    "abSignInGateMainControl": true,
    "ampPrebid": true,
    "googleSearch": true,
    "brazeSwitch": true,
    "consentManagement": true,
    "commercial": true,
    "redplanetForAus": true,
    "prebidSonobi": true,
    "idProfileNavigation": true,
    "confiantAdVerification": true,
    "discussionAllowAnonymousRecommendsSwitch": false,
    "scrollDepth": true,
    "permutive": true,
    "comscore": true,
    "webFonts": true,
    "prebidImproveDigital": true,
    "ophan": true,
    "crosswordSvgThumbnails": true,
    "prebidTriplelift": true,
    "weather": true,
    "commercialOutbrainNewids": true,
    "abSignInGateMainVariant": true,
    "abAdblockAsk": true,
    "prebidPubmatic": true,
    "serverShareCounts": false,
    "autoRefresh": true,
    "enhanceTweets": true,
    "prebidIndexExchange": true,
    "prebidOpenx": true,
    "prebidHeaderBidding": true,
    "idCookieRefresh": true,
    "sharingComments": true,
    "discussionPageSize": true,
    "smartAppBanner": false,
    "boostGaUserTimingFidelity": false,
    "historyTags": true,
    "mobileStickyLeaderboard": true,
    "surveys": true,
    "remoteBanner": true,
    "emailSignupRecaptcha": true,
    "prebidSmart": true,
    "inizio": true
  },
  "pageIsSensitive": false,
  "isDev": false
}
```

### After

```json
{
  "abTestSwitches": {
    "abSpacefinderOkrMegaTest": false,
    "abCommercialLazyLoadMargin": true,
    "abSignInGateMainControl": true,
    "abSignInGateMainVariant": true,
    "abAdblockAsk": true
  },
  "pageIsSensitive": false,
  "isDev": false
}
```