### PR TITLE
feat: link to article from clipboard

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -29,7 +29,7 @@
     <body>
         <h2>Default Endpoints</h2>
 
-        <ul>
+        <ul id="default-endpoints">
             <li><a href="/Article?url=https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software">Article</a></li>
             <li><a href="/AMPArticle?url=https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance">⚡️Article</a></li>
 			<li><a href="/Interactive?url=https://www.theguardian.com/world/ng-interactive/2021/dec/03/french-election-polls-who-is-leading-the-race-to-be-the-next-president-of-france">Interactive</a></li>
@@ -308,6 +308,24 @@
                         '/sport/blog/2020/jul/09/why-chris-froome-and-team-ineos-parting-of-the-ways-cycling',
                 },
             ];
+
+			if(navigator?.clipboard) {
+				navigator.clipboard.readText().then(text=> {
+					if (text.startsWith("https://www.theguardian.com/")) {
+						const fragment = document.createDocumentFragment()
+						const li = document.createElement("li")
+						const a = document.createElement("a")
+
+						a.setAttribute("href", `/Article?url=${text}`)
+						a.innerText = "📋 Article from clipboard";
+
+						li.appendChild(a);
+						fragment.appendChild(li);
+
+						document.querySelector("#default-endpoints").appendChild(fragment)
+					}
+				})
+			}
 
             var makeTestArticle = (a) => `
                 <div class="test-article">


### PR DESCRIPTION
## What does this change?

If the clipboard starts with https://www.theguardian.com/
add a link to the article endpoint with that URL

## Why?

Convenience.