### PR TITLE
`Placeholder` can be different colours

### DIFF
--- a/dotcom-rendering/src/web/components/Placeholder.stories.tsx
+++ b/dotcom-rendering/src/web/components/Placeholder.stories.tsx
@@ -101,3 +101,16 @@ export const NoShimmer = () => {
 	);
 };
 NoShimmer.story = { name: 'without shimmer' };
+
+export const Background = () => {
+	return (
+		<Container>
+			<Placeholder
+				height={200}
+				shouldShimmer={true}
+				backgroundColor="#ffff00"
+			/>
+		</Container>
+	);
+};
+Background.story = { name: 'with backgroundColor set' };

--- a/dotcom-rendering/src/web/components/Placeholder.tsx
+++ b/dotcom-rendering/src/web/components/Placeholder.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-bitwise */
 import { css, keyframes } from '@emotion/react';
 
 import { space, neutral } from '@guardian/source-foundations';
@@ -11,6 +12,7 @@ type Props = {
 	spaceBelow?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
 	spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
 	shouldShimmer?: boolean;
+	backgroundColor?: string;
 };
 
 const shimmer = keyframes`
@@ -22,13 +24,13 @@ const shimmer = keyframes`
   }
 `;
 
-const shimmerStyles = css`
+const shimmerStyles = (backgroundColor: string) => css`
 	animation: ${shimmer} 2s infinite linear;
 	background: linear-gradient(
 		to right,
-		${BACKGROUND_COLOUR} 4%,
-		${neutral[86]} 25%,
-		${BACKGROUND_COLOUR} 36%
+		${backgroundColor} 4%,
+		white 25%,
+		${backgroundColor} 36%
 	);
 	background-size: 1500px 100%;
 `;
@@ -40,6 +42,7 @@ export const Placeholder = ({
 	spaceBelow,
 	spaceLeft,
 	shouldShimmer = true,
+	backgroundColor = BACKGROUND_COLOUR,
 }: Props) => (
 	<div
 		id={rootId}
@@ -54,9 +57,9 @@ export const Placeholder = ({
 				width: ${width ? `${width}px` : '100%'};
 				margin-bottom: ${spaceBelow && space[spaceBelow]}px;
 				margin-left: ${spaceLeft && space[spaceLeft]}px;
-				background-color: ${BACKGROUND_COLOUR};
+				background-color: ${backgroundColor};
 
-				${shouldShimmer && shimmerStyles}
+				${shouldShimmer && shimmerStyles(backgroundColor)}
 			`}
 		/>
 	</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4383 by adding the `backgroundColor` prop to the `Placeholder` component

## Why?
We want to use a placeholder when loading in the `MatchNav` component but this sits on a yellow background

### Before
![2022-03-25 12 50 55](https://user-images.githubusercontent.com/1336821/160124011-baf39de3-3840-40d6-8679-7a2ecfe0d72b.gif)


### After
![2022-03-25 12 51 16](https://user-images.githubusercontent.com/1336821/160124040-68724a61-b574-4afd-a5d9-4cc57a44efb0.gif)
