### PR TITLE
Remove certain ad sizes from `comments` and `mostpop` slots

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -293,7 +293,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							adSizes.empty,
 							adSizes.mpu,
 							adSizes.googleCard,
-							adSizes.video,
 							adSizes.outstreamDesktop,
 							adSizes.outstreamGoogleDesktop,
 							adSizes.fluid,

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -293,8 +293,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							adSizes.empty,
 							adSizes.mpu,
 							adSizes.googleCard,
-							adSizes.outstreamDesktop,
-							adSizes.outstreamGoogleDesktop,
 							adSizes.fluid,
 							adSizes.halfPage,
 							adSizes.skyscraper,
@@ -307,8 +305,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 							adSizes.outstreamMobile,
 							adSizes.mpu,
 							adSizes.googleCard,
-							adSizes.outstreamDesktop,
-							adSizes.outstreamGoogleDesktop,
 							adSizes.fluid,
 						]
 							.map((size) => size.toString())
@@ -419,7 +415,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						adSizes.mpu,
 						adSizes.googleCard,
 						adSizes.halfPage,
-						adSizes.outstreamGoogleDesktop,
 						adSizes.fluid,
 					]
 						.map((size) => size.toString())


### PR DESCRIPTION
## What does this change?

Remove `video` and `outstream` ad size targeting from `comments` and `mostpop` ad slots

## Why?

Only `inline1` slots need to target `outstream` ad sizes.

The `video` ad size has been deprecated: https://github.com/guardian/commercial-core/pull/527

