### PR TITLE
Cypress Consistency - Remove pre-hydration checks for "idle" loading rich links

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -81,10 +81,6 @@ describe('Interactivity', function () {
 				.should('eq', 2);
 			// Verify hydration
 			cy.get('img[alt="Michael Barnier and the EU flag"]').should(
-				'not.exist',
-			);
-			cy.scrollTo('bottom', { duration: 300 });
-			cy.get('img[alt="Michael Barnier and the EU flag"]').should(
 				'be.visible',
 			);
 		});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes checks designed to check for the 'pre-hydration' state of rich links.

## Why?

This test if failing consistently in TC main builds. My hope is that this change will improve the consistency on main TC builds - but this can only be tested by merging it in!

Rich-links hydrate on CPU idle, rather than on-scroll; This means that it's essentially a race condition between the cypress pre-hydration check and actual hydration of the rich link to verify the 'pre-hydration' state.

Since we know that without hydration the image in the rich link should not exist, I believe the test will still perform its desired purpose without the pre-hydration check.

