### PR TITLE
fix: sentryLoader file typo

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -33,7 +33,7 @@ const decideAssetOrigin = (stage: string | undefined): string => {
 export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE);
 
 export const getScriptArrayFromFile = (
-	file: string,
+	file: `${string}.js`,
 ): { src: string; legacy?: boolean }[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -35,6 +35,9 @@ export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE);
 export const getScriptArrayFromFile = (
 	file: string,
 ): { src: string; legacy?: boolean }[] => {
+	if (!file.endsWith('.js'))
+		throw new Error('Invalid filename: extension must be .js');
+
 	const isDev = process.env.NODE_ENV === 'development';
 
 	const filename = isDev ? file : manifest[file];

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -117,7 +117,7 @@ export const document = ({ data }: Props): string => {
 			...getScriptArrayFromFile('bootCmp.js'),
 			...getScriptArrayFromFile('ophan.js'),
 			CAPI.config && { src: CAPI.config.commercialBundleUrl },
-			...getScriptArrayFromFile('sentryLoader.ks'),
+			...getScriptArrayFromFile('sentryLoader.js'),
 			...getScriptArrayFromFile('dynamicImport.js'),
 			pageHasNonBootInteractiveElements && {
 				src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,


### PR DESCRIPTION
## What does this change?

Switches the less common `.ks` extension for a `.js` extension.

**For serious future travellers:** this adds a TS template string check and `getScriptArrayFromFile` now throws an error if the extension is erroneous. This previously caused a bug where we failed to load `sentryLoader`, but did not fail the build.

## Why?

Kickstart files aren’t being read as easily by browsers as JavaScript ones.

**For serious future travellers:** We have omitted `sentryLoader` by mistake since https://github.com/guardian/dotcom-rendering/commit/f095976572ec91461415a6c5c646be4eab18aaef

h/t @tjmw 