### PR TITLE
Small refactors in document.tsx

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -17,8 +17,8 @@ try {
 /**
  * Decides the url to use for fetching assets
  *
- * @param stage {'PROD' | 'CODE' | undefined} the environment code is executing in
- * @returns
+ * @param {'PROD' | 'CODE' | undefined} stage the environment code is executing in
+ * @returns {string}
  */
 const decideAssetOrigin = (stage: string | undefined): string => {
 	switch (stage?.toUpperCase()) {

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -28,7 +28,7 @@ const generateScriptTags = (
 		let attrs: string;
 		switch (script.legacy) {
 			case true:
-				attrs = 'defer nomodules';
+				attrs = 'defer nomodule';
 				break;
 			case false:
 				attrs = 'type="module"';

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -146,15 +146,11 @@ export const document = ({ data }: Props): string => {
 	]);
 
 	const gaChunk = getScriptArrayFromFile('ga.js');
-	const modernScript = gaChunk.filter(
-		(script) => script && script.legacy === false,
-	)[0];
-	const legacyScript = gaChunk.filter(
-		(script) => script && script.legacy === true,
-	)[0];
+	const modernScript = gaChunk.find((script) => script?.legacy === false);
+	const legacyScript = gaChunk.find((script) => script?.legacy === true);
 	const gaPath = {
-		modern: modernScript.src,
-		legacy: legacyScript?.src,
+		modern: modernScript?.src as string,
+		legacy: legacyScript?.src as string,
 	};
 
 	/**


### PR DESCRIPTION
## What does this change?

- docs(assets): fix JSDoc types
- refactor: handle false in scripts array
- refactor: use find instead of filter

## Why?

Consistency, simplicity, type safety.

## Comparison

Compared DEV with PROD, and the generated document is identical (except for the asset path):

```html
<script defer src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1"></script>
<script type="module" src="/assets/bootCmp.js"></script>
<script defer nomodules src="/assets/bootCmp.legacy.js"></script>
<script type="module" src="/assets/ophan.js"></script>
<script defer nomodules src="/assets/ophan.legacy.js"></script>
<script defer src="https://assets.guim.co.uk/javascripts/commercial/82b653af5636e981226d/graun.standalone.commercial.js"></script>
<script type="module" src="/assets/sentryLoader.js"></script>
<script defer nomodules src="/assets/sentryLoader.legacy.js"></script>
<script type="module" src="/assets/dynamicImport.js"></script>
<script defer nomodules src="/assets/dynamicImport.legacy.js"></script>
<script type="module" src="/assets/islands.js"></script>
<script defer nomodules src="/assets/islands.legacy.js"></script>
```