### PR TITLE
direct to first page on toggling the filter

### DIFF
--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -30,7 +30,7 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 	const handleClick = () => {
 		setChecked(!checked);
 
-		const urlParams = new URLSearchParams(window.location.search);
+		const urlParams = new URLSearchParams();
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
 		window.location.hash = 'filter-toggle';

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -31,7 +31,7 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 		setChecked(!checked);
 
 		const urlParams = new URLSearchParams(window.location.search);
-		urlParams.delete('page');
+		urlParams.delete('page'); // direct to the first page
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
 		window.location.hash = 'filter-toggle';

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -30,7 +30,8 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 	const handleClick = () => {
 		setChecked(!checked);
 
-		const urlParams = new URLSearchParams();
+		const urlParams = new URLSearchParams(window.location.search);
+		urlParams.delete('page');
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
 		window.location.hash = 'filter-toggle';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When toggling the filter button we will now always redirect to the first page of a blog. This needs to happen because pagination needs to reset as the list of posts changes based on the filter. 

https://trello.com/c/GsRNN3TS/297-filter-key-events-in-dcr-breaks-on-second-page

## Why?

Currently, if you navigate to an older page in a liveblog, then click filter, you will get a 404 response if the page parameter points to a block that is not a key event, as this block will not exist in the filtered version of the page. 

### Before

https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?filterKeyEvents=true&page=with:block-62419a7e8f08118734a73e89

<img width="425" alt="Screenshot 2022-03-28 at 15 27 09" src="https://user-images.githubusercontent.com/1229808/160420361-d91c8dbf-7542-4b60-85cf-99e7feaacab3.png">

### After

https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?filterKeyEvents=true#filter-toggle

<img width="1396" alt="Screenshot 2022-03-28 at 15 28 15" src="https://user-images.githubusercontent.com/1229808/160420600-5ea4a2d7-59bc-43fe-8057-7abf2922e415.png">
