### PR TITLE
Refactor `ArticleHeadline` to include age warning

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -142,6 +142,7 @@ type Palette = {
 		matchNav: Colour;
 		analysisUnderline: Colour;
 		matchStats: Colour;
+		ageWarning: Colour;
 	};
 	fill: {
 		commentCount: Colour;
@@ -211,13 +212,13 @@ type CustomParams = {
 
 type AdTargeting =
 	| {
-		adUnit: string;
-		customParams: CustomParams;
-		disableAds?: false;
-	}
+			adUnit: string;
+			customParams: CustomParams;
+			disableAds?: false;
+	  }
 	| {
-		disableAds: true;
-	};
+			disableAds: true;
+	  };
 
 interface SectionNielsenAPI {
 	name: string;

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -40,6 +40,7 @@ export const ArticleStory = () => {
 						headlineString="This is how the default headline looks"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -65,6 +66,7 @@ export const Feature = () => {
 						headlineString="This is a Feature headline, it has colour applied based on pillar"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -95,6 +97,7 @@ export const ShowcaseInterview = () => {
 							headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
 							format={format}
 							tags={[]}
+							webPublicationDateDeprecated=""
 							byline="Byline text"
 						/>
 					</div>
@@ -138,6 +141,7 @@ export const ShowcaseInterviewNobyline = () => {
 							headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
 							format={format}
 							tags={[]}
+							webPublicationDateDeprecated=""
 							byline=""
 						/>
 					</div>
@@ -178,6 +182,7 @@ export const Interview = () => {
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 						byline="Byline text"
 					/>
 					<Standfirst
@@ -219,6 +224,7 @@ export const InterviewSpecialReport = () => {
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 						byline="Byline text"
 					/>
 					<Standfirst
@@ -262,6 +268,7 @@ export const InterviewNoByline = () => {
 						headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 						byline=""
 					/>
 					<Standfirst
@@ -305,6 +312,7 @@ export const Comment = () => {
 						headlineString="Yes, the billionaire club is one we really need to shut down"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -341,6 +349,7 @@ export const Analysis = () => {
 									headlineString={`This is an Analysis headline in ${themeName}, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor`}
 									format={format(theme)}
 									tags={[]}
+									webPublicationDateDeprecated=""
 								/>
 							</ArticleContainer>
 						</Flex>
@@ -370,6 +379,7 @@ export const Media = () => {
 						headlineString="This is the headline you see when design type is Media"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -395,6 +405,7 @@ export const Review = () => {
 						headlineString="This is the headline you see when design type is Review"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -420,6 +431,7 @@ export const PhotoEssay = () => {
 						headlineString="This is the headline you see when design type is PhotoEssay"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -445,6 +457,7 @@ export const Quiz = () => {
 						headlineString="This is the headline you see when design type is Quiz"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -470,6 +483,7 @@ export const Recipe = () => {
 						headlineString="This is the headline you see when design type is Recipe"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -495,6 +509,7 @@ export const Immersive = () => {
 						headlineString="This is the headline you see when display type is Immersive"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -520,6 +535,7 @@ export const ImmersiveNoMainMedia = () => {
 						headlineString="This is the headline you see when design type is PrintShop, which has no main media"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -549,6 +565,7 @@ export const ImmersiveComment = () => {
 						headlineString="This is the headline you see when display type is Immersive and design Comment"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -574,6 +591,7 @@ export const Editorial = () => {
 						headlineString="This is the headline you see when design type is Editorial"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -599,6 +617,7 @@ export const MatchReport = () => {
 						headlineString="This is the headline you see when design type is MatchReport"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -624,6 +643,7 @@ export const SpecialReport = () => {
 						headlineString="This is the headline you see when pillar is SpecialReport"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -649,6 +669,7 @@ export const LiveBlog = () => {
 						headlineString="This is the headline you see when design type is LiveBlog"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -687,6 +708,7 @@ export const DeadBlog = () => {
 						headlineString="This is the headline you see when design type is DeadBlog"
 						format={format}
 						tags={[]}
+						webPublicationDateDeprecated=""
 					/>
 				</ArticleContainer>
 			</Flex>
@@ -716,6 +738,7 @@ export const ReviewWithoutStars = () => {
 							headlineString="This is a Review headline."
 							format={format}
 							tags={[]}
+							webPublicationDateDeprecated=""
 							byline="Byline text"
 						/>
 					</ArticleHeadlinePadding>

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -752,3 +752,53 @@ export const ReviewWithoutStars = () => {
 	);
 };
 ReviewWithoutStars.story = { name: 'Review without stars' };
+
+export const AgeWarning = () => {
+	const designs: [string, ArticleDesign][] = [
+		['Comment', ArticleDesign.Comment],
+		['Interview', ArticleDesign.Interview],
+		['MatchReport', ArticleDesign.MatchReport],
+		['Feature', ArticleDesign.Feature],
+		['Interactive', ArticleDesign.Interactive],
+		['Media', ArticleDesign.Media],
+		['Analysis', ArticleDesign.Analysis],
+		['Review', ArticleDesign.Review],
+	];
+	const format = (design: ArticleDesign): ArticleFormat => ({
+		display: ArticleDisplay.Standard,
+		design,
+		theme: ArticlePillar.News,
+	});
+
+	return (
+		<>
+			{designs.map(([themeName, design]) => (
+				<>
+					<ElementContainer>
+						<Flex>
+							<LeftColumn>
+								<></>
+							</LeftColumn>
+							<ArticleContainer format={format(design)}>
+								<ArticleHeadline
+									headlineString={`This is a headline in ${themeName} with an age warning showing`}
+									format={format(design)}
+									tags={[
+										{
+											id: 'tone/news',
+											type: '',
+											title: '',
+										},
+									]}
+									webPublicationDateDeprecated="2020-03-28T07:27:19.000Z"
+								/>
+							</ArticleContainer>
+						</Flex>
+					</ElementContainer>
+					<br />
+				</>
+			))}
+		</>
+	);
+};
+AgeWarning.story = { name: 'with age warning' };

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -253,7 +253,7 @@ const ageWarningMargins = (format: ArticleFormat) =>
 		  `;
 
 const backgroundStyles = (palette: Palette) => css`
-	background-color: ${palette.background.headline};
+	background-color: ${palette.background.ageWarning};
 `;
 
 const WithAgeWarning = ({

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -234,6 +234,7 @@ const HeadlineAgeWarning = ({
 	isScreenReader?: boolean;
 	format: ArticleFormat;
 }) => {
+	const palette = decidePalette(format);
 	const ageWarningMargins =
 		format.display === ArticleDisplay.Immersive
 			? css`
@@ -263,6 +264,9 @@ const HeadlineAgeWarning = ({
 						margin-top: 0;
 					}
 			  `;
+	const backgroundStyles = css`
+		background-color: ${palette.background.headline};
+	`;
 
 	const age = getAgeWarning(tags, webPublicationDateDeprecated);
 
@@ -272,7 +276,7 @@ const HeadlineAgeWarning = ({
 
 	if (age) {
 		return (
-			<div css={ageWarningMargins}>
+			<div css={[ageWarningMargins, backgroundStyles]}>
 				<AgeWarning age={age} />
 			</div>
 		);

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -227,25 +227,42 @@ const HeadlineAgeWarning = ({
 	tags,
 	webPublicationDateDeprecated,
 	isScreenReader = false,
+	format,
 }: {
 	tags: TagType[];
 	webPublicationDateDeprecated: string;
 	isScreenReader?: boolean;
+	format: ArticleFormat;
 }) => {
-	const ageWarningMargins = css`
-		margin-top: 12px;
-		margin-left: -10px;
-		margin-bottom: 6px;
+	const ageWarningMargins =
+		format.display === ArticleDisplay.Immersive
+			? css`
+					margin-top: -44px;
+					margin-left: 0px;
+					margin-bottom: 0px;
 
-		${from.tablet} {
-			margin-left: -20px;
-		}
+					${from.tablet} {
+						margin-left: 10px;
+					}
 
-		${from.leftCol} {
-			margin-left: -10px;
-			margin-top: 0;
-		}
-	`;
+					${from.leftCol} {
+						margin-left: 20px;
+					}
+			  `
+			: css`
+					margin-top: 12px;
+					margin-left: -10px;
+					margin-bottom: 6px;
+
+					${from.tablet} {
+						margin-left: -20px;
+					}
+
+					${from.leftCol} {
+						margin-left: -10px;
+						margin-top: 0;
+					}
+			  `;
 
 	const age = getAgeWarning(tags, webPublicationDateDeprecated);
 
@@ -285,6 +302,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -302,6 +320,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -316,6 +335,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -333,6 +353,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 							{byline && (
@@ -354,6 +375,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -383,6 +405,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -397,6 +420,7 @@ export const ArticleHeadline = ({
 						webPublicationDateDeprecated={
 							webPublicationDateDeprecated
 						}
+						format={format}
 					/>
 					<h1
 						css={[
@@ -414,6 +438,7 @@ export const ArticleHeadline = ({
 						webPublicationDateDeprecated={
 							webPublicationDateDeprecated
 						}
+						format={format}
 						isScreenReader={true}
 					/>
 				</>
@@ -432,6 +457,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -449,6 +475,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -462,6 +489,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -479,6 +507,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 							{byline && (
@@ -499,6 +528,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -516,6 +546,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -528,6 +559,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -548,6 +580,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -562,6 +595,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<HeadlineTag
 								tagText="Interview"
@@ -592,6 +626,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 							{byline && (
@@ -612,6 +647,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -629,6 +665,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>
@@ -645,6 +682,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								className={interactiveLegacyClasses.headline}
@@ -663,6 +701,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</div>
@@ -675,6 +714,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 							/>
 							<h1
 								css={[
@@ -694,6 +734,7 @@ export const ArticleHeadline = ({
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
+								format={format}
 								isScreenReader={true}
 							/>
 						</>

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -238,7 +238,6 @@ const WithAgeWarning = ({
 	const ageWarningMargins =
 		format.display === ArticleDisplay.Immersive
 			? css`
-					padding-top: 12px;
 					margin-left: 0px;
 					margin-bottom: 0px;
 

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -223,6 +223,39 @@ const zIndex = css`
 	z-index: 1;
 `;
 
+const ageWarningMargins = (format: ArticleFormat) =>
+	format.display === ArticleDisplay.Immersive
+		? css`
+				margin-left: 0px;
+				margin-bottom: 0px;
+
+				${from.tablet} {
+					margin-left: 10px;
+				}
+
+				${from.leftCol} {
+					margin-left: 20px;
+				}
+		  `
+		: css`
+				margin-top: 12px;
+				margin-left: -10px;
+				margin-bottom: 6px;
+
+				${from.tablet} {
+					margin-left: -20px;
+				}
+
+				${from.leftCol} {
+					margin-left: -10px;
+					margin-top: 0;
+				}
+		  `;
+
+const backgroundStyles = (palette: Palette) => css`
+	background-color: ${palette.background.headline};
+`;
+
 const WithAgeWarning = ({
 	tags,
 	webPublicationDateDeprecated,
@@ -235,44 +268,14 @@ const WithAgeWarning = ({
 	children: React.ReactNode;
 }) => {
 	const palette = decidePalette(format);
-	const ageWarningMargins =
-		format.display === ArticleDisplay.Immersive
-			? css`
-					margin-left: 0px;
-					margin-bottom: 0px;
-
-					${from.tablet} {
-						margin-left: 10px;
-					}
-
-					${from.leftCol} {
-						margin-left: 20px;
-					}
-			  `
-			: css`
-					margin-top: 12px;
-					margin-left: -10px;
-					margin-bottom: 6px;
-
-					${from.tablet} {
-						margin-left: -20px;
-					}
-
-					${from.leftCol} {
-						margin-left: -10px;
-						margin-top: 0;
-					}
-			  `;
-	const backgroundStyles = css`
-		background-color: ${palette.background.headline};
-	`;
-
 	const age = getAgeWarning(tags, webPublicationDateDeprecated);
 
 	if (age) {
 		return (
 			<>
-				<div css={[backgroundStyles, ageWarningMargins]}>
+				<div
+					css={[backgroundStyles(palette), ageWarningMargins(format)]}
+				>
 					<AgeWarning age={age} />
 				</div>
 				{children}

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -238,7 +238,7 @@ const HeadlineAgeWarning = ({
 	const ageWarningMargins =
 		format.display === ArticleDisplay.Immersive
 			? css`
-					margin-top: -44px;
+					padding-top: 12px;
 					margin-left: 0px;
 					margin-bottom: 0px;
 

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -223,16 +223,16 @@ const zIndex = css`
 	z-index: 1;
 `;
 
-const HeadlineAgeWarning = ({
+const WithAgeWarning = ({
 	tags,
 	webPublicationDateDeprecated,
-	isScreenReader = false,
 	format,
+	children,
 }: {
 	tags: TagType[];
 	webPublicationDateDeprecated: string;
-	isScreenReader?: boolean;
 	format: ArticleFormat;
+	children: React.ReactNode;
 }) => {
 	const palette = decidePalette(format);
 	const ageWarningMargins =
@@ -270,19 +270,19 @@ const HeadlineAgeWarning = ({
 
 	const age = getAgeWarning(tags, webPublicationDateDeprecated);
 
-	if (age && isScreenReader) {
-		return <AgeWarning age={age} isScreenReader={true} />;
-	}
-
 	if (age) {
 		return (
-			<div css={[ageWarningMargins, backgroundStyles]}>
-				<AgeWarning age={age} />
-			</div>
+			<>
+				<div css={[backgroundStyles, ageWarningMargins]}>
+					<AgeWarning age={age} />
+				</div>
+				{children}
+				<AgeWarning age={age} isScreenReader={true} />
+			</>
 		);
 	}
 
-	return null;
+	return <>{children}</>;
 };
 
 export const ArticleHeadline = ({
@@ -298,35 +298,28 @@ export const ArticleHeadline = ({
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.PrintShop:
+					// Immersive headlines have two versions, with main media, and (this one) without
 					return (
-						// Immersive headlines have two versions, with main media, and (this one) without
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									jumboFont,
-									maxWidth,
-									immersiveStyles,
-									displayBlock,
-									reducedBottomPadding,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										jumboFont,
+										maxWidth,
+										immersiveStyles,
+										displayBlock,
+										reducedBottomPadding,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 				case ArticleDesign.Comment:
@@ -334,32 +327,25 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Letter:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									lightFont,
-									invertedText,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										lightFont,
+										invertedText,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -374,44 +360,37 @@ export const ArticleHeadline = ({
 						// Immersive headlines with main media present, are large and inverted with
 						// a black background
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									immersiveWrapper,
-									darkBackground(palette),
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								<span
+								<h1
 									css={[
-										format.theme === ArticleSpecial.Labs
-											? jumboLabsFont
-											: jumboFont,
-										maxWidth,
-										invertedStyles(palette),
-										immersiveStyles,
-										displayBlock,
+										immersiveWrapper,
+										darkBackground(palette),
+										css`
+											color: ${palette.text.headline};
+										`,
 									]}
 								>
-									{curly(headlineString)}
-								</span>
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+									<span
+										css={[
+											format.theme === ArticleSpecial.Labs
+												? jumboLabsFont
+												: jumboFont,
+											maxWidth,
+											invertedStyles(palette),
+											immersiveStyles,
+											displayBlock,
+										]}
+									>
+										{curly(headlineString)}
+									</span>
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 			}
@@ -419,32 +398,25 @@ export const ArticleHeadline = ({
 		case ArticleDisplay.NumberedList:
 			return (
 				<>
-					<HeadlineAgeWarning
+					<WithAgeWarning
 						tags={tags}
 						webPublicationDateDeprecated={
 							webPublicationDateDeprecated
 						}
 						format={format}
-					/>
-					<h1
-						css={[
-							boldFont,
-							topPadding,
-							css`
-								color: ${palette.text.headline};
-							`,
-						]}
 					>
-						{curly(headlineString)}
-					</h1>
-					<HeadlineAgeWarning
-						tags={tags}
-						webPublicationDateDeprecated={
-							webPublicationDateDeprecated
-						}
-						format={format}
-						isScreenReader={true}
-					/>
+						<h1
+							css={[
+								boldFont,
+								topPadding,
+								css`
+									color: ${palette.text.headline};
+								`,
+							]}
+						>
+							{curly(headlineString)}
+						</h1>
+					</WithAgeWarning>
 				</>
 			);
 		case ArticleDisplay.Showcase:
@@ -456,64 +428,50 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Feature:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									boldFont,
-									topPadding,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										boldFont,
+										topPadding,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									lightFont,
-									topPadding,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										lightFont,
+										topPadding,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -527,66 +485,53 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Letter:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									lightFont,
-									topPadding,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										lightFont,
+										topPadding,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 				case ArticleDesign.Analysis:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									standardFont,
-									topPadding,
-									underlinedStyles(
-										palette.background.analysisUnderline,
-									),
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										standardFont,
+										topPadding,
+										underlinedStyles(
+											palette.background
+												.analysisUnderline,
+										),
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 				case ArticleDesign.Interview:
@@ -594,45 +539,38 @@ export const ArticleHeadline = ({
 						// Inverted headlines have a wrapper div for positioning
 						// and a black background (only for the text)
 						<div css={[shiftSlightly, maxWidth, displayFlex]}>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<HeadlineTag
-								tagText="Interview"
-								palette={palette}
-							/>
-							<h1
-								css={[
-									invertedFont,
-									invertedWrapper,
-									zIndex,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								<span
+								<HeadlineTag
+									tagText="Interview"
+									palette={palette}
+								/>
+								<h1
 									css={[
-										darkBackground(palette),
-										invertedStyles(palette),
-										displayInline,
+										invertedFont,
+										invertedWrapper,
+										zIndex,
+										css`
+											color: ${palette.text.headline};
+										`,
 									]}
 								>
-									{curly(headlineString)}
-								</span>
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+									<span
+										css={[
+											darkBackground(palette),
+											invertedStyles(palette),
+											displayInline,
+										]}
+									>
+										{curly(headlineString)}
+									</span>
+								</h1>
+							</WithAgeWarning>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -646,32 +584,25 @@ export const ArticleHeadline = ({
 				case ArticleDesign.DeadBlog:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									standardFont,
-									css`
-										color: ${palette.text.headline};
-										padding-bottom: ${space[9]}px;
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										standardFont,
+										css`
+											color: ${palette.text.headline};
+											padding-bottom: ${space[9]}px;
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 				case ArticleDesign.Interactive:
@@ -681,66 +612,54 @@ export const ArticleHeadline = ({
 								position: relative;
 							`}
 						>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								className={interactiveLegacyClasses.headline}
-								css={[
-									standardFont,
-									topPadding,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									className={
+										interactiveLegacyClasses.headline
+									}
+									css={[
+										standardFont,
+										topPadding,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</div>
 					);
 				default:
 					return (
 						<>
-							<HeadlineAgeWarning
+							<WithAgeWarning
 								tags={tags}
 								webPublicationDateDeprecated={
 									webPublicationDateDeprecated
 								}
 								format={format}
-							/>
-							<h1
-								css={[
-									format.theme === ArticleSpecial.Labs
-										? labsFont
-										: standardFont,
-									topPadding,
-									css`
-										color: ${palette.text.headline};
-									`,
-								]}
 							>
-								{curly(headlineString)}
-							</h1>
-							<HeadlineAgeWarning
-								tags={tags}
-								webPublicationDateDeprecated={
-									webPublicationDateDeprecated
-								}
-								format={format}
-								isScreenReader={true}
-							/>
+								<h1
+									css={[
+										format.theme === ArticleSpecial.Labs
+											? labsFont
+											: standardFont,
+										topPadding,
+										css`
+											color: ${palette.text.headline};
+										`,
+									]}
+								>
+									{curly(headlineString)}
+								</h1>
+							</WithAgeWarning>
 						</>
 					);
 			}

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -19,12 +19,15 @@ import { HeadlineByline } from './HeadlineByline';
 import { getZIndex } from '../lib/getZIndex';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
+import { AgeWarning } from './AgeWarning';
+import { getAgeWarning } from '../../lib/age-warning';
 
 type Props = {
 	headlineString: string;
 	format: ArticleFormat;
 	byline?: string;
 	tags: TagType[];
+	webPublicationDateDeprecated: string;
 };
 
 const curly = (x: any) => x;
@@ -220,36 +223,100 @@ const zIndex = css`
 	z-index: 1;
 `;
 
+const HeadlineAgeWarning = ({
+	tags,
+	webPublicationDateDeprecated,
+	isScreenReader = false,
+}: {
+	tags: TagType[];
+	webPublicationDateDeprecated: string;
+	isScreenReader?: boolean;
+}) => {
+	const ageWarningMargins = css`
+		margin-top: 12px;
+		margin-left: -10px;
+		margin-bottom: 6px;
+
+		${from.tablet} {
+			margin-left: -20px;
+		}
+
+		${from.leftCol} {
+			margin-left: -10px;
+			margin-top: 0;
+		}
+	`;
+
+	const age = getAgeWarning(tags, webPublicationDateDeprecated);
+
+	if (age && isScreenReader) {
+		return <AgeWarning age={age} isScreenReader={true} />;
+	}
+
+	if (age) {
+		return (
+			<div css={ageWarningMargins}>
+				<AgeWarning age={age} />
+			</div>
+		);
+	}
+
+	return null;
+};
+
 export const ArticleHeadline = ({
 	headlineString,
 	format,
 	tags,
 	byline,
+	webPublicationDateDeprecated,
 }: Props) => {
 	const palette = decidePalette(format);
+
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.PrintShop:
 					return (
 						// Immersive headlines have two versions, with main media, and (this one) without
-						<h1
-							css={[
-								jumboFont,
-								maxWidth,
-								immersiveStyles,
-								displayBlock,
-								reducedBottomPadding,
-							]}
-						>
-							{curly(headlineString)}
-						</h1>
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
+								css={[
+									jumboFont,
+									maxWidth,
+									immersiveStyles,
+									displayBlock,
+									reducedBottomPadding,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 					return (
 						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
 							<h1
 								css={[
 									lightFont,
@@ -261,6 +328,13 @@ export const ArticleHeadline = ({
 							>
 								{curly(headlineString)}
 							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -274,45 +348,75 @@ export const ArticleHeadline = ({
 					return (
 						// Immersive headlines with main media present, are large and inverted with
 						// a black background
-						<h1
-							css={[
-								immersiveWrapper,
-								darkBackground(palette),
-								css`
-									color: ${palette.text.headline};
-								`,
-							]}
-						>
-							<span
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
 								css={[
-									format.theme === ArticleSpecial.Labs
-										? jumboLabsFont
-										: jumboFont,
-									maxWidth,
-									invertedStyles(palette),
-									immersiveStyles,
-									displayBlock,
+									immersiveWrapper,
+									darkBackground(palette),
+									css`
+										color: ${palette.text.headline};
+									`,
 								]}
 							>
-								{curly(headlineString)}
-							</span>
-						</h1>
+								<span
+									css={[
+										format.theme === ArticleSpecial.Labs
+											? jumboLabsFont
+											: jumboFont,
+										maxWidth,
+										invertedStyles(palette),
+										immersiveStyles,
+										displayBlock,
+									]}
+								>
+									{curly(headlineString)}
+								</span>
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 			}
 		}
 		case ArticleDisplay.NumberedList:
 			return (
-				<h1
-					css={[
-						boldFont,
-						topPadding,
-						css`
-							color: ${palette.text.headline};
-						`,
-					]}
-				>
-					{curly(headlineString)}
-				</h1>
+				<>
+					<HeadlineAgeWarning
+						tags={tags}
+						webPublicationDateDeprecated={
+							webPublicationDateDeprecated
+						}
+					/>
+					<h1
+						css={[
+							boldFont,
+							topPadding,
+							css`
+								color: ${palette.text.headline};
+							`,
+						]}
+					>
+						{curly(headlineString)}
+					</h1>
+					<HeadlineAgeWarning
+						tags={tags}
+						webPublicationDateDeprecated={
+							webPublicationDateDeprecated
+						}
+						isScreenReader={true}
+					/>
+				</>
 			);
 		case ArticleDisplay.Showcase:
 		case ArticleDisplay.Standard:
@@ -322,22 +426,43 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Feature:
 					return (
-						<h1
-							css={[
-								boldFont,
-								topPadding,
-								css`
-									color: ${palette.text.headline};
-								`,
-							]}
-						>
-							{curly(headlineString)}
-						</h1>
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
+								css={[
+									boldFont,
+									topPadding,
+									css`
+										color: ${palette.text.headline};
+									`,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 					return (
 						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
 							<h1
 								css={[
 									lightFont,
@@ -349,6 +474,13 @@ export const ArticleHeadline = ({
 							>
 								{curly(headlineString)}
 							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -362,6 +494,12 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Letter:
 					return (
 						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
 							<h1
 								css={[
 									lightFont,
@@ -373,30 +511,58 @@ export const ArticleHeadline = ({
 							>
 								{curly(headlineString)}
 							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
 						</>
 					);
 				case ArticleDesign.Analysis:
 					return (
-						<h1
-							css={[
-								standardFont,
-								topPadding,
-								underlinedStyles(
-									palette.background.analysisUnderline,
-								),
-								css`
-									color: ${palette.text.headline};
-								`,
-							]}
-						>
-							{curly(headlineString)}
-						</h1>
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
+								css={[
+									standardFont,
+									topPadding,
+									underlinedStyles(
+										palette.background.analysisUnderline,
+									),
+									css`
+										color: ${palette.text.headline};
+									`,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 				case ArticleDesign.Interview:
 					return (
 						// Inverted headlines have a wrapper div for positioning
 						// and a black background (only for the text)
 						<div css={[shiftSlightly, maxWidth, displayFlex]}>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
 							<HeadlineTag
 								tagText="Interview"
 								palette={palette}
@@ -421,6 +587,13 @@ export const ArticleHeadline = ({
 									{curly(headlineString)}
 								</span>
 							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
 							{byline && (
 								<HeadlineByline
 									format={format}
@@ -433,17 +606,32 @@ export const ArticleHeadline = ({
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 					return (
-						<h1
-							css={[
-								standardFont,
-								css`
-									color: ${palette.text.headline};
-									padding-bottom: ${space[9]}px;
-								`,
-							]}
-						>
-							{curly(headlineString)}
-						</h1>
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
+								css={[
+									standardFont,
+									css`
+										color: ${palette.text.headline};
+										padding-bottom: ${space[9]}px;
+									`,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 				case ArticleDesign.Interactive:
 					return (
@@ -452,6 +640,12 @@ export const ArticleHeadline = ({
 								position: relative;
 							`}
 						>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
 							<h1
 								className={interactiveLegacyClasses.headline}
 								css={[
@@ -464,23 +658,45 @@ export const ArticleHeadline = ({
 							>
 								{curly(headlineString)}
 							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
 						</div>
 					);
 				default:
 					return (
-						<h1
-							css={[
-								format.theme === ArticleSpecial.Labs
-									? labsFont
-									: standardFont,
-								topPadding,
-								css`
-									color: ${palette.text.headline};
-								`,
-							]}
-						>
-							{curly(headlineString)}
-						</h1>
+						<>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+							/>
+							<h1
+								css={[
+									format.theme === ArticleSpecial.Labs
+										? labsFont
+										: standardFont,
+									topPadding,
+									css`
+										color: ${palette.text.headline};
+									`,
+								]}
+							>
+								{curly(headlineString)}
+							</h1>
+							<HeadlineAgeWarning
+								tags={tags}
+								webPublicationDateDeprecated={
+									webPublicationDateDeprecated
+								}
+								isScreenReader={true}
+							/>
+						</>
 					);
 			}
 		}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -33,12 +33,10 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '../components/AdSlot';
 import { Border } from '../components/Border';
 import { GridItem } from '../components/GridItem';
-import { AgeWarning } from '../components/AgeWarning';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
-import { getAgeWarning } from '../../lib/age-warning';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import { Stuck, SendToBack, BannerWrapper } from './lib/stickiness';
 import { Island } from '../components/Island';
@@ -255,21 +253,6 @@ const headlinePadding = css`
 	padding-bottom: 43px;
 `;
 
-const ageWarningMargins = css`
-	margin-top: 12px;
-	margin-left: -10px;
-	margin-bottom: 6px;
-
-	${from.tablet} {
-		margin-left: -20px;
-	}
-
-	${from.leftCol} {
-		margin-left: -10px;
-		margin-top: 0;
-	}
-`;
-
 const mainMediaWrapper = css`
 	position: relative;
 `;
@@ -316,8 +299,6 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 		CAPI.tags.filter((tag) => tag.type === 'Contributor').length === 1;
 
 	const showAvatar = avatarUrl && onlyOneContributor;
-
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
@@ -445,23 +426,15 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								>
 									{/* TOP - we use divs here to position content in groups using flex */}
 									<div css={!showAvatar && headlinePadding}>
-										{age && (
-											<div css={ageWarningMargins}>
-												<AgeWarning age={age} />
-											</div>
-										)}
 										<ArticleHeadline
 											format={format}
 											headlineString={CAPI.headline}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
+											webPublicationDateDeprecated={
+												CAPI.webPublicationDateDeprecated
+											}
 										/>
-										{age && (
-											<AgeWarning
-												age={age}
-												isScreenReader={true}
-											/>
-										)}
 									</div>
 									{/* BOTTOM */}
 									<div>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -291,6 +291,9 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 											headlineString={CAPI.headline}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
+											webPublicationDateDeprecated={
+												CAPI.webPublicationDateDeprecated
+											}
 										/>
 									</div>
 								)}

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -358,6 +358,9 @@ export const InteractiveImmersiveLayout = ({
 											headlineString={CAPI.headline}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
+											webPublicationDateDeprecated={
+												CAPI.webPublicationDateDeprecated
+											}
 										/>
 									</div>
 								)}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -35,13 +35,11 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '../components/AdSlot';
 import { Border } from '../components/Border';
 import { GridItem } from '../components/GridItem';
-import { AgeWarning } from '../components/AgeWarning';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Nav } from '../components/Nav/Nav';
 import { LabsHeader } from '../components/LabsHeader.importable';
 
 import { buildAdTargeting } from '../../lib/ad-targeting';
-import { getAgeWarning } from '../../lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
@@ -217,21 +215,6 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-const ageWarningMargins = css`
-	margin-top: 12px;
-	margin-left: -10px;
-	margin-bottom: 6px;
-
-	${from.tablet} {
-		margin-left: -20px;
-	}
-
-	${from.leftCol} {
-		margin-left: -10px;
-		margin-top: 0;
-	}
-`;
-
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
@@ -260,8 +243,6 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
 	const showComments = CAPI.isCommentable;
-
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
@@ -428,23 +409,15 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 											CAPI.starRating === 0
 										}
 									>
-										{age && (
-											<div css={ageWarningMargins}>
-												<AgeWarning age={age} />
-											</div>
-										)}
 										<ArticleHeadline
 											format={format}
 											headlineString={CAPI.headline}
 											tags={CAPI.tags}
 											byline={CAPI.author.byline}
+											webPublicationDateDeprecated={
+												CAPI.webPublicationDateDeprecated
+											}
 										/>
-										{age && (
-											<AgeWarning
-												age={age}
-												isScreenReader={true}
-											/>
-										)}
 									</ArticleHeadlinePadding>
 								</div>
 								{CAPI.starRating || CAPI.starRating === 0 ? (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -34,14 +34,12 @@ import { Nav } from '../components/Nav/Nav';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '../components/AdSlot';
 import { GridItem } from '../components/GridItem';
-import { AgeWarning } from '../components/AgeWarning';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 
 import { KeyEventsContainer } from '../components/KeyEventsContainer';
 
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
-import { getAgeWarning } from '../../lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
@@ -248,19 +246,6 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-const ageWarningMargins = css`
-	margin-top: 12px;
-	margin-left: -10px;
-	margin-bottom: 6px;
-	${from.tablet} {
-		margin-left: -20px;
-	}
-	${from.leftCol} {
-		margin-left: -10px;
-		margin-top: 0;
-	}
-`;
-
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
@@ -295,8 +280,6 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 	);
 
 	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
-
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	// Set a default pagination if it is missing from CAPI
 	const pagination: Pagination = CAPI.pagination ?? {
@@ -462,11 +445,6 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 										<ArticleHeadlinePadding
 											design={format.design}
 										>
-											{age && (
-												<div css={ageWarningMargins}>
-													<AgeWarning age={age} />
-												</div>
-											)}
 											{!CAPI.matchUrl && (
 												<ArticleHeadline
 													format={format}
@@ -475,12 +453,9 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 													}
 													tags={CAPI.tags}
 													byline={CAPI.author.byline}
-												/>
-											)}
-											{age && (
-												<AgeWarning
-													age={age}
-													isScreenReader={true}
+													webPublicationDateDeprecated={
+														CAPI.webPublicationDateDeprecated
+													}
 												/>
 											)}
 										</ArticleHeadlinePadding>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -32,13 +32,11 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '../components/AdSlot';
 import { Border } from '../components/Border';
 import { GridItem } from '../components/GridItem';
-import { AgeWarning } from '../components/AgeWarning';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { LabsHeader } from '../components/LabsHeader.importable';
 
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
-import { getAgeWarning } from '../../lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
@@ -205,21 +203,6 @@ const PositionHeadline = ({
 	}
 };
 
-const ageWarningMargins = css`
-	margin-top: 12px;
-	margin-left: -10px;
-	margin-bottom: 6px;
-
-	${from.tablet} {
-		margin-left: -20px;
-	}
-
-	${from.leftCol} {
-		margin-left: -10px;
-		margin-top: 0;
-	}
-`;
-
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
@@ -255,8 +238,6 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
 	const showComments = CAPI.isCommentable;
-
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
@@ -445,23 +426,15 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 										padding-bottom: 24px;
 									`}
 								>
-									{age && (
-										<div css={ageWarningMargins}>
-											<AgeWarning age={age} />
-										</div>
-									)}
 									<ArticleHeadline
 										format={format}
 										headlineString={CAPI.headline}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
+										webPublicationDateDeprecated={
+											CAPI.webPublicationDateDeprecated
+										}
 									/>
-									{age && (
-										<AgeWarning
-											age={age}
-											isScreenReader={true}
-										/>
-									)}
 								</div>
 							</PositionHeadline>
 						</GridItem>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -34,7 +34,6 @@ import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '../components/AdSlot';
 import { Border } from '../components/Border';
 import { GridItem } from '../components/GridItem';
-import { AgeWarning } from '../components/AgeWarning';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Nav } from '../components/Nav/Nav';
 import { LabsHeader } from '../components/LabsHeader.importable';
@@ -42,7 +41,6 @@ import { GuardianLabsLines } from '../components/GuardianLabsLines';
 
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
-import { getAgeWarning } from '../../lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
@@ -292,21 +290,6 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-const ageWarningMargins = css`
-	margin-top: 12px;
-	margin-left: -10px;
-	margin-bottom: 6px;
-
-	${from.tablet} {
-		margin-left: -20px;
-	}
-
-	${from.leftCol} {
-		margin-left: -10px;
-		margin-top: 0;
-	}
-`;
-
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
@@ -346,8 +329,6 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 		format.design === ArticleDesign.MatchReport && !!CAPI.matchUrl;
 
 	const showComments = CAPI.isCommentable;
-
-	const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDateDeprecated);
 
 	const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
@@ -542,23 +523,15 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 										CAPI.starRating === 0
 									}
 								>
-									{age && (
-										<div css={ageWarningMargins}>
-											<AgeWarning age={age} />
-										</div>
-									)}
 									<ArticleHeadline
 										format={format}
 										headlineString={CAPI.headline}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
+										webPublicationDateDeprecated={
+											CAPI.webPublicationDateDeprecated
+										}
 									/>
-									{age && (
-										<AgeWarning
-											age={age}
-											isScreenReader={true}
-										/>
-									)}
 								</ArticleHeadlinePadding>
 							</div>
 							{CAPI.starRating || CAPI.starRating === 0 ? (

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -260,6 +260,9 @@ export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 										headlineString={CAPI.headline}
 										tags={CAPI.tags}
 										byline={CAPI.author.byline}
+										webPublicationDateDeprecated={
+											CAPI.webPublicationDateDeprecated
+										}
 									/>
 								</ContainerLayout>
 							</Box>

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -556,6 +556,15 @@ const backgroundHeadline = (format: ArticleFormat): string => {
 	}
 };
 
+const backgroundAgeWarning = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Interview:
+			return backgroundArticle(format);
+		default:
+			return backgroundHeadline(format);
+	}
+};
+
 const backgroundHeadlineByline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
@@ -1096,6 +1105,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			matchNav: backgroundMatchNav(),
 			analysisUnderline: backgroundUnderline(format),
 			matchStats: backgroundMatchStats(format),
+			ageWarning: backgroundAgeWarning(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This refactors the code to move control for when an age warning is shown away from the templates and into the `ArticleHeadline` component

## Why?
Because we always want to show this but if we leave it up to the layout files we risk it being overlooked.

