### PR TITLE
feat: add a `/Front` endpoint

### DIFF
--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -4,6 +4,7 @@ import {
 	renderArticle,
 	renderArticleJson,
 	renderBlocks,
+	renderFront,
 	renderInteractive,
 	renderKeyEvents,
 } from '../web/server';
@@ -27,6 +28,8 @@ export const devServer = () => {
 				return renderBlocks(req, res);
 			case '/KeyEvents':
 				return renderKeyEvents(req, res);
+			case '/Front':
+				return renderFront(req, res);
 			default:
 				next();
 		}

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -110,7 +110,7 @@ export const prodServer = () => {
 		logRenderTime,
 		// TODO: implement Fronts’ getContentFromURLMiddleware,
 		async (req: Request, res: Response) => {
-			// Eg. http://localhost:9000/AMPArticle?url=https://www.theguardian.com/commentisfree/...
+			// Eg. http://localhost:9000/Front?url=https://www.theguardian.com/uk/sport
 			try {
 				return renderFront(req, res);
 			} catch (error) {

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -5,6 +5,7 @@ import {
 	renderArticle,
 	renderArticleJson,
 	renderBlocks,
+	renderFront,
 	renderInteractive,
 	renderKeyEvents,
 	renderPerfTest as renderArticlePerfTest,
@@ -71,6 +72,7 @@ export const prodServer = () => {
 	app.post('/AMPInteractive', logRenderTime, renderAMPArticle);
 	app.post('/Blocks', logRenderTime, renderBlocks);
 	app.post('/KeyEvents', logRenderTime, renderKeyEvents);
+	app.post('/Front', logRenderTime, renderFront);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -96,6 +98,21 @@ export const prodServer = () => {
 			// Eg. http://localhost:9000/AMPArticle?url=https://www.theguardian.com/commentisfree/...
 			try {
 				return renderAMPArticle(req, res);
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(error);
+			}
+		},
+	);
+
+	app.get(
+		'/Front',
+		logRenderTime,
+		// TODO: implement Fronts’ getContentFromURLMiddleware,
+		async (req: Request, res: Response) => {
+			// Eg. http://localhost:9000/AMPArticle?url=https://www.theguardian.com/commentisfree/...
+			try {
+				return renderFront(req, res);
 			} catch (error) {
 				// eslint-disable-next-line no-console
 				console.error(error);

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -1,0 +1,41 @@
+import { isObject } from '@guardian/libs';
+import type { Request } from 'express';
+
+type FrontData = { query: Request['query']; body: unknown };
+
+export const frontToHtml = ({ query, body }: FrontData) => {
+	const config =
+		(isObject(body) && isObject(body?.config) && body.config) || {};
+
+	const slug: string =
+		query?.url?.toString().replace('https://www.theguardian.com/', '/') ??
+		'Missing url query param';
+
+	return `<!DOCTYPE html>
+	<html lang="en">
+	<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Dummy Front | The Guardian</title>
+	</head>
+	<body>
+	<h1>Dummy Front: ${slug}</h1>
+	<h2><a href="https://www.theguardian.com${slug}.json">See JSON endpoint ${slug}.json</a></h2>
+	<ul>
+	${Object.entries(config)
+		.map(([key, value]) => {
+			return `<li>${key}: ${JSON.stringify(value)}</li>`;
+		})
+		.join(' ')}
+	<style>
+	li {
+		padding-top: 1em;
+		font-family: monospace;
+		word-break: break-all;
+	}
+	</style>
+	</ul>
+	</body>
+	</html>`;
+};

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -8,6 +8,7 @@ import { validateAsCAPIType } from '../../model/validate';
 import { extract as extractGA } from '../../model/extract-ga';
 import { blocksToHtml } from './blocksToHtml';
 import { keyEventsToHtml } from './keyEventsToHtml';
+import { frontToHtml } from './frontToHtml';
 
 function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
@@ -164,6 +165,22 @@ export const renderKeyEvents = (
 			filterKeyEvents,
 		});
 
+		res.status(200).send(html);
+	} catch (e) {
+		const message = e instanceof Error ? e.stack : 'Unknown Error';
+		res.status(500).send(`<pre>${message}</pre>`);
+	}
+};
+
+export const renderFront = (
+	{ body, query }: express.Request,
+	res: express.Response,
+): void => {
+	try {
+		const html = frontToHtml({
+			query,
+			body,
+		});
 		res.status(200).send(html);
 	} catch (e) {
 		const message = e instanceof Error ? e.stack : 'Unknown Error';


### PR DESCRIPTION
## What does this change?

Returns a dummy page with the JSON config from PROD.

This **does not yet** get the relevant fronts data as JSON, because this endpoint does not exist.

## Why?

So we can start working on Fronts in DCR. Closing #4410 

### Screenshot

<img width="643" alt="image" src="https://user-images.githubusercontent.com/76776/160423055-d3287d54-1d0d-4a50-a530-81e6779e28b5.png">

