### PR TITLE
Fix: prevent default scroll on `show more` button

### DIFF
--- a/dotcom-rendering/src/web/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/web/components/PinnedPost.tsx
@@ -147,6 +147,7 @@ export const PinnedPost = ({ pinnedPost, children, format }: Props) => {
 			<input
 				type="checkbox"
 				css={css`
+					visibility: hidden;
 					${visuallyHidden};
 				`}
 				id="pinned-post-checkbox"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hide the checkbox input in the pinned post component to prevent the default scroll.

## Why?
There was a bug where, if the top of the pinned post was out of view, clicking `show more` would scroll the user up. This is because the pinned post accordion is [built as a checkbox so that it works without JS](https://github.com/guardian/dotcom-rendering/pull/4211) and the default behaviour of a checkbox is to scroll to the input when the check value changes. 

As the input sits at the the top of the pinned post, having the top out of view resulted in a scroll up to position the input in view. By setting the visibility of the input to `hidden` there is nothing to scroll to and so the user's position is persisted.

### Before
https://user-images.githubusercontent.com/20416599/160427777-461bea31-5e64-4c58-8845-e1534dc290b8.mov

### After
https://user-images.githubusercontent.com/20416599/160428346-cb520be5-0781-44a9-b86d-48d1dedc2ce3.mov


