### PR TITLE
feat: add type checking to `getContentFromURL`

### DIFF
--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -33,8 +33,9 @@ async function getContentFromURL(_url, _headers) {
 				.filter(isStringTuple),
 		);
 
+		// pick all the keys from the JSON except `html`
 		const { html, ...config } = await fetch(jsonUrl, { headers }).then(
-			(article) => article.json(),
+			(response) => response.json(),
 		);
 
 		return config;


### PR DESCRIPTION
## What does this change?

Type-check `getContentFromURL`.

## Why?

We’ll need to augment or update this function with the work on Fronts.
