### PR TITLE
Pillars go yellow and underline on hover

### DIFF
--- a/dotcom-rendering/src/web/components/Pillars.tsx
+++ b/dotcom-rendering/src/web/components/Pillars.tsx
@@ -6,6 +6,7 @@ import {
 	headline,
 	from,
 	until,
+	brandAlt,
 } from '@guardian/source-foundations';
 import { ArticleDisplay, ArticleDesign } from '@guardian/libs';
 import { decidePalette } from '../lib/decidePalette';
@@ -88,6 +89,7 @@ const showMenuUnderlineStyles = css`
 
 		:hover {
 			text-decoration: underline;
+			color: ${brandAlt[400]};
 		}
 
 		:after {


### PR DESCRIPTION
## What does this change?
Updates navigation pillar styling - now on hover pillar links will be unlined and yellow.

## Why?
To more closely meet the design

### Before
![Screenshot 2022-03-29 at 10 58 17](https://user-images.githubusercontent.com/45561419/160586208-f50dcf83-dad4-4b3d-a5aa-110224a28700.png)


### After
<img width="152" alt="Screenshot 2022-03-29 at 10 58 28" src="https://user-images.githubusercontent.com/45561419/160586248-a74adf16-552c-41a1-9a03-213bcf8b0940.png">

