### PR TITLE
fix: only add chunk hash in prod

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -10,7 +10,8 @@ const DEV = process.env.NODE_ENV === 'development';
  */
 const generateName = (isLegacyJS) => {
 	const legacyString = isLegacyJS ? '.legacy' : '';
-	return `[name]${legacyString}.[chunkhash].js`;
+	const chunkhashString = DEV ? '' : '.[chunkhash]';
+	return `[name]${legacyString}${chunkhashString}.js`;
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Only add chunkhash to js assets in PROD. Follow-up on #4305 

## Why?

Otherwise local development environments cannot load JS files. Closes #4442 