### PR TITLE
Only stick videos on liveblogs

### DIFF
--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -135,6 +135,11 @@ export const renderElement = ({
 	isSensitive,
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
+
+	const isLiveBlog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
+
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return [
@@ -725,7 +730,7 @@ export const renderElement = ({
 						mediaTitle={element.mediaTitle}
 						altText={element.altText}
 						origin={host}
-						stickyVideos={switches.stickyVideos}
+						stickyVideos={isLiveBlog && switches.stickyVideos}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a check to ensure we only stick videos on live blogs and dead blogs, **not** on articles.

### Article Before
![Screenshot 2022-03-29 at 14 01 51](https://user-images.githubusercontent.com/77005274/160617107-0134e5f9-f4dc-4b27-aa88-a28cbc58e0cc.png)

### Article After
![Screenshot 2022-03-29 at 13 57 42](https://user-images.githubusercontent.com/77005274/160617130-ae615932-9bbc-4f3a-9afb-a3d6d25442b6.png)

