### PR TITLE
Cypress Consistency - Use mocks on article.e2e AB tests tests

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-1/article.e2e.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-1/article.e2e.spec.js
@@ -2,6 +2,7 @@ import { articles, AMPArticles } from '../../lib/articles.js';
 import { disableCMP } from '../../lib/disableCMP.js';
 import { setUrlFragment } from '../../lib/setUrlFragment.js';
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
+import { mockApi } from '../../lib/mocks';
 
 describe('E2E Page rendering', function () {
 	beforeEach(function () {
@@ -66,6 +67,10 @@ describe('E2E Page rendering', function () {
 	});
 
 	describe('AB Tests - Can modify page', function () {
+		beforeEach(function () {
+			mockApi();
+		});
+
 		it('should set the correct AB Test Variant', function () {
 			// The A/B test has an audience of 0.001 and test offset of 0
 			// Therefore the test will run from MVTIds 0 - 100


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use mocks on AB Test tests! The AB test test relies on on a `**/most-read/**` completing, by mocking this response we eliminate network conditions that might cause the call to fail!

Note: This is a guess as what might be causing the issue! I will monitor after merging to see if it helps!

## Why?

More consistent cypress tests = Yay
