### PR TITLE
Display facebook and twitter links on subnav until desktop

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -256,41 +256,49 @@ export const MoreColumn: React.FC<{
 				</ul>
 			</li>
 			<li css={columnStyle} role="none">
-				<li
-					key="facebook"
-					css={[mainMenuLinkStyle, hideDesktop]}
-					role="none"
+				<ul
+					css={[
+						columnLinks,
+						!!moreColumn.pillar && pillarColumnLinks,
+					]}
+					role="menu"
 				>
-					<a
-						className="selectableMenuItem"
-						css={columnLinkTitle}
-						data-link-name="nav2 : secondary : facebook"
-						href="https://www.facebook.com/theguardian"
-						role="menuitem"
-						tabIndex={-1}
+					<li
+						key="facebook"
+						css={[mainMenuLinkStyle, hideDesktop]}
+						role="none"
 					>
-						<FacebookIcon css={shareIconStyles} />
-						Facebook
-					</a>
-				</li>
+						<a
+							className="selectableMenuItem"
+							css={columnLinkTitle}
+							data-link-name="nav2 : secondary : facebook"
+							href="https://www.facebook.com/theguardian"
+							role="menuitem"
+							tabIndex={-1}
+						>
+							<FacebookIcon css={shareIconStyles} />
+							Facebook
+						</a>
+					</li>
 
-				<li
-					key="twitter"
-					css={[mainMenuLinkStyle, hideDesktop]}
-					role="none"
-				>
-					<a
-						className="selectableMenuItem"
-						css={columnLinkTitle}
-						data-link-name="nav2 : secondary : twitter"
-						href="https://twitter.com/guardian"
-						role="menuitem"
-						tabIndex={-1}
+					<li
+						key="twitter"
+						css={[mainMenuLinkStyle, hideDesktop]}
+						role="none"
 					>
-						<TwitterIconPadded css={shareIconStyles} />
-						Twitter
-					</a>
-				</li>
+						<a
+							className="selectableMenuItem"
+							css={columnLinkTitle}
+							data-link-name="nav2 : secondary : twitter"
+							href="https://twitter.com/guardian"
+							role="menuitem"
+							tabIndex={-1}
+						>
+							<TwitterIconPadded css={shareIconStyles} />
+							Twitter
+						</a>
+					</li>
+				</ul>
 			</li>
 		</>
 	);

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -9,6 +9,9 @@ import {
 	until,
 } from '@guardian/source-foundations';
 
+import FacebookIcon from '../../../../static/icons/facebook.svg';
+import TwitterIconPadded from '../../../../static/icons/twitter-padded.svg';
+
 const pillarHeight = 42;
 
 export const hideDesktop = css`
@@ -189,6 +192,15 @@ const mainMenuLinkStyle = css`
 	}
 `;
 
+const shareIconStyles = css`
+	fill: currentColor;
+	height: 28px;
+	left: 18px;
+	position: absolute;
+	top: 5px;
+	width: 28px;
+`;
+
 export const MoreColumn: React.FC<{
 	column: LinkType;
 	brandExtensions: LinkType[];
@@ -206,38 +218,80 @@ export const MoreColumn: React.FC<{
 		],
 	};
 	return (
-		<li
-			css={[columnStyle, pillarDivider, pillarDividerExtended]}
-			role="none"
-		>
-			<ul
-				css={[columnLinks, !!moreColumn.pillar && pillarColumnLinks]}
-				role="menu"
-				id={subNavId}
+		<>
+			<li
+				css={[columnStyle, pillarDivider, pillarDividerExtended]}
+				role="none"
 			>
-				{(moreColumn.children || []).map((link) => (
-					<li
-						key={link.title.toLowerCase()}
-						css={[
-							mainMenuLinkStyle,
-							!!link.mobileOnly && hideDesktop,
-						]}
-						role="none"
-					>
-						<a
-							className="selectableMenuItem"
-							css={columnLinkTitle}
-							href={link.url}
-							role="menuitem"
-							data-link-name={`nav2 : secondary : ${link.longTitle}`}
-							data-cy={`column-collapse-sublink-${link.title}`}
-							tabIndex={-1}
+				<ul
+					css={[
+						columnLinks,
+						!!moreColumn.pillar && pillarColumnLinks,
+					]}
+					role="menu"
+					id={subNavId}
+				>
+					{(moreColumn.children || []).map((link) => (
+						<li
+							key={link.title.toLowerCase()}
+							css={[
+								mainMenuLinkStyle,
+								!!link.mobileOnly && hideDesktop,
+							]}
+							role="none"
 						>
-							{link.longTitle}
-						</a>
-					</li>
-				))}
-			</ul>
-		</li>
+							<a
+								className="selectableMenuItem"
+								css={columnLinkTitle}
+								href={link.url}
+								role="menuitem"
+								data-link-name={`nav2 : secondary : ${link.longTitle}`}
+								data-cy={`column-collapse-sublink-${link.title}`}
+								tabIndex={-1}
+							>
+								{link.longTitle}
+							</a>
+						</li>
+					))}
+				</ul>
+			</li>
+			<li css={columnStyle} role="none">
+				<li
+					key="facebook"
+					css={[mainMenuLinkStyle, hideDesktop]}
+					role="none"
+				>
+					<a
+						className="selectableMenuItem"
+						css={columnLinkTitle}
+						data-link-name="nav2 : secondary : facebook"
+						href="https://www.facebook.com/theguardian"
+						role="menuitem"
+						tabIndex={-1}
+					>
+						<FacebookIcon css={shareIconStyles} />
+						Facebook
+					</a>
+				</li>
+
+				<li
+					key="twitter"
+					css={[mainMenuLinkStyle, hideDesktop]}
+					role="none"
+				>
+					<a
+						className="selectableMenuItem"
+						css={columnLinkTitle}
+						data-link-name="nav2 : secondary : twitter"
+						href="https://twitter.com/guardian"
+						role="menuitem"
+						tabIndex={-1}
+					>
+						<TwitterIconPadded css={shareIconStyles} />
+						Twitter
+					</a>
+				</li>
+			</li>
+		</>
 	);
 };


### PR DESCRIPTION
## What does this change?
This adds twitter and facebook links to the subnav until desktop. The [designs](https://www.figma.com/file/V8u2r27TFdjAWNM3p84ypC/%E2%9C%AD-Header-%26-footer?node-id=2378%3A91098) specify that we only see these share links in the subnav until desktop.

## Why?
These links were missing in the DCR version of the subnav. This change gets us closer to the intended design. This change forms part of this issue: https://github.com/guardian/dotcom-rendering/issues/4434

| Frontend      | DCR before      | DCR after      |
|-------------|------------|-----------|
| ![frontend][] | ![dcrBefore][] | ![dcrAfter][] |

[frontend]: https://user-images.githubusercontent.com/45561419/160650106-1c4099da-d652-4983-a212-dea43885d66a.png
[dcrBefore]: https://user-images.githubusercontent.com/45561419/160649944-434499f8-eb7b-4ebe-b46e-1da99b9b1aa2.png
[dcrAfter]: https://user-images.githubusercontent.com/45561419/160650034-70ad2506-d935-4cec-b5f0-cdb211a5995b.png
