### PR TITLE
Add subnav pillar styling on focus

### DIFF
--- a/dotcom-rendering/src/web/components/Pillars.tsx
+++ b/dotcom-rendering/src/web/components/Pillars.tsx
@@ -87,7 +87,8 @@ const showMenuUnderlineStyles = css`
 			}
 		}
 
-		:hover {
+		:hover,
+		:focus {
 			text-decoration: underline;
 			color: ${brandAlt[400]};
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
In https://github.com/guardian/dotcom-rendering/pull/4440 we updated the pillar styling on the subnav to match the design but also get us closer to meeting certain accessibility standards (underline + colour change on `hover`). However, this styling was never applied on `focus` so readers using keyboard navigation would miss these visual cues. This change applies the same pillar styling to for `focus`.

## Why?
This will be better for readers using keyboard navigation.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/160787643-9533fed3-4eb2-454b-899d-4c14a649b571.png
[after]: https://user-images.githubusercontent.com/45561419/160787708-2bee7834-89bf-4861-a7de-93b62ddc46de.png


