### PR TITLE
`GetMatchNav` falls back to headline on error

### DIFF
--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -1,16 +1,29 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source-foundations';
 import { useApi } from '../lib/useApi';
 
 import { Placeholder } from './Placeholder';
 
 import { MatchNav } from './MatchNav';
+import { ArticleHeadline } from './ArticleHeadline';
 
 type Props = {
 	matchUrl: string;
+	headlineString: string;
+	format: ArticleFormat;
+	tags: TagType[];
+	webPublicationDateDeprecated: string;
 };
 
 const Loading = () => <Placeholder height={230} />;
 
-export const GetMatchNav = ({ matchUrl }: Props) => {
+export const GetMatchNav = ({
+	matchUrl,
+	headlineString,
+	format,
+	tags,
+	webPublicationDateDeprecated,
+}: Props) => {
 	const { data, error, loading } = useApi<{
 		homeTeam: TeamType;
 		awayTeam: TeamType;
@@ -21,10 +34,28 @@ export const GetMatchNav = ({ matchUrl }: Props) => {
 
 	if (loading) return <Loading />;
 	if (error) {
-		// Send the error to Sentry and then prevent the element from rendering
+		// Send the error to Sentry and then render the headline in its place as a fallback
 		window.guardian?.modules?.sentry?.reportError?.(error, 'match-nav');
 
-		return null;
+		return (
+			<div
+				css={css`
+					${from.leftCol} {
+						margin-left: 10px;
+					}
+					${from.desktop} {
+						max-width: 700px;
+					}
+				`}
+			>
+				<ArticleHeadline
+					headlineString={headlineString}
+					format={format}
+					tags={tags}
+					webPublicationDateDeprecated={webPublicationDateDeprecated}
+				/>
+			</div>
+		);
 	}
 	if (data) {
 		return (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -422,7 +422,15 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 								clientOnly={true}
 								placeholderHeight={230}
 							>
-								<GetMatchNav matchUrl={CAPI.matchUrl} />
+								<GetMatchNav
+									matchUrl={CAPI.matchUrl}
+									format={format}
+									headlineString={CAPI.headline}
+									tags={CAPI.tags}
+									webPublicationDateDeprecated={
+										CAPI.webPublicationDateDeprecated
+									}
+								/>
 							</Island>
 						</ContainerLayout>
 					) : (

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -495,6 +495,12 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 										>
 											<GetMatchNav
 												matchUrl={CAPI.matchUrl}
+												format={format}
+												headlineString={CAPI.headline}
+												tags={CAPI.tags}
+												webPublicationDateDeprecated={
+													CAPI.webPublicationDateDeprecated
+												}
 											/>
 										</Island>
 									)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
If there is an error when making the call to get match nav then we now fallback to rendering the article headline

## Why?
Because sometimes the only way for us to know if match data is available is to make an api call but that call can return a 404 which is a 'valid' response and tells the client that no data was able to be returned. In this scenario we should fallback to rendering the headline

### Before
<img width="1017" alt="Screenshot 2022-03-30 at 17 07 41" src="https://user-images.githubusercontent.com/1336821/160868989-fd5737be-3d70-48f1-aa1d-90914fd398ea.png">


### After
<img width="1017" alt="Screenshot 2022-03-30 at 17 07 59" src="https://user-images.githubusercontent.com/1336821/160868983-3789817d-377e-4551-b54b-4d9e69938da2.png">
