### PR TITLE
Update lazy load margin test

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
@@ -20,35 +20,35 @@ export const commercialLazyLoadMargin: ABTest = {
 			test: (): void => {},
 		},
 		{
-			id: 'variant 1',
+			id: 'variant-1',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 2',
+			id: 'variant-2',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 3',
+			id: 'variant-3',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 4',
+			id: 'variant-4',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 5',
+			id: 'variant-5',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 6',
+			id: 'variant-6',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 7',
+			id: 'variant-7',
 			test: (): void => {},
 		},
 		{
-			id: 'variant 8',
+			id: 'variant-8',
 			test: (): void => {},
 		},
 	],

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin.ts
@@ -5,18 +5,52 @@ export const commercialLazyLoadMargin: ABTest = {
 	author: 'Zeke Hunter-Green (@zekehuntergreen)',
 	description:
 		'Test various margins at which ads are lazily-loaded in order to find the optimal one',
-	start: '2022-03-24',
-	// test should be in place for a minimum of 14 days
-	expiry: '2022-04-14',
-	audience: 5 / 100,
-	audienceOffset: 11 / 100,
+	start: '2022-03-29',
+	// test should be in place for a minimum of 16 days
+	expiry: '2022-04-19',
+	audience: 10 / 100,
+	audienceOffset: 10 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
 	idealOutcome:
 		'One of the variants shows a marked improvement in all of the metrics that we are considering',
 	variants: [
-		{ id: 'control', test: (): void => {} },
-		{ id: 'variant', test: (): void => {} },
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 1',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 2',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 3',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 4',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 5',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 6',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 7',
+			test: (): void => {},
+		},
+		{
+			id: 'variant 8',
+			test: (): void => {},
+		},
 	],
 	canRun: () => true,
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates duration, audience, offset, and variants of the lazy load margin test

## Why?
See description in https://github.com/guardian/frontend/pull/24839
