### PR TITLE
fix: Render key event bullets in the correct place in Firefox

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -97,7 +97,6 @@ const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 		content: '';
 		display: block;
 		position: absolute;
-		top: 0;
 		left: -0.313rem;
 		height: 0.563rem;
 		width: 0.563rem;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Seems like firefox is treating `position: absolute;` differently than other browsers. This `top` styling doesn't seem to actually do anything except break the styling on firefox.

## Why?

Closes #4471

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/161025129-12560715-c9c8-4ebf-af6d-5c86963c5c42.png
[after]: https://user-images.githubusercontent.com/21217225/161025242-67aa9f09-f26a-4275-8167-59dc2f20a5b3.png
