### PR TITLE
Carousel margins at tablet

### DIFF
--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -72,48 +72,26 @@ const wrapperStyle = (length: number) => css`
 const isLastCardShowing = (index: number, totalStories: number) =>
 	index >= totalStories - 4;
 
-const containerMargins = (format: ArticleFormat) => {
-	switch (format.design) {
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog: {
-			return css`
-				margin-top: 6px;
-				margin-bottom: 24px;
+const containerMargins = css`
+	margin-top: 6px;
+	margin-bottom: 24px;
 
-				margin-left: 0px;
-				margin-right: 0px;
+	margin-left: 0px;
+	margin-right: 0px;
 
-				${from.leftCol} {
-					margin-left: -1px;
-					margin-right: -10px;
-					margin-top: 6px;
-				}
-			`;
-		}
-		default: {
-			return css`
-				margin-top: 6px;
-				margin-bottom: 24px;
-
-				margin-left: 0px;
-				margin-right: 0px;
-
-				${from.tablet} {
-					/* Shrink the container to remove the leading and
+	${from.tablet} {
+		/* Shrink the container to remove the leading and
        				   trailing side margins from the list of cards */
-					margin-left: -10px;
-					margin-right: -10px;
-				}
-
-				${from.leftCol} {
-					margin-left: -1px;
-					margin-right: -10px;
-					margin-top: 6px;
-				}
-			`;
-		}
+		margin-left: -10px;
+		margin-right: -10px;
 	}
-};
+
+	${from.leftCol} {
+		margin-left: -1px;
+		margin-right: -10px;
+		margin-top: 6px;
+	}
+`;
 
 const containerStyles = css`
 	display: flex;
@@ -635,7 +613,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 				</button>
 			</div>
 			<div
-				css={[containerStyles, containerMargins(format)]}
+				css={[containerStyles, containerMargins]}
 				data-component={ophanComponentName}
 				data-link={formatAttrString(heading)}
 			>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4149 by adjusting the margins margins for tablet

The actual change here is to include the tablet css but that then removed the need to have the switch on `format` so I simplified that function

### Before
<img width="255" alt="Screenshot 2022-03-31 at 15 36 48" src="https://user-images.githubusercontent.com/1336821/161068030-51474a30-be58-465a-8de5-6f156b893cd3.png">

### After
<img width="255" alt="Screenshot 2022-03-31 at 15 37 12" src="https://user-images.githubusercontent.com/1336821/161068027-81d21d14-6821-4676-8e81-203669b8a855.png">
