### PR TITLE
Paragraph spacing in blockquotes

### DIFF
--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -23,6 +23,9 @@ export const BlockquoteBlockComponent: React.FC<Props> = ({
 				margin-bottom: 16px;
 				${body.medium()};
 				font-style: italic;
+				p {
+					margin-bottom: 8px;
+				}
 			`;
 
 			const simpleBlockquoteStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4429 by adding 8px of space below paragraphs in blockquotes

### Before
<img width="726" alt="Screenshot 2022-03-31 at 17 13 10" src="https://user-images.githubusercontent.com/1336821/161089381-31ea10d1-6e7e-40da-8e1a-345b0041c4b4.png">


### After
<img width="726" alt="Screenshot 2022-03-31 at 17 12 37" src="https://user-images.githubusercontent.com/1336821/161089331-4b5daeb3-b824-4319-8e7f-515d11c17532.png">

