### PR TITLE
Remove 'stick' and 'close' tracking from `YoutubeBlockComponent`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -59,7 +59,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^22.6.2",
+    "@guardian/atoms-rendering": "^23.1.0",
     "@guardian/braze-components": "^7.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -7,7 +7,7 @@ import { YoutubeAtom } from '@guardian/atoms-rendering';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
 import { trackVideoInteraction } from '../browser/ga/ga';
-import { record, submitComponentEvent } from '../browser/ophan/ophan';
+import { record } from '../browser/ophan/ophan';
 
 import { Caption } from './Caption';
 
@@ -154,32 +154,14 @@ export const YoutubeBlockComponent = ({
 
 	const ophanTracking = (trackingEvent: string) => {
 		if (!id) return;
-
-		if (trackingEvent === 'stick') {
-			submitComponentEvent({
-				component: {
-					componentType: 'STICKY_VIDEO',
-					id: assetId,
-				},
-				action: 'STICK',
-			});
-		} else if (trackingEvent === 'close') {
-			submitComponentEvent({
-				component: {
-					componentType: 'STICKY_VIDEO',
-					id: assetId,
-				},
-				action: 'CLOSE',
-			});
-		} else {
-			record({
-				video: {
-					id: `gu-video-youtube-${id}`,
-					eventType: `video:content:${trackingEvent}`,
-				},
-			});
-		}
+		record({
+			video: {
+				id: `gu-video-youtube-${id}`,
+				eventType: `video:content:${trackingEvent}`,
+			},
+		});
 	};
+
 	const gaTracking = (trackingEvent: string) => {
 		if (!id) return;
 		trackVideoInteraction({
@@ -191,7 +173,8 @@ export const YoutubeBlockComponent = ({
 	return (
 		<div data-chromatic="ignore" data-component="youtube-atom">
 			<YoutubeAtom
-				assetId={assetId}
+				elementId={id}
+				videoId={assetId}
 				overrideImage={
 					overrideImage
 						? [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,10 +2802,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^22.6.2":
-  version "22.6.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.6.2.tgz#43a9d70173cfae9002d707fffc31f3627a875790"
-  integrity sha512-SFfTea4Y+CjvyuidXG+5x9HvgJi80/J9ypdrOUsdaxFkMPAL1zaYN0Jl+zcYkRxBNkJvS470Og6GYLsiR9XI+w==
+"@guardian/atoms-rendering@^23.1.0":
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.1.0.tgz#4091406e9fed553eba3278f5b563d489d2108222"
+  integrity sha512-ezw42JHr5HJQaoKlL9GzouCF+07//n6rRrZhKuzYPY3WcWSkGfvQGWBNdJ7FS6pon/6qhApZsxy3BDTvBSeD4w==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR removes the `STICK` and `CLOSE` component event tracking from `YoutubeBlockComponent`.

The companion PR in Atoms-Rendering which brings that tracking into the `YoutubeAtomSticky` component is here:
https://github.com/guardian/atoms-rendering/pull/379/files


## Why?

The benefit of this is that we keep the video player events, and the sticky video events separate, and remove the need for a conditional on the `ophanTracking` function.

