### PR TITLE
Bump `atoms-rendering` to v23.0.2

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -2,7 +2,7 @@ import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
-const interceptPlayEvent = (id) => {
+const interceptPlayEvent = ({ id }) => {
 	return cy.intercept(
 		{
 			url: 'http://ophan.theguardian.com/img/2?**',
@@ -104,9 +104,9 @@ describe('YouTube Atom', function () {
 		cy.window().its('onYouTubeIframeAPIReady').should('not.exist');
 
 		// Listen for the ophan call made when the video is played
-		interceptPlayEvent(
-			'gu-video-youtube-2b33a7b7-e639-4232-9ecd-0fb920fa8147',
-		).as('ophanCall');
+		interceptPlayEvent({
+			id: 'gu-video-youtube-2b33a7b7-e639-4232-9ecd-0fb920fa8147',
+		}).as('ophanCall');
 
 		// Listen for the YouTube embed call made when the video is played
 		interceptYouTubeEmbed({
@@ -150,9 +150,9 @@ describe('YouTube Atom', function () {
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
-		interceptPlayEvent(
-			'gu-video-youtube-2bc6f709-865e-49ae-b01b-8fc38eb4e9a7',
-		).as('ophanCall');
+		interceptPlayEvent({
+			id: 'gu-video-youtube-2bc6f709-865e-49ae-b01b-8fc38eb4e9a7',
+		}).as('ophanCall');
 
 		// Listen for the YouTube embed call made when the video is played
 		interceptYouTubeEmbed({
@@ -211,9 +211,9 @@ describe('YouTube Atom', function () {
 			.and('be.visible');
 
 		// Listen for the ophan call made when the video is played
-		interceptPlayEvent(
-			'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec',
-		).as('ophanCall');
+		interceptPlayEvent({
+			id: 'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec',
+		}).as('ophanCall');
 
 		// Listen for the YouTube embed call made when the video is played
 		interceptYouTubeEmbed({
@@ -274,9 +274,9 @@ describe('YouTube Atom', function () {
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
-		interceptPlayEvent(
-			'gu-video-youtube-2bc6f709-865e-49ae-b01b-8fc38eb4e9a7',
-		).as('ophanCall');
+		interceptPlayEvent({
+			id: 'gu-video-youtube-2bc6f709-865e-49ae-b01b-8fc38eb4e9a7',
+		}).as('ophanCall');
 
 		// Listen for the YouTube embed call made when the video is played
 		interceptYouTubeEmbed({

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -177,7 +177,7 @@ describe('YouTube Atom', function () {
 	it('plays in video when same video exists both in body and in main media of the blog', function () {
 		// cy.intercept('**youtube**').as('callToYouTube');
 		cy.visit(
-			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates',
+			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);
 		cmpIframe().contains("It's your choice");
 		cmpIframe().find("[title='Manage my cookies']").click();

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -2,13 +2,14 @@ import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
-const interceptPlayEvent = ({ id }) => {
+const interceptPlayEvent = ({ id, times = 1 }) => {
 	return cy.intercept(
 		{
 			url: 'http://ophan.theguardian.com/img/2?**',
 			query: {
 				video: /(.*)eventType\":\"video:content:play(.*)/,
 			},
+			times,
 		},
 		function (req) {
 			const url = new URL(req.url);
@@ -21,10 +22,11 @@ const interceptPlayEvent = ({ id }) => {
 	);
 };
 
-const interceptYouTubeEmbed = ({ videoId, adUnit, pageUrl, rejectAll }) => {
+const interceptYouTubeEmbed = ({ videoId, adUnit, pageUrl, rejectAll, times = 1 }) => {
 	return cy.intercept(
 		{
 			url: `https://www.youtube.com/embed/${videoId}?**`,
+			times,
 		},
 		function (req) {
 			// https://guardian.github.io/commercial-request-parser/ is useful to parse YouTube requests

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -195,18 +195,24 @@ describe('YouTube Atom', function () {
 		const mediaDiv = 'div[data-gu-name="media"]';
 		const bodyDiv = 'div[data-gu-name="body"]';
 		const overlaySelectorforMultipleVideos = `[data-cy^="youtube-overlay-qkC9z-dSAOE"]`;
-		
-		cy.get(mediaDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos)
-		}).should('have.length', 1).and('be.visible');
 
-		cy.get(bodyDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos)
-		}).should('have.length', 1).and('be.visible');
+		cy.get(mediaDiv)
+			.within(() => {
+				cy.get(overlaySelectorforMultipleVideos);
+			})
+			.should('have.length', 1)
+			.and('be.visible');
+
+		cy.get(bodyDiv)
+			.within(() => {
+				cy.get(overlaySelectorforMultipleVideos);
+			})
+			.should('have.length', 1)
+			.and('be.visible');
 
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent(
-			'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec'
+			'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec',
 		).as('ophanCall');
 
 		// Listen for the YouTube embed call made when the video is played
@@ -220,21 +226,21 @@ describe('YouTube Atom', function () {
 
 		// Play main media video
 		cy.get(mediaDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos).click()
+			cy.get(overlaySelectorforMultipleVideos).click();
 		});
 
 		// check if the ophan call and YouTube embed call were made
 		cy.wait('@ophanCall', { timeout: 30000 });
 		cy.wait('@youtubeEmbed', { timeout: 30000 });
-		
+
 		// check if the main media video overplay is gone
 		cy.get(mediaDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos).should('not.exist')
+			cy.get(overlaySelectorforMultipleVideos).should('not.exist');
 		});
 
 		// Play body video
 		cy.get(bodyDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos).click()
+			cy.get(overlaySelectorforMultipleVideos).click();
 		});
 
 		// check if the second ophan call and YouTube embed call were made
@@ -243,7 +249,7 @@ describe('YouTube Atom', function () {
 
 		// check if the body video overplay is gone
 		cy.get(bodyDiv).within(() => {
-			cy.get(overlaySelectorforMultipleVideos).should('not.exist')
+			cy.get(overlaySelectorforMultipleVideos).should('not.exist');
 		});
 	});
 

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -174,7 +174,7 @@ describe('YouTube Atom', function () {
 		cy.get(overlaySelector).should('not.exist');
 	});
 
-	it('plays in video when same video exists both in body and in main media of the blog', function () {
+	it('plays when the same video exists both in body and in main media of the blog', function () {
 		// cy.intercept('**youtube**').as('callToYouTube');
 		cy.visit(
 			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
@@ -253,7 +253,7 @@ describe('YouTube Atom', function () {
 		});
 	});
 
-	it('still plays the video if the reader rejects consent', function () {
+	it('plays the video if the reader rejects consent', function () {
 		cy.visit(
 			'/Article?url=https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -194,8 +194,12 @@ describe('YouTube Atom', function () {
 
 		// Wait for hydration
 		cy.get('[data-component=youtube-atom]')
-			.parent()
-			.should('have.attr', 'data-gu-ready', 'true');
+			.should('have.length', 3)
+			.each((item) => {
+				cy.wrap(item)
+					.parent()
+					.should('have.attr', 'data-gu-ready', 'true');
+			});
 
 		// Make sure overlays for both videos are displayed
 		const mediaDiv = 'div[data-gu-name="media"]';

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -97,7 +97,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = `[data-cy="youtube-overlay-S0CE1n-R3OY"]`;
+		const overlaySelector = `[data-cy^="youtube-overlay-S0CE1n-R3OY"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// YouTube has not initialised
@@ -146,7 +146,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = `[data-cy="youtube-overlay-NtN-a6inr1E"]`;
+		const overlaySelector = `[data-cy^="youtube-overlay-NtN-a6inr1E"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played
@@ -191,7 +191,7 @@ describe('YouTube Atom', function () {
 			.should('have.attr', 'data-gu-ready', 'true');
 
 		// Make sure overlay is displayed
-		const overlaySelector = `[data-cy="youtube-overlay-NtN-a6inr1E"]`;
+		const overlaySelector = `[data-cy^="youtube-overlay-NtN-a6inr1E"]`;
 		cy.get(overlaySelector).should('be.visible');
 
 		// Listen for the ophan call made when the video is played

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -137,7 +137,6 @@ describe('YouTube Atom', function () {
 	});
 
 	it('plays in body videos', function () {
-		// cy.intercept('**youtube**').as('callToYouTube');
 		cy.visit(
 			'/Article?url=https://www.theguardian.com/environment/2021/oct/05/volcanoes-are-life-how-the-ocean-is-enriched-by-eruptions-devastating-on-land',
 		);
@@ -178,12 +177,11 @@ describe('YouTube Atom', function () {
 
 		cy.wait('@youtubeEmbed', { timeout: 30000 });
 
-		// // Video is playing, overlay is gone
+		// Video is playing, overlay is gone
 		cy.get(overlaySelector).should('not.exist');
 	});
 
 	it('plays when the same video exists both in body and in main media of the blog', function () {
-		// cy.intercept('**youtube**').as('callToYouTube');
 		cy.visit(
 			'/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates?dcr=true',
 		);

--- a/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/atom.video.spec.js
@@ -22,7 +22,13 @@ const interceptPlayEvent = ({ id, times = 1 }) => {
 	);
 };
 
-const interceptYouTubeEmbed = ({ videoId, adUnit, pageUrl, rejectAll, times = 1 }) => {
+const interceptYouTubeEmbed = ({
+	videoId,
+	adUnit,
+	pageUrl,
+	rejectAll,
+	times = 1,
+}) => {
 	return cy.intercept(
 		{
 			url: `https://www.youtube.com/embed/${videoId}?**`,
@@ -212,10 +218,14 @@ describe('YouTube Atom', function () {
 			.should('have.length', 1)
 			.and('be.visible');
 
+		/**
+		 * Main media video
+		 */
+
 		// Listen for the ophan call made when the video is played
 		interceptPlayEvent({
 			id: 'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec',
-		}).as('ophanCall');
+		}).as('ophanCall1');
 
 		// Listen for the YouTube embed call made when the video is played
 		interceptYouTubeEmbed({
@@ -224,35 +234,53 @@ describe('YouTube Atom', function () {
 			pageUrl:
 				'/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates',
 			rejectAll: false,
-		}).as('youtubeEmbed');
+		}).as('youtubeEmbed1');
 
 		// Play main media video
 		cy.get(mediaDiv).within(() => {
 			cy.get(overlaySelectorforMultipleVideos).click();
 		});
 
-		// check if the ophan call and YouTube embed call were made
-		cy.wait('@ophanCall', { timeout: 30000 });
-		cy.wait('@youtubeEmbed', { timeout: 30000 });
-
 		// check if the main media video overplay is gone
 		cy.get(mediaDiv).within(() => {
 			cy.get(overlaySelectorforMultipleVideos).should('not.exist');
 		});
+
+		// check if the ophan call and YouTube embed call were made
+		cy.wait('@ophanCall1', { timeout: 30000 });
+		cy.wait('@youtubeEmbed1', { timeout: 30000 });
+
+		/**
+		 * Body video
+		 */
+
+		// Listen for the ophan call made when the video is played
+		interceptPlayEvent({
+			id: 'gu-video-youtube-1e89d5bd-489e-470a-857e-4f30e85b5aec',
+		}).as('ophanCall2');
+
+		// Listen for the YouTube embed call made when the video is played
+		interceptYouTubeEmbed({
+			videoId: 'qkC9z-dSAOE',
+			adUnit: '/59666047/theguardian.com/world/liveblog/ng',
+			pageUrl:
+				'/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates',
+			rejectAll: false,
+		}).as('youtubeEmbed2');
 
 		// Play body video
 		cy.get(bodyDiv).within(() => {
 			cy.get(overlaySelectorforMultipleVideos).click();
 		});
 
-		// check if the second ophan call and YouTube embed call were made
-		cy.wait('@ophanCall', { timeout: 30000 });
-		cy.wait('@youtubeEmbed', { timeout: 30000 });
-
 		// check if the body video overplay is gone
 		cy.get(bodyDiv).within(() => {
 			cy.get(overlaySelectorforMultipleVideos).should('not.exist');
 		});
+
+		// check if the ophan call and YouTube embed call were made
+		cy.wait('@ophanCall2', { timeout: 30000 });
+		cy.wait('@youtubeEmbed2', { timeout: 30000 });
 	});
 
 	it('plays the video if the reader rejects consent', function () {

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -59,7 +59,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^22.6.2",
+    "@guardian/atoms-rendering": "^23.0.0",
     "@guardian/braze-components": "^7.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -59,7 +59,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.0.0",
+    "@guardian/atoms-rendering": "^23.0.2",
     "@guardian/braze-components": "^7.1.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.3.1",

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -230,7 +230,7 @@ export const YoutubeBlockComponent = ({
 				eventEmitters={[ophanTracking, gaTracking]}
 				pillar={format.theme}
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
-				shouldStick={stickyVideos}
+				shouldStick={!!stickyVideos}
 				isMainMedia={isMainMedia}
 			/>
 			{!hideCaption && (

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -13,6 +13,7 @@ import { Caption } from './Caption';
 
 type Props = {
 	id: string;
+	elementId: string;
 	mediaTitle?: string;
 	altText?: string;
 	assetId: string;
@@ -70,6 +71,7 @@ const expiredSVGWrapperStyles = css`
 
 export const YoutubeBlockComponent = ({
 	id,
+	elementId,
 	assetId,
 	mediaTitle,
 	altText,
@@ -191,7 +193,7 @@ export const YoutubeBlockComponent = ({
 	return (
 		<div data-chromatic="ignore" data-component="youtube-atom">
 			<YoutubeAtom
-				elementId={id}
+				elementId={elementId}
 				videoId={assetId}
 				overrideImage={
 					overrideImage

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -32,7 +32,7 @@ type Props = {
 	width?: number;
 	duration?: number; // in seconds
 	origin?: string;
-	stickyVideos?: boolean;
+	stickyVideos: boolean;
 };
 
 const expiredOverlayStyles = (overrideImage: string) => css`
@@ -232,7 +232,7 @@ export const YoutubeBlockComponent = ({
 				eventEmitters={[ophanTracking, gaTracking]}
 				pillar={format.theme}
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
-				shouldStick={!!stickyVideos}
+				shouldStick={stickyVideos}
 				isMainMedia={isMainMedia}
 			/>
 			{!hideCaption && (

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -191,7 +191,8 @@ export const YoutubeBlockComponent = ({
 	return (
 		<div data-chromatic="ignore" data-component="youtube-atom">
 			<YoutubeAtom
-				assetId={assetId}
+				elementId={id}
+				videoId={assetId}
 				overrideImage={
 					overrideImage
 						? [

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.stories.tsx
@@ -57,6 +57,7 @@ export const Default = () => {
 				expired={false}
 				// eslint-disable-next-line jsx-a11y/aria-role
 				role="inline"
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -93,6 +94,7 @@ export const Vertical = () => {
 				role="inline"
 				height={259}
 				width={460}
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -130,6 +132,7 @@ export const Expired = () => {
 				role="inline"
 				height={259}
 				width={460}
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -168,6 +171,7 @@ export const WithOverlayImage = () => {
 				role="inline"
 				height={259}
 				width={460}
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -227,6 +231,7 @@ export const WithPosterImage = () => {
 				role="inline"
 				height={259}
 				width={460}
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -287,6 +292,7 @@ export const WithPosterAndOverlayImage = () => {
 				role="inline"
 				height={259}
 				width={460}
+				stickyVideos={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.stories.tsx
@@ -53,6 +53,7 @@ export const Default = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={false}
 				// eslint-disable-next-line jsx-a11y/aria-role
 				role="inline"
@@ -86,6 +87,7 @@ export const Vertical = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={false}
 				// eslint-disable-next-line jsx-a11y/aria-role
 				role="inline"
@@ -121,6 +123,7 @@ export const Expired = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={true}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				// eslint-disable-next-line jsx-a11y/aria-role
@@ -157,6 +160,7 @@ export const WithOverlayImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={false}
 				duration={333}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
@@ -194,6 +198,7 @@ export const WithPosterImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={false}
 				duration={333}
 				posterImage={[
@@ -252,6 +257,7 @@ export const WithPosterAndOverlayImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				elementId="5ab531a2-f6ea-499d-b274-191114c8628c"
 				expired={false}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				duration={333}

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -722,6 +722,7 @@ export const renderElement = ({
 						adTargeting={adTargeting}
 						isMainMedia={isMainMedia}
 						id={element.id}
+						elementId={element.elementId}
 						assetId={element.assetId}
 						expired={element.expired}
 						overrideImage={element.overrideImage}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,10 +2802,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^22.6.2":
-  version "22.6.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-22.6.2.tgz#43a9d70173cfae9002d707fffc31f3627a875790"
-  integrity sha512-SFfTea4Y+CjvyuidXG+5x9HvgJi80/J9ypdrOUsdaxFkMPAL1zaYN0Jl+zcYkRxBNkJvS470Og6GYLsiR9XI+w==
+"@guardian/atoms-rendering@^23.0.0":
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.0.0.tgz#09074dce6836bf35d7c911ac2427d65f3d0aeb8b"
+  integrity sha512-s0Fwqf/cZmUd/pXk1+m/bPmScqCUcXO15wWhhTPQT9mLuDxkampMwqz3hiAjmae1Rc3RpKu/WyMOfK4CcVokMA==
   dependencies:
     youtube-player "^5.5.2"
 
@@ -19622,9 +19622,9 @@ type-detect@4.0.8:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.4.0, type-fest@^2.8.0:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.1.tgz#d2be8f50bf5f8f0a5fd916d29bf3e98c17e960be"
-  integrity sha512-AiknQSEqKVGDDjtZqeKrUoTlcj7FKhupmnVUgz6KoOKtvMwRGE6hUNJ/nVear+h7fnUPO1q/htSkYKb1pyntkQ==
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
 
 type-is@~1.6.18:
   version "1.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,10 +2802,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.0.0":
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.0.0.tgz#09074dce6836bf35d7c911ac2427d65f3d0aeb8b"
-  integrity sha512-s0Fwqf/cZmUd/pXk1+m/bPmScqCUcXO15wWhhTPQT9mLuDxkampMwqz3hiAjmae1Rc3RpKu/WyMOfK4CcVokMA==
+"@guardian/atoms-rendering@^23.0.2":
+  version "23.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.0.2.tgz#022ade58a313b4b5c9858d624d7db751dabb31d1"
+  integrity sha512-82PGb+yzs6wLAxpn/kuDoWxYlEuXNEJpJ7ONkUV8k8tesGi2tEiDEwH5/gURgmpe/I+GkKm2n46bsxRczZ74FA==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
## Why?

Bump `atoms-rendering` to the latest version to bring in:

### v22.6.3
Fix sticky video content layout jump:
https://github.com/guardian/atoms-rendering/pull/374
Unstick YoutubeAtom on pause:
https://github.com/guardian/atoms-rendering/pull/376

### v23.0.0
YoutubeAtom - Fix Duplicate Videos:
https://github.com/guardian/atoms-rendering/pull/365

| Before      | After |
| ----------- | ----------- |
|   ![Screenshot 2022-03-24 at 11 24 08](https://user-images.githubusercontent.com/7014230/159906969-fdc1b292-11fe-488d-a249-01ecd430db90.png) | ![Screenshot 2022-03-24 at 11 24 55](https://user-images.githubusercontent.com/7014230/159907000-050ff3d3-f968-47cb-a284-86af6d9c93b4.png) |

### v23.0.1
YoutubeAtom - stop other playing videos when a video plays
https://github.com/guardian/atoms-rendering/pull/373

https://user-images.githubusercontent.com/15894063/161256708-d7620ea1-7d15-457a-af80-625be820df49.mov

### v23.0.2
YoutubeAtom - fix dispatch play event when duplicate videos exist in page
https://github.com/guardian/atoms-rendering/pull/383

https://user-images.githubusercontent.com/15894063/161565631-a053d22c-f89b-4a1f-aa53-c3a6c4cb4ac9.mov