### PR TITLE
Poll for latest stats

### DIFF
--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
+import { SWRConfiguration } from 'swr';
+import { ArticleDesign } from '@guardian/libs';
 import { useApi } from '../lib/useApi';
 
 import { Placeholder } from './Placeholder';
@@ -24,13 +26,18 @@ export const GetMatchNav = ({
 	tags,
 	webPublicationDateDeprecated,
 }: Props) => {
+	const options: SWRConfiguration = { errorRetryCount: 1 };
+	// If this blog is live then poll for new stats
+	if (format.design === ArticleDesign.LiveBlog) {
+		options.refreshInterval = 16_000;
+	}
 	const { data, error, loading } = useApi<{
 		homeTeam: TeamType;
 		awayTeam: TeamType;
 		comments?: string;
 		minByMinUrl?: string;
 		venue?: string;
-	}>(matchUrl, { errorRetryCount: 1 });
+	}>(matchUrl, options);
 
 	if (loading) return <Loading />;
 	if (error) {

--- a/dotcom-rendering/src/web/components/GetMatchStats.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchStats.importable.tsx
@@ -1,3 +1,5 @@
+import { ArticleDesign } from '@guardian/libs';
+import { SWRConfiguration } from 'swr';
 import { useApi } from '../lib/useApi';
 
 import { Placeholder } from './Placeholder';
@@ -12,11 +14,16 @@ type Props = {
 const Loading = () => <Placeholder height={800} />;
 
 export const GetMatchStats = ({ matchUrl, format }: Props) => {
+	const options: SWRConfiguration = {};
+	// If this blog is live then poll for new stats
+	if (format.design === ArticleDesign.LiveBlog) {
+		options.refreshInterval = 14_000;
+	}
 	const { data, error, loading } = useApi<{
 		id: string;
 		homeTeam: TeamType;
 		awayTeam: TeamType;
-	}>(matchUrl);
+	}>(matchUrl, options);
 
 	if (loading) return <Loading />;
 	if (error) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds polling for sport live blogs

## Why?
So that we show the latest match stats without the page needing to be refreshed.
