### PR TITLE
Show black text on yellow backgrounds

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -88,6 +88,7 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 						case ArticlePillar.News:
 							return news[600];
 						case ArticlePillar.Sport:
+							return BLACK;
 						case ArticlePillar.Lifestyle:
 						case ArticlePillar.Culture:
 						case ArticlePillar.Opinion:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the colour of the section title for live sport blogs

## Why?
It was appearing as white on a yellow background which was hard to read

### Before
<img width="407" alt="Screenshot 2022-04-05 at 16 18 12" src="https://user-images.githubusercontent.com/1336821/161789573-d95edde9-82f9-427c-b6d7-a3429b0d2287.png">


### After
<img width="407" alt="Screenshot 2022-04-05 at 16 19 16" src="https://user-images.githubusercontent.com/1336821/161789570-de9b4f35-0089-452d-8cac-fa71319180a8.png">
