### PR TITLE
Allow interviews to be rendered by Apps Rendering

### DIFF
--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -96,7 +96,8 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 		item.design === ArticleDesign.Quiz ||
 		item.design === ArticleDesign.MatchReport ||
 		item.design === ArticleDesign.Obituary ||
-		item.design === ArticleDesign.Correction
+		item.design === ArticleDesign.Correction ||
+		item.design === ArticleDesign.Interview
 	) {
 		return <Standard item={item}>{render(item, body)}</Standard>;
 	}


### PR DESCRIPTION
## Why?
This PR paves the way to start rendering the Interview design by AR.

Note that this won't affect the live app as there is currently a filter in MAPI that prevents Interviews from being rendered by AR:
https://github.com/guardian/mobile-apps-api/blob/main/common-play/src/main/scala/data/RenderedItemUtils.scala#L52

This change will make it easier to test the interview design locally and build incrementally to make it look like DCR.

### Before
<img width="305" alt="image" src="https://user-images.githubusercontent.com/57295823/161804034-17a299a6-e9e7-49e4-8ee7-fd2063a4ef16.png">

### After
<img width="778" alt="image" src="https://user-images.githubusercontent.com/57295823/161804116-bfdb6488-ca42-4d62-acf4-c1af447073ea.png">

