### PR TITLE
Content Security Policy: add `data:` scheme to `img-src`

### DIFF
--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -95,7 +95,7 @@ const buildCsp = (
 	`
     default-src 'self';
     style-src ${styleSrc(styles, thirdPartyEmbed.twitter, hasInlineStyles)}
-    img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${
+    img-src 'self' data: https://static.theguardian.com https://*.guim.co.uk ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'
 			: ''
@@ -135,7 +135,7 @@ function buildCspEditions(
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-	img-src 'self' https://static.theguardian.com https://*.guim.co.uk ${
+	img-src 'self' data: https://static.theguardian.com https://*.guim.co.uk ${
 		thirdPartyEmbed.twitter
 			? 'https://platform.twitter.com https://syndication.twitter.com https://pbs.twimg.com data:'
 			: ''


### PR DESCRIPTION
## Why?
It is currently not possible to render SVGs in Apps Rendering via CSS using `data: svg+xml`.

This is exactly how the squiggly/dotted/dashed variations of the `<Lines>` component are rendered: they use [`mini-svg-data-uri`](https://www.npmjs.com/package/mini-svg-data-uri) under the hood, which converts SVGs into compressed `data:` URIs, resulting in `background-image: url(data:svg+xml,...)`.

AR's current Content Security Policy`img-src` directive only allows 4 origins: 

- `'self'`
- `https://static.theguardian.com`
- `https://*.guim.co.uk`
- Optionally, Twitter (but only if the article contains a Twitter embed)

The `data:` scheme is excluded from the allowed origins, meaning that SVGs rendered in that way will not be displayed in AR. This is a problems because we need to use variations of the `<Lines>` component (the default straight lines used in most articles are rendered with `background-image: repeating-linear-gradient` instead of an SVG, which is why we never noticed the issue before).

@sndrs confirmed that we do not need to be this strict with our CSP and we can allow `data:`.
This PR therefore adds it to both AR and Editions' Content Security Policies.