### PR TITLE
Rename files to be more articlely

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -744,44 +744,6 @@ interface ConfigType extends CommercialConfigType {
 	isPreview?: boolean;
 }
 
-interface ConfigTypeBrowser {
-	frontendAssetsFullURL: string;
-	isDev: boolean;
-	ajaxUrl: string;
-	shortUrlId: string;
-	pageId: string;
-	isPaidContent: boolean;
-	showRelatedContent: boolean;
-	keywordIds: string;
-	ampIframeUrl: string;
-	ampPrebid: boolean;
-	permutive: boolean;
-	enableSentryReporting: boolean;
-	enableDiscussionSwitch: boolean;
-	slotBodyEnd: boolean;
-	isSensitive: boolean;
-	videoDuration: number;
-	edition: string;
-	section: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	sharedAdTargeting: { [key: string]: any };
-	adUnit: string;
-	idApiUrl: string;
-	discussionApiUrl: string;
-	discussionD2Uid: string;
-	discussionApiClientHeader: string;
-	dcrSentryDsn: string;
-	remoteBanner: boolean;
-	remoteHeader: boolean;
-	puzzlesBanner: boolean;
-	ausMoment2020Header: boolean;
-	switches: CAPIType['config']['switches'];
-	abTests: CAPIType['config']['abTests'];
-	host?: string;
-	idUrl?: string;
-	mmaUrl?: string;
-}
-
 interface GADataType {
 	pillar: LegacyPillar;
 	webTitle: string;

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -22,14 +22,14 @@ type Props = {
 
 /**
  * @description
- * Page is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
+ * Article is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
  * @param {CAPIType} props.CAPI - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */
-export const Page = ({ CAPI, NAV, format }: Props) => {
+export const Article = ({ CAPI, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global

--- a/dotcom-rendering/src/web/server/articleTemplate.ts
+++ b/dotcom-rendering/src/web/server/articleTemplate.ts
@@ -4,7 +4,7 @@ import { ArticleDesign } from '@guardian/libs';
 import { getFontsCss } from '../../lib/fonts-css';
 import { ASSET_ORIGIN } from '../../lib/assets';
 
-export const htmlTemplate = ({
+export const articleTemplate = ({
 	title = 'The Guardian',
 	description,
 	linkedData,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -7,7 +7,7 @@ import { ArticlePillar } from '@guardian/libs';
 import { decideTheme } from '../lib/decideTheme';
 import { decideFormat } from '../lib/decideFormat';
 
-import { Page } from '../components/Page';
+import { Article } from '../components/Article';
 
 import { escapeData } from '../../lib/escapeData';
 import { ASSET_ORIGIN, getScriptArrayFromFile } from '../../lib/assets';
@@ -68,7 +68,7 @@ export const articleToHtml = ({ data }: Props): string => {
 
 	const html = renderToString(
 		<CacheProvider value={cache}>
-			<Page format={format} CAPI={CAPI} NAV={NAV} />
+			<Article format={format} CAPI={CAPI} NAV={NAV} />
 		</CacheProvider>,
 	);
 

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -54,7 +54,7 @@ const decideTitle = (CAPI: CAPIType): string => {
 	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
 };
 
-export const document = ({ data }: Props): string => {
+export const articleToHtml = ({ data }: Props): string => {
 	const { CAPI, NAV, linkedData } = data;
 	const title = decideTitle(CAPI);
 	const key = 'dcr';

--- a/dotcom-rendering/src/web/server/document.tsx
+++ b/dotcom-rendering/src/web/server/document.tsx
@@ -13,7 +13,7 @@ import { escapeData } from '../../lib/escapeData';
 import { ASSET_ORIGIN, getScriptArrayFromFile } from '../../lib/assets';
 
 import { makeWindowGuardian } from '../../model/window-guardian';
-import { htmlTemplate } from './htmlTemplate';
+import { articleTemplate } from './articleTemplate';
 
 interface Props {
 	data: DCRServerDocumentData;
@@ -177,7 +177,7 @@ export const document = ({ data }: Props): string => {
 			? ''
 			: CAPI.config.keywords;
 
-	return htmlTemplate({
+	return articleTemplate({
 		linkedData,
 		priorityScriptTags,
 		lowPriorityScriptTags,

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -1,7 +1,7 @@
 import type express from 'express';
 import { Article as ExampleArticle } from '../../../fixtures/generated/articles/Article';
 import { extractNAV } from '../../model/extract-nav';
-import { document } from './document';
+import { articleToHtml } from './articleToHtml';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { validateAsCAPIType } from '../../model/validate';
@@ -31,7 +31,7 @@ export const renderArticle = (
 ): void => {
 	try {
 		const CAPI = enhanceCAPIType(body);
-		const resp = document({
+		const resp = articleToHtml({
 			data: {
 				CAPI,
 				site: 'frontend',
@@ -87,7 +87,7 @@ export const renderInteractive = (
 ): void => {
 	try {
 		const CAPI = enhanceCAPIType(body);
-		const resp = document({
+		const resp = articleToHtml({
 			data: {
 				CAPI,
 				site: 'frontend',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Renames

`document` to `articleToHtml`
`htmlTemplate` to `articleTemplate`
and
`Page` to `Article`

## Why?
To mark these parts of the DCR codebase as article specific