### PR TITLE
Rename `CAPI` to be more articlely

### DIFF
--- a/dotcom-rendering/docs/architecture/025-click-to-view.md
+++ b/dotcom-rendering/docs/architecture/025-click-to-view.md
@@ -57,18 +57,18 @@ rendered, there is no need to hydrate the component.
 Here is a list of elements in the 'frontend' article json model that can contain third party content with details
 of the decision to wrap them in ClickToView or not.
 
-Element | Wrapped in Click to View | Details
---------|--------|-------
-DocumentBlockElement | yes | Can contain both Scribd (tracking) and DocumentCloud (non-tracking)
-EmbedBlockElement | yes | Can contain almost anything including content which has its own specific element type eg youtube, twitter
-InstagramBlockElement | yes | Facebook
-MapBlockElement | yes | maps are provided by google who track
-PullquoteBlockElement | yes | It is possible to include an iframe in a pullquote, its arguable if this should be wrapped in click to view as this rarely if ever happens
-SoundcloudBlockElement | no | Soundcloud claim to not track users
-SpotifyBlockElement | yes | Spotify track users
-TweetBlockElement | no | twitter support a [do-not-track](https://developer.twitter.com/en/docs/twitter-for-websites/privacy) feature
-VideoBlockElement | no | These contain videos from random providers which may track. However we do not currently render these videos 😱
-VideoFacebookBlockElement | yes | Facebook
-VideoVimeoBlockElement | no | Vimeo provide a 'do-not-track' feature
-VideoYoutubeBlockElement | no | Youtube provide a 'do-not-track' feature
-WitnessTypeBlockElement | no | Witness is part of the Guardian, post can contain Youtube videos which supports a 'do-not-track' feature.
+| Element                   | Wrapped in Click to View | Details                                                                                                                                    |
+| ------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| DocumentBlockElement      | yes                      | Can contain both Scribd (tracking) and DocumentCloud (non-tracking)                                                                        |
+| EmbedBlockElement         | yes                      | Can contain almost anything including content which has its own specific element type eg youtube, twitter                                  |
+| InstagramBlockElement     | yes                      | Facebook                                                                                                                                   |
+| MapBlockElement           | yes                      | maps are provided by google who track                                                                                                      |
+| PullquoteBlockElement     | yes                      | It is possible to include an iframe in a pullquote, its arguable if this should be wrapped in click to view as this rarely if ever happens |
+| SoundcloudBlockElement    | no                       | Soundcloud claim to not track users                                                                                                        |
+| SpotifyBlockElement       | yes                      | Spotify track users                                                                                                                        |
+| TweetBlockElement         | no                       | twitter support a [do-not-track](https://developer.twitter.com/en/docs/twitter-for-websites/privacy) feature                               |
+| VideoBlockElement         | no                       | These contain videos from random providers which may track. However we do not currently render these videos 😱                             |
+| VideoFacebookBlockElement | yes                      | Facebook                                                                                                                                   |
+| VideoVimeoBlockElement    | no                       | Vimeo provide a 'do-not-track' feature                                                                                                     |
+| VideoYoutubeBlockElement  | no                       | Youtube provide a 'do-not-track' feature                                                                                                   |
+| WitnessTypeBlockElement   | no                       | Witness is part of the Guardian, post can contain Youtube videos which supports a 'do-not-track' feature.                                  |

--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -59,8 +59,8 @@ In order to set up a server-side test in DCR, follow steps 1-4 outlined in the `
 
 On the live website, Fastly automatically assigns users to buckets. You can force yourself into a test on your local machine by following these steps:
 
-1) Ensure you are running `frontend` locally and your server-side experiment is enabled in the dashboard.
-2) Use the Header Hacker extension to change the HTTP headers as described in the `frontend` documentation. Please note that this is the only way to opt-in locally. If testing in the CODE environment, use the `/opt/in/` link.
+1. Ensure you are running `frontend` locally and your server-side experiment is enabled in the dashboard.
+2. Use the Header Hacker extension to change the HTTP headers as described in the `frontend` documentation. Please note that this is the only way to opt-in locally. If testing in the CODE environment, use the `/opt/in/` link.
 
 You can verify that you have been correctly assigned to the variant by appending `.json?dcr` to the end of an article link (e.g. `http://localhost:9000/world/2021/jan/01/your-article.json?dcr`. This will return the document data in `JSON` format. Your A/B test will be within the `config` object in camel case, as follows:
 
@@ -70,4 +70,4 @@ You can verify that you have been correctly assigned to the variant by appending
 }
 ```
 
-You can access server-side `abTests` within DCR wherever the CAPI object is used (`CAPI.config.abTests`).
+You can access server-side `abTests` within DCR wherever the CAPI object is used (`CAPIArticle.config.abTests`).

--- a/dotcom-rendering/docs/important-files.md
+++ b/dotcom-rendering/docs/important-files.md
@@ -6,7 +6,7 @@ This file maps data provided by frontend to data types defined in DCR, so make s
 
 ### index.d.ts
 
-The index file defines the CAPIType used in DCR as well as various other types and interfaces that can be used within the application. In this file add an array of your atoms to the [CAPIBrowserType type](https://github.com/guardian/dotcom-rendering/blob/main/index.d.ts#L359). You will also need to add your atom type to the [Island-Type list](https://github.com/guardian/dotcom-rendering/blob/main/index.d.ts#L666), which will be required for the root of the atom element.
+The index file defines the CAPIArticleType used in DCR as well as various other types and interfaces that can be used within the application. In this file add an array of your atoms to the [CAPIBrowserType type](https://github.com/guardian/dotcom-rendering/blob/main/index.d.ts#L359). You will also need to add your atom type to the [Island-Type list](https://github.com/guardian/dotcom-rendering/blob/main/index.d.ts#L666), which will be required for the root of the atom element.
 
 ### window-guardian.ts
 

--- a/dotcom-rendering/docs/important-files.md
+++ b/dotcom-rendering/docs/important-files.md
@@ -10,7 +10,7 @@ The index file defines the CAPIArticleType used in DCR as well as various other 
 
 ### window-guardian.ts
 
-This file generates the DCR Guardian browser config, and will populate the array of atom elements that were defined in index.d.ts. The generic [blockElementWithIndex function](https://github.com/guardian/dotcom-rendering/blob/main/src/model/window-guardian.ts#L72) will produce the array of elements given the full list of [CAPI.blocks, the model type and the name of the atom index field](https://github.com/guardian/dotcom-rendering/blob/main/src/model/window-guardian.ts#L190).
+This file generates the DCR Guardian browser config, and will populate the array of atom elements that were defined in index.d.ts. The generic [blockElementWithIndex function](https://github.com/guardian/dotcom-rendering/blob/main/src/model/window-guardian.ts#L72) will produce the array of elements given the full list of [CAPIArticle.blocks, the model type and the name of the atom index field](https://github.com/guardian/dotcom-rendering/blob/main/src/model/window-guardian.ts#L190).
 
 ### ArticleRenderer.tsx
 

--- a/dotcom-rendering/docs/patterns/enhance-capi.md
+++ b/dotcom-rendering/docs/patterns/enhance-capi.md
@@ -1,20 +1,25 @@
 # Enhance CAPI
-The enhance CAPI pattern is one where the CAPI object is transformed into a different, more useable, format. In particular, it relates to the `blocks` array. Each enhancement function, takes the `CAPIType` and returns the `CAPIType`.
+
+The enhance CAPI pattern is one where the CAPI object is transformed into a different, more useable, format. In particular, it relates to the `blocks` array. Each enhancement function, takes the `CAPIArticleType` and returns the `CAPIArticleType`.
 
 ## Lexicon
+
 An 'enhancement' could also be termed a 'transformation' and in other places similar functions are referred to as 'cleaners'.
 
 ## Why?
+
 Ideally, these transformations would not be required. A better solution would be to construct the array at source, in Composer or CAPI, with the ideal structure. But for - probably very good - reasons the decision was taken to use [cleaners in frontend](https://github.com/guardian/frontend/blob/aa0013a6f9c247be36d29b9716e0ccc80cc8b218/common/app/views/support/HtmlCleaner.scala) to solve design problems. So now, in order to support the same designs, we need to replicate these cleaners in DCR. The enhancements are applied in the [server/index.ts](/dotcom-rendering/src/web/server/index.ts).
 
 ## Examples
 
 ### DropCaps
-Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, `dropcap: true`, so instead a convention was invented where, if the preceding element was an `h2` tag containing '* * *', then that was the trigger to give the following paragraph drop cap styling.
+
+Certain article types, such as Features, have the first letter of the first paragraph marked as a DropCap. However, there was a requirement to sometimes also have other paragraphs be given a DropCap. But composer does not offer a way to mark a paragraph as, say, `dropcap: true`, so instead a convention was invented where, if the preceding element was an `h2` tag containing '\* \* \*', then that was the trigger to give the following paragraph drop cap styling.
 
 In DCR we replicate this using [enhance-dividers.ts](/dotcom-rendering/src/model/enhance-dividers.ts)
 
 ### Images
+
 There are some conventions that can result in images appearing differently, we need a cleaner to support these while we wait for support for them to be added natively to Composer.
 
 Multi images. Consecutive sequences of two halfWidth images will be merged into a MultiImageBlockElement and shown side by side
@@ -25,6 +30,7 @@ In particular, Photo essay articles needs a lot of cleaning to achieve the inten
 In DCR we support these conventions using [enhance-images.ts](/dotcom-rendering/src/model/enhance-images.ts)
 
 ## How remove these enhancement functions
-The construction of these functions has been done  with the goal of removing them in mind. Where changes to elements have been needed they have been done in such  a way as to be generic. For example, the special image titles used in photo essays are available for all images, on all article types. By doing this we create a design language that is more flexible so that if we later improve Composer to support, say, adding drop caps to any paragraph, or adding a title string to an image, then this will just work.
+
+The construction of these functions has been done with the goal of removing them in mind. Where changes to elements have been needed they have been done in such a way as to be generic. For example, the special image titles used in photo essays are available for all images, on all article types. By doing this we create a design language that is more flexible so that if we later improve Composer to support, say, adding drop caps to any paragraph, or adding a title string to an image, then this will just work.
 
 For more information on how and why we'd like to improve cleaners see: https://docs.google.com/document/d/1ESuP7jEOEdbqbJ3mwuBXJxt6wXuGv9_klP3e2JXfSQY/edit

--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Analysis: CAPIType = {
+export const Analysis: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="59ff93fd27eea2be66feecf0b9a7c0b98d12877a"> \n <img src="https://media.guim.co.uk/59ff93fd27eea2be66feecf0b9a7c0b98d12877a/0_71_6720_4032/1000.jpg" alt="The Sinn Féin leader, Mary Lou McDonald, celebrates with supporters" width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">The Sinn Féin leader, Mary Lou McDonald, celebrates with supporters.</span> \n  <span class="element-image__credit">Photograph: Peter Morrison/AP</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Article.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Article.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Article: CAPIType = {
+export const Article: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="82cf4777db1bc8aee728f88202118ec67f535156"> <img src="https://media.guim.co.uk/82cf4777db1bc8aee728f88202118ec67f535156/305_0_4571_2743/1000.jpg" alt="A digitally manipulated image showing a flooded Rotterdam." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">A digitally manipulated image showing a flooded Rotterdam.</span> <span class="element-image__credit">Photograph: Alexandre Rotenberg/Alamy</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Comment: CAPIType = {
+export const Comment: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="90f6640a4b3a916602353d2158a042b6a7e63726"> <img src="https://media.guim.co.uk/90f6640a4b3a916602353d2158a042b6a7e63726/0_86_3240_1944/1000.jpg" alt="A protest in Newcastle against cuts to library services in 2012. ‘Hacked-back spending has taken an inevitable toll, and reflects something happening all over the country.’" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">A protest in Newcastle against cuts to library services in 2012. ‘Hacked-back spending has taken an inevitable toll, and reflects something happening all over the country.’</span> <span class="element-image__credit">Photograph: Mark Pinder/The Guardian</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Dead: CAPIType = {
+export const Dead: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2dbb8d5200a0c46420d3d9145194d7bcb9311d44"> \n <img src="https://media.guim.co.uk/2dbb8d5200a0c46420d3d9145194d7bcb9311d44/0_178_2048_1229/1000.jpg" alt="Perseverance rover as it touched down in the area known as Jezero crater." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Perseverance rover as it touched down in the area known as Jezero crater.</span> \n  <span class="element-image__credit">Photograph: NASA/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Editorial: CAPIType = {
+export const Editorial: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="c8200f3ea53cda44927b11af11e8fc731afc3f34"> <img src="https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/1000.jpg" alt="‘Ministers have said further border measures are required, but cannot say when they will be applied.’ A man waiting at the Heathrow international arrivals hall on 29 January." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘Ministers have said further border measures are required, but cannot say when they will be applied.’</span> <span class="element-image__credit">Photograph: May James/ZUMA Wire/REX/Shutterstock</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Feature: CAPIType = {
+export const Feature: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-atom"> \n <gu-atom data-atom-id="d904f65f-f5c1-4786-8d7a-54fc2a4abe72" data-atom-type="media"> \n  <div>\n   <iframe frameborder="0" allowfullscreen="true" src="https://www.youtube-nocookie.com/embed/7z3iv-HkI7o?showinfo=0&amp;rel=0"></iframe>\n  </div>\n </gu-atom> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Interview: CAPIType = {
+export const Interview: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="e193f0cc579ba041293d4616fd9929db9e2b62e8"> <img src="https://media.guim.co.uk/e193f0cc579ba041293d4616fd9929db9e2b62e8/0_889_5480_3288/1000.jpg" alt="‘The hijab is part of my identity’: Halima Aden wears dress by yufash.com; headscarf by Halima x Modanisa, modanisa.com; and bracelet by togetherband.org. " width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘The hijab is part of my identity’: Halima Aden wears dress by <a href="http://yufash.com">yufash.com</a>; headscarf by Halima x Modanisa, <a href="http://modanisa.com">modanisa.com</a>; and bracelet by <a href="http://togetherband.org">togetherband.org</a>. </span> <span class="element-image__credit">Photograph: Jean-Paul Pietrus/The Observer</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Labs: CAPIType = {
+export const Labs: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="8b723eb4d94368efc040dc26313a01cec69b588a"> <img src="https://media.guim.co.uk/8b723eb4d94368efc040dc26313a01cec69b588a/0_0_3000_1800/1000.jpg" alt="Are you royal?" width="1000" height="600" class="gu-image" /> </figure>',
 	subMetaSectionLinks: [],

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Letter: CAPIType = {
+export const Letter: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0"> <img src="https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/1000.jpg" alt="Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras a week before making her challenge for the Conservative party leadership in 1975." width="1000" height="797" class="gu-image" /> <figcaption> <span class="element-image__caption">Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras, a week before making her challenge for the Conservative party leadership in 1975.</span> <span class="element-image__credit">Photograph: taken from picture library</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Live: CAPIType = {
+export const Live: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2dbb8d5200a0c46420d3d9145194d7bcb9311d44"> \n <img src="https://media.guim.co.uk/2dbb8d5200a0c46420d3d9145194d7bcb9311d44/0_178_2048_1229/1000.jpg" alt="Perseverance rover as it touched down in the area known as Jezero crater." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Perseverance rover as it touched down in the area known as Jezero crater.</span> \n  <span class="element-image__credit">Photograph: NASA/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const MatchReport: CAPIType = {
+export const MatchReport: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="cc1d3dc14ab9104587323ef12ac477004b369637"> <img src="https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/1000.jpg" alt="André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich.</span> <span class="element-image__credit">Photograph: Kieran McManus/BPI/Shutterstock</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const NumberedList: CAPIType = {
+export const NumberedList: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2ce8db064eabb9e22a69cc45a9b6d4e10d595f06"> \n <img src="https://media.guim.co.uk/2ce8db064eabb9e22a69cc45a9b6d4e10d595f06/392_612_4171_2503/1000.jpg" alt="best smartphone 2019" width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Which is the best premium smartphone for you? Check out this guide to the top mobile phones including iPhone, Samsung, Huawei, OnePlus and Google. </span> \n  <span class="element-image__credit">Photograph: Samuel Gibbs/The Guardian</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const PhotoEssay: CAPIType = {
+export const PhotoEssay: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="00ddc088d562eef31c3dd50729182c4289d06a49"> <img src="https://media.guim.co.uk/00ddc088d562eef31c3dd50729182c4289d06a49/391_441_2719_1632/1000.jpg" alt="Joe Bracegirdle Lanterdan Quarry above Vean Hole Beach, North Coast Shot for Sidetracked Equipped" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Joe Bracegirdle at Lanterdan Quarry, above Vean Hole beach, north Cornwall. All photographs: Cat Vinton/The Guardian</span> <span class="element-image__credit">Photograph: The Guardian</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const PrintShop: CAPIType = {
+export const PrintShop: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Quiz: CAPIType = {
+export const Quiz: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="0584dd0a4813e6002e11ff67c28aff9b32da7abf"> \n <img src="https://media.guim.co.uk/0584dd0a4813e6002e11ff67c28aff9b32da7abf/2_0_3020_1814/1000.jpg" alt="Steaua Bucharest, astroturf, Ipswich Town, Italy and Diamond Lights were all big in the 1980s." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Steaua Bucharest, astroturf, Ipswich Town, Italy and Diamond Lights were all big in the 1980s.</span> \n  <span class="element-image__credit">Composite: Allsport/Getty Images; Offside/Getty Images; dpa picture alliance/Alamy</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Recipe: CAPIType = {
+export const Recipe: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="e5a2cb2a63b788eae68ff654f739eff53a0cee28"> <img src="https://media.guim.co.uk/e5a2cb2a63b788eae68ff654f739eff53a0cee28/0_0_3731_4384/851.jpg" alt="Meera Sodha’s spring onion pancakes with sesame sauce" width="851" height="1000" class="gu-image" /> <figcaption> <span class="element-image__caption">Meera Sodha’s spring onion pancakes with sesame sauce.</span> <span class="element-image__credit">Photograph: Louise Hagger/The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay. Food assistant: Susanna Unsworth.</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const Review: CAPIType = {
+export const Review: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="39892d930be2203c5ea452d130772c0279f7dc0c"> <img src="https://media.guim.co.uk/39892d930be2203c5ea452d130772c0279f7dc0c/0_400_6000_3600/1000.jpg" alt="Sex Education." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">So brilliant you can only boggle ... Ncuti Gatwa as Eric in Sex Education.</span> <span class="element-image__credit">Photograph: Sam Taylor/Netflix</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -11,7 +11,7 @@
  *    gen-fixtures.ts directly.
  */
 
-export const SpecialReport: CAPIType = {
+export const SpecialReport: CAPIArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="d302a26f2229a71ab1dfa231208cefc9ae72e3e8"> \n <img src="https://media.guim.co.uk/d302a26f2229a71ab1dfa231208cefc9ae72e3e8/0_200_3000_1800/1000.jpg" alt="Lindsey oil refinery in north Lincolnshire." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Lindsey oil refinery in north Lincolnshire.</span> \n  <span class="element-image__credit">Photograph: Christopher Furlong/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1,5 +1,5 @@
 // ------------------------  //
-// CAPIType and its subtypes //
+// CAPIArticleType and its subtypes //
 // ------------------------- //
 
 // Pillars are used for styling
@@ -428,7 +428,7 @@ interface CAPINavType {
 
 // WARNING: run `gen-schema` task if changing this to update the associated JSON
 // schema definition.
-interface CAPIType {
+interface CAPIArticleType {
 	headline: string;
 	standfirst: string;
 	webTitle: string;
@@ -767,7 +767,7 @@ interface GADataType {
 interface DCRServerDocumentData {
 	page: string;
 	site: string;
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	GA: GADataType;
 	linkedData: { [key: string]: any };

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -767,7 +767,7 @@ interface GADataType {
 interface DCRServerDocumentData {
 	page: string;
 	site: string;
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	GA: GADataType;
 	linkedData: { [key: string]: any };

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -12,13 +12,13 @@ const program = TJS.getProgramFromFiles(
 );
 
 const settings = { rejectDateType: true, required: true };
-const schema = TJS.generateSchema(program, 'CAPIType', settings);
+const schema = TJS.generateSchema(program, 'CAPIArticleType', settings);
 
 fs.writeFile(
 	`${root}/src/model/json-schema.json`,
 	JSON.stringify(schema, null, 4),
 	'utf8',
-	function (err) {
+	(err) => {
 		if (err) {
 			// eslint-disable-next-line @typescript-eslint/tslint/config
 			console.log(err);

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -146,7 +146,7 @@ try {
 				// Write the new fixture data
 				const contents = `${HEADER}export const ${
 					article.name
-				}: CAPIType = ${JSON.stringify(json, null, 4)}`;
+				}: CAPIArticleType = ${JSON.stringify(json, null, 4)}`;
 				fs.writeFileSync(
 					`${root}/fixtures/generated/articles/${article.name}.ts`,
 					contents,

--- a/dotcom-rendering/src/amp/server/document.test.tsx
+++ b/dotcom-rendering/src/amp/server/document.test.tsx
@@ -1,5 +1,5 @@
 import validator from 'amphtml-validator';
-import { Article as CAPI } from '../../../fixtures/generated/articles/Article';
+import { Article as ExampleArticle } from '../../../fixtures/generated/articles/Article';
 import { Article } from '../pages/Article';
 import { extractNAV } from '../../model/extract-nav';
 import { AnalyticsModel } from '../components/Analytics';
@@ -26,13 +26,13 @@ test('rejects invalid AMP doc (to test validator)', async () => {
 // fields. This then errors in Elements.tsx.
 test('produces valid AMP doc', async () => {
 	const v = await validator.getInstance();
-	const { config } = CAPI;
-	const nav = extractNAV(CAPI.nav);
-	const { linkedData } = CAPI;
+	const { config } = ExampleArticle;
+	const nav = extractNAV(ExampleArticle.nav);
+	const { linkedData } = ExampleArticle;
 
 	const metadata = {
-		description: CAPI.trailText,
-		canonicalURL: CAPI.webURL,
+		description: ExampleArticle.trailText,
+		canonicalURL: ExampleArticle.webURL,
 	};
 
 	const analytics: AnalyticsModel = {
@@ -40,9 +40,9 @@ test('produces valid AMP doc', async () => {
 		title: 'Foo',
 		fbPixelaccount: 'XXXXXXXXXX',
 		comscoreID: 'XXXXXXX',
-		section: CAPI.sectionName,
-		contentType: CAPI.contentType,
-		id: CAPI.pageId,
+		section: ExampleArticle.sectionName,
+		contentType: ExampleArticle.contentType,
+		id: ExampleArticle.pageId,
 		neilsenAPIID: 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXX',
 		domain: 'amp.theguardian.com',
 		permutive: {
@@ -59,7 +59,7 @@ test('produces valid AMP doc', async () => {
 		<Article
 			experimentsData={{}}
 			nav={nav}
-			articleData={{ ...CAPI, shouldHideReaderRevenue: false }}
+			articleData={{ ...ExampleArticle, shouldHideReaderRevenue: false }}
 			config={config}
 			analytics={analytics}
 		/>

--- a/dotcom-rendering/src/amp/server/index.tsx
+++ b/dotcom-rendering/src/amp/server/index.tsx
@@ -15,27 +15,29 @@ import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
 export const render = ({ body }: express.Request, res: express.Response) => {
 	try {
 		// TODO remove when migrated to v2
-		const CAPI = validateV2(body);
-		const { linkedData } = CAPI;
-		const { config } = CAPI;
-		const blockElements = CAPI.blocks.map((block) => block.elements);
+		const CAPIArticle = validateV2(body);
+		const { linkedData } = CAPIArticle;
+		const { config } = CAPIArticle;
+		const blockElements = CAPIArticle.blocks.map((block) => block.elements);
 
 		// This is simply to flatten the elements
 		const elements = ([] as CAPIElement[]).concat(...blockElements);
 
-		const scripts = [...extractScripts(elements, CAPI.mainMediaElements)];
+		const scripts = [
+			...extractScripts(elements, CAPIArticle.mainMediaElements),
+		];
 
-		const sectionName = CAPI.sectionName || '';
+		const sectionName = CAPIArticle.sectionName || '';
 		const neilsenAPIID = findBySubsection(sectionName).apiID;
 
 		const analytics: AnalyticsModel = {
 			gaTracker: 'UA-78705427-1',
-			title: CAPI.headline,
+			title: CAPIArticle.headline,
 			fbPixelaccount: '279880532344561',
 			comscoreID: '6035250',
 			section: sectionName,
-			contentType: CAPI.contentType,
-			id: CAPI.pageId,
+			contentType: CAPIArticle.contentType,
+			id: CAPIArticle.pageId,
 			neilsenAPIID,
 			domain: 'amp.theguardian.com',
 			permutive: {
@@ -47,20 +49,20 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 		};
 
 		const metadata = {
-			description: CAPI.trailText,
-			canonicalURL: CAPI.webURL,
+			description: CAPIArticle.trailText,
+			canonicalURL: CAPIArticle.webURL,
 		};
 
 		const resp = document({
 			linkedData,
 			scripts,
 			metadata,
-			title: `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`,
+			title: `${CAPIArticle.headline} | ${CAPIArticle.sectionLabel} | The Guardian`,
 			body: (
 				<Article
 					experimentsData={getAmpExperimentCache()}
-					articleData={CAPI}
-					nav={extractNAV(CAPI.nav)}
+					articleData={CAPIArticle}
+					nav={extractNAV(CAPIArticle.nav)}
 					analytics={analytics}
 					config={config}
 				/>

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -1,4 +1,4 @@
-// This is a subset of CAPIType for use in AMP and as a result there needs to be parity between the types of shared fields.
+// This is a subset of CAPIArticleType for use in AMP and as a result there needs to be parity between the types of shared fields.
 export interface ArticleModel {
 	headline: string;
 	standfirst: string;

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -1,7 +1,7 @@
 import { Article } from '../../fixtures/generated/articles/Article';
 import { enhanceBlockquotes } from './enhance-blockquotes';
 
-const example: CAPIType = Article;
+const example: CAPIArticleType = Article;
 
 const metaData = {
 	id: '123',

--- a/dotcom-rendering/src/model/extract-ga.test.ts
+++ b/dotcom-rendering/src/model/extract-ga.test.ts
@@ -21,7 +21,7 @@ const base = {
 		"Ticket touts face unlimited fines for using 'bots' to buy in bulk",
 };
 
-const CAPI = {
+const CAPIArticle = {
 	...Article,
 	tags: [
 		...Article.tags,
@@ -34,8 +34,8 @@ const CAPI = {
 	...base,
 };
 
-describe('Google Analytics extracts and formats CAPI response correctly', () => {
+describe('Google Analytics extracts and formats CAPIArticle response correctly', () => {
 	it('GA Extract returns correctly formatted GA response', () => {
-		expect(extract(CAPI)).toEqual(base);
+		expect(extract(CAPIArticle)).toEqual(base);
 	});
 });

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -1,7 +1,7 @@
 // All GA fields should  fall back to default values -
 
 const filterTags = (
-	tags: CAPIType['tags'],
+	tags: CAPIArticleType['tags'],
 	tagType: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Let’s make a decision to keep this tag getter small and well defined, we don't really want to use tags
 ): TagType['id'] | '' => {
 	const tagArr = tags.filter((tag) => tag.type === tagType);
@@ -17,7 +17,7 @@ const filterTags = (
 
 // Annoyingly we ping GA with commissioningdesk as the title of the tag, not the id so handle that separately
 const getCommissioningDesk = (
-	tags: CAPIType['tags'],
+	tags: CAPIArticleType['tags'],
 ): TagType['title'] | '' => {
 	const tag = tags.find((thisTag) =>
 		thisTag.id.includes('tracking/commissioningdesk'),
@@ -46,7 +46,7 @@ const formatStringForGa = (string: string): string =>
 	string.toLowerCase().split(' ').join('');
 
 // we should not bring down the website if a trackable field is missing!
-export const extract = (data: CAPIType): GADataType => ({
+export const extract = (data: CAPIArticleType): GADataType => ({
 	webTitle: data.webTitle,
 	pillar: convertToLegacyPillar(data.format.theme),
 	section: data.sectionName || '',

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -15,7 +15,9 @@ addFormats(ajv);
 
 const validate = ajv.compile(schema);
 
-export const validateAsCAPIType = (data: { [key: string]: any }): CAPIType => {
+export const validateAsCAPIType = (data: {
+	[key: string]: any;
+}): CAPIArticleType => {
 	const isValid = validate(data);
 
 	if (!isValid) {
@@ -28,5 +30,5 @@ export const validateAsCAPIType = (data: { [key: string]: any }): CAPIType => {
 		);
 	}
 
-	return data as CAPIType;
+	return data as CAPIArticleType;
 };

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -34,7 +34,7 @@ export interface WindowGuardianConfig {
 const makeWindowGuardianConfig = (
 	dcrDocumentData: DCRServerDocumentData,
 ): WindowGuardianConfig => {
-	const { config } = dcrDocumentData.CAPI;
+	const { config } = dcrDocumentData.CAPIArticle;
 	return {
 		// This indicates to the client side code that we are running a dotcom-rendering rendered page.
 		isDotcomRendering: true,
@@ -43,8 +43,8 @@ const makeWindowGuardianConfig = (
 		frontendAssetsFullURL: config.frontendAssetsFullURL,
 		page: Object.assign(config, {
 			dcrCouldRender: true,
-			contentType: dcrDocumentData.CAPI.contentType,
-			edition: dcrDocumentData.CAPI.editionId,
+			contentType: dcrDocumentData.CAPIArticle.contentType,
+			edition: dcrDocumentData.CAPIArticle.editionId,
 			revisionNumber: config.revisionNumber,
 			dcrSentryDsn:
 				'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -28,7 +28,7 @@ import { getContentFromURLMiddleware } from './lib/get-content-from-url';
 const logRenderTime = responseTime(
 	(req: Request, _: Response, time: number) => {
 		// eslint-disable-next-line prefer-destructuring
-		const body: CAPIType = req.body;
+		const body: CAPIArticleType = req.body;
 		logger.info({
 			pageId: body.pageId,
 			renderTime: time,

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -15,7 +15,7 @@ import { CoreVitals } from './CoreVitals.importable';
 import { SetABTests } from './SetABTests.importable';
 
 type Props = {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -25,11 +25,11 @@ type Props = {
  * Article is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
- * @param {CAPIArticleType} props.CAPI - The article JSON data
+ * @param {CAPIArticleType} props.CAPIArticle - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */
-export const Article = ({ CAPI, NAV, format }: Props) => {
+export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 	return (
 		<StrictMode>
 			<Global
@@ -59,28 +59,32 @@ export const Article = ({ CAPI, NAV, format }: Props) => {
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<CommercialMetrics
-					enabled={CAPI.config.switches.commercialMetrics}
+					enabled={CAPIArticle.config.switches.commercialMetrics}
 				/>
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<CoreVitals />
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
-				<BrazeMessaging idApiUrl={CAPI.config.idApiUrl} />
+				<BrazeMessaging idApiUrl={CAPIArticle.config.idApiUrl} />
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<ReaderRevenueDev
-					shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+					shouldHideReaderRevenue={
+						CAPIArticle.shouldHideReaderRevenue
+					}
 				/>
 			</Island>
 			<Island clientOnly={true}>
 				<SetABTests
-					abTestSwitches={filterABTestSwitches(CAPI.config.switches)}
-					pageIsSensitive={CAPI.config.isSensitive}
-					isDev={!!CAPI.config.isDev}
+					abTestSwitches={filterABTestSwitches(
+						CAPIArticle.config.switches,
+					)}
+					pageIsSensitive={CAPIArticle.config.isSensitive}
+					isDev={!!CAPIArticle.config.isDev}
 				/>
 			</Island>
-			<DecideLayout CAPI={CAPI} NAV={NAV} format={format} />
+			<DecideLayout CAPIArticle={CAPIArticle} NAV={NAV} format={format} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -15,7 +15,7 @@ import { CoreVitals } from './CoreVitals.importable';
 import { SetABTests } from './SetABTests.importable';
 
 type Props = {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -25,7 +25,7 @@ type Props = {
  * Article is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
- * @param {CAPIType} props.CAPI - The article JSON data
+ * @param {CAPIArticleType} props.CAPI - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -23,7 +23,7 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 		{children}
 	</div>
 );
-const CAPI = {
+const CAPIArticle = {
 	tags: [],
 	guardianBaseURL: 'https://theguardian.com',
 	inLeftCol: true,
@@ -32,7 +32,7 @@ const CAPI = {
 	sectionUrl: '/section_url',
 };
 const brexitCAPI = {
-	...CAPI,
+	...CAPIArticle,
 	...{
 		sectionLabel: 'Brexit',
 		sectionUrl: '/brexit',
@@ -45,7 +45,7 @@ const brexitCAPI = {
 };
 
 const beyondTheBladeCAPI = {
-	...CAPI,
+	...CAPIArticle,
 	...{
 		sectionLabel: 'Beyond the blade',
 		sectionUrl: '/beyond-the-blade',
@@ -128,7 +128,7 @@ export const immersiveCommentTag = () => {
 		>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Immersive,
 					theme: ArticlePillar.Sport,
@@ -152,7 +152,7 @@ export const ImmersiveSeriesTag = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Immersive,
 					theme: ArticlePillar.Sport,
@@ -176,7 +176,7 @@ export const ArticleBlogTag = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -200,7 +200,7 @@ export const ArticleOpinionTag = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -224,7 +224,7 @@ export const ArticleSeriesTag = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
@@ -248,7 +248,7 @@ export const SpecialReportTitle = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticleSpecial.SpecialReport,
@@ -272,7 +272,7 @@ export const ArticleNoTags = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Culture,
@@ -289,7 +289,7 @@ export const LabsStory = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticleSpecial.Labs,
@@ -313,7 +313,7 @@ export const LongStory = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
@@ -337,7 +337,7 @@ export const LongWord = () => {
 		<Container>
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...CAPI}
+				{...CAPIArticle}
 				format={{
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.News,
@@ -367,7 +367,7 @@ export const ArticleDeadBlogTitle = () => {
 					<p>{getThemeNameAsString(format)}</p>
 					<ArticleTitle
 						// eslint-disable-next-line react/jsx-props-no-spreading
-						{...CAPI}
+						{...CAPIArticle}
 						format={format}
 						tags={[
 							{

--- a/dotcom-rendering/src/web/components/SignInGate/README.md
+++ b/dotcom-rendering/src/web/components/SignInGate/README.md
@@ -289,19 +289,18 @@ The disadvantage of this method is that it's a bit tricky to work out exactly wh
 
 ```tsx
 <Island clientOnly={true}>
-	<SetABTests
-		abTestSwitches={CAPI.config.switches}
-		pageIsSensitive={CAPI.config.isSensitive}
-		isDev={!!CAPI.config.isDev}
-
-		// forced test variant prop
-    	forcedTestVariant={{
-			// id of the test from the test definition
-			testId: 'SignInGatePatientia',
-			// name of the variant to force into
-			variant: { id: 'patientia-variant-1', test: () => {} },
-    	}}
-	/>
+    <SetABTests
+        abTestSwitches={CAPIArticle.config.switches}
+        pageIsSensitive={CAPIArticle.config.isSensitive}
+        isDev={!!CAPIArticle.config.isDev}
+        // forced test variant prop
+        forcedTestVariant={{
+            // id of the test from the test definition
+            testId: 'SignInGatePatientia',
+            // name of the variant to force into
+            variant: { id: 'patientia-variant-1', test: () => {} },
+        }}
+    />
 </Island>
 ```
 
@@ -312,7 +311,7 @@ The advantages of using the forcedTestVariant:
 
 ```tsx
  abTestSwitches={{
-       ...CAPI.config.switches,
+       ...CAPIArticle.config.switches,
        ...cypressAbSwitches,
        ...{ abSignInGateSwitchName: true }, // DO NOT COMMIT THIS!!
    }}

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -52,7 +52,7 @@ type RRBannerConfig = {
 	id: string;
 	BannerComponent: React.FC<BannerProps>;
 	canShowFn: CanShowFunctionType<BannerProps>;
-	isEnabled: (switches: CAPIType['config']['switches']) => boolean;
+	isEnabled: (switches: CAPIArticleType['config']['switches']) => boolean;
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -254,7 +254,7 @@ const mainMediaWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -254,53 +254,61 @@ const mainMediaWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
+export const CommentLayout = ({
+	CAPIArticle,
+	NAV,
+	format,
+}: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
+		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
+		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
-	const showComments = CAPI.isCommentable;
+	const showComments = CAPIArticle.isCommentable;
 
-	const contributorTag = CAPI.tags.find((tag) => tag.type === 'Contributor');
+	const contributorTag = CAPIArticle.tags.find(
+		(tag) => tag.type === 'Contributor',
+	);
 	const avatarUrl = contributorTag && contributorTag.bylineImageUrl;
 	const onlyOneContributor: boolean =
-		CAPI.tags.filter((tag) => tag.type === 'Contributor').length === 1;
+		CAPIArticle.tags.filter((tag) => tag.type === 'Contributor').length ===
+		1;
 
 	const showAvatar = avatarUrl && onlyOneContributor;
 
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	const palette = decidePalette(format);
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	return (
 		<>
@@ -313,8 +321,8 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						shouldCenter={false}
 					>
 						<HeaderAdSlot
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 							display={format.display}
 						/>
 					</ElementContainer>
@@ -329,18 +337,24 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							element="header"
 						>
 							<Header
-								edition={CAPI.editionId}
-								idUrl={CAPI.config.idUrl}
-								mmaUrl={CAPI.config.mmaUrl}
+								edition={CAPIArticle.editionId}
+								idUrl={CAPIArticle.config.idUrl}
+								mmaUrl={CAPIArticle.config.mmaUrl}
 								supporterCTA={
-									CAPI.nav.readerRevenueLinks.header.supporter
+									CAPIArticle.nav.readerRevenueLinks.header
+										.supporter
 								}
-								discussionApiUrl={CAPI.config.discussionApiUrl}
+								discussionApiUrl={
+									CAPIArticle.config.discussionApiUrl
+								}
 								isAnniversary={
-									CAPI.config.switches.anniversaryHeaderSvg
+									CAPIArticle.config.switches
+										.anniversaryHeaderSvg
 								}
-								urls={CAPI.nav.readerRevenueLinks.header}
-								remoteHeader={CAPI.config.switches.remoteHeader}
+								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								remoteHeader={
+									CAPIArticle.config.switches.remoteHeader
+								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
@@ -360,12 +374,13 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							nav={NAV}
 							format={{
 								...format,
-								theme: getCurrentPillar(CAPI),
+								theme: getCurrentPillar(CAPIArticle),
 							}}
 							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
+								CAPIArticle.nav.readerRevenueLinks.header
+									.subscribe
 							}
-							edition={CAPI.editionId}
+							edition={CAPIArticle.editionId}
 						/>
 					</ElementContainer>
 
@@ -405,11 +420,11 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPI.tags}
-								sectionLabel={CAPI.sectionLabel}
-								sectionUrl={CAPI.sectionUrl}
-								guardianBaseURL={CAPI.guardianBaseURL}
-								badge={CAPI.badge}
+								tags={CAPIArticle.tags}
+								sectionLabel={CAPIArticle.sectionLabel}
+								sectionUrl={CAPIArticle.sectionUrl}
+								guardianBaseURL={CAPIArticle.guardianBaseURL}
+								badge={CAPIArticle.badge}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -426,15 +441,15 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									{/* TOP - we position content in groups here using flex */}
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPI.headline}
-										tags={CAPI.tags}
-										byline={CAPI.author.byline}
+										headlineString={CAPIArticle.headline}
+										tags={CAPIArticle.tags}
+										byline={CAPIArticle.author.byline}
 										webPublicationDateDeprecated={
-											CAPI.webPublicationDateDeprecated
+											CAPIArticle.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											!!CAPI.starRating ||
-											CAPI.starRating === 0
+											!!CAPIArticle.starRating ||
+											CAPIArticle.starRating === 0
 										}
 										hasAvatar={!!showAvatar}
 									/>
@@ -445,7 +460,8 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 												<ContributorAvatar
 													imageSrc={avatarUrl}
 													imageAlt={
-														CAPI.author.byline || ''
+														CAPIArticle.author
+															.byline || ''
 													}
 												/>
 											</div>
@@ -463,7 +479,7 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPI.standfirst}
+								standfirst={CAPIArticle.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="media">
@@ -476,22 +492,22 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							>
 								<MainMedia
 									format={format}
-									elements={CAPI.mainMediaElements}
+									elements={CAPIArticle.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
-										CAPI.starRating
-											? CAPI.starRating
+										CAPIArticle.starRating
+											? CAPIArticle.starRating
 											: undefined
 									}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									isSensitive={CAPI.config.isSensitive}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									isSensitive={CAPIArticle.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
@@ -500,24 +516,25 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									author={CAPI.author}
-									tags={CAPI.tags}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									author={CAPIArticle.author}
+									tags={CAPIArticle.tags}
 									primaryDateline={
-										CAPI.webPublicationDateDisplay
+										CAPIArticle.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPI.webPublicationSecondaryDateDisplay
+										CAPIArticle.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPI.isCommentable}
+									isCommentable={CAPIArticle.isCommentable}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
-									shortUrlId={CAPI.config.shortUrlId}
-									ajaxUrl={CAPI.config.ajaxUrl}
+									shortUrlId={CAPIArticle.config.shortUrlId}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPI.config.switches.serverShareCounts
+										CAPIArticle.config.switches
+											.serverShareCounts
 									}
 								/>
 							</div>
@@ -527,58 +544,72 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<div css={maxWidth}>
 									<ArticleBody
 										format={format}
-										blocks={CAPI.blocks}
+										blocks={CAPIArticle.blocks}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-										ajaxUrl={CAPI.config.ajaxUrl}
-										switches={CAPI.config.switches}
-										isSensitive={CAPI.config.isSensitive}
-										isAdFreeUser={CAPI.isAdFreeUser}
-										section={CAPI.config.section}
-										shouldHideReaderRevenue={
-											CAPI.shouldHideReaderRevenue
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										switches={CAPIArticle.config.switches}
+										isSensitive={
+											CAPIArticle.config.isSensitive
 										}
-										tags={CAPI.tags}
+										isAdFreeUser={CAPIArticle.isAdFreeUser}
+										section={CAPIArticle.config.section}
+										shouldHideReaderRevenue={
+											CAPIArticle.shouldHideReaderRevenue
+										}
+										tags={CAPIArticle.tags}
 										isPaidContent={
-											!!CAPI.config.isPaidContent
+											!!CAPIArticle.config.isPaidContent
 										}
 										contributionsServiceUrl={
 											contributionsServiceUrl
 										}
-										contentType={CAPI.contentType}
-										sectionName={CAPI.sectionName || ''}
-										isPreview={CAPI.config.isPreview}
-										idUrl={CAPI.config.idUrl || ''}
-										isDev={!!CAPI.config.isDev}
+										contentType={CAPIArticle.contentType}
+										sectionName={
+											CAPIArticle.sectionName || ''
+										}
+										isPreview={CAPIArticle.config.isPreview}
+										idUrl={CAPIArticle.config.idUrl || ''}
+										isDev={!!CAPIArticle.config.isDev}
 									/>
 									{showBodyEndSlot && (
 										<Island clientOnly={true}>
 											<SlotBodyEnd
-												contentType={CAPI.contentType}
+												contentType={
+													CAPIArticle.contentType
+												}
 												contributionsServiceUrl={
 													contributionsServiceUrl
 												}
-												idApiUrl={CAPI.config.idApiUrl}
+												idApiUrl={
+													CAPIArticle.config.idApiUrl
+												}
 												isMinuteArticle={
-													CAPI.pageType
+													CAPIArticle.pageType
 														.isMinuteArticle
 												}
 												isPaidContent={
-													CAPI.pageType.isPaidContent
+													CAPIArticle.pageType
+														.isPaidContent
 												}
 												keywordsId={
-													CAPI.config.keywordIds
+													CAPIArticle.config
+														.keywordIds
 												}
-												pageId={CAPI.pageId}
-												sectionId={CAPI.config.section}
-												sectionName={CAPI.sectionName}
+												pageId={CAPIArticle.pageId}
+												sectionId={
+													CAPIArticle.config.section
+												}
+												sectionName={
+													CAPIArticle.sectionName
+												}
 												shouldHideReaderRevenue={
-													CAPI.shouldHideReaderRevenue
+													CAPIArticle.shouldHideReaderRevenue
 												}
-												stage={CAPI.config.stage}
-												tags={CAPI.tags}
+												stage={CAPIArticle.config.stage}
+												tags={CAPIArticle.tags}
 											/>
 										</Island>
 									)}
@@ -586,18 +617,18 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									<SubMeta
 										format={format}
 										subMetaKeywordLinks={
-											CAPI.subMetaKeywordLinks
+											CAPIArticle.subMetaKeywordLinks
 										}
 										subMetaSectionLinks={
-											CAPI.subMetaSectionLinks
+											CAPIArticle.subMetaSectionLinks
 										}
-										pageId={CAPI.pageId}
-										webUrl={CAPI.webURL}
-										webTitle={CAPI.webTitle}
+										pageId={CAPIArticle.pageId}
+										webUrl={CAPIArticle.webURL}
+										webTitle={CAPIArticle.webTitle}
 										showBottomSocialButtons={
-											CAPI.showBottomSocialButtons
+											CAPIArticle.showBottomSocialButtons
 										}
-										badge={CAPI.badge}
+										badge={CAPIArticle.badge}
 									/>
 								</div>
 							</ArticleContainer>
@@ -624,10 +655,10 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 										position="right"
 										display={format.display}
 										shouldHideReaderRevenue={
-											CAPI.shouldHideReaderRevenue
+											CAPIArticle.shouldHideReaderRevenue
 										}
 										isPaidContent={
-											CAPI.pageType.isPaidContent
+											CAPIArticle.pageType.isPaidContent
 										}
 									/>
 									{!isPaidContent ? (
@@ -636,7 +667,9 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 											deferUntil="visible"
 										>
 											<MostViewedRightWrapper
-												isAdFreeUser={CAPI.isAdFreeUser}
+												isAdFreeUser={
+													CAPIArticle.isAdFreeUser
+												}
 											/>
 										</Island>
 									) : (
@@ -663,20 +696,24 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -687,9 +724,9 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
@@ -699,18 +736,21 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="aside">
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -719,8 +759,8 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -756,32 +796,36 @@ export const CommentLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
+						contentType={CAPIArticle.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -10,7 +10,7 @@ import { InteractiveLayout } from './InteractiveLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
 
 type Props = {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -10,12 +10,16 @@ import { InteractiveLayout } from './InteractiveLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
 
 type Props = {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
 
-export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
+export const DecideLayout = ({
+	CAPIArticle,
+	NAV,
+	format,
+}: Props): JSX.Element => {
 	// TODO we can probably better express this as data
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
@@ -27,7 +31,7 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					// if published before.
 					return (
 						<FullPageInteractiveLayout
-							CAPI={CAPI}
+							CAPIArticle={CAPIArticle}
 							NAV={NAV}
 							format={format}
 						/>
@@ -36,7 +40,7 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				default: {
 					return (
 						<ImmersiveLayout
-							CAPI={CAPI}
+							CAPIArticle={CAPIArticle}
 							NAV={NAV}
 							format={format}
 						/>
@@ -49,16 +53,30 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
-					return <LiveLayout CAPI={CAPI} NAV={NAV} format={format} />;
+					return (
+						<LiveLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
+					);
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 					return (
-						<CommentLayout CAPI={CAPI} NAV={NAV} format={format} />
+						<CommentLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
 					);
 				default:
 					return (
-						<ShowcaseLayout CAPI={CAPI} NAV={NAV} format={format} />
+						<ShowcaseLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
 					);
 			}
 		}
@@ -68,7 +86,7 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				case ArticleDesign.Interactive:
 					return (
 						<InteractiveLayout
-							CAPI={CAPI}
+							CAPIArticle={CAPIArticle}
 							NAV={NAV}
 							format={format}
 						/>
@@ -76,7 +94,7 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				case ArticleDesign.FullPageInteractive: {
 					return (
 						<FullPageInteractiveLayout
-							CAPI={CAPI}
+							CAPIArticle={CAPIArticle}
 							NAV={NAV}
 							format={format}
 						/>
@@ -84,16 +102,30 @@ export const DecideLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				}
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
-					return <LiveLayout CAPI={CAPI} NAV={NAV} format={format} />;
+					return (
+						<LiveLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
+					);
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
 				case ArticleDesign.Letter:
 					return (
-						<CommentLayout CAPI={CAPI} NAV={NAV} format={format} />
+						<CommentLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
 					);
 				default:
 					return (
-						<StandardLayout CAPI={CAPI} NAV={NAV} format={format} />
+						<StandardLayout
+							CAPIArticle={CAPIArticle}
+							NAV={NAV}
+							format={format}
+						/>
 					);
 			}
 		}

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -37,7 +37,7 @@ import { Island } from '../components/Island';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -37,7 +37,7 @@ import { Island } from '../components/Island';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
@@ -130,12 +130,12 @@ const Renderer: React.FC<{
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
+const NavHeader = ({ CAPIArticle, NAV, format }: Props): JSX.Element => {
 	// Typically immersives use the slim nav, but this switch is used to force
 	// the full nav - typically during special events such as Project 200, or
 	// the Euros. The motivation is to better onboard new visitors; interactives
 	// often reach readers who are less familiar with the Guardian.
-	const isSlimNav = !CAPI.config.switches.interactiveFullHeaderSwitch;
+	const isSlimNav = !CAPIArticle.config.switches.interactiveFullHeaderSwitch;
 
 	if (isSlimNav) {
 		return (
@@ -157,13 +157,13 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						format={{
 							display: format.display,
 							design: format.design,
-							theme: getCurrentPillar(CAPI),
+							theme: getCurrentPillar(CAPIArticle),
 						}}
 						nav={NAV}
 						subscribeUrl={
-							CAPI.nav.readerRevenueLinks.header.subscribe
+							CAPIArticle.nav.readerRevenueLinks.header.subscribe
 						}
-						edition={CAPI.editionId}
+						edition={CAPIArticle.editionId}
 					/>
 				</ElementContainer>
 			</div>
@@ -188,8 +188,8 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						element="aside"
 					>
 						<HeaderAdSlot
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 							display={format.display}
 						/>
 					</ElementContainer>
@@ -206,20 +206,25 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						element="header"
 					>
 						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
+							edition={CAPIArticle.editionId}
+							idUrl={CAPIArticle.config.idUrl}
+							mmaUrl={CAPIArticle.config.mmaUrl}
 							supporterCTA={
-								CAPI.nav.readerRevenueLinks.header.supporter
+								CAPIArticle.nav.readerRevenueLinks.header
+									.supporter
 							}
-							discussionApiUrl={CAPI.config.discussionApiUrl}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
 							isAnniversary={
-								CAPI.config.switches.anniversaryHeaderSvg
+								CAPIArticle.config.switches.anniversaryHeaderSvg
 							}
-							urls={CAPI.nav.readerRevenueLinks.header}
-							remoteHeader={CAPI.config.switches.remoteHeader}
+							urls={CAPIArticle.nav.readerRevenueLinks.header}
+							remoteHeader={
+								CAPIArticle.config.switches.remoteHeader
+							}
 							contributionsServiceUrl={
-								CAPI.contributionsServiceUrl
+								CAPIArticle.contributionsServiceUrl
 							}
 						/>
 					</ElementContainer>
@@ -238,11 +243,13 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					format={{
 						display: ArticleDisplay.Standard,
 						design: format.design,
-						theme: getCurrentPillar(CAPI),
+						theme: getCurrentPillar(CAPIArticle),
 					}}
 					nav={NAV}
-					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
-					edition={CAPI.editionId}
+					subscribeUrl={
+						CAPIArticle.nav.readerRevenueLinks.header.subscribe
+					}
+					edition={CAPIArticle.editionId}
 				/>
 			</ElementContainer>
 
@@ -266,19 +273,19 @@ const NavHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 };
 
 export const FullPageInteractiveLayout = ({
-	CAPI,
+	CAPIArticle,
 	NAV,
 	format,
 }: Props): JSX.Element => {
 	const {
 		config: { host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const palette = decidePalette(format);
 
 	return (
 		<>
-			{CAPI.isLegacyInteractive && (
+			{CAPIArticle.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
 			<header
@@ -286,7 +293,11 @@ export const FullPageInteractiveLayout = ({
 					background-color: ${palette.background.article};
 				`}
 			>
-				<NavHeader CAPI={CAPI} NAV={NAV} format={format} />
+				<NavHeader
+					CAPIArticle={CAPIArticle}
+					NAV={NAV}
+					format={format}
+				/>
 
 				{format.theme === ArticleSpecial.Labs && (
 					<Stuck>
@@ -316,14 +327,18 @@ export const FullPageInteractiveLayout = ({
 				<article>
 					<Renderer
 						format={format}
-						elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
+						elements={
+							CAPIArticle.blocks[0]
+								? CAPIArticle.blocks[0].elements
+								: []
+						}
 						host={host}
-						pageId={CAPI.pageId}
-						webTitle={CAPI.webTitle}
-						ajaxUrl={CAPI.config.ajaxUrl}
-						switches={CAPI.config.switches}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						isSensitive={CAPI.config.isSensitive}
+						pageId={CAPIArticle.pageId}
+						webTitle={CAPIArticle.webTitle}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						switches={CAPIArticle.config.switches}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						isSensitive={CAPIArticle.config.isSensitive}
 					/>
 				</article>
 			</ElementContainer>
@@ -352,32 +367,38 @@ export const FullPageInteractiveLayout = ({
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						contentType={CAPIArticle.contentType}
+						contributionsServiceUrl={
+							CAPIArticle.contributionsServiceUrl
+						}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -45,13 +45,13 @@ function isImageBlockElement(block: CAPIElement): block is ImageBlockElement {
 	);
 }
 
-const convertToImmersive = (CAPI: CAPIArticleType) => ({
-	...CAPI,
+const convertToImmersive = (CAPIArticle: CAPIArticleType) => ({
+	...CAPIArticle,
 	format: {
-		...CAPI.format,
+		...CAPIArticle.format,
 		display: 'ImmersiveDisplay' as CAPIDisplay,
 	},
-	mainMediaElements: CAPI.mainMediaElements.map((el) => {
+	mainMediaElements: CAPIArticle.mainMediaElements.map((el) => {
 		if (isImageBlockElement(el)) {
 			return {
 				...el,
@@ -76,7 +76,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 		injectPrivacySettingsLink();
 		doStorybookHydration();
 	}, [ServerCAPI]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
+	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -45,7 +45,7 @@ function isImageBlockElement(block: CAPIElement): block is ImageBlockElement {
 	);
 }
 
-const convertToImmersive = (CAPI: CAPIType) => ({
+const convertToImmersive = (CAPI: CAPIArticleType) => ({
 	...CAPI,
 	format: {
 		...CAPI.format,
@@ -65,7 +65,7 @@ const convertToImmersive = (CAPI: CAPIType) => ({
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 	const NAV = extractNAV(ServerCAPI.nav);
 	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 	useEffect(() => {

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -171,7 +171,7 @@ const stretchLines = css`
 	}
 `;
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
@@ -190,45 +190,54 @@ const decideCaption = (mainMedia: ImageBlockElement): string => {
 	return caption.join(' ');
 };
 
-export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
+export const ImmersiveLayout = ({
+	CAPIArticle,
+	NAV,
+	format,
+}: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
+		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
+		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
-	const showComments = CAPI.isCommentable;
+	const showComments = CAPIArticle.isCommentable;
 
-	const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
+	const mainMedia = CAPIArticle.mainMediaElements[0] as ImageBlockElement;
 	const captionText = decideCaption(mainMedia);
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	return (
 		<>
-			<ImmersiveHeader CAPI={CAPI} NAV={NAV} format={format} />
+			<ImmersiveHeader
+				CAPIArticle={CAPIArticle}
+				NAV={NAV}
+				format={format}
+			/>
 			<main>
 				<ElementContainer
 					showTopBorder={false}
@@ -270,13 +279,15 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									>
 										<ArticleTitle
 											format={format}
-											tags={CAPI.tags}
-											sectionLabel={CAPI.sectionLabel}
-											sectionUrl={CAPI.sectionUrl}
-											guardianBaseURL={
-												CAPI.guardianBaseURL
+											tags={CAPIArticle.tags}
+											sectionLabel={
+												CAPIArticle.sectionLabel
 											}
-											badge={CAPI.badge}
+											sectionUrl={CAPIArticle.sectionUrl}
+											guardianBaseURL={
+												CAPIArticle.guardianBaseURL
+											}
+											badge={CAPIArticle.badge}
 										/>
 									</div>
 								)}
@@ -288,15 +299,17 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									<div css={maxWidth}>
 										<ArticleHeadline
 											format={format}
-											headlineString={CAPI.headline}
-											tags={CAPI.tags}
-											byline={CAPI.author.byline}
+											headlineString={
+												CAPIArticle.headline
+											}
+											tags={CAPIArticle.tags}
+											byline={CAPIArticle.author.byline}
 											webPublicationDateDeprecated={
-												CAPI.webPublicationDateDeprecated
+												CAPIArticle.webPublicationDateDeprecated
 											}
 											hasStarRating={
-												!!CAPI.starRating ||
-												CAPI.starRating === 0
+												!!CAPIArticle.starRating ||
+												CAPIArticle.starRating === 0
 											}
 										/>
 									</div>
@@ -306,15 +319,17 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPI.standfirst}
+								standfirst={CAPIArticle.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="byline">
 							<HeadlineByline
 								format={format}
-								tags={CAPI.tags}
+								tags={CAPIArticle.tags}
 								byline={
-									CAPI.author.byline ? CAPI.author.byline : ''
+									CAPIArticle.author.byline
+										? CAPIArticle.author.byline
+										: ''
 								}
 							/>
 						</GridItem>
@@ -348,24 +363,25 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									author={CAPI.author}
-									tags={CAPI.tags}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									author={CAPIArticle.author}
+									tags={CAPIArticle.tags}
 									primaryDateline={
-										CAPI.webPublicationDateDisplay
+										CAPIArticle.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPI.webPublicationSecondaryDateDisplay
+										CAPIArticle.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPI.isCommentable}
+									isCommentable={CAPIArticle.isCommentable}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
-									shortUrlId={CAPI.config.shortUrlId}
-									ajaxUrl={CAPI.config.ajaxUrl}
+									shortUrlId={CAPIArticle.config.shortUrlId}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPI.config.switches.serverShareCounts
+										CAPIArticle.config.switches
+											.serverShareCounts
 									}
 								/>
 							</div>
@@ -374,53 +390,67 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPI.blocks}
+									blocks={CAPIArticle.blocks}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isSensitive={CAPI.config.isSensitive}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									section={CAPI.config.section}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isSensitive={CAPIArticle.config.isSensitive}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									section={CAPIArticle.config.section}
 									shouldHideReaderRevenue={
-										CAPI.shouldHideReaderRevenue
+										CAPIArticle.shouldHideReaderRevenue
 									}
-									tags={CAPI.tags}
-									isPaidContent={!!CAPI.config.isPaidContent}
+									tags={CAPIArticle.tags}
+									isPaidContent={
+										!!CAPIArticle.config.isPaidContent
+									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPI.contentType}
-									sectionName={CAPI.sectionName || ''}
-									isPreview={CAPI.config.isPreview}
-									idUrl={CAPI.config.idUrl || ''}
-									isDev={!!CAPI.config.isDev}
+									contentType={CAPIArticle.contentType}
+									sectionName={CAPIArticle.sectionName || ''}
+									isPreview={CAPIArticle.config.isPreview}
+									idUrl={CAPIArticle.config.idUrl || ''}
+									isDev={!!CAPIArticle.config.isDev}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={CAPI.contentType}
+											contentType={
+												CAPIArticle.contentType
+											}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={CAPI.config.idApiUrl}
+											idApiUrl={
+												CAPIArticle.config.idApiUrl
+											}
 											isMinuteArticle={
-												CAPI.pageType.isMinuteArticle
+												CAPIArticle.pageType
+													.isMinuteArticle
 											}
 											isPaidContent={
-												CAPI.pageType.isPaidContent
+												CAPIArticle.pageType
+													.isPaidContent
 											}
-											keywordsId={CAPI.config.keywordIds}
-											pageId={CAPI.pageId}
-											sectionId={CAPI.config.section}
-											sectionName={CAPI.sectionName}
+											keywordsId={
+												CAPIArticle.config.keywordIds
+											}
+											pageId={CAPIArticle.pageId}
+											sectionId={
+												CAPIArticle.config.section
+											}
+											sectionName={
+												CAPIArticle.sectionName
+											}
 											shouldHideReaderRevenue={
-												CAPI.shouldHideReaderRevenue
+												CAPIArticle.shouldHideReaderRevenue
 											}
-											stage={CAPI.config.stage}
-											tags={CAPI.tags}
+											stage={CAPIArticle.config.stage}
+											tags={CAPIArticle.tags}
 										/>
 									</Island>
 								)}
@@ -428,18 +458,18 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPI.subMetaKeywordLinks
+										CAPIArticle.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPI.subMetaSectionLinks
+										CAPIArticle.subMetaSectionLinks
 									}
-									pageId={CAPI.pageId}
-									webUrl={CAPI.webURL}
-									webTitle={CAPI.webTitle}
+									pageId={CAPIArticle.pageId}
+									webUrl={CAPIArticle.webURL}
+									webTitle={CAPIArticle.webTitle}
 									showBottomSocialButtons={
-										CAPI.showBottomSocialButtons
+										CAPIArticle.showBottomSocialButtons
 									}
-									badge={CAPI.badge}
+									badge={CAPIArticle.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -472,10 +502,10 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 													position="right"
 													display={format.display}
 													shouldHideReaderRevenue={
-														CAPI.shouldHideReaderRevenue
+														CAPIArticle.shouldHideReaderRevenue
 													}
 													isPaidContent={
-														CAPI.pageType
+														CAPIArticle.pageType
 															.isPaidContent
 													}
 												/>
@@ -503,20 +533,24 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -527,9 +561,9 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
@@ -539,18 +573,21 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="aside">
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -559,8 +596,8 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -596,32 +633,36 @@ export const ImmersiveLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
+						contentType={CAPIArticle.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -171,7 +171,7 @@ const stretchLines = css`
 	}
 `;
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -21,7 +21,7 @@ export default {
 	},
 };
 
-const convertToInteractiveImmersive = (CAPI: CAPIType) => {
+const convertToInteractiveImmersive = (CAPI: CAPIArticleType) => {
 	return {
 		...CAPI,
 		format: {
@@ -35,7 +35,7 @@ const convertToInteractiveImmersive = (CAPI: CAPIType) => {
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 	const NAV = extractNAV(ServerCAPI.nav);
 	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersive.stories.tsx
@@ -21,11 +21,11 @@ export default {
 	},
 };
 
-const convertToInteractiveImmersive = (CAPI: CAPIArticleType) => {
+const convertToInteractiveImmersive = (CAPIArticle: CAPIArticleType) => {
 	return {
-		...CAPI,
+		...CAPIArticle,
 		format: {
-			...CAPI.format,
+			...CAPIArticle.format,
 			display: 'ImmersiveDisplay' as CAPIDisplay,
 			design: 'InteractiveDesign' as CAPIDesign,
 		},
@@ -47,7 +47,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 		injectPrivacySettingsLink();
 		doStorybookHydration();
 	}, [ServerCAPI]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
+	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -266,36 +266,41 @@ const stretchLines = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 	palette: Palette;
 }
 
 export const InteractiveImmersiveLayout = ({
-	CAPI,
+	CAPIArticle,
 	NAV,
 	format,
 	palette,
 }: Props) => {
 	const {
 		config: { host },
-	} = CAPI;
+	} = CAPIArticle;
 
-	const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
+	const mainMedia = CAPIArticle.mainMediaElements[0] as ImageBlockElement;
 	const captionText = decideCaption(mainMedia);
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	return (
 		<>
-			{CAPI.isLegacyInteractive && (
+			{CAPIArticle.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
-			{CAPI.config.switches.surveys && (
+			{CAPIArticle.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 
-			<ImmersiveHeader CAPI={CAPI} NAV={NAV} format={format} />
+			<ImmersiveHeader
+				CAPIArticle={CAPIArticle}
+				NAV={NAV}
+				format={format}
+			/>
 			<main>
 				<ElementContainer
 					showTopBorder={false}
@@ -337,13 +342,15 @@ export const InteractiveImmersiveLayout = ({
 									>
 										<ArticleTitle
 											format={format}
-											tags={CAPI.tags}
-											sectionLabel={CAPI.sectionLabel}
-											sectionUrl={CAPI.sectionUrl}
-											guardianBaseURL={
-												CAPI.guardianBaseURL
+											tags={CAPIArticle.tags}
+											sectionLabel={
+												CAPIArticle.sectionLabel
 											}
-											badge={CAPI.badge}
+											sectionUrl={CAPIArticle.sectionUrl}
+											guardianBaseURL={
+												CAPIArticle.guardianBaseURL
+											}
+											badge={CAPIArticle.badge}
 										/>
 									</div>
 								)}
@@ -355,15 +362,17 @@ export const InteractiveImmersiveLayout = ({
 									<div css={maxWidth}>
 										<ArticleHeadline
 											format={format}
-											headlineString={CAPI.headline}
-											tags={CAPI.tags}
-											byline={CAPI.author.byline}
+											headlineString={
+												CAPIArticle.headline
+											}
+											tags={CAPIArticle.tags}
+											byline={CAPIArticle.author.byline}
 											webPublicationDateDeprecated={
-												CAPI.webPublicationDateDeprecated
+												CAPIArticle.webPublicationDateDeprecated
 											}
 											hasStarRating={
-												!!CAPI.starRating ||
-												CAPI.starRating === 0
+												!!CAPIArticle.starRating ||
+												CAPIArticle.starRating === 0
 											}
 										/>
 									</div>
@@ -373,15 +382,17 @@ export const InteractiveImmersiveLayout = ({
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPI.standfirst}
+								standfirst={CAPIArticle.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="byline">
 							<HeadlineByline
 								format={format}
-								tags={CAPI.tags}
+								tags={CAPIArticle.tags}
 								byline={
-									CAPI.author.byline ? CAPI.author.byline : ''
+									CAPIArticle.author.byline
+										? CAPIArticle.author.byline
+										: ''
 								}
 							/>
 						</GridItem>
@@ -415,24 +426,25 @@ export const InteractiveImmersiveLayout = ({
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									author={CAPI.author}
-									tags={CAPI.tags}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									author={CAPIArticle.author}
+									tags={CAPIArticle.tags}
 									primaryDateline={
-										CAPI.webPublicationDateDisplay
+										CAPIArticle.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPI.webPublicationSecondaryDateDisplay
+										CAPIArticle.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPI.isCommentable}
+									isCommentable={CAPIArticle.isCommentable}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
-									shortUrlId={CAPI.config.shortUrlId}
-									ajaxUrl={CAPI.config.ajaxUrl}
+									shortUrlId={CAPIArticle.config.shortUrlId}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPI.config.switches.serverShareCounts
+										CAPIArticle.config.switches
+											.serverShareCounts
 									}
 								/>
 							</div>
@@ -451,15 +463,17 @@ export const InteractiveImmersiveLayout = ({
 						<Renderer
 							format={format}
 							elements={
-								CAPI.blocks[0] ? CAPI.blocks[0].elements : []
+								CAPIArticle.blocks[0]
+									? CAPIArticle.blocks[0].elements
+									: []
 							}
 							host={host}
-							pageId={CAPI.pageId}
-							webTitle={CAPI.webTitle}
-							ajaxUrl={CAPI.config.ajaxUrl}
-							switches={CAPI.config.switches}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							isSensitive={CAPI.config.isSensitive}
+							pageId={CAPIArticle.pageId}
+							webTitle={CAPIArticle.webTitle}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
+							switches={CAPIArticle.config.switches}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							isSensitive={CAPIArticle.config.isSensitive}
 						/>
 					</article>
 				</ElementContainer>
@@ -489,32 +503,38 @@ export const InteractiveImmersiveLayout = ({
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						contentType={CAPIArticle.contentType}
+						contributionsServiceUrl={
+							CAPIArticle.contributionsServiceUrl
+						}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -266,7 +266,7 @@ const stretchLines = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 	palette: Palette;

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -215,41 +215,42 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
+export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
 
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
-	const showComments = CAPI.isCommentable;
+	const showComments = CAPIArticle.isCommentable;
 
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	const palette = decidePalette(format);
 
 	return (
 		<>
-			{CAPI.isLegacyInteractive && (
+			{CAPIArticle.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
 
@@ -263,8 +264,8 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 							shouldCenter={false}
 						>
 							<HeaderAdSlot
-								isAdFreeUser={CAPI.isAdFreeUser}
-								shouldHideAds={CAPI.shouldHideAds}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								shouldHideAds={CAPIArticle.shouldHideAds}
 								display={format.display}
 							/>
 						</ElementContainer>
@@ -281,20 +282,26 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 							element="header"
 						>
 							<Header
-								edition={CAPI.editionId}
-								idUrl={CAPI.config.idUrl}
-								mmaUrl={CAPI.config.mmaUrl}
+								edition={CAPIArticle.editionId}
+								idUrl={CAPIArticle.config.idUrl}
+								mmaUrl={CAPIArticle.config.mmaUrl}
 								supporterCTA={
-									CAPI.nav.readerRevenueLinks.header.supporter
+									CAPIArticle.nav.readerRevenueLinks.header
+										.supporter
 								}
-								discussionApiUrl={CAPI.config.discussionApiUrl}
+								discussionApiUrl={
+									CAPIArticle.config.discussionApiUrl
+								}
 								isAnniversary={
-									CAPI.config.switches.anniversaryHeaderSvg
+									CAPIArticle.config.switches
+										.anniversaryHeaderSvg
 								}
-								urls={CAPI.nav.readerRevenueLinks.header}
-								remoteHeader={CAPI.config.switches.remoteHeader}
+								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								remoteHeader={
+									CAPIArticle.config.switches.remoteHeader
+								}
 								contributionsServiceUrl={
-									CAPI.contributionsServiceUrl
+									CAPIArticle.contributionsServiceUrl
 								}
 							/>
 						</ElementContainer>
@@ -313,12 +320,12 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 						nav={NAV}
 						format={{
 							...format,
-							theme: getCurrentPillar(CAPI),
+							theme: getCurrentPillar(CAPIArticle),
 						}}
 						subscribeUrl={
-							CAPI.nav.readerRevenueLinks.header.subscribe
+							CAPIArticle.nav.readerRevenueLinks.header.subscribe
 						}
-						edition={CAPI.editionId}
+						edition={CAPIArticle.editionId}
 					/>
 				</ElementContainer>
 
@@ -365,7 +372,7 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 				</Stuck>
 			)}
 
-			{CAPI.config.switches.surveys && (
+			{CAPIArticle.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 			<main>
@@ -387,11 +394,13 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 								>
 									<ArticleTitle
 										format={format}
-										tags={CAPI.tags}
-										sectionLabel={CAPI.sectionLabel}
-										sectionUrl={CAPI.sectionUrl}
-										guardianBaseURL={CAPI.guardianBaseURL}
-										badge={CAPI.badge}
+										tags={CAPIArticle.tags}
+										sectionLabel={CAPIArticle.sectionLabel}
+										sectionUrl={CAPIArticle.sectionUrl}
+										guardianBaseURL={
+											CAPIArticle.guardianBaseURL
+										}
+										badge={CAPIArticle.badge}
 									/>
 								</div>
 							</GridItem>
@@ -406,22 +415,23 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 								<div css={maxWidth}>
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPI.headline}
-										tags={CAPI.tags}
-										byline={CAPI.author.byline}
+										headlineString={CAPIArticle.headline}
+										tags={CAPIArticle.tags}
+										byline={CAPIArticle.author.byline}
 										webPublicationDateDeprecated={
-											CAPI.webPublicationDateDeprecated
+											CAPIArticle.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											!!CAPI.starRating ||
-											CAPI.starRating === 0
+											!!CAPIArticle.starRating ||
+											CAPIArticle.starRating === 0
 										}
 									/>
 								</div>
-								{CAPI.starRating || CAPI.starRating === 0 ? (
+								{CAPIArticle.starRating ||
+								CAPIArticle.starRating === 0 ? (
 									<div css={starWrapper}>
 										<StarRating
-											rating={CAPI.starRating}
+											rating={CAPIArticle.starRating}
 											size="large"
 										/>
 									</div>
@@ -432,22 +442,24 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 							<GridItem area="standfirst">
 								<Standfirst
 									format={format}
-									standfirst={CAPI.standfirst}
+									standfirst={CAPIArticle.standfirst}
 								/>
 							</GridItem>
 							<GridItem area="media">
 								<div css={maxWidth}>
 									<MainMedia
 										format={format}
-										elements={CAPI.mainMediaElements}
+										elements={CAPIArticle.mainMediaElements}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-										ajaxUrl={CAPI.config.ajaxUrl}
-										switches={CAPI.config.switches}
-										isAdFreeUser={CAPI.isAdFreeUser}
-										isSensitive={CAPI.config.isSensitive}
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										switches={CAPIArticle.config.switches}
+										isAdFreeUser={CAPIArticle.isAdFreeUser}
+										isSensitive={
+											CAPIArticle.config.isSensitive
+										}
 									/>
 								</div>
 							</GridItem>
@@ -471,24 +483,28 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 									<ArticleMeta
 										branding={branding}
 										format={format}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-										author={CAPI.author}
-										tags={CAPI.tags}
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										author={CAPIArticle.author}
+										tags={CAPIArticle.tags}
 										primaryDateline={
-											CAPI.webPublicationDateDisplay
+											CAPIArticle.webPublicationDateDisplay
 										}
 										secondaryDateline={
-											CAPI.webPublicationSecondaryDateDisplay
+											CAPIArticle.webPublicationSecondaryDateDisplay
 										}
-										isCommentable={CAPI.isCommentable}
+										isCommentable={
+											CAPIArticle.isCommentable
+										}
 										discussionApiUrl={
-											CAPI.config.discussionApiUrl
+											CAPIArticle.config.discussionApiUrl
 										}
-										shortUrlId={CAPI.config.shortUrlId}
-										ajaxUrl={CAPI.config.ajaxUrl}
+										shortUrlId={
+											CAPIArticle.config.shortUrlId
+										}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
 										showShareCount={
-											CAPI.config.switches
+											CAPIArticle.config.switches
 												.serverShareCounts
 										}
 									/>
@@ -498,31 +514,35 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 								<ArticleContainer format={format}>
 									<ArticleBody
 										format={format}
-										blocks={CAPI.blocks}
+										blocks={CAPIArticle.blocks}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-										ajaxUrl={CAPI.config.ajaxUrl}
-										switches={CAPI.config.switches}
-										isSensitive={CAPI.config.isSensitive}
-										isAdFreeUser={CAPI.isAdFreeUser}
-										section={CAPI.config.section}
-										shouldHideReaderRevenue={
-											CAPI.shouldHideReaderRevenue
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										switches={CAPIArticle.config.switches}
+										isSensitive={
+											CAPIArticle.config.isSensitive
 										}
-										tags={CAPI.tags}
+										isAdFreeUser={CAPIArticle.isAdFreeUser}
+										section={CAPIArticle.config.section}
+										shouldHideReaderRevenue={
+											CAPIArticle.shouldHideReaderRevenue
+										}
+										tags={CAPIArticle.tags}
 										isPaidContent={
-											!!CAPI.config.isPaidContent
+											!!CAPIArticle.config.isPaidContent
 										}
 										contributionsServiceUrl={
-											CAPI.contributionsServiceUrl
+											CAPIArticle.contributionsServiceUrl
 										}
-										contentType={CAPI.contentType}
-										sectionName={CAPI.sectionName || ''}
-										isPreview={CAPI.config.isPreview}
-										idUrl={CAPI.config.idUrl || ''}
-										isDev={!!CAPI.config.isDev}
+										contentType={CAPIArticle.contentType}
+										sectionName={
+											CAPIArticle.sectionName || ''
+										}
+										isPreview={CAPIArticle.config.isPreview}
+										idUrl={CAPIArticle.config.idUrl || ''}
+										isDev={!!CAPIArticle.config.isDev}
 									/>
 
 									{/* <Lines data-print-layout="hide" count={4} /> */}
@@ -535,18 +555,18 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 									<SubMeta
 										format={format}
 										subMetaKeywordLinks={
-											CAPI.subMetaKeywordLinks
+											CAPIArticle.subMetaKeywordLinks
 										}
 										subMetaSectionLinks={
-											CAPI.subMetaSectionLinks
+											CAPIArticle.subMetaSectionLinks
 										}
-										pageId={CAPI.pageId}
-										webUrl={CAPI.webURL}
-										webTitle={CAPI.webTitle}
+										pageId={CAPIArticle.pageId}
+										webUrl={CAPIArticle.webURL}
+										webTitle={CAPIArticle.webTitle}
 										showBottomSocialButtons={
-											CAPI.showBottomSocialButtons
+											CAPIArticle.showBottomSocialButtons
 										}
-										badge={CAPI.badge}
+										badge={CAPIArticle.badge}
 									/>
 								</ArticleContainer>
 							</GridItem>
@@ -571,20 +591,24 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -595,9 +619,9 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
@@ -611,18 +635,21 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -631,8 +658,8 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -674,32 +701,38 @@ export const InteractiveLayout = ({ CAPI, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
-						contributionsServiceUrl={CAPI.contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						contentType={CAPIArticle.contentType}
+						contributionsServiceUrl={
+							CAPIArticle.contributionsServiceUrl
+						}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -215,7 +215,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -246,7 +246,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -246,49 +246,50 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
+export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
+		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
+		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
 
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
 	// Set a default pagination if it is missing from CAPI
-	const pagination: Pagination = CAPI.pagination ?? {
+	const pagination: Pagination = CAPIArticle.pagination ?? {
 		currentPage: 1,
 		totalPages: 1,
 	};
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	const palette = decidePalette(format);
 
@@ -304,8 +305,8 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 						element="aside"
 					>
 						<HeaderAdSlot
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 							display={format.display}
 						/>
 					</ElementContainer>
@@ -319,18 +320,23 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 						element="header"
 					>
 						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
+							edition={CAPIArticle.editionId}
+							idUrl={CAPIArticle.config.idUrl}
+							mmaUrl={CAPIArticle.config.mmaUrl}
 							supporterCTA={
-								CAPI.nav.readerRevenueLinks.header.supporter
+								CAPIArticle.nav.readerRevenueLinks.header
+									.supporter
 							}
-							discussionApiUrl={CAPI.config.discussionApiUrl}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
 							isAnniversary={
-								CAPI.config.switches.anniversaryHeaderSvg
+								CAPIArticle.config.switches.anniversaryHeaderSvg
 							}
-							urls={CAPI.nav.readerRevenueLinks.header}
-							remoteHeader={CAPI.config.switches.remoteHeader}
+							urls={CAPIArticle.nav.readerRevenueLinks.header}
+							remoteHeader={
+								CAPIArticle.config.switches.remoteHeader
+							}
 							contributionsServiceUrl={contributionsServiceUrl}
 						/>
 					</ElementContainer>
@@ -347,12 +353,13 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 							nav={NAV}
 							format={{
 								...format,
-								theme: getCurrentPillar(CAPI),
+								theme: getCurrentPillar(CAPIArticle),
 							}}
 							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
+								CAPIArticle.nav.readerRevenueLinks.header
+									.subscribe
 							}
-							edition={CAPI.editionId}
+							edition={CAPIArticle.editionId}
 						/>
 					</ElementContainer>
 
@@ -386,7 +393,7 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 
 			<main>
 				<article>
-					{CAPI.matchUrl ? (
+					{CAPIArticle.matchUrl ? (
 						<ContainerLayout
 							showTopBorder={false}
 							backgroundColour={palette.background.matchNav}
@@ -394,11 +401,13 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 							leftContent={
 								<ArticleTitle
 									format={format}
-									tags={CAPI.tags}
-									sectionLabel={CAPI.sectionLabel}
-									sectionUrl={CAPI.sectionUrl}
-									guardianBaseURL={CAPI.guardianBaseURL}
-									badge={CAPI.badge}
+									tags={CAPIArticle.tags}
+									sectionLabel={CAPIArticle.sectionLabel}
+									sectionUrl={CAPIArticle.sectionUrl}
+									guardianBaseURL={
+										CAPIArticle.guardianBaseURL
+									}
+									badge={CAPIArticle.badge}
 								/>
 							}
 							leftColSize="wide"
@@ -409,11 +418,13 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 							<Hide above="leftCol">
 								<ArticleTitle
 									format={format}
-									tags={CAPI.tags}
-									sectionLabel={CAPI.sectionLabel}
-									sectionUrl={CAPI.sectionUrl}
-									guardianBaseURL={CAPI.guardianBaseURL}
-									badge={CAPI.badge}
+									tags={CAPIArticle.tags}
+									sectionLabel={CAPIArticle.sectionLabel}
+									sectionUrl={CAPIArticle.sectionUrl}
+									guardianBaseURL={
+										CAPIArticle.guardianBaseURL
+									}
+									badge={CAPIArticle.badge}
 								/>
 							</Hide>
 
@@ -423,12 +434,12 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 								placeholderHeight={230}
 							>
 								<GetMatchNav
-									matchUrl={CAPI.matchUrl}
+									matchUrl={CAPIArticle.matchUrl}
 									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
+									headlineString={CAPIArticle.headline}
+									tags={CAPIArticle.tags}
 									webPublicationDateDeprecated={
-										CAPI.webPublicationDateDeprecated
+										CAPIArticle.webPublicationDateDeprecated
 									}
 								/>
 							</Island>
@@ -443,36 +454,42 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 								<GridItem area="title">
 									<ArticleTitle
 										format={format}
-										tags={CAPI.tags}
-										sectionLabel={CAPI.sectionLabel}
-										sectionUrl={CAPI.sectionUrl}
-										guardianBaseURL={CAPI.guardianBaseURL}
-										badge={CAPI.badge}
+										tags={CAPIArticle.tags}
+										sectionLabel={CAPIArticle.sectionLabel}
+										sectionUrl={CAPIArticle.sectionUrl}
+										guardianBaseURL={
+											CAPIArticle.guardianBaseURL
+										}
+										badge={CAPIArticle.badge}
 									/>
 								</GridItem>
 								<GridItem area="headline">
 									<div css={maxWidth}>
-										{!CAPI.matchUrl && (
+										{!CAPIArticle.matchUrl && (
 											<ArticleHeadline
 												format={format}
-												headlineString={CAPI.headline}
-												tags={CAPI.tags}
-												byline={CAPI.author.byline}
+												headlineString={
+													CAPIArticle.headline
+												}
+												tags={CAPIArticle.tags}
+												byline={
+													CAPIArticle.author.byline
+												}
 												webPublicationDateDeprecated={
-													CAPI.webPublicationDateDeprecated
+													CAPIArticle.webPublicationDateDeprecated
 												}
 												hasStarRating={
-													!!CAPI.starRating ||
-													CAPI.starRating === 0
+													!!CAPIArticle.starRating ||
+													CAPIArticle.starRating === 0
 												}
 											/>
 										)}
 									</div>
-									{CAPI.starRating ||
-									CAPI.starRating === 0 ? (
+									{CAPIArticle.starRating ||
+									CAPIArticle.starRating === 0 ? (
 										<div css={starWrapper}>
 											<StarRating
-												rating={CAPI.starRating}
+												rating={CAPIArticle.starRating}
 												size="large"
 											/>
 										</div>
@@ -493,17 +510,18 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 							<GridItem area="standfirst">
 								<Standfirst
 									format={format}
-									standfirst={CAPI.standfirst}
+									standfirst={CAPIArticle.standfirst}
 								/>
 							</GridItem>
 							<GridItem area="lastupdated">
 								<Hide until="desktop">
-									{CAPI.blocks.length &&
-										CAPI.blocks[0].blockLastUpdated && (
+									{CAPIArticle.blocks.length &&
+										CAPIArticle.blocks[0]
+											.blockLastUpdated && (
 											<ArticleLastUpdated
 												format={format}
 												lastUpdated={
-													CAPI.blocks[0]
+													CAPIArticle.blocks[0]
 														.blockLastUpdated
 												}
 											/>
@@ -537,24 +555,29 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 										<ArticleMeta
 											branding={branding}
 											format={format}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-											author={CAPI.author}
-											tags={CAPI.tags}
+											pageId={CAPIArticle.pageId}
+											webTitle={CAPIArticle.webTitle}
+											author={CAPIArticle.author}
+											tags={CAPIArticle.tags}
 											primaryDateline={
-												CAPI.webPublicationDateDisplay
+												CAPIArticle.webPublicationDateDisplay
 											}
 											secondaryDateline={
-												CAPI.webPublicationSecondaryDateDisplay
+												CAPIArticle.webPublicationSecondaryDateDisplay
 											}
-											isCommentable={CAPI.isCommentable}
+											isCommentable={
+												CAPIArticle.isCommentable
+											}
 											discussionApiUrl={
-												CAPI.config.discussionApiUrl
+												CAPIArticle.config
+													.discussionApiUrl
 											}
-											shortUrlId={CAPI.config.shortUrlId}
-											ajaxUrl={CAPI.config.ajaxUrl}
+											shortUrlId={
+												CAPIArticle.config.shortUrlId
+											}
+											ajaxUrl={CAPIArticle.config.ajaxUrl}
 											showShareCount={
-												CAPI.config.switches
+												CAPIArticle.config.switches
 													.serverShareCounts
 											}
 										/>
@@ -587,28 +610,30 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 						<LiveGrid>
 							<GridItem area="media">
 								<div css={maxWidth}>
-									{CAPI.matchUrl && (
+									{CAPIArticle.matchUrl && (
 										<Island
 											clientOnly={true}
 											placeholderHeight={40}
 										>
 											<GetMatchTabs
-												matchUrl={CAPI.matchUrl}
+												matchUrl={CAPIArticle.matchUrl}
 												format={format}
 											/>
 										</Island>
 									)}
 									<MainMedia
 										format={format}
-										elements={CAPI.mainMediaElements}
+										elements={CAPIArticle.mainMediaElements}
 										adTargeting={adTargeting}
 										host={host}
-										pageId={CAPI.pageId}
-										webTitle={CAPI.webTitle}
-										ajaxUrl={CAPI.config.ajaxUrl}
-										switches={CAPI.config.switches}
-										isSensitive={CAPI.config.isSensitive}
-										isAdFreeUser={CAPI.isAdFreeUser}
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										switches={CAPIArticle.config.switches}
+										isSensitive={
+											CAPIArticle.config.isSensitive
+										}
+										isAdFreeUser={CAPIArticle.isAdFreeUser}
 									/>
 								</div>
 							</GridItem>
@@ -633,24 +658,29 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 										<ArticleMeta
 											branding={branding}
 											format={format}
-											pageId={CAPI.pageId}
-											webTitle={CAPI.webTitle}
-											author={CAPI.author}
-											tags={CAPI.tags}
+											pageId={CAPIArticle.pageId}
+											webTitle={CAPIArticle.webTitle}
+											author={CAPIArticle.author}
+											tags={CAPIArticle.tags}
 											primaryDateline={
-												CAPI.webPublicationDateDisplay
+												CAPIArticle.webPublicationDateDisplay
 											}
 											secondaryDateline={
-												CAPI.webPublicationSecondaryDateDisplay
+												CAPIArticle.webPublicationSecondaryDateDisplay
 											}
-											isCommentable={CAPI.isCommentable}
+											isCommentable={
+												CAPIArticle.isCommentable
+											}
 											discussionApiUrl={
-												CAPI.config.discussionApiUrl
+												CAPIArticle.config
+													.discussionApiUrl
 											}
-											shortUrlId={CAPI.config.shortUrlId}
-											ajaxUrl={CAPI.config.ajaxUrl}
+											shortUrlId={
+												CAPIArticle.config.shortUrlId
+											}
+											ajaxUrl={CAPIArticle.config.ajaxUrl}
 											showShareCount={
-												CAPI.config.switches
+												CAPIArticle.config.switches
 													.serverShareCounts
 											}
 										/>
@@ -659,26 +689,28 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 								{/* Key events */}
 								<div
 									css={[
-										!CAPI.matchUrl && sticky,
+										!CAPIArticle.matchUrl && sticky,
 										keyEventsMargins,
 										sidePaddingDesktop,
 									]}
 								>
 									<KeyEventsContainer
 										format={format}
-										keyEvents={CAPI.keyEvents}
-										filterKeyEvents={CAPI.filterKeyEvents}
+										keyEvents={CAPIArticle.keyEvents}
+										filterKeyEvents={
+											CAPIArticle.filterKeyEvents
+										}
 									/>
 								</div>
 								{/* Match stats */}
-								{CAPI.matchUrl && (
+								{CAPIArticle.matchUrl && (
 									<Island
 										deferUntil="visible"
 										clientOnly={true}
 										placeholderHeight={800}
 									>
 										<GetMatchStats
-											matchUrl={CAPI.matchUrl}
+											matchUrl={CAPIArticle.matchUrl}
 											format={format}
 										/>
 									</Island>
@@ -705,31 +737,35 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 												deferUntil="idle"
 											>
 												<Liveness
-													pageId={CAPI.pageId}
-													webTitle={CAPI.webTitle}
+													pageId={CAPIArticle.pageId}
+													webTitle={
+														CAPIArticle.webTitle
+													}
 													ajaxUrl={
-														CAPI.config.ajaxUrl
+														CAPIArticle.config
+															.ajaxUrl
 													}
 													filterKeyEvents={
-														CAPI.filterKeyEvents
+														CAPIArticle.filterKeyEvents
 													}
 													format={format}
 													switches={
-														CAPI.config.switches
+														CAPIArticle.config
+															.switches
 													}
 													onFirstPage={
 														pagination.currentPage ===
 														1
 													}
-													webURL={CAPI.webURL}
+													webURL={CAPIArticle.webURL}
 													// We default to string here because the property is optional but we
 													// know it will exist for all blogs
 													mostRecentBlockId={
-														CAPI.mostRecentBlockId ||
+														CAPIArticle.mostRecentBlockId ||
 														''
 													}
 													hasPinnedPost={
-														!!CAPI.pinnedPost
+														!!CAPIArticle.pinnedPost
 													}
 												/>
 											</Island>
@@ -739,7 +775,7 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 										<Island deferUntil="visible">
 											<FilterKeyEventsToggle
 												filterKeyEvents={
-													CAPI.filterKeyEvents
+													CAPIArticle.filterKeyEvents
 												}
 											/>
 										</Island>
@@ -753,7 +789,7 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
 													filterKeyEvents={
-														CAPI.filterKeyEvents
+														CAPIArticle.filterKeyEvents
 													}
 												/>
 											</Island>
@@ -776,38 +812,58 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 											)}
 											<ArticleBody
 												format={format}
-												blocks={CAPI.blocks}
-												pinnedPost={CAPI.pinnedPost}
+												blocks={CAPIArticle.blocks}
+												pinnedPost={
+													CAPIArticle.pinnedPost
+												}
 												adTargeting={adTargeting}
 												host={host}
-												pageId={CAPI.pageId}
-												webTitle={CAPI.webTitle}
-												ajaxUrl={CAPI.config.ajaxUrl}
-												section={CAPI.config.section}
-												switches={CAPI.config.switches}
+												pageId={CAPIArticle.pageId}
+												webTitle={CAPIArticle.webTitle}
+												ajaxUrl={
+													CAPIArticle.config.ajaxUrl
+												}
+												section={
+													CAPIArticle.config.section
+												}
+												switches={
+													CAPIArticle.config.switches
+												}
 												isSensitive={
-													CAPI.config.isSensitive
+													CAPIArticle.config
+														.isSensitive
 												}
-												isAdFreeUser={CAPI.isAdFreeUser}
+												isAdFreeUser={
+													CAPIArticle.isAdFreeUser
+												}
 												shouldHideReaderRevenue={
-													CAPI.shouldHideReaderRevenue
+													CAPIArticle.shouldHideReaderRevenue
 												}
-												tags={CAPI.tags}
+												tags={CAPIArticle.tags}
 												isPaidContent={
-													!!CAPI.config.isPaidContent
+													!!CAPIArticle.config
+														.isPaidContent
 												}
 												contributionsServiceUrl={
 													contributionsServiceUrl
 												}
-												contentType={CAPI.contentType}
+												contentType={
+													CAPIArticle.contentType
+												}
 												sectionName={
-													CAPI.sectionName || ''
+													CAPIArticle.sectionName ||
+													''
 												}
 												isPreview={
-													CAPI.config.isPreview
+													CAPIArticle.config.isPreview
 												}
-												idUrl={CAPI.config.idUrl || ''}
-												isDev={!!CAPI.config.isDev}
+												idUrl={
+													CAPIArticle.config.idUrl ||
+													''
+												}
+												isDev={
+													!!CAPIArticle.config.isDev
+												}
 												onFirstPage={
 													pagination.currentPage === 1
 												}
@@ -831,40 +887,45 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 												<Island clientOnly={true}>
 													<SlotBodyEnd
 														contentType={
-															CAPI.contentType
+															CAPIArticle.contentType
 														}
 														contributionsServiceUrl={
 															contributionsServiceUrl
 														}
 														idApiUrl={
-															CAPI.config.idApiUrl
+															CAPIArticle.config
+																.idApiUrl
 														}
 														isMinuteArticle={
-															CAPI.pageType
+															CAPIArticle.pageType
 																.isMinuteArticle
 														}
 														isPaidContent={
-															CAPI.pageType
+															CAPIArticle.pageType
 																.isPaidContent
 														}
 														keywordsId={
-															CAPI.config
+															CAPIArticle.config
 																.keywordIds
 														}
-														pageId={CAPI.pageId}
+														pageId={
+															CAPIArticle.pageId
+														}
 														sectionId={
-															CAPI.config.section
+															CAPIArticle.config
+																.section
 														}
 														sectionName={
-															CAPI.sectionName
+															CAPIArticle.sectionName
 														}
 														shouldHideReaderRevenue={
-															CAPI.shouldHideReaderRevenue
+															CAPIArticle.shouldHideReaderRevenue
 														}
 														stage={
-															CAPI.config.stage
+															CAPIArticle.config
+																.stage
 														}
-														tags={CAPI.tags}
+														tags={CAPIArticle.tags}
 													/>
 												</Island>
 											)}
@@ -876,18 +937,18 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 											<SubMeta
 												format={format}
 												subMetaKeywordLinks={
-													CAPI.subMetaKeywordLinks
+													CAPIArticle.subMetaKeywordLinks
 												}
 												subMetaSectionLinks={
-													CAPI.subMetaSectionLinks
+													CAPIArticle.subMetaSectionLinks
 												}
-												pageId={CAPI.pageId}
-												webUrl={CAPI.webURL}
-												webTitle={CAPI.webTitle}
+												pageId={CAPIArticle.pageId}
+												webUrl={CAPIArticle.webURL}
+												webTitle={CAPIArticle.webTitle}
 												showBottomSocialButtons={
-													CAPI.showBottomSocialButtons
+													CAPIArticle.showBottomSocialButtons
 												}
-												badge={CAPI.badge}
+												badge={CAPIArticle.badge}
 											/>
 										</ArticleContainer>
 									</Accordion>
@@ -918,10 +979,11 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 											position="right"
 											display={format.display}
 											shouldHideReaderRevenue={
-												CAPI.shouldHideReaderRevenue
+												CAPIArticle.shouldHideReaderRevenue
 											}
 											isPaidContent={
-												CAPI.pageType.isPaidContent
+												CAPIArticle.pageType
+													.isPaidContent
 											}
 										/>
 									</RightColumn>
@@ -948,20 +1010,24 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -972,34 +1038,37 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
 					</ElementContainer>
 				)}
 
-				{!isPaidContent && CAPI.isCommentable && (
+				{!isPaidContent && CAPIArticle.isCommentable && (
 					<ElementContainer
 						sectionId="comments"
 						data-print-layout="hide"
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -1008,8 +1077,8 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -1051,32 +1120,36 @@ export const LiveLayout = ({ CAPI, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
+						contentType={CAPIArticle.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -38,7 +38,7 @@ export default {
 	},
 };
 
-const convertToShowcase = (CAPI: CAPIType) => {
+const convertToShowcase = (CAPI: CAPIArticleType) => {
 	return {
 		...CAPI,
 		format: {
@@ -51,7 +51,7 @@ const convertToShowcase = (CAPI: CAPIType) => {
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 	const NAV = extractNAV(ServerCAPI.nav);
 	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 

--- a/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Showcase.stories.tsx
@@ -38,11 +38,11 @@ export default {
 	},
 };
 
-const convertToShowcase = (CAPI: CAPIArticleType) => {
+const convertToShowcase = (CAPIArticle: CAPIArticleType) => {
 	return {
-		...CAPI,
+		...CAPIArticle,
 		format: {
-			...CAPI.format,
+			...CAPIArticle.format,
 			display: 'ShowcaseDisplay' as CAPIDisplay,
 		},
 	};
@@ -63,7 +63,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
 		injectPrivacySettingsLink();
 		doStorybookHydration();
 	}, [ServerCAPI]);
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
+	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -204,46 +204,51 @@ const PositionHeadline = ({
 };
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
+export const ShowcaseLayout = ({
+	CAPIArticle,
+	NAV,
+	format,
+}: Props): JSX.Element => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
+		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
+		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
-	const showComments = CAPI.isCommentable;
+	const showComments = CAPIArticle.isCommentable;
 
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	const palette = decidePalette(format);
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	return (
 		<>
@@ -258,8 +263,8 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								shouldCenter={false}
 							>
 								<HeaderAdSlot
-									isAdFreeUser={CAPI.isAdFreeUser}
-									shouldHideAds={CAPI.shouldHideAds}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									shouldHideAds={CAPIArticle.shouldHideAds}
 									display={format.display}
 								/>
 							</ElementContainer>
@@ -273,23 +278,26 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								element="header"
 							>
 								<Header
-									edition={CAPI.editionId}
-									idUrl={CAPI.config.idUrl}
-									mmaUrl={CAPI.config.mmaUrl}
+									edition={CAPIArticle.editionId}
+									idUrl={CAPIArticle.config.idUrl}
+									mmaUrl={CAPIArticle.config.mmaUrl}
 									supporterCTA={
-										CAPI.nav.readerRevenueLinks.header
-											.supporter
+										CAPIArticle.nav.readerRevenueLinks
+											.header.supporter
 									}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
 									isAnniversary={
-										CAPI.config.switches
+										CAPIArticle.config.switches
 											.anniversaryHeaderSvg
 									}
-									urls={CAPI.nav.readerRevenueLinks.header}
+									urls={
+										CAPIArticle.nav.readerRevenueLinks
+											.header
+									}
 									remoteHeader={
-										CAPI.config.switches.remoteHeader
+										CAPIArticle.config.switches.remoteHeader
 									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
@@ -308,13 +316,13 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									nav={NAV}
 									format={{
 										...format,
-										theme: getCurrentPillar(CAPI),
+										theme: getCurrentPillar(CAPIArticle),
 									}}
 									subscribeUrl={
-										CAPI.nav.readerRevenueLinks.header
-											.subscribe
+										CAPIArticle.nav.readerRevenueLinks
+											.header.subscribe
 									}
-									edition={CAPI.editionId}
+									edition={CAPIArticle.editionId}
 								/>
 							</ElementContainer>
 
@@ -357,8 +365,8 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								padded={false}
 							>
 								<HeaderAdSlot
-									isAdFreeUser={CAPI.isAdFreeUser}
-									shouldHideAds={CAPI.shouldHideAds}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									shouldHideAds={CAPIArticle.shouldHideAds}
 									display={format.display}
 								/>
 							</ElementContainer>
@@ -376,13 +384,13 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 									nav={NAV}
 									format={{
 										...format,
-										theme: getCurrentPillar(CAPI),
+										theme: getCurrentPillar(CAPIArticle),
 									}}
 									subscribeUrl={
-										CAPI.nav.readerRevenueLinks.header
-											.subscribe
+										CAPIArticle.nav.readerRevenueLinks
+											.header.subscribe
 									}
-									edition={CAPI.editionId}
+									edition={CAPIArticle.editionId}
 								/>
 							</ElementContainer>
 						</Stuck>
@@ -413,11 +421,11 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPI.tags}
-								sectionLabel={CAPI.sectionLabel}
-								sectionUrl={CAPI.sectionUrl}
-								guardianBaseURL={CAPI.guardianBaseURL}
-								badge={CAPI.badge}
+								tags={CAPIArticle.tags}
+								sectionLabel={CAPIArticle.sectionLabel}
+								sectionUrl={CAPIArticle.sectionUrl}
+								guardianBaseURL={CAPIArticle.guardianBaseURL}
+								badge={CAPIArticle.badge}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -427,15 +435,15 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							<PositionHeadline design={format.design}>
 								<ArticleHeadline
 									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
-									byline={CAPI.author.byline}
+									headlineString={CAPIArticle.headline}
+									tags={CAPIArticle.tags}
+									byline={CAPIArticle.author.byline}
 									webPublicationDateDeprecated={
-										CAPI.webPublicationDateDeprecated
+										CAPIArticle.webPublicationDateDeprecated
 									}
 									hasStarRating={
-										!!CAPI.starRating ||
-										CAPI.starRating === 0
+										!!CAPIArticle.starRating ||
+										CAPIArticle.starRating === 0
 									}
 								/>
 							</PositionHeadline>
@@ -444,29 +452,29 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							<div css={mainMediaWrapper}>
 								<MainMedia
 									format={format}
-									elements={CAPI.mainMediaElements}
+									elements={CAPIArticle.mainMediaElements}
 									adTargeting={adTargeting}
 									starRating={
 										format.design ===
 											ArticleDesign.Review &&
-										CAPI.starRating
-											? CAPI.starRating
+										CAPIArticle.starRating
+											? CAPIArticle.starRating
 											: undefined
 									}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									isSensitive={CAPI.config.isSensitive}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									isSensitive={CAPIArticle.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPI.standfirst}
+								standfirst={CAPIArticle.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="lines">
@@ -487,24 +495,25 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									author={CAPI.author}
-									tags={CAPI.tags}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									author={CAPIArticle.author}
+									tags={CAPIArticle.tags}
 									primaryDateline={
-										CAPI.webPublicationDateDisplay
+										CAPIArticle.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPI.webPublicationSecondaryDateDisplay
+										CAPIArticle.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPI.isCommentable}
+									isCommentable={CAPIArticle.isCommentable}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
-									shortUrlId={CAPI.config.shortUrlId}
-									ajaxUrl={CAPI.config.ajaxUrl}
+									shortUrlId={CAPIArticle.config.shortUrlId}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPI.config.switches.serverShareCounts
+										CAPIArticle.config.switches
+											.serverShareCounts
 									}
 								/>
 							</div>
@@ -513,53 +522,67 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPI.blocks}
+									blocks={CAPIArticle.blocks}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isSensitive={CAPI.config.isSensitive}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									section={CAPI.config.section}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isSensitive={CAPIArticle.config.isSensitive}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									section={CAPIArticle.config.section}
 									shouldHideReaderRevenue={
-										CAPI.shouldHideReaderRevenue
+										CAPIArticle.shouldHideReaderRevenue
 									}
-									tags={CAPI.tags}
-									isPaidContent={!!CAPI.config.isPaidContent}
+									tags={CAPIArticle.tags}
+									isPaidContent={
+										!!CAPIArticle.config.isPaidContent
+									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPI.contentType}
-									sectionName={CAPI.sectionName || ''}
-									isPreview={CAPI.config.isPreview}
-									idUrl={CAPI.config.idUrl || ''}
-									isDev={!!CAPI.config.isDev}
+									contentType={CAPIArticle.contentType}
+									sectionName={CAPIArticle.sectionName || ''}
+									isPreview={CAPIArticle.config.isPreview}
+									idUrl={CAPIArticle.config.idUrl || ''}
+									isDev={!!CAPIArticle.config.isDev}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={CAPI.contentType}
+											contentType={
+												CAPIArticle.contentType
+											}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={CAPI.config.idApiUrl}
+											idApiUrl={
+												CAPIArticle.config.idApiUrl
+											}
 											isMinuteArticle={
-												CAPI.pageType.isMinuteArticle
+												CAPIArticle.pageType
+													.isMinuteArticle
 											}
 											isPaidContent={
-												CAPI.pageType.isPaidContent
+												CAPIArticle.pageType
+													.isPaidContent
 											}
-											keywordsId={CAPI.config.keywordIds}
-											pageId={CAPI.pageId}
-											sectionId={CAPI.config.section}
-											sectionName={CAPI.sectionName}
+											keywordsId={
+												CAPIArticle.config.keywordIds
+											}
+											pageId={CAPIArticle.pageId}
+											sectionId={
+												CAPIArticle.config.section
+											}
+											sectionName={
+												CAPIArticle.sectionName
+											}
 											shouldHideReaderRevenue={
-												CAPI.shouldHideReaderRevenue
+												CAPIArticle.shouldHideReaderRevenue
 											}
-											stage={CAPI.config.stage}
-											tags={CAPI.tags}
+											stage={CAPIArticle.config.stage}
+											tags={CAPIArticle.tags}
 										/>
 									</Island>
 								)}
@@ -567,18 +590,18 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPI.subMetaKeywordLinks
+										CAPIArticle.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPI.subMetaSectionLinks
+										CAPIArticle.subMetaSectionLinks
 									}
-									pageId={CAPI.pageId}
-									webUrl={CAPI.webURL}
-									webTitle={CAPI.webTitle}
+									pageId={CAPIArticle.pageId}
+									webUrl={CAPIArticle.webURL}
+									webTitle={CAPIArticle.webTitle}
 									showBottomSocialButtons={
-										CAPI.showBottomSocialButtons
+										CAPIArticle.showBottomSocialButtons
 									}
-									badge={CAPI.badge}
+									badge={CAPIArticle.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -604,10 +627,10 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 										position="right"
 										display={format.display}
 										shouldHideReaderRevenue={
-											CAPI.shouldHideReaderRevenue
+											CAPIArticle.shouldHideReaderRevenue
 										}
 										isPaidContent={
-											CAPI.pageType.isPaidContent
+											CAPIArticle.pageType.isPaidContent
 										}
 									/>
 									{!isPaidContent ? (
@@ -616,7 +639,9 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 											deferUntil="visible"
 										>
 											<MostViewedRightWrapper
-												isAdFreeUser={CAPI.isAdFreeUser}
+												isAdFreeUser={
+													CAPIArticle.isAdFreeUser
+												}
 											/>
 										</Island>
 									) : (
@@ -643,20 +668,24 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -667,9 +696,9 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
@@ -679,18 +708,21 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="section">
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -699,8 +731,8 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -736,32 +768,36 @@ export const ShowcaseLayout = ({ CAPI, NAV, format }: Props): JSX.Element => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper>
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
+						contentType={CAPIArticle.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -204,7 +204,7 @@ const PositionHeadline = ({
 };
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -43,11 +43,11 @@ export default {
 	},
 };
 
-const convertToStandard = (CAPI: CAPIArticleType) => {
+const convertToStandard = (CAPIArticle: CAPIArticleType) => {
 	return {
-		...CAPI,
+		...CAPIArticle,
 		format: {
-			...CAPI.format,
+			...CAPIArticle.format,
 			display: 'StandardDisplay' as CAPIDisplay,
 		},
 	};
@@ -77,7 +77,7 @@ const HydratedLayout = ({
 	if (modifyPage) {
 		modifyPage();
 	}
-	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} format={format} />;
+	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
 };
 
 export const ArticleStory = (): React.ReactNode => {

--- a/dotcom-rendering/src/web/layouts/Standard.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Standard.stories.tsx
@@ -43,7 +43,7 @@ export default {
 	},
 };
 
-const convertToStandard = (CAPI: CAPIType) => {
+const convertToStandard = (CAPI: CAPIArticleType) => {
 	return {
 		...CAPI,
 		format: {
@@ -60,7 +60,7 @@ const HydratedLayout = ({
 	ServerCAPI,
 	modifyPage,
 }: {
-	ServerCAPI: CAPIType;
+	ServerCAPI: CAPIArticleType;
 	modifyPage?: () => void;
 }) => {
 	const NAV = extractNAV(ServerCAPI.nav);

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -290,7 +290,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -290,46 +290,47 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
 
-export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
+export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const {
 		config: { isPaidContent, host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	const showBodyEndSlot =
-		parse(CAPI.slotMachineFlags || '').showBodyEnd ||
-		CAPI.config.switches.slotBodyEnd;
+		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
+		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const seriesTag = CAPI.tags.find(
+	const seriesTag = CAPIArticle.tags.find(
 		(tag) => tag.type === 'Series' || tag.type === 'Blog',
 	);
 
-	const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+	const showOnwardsLower = seriesTag && CAPIArticle.hasStoryPackage;
 
 	const isMatchReport =
-		format.design === ArticleDesign.MatchReport && !!CAPI.matchUrl;
+		format.design === ArticleDesign.MatchReport && !!CAPIArticle.matchUrl;
 
-	const showComments = CAPI.isCommentable;
+	const showComments = CAPIArticle.isCommentable;
 
-	const { branding } = CAPI.commercialProperties[CAPI.editionId];
+	const { branding } =
+		CAPIArticle.commercialProperties[CAPIArticle.editionId];
 
 	const palette = decidePalette(format);
 
@@ -338,10 +339,10 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 			? format
 			: {
 					...format,
-					theme: getCurrentPillar(CAPI),
+					theme: getCurrentPillar(CAPIArticle),
 			  };
 
-	const contributionsServiceUrl = getContributionsServiceUrl(CAPI);
+	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	return (
 		<>
@@ -355,8 +356,8 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 							shouldCenter={false}
 						>
 							<HeaderAdSlot
-								isAdFreeUser={CAPI.isAdFreeUser}
-								shouldHideAds={CAPI.shouldHideAds}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								shouldHideAds={CAPIArticle.shouldHideAds}
 								display={format.display}
 							/>
 						</ElementContainer>
@@ -370,18 +371,24 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 							element="header"
 						>
 							<Header
-								edition={CAPI.editionId}
-								idUrl={CAPI.config.idUrl}
-								mmaUrl={CAPI.config.mmaUrl}
+								edition={CAPIArticle.editionId}
+								idUrl={CAPIArticle.config.idUrl}
+								mmaUrl={CAPIArticle.config.mmaUrl}
 								supporterCTA={
-									CAPI.nav.readerRevenueLinks.header.supporter
+									CAPIArticle.nav.readerRevenueLinks.header
+										.supporter
 								}
-								discussionApiUrl={CAPI.config.discussionApiUrl}
+								discussionApiUrl={
+									CAPIArticle.config.discussionApiUrl
+								}
 								isAnniversary={
-									CAPI.config.switches.anniversaryHeaderSvg
+									CAPIArticle.config.switches
+										.anniversaryHeaderSvg
 								}
-								urls={CAPI.nav.readerRevenueLinks.header}
-								remoteHeader={CAPI.config.switches.remoteHeader}
+								urls={CAPIArticle.nav.readerRevenueLinks.header}
+								remoteHeader={
+									CAPIArticle.config.switches.remoteHeader
+								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
@@ -400,9 +407,10 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 							nav={NAV}
 							format={formatForNav}
 							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
+								CAPIArticle.nav.readerRevenueLinks.header
+									.subscribe
 							}
-							edition={CAPI.editionId}
+							edition={CAPIArticle.editionId}
 						/>
 					</ElementContainer>
 					{NAV.subNavSections &&
@@ -454,7 +462,7 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 				</Stuck>
 			)}
 
-			{CAPI.config.switches.surveys && (
+			{CAPIArticle.config.switches.surveys && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 
@@ -470,11 +478,11 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 						<GridItem area="title" element="aside">
 							<ArticleTitle
 								format={format}
-								tags={CAPI.tags}
-								sectionLabel={CAPI.sectionLabel}
-								sectionUrl={CAPI.sectionUrl}
-								guardianBaseURL={CAPI.guardianBaseURL}
-								badge={CAPI.badge}
+								tags={CAPIArticle.tags}
+								sectionLabel={CAPIArticle.sectionLabel}
+								sectionUrl={CAPIArticle.sectionUrl}
+								guardianBaseURL={CAPIArticle.guardianBaseURL}
+								badge={CAPIArticle.badge}
 							/>
 						</GridItem>
 						<GridItem area="border">
@@ -487,19 +495,21 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 						<GridItem area="matchNav" element="aside">
 							<div css={maxWidth}>
 								{format.design === ArticleDesign.MatchReport &&
-									CAPI.matchUrl && (
+									CAPIArticle.matchUrl && (
 										<Island
 											deferUntil="visible"
 											clientOnly={true}
 											placeholderHeight={230}
 										>
 											<GetMatchNav
-												matchUrl={CAPI.matchUrl}
+												matchUrl={CAPIArticle.matchUrl}
 												format={format}
-												headlineString={CAPI.headline}
-												tags={CAPI.tags}
+												headlineString={
+													CAPIArticle.headline
+												}
+												tags={CAPIArticle.tags}
 												webPublicationDateDeprecated={
-													CAPI.webPublicationDateDeprecated
+													CAPIArticle.webPublicationDateDeprecated
 												}
 											/>
 										</Island>
@@ -509,13 +519,13 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
 								{format.design === ArticleDesign.MatchReport &&
-									CAPI.matchUrl && (
+									CAPIArticle.matchUrl && (
 										<Island
 											clientOnly={true}
 											placeholderHeight={40}
 										>
 											<GetMatchTabs
-												matchUrl={CAPI.matchUrl}
+												matchUrl={CAPIArticle.matchUrl}
 												format={format}
 											/>
 										</Island>
@@ -526,22 +536,23 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 							<div css={maxWidth}>
 								<ArticleHeadline
 									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
-									byline={CAPI.author.byline}
+									headlineString={CAPIArticle.headline}
+									tags={CAPIArticle.tags}
+									byline={CAPIArticle.author.byline}
 									webPublicationDateDeprecated={
-										CAPI.webPublicationDateDeprecated
+										CAPIArticle.webPublicationDateDeprecated
 									}
 									hasStarRating={
-										!!CAPI.starRating ||
-										CAPI.starRating === 0
+										!!CAPIArticle.starRating ||
+										CAPIArticle.starRating === 0
 									}
 								/>
 							</div>
-							{CAPI.starRating || CAPI.starRating === 0 ? (
+							{CAPIArticle.starRating ||
+							CAPIArticle.starRating === 0 ? (
 								<div css={starWrapper}>
 									<StarRating
-										rating={CAPI.starRating}
+										rating={CAPIArticle.starRating}
 										size="large"
 									/>
 								</div>
@@ -552,22 +563,22 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
-								standfirst={CAPI.standfirst}
+								standfirst={CAPIArticle.standfirst}
 							/>
 						</GridItem>
 						<GridItem area="media">
 							<div css={maxWidth}>
 								<MainMedia
 									format={format}
-									elements={CAPI.mainMediaElements}
+									elements={CAPIArticle.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									isSensitive={CAPI.config.isSensitive}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									isSensitive={CAPIArticle.config.isSensitive}
 								/>
 							</div>
 						</GridItem>
@@ -595,24 +606,25 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 								<ArticleMeta
 									branding={branding}
 									format={format}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									author={CAPI.author}
-									tags={CAPI.tags}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									author={CAPIArticle.author}
+									tags={CAPIArticle.tags}
 									primaryDateline={
-										CAPI.webPublicationDateDisplay
+										CAPIArticle.webPublicationDateDisplay
 									}
 									secondaryDateline={
-										CAPI.webPublicationSecondaryDateDisplay
+										CAPIArticle.webPublicationSecondaryDateDisplay
 									}
-									isCommentable={CAPI.isCommentable}
+									isCommentable={CAPIArticle.isCommentable}
 									discussionApiUrl={
-										CAPI.config.discussionApiUrl
+										CAPIArticle.config.discussionApiUrl
 									}
-									shortUrlId={CAPI.config.shortUrlId}
-									ajaxUrl={CAPI.config.ajaxUrl}
+									shortUrlId={CAPIArticle.config.shortUrlId}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPI.config.switches.serverShareCounts
+										CAPIArticle.config.switches
+											.serverShareCounts
 									}
 								/>
 							</div>
@@ -621,40 +633,42 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
-									blocks={CAPI.blocks}
-									pinnedPost={CAPI.pinnedPost}
+									blocks={CAPIArticle.blocks}
+									pinnedPost={CAPIArticle.pinnedPost}
 									adTargeting={adTargeting}
 									host={host}
-									pageId={CAPI.pageId}
-									webTitle={CAPI.webTitle}
-									ajaxUrl={CAPI.config.ajaxUrl}
-									switches={CAPI.config.switches}
-									isSensitive={CAPI.config.isSensitive}
-									isAdFreeUser={CAPI.isAdFreeUser}
-									section={CAPI.config.section}
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									switches={CAPIArticle.config.switches}
+									isSensitive={CAPIArticle.config.isSensitive}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									section={CAPIArticle.config.section}
 									shouldHideReaderRevenue={
-										CAPI.shouldHideReaderRevenue
+										CAPIArticle.shouldHideReaderRevenue
 									}
-									tags={CAPI.tags}
-									isPaidContent={!!CAPI.config.isPaidContent}
+									tags={CAPIArticle.tags}
+									isPaidContent={
+										!!CAPIArticle.config.isPaidContent
+									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
-									contentType={CAPI.contentType}
-									sectionName={CAPI.sectionName || ''}
-									isPreview={CAPI.config.isPreview}
-									idUrl={CAPI.config.idUrl || ''}
-									isDev={!!CAPI.config.isDev}
+									contentType={CAPIArticle.contentType}
+									sectionName={CAPIArticle.sectionName || ''}
+									isPreview={CAPIArticle.config.isPreview}
+									idUrl={CAPIArticle.config.idUrl || ''}
+									isDev={!!CAPIArticle.config.isDev}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
-									!!CAPI.matchUrl && (
+									!!CAPIArticle.matchUrl && (
 										<Island
 											deferUntil="visible"
 											clientOnly={true}
 											placeholderHeight={800}
 										>
 											<GetMatchStats
-												matchUrl={CAPI.matchUrl}
+												matchUrl={CAPIArticle.matchUrl}
 												format={format}
 											/>
 										</Island>
@@ -663,26 +677,38 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>
 										<SlotBodyEnd
-											contentType={CAPI.contentType}
+											contentType={
+												CAPIArticle.contentType
+											}
 											contributionsServiceUrl={
 												contributionsServiceUrl
 											}
-											idApiUrl={CAPI.config.idApiUrl}
+											idApiUrl={
+												CAPIArticle.config.idApiUrl
+											}
 											isMinuteArticle={
-												CAPI.pageType.isMinuteArticle
+												CAPIArticle.pageType
+													.isMinuteArticle
 											}
 											isPaidContent={
-												CAPI.pageType.isPaidContent
+												CAPIArticle.pageType
+													.isPaidContent
 											}
-											keywordsId={CAPI.config.keywordIds}
-											pageId={CAPI.pageId}
-											sectionId={CAPI.config.section}
-											sectionName={CAPI.sectionName}
+											keywordsId={
+												CAPIArticle.config.keywordIds
+											}
+											pageId={CAPIArticle.pageId}
+											sectionId={
+												CAPIArticle.config.section
+											}
+											sectionName={
+												CAPIArticle.sectionName
+											}
 											shouldHideReaderRevenue={
-												CAPI.shouldHideReaderRevenue
+												CAPIArticle.shouldHideReaderRevenue
 											}
-											stage={CAPI.config.stage}
-											tags={CAPI.tags}
+											stage={CAPIArticle.config.stage}
+											tags={CAPIArticle.tags}
 										/>
 									</Island>
 								)}
@@ -694,18 +720,18 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={
-										CAPI.subMetaKeywordLinks
+										CAPIArticle.subMetaKeywordLinks
 									}
 									subMetaSectionLinks={
-										CAPI.subMetaSectionLinks
+										CAPIArticle.subMetaSectionLinks
 									}
-									pageId={CAPI.pageId}
-									webUrl={CAPI.webURL}
-									webTitle={CAPI.webTitle}
+									pageId={CAPIArticle.pageId}
+									webUrl={CAPIArticle.webURL}
+									webTitle={CAPIArticle.webTitle}
 									showBottomSocialButtons={
-										CAPI.showBottomSocialButtons
+										CAPIArticle.showBottomSocialButtons
 									}
-									badge={CAPI.badge}
+									badge={CAPIArticle.badge}
 								/>
 							</ArticleContainer>
 						</GridItem>
@@ -731,10 +757,10 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 										position="right"
 										display={format.display}
 										shouldHideReaderRevenue={
-											CAPI.shouldHideReaderRevenue
+											CAPIArticle.shouldHideReaderRevenue
 										}
 										isPaidContent={
-											CAPI.pageType.isPaidContent
+											CAPIArticle.pageType.isPaidContent
 										}
 									/>
 									{!isPaidContent ? (
@@ -743,7 +769,9 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 											deferUntil="visible"
 										>
 											<MostViewedRightWrapper
-												isAdFreeUser={CAPI.isAdFreeUser}
+												isAdFreeUser={
+													CAPIArticle.isAdFreeUser
+												}
 											/>
 										</Island>
 									) : (
@@ -772,20 +800,24 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 
 				<Island clientOnly={true} deferUntil="visible">
 					<OnwardsUpper
-						ajaxUrl={CAPI.config.ajaxUrl}
-						hasRelated={CAPI.hasRelated}
-						hasStoryPackage={CAPI.hasStoryPackage}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						pageId={CAPI.pageId}
-						isPaidContent={CAPI.config.isPaidContent || false}
-						showRelatedContent={CAPI.config.showRelatedContent}
-						keywordIds={CAPI.config.keywordIds}
-						contentType={CAPI.contentType}
-						tags={CAPI.tags}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						hasRelated={CAPIArticle.hasRelated}
+						hasStoryPackage={CAPIArticle.hasStoryPackage}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						pageId={CAPIArticle.pageId}
+						isPaidContent={
+							CAPIArticle.config.isPaidContent || false
+						}
+						showRelatedContent={
+							CAPIArticle.config.showRelatedContent
+						}
+						keywordIds={CAPIArticle.config.keywordIds}
+						contentType={CAPIArticle.contentType}
+						tags={CAPIArticle.tags}
 						format={format}
 						pillar={format.theme}
-						edition={CAPI.editionId}
-						shortUrlId={CAPI.config.shortUrlId}
+						edition={CAPIArticle.editionId}
+						shortUrlId={CAPIArticle.config.shortUrlId}
 					/>
 				</Island>
 
@@ -796,9 +828,9 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 					>
 						<Island clientOnly={true} deferUntil="visible">
 							<OnwardsLower
-								ajaxUrl={CAPI.config.ajaxUrl}
-								hasStoryPackage={CAPI.hasStoryPackage}
-								tags={CAPI.tags}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								tags={CAPIArticle.tags}
 								format={format}
 							/>
 						</Island>
@@ -812,18 +844,21 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 						element="section"
 					>
 						<DiscussionLayout
-							discussionApiUrl={CAPI.config.discussionApiUrl}
-							shortUrlId={CAPI.config.shortUrlId}
+							discussionApiUrl={
+								CAPIArticle.config.discussionApiUrl
+							}
+							shortUrlId={CAPIArticle.config.shortUrlId}
 							format={format}
-							discussionD2Uid={CAPI.config.discussionD2Uid}
+							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
 							discussionApiClientHeader={
-								CAPI.config.discussionApiClientHeader
+								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPI.config.switches.enableDiscussionSwitch
+								CAPIArticle.config.switches
+									.enableDiscussionSwitch
 							}
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							shouldHideAds={CAPIArticle.shouldHideAds}
 						/>
 					</ElementContainer>
 				)}
@@ -832,8 +867,8 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 					<ElementContainer data-print-layout="hide" element="aside">
 						<MostViewedFooterLayout
 							format={format}
-							sectionName={CAPI.sectionName}
-							ajaxUrl={CAPI.config.ajaxUrl}
+							sectionName={CAPIArticle.sectionName}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
 						/>
 					</ElementContainer>
 				)}
@@ -875,32 +910,36 @@ export const StandardLayout = ({ CAPI, NAV, format }: Props) => {
 				element="footer"
 			>
 				<Footer
-					pageFooter={CAPI.pageFooter}
+					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPI.nav.readerRevenueLinks.header}
-					edition={CAPI.editionId}
-					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					urls={CAPIArticle.nav.readerRevenueLinks.header}
+					edition={CAPIArticle.editionId}
+					contributionsServiceUrl={
+						CAPIArticle.contributionsServiceUrl
+					}
 				/>
 			</ElementContainer>
 
 			<BannerWrapper data-print-layout="hide">
 				<Island deferUntil="idle" clientOnly={true}>
 					<StickyBottomBanner
-						contentType={CAPI.contentType}
+						contentType={CAPIArticle.contentType}
 						contributionsServiceUrl={contributionsServiceUrl}
-						idApiUrl={CAPI.config.idApiUrl}
-						isMinuteArticle={CAPI.pageType.isMinuteArticle}
-						isPaidContent={CAPI.pageType.isPaidContent}
-						isPreview={!!CAPI.config.isPreview}
-						isSensitive={CAPI.config.isSensitive}
-						keywordsId={CAPI.config.keywordIds}
-						pageId={CAPI.pageId}
-						section={CAPI.config.section}
-						sectionName={CAPI.sectionName}
-						shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-						switches={CAPI.config.switches}
-						tags={CAPI.tags}
+						idApiUrl={CAPIArticle.config.idApiUrl}
+						isMinuteArticle={CAPIArticle.pageType.isMinuteArticle}
+						isPaidContent={CAPIArticle.pageType.isPaidContent}
+						isPreview={!!CAPIArticle.config.isPreview}
+						isSensitive={CAPIArticle.config.isSensitive}
+						keywordsId={CAPIArticle.config.keywordIds}
+						pageId={CAPIArticle.pageId}
+						section={CAPIArticle.config.section}
+						sectionName={CAPIArticle.sectionName}
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+						switches={CAPIArticle.config.switches}
+						tags={CAPIArticle.tags}
 					/>
 				</Island>
 			</BannerWrapper>

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -42,7 +42,7 @@ const hasMainMediaStyles = css`
 `;
 
 interface Props {
-	CAPI: CAPIType;
+	CAPI: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -42,7 +42,7 @@ const hasMainMediaStyles = css`
 `;
 
 interface Props {
-	CAPI: CAPIArticleType;
+	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }
@@ -98,26 +98,30 @@ const Box = ({
 	</div>
 );
 
-export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
+export const ImmersiveHeader = ({
+	CAPIArticle,
+	NAV,
+	format,
+}: Props): JSX.Element => {
 	const {
 		config: { host },
-	} = CAPI;
+	} = CAPIArticle;
 
 	const adTargeting: AdTargeting = buildAdTargeting({
-		isAdFreeUser: CAPI.isAdFreeUser,
-		isSensitive: CAPI.config.isSensitive,
-		videoDuration: CAPI.config.videoDuration,
-		edition: CAPI.config.edition,
-		section: CAPI.config.section,
-		sharedAdTargeting: CAPI.config.sharedAdTargeting,
-		adUnit: CAPI.config.adUnit,
+		isAdFreeUser: CAPIArticle.isAdFreeUser,
+		isSensitive: CAPIArticle.config.isSensitive,
+		videoDuration: CAPIArticle.config.videoDuration,
+		edition: CAPIArticle.config.edition,
+		section: CAPIArticle.config.section,
+		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
+		adUnit: CAPIArticle.config.adUnit,
 	});
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
-	// 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
 
-	const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
+	const mainMedia = CAPIArticle.mainMediaElements[0] as ImageBlockElement;
 	const captionText = decideCaption(mainMedia);
 
 	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
@@ -173,13 +177,14 @@ export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							<Nav
 								format={{
 									...format,
-									theme: getCurrentPillar(CAPI),
+									theme: getCurrentPillar(CAPIArticle),
 								}}
 								nav={NAV}
 								subscribeUrl={
-									CAPI.nav.readerRevenueLinks.header.subscribe
+									CAPIArticle.nav.readerRevenueLinks.header
+										.subscribe
 								}
-								edition={CAPI.editionId}
+								edition={CAPIArticle.editionId}
 							/>
 						</ElementContainer>
 					</div>
@@ -202,22 +207,22 @@ export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 
 					<MainMedia
 						format={format}
-						elements={CAPI.mainMediaElements}
+						elements={CAPIArticle.mainMediaElements}
 						adTargeting={adTargeting}
 						starRating={
 							format.design === ArticleDesign.Review &&
-							CAPI.starRating
-								? CAPI.starRating
+							CAPIArticle.starRating
+								? CAPIArticle.starRating
 								: undefined
 						}
 						host={host}
 						hideCaption={true}
-						pageId={CAPI.pageId}
-						webTitle={CAPI.webTitle}
-						ajaxUrl={CAPI.config.ajaxUrl}
-						switches={CAPI.config.switches}
-						isAdFreeUser={CAPI.isAdFreeUser}
-						isSensitive={CAPI.config.isSensitive}
+						pageId={CAPIArticle.pageId}
+						webTitle={CAPIArticle.webTitle}
+						ajaxUrl={CAPIArticle.config.ajaxUrl}
+						switches={CAPIArticle.config.switches}
+						isAdFreeUser={CAPIArticle.isAdFreeUser}
+						isSensitive={CAPIArticle.config.isSensitive}
 					/>
 				</div>
 				{mainMedia && (
@@ -242,11 +247,13 @@ export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 							>
 								<ArticleTitle
 									format={format}
-									tags={CAPI.tags}
-									sectionLabel={CAPI.sectionLabel}
-									sectionUrl={CAPI.sectionUrl}
-									guardianBaseURL={CAPI.guardianBaseURL}
-									badge={CAPI.badge}
+									tags={CAPIArticle.tags}
+									sectionLabel={CAPIArticle.sectionLabel}
+									sectionUrl={CAPIArticle.sectionUrl}
+									guardianBaseURL={
+										CAPIArticle.guardianBaseURL
+									}
+									badge={CAPIArticle.badge}
 								/>
 							</ContainerLayout>
 							<Box palette={palette}>
@@ -257,15 +264,15 @@ export const ImmersiveHeader = ({ CAPI, NAV, format }: Props): JSX.Element => {
 								>
 									<ArticleHeadline
 										format={format}
-										headlineString={CAPI.headline}
-										tags={CAPI.tags}
-										byline={CAPI.author.byline}
+										headlineString={CAPIArticle.headline}
+										tags={CAPIArticle.tags}
+										byline={CAPIArticle.author.byline}
 										webPublicationDateDeprecated={
-											CAPI.webPublicationDateDeprecated
+											CAPIArticle.webPublicationDateDeprecated
 										}
 										hasStarRating={
-											!!CAPI.starRating ||
-											CAPI.starRating === 0
+											!!CAPIArticle.starRating ||
+											CAPIArticle.starRating === 0
 										}
 									/>
 								</ContainerLayout>

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -242,5 +242,5 @@ export const lazyFetchEmailWithTimeout =
 		});
 	};
 
-export const getContributionsServiceUrl = (CAPI: CAPIType): string =>
+export const getContributionsServiceUrl = (CAPI: CAPIArticleType): string =>
 	process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -242,5 +242,6 @@ export const lazyFetchEmailWithTimeout =
 		});
 	};
 
-export const getContributionsServiceUrl = (CAPI: CAPIArticleType): string =>
-	process?.env?.SDC_URL ?? CAPI.contributionsServiceUrl;
+export const getContributionsServiceUrl = (
+	CAPIArticle: CAPIArticleType,
+): string => process?.env?.SDC_URL ?? CAPIArticle.contributionsServiceUrl;

--- a/dotcom-rendering/src/web/lib/layoutHelpers.ts
+++ b/dotcom-rendering/src/web/lib/layoutHelpers.ts
@@ -25,7 +25,7 @@ export const decideLineCount = (design?: ArticleDesign): 8 | 4 => {
 	return 4;
 };
 
-export const getCurrentPillar = (CAPI: CAPIType): ArticleTheme => {
+export const getCurrentPillar = (CAPI: CAPIArticleType): ArticleTheme => {
 	const currentPillar =
 		(CAPI.nav.currentPillarTitle &&
 			(CAPI.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||

--- a/dotcom-rendering/src/web/lib/layoutHelpers.ts
+++ b/dotcom-rendering/src/web/lib/layoutHelpers.ts
@@ -25,10 +25,12 @@ export const decideLineCount = (design?: ArticleDesign): 8 | 4 => {
 	return 4;
 };
 
-export const getCurrentPillar = (CAPI: CAPIArticleType): ArticleTheme => {
+export const getCurrentPillar = (
+	CAPIArticle: CAPIArticleType,
+): ArticleTheme => {
 	const currentPillar =
-		(CAPI.nav.currentPillarTitle &&
-			(CAPI.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||
-		CAPI.pillar;
+		(CAPIArticle.nav.currentPillarTitle &&
+			(CAPIArticle.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||
+		CAPIArticle.pillar;
 	return decideNavTheme(currentPillar);
 };

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -44,19 +44,19 @@ const generateScriptTags = (
 		];
 	}, []);
 
-const decideTitle = (CAPI: CAPIArticleType): string => {
+const decideTitle = (CAPIArticle: CAPIArticleType): string => {
 	if (
-		decideTheme(CAPI.format) === ArticlePillar.Opinion &&
-		CAPI.author.byline
+		decideTheme(CAPIArticle.format) === ArticlePillar.Opinion &&
+		CAPIArticle.author.byline
 	) {
-		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
+		return `${CAPIArticle.headline} | ${CAPIArticle.author.byline} | The Guardian`;
 	}
-	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
+	return `${CAPIArticle.headline} | ${CAPIArticle.sectionLabel} | The Guardian`;
 };
 
 export const articleToHtml = ({ data }: Props): string => {
-	const { CAPI, NAV, linkedData } = data;
-	const title = decideTitle(CAPI);
+	const { CAPIArticle, NAV, linkedData } = data;
+	const title = decideTitle(CAPIArticle);
 	const key = 'dcr';
 	const cache = createCache({ key });
 
@@ -64,11 +64,11 @@ export const articleToHtml = ({ data }: Props): string => {
 	const { extractCriticalToChunks, constructStyleTagsFromChunks } =
 		createEmotionServer(cache);
 
-	const format: ArticleFormat = decideFormat(CAPI.format);
+	const format: ArticleFormat = decideFormat(CAPIArticle.format);
 
 	const html = renderToString(
 		<CacheProvider value={cache}>
-			<Article format={format} CAPI={CAPI} NAV={NAV} />
+			<Article format={format} CAPIArticle={CAPIArticle} NAV={NAV} />
 		</CacheProvider>,
 	);
 
@@ -77,7 +77,7 @@ export const articleToHtml = ({ data }: Props): string => {
 
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name
-	const CAPIElements: CAPIElement[] = CAPI.blocks
+	const CAPIElements: CAPIElement[] = CAPIArticle.blocks
 		.map((block) => block.elements)
 		.flat();
 
@@ -121,7 +121,7 @@ export const articleToHtml = ({ data }: Props): string => {
 		{ src: polyfillIO },
 		...getScriptArrayFromFile('bootCmp.js'),
 		...getScriptArrayFromFile('ophan.js'),
-		CAPI.config && { src: CAPI.config.commercialBundleUrl },
+		CAPIArticle.config && { src: CAPIArticle.config.commercialBundleUrl },
 		...getScriptArrayFromFile('sentryLoader.js'),
 		...getScriptArrayFromFile('dynamicImport.js'),
 		pageHasNonBootInteractiveElements && {
@@ -159,23 +159,24 @@ export const articleToHtml = ({ data }: Props): string => {
 	 */
 	const windowGuardian = escapeData(JSON.stringify(makeWindowGuardian(data)));
 
-	const hasAmpInteractiveTag = CAPI.tags.some(
+	const hasAmpInteractiveTag = CAPIArticle.tags.some(
 		(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',
 	);
 
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
 	const ampLink =
-		CAPI.format.design !== 'InteractiveDesign' || hasAmpInteractiveTag
-			? `https://amp.theguardian.com/${data.CAPI.pageId}`
+		CAPIArticle.format.design !== 'InteractiveDesign' ||
+		hasAmpInteractiveTag
+			? `https://amp.theguardian.com/${data.CAPIArticle.pageId}`
 			: undefined;
 
-	const { openGraphData } = CAPI;
-	const { twitterData } = CAPI;
+	const { openGraphData } = CAPIArticle;
+	const { twitterData } = CAPIArticle;
 	const keywords =
-		typeof CAPI.config.keywords === 'undefined' ||
-		CAPI.config.keywords === 'Network Front'
+		typeof CAPIArticle.config.keywords === 'undefined' ||
+		CAPIArticle.config.keywords === 'Network Front'
 			? ''
-			: CAPI.config.keywords;
+			: CAPIArticle.config.keywords;
 
 	return articleTemplate({
 		linkedData,
@@ -185,7 +186,7 @@ export const articleToHtml = ({ data }: Props): string => {
 		html,
 		fontFiles,
 		title,
-		description: CAPI.trailText,
+		description: CAPIArticle.trailText,
 		windowGuardian,
 		gaPath,
 		ampLink,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -44,7 +44,7 @@ const generateScriptTags = (
 		];
 	}, []);
 
-const decideTitle = (CAPI: CAPIType): string => {
+const decideTitle = (CAPI: CAPIArticleType): string => {
 	if (
 		decideTheme(CAPI.format) === ArticlePillar.Opinion &&
 		CAPI.author.byline

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -14,9 +14,9 @@ function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
 }
 
-const enhanceCAPIType = (body: Record<string, unknown>): CAPIType => {
+const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 	const data = validateAsCAPIType(body);
-	const CAPI: CAPIType = {
+	const CAPI: CAPIArticleType = {
 		...data,
 		blocks: enhanceBlocks(data.blocks, data.format),
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -16,13 +16,13 @@ function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 
 const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 	const data = validateAsCAPIType(body);
-	const CAPI: CAPIArticleType = {
+	const CAPIArticle: CAPIArticleType = {
 		...data,
 		blocks: enhanceBlocks(data.blocks, data.format),
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),
 		standfirst: enhanceStandfirst(data.standfirst),
 	};
-	return CAPI;
+	return CAPIArticle;
 };
 
 export const renderArticle = (
@@ -30,15 +30,15 @@ export const renderArticle = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPI = enhanceCAPIType(body);
+		const CAPIArticle = enhanceCAPIType(body);
 		const resp = articleToHtml({
 			data: {
-				CAPI,
+				CAPIArticle,
 				site: 'frontend',
 				page: 'Article',
-				NAV: extractNAV(CAPI.nav),
-				GA: extractGA(CAPI),
-				linkedData: CAPI.linkedData,
+				NAV: extractNAV(CAPIArticle.nav),
+				GA: extractGA(CAPIArticle),
+				linkedData: CAPIArticle.linkedData,
 			},
 		});
 
@@ -54,15 +54,15 @@ export const renderArticleJson = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPI = enhanceCAPIType(body);
+		const CAPIArticle = enhanceCAPIType(body);
 		const resp = {
 			data: {
-				CAPI,
+				CAPIArticle,
 				site: 'frontend',
 				page: 'Article',
-				NAV: extractNAV(CAPI.nav),
-				GA: extractGA(CAPI),
-				linkedData: CAPI.linkedData,
+				NAV: extractNAV(CAPIArticle.nav),
+				GA: extractGA(CAPIArticle),
+				linkedData: CAPIArticle.linkedData,
 			},
 		};
 
@@ -86,15 +86,15 @@ export const renderInteractive = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPI = enhanceCAPIType(body);
+		const CAPIArticle = enhanceCAPIType(body);
 		const resp = articleToHtml({
 			data: {
-				CAPI,
+				CAPIArticle,
 				site: 'frontend',
 				page: 'Interactive',
-				NAV: extractNAV(CAPI.nav),
-				GA: extractGA(CAPI),
-				linkedData: CAPI.linkedData,
+				NAV: extractNAV(CAPIArticle.nav),
+				GA: extractGA(CAPIArticle),
+				linkedData: CAPIArticle.linkedData,
 			},
 		});
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR renames:

`CAPI` > `CAPIArticle`
and
`CAPIType` to `CAPIArticleType`

## Why?
So there's a clearer distinction between article data and other types of data

## But the word `capi` still, really?
I know, I did consider dropping this prefix in this PR but because there are a lot of diffs happening here I thought it safer to try and keep things as simple as possible. After this PR is merged we will have a more specific name `CAPIArticle` which will be a lot easier to change in future (it was hard before because the lexicon of 'CAPI' is written throughout the documentation.
