### PR TITLE
Prebid price granularity AB test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -10,6 +10,7 @@ import { tests } from '../experiments/ab-tests';
 import { spacefinderOkrMegaTest } from '../experiments/tests/spacefinder-okr-mega-test';
 import { commercialLazyLoadMargin } from '../experiments/tests/commercial-lazy-load-margin';
 import { useAB } from '../lib/useAB';
+import { prebidPriceGranularity } from '../experiments/tests/prebid-price-granularity';
 
 type Props = {
 	enabled: boolean;
@@ -30,6 +31,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 			/* keep array multi-line */
 			spacefinderOkrMegaTest,
 			commercialLazyLoadMargin,
+			prebidPriceGranularity,
 		];
 		const shouldForceMetrics = ABTestAPI?.allRunnableTests(tests).some(
 			(test) => testsToForceMetrics.map((t) => t.id).includes(test.id),

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -9,6 +9,7 @@ import {
 import { spacefinderOkrMegaTest } from './tests/spacefinder-okr-mega-test';
 import { commercialGptLazyLoad } from './tests/commercial-gpt-lazy-load';
 import { commercialLazyLoadMargin } from './tests/commercial-lazy-load-margin';
+import { prebidPriceGranularity } from './tests/prebid-price-granularity';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	spacefinderOkrMegaTest,
 	commercialGptLazyLoad,
 	commercialLazyLoadMargin,
+	prebidPriceGranularity,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/prebid-price-granularity.ts
+++ b/dotcom-rendering/src/web/experiments/tests/prebid-price-granularity.ts
@@ -1,0 +1,26 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidPriceGranularity: ABTest = {
+	id: 'PrebidPriceGranularity',
+	start: '2022-04-05',
+	expiry: '2022-05-03',
+	author: 'Chris Jones (@chrislomaxjones)',
+	description:
+		'Test the commercial impact of changing Prebid Price granularity for Ozone',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	successMeasure:
+		'No significant negative impact on CPM when using a granularity that permits fewer line items',
+	audienceCriteria: 'n/a',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: () => {},
+		},
+		{
+			id: 'variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Add's the DCR equivalent AB test introduced in [Frontend #24849](https://github.com/guardian/frontend/pull/24849).

## Why?

Introduce the test here so it runs on DCR rendered content. See [Frontend #24849](https://github.com/guardian/frontend/pull/24849) for details on the AB test itself.
