### PR TITLE
Bump braze components dependency to 7.2.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.1.0",
-    "@guardian/braze-components": "^7.1.0",
+    "@guardian/braze-components": "^7.2.0",
     "@guardian/commercial-core": "^3.0.0",
     "@guardian/consent-management-platform": "^10.4.0",
     "@guardian/discussion-rendering": "^9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.1.0.tgz#b8812002cc77f5c65a091ebf0f5b78d6fc1403f4"
-  integrity sha512-6X+CKHfElQQj7k8JELFuiUW0JyMJArY8XEum2RpnNs1qelPSwtmtibo4bh5LKtKVXf83zYs9PwUXd3AJwp3x1g==
+"@guardian/braze-components@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
+  integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
 
 "@guardian/commercial-core@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We're changing the colour scheme of our `BannerWithLink`. This brings the banner inline with our standard colour palette.

## Why?
We are not using the orangey banner anymore as it was developed for a single occasion. Shifting the colours to something standard allows us to enable multiple uses cases that can be serviced without developer input.

The styling around the image has shifted slightly, this is intentional, now the banner uses a common styling to bring it in line with our other banner options.

### Before
![image](https://user-images.githubusercontent.com/5294853/161989907-f790c026-b10f-4316-83c5-059e909093ba.png)

### After
![image](https://user-images.githubusercontent.com/5294853/161989786-a2ef373c-83a4-4b6f-a822-8dddad6d5f22.png)
