### PR TITLE
feat: colours in Fronts JSON data

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -108,7 +108,8 @@ export const prodServer = () => {
 	app.get(
 		'/Front',
 		logRenderTime,
-		// TODO: implement Fronts’ getContentFromURLMiddleware,
+		// TODO: ensure getContentFromURLMiddleware supports fronts
+		getContentFromURLMiddleware,
 		async (req: Request, res: Response) => {
 			// Eg. http://localhost:9000/Front?url=https://www.theguardian.com/uk/sport
 			try {

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -1,11 +1,36 @@
-import { isObject } from '@guardian/libs';
+import { isBoolean, isObject, isString } from '@guardian/libs';
 import type { Request } from 'express';
+import { escape } from 'he';
 
 type FrontData = { query: Request['query']; body: unknown };
 
+const displayJSON = (json: unknown): string => {
+	if (isString(json)) return `<span class="string">"${escape(json)}"</span>`;
+	if (isBoolean(json) || Number.isFinite(json))
+		return `<span class="number">${json}</span>`;
+
+	if (json === null) return `null`;
+
+	if (isObject(json))
+		return `<ul>${Object.entries(json)
+			.map(([key, value]) => {
+				return `<li>${key}: ${displayJSON(value)}</li>`;
+			})
+			.join(' ')}</ul>`;
+
+	if (Array.isArray(json)) {
+		if (json.length === 0) return '<span class="array">[]</span>';
+		return `<ol>${json
+			.map(displayJSON)
+			.map((value) => `<li>${value}</li>`)
+			.join('')}</ol>`;
+	}
+
+	return `(unknown type) : ${json}`;
+};
+
 export const frontToHtml = ({ query, body }: FrontData) => {
-	const config =
-		(isObject(body) && isObject(body?.config) && body.config) || {};
+	const config = (isObject(body) && body) || {};
 
 	const slug: string =
 		query?.url?.toString().replace('https://www.theguardian.com/', '/') ??
@@ -21,21 +46,34 @@ export const frontToHtml = ({ query, body }: FrontData) => {
 	</head>
 	<body>
 	<h1>Dummy Front: ${slug}</h1>
-	<h2><a href="https://www.theguardian.com${slug}.json">See JSON endpoint ${slug}.json</a></h2>
-	<ul>
-	${Object.entries(config)
-		.map(([key, value]) => {
-			return `<li>${key}: ${JSON.stringify(value)}</li>`;
-		})
-		.join(' ')}
+	<h2><a href="https://www.theguardian.com${slug}.json?dcr=true">See JSON endpoint ${slug}.json</a></h2>
 	<style>
 	li {
 		padding-top: 1em;
 		font-family: monospace;
 		word-break: break-all;
 	}
+
+	ul {
+		border-left: 2px solid #aaa;
+		padding-left: 18px;
+	}
+
+	.string {
+		color: orangered;
+	}
+
+	.number {
+		color: darkcyan;
+	}
+
+	.array {
+		color: darkblue;
+	}
 	</style>
-	</ul>
+
+	${displayJSON(config)}
+
 	</body>
 	</html>`;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add colours and styles to the JSON display.

## Why?

We also get a lot more than just config, so we can investigate in more detail.

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/76776/162022519-8a2c5289-a8ef-4c72-8ba2-b483773f2187.png">
