### PR TITLE
`FrontType`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -513,6 +513,123 @@ interface CAPIArticleType {
 	mostRecentBlockId?: string;
 }
 
+interface FrontType {
+	pressedPage: PressedPageType;
+	nav: CAPINavType;
+	editionId: string;
+	editionLongForm: string;
+	guardianBaseURL: string;
+	pageId: string;
+	webTitle: string;
+	webURL: string;
+	config: FrontConfigType;
+	commercialProperties: Record<string, unknown>;
+}
+
+type PressedPageType = {
+	id: string;
+	seoData: SeoDataType;
+	frontProperties: FrontPropertiesType;
+	collections: PressedCollectionType[];
+};
+
+type SeoDataType = {
+	id: string;
+	navSection: string;
+	webTitle: string;
+	description: string;
+};
+
+type FrontPropertiesType = {
+	isImageDisplayed: boolean;
+	commercial: Record<string, unknown>;
+};
+
+type PressedCollectionType = Record<string, unknown>;
+
+type FrontConfigType = {
+	avatarApiUrl: string;
+	externalEmbedHost: string;
+	ajaxUrl: string;
+	keywords: string;
+	revisionNumber: string;
+	isProd: boolean;
+	switches: Switches;
+	section: string;
+	keywordIds: string;
+	locationapiurl: string;
+	sharedAdTargeting: { [key: string]: any };
+	buildNumber: string;
+	abTests: Record<string, unknown>;
+	pbIndexSites: { [key: string]: unknown }[];
+	ampIframeUrl: string;
+	beaconUrl: string;
+	userAttributesApiUrl: string;
+	host: string;
+	brazeApiKey: string;
+	calloutsUrl: string;
+	requiresMembershipAccess: boolean;
+	onwardWebSocket: string;
+	a9PublisherId: string;
+	contentType: string;
+	facebookIaAdUnitRoot: string;
+	ophanEmbedJsUrl: string;
+	idUrl: string;
+	dcrSentryDsn: string;
+	isFront: true;
+	idWebAppUrl: string;
+	discussionApiUrl: string;
+	sentryPublicApiKey: string;
+	omnitureAccount: string;
+	dfpAccountId: string;
+	pageId: string;
+	forecastsapiurl: string;
+	assetsPath: string;
+	pillar: string;
+	commercialBundleUrl: string;
+	discussionApiClientHeader: string;
+	membershipUrl: string;
+	dfpHost: string;
+	cardStyle: string;
+	googletagUrl: string;
+	sentryHost: string;
+	shouldHideAdverts: boolean;
+	mmaUrl: string;
+	membershipAccess: string;
+	isPreview: boolean;
+	googletagJsUrl: string;
+	supportUrl: string;
+	edition: string;
+	discussionFrontendUrl: string;
+	ipsosTag: string;
+	ophanJsUrl: string;
+	isPaidContent: boolean;
+	mobileAppsAdUnitRoot: string;
+	plistaPublicApiKey: string;
+	frontendAssetsFullURL: string;
+	googleSearchId: string;
+	allowUserGeneratedContent: boolean;
+	dfpAdUnitRoot: string;
+	idApiUrl: string;
+	omnitureAmpAccount: string;
+	adUnit: string;
+	hasPageSkin: boolean;
+	webTitle: string;
+	stripePublicToken: string;
+	googleRecaptchaSiteKey: string;
+	discussionD2Uid: string;
+	weatherapiurl: string;
+	googleSearchUrl: string;
+	optimizeEpicUrl: string;
+	stage: string;
+	idOAuthUrl: string;
+	isSensitive: boolean;
+	isDev: boolean;
+	thirdPartyAppsAccount: string;
+	avatarImagesUrl: string;
+	fbAppId: string;
+};
+
 interface TagType {
 	id: string;
 	type: string;

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -164,9 +164,10 @@ clear: # private
 	@clear
 
 gen-schema:
-	$(call log, "Generating new schema")
+	$(call log, "Generating new schemas")
 	@node scripts/json-schema/gen-schema.js
 	@git add src/model/json-schema.json
+	@git add src/model/front-schema.json
 
 gen-fixtures:
 	$(call log, "Generating new article fixture data")

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -13,10 +13,23 @@ const program = TJS.getProgramFromFiles(
 
 const settings = { rejectDateType: true, required: true };
 const schema = TJS.generateSchema(program, 'CAPIArticleType', settings);
+const frontSchema = TJS.generateSchema(program, 'FrontType', settings);
 
 fs.writeFile(
 	`${root}/src/model/json-schema.json`,
 	JSON.stringify(schema, null, 4),
+	'utf8',
+	(err) => {
+		if (err) {
+			// eslint-disable-next-line @typescript-eslint/tslint/config
+			console.log(err);
+		}
+	},
+);
+
+fs.writeFile(
+	`${root}/src/model/front-schema.json`,
+	JSON.stringify(frontSchema, null, 4),
 	'utf8',
 	(err) => {
 		if (err) {

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1,0 +1,588 @@
+{
+    "type": "object",
+    "properties": {
+        "pressedPage": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "seoData": {
+                    "$ref": "#/definitions/SeoDataType"
+                },
+                "frontProperties": {
+                    "$ref": "#/definitions/FrontPropertiesType"
+                },
+                "collections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PressedCollectionType"
+                    }
+                }
+            },
+            "required": [
+                "collections",
+                "frontProperties",
+                "id",
+                "seoData"
+            ]
+        },
+        "nav": {
+            "$ref": "#/definitions/CAPINavType"
+        },
+        "editionId": {
+            "type": "string"
+        },
+        "editionLongForm": {
+            "type": "string"
+        },
+        "guardianBaseURL": {
+            "type": "string"
+        },
+        "pageId": {
+            "type": "string"
+        },
+        "webTitle": {
+            "type": "string"
+        },
+        "webURL": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "keywordIds": {
+                    "type": "string"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "$ref": "#/definitions/Record<string,unknown>"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "userAttributesApiUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "isFront": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "discussionFrontendUrl": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "weatherapiurl": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "type": "string"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "brazeApiKey",
+                "buildNumber",
+                "calloutsUrl",
+                "cardStyle",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "discussionFrontendUrl",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isFront",
+                "isPaidContent",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "keywordIds",
+                "keywords",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "thirdPartyAppsAccount",
+                "userAttributesApiUrl",
+                "weatherapiurl",
+                "webTitle"
+            ]
+        },
+        "commercialProperties": {
+            "$ref": "#/definitions/Record<string,unknown>"
+        }
+    },
+    "required": [
+        "commercialProperties",
+        "config",
+        "editionId",
+        "editionLongForm",
+        "guardianBaseURL",
+        "nav",
+        "pageId",
+        "pressedPage",
+        "webTitle",
+        "webURL"
+    ],
+    "definitions": {
+        "SeoDataType": {
+            "type": "object"
+        },
+        "FrontPropertiesType": {
+            "type": "object"
+        },
+        "PressedCollectionType": {
+            "type": "object"
+        },
+        "CAPINavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/CAPILinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/CAPILinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAPILinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "CAPILinkType": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "Record<string,unknown>": {
+            "type": "object"
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -2,6 +2,7 @@ import Ajv, { Options } from 'ajv';
 import addFormats from 'ajv-formats';
 
 import schema from './json-schema.json';
+import frontSchema from './front-schema.json';
 
 const options: Options = {
 	verbose: false,
@@ -14,6 +15,7 @@ const ajv = new Ajv(options);
 addFormats(ajv);
 
 const validate = ajv.compile(schema);
+const validateFront = ajv.compile(frontSchema);
 
 export const validateAsCAPIType = (data: {
 	[key: string]: any;
@@ -31,4 +33,22 @@ export const validateAsCAPIType = (data: {
 	}
 
 	return data as CAPIArticleType;
+};
+
+export const validateAsFrontType = (
+	data: Record<string, unknown>,
+): FrontType => {
+	const isValid = validateFront(data);
+
+	if (!isValid) {
+		// @ts-expect-error
+		const url = data.webURL || 'unknown url';
+
+		throw new TypeError(
+			`Unable to validate request body for url ${url}.\n
+            ${JSON.stringify(validateFront.errors, null, 2)}`,
+		);
+	}
+
+	return data as unknown as FrontType;
 };

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -1,7 +1,7 @@
 import { isObject } from '@guardian/libs';
 import type { Request } from 'express';
 
-type FrontData = { query: Request['query']; body: unknown };
+type FrontData = { query: Request['query']; body: FrontType };
 
 export const frontToHtml = ({ query, body }: FrontData) => {
 	const config =

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -4,7 +4,7 @@ import { extractNAV } from '../../model/extract-nav';
 import { articleToHtml } from './articleToHtml';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
-import { validateAsCAPIType } from '../../model/validate';
+import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import { extract as extractGA } from '../../model/extract-ga';
 import { blocksToHtml } from './blocksToHtml';
 import { keyEventsToHtml } from './keyEventsToHtml';
@@ -23,6 +23,14 @@ const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 		standfirst: enhanceStandfirst(data.standfirst),
 	};
 	return CAPIArticle;
+};
+
+const enhanceFront = (body: Record<string, unknown>): FrontType => {
+	const enhanced = validateAsFrontType(body);
+	const Front: FrontType = {
+		...enhanced,
+	};
+	return Front;
 };
 
 export const renderArticle = (
@@ -177,9 +185,10 @@ export const renderFront = (
 	res: express.Response,
 ): void => {
 	try {
+		const enhanced = enhanceFront(body);
 		const html = frontToHtml({
 			query,
-			body,
+			body: enhanced,
 		});
 		res.status(200).send(html);
 	} catch (e) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds `FrontType`, the type that we use for data sent to use for a front page by Frontend

## Why?
So we can check we get what we expect and also to help developers predict what values will be available to them.

