### PR TITLE
Fix share icons links

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -686,8 +686,6 @@ type MediaType = 'Video' | 'Audio' | 'Gallery';
 
 type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
-type ShareIconSize = 'small' | 'medium';
-
 type LeftColSize = 'compact' | 'wide';
 
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -53,7 +53,7 @@ class BlockEnhancer {
 }
 
 // IMPORTANT: the ordering of the enhancer is IMPORTANT to keep in mind
-// exmaple: enhanceInteractiveContentElements needs to be before enhanceNumberedLists
+// example: enhanceInteractiveContentElements needs to be before enhanceNumberedLists
 // as they both effect SubheadingBlockElement
 export const enhanceBlocks = (blocks: Block[], format: CAPIFormat): Block[] => {
 	return new BlockEnhancer(blocks, format)

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -104,6 +104,7 @@ export const LiveBlock = ({
 			>
 				<ShareIcons
 					pageId={pageId}
+					blockId={block.id}
 					webTitle={webTitle}
 					displayIcons={['facebook', 'twitter']}
 					format={format}

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -146,9 +146,7 @@ export const Liveness = ({
 	hasPinnedPost,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
-	const [topOfBlogVisible, setTopOfBlogVisible] = useState<
-		boolean | undefined
-	>();
+	const [topOfBlogVisible, setTopOfBlogVisible] = useState<boolean>();
 	const [numHiddenBlocks, setNumHiddenBlocks] = useState(0);
 	const [latestBlockId, setLatestBlockId] = useState(mostRecentBlockId);
 

--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -14,6 +14,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { Hide } from './Hide';
 
 type Context = 'ArticleMeta' | 'LiveBlock' | 'SubMeta';
+type ShareIconSize = 'small' | 'medium';
 
 type Props = {
 	pageId: string;
@@ -133,7 +134,7 @@ const getUrl = ({
 	CMP?: string;
 	blockId?: string;
 }) => {
-	const searchParams = new URLSearchParams();
+	const searchParams = new URLSearchParams({});
 	if (CMP) searchParams.append('CMP', CMP);
 	if (blockId) searchParams.append('page', `with:block-${blockId}`);
 

--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -330,7 +330,7 @@ export const ShareIcons = ({
 								app_id: '180444840287',
 							})}`}
 							role="button"
-							aria-label="Share on Messenger>"
+							aria-label="Share on Messenger"
 							target="_blank"
 							rel="noreferrer"
 							data-ignore="global-link-styling"

--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -17,6 +17,7 @@ type Context = 'ArticleMeta' | 'LiveBlock' | 'SubMeta';
 
 type Props = {
 	pageId: string;
+	blockId?: string;
 	webTitle: string;
 	displayIcons: SharePlatform[];
 	format: ArticleFormat;
@@ -123,15 +124,32 @@ const iconStyles = ({
 	}
 `;
 
-const encodeUrl = (pageId: string): string => {
-	return encodeURIComponent(`https://www.theguardian.com/${pageId}`);
+const getUrl = ({
+	pageId,
+	CMP,
+	blockId,
+}: {
+	pageId: string;
+	CMP?: string;
+	blockId?: string;
+}) => {
+	const searchParams = new URLSearchParams();
+	if (CMP) searchParams.append('CMP', CMP);
+	if (blockId) searchParams.append('page', `with:block-${blockId}`);
+
+	const blockHash = blockId ? `#block-${blockId}` : '';
+	return new URL(
+		`${pageId}?${searchParams}${blockHash}`,
+		'https://www.theguardian.com/',
+	).href;
 };
 
-const encodeTitle = (webTitle: string): string => {
-	return encodeURIComponent(webTitle.replace(/Leave.EU/gi, 'Leave. EU'));
-};
+const encodeTitle = (webTitle: string): string =>
+	webTitle.replace(/Leave.EU/gi, 'Leave. EU');
+
 export const ShareIcons = ({
 	pageId,
+	blockId,
 	webTitle,
 	displayIcons,
 	format,
@@ -144,9 +162,16 @@ export const ShareIcons = ({
 			{displayIcons.includes('facebook') && (
 				<li css={liStyles(size)} key="facebook">
 					<a
-						href={`https://www.facebook.com/dialog/share?app_id=180444840287&href=${encodeUrl(
-							pageId,
-						)}&CMP=share_btn_fb`}
+						href={`https://www.facebook.com/dialog/share?${new URLSearchParams(
+							{
+								app_id: '180444840287',
+								href: getUrl({
+									pageId,
+									blockId,
+									CMP: 'share_btn_fb',
+								}),
+							},
+						).toString()}`}
 						role="button"
 						aria-label="Share on Facebook"
 						target="_blank"
@@ -169,9 +194,16 @@ export const ShareIcons = ({
 			{displayIcons.includes('twitter') && (
 				<li css={liStyles(size)} key="twitter">
 					<a
-						href={`https://twitter.com/intent/tweet?text=${encodeTitle(
-							webTitle,
-						)}&url=${encodeUrl(pageId)}&CMP=share_btn_tw`}
+						href={`https://twitter.com/intent/tweet?${new URLSearchParams(
+							{
+								text: encodeTitle(webTitle),
+								url: getUrl({
+									pageId,
+									blockId,
+									CMP: 'share_btn_tw',
+								}),
+							},
+						)}`}
 						role="button"
 						aria-label="Share on Twitter"
 						target="_blank"
@@ -194,9 +226,14 @@ export const ShareIcons = ({
 			{displayIcons.includes('email') && (
 				<li css={liStyles(size)} key="email">
 					<a
-						href={`mailto:?subject=${encodeTitle(
-							webTitle,
-						)}&body=${encodeUrl(pageId)}&CMP=share_btn_link`}
+						href={`mailto:?${new URLSearchParams({
+							subject: encodeTitle(webTitle),
+							body: getUrl({
+								pageId,
+								blockId,
+								CMP: 'share_btn_link',
+							}),
+						})}`}
 						role="button"
 						aria-label="Share via Email"
 						target="_blank"
@@ -218,9 +255,14 @@ export const ShareIcons = ({
 			{displayIcons.includes('linkedIn') && (
 				<li css={liStyles(size)} key="linkedIn">
 					<a
-						href={`http://www.linkedin.com/shareArticle?title=${encodeTitle(
-							webTitle,
-						)}&mini=true&url=${encodeUrl(pageId)}`}
+						href={`http://www.linkedin.com/shareArticle?=${new URLSearchParams(
+							{
+								title: encodeTitle(webTitle),
+								mini: 'true',
+								// TODO?: add &CMP=share_btn_*
+								url: getUrl({ pageId, blockId }),
+							},
+						)}`}
 						role="button"
 						aria-label="Share on LinkedIn"
 						target="_blank"
@@ -244,9 +286,16 @@ export const ShareIcons = ({
 				<Hide when="above" breakpoint="phablet" el="li" key="whatsApp">
 					<span css={[liStyles(size), topMarginStlyes]}>
 						<a
-							href={`whatsapp://send?text="${encodeTitle(
-								webTitle,
-							)}" ${encodeUrl(pageId)}&CMP=share_btn_wa`}
+							href={`whatsapp://send?${new URLSearchParams({
+								text: [
+									encodeTitle(webTitle),
+									getUrl({
+										pageId,
+										blockId,
+										CMP: 'share_btn_wa',
+									}),
+								].join(' '),
+							})}`}
 							role="button"
 							aria-label="Share on WhatsApp"
 							target="_blank"
@@ -271,9 +320,14 @@ export const ShareIcons = ({
 				<Hide when="above" breakpoint="phablet" el="li" key="messenger">
 					<span css={[liStyles(size), topMarginStlyes]}>
 						<a
-							href={`fb-messenger://share?link=${encodeUrl(
-								pageId,
-							)}&app_id=180444840287&CMP=share_btn_me`}
+							href={`fb-messenger://share?${new URLSearchParams({
+								link: getUrl({
+									pageId,
+									blockId,
+									CMP: 'share_btn_me',
+								}),
+								app_id: '180444840287',
+							})}`}
 							role="button"
 							aria-label="Share on Messenger>"
 							target="_blank"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Refactors the way `ShareIcons` links work to use `URL` and `URLSearchParams`. Add the campaign/`CMP` and block ID for liveblogs.

Using these constructors is more verbose and makes it explicit what we're trying to achieve with these complex, nested URLs. I don't think we need to worry about browser support, as these are only used server-side: [node supports it since v6/7](https://nodejs.org/docs/latest-v14.x/api/url.html#url_class_urlsearchparams).

Also: fix small spelling mistakes.

## Why?

Previously, we did not include block IDs in share links. This meant sharing on Twitter would always link to the first page of a blog.

Fixes #4193 
Fixes #4534 

This also places the campaign code as part of the Guardian URL, so we can measure referrals more accurately. Previously, the campaign code was passed to the platform shared on, which they probably disregarded.

### Before

<img width="607" alt="image" src="https://user-images.githubusercontent.com/76776/162184782-a3e3663c-fb54-4277-82b8-a0a1b3ed7275.png">


### After

<img width="605" alt="image" src="https://user-images.githubusercontent.com/76776/162184739-45fa24fa-ac4c-4189-8451-1bea103a757a.png">
