### PR TITLE
Fix series title colours (match & sport non-match)

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -81,6 +81,7 @@ type Palette = {
 	text: {
 		headline: Colour;
 		seriesTitle: Colour;
+		matchSeriesTitle: Colour;
 		sectionTitle: Colour;
 		byline: Colour;
 		twitterHandle: Colour;

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -12,6 +12,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	badge?: BadgeType;
+	isMatch?: boolean;
 };
 
 const sectionStyles = css`
@@ -63,6 +64,7 @@ export const ArticleTitle = ({
 	sectionUrl,
 	guardianBaseURL,
 	badge,
+	isMatch,
 }: Props) => (
 	<div css={[sectionStyles, badge && badgeContainer]}>
 		{badge && format.display !== ArticleDisplay.Immersive && (
@@ -85,6 +87,7 @@ export const ArticleTitle = ({
 				sectionUrl={sectionUrl}
 				guardianBaseURL={guardianBaseURL}
 				badge={badge}
+				isMatch={isMatch}
 			/>
 		</div>
 	</div>

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -21,6 +21,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	badge?: BadgeType;
+	isMatch?: boolean;
 };
 
 const sectionLabelLink = css`
@@ -174,6 +175,7 @@ export const SeriesSectionLink = ({
 	sectionUrl,
 	guardianBaseURL,
 	badge,
+	isMatch,
 }: Props) => {
 	// If we have a tag, use it to show 2 section titles
 	const tag = tags.find(
@@ -189,6 +191,10 @@ export const SeriesSectionLink = ({
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
 	const palette = decidePalette(format);
+
+	const seriesTitleColour = isMatch
+		? palette.text.matchSeriesTitle
+		: palette.text.seriesTitle;
 
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
@@ -209,7 +215,7 @@ export const SeriesSectionLink = ({
 										fontStyles(format),
 										breakWord,
 										css`
-											color: ${palette.text.seriesTitle};
+											color: ${seriesTitleColour};
 											background-color: ${palette
 												.background.seriesTitle};
 											box-shadow: -6px 0 0 0
@@ -316,7 +322,7 @@ export const SeriesSectionLink = ({
 										breakWord,
 										!badge && sectionPadding,
 										css`
-											color: ${palette.text.seriesTitle};
+											color: ${seriesTitleColour};
 											background-color: ${palette
 												.background.seriesTitle};
 											box-shadow: -6px 0 0 0
@@ -355,7 +361,7 @@ export const SeriesSectionLink = ({
 							css={[
 								sectionLabelLink,
 								css`
-									color: ${palette.text.seriesTitle};
+									color: ${seriesTitleColour};
 									background-color: ${palette.background
 										.seriesTitle};
 								`,

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -408,6 +408,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										CAPIArticle.guardianBaseURL
 									}
 									badge={CAPIArticle.badge}
+									isMatch={true}
 								/>
 							}
 							leftColSize="wide"
@@ -425,6 +426,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										CAPIArticle.guardianBaseURL
 									}
 									badge={CAPIArticle.badge}
+									isMatch={true}
 								/>
 							</Hide>
 

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -483,6 +483,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								sectionUrl={CAPIArticle.sectionUrl}
 								guardianBaseURL={CAPIArticle.guardianBaseURL}
 								badge={CAPIArticle.badge}
+								isMatch={!!CAPIArticle.matchUrl}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -72,6 +72,10 @@ const textHeadline = (format: ArticleFormat): string => {
 	}
 };
 
+const textSeriesMatchTitle = (): string => {
+	return BLACK;
+};
+
 const textSeriesTitle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -88,7 +92,6 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 						case ArticlePillar.News:
 							return news[600];
 						case ArticlePillar.Sport:
-							return BLACK;
 						case ArticlePillar.Lifestyle:
 						case ArticlePillar.Culture:
 						case ArticlePillar.Opinion:
@@ -1045,6 +1048,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 		text: {
 			headline: textHeadline(format),
 			seriesTitle: textSeriesTitle(format),
+			matchSeriesTitle: textSeriesMatchTitle(),
 			sectionTitle: textSectionTitle(format),
 			byline: textByline(format),
 			twitterHandle: textTwitterHandle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Differentiate between match & non-match colours for series title

Respects the fix in https://github.com/guardian/dotcom-rendering/pull/4511

## Why?

Didn't look quite right

### Before
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/9575458/162248148-2cfcc677-41ce-48dc-bc74-128e7fb0dad8.png">
<img width="853" alt="image" src="https://user-images.githubusercontent.com/9575458/162248329-c8157cc6-153e-4a97-9fc3-259b86d9e091.png">


### After
<img width="957" alt="image" src="https://user-images.githubusercontent.com/9575458/162248051-b165c243-4929-42ef-b192-efa67a06e118.png">
<img width="980" alt="image" src="https://user-images.githubusercontent.com/9575458/162248113-0cbd4fae-d7bb-42f1-88a1-1da2a8875be2.png">

