### PR TITLE
Add issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,8 @@ assignees: ''
 
 A clear and concise description of what the bug is.
 
-Does it occur on any specific browsers or breakpoints?
+- Does it occur on any specific browsers or breakpoints?
+- Should this issue be assigned to one of our GitHub project boards, or to a milestone?
 
 ## Steps To Reproduce
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create an issue to track a bug
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+Does it occur on any specific browsers or breakpoints?
+
+## Steps To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Screenshots
+
+*Delete if unnecessary.*
+
+| Screenshot One | Screenshot Two |
+| - | - |
+| ![screenshot-one][] | ![screenshot-two][] |
+
+[screenshot-one]: *url here*
+[screenshot-two]: *url here*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Does it occur on any specific browsers or breakpoints?
 
 ## Steps To Reproduce
 
-Steps to reproduce the behavior:
+Steps to reproduce the behaviour:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,14 +12,14 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 - Does it occur on any specific browsers or breakpoints?
-- Should this issue be assigned to one of our GitHub project boards, or to a milestone?
+- Remember to assign this to one of our GitHub project boards and to a milestone if applicable
 
 ## Steps To Reproduce
 
 Steps to reproduce the behaviour:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to '…'
 4. See error
 
 ## Screenshots


### PR DESCRIPTION
## Why?

It might be handy to prompt for some useful information when recording a bug, like we do for pull requests. This adds a short issue template for bug reports, and allows the "bug" label to be auto-assigned when the issue is created.

## Changes

- Added an issue template for bugs
