### PR TITLE
More front types

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -580,7 +580,7 @@ type CollectionCard = {
 		imageSlideshowReplace: boolean;
 		maybeContent?: {
 			trail: {
-				trailPicture: {
+				trailPicture?: {
 					allImages: {
 						index: number;
 						fields: {
@@ -599,7 +599,7 @@ type CollectionCard = {
 					}[];
 				};
 				byline?: string;
-				thumbnailPath: string;
+				thumbnailPath?: string;
 				webPublicationDate: number;
 			};
 			metadata: {
@@ -613,7 +613,7 @@ type CollectionCard = {
 			fields: {
 				main: string;
 				body: string;
-				standfirst: string;
+				standfirst?: string;
 			};
 			elements: Record<string, unknown>;
 			tags: Record<string, unknown>;
@@ -663,7 +663,7 @@ type CollectionCard = {
 		showLivePlayable: boolean;
 	};
 	format?: CAPIFormat;
-	enriched: Record<string, unknown>;
+	enriched?: Record<string, unknown>;
 	supportingContent?: unknown[];
 	cardStyle?: {
 		type: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -547,8 +547,164 @@ type FrontPropertiesType = {
 	commercial: Record<string, unknown>;
 };
 
+type CollectionType =
+	| 'dynamic/fast'
+	| 'dynamic/package'
+	| 'dynamic/slow'
+	| 'dynamic/slow-mpu'
+	| 'fixed/large/slow-XIV'
+	| 'fixed/medium/fast-XI'
+	| 'fixed/medium/fast-XII'
+	| 'fixed/medium/slow-VI'
+	| 'fixed/medium/slow-VII'
+	| 'fixed/medium/slow-XII-mpu'
+	| 'fixed/small/fast-VIII'
+	| 'fixed/small/slow-I'
+	| 'fixed/small/slow-III'
+	| 'fixed/small/slow-IV'
+	| 'fixed/small/slow-V-half'
+	| 'fixed/small/slow-V-mpu'
+	| 'fixed/small/slow-V-third'
+	| 'fixed/thrasher'
+	| 'fixed/video'
+	| 'nav/list'
+	| 'nav/media-list'
+	| 'news/most-popular';
+
+type CollectionCard = {
+	properties: {
+		isBreaking: boolean;
+		showMainVideo: boolean;
+		showKickerTag: boolean;
+		showByline: boolean;
+		imageSlideshowReplace: boolean;
+		maybeContent?: {
+			trail: {
+				trailPicture: {
+					allImages: {
+						index: number;
+						fields: {
+							displayCredit?: string;
+							source: string;
+							photographer?: string;
+							isMaster?: string;
+							altText: string;
+							height: string;
+							credit: string;
+							mediaId: string;
+							width: string;
+						};
+						mediaType: string;
+						url: string;
+					}[];
+				};
+				byline?: string;
+				thumbnailPath: string;
+				webPublicationDate: number;
+			};
+			metadata: {
+				id: string;
+				webTitle: string;
+				webUrl: string;
+				type: string;
+				sectionId?: { value: string };
+				format: CAPIFormat;
+			};
+			fields: {
+				main: string;
+				body: string;
+				standfirst: string;
+			};
+			elements: Record<string, unknown>;
+			tags: Record<string, unknown>;
+		};
+		maybeContentId?: string;
+		isLiveBlog: boolean;
+		isCrossword: boolean;
+		byline?: string;
+		webTitle: string;
+		linkText?: string;
+		webUrl?: string;
+		editionBrandings: { edition: { id: Edition } }[];
+	};
+	header: {
+		isVideo: boolean;
+		isComment: boolean;
+		isGallery: boolean;
+		isAudio: boolean;
+		headline: string;
+		url: string;
+		hasMainVideoElement: boolean;
+	};
+	card: {
+		id: string;
+		cardStyle: {
+			type: string;
+		};
+		webPublicationDateOption?: number;
+		lastModifiedOption?: number;
+		trailText?: string;
+		starRating?: number;
+		shortUrlPath?: string;
+		shortUrl: string;
+		group: string;
+		isLive: boolean;
+	};
+	discussion: {
+		isCommentable: boolean;
+		isClosedForComments: boolean;
+		discussionId?: string;
+	};
+	display: {
+		isBoosted: boolean;
+		showBoostedHeadline: boolean;
+		showQuotedHeadline: boolean;
+		imageHide: boolean;
+		showLivePlayable: boolean;
+	};
+	format?: CAPIFormat;
+	enriched: Record<string, unknown>;
+	supportingContent?: unknown[];
+	cardStyle?: {
+		type: string;
+	};
+	type: string;
+};
+
 type PressedCollectionType = {
+	id: string;
 	displayName: string;
+	curated: CollectionCard[];
+	backfill: CollectionCard[];
+	treats: CollectionCard[];
+	lastUpdate?: number;
+	href?: string;
+	groups?: string[];
+	collectionType: CollectionType;
+	uneditable: boolean;
+	showTags: boolean;
+	showSections: boolean;
+	hideKickers: boolean;
+	showDateHeader: boolean;
+	showLatestUpdate: boolean;
+	config: {
+		displayName: string;
+		metadata?: { type: string }[];
+		collectionType: CollectionType;
+		href?: string;
+		groups?: string[];
+		uneditable: boolean;
+		showTags: boolean;
+		showSections: boolean;
+		hideKickers: boolean;
+		showDateHeader: boolean;
+		showLatestUpdate: boolean;
+		excludeFromRss: boolean;
+		showTimestamps: boolean;
+		hideShowMore: boolean;
+		platform: string;
+	};
+	hasMore: boolean;
 };
 
 type FrontConfigType = {
@@ -594,7 +750,7 @@ type FrontConfigType = {
 	discussionApiClientHeader: string;
 	membershipUrl: string;
 	dfpHost: string;
-	cardStyle: string;
+	cardStyle?: string;
 	googletagUrl: string;
 	sentryHost: string;
 	shouldHideAdverts: boolean;

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -8,15 +8,1511 @@
                     "type": "string"
                 },
                 "seoData": {
-                    "$ref": "#/definitions/SeoDataType"
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "navSection": {
+                            "type": "string"
+                        },
+                        "webTitle": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "description",
+                        "id",
+                        "navSection",
+                        "webTitle"
+                    ]
                 },
                 "frontProperties": {
-                    "$ref": "#/definitions/FrontPropertiesType"
+                    "type": "object",
+                    "properties": {
+                        "isImageDisplayed": {
+                            "type": "boolean"
+                        },
+                        "commercial": {
+                            "$ref": "#/definitions/Record<string,unknown>"
+                        }
+                    },
+                    "required": [
+                        "commercial",
+                        "isImageDisplayed"
+                    ]
                 },
                 "collections": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/PressedCollectionType"
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "curated": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "altText",
+                                                                                            "credit",
+                                                                                            "height",
+                                                                                            "mediaId",
+                                                                                            "source",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "thumbnailPath",
+                                                                "trailPicture",
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main",
+                                                                "standfirst"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        },
+                                                        "tags": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/Edition"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/CAPIDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/CAPITheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "$ref": "#/definitions/Record<string,unknown>"
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {}
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "enriched",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "backfill": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "altText",
+                                                                                            "credit",
+                                                                                            "height",
+                                                                                            "mediaId",
+                                                                                            "source",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "thumbnailPath",
+                                                                "trailPicture",
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main",
+                                                                "standfirst"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        },
+                                                        "tags": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/Edition"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/CAPIDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/CAPITheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "$ref": "#/definitions/Record<string,unknown>"
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {}
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "enriched",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "treats": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBreaking": {
+                                                    "type": "boolean"
+                                                },
+                                                "showMainVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "showKickerTag": {
+                                                    "type": "boolean"
+                                                },
+                                                "showByline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "maybeContent": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "trail": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "trailPicture": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "allImages": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "index": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "fields": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "displayCredit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "source": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "photographer": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "isMaster": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "altText": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "height": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "credit": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "mediaId": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "width": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "altText",
+                                                                                            "credit",
+                                                                                            "height",
+                                                                                            "mediaId",
+                                                                                            "source",
+                                                                                            "width"
+                                                                                        ]
+                                                                                    },
+                                                                                    "mediaType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "fields",
+                                                                                    "index",
+                                                                                    "mediaType",
+                                                                                    "url"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "allImages"
+                                                                    ]
+                                                                },
+                                                                "byline": {
+                                                                    "type": "string"
+                                                                },
+                                                                "thumbnailPath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webPublicationDate": {
+                                                                    "type": "number"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "thumbnailPath",
+                                                                "trailPicture",
+                                                                "webPublicationDate"
+                                                            ]
+                                                        },
+                                                        "metadata": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webTitle": {
+                                                                    "type": "string"
+                                                                },
+                                                                "webUrl": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "sectionId": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "value": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "value"
+                                                                    ]
+                                                                },
+                                                                "format": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "design": {
+                                                                            "$ref": "#/definitions/CAPIDesign"
+                                                                        },
+                                                                        "theme": {
+                                                                            "$ref": "#/definitions/CAPITheme"
+                                                                        },
+                                                                        "display": {
+                                                                            "$ref": "#/definitions/CAPIDisplay"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "design",
+                                                                        "display",
+                                                                        "theme"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "format",
+                                                                "id",
+                                                                "type",
+                                                                "webTitle",
+                                                                "webUrl"
+                                                            ]
+                                                        },
+                                                        "fields": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "main": {
+                                                                    "type": "string"
+                                                                },
+                                                                "body": {
+                                                                    "type": "string"
+                                                                },
+                                                                "standfirst": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "body",
+                                                                "main",
+                                                                "standfirst"
+                                                            ]
+                                                        },
+                                                        "elements": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        },
+                                                        "tags": {
+                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "elements",
+                                                        "fields",
+                                                        "metadata",
+                                                        "tags",
+                                                        "trail"
+                                                    ]
+                                                },
+                                                "maybeContentId": {
+                                                    "type": "string"
+                                                },
+                                                "isLiveBlog": {
+                                                    "type": "boolean"
+                                                },
+                                                "isCrossword": {
+                                                    "type": "boolean"
+                                                },
+                                                "byline": {
+                                                    "type": "string"
+                                                },
+                                                "webTitle": {
+                                                    "type": "string"
+                                                },
+                                                "linkText": {
+                                                    "type": "string"
+                                                },
+                                                "webUrl": {
+                                                    "type": "string"
+                                                },
+                                                "editionBrandings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "edition": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "$ref": "#/definitions/Edition"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "edition"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "editionBrandings",
+                                                "imageSlideshowReplace",
+                                                "isBreaking",
+                                                "isCrossword",
+                                                "isLiveBlog",
+                                                "showByline",
+                                                "showKickerTag",
+                                                "showMainVideo",
+                                                "webTitle"
+                                            ]
+                                        },
+                                        "header": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isVideo": {
+                                                    "type": "boolean"
+                                                },
+                                                "isComment": {
+                                                    "type": "boolean"
+                                                },
+                                                "isGallery": {
+                                                    "type": "boolean"
+                                                },
+                                                "isAudio": {
+                                                    "type": "boolean"
+                                                },
+                                                "headline": {
+                                                    "type": "string"
+                                                },
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "hasMainVideoElement": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "hasMainVideoElement",
+                                                "headline",
+                                                "isAudio",
+                                                "isComment",
+                                                "isGallery",
+                                                "isVideo",
+                                                "url"
+                                            ]
+                                        },
+                                        "card": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "cardStyle": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "webPublicationDateOption": {
+                                                    "type": "number"
+                                                },
+                                                "lastModifiedOption": {
+                                                    "type": "number"
+                                                },
+                                                "trailText": {
+                                                    "type": "string"
+                                                },
+                                                "starRating": {
+                                                    "type": "number"
+                                                },
+                                                "shortUrlPath": {
+                                                    "type": "string"
+                                                },
+                                                "shortUrl": {
+                                                    "type": "string"
+                                                },
+                                                "group": {
+                                                    "type": "string"
+                                                },
+                                                "isLive": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "cardStyle",
+                                                "group",
+                                                "id",
+                                                "isLive",
+                                                "shortUrl"
+                                            ]
+                                        },
+                                        "discussion": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isCommentable": {
+                                                    "type": "boolean"
+                                                },
+                                                "isClosedForComments": {
+                                                    "type": "boolean"
+                                                },
+                                                "discussionId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "isClosedForComments",
+                                                "isCommentable"
+                                            ]
+                                        },
+                                        "display": {
+                                            "type": "object",
+                                            "properties": {
+                                                "isBoosted": {
+                                                    "type": "boolean"
+                                                },
+                                                "showBoostedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "showQuotedHeadline": {
+                                                    "type": "boolean"
+                                                },
+                                                "imageHide": {
+                                                    "type": "boolean"
+                                                },
+                                                "showLivePlayable": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "imageHide",
+                                                "isBoosted",
+                                                "showBoostedHeadline",
+                                                "showLivePlayable",
+                                                "showQuotedHeadline"
+                                            ]
+                                        },
+                                        "format": {
+                                            "type": "object",
+                                            "properties": {
+                                                "design": {
+                                                    "$ref": "#/definitions/CAPIDesign"
+                                                },
+                                                "theme": {
+                                                    "$ref": "#/definitions/CAPITheme"
+                                                },
+                                                "display": {
+                                                    "$ref": "#/definitions/CAPIDisplay"
+                                                }
+                                            },
+                                            "required": [
+                                                "design",
+                                                "display",
+                                                "theme"
+                                            ]
+                                        },
+                                        "enriched": {
+                                            "$ref": "#/definitions/Record<string,unknown>"
+                                        },
+                                        "supportingContent": {
+                                            "type": "array",
+                                            "items": {}
+                                        },
+                                        "cardStyle": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "card",
+                                        "discussion",
+                                        "display",
+                                        "enriched",
+                                        "header",
+                                        "properties",
+                                        "type"
+                                    ]
+                                }
+                            },
+                            "lastUpdate": {
+                                "type": "number"
+                            },
+                            "href": {
+                                "type": "string"
+                            },
+                            "groups": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "collectionType": {
+                                "$ref": "#/definitions/CollectionType"
+                            },
+                            "uneditable": {
+                                "type": "boolean"
+                            },
+                            "showTags": {
+                                "type": "boolean"
+                            },
+                            "showSections": {
+                                "type": "boolean"
+                            },
+                            "hideKickers": {
+                                "type": "boolean"
+                            },
+                            "showDateHeader": {
+                                "type": "boolean"
+                            },
+                            "showLatestUpdate": {
+                                "type": "boolean"
+                            },
+                            "config": {
+                                "type": "object",
+                                "properties": {
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "metadata": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ]
+                                        }
+                                    },
+                                    "collectionType": {
+                                        "$ref": "#/definitions/CollectionType"
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    },
+                                    "groups": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "uneditable": {
+                                        "type": "boolean"
+                                    },
+                                    "showTags": {
+                                        "type": "boolean"
+                                    },
+                                    "showSections": {
+                                        "type": "boolean"
+                                    },
+                                    "hideKickers": {
+                                        "type": "boolean"
+                                    },
+                                    "showDateHeader": {
+                                        "type": "boolean"
+                                    },
+                                    "showLatestUpdate": {
+                                        "type": "boolean"
+                                    },
+                                    "excludeFromRss": {
+                                        "type": "boolean"
+                                    },
+                                    "showTimestamps": {
+                                        "type": "boolean"
+                                    },
+                                    "hideShowMore": {
+                                        "type": "boolean"
+                                    },
+                                    "platform": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "collectionType",
+                                    "displayName",
+                                    "excludeFromRss",
+                                    "hideKickers",
+                                    "hideShowMore",
+                                    "platform",
+                                    "showDateHeader",
+                                    "showLatestUpdate",
+                                    "showSections",
+                                    "showTags",
+                                    "showTimestamps",
+                                    "uneditable"
+                                ]
+                            },
+                            "hasMore": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "backfill",
+                            "collectionType",
+                            "config",
+                            "curated",
+                            "displayName",
+                            "hasMore",
+                            "hideKickers",
+                            "id",
+                            "showDateHeader",
+                            "showLatestUpdate",
+                            "showSections",
+                            "showTags",
+                            "treats",
+                            "uneditable"
+                        ]
                     }
                 }
             },
@@ -31,7 +1527,7 @@
             "$ref": "#/definitions/CAPINavType"
         },
         "editionId": {
-            "type": "string"
+            "$ref": "#/definitions/Edition"
         },
         "editionLongForm": {
             "type": "string"
@@ -89,7 +1585,7 @@
                     "type": "string"
                 },
                 "abTests": {
-                    "$ref": "#/definitions/Record<string,unknown>"
+                    "type": "object"
                 },
                 "pbIndexSites": {
                     "type": "array",
@@ -279,7 +1775,7 @@
                     "type": "string"
                 },
                 "stage": {
-                    "type": "string"
+                    "$ref": "#/definitions/StageType"
                 },
                 "idOAuthUrl": {
                     "type": "string"
@@ -314,7 +1810,6 @@
                 "brazeApiKey",
                 "buildNumber",
                 "calloutsUrl",
-                "cardStyle",
                 "commercialBundleUrl",
                 "contentType",
                 "dcrSentryDsn",
@@ -400,14 +1895,89 @@
         "webURL"
     ],
     "definitions": {
-        "SeoDataType": {
+        "Record<string,unknown>": {
             "type": "object"
         },
-        "FrontPropertiesType": {
-            "type": "object"
+        "CAPIDesign": {
+            "enum": [
+                "AnalysisDesign",
+                "ArticleDesign",
+                "CommentDesign",
+                "DeadBlogDesign",
+                "EditorialDesign",
+                "FeatureDesign",
+                "FullPageInteractiveDesign",
+                "InteractiveDesign",
+                "InterviewDesign",
+                "LetterDesign",
+                "LiveBlogDesign",
+                "MatchReportDesign",
+                "MediaDesign",
+                "ObituaryDesign",
+                "PhotoEssayDesign",
+                "PrintShopDesign",
+                "QuizDesign",
+                "RecipeDesign",
+                "ReviewDesign"
+            ],
+            "type": "string"
         },
-        "PressedCollectionType": {
-            "type": "object"
+        "CAPITheme": {
+            "enum": [
+                "CulturePillar",
+                "Labs",
+                "LifestylePillar",
+                "NewsPillar",
+                "OpinionPillar",
+                "SpecialReportTheme",
+                "SportPillar"
+            ],
+            "type": "string"
+        },
+        "CAPIDisplay": {
+            "enum": [
+                "ImmersiveDisplay",
+                "NumberedListDisplay",
+                "ShowcaseDisplay",
+                "StandardDisplay"
+            ],
+            "type": "string"
+        },
+        "Edition": {
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "CollectionType": {
+            "enum": [
+                "dynamic/fast",
+                "dynamic/package",
+                "dynamic/slow",
+                "dynamic/slow-mpu",
+                "fixed/large/slow-XIV",
+                "fixed/medium/fast-XI",
+                "fixed/medium/fast-XII",
+                "fixed/medium/slow-VI",
+                "fixed/medium/slow-VII",
+                "fixed/medium/slow-XII-mpu",
+                "fixed/small/fast-VIII",
+                "fixed/small/slow-I",
+                "fixed/small/slow-III",
+                "fixed/small/slow-IV",
+                "fixed/small/slow-V-half",
+                "fixed/small/slow-V-mpu",
+                "fixed/small/slow-V-third",
+                "fixed/thrasher",
+                "fixed/video",
+                "nav/list",
+                "nav/media-list",
+                "news/most-popular"
+            ],
+            "type": "string"
         },
         "CAPINavType": {
             "type": "object",
@@ -580,8 +2150,13 @@
                 "type": "boolean"
             }
         },
-        "Record<string,unknown>": {
-            "type": "object"
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -167,8 +167,6 @@
                                                                 }
                                                             },
                                                             "required": [
-                                                                "thumbnailPath",
-                                                                "trailPicture",
                                                                 "webPublicationDate"
                                                             ]
                                                         },
@@ -241,8 +239,7 @@
                                                             },
                                                             "required": [
                                                                 "body",
-                                                                "main",
-                                                                "standfirst"
+                                                                "main"
                                                             ]
                                                         },
                                                         "elements": {
@@ -491,7 +488,6 @@
                                         "card",
                                         "discussion",
                                         "display",
-                                        "enriched",
                                         "header",
                                         "properties",
                                         "type"
@@ -609,8 +605,6 @@
                                                                 }
                                                             },
                                                             "required": [
-                                                                "thumbnailPath",
-                                                                "trailPicture",
                                                                 "webPublicationDate"
                                                             ]
                                                         },
@@ -683,8 +677,7 @@
                                                             },
                                                             "required": [
                                                                 "body",
-                                                                "main",
-                                                                "standfirst"
+                                                                "main"
                                                             ]
                                                         },
                                                         "elements": {
@@ -933,7 +926,6 @@
                                         "card",
                                         "discussion",
                                         "display",
-                                        "enriched",
                                         "header",
                                         "properties",
                                         "type"
@@ -1051,8 +1043,6 @@
                                                                 }
                                                             },
                                                             "required": [
-                                                                "thumbnailPath",
-                                                                "trailPicture",
                                                                 "webPublicationDate"
                                                             ]
                                                         },
@@ -1125,8 +1115,7 @@
                                                             },
                                                             "required": [
                                                                 "body",
-                                                                "main",
-                                                                "standfirst"
+                                                                "main"
                                                             ]
                                                         },
                                                         "elements": {
@@ -1375,7 +1364,6 @@
                                         "card",
                                         "discussion",
                                         "display",
-                                        "enriched",
                                         "header",
                                         "properties",
                                         "type"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR builds out `FrontType` to include more typings

## Why?
So we can start to use this data with more confidence
