### PR TITLE
Refactor constructQuery to use URLSearchParams

### DIFF
--- a/dotcom-rendering/src/lib/querystring.ts
+++ b/dotcom-rendering/src/lib/querystring.ts
@@ -1,12 +1,4 @@
 const constructQuery = (query: { [key: string]: any }): string =>
-	Object.keys(query)
-		.map((param: string) => {
-			const value = query[param];
-			const queryValue = Array.isArray(value)
-				? value.map((v) => encodeURIComponent(v)).join(',')
-				: encodeURIComponent(value);
-			return `${param}=${queryValue}`;
-		})
-		.join('&');
+	new URLSearchParams(query).toString();
 
 export { constructQuery };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Refactors `constructQuery` to use `URLSearchParams` instead of the custom implementation

Although the companion test passes, I'm not 100% certain that this is backwards compatible as the `query` parameter has quite a broad type.

## Why?

Less code :)