### PR TITLE
Filter LiveBlocks by dates

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -15,7 +15,6 @@ import {
 	pxToRem,
 	remSpace,
 } from '@guardian/source-foundations';
-import { OptionKind } from '@guardian/types';
 import Footer from 'components/footer';
 import GridItem from 'components/gridItem';
 import LiveBlocks from 'components/liveBlocks';
@@ -99,11 +98,11 @@ const keyEventsWrapperStyles = css`
 const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
 	blocks.reduce<KeyEvent[]>(
 		(events, block) =>
-			block.isKeyEvent && block.firstPublished.kind !== OptionKind.None
+			block.isKeyEvent
 				? [
 						...events,
 						{
-							date: block.firstPublished.value,
+							date: block.firstPublished,
 							text: block.title,
 							url: `?page=with:block-${block.id}#block-${block.id}`,
 						},

--- a/apps-rendering/src/components/liveBlocks.tsx
+++ b/apps-rendering/src/components/liveBlocks.tsx
@@ -4,11 +4,11 @@ import { css } from '@emotion/react';
 import type { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { map, OptionKind, partition, withDefault } from '@guardian/types';
+import { map, partition, withDefault } from '@guardian/types';
 import { LastUpdated } from 'components/lastUpdated';
 import type { Contributor } from 'contributor';
 import { formatUTCTimeDateTz } from 'date';
-import { pipe, toNullable } from 'lib';
+import { pipe } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { renderAll } from 'renderer';
@@ -42,6 +42,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 					map(Number),
 					toNullable,
 				);
+				const blockLink = `?page=with:block-${block.id}#block-${block.id}`;
 
 				return (
 					<LiveBlockContainer
@@ -50,7 +51,7 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 						format={format}
 						blockTitle={block.title}
 						blockFirstPublished={blockFirstPublished}
-						blockId={block.id}
+						blockLink={blockLink}
 						// TODO pass this value in when available
 						isPinnedPost={false}
 						supportsDarkMode={true}
@@ -66,17 +67,14 @@ const LiveBlocks: FC<LiveBlocksProps> = ({ blocks, format }) => {
 								justify-content: end;
 							`}
 						>
-							{block.lastModified.kind === OptionKind.Some &&
-								block.firstPublished.kind === OptionKind.Some &&
-								block.lastModified.value >
-									block.firstPublished.value && (
-									<LastUpdated
-										lastUpdated={block.lastModified.value}
-										lastUpdatedDisplay={formatUTCTimeDateTz(
-											block.lastModified.value,
-										)}
-									/>
-								)}
+							{block.lastModified > block.firstPublished && (
+								<LastUpdated
+									lastUpdated={block.lastModified}
+									lastUpdatedDisplay={formatUTCTimeDateTz(
+										block.lastModified,
+									)}
+								/>
+							)}
 						</footer>
 					</LiveBlockContainer>
 				);

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -2,7 +2,8 @@
 
 import type { Block } from '@guardian/content-api-models/v1/block';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import type { Option } from '@guardian/types';
+import type { Result } from '@guardian/types';
+import { err, ok, OptionKind, partition } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
@@ -16,8 +17,8 @@ type LiveBlock = {
 	id: string;
 	isKeyEvent: boolean;
 	title: string;
-	firstPublished: Option<Date>;
-	lastModified: Option<Date>;
+	firstPublished: Date;
+	lastModified: Date;
 	body: Body;
 	contributors: Contributor[];
 };
@@ -38,23 +39,35 @@ const tagsToContributors = (tags: Tag[], context: Context): Contributor[] =>
 
 const parse =
 	(context: Context, tags: Tag[]) =>
-	(block: Block): LiveBlock => ({
-		id: block.id,
-		isKeyEvent: block.attributes.keyEvent ?? false,
-		title: block.title ?? '',
-		firstPublished: maybeCapiDate(block.firstPublishedDate),
-		lastModified: maybeCapiDate(block.lastModifiedDate),
-		body: parseElements(context)(block.elements),
-		contributors: tagsToContributors(
-			contributorTags(block.contributors, tags),
-			context,
-		),
-	});
+	(block: Block): Result<string, LiveBlock> => {
+		const firstPublishedDate = maybeCapiDate(block.firstPublishedDate);
+		const lastModifiedDate = maybeCapiDate(block.lastModifiedDate);
+
+		if (
+			firstPublishedDate.kind === OptionKind.None ||
+			lastModifiedDate.kind === OptionKind.None
+		) {
+			return err('Invalid dates');
+		}
+
+		return ok({
+			id: block.id,
+			isKeyEvent: block.attributes.keyEvent ?? false,
+			title: block.title ?? '',
+			firstPublished: firstPublishedDate.value,
+			lastModified: lastModifiedDate.value,
+			body: parseElements(context)(block.elements),
+			contributors: tagsToContributors(
+				contributorTags(block.contributors, tags),
+				context,
+			),
+		});
+	};
 
 const parseMany =
 	(context: Context) =>
 	(blocks: Block[], tags: Tag[]): LiveBlock[] =>
-		blocks.map(parse(context, tags));
+		partition(blocks.map(parse(context, tags))).oks;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/pagination.test.ts
+++ b/apps-rendering/src/pagination.test.ts
@@ -7,8 +7,8 @@ const generateBlocks = (numberOfBlocks: number): LiveBlock[] => {
 		id: '1',
 		isKeyEvent: true,
 		title: 'Block One',
-		firstPublished: some(new Date('2021-11-02T12:00:00Z')),
-		lastModified: some(new Date('2021-11-02T13:13:13Z')),
+		firstPublished: new Date('2021-11-02T12:00:00Z'),
+		lastModified: new Date('2021-11-02T13:13:13Z'),
 		body: [],
 		contributors: [],
 	};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Filters the liveblocks before they're passed to the container by the dates

## Why?
Expecting this to raise further optimisation discussions about how we can refactor out a lot of the conditional rendering further down the tree
