### PR TITLE
Hide key events heading on mobile when empty

### DIFF
--- a/apps-rendering/src/components/layout/live.tsx
+++ b/apps-rendering/src/components/layout/live.tsx
@@ -128,6 +128,7 @@ const Live: FC<Props> = ({ item }) => {
 			older={toNullable(item.pagedBlocks.pagination.older)}
 		/>
 	);
+
 	return (
 		<article
 			className="js-article"
@@ -142,6 +143,7 @@ const Live: FC<Props> = ({ item }) => {
 						<Metadata item={item} />
 					</div>
 				</GridItem>
+
 				<GridItem area="key-events">
 					<div css={keyEventsWrapperStyles} data-chromatic="ignore">
 						<KeyEvents

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -62,10 +62,17 @@ const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
 const keyEventWrapperStyles = (
 	format: ArticleFormat,
 	supportsDarkMode: boolean,
+	hideMobile: boolean,
 ): SerializedStyles => css`
 	width: 100%;
 
+	${hideMobile &&
+	css`
+		display: none;
+	`}
+
 	${from.desktop} {
+		display: block;
 		border-top: 1px solid ${neutral[86]};
 		padding-top: ${remSpace[2]};
 	}
@@ -230,7 +237,11 @@ const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
 			tabIndex={0}
 			id="keyevents"
-			css={keyEventWrapperStyles(format, supportsDarkMode)}
+			css={keyEventWrapperStyles(
+				format,
+				supportsDarkMode,
+				keyEvents.length === 0,
+			)}
 			aria-label="Key Events"
 		>
 			<Accordion


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides the key events header on mobile when empty 

## Why?
When there were no key events the heading would still appear on mobile

