### PR TITLE
Force collection of core web vitals for users in mega test

### DIFF
--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -7,6 +7,7 @@ import {
 import { useAB } from '../lib/useAB';
 import { tests } from '../experiments/ab-tests';
 import { commercialGptLazyLoad } from '../experiments/tests/commercial-gpt-lazy-load';
+import { spacefinderOkrMegaTest } from '../experiments/tests/spacefinder-okr-mega-test';
 
 export const CoreVitals = () => {
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
@@ -28,6 +29,7 @@ export const CoreVitals = () => {
 
 	const testsToForceMetrics: ABTest[] = [
 		/* keep array multi-line */
+		spacefinderOkrMegaTest,
 		commercialGptLazyLoad,
 	];
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Sets the sampling of core web vitals to 100% for users in the audience of the Q4 mega test.

## Why?
- We want to measure the impact that the changes involved in [the test](https://github.com/guardian/frontend/pull/24726)  have on core web vitals.
- We force collection of these metrics for users in the test on [frontend](https://github.com/guardian/frontend/blob/3da22d73f100ecfdd7302325d1f2331c5eb3c812/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts#L9).