### PR TITLE
Added `enhanceCollections` pattern for Fronts

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -528,11 +528,26 @@ interface FrontType {
 	commercialProperties: Record<string, unknown>;
 }
 
+type DCRFrontType = {
+	pressedPage: DCRPressedPageType;
+	nav: CAPINavType;
+	editionId: Edition;
+	webTitle: string;
+	config: FrontConfigType;
+};
+
 type PressedPageType = {
 	id: string;
 	seoData: SeoDataType;
 	frontProperties: FrontPropertiesType;
-	collections: PressedCollectionType[];
+	collections: CollectionType[];
+};
+
+type DCRPressedPageType = {
+	id: string;
+	seoData: SeoDataType;
+	frontProperties: FrontPropertiesType;
+	collections: DCRCollectionType[];
 };
 
 type SeoDataType = {
@@ -547,7 +562,7 @@ type FrontPropertiesType = {
 	commercial: Record<string, unknown>;
 };
 
-type CollectionType =
+type ContainerType =
 	| 'dynamic/fast'
 	| 'dynamic/package'
 	| 'dynamic/slow'
@@ -571,7 +586,7 @@ type CollectionType =
 	| 'nav/media-list'
 	| 'news/most-popular';
 
-type CollectionCard = {
+type FrontCard = {
 	properties: {
 		isBreaking: boolean;
 		showMainVideo: boolean;
@@ -588,7 +603,7 @@ type CollectionCard = {
 							source: string;
 							photographer?: string;
 							isMaster?: string;
-							altText: string;
+							altText?: string;
 							height: string;
 							credit: string;
 							mediaId: string;
@@ -632,6 +647,22 @@ type CollectionCard = {
 		isComment: boolean;
 		isGallery: boolean;
 		isAudio: boolean;
+		kicker?: {
+			type: string;
+			item?: {
+				properties: {
+					kickerText: string;
+				};
+			};
+		};
+		seriesOrBlogKicker?: {
+			properties: {
+				kickerText: string;
+			};
+			name: string;
+			url: string;
+			id: string;
+		};
 		headline: string;
 		url: string;
 		hasMainVideoElement: boolean;
@@ -671,16 +702,26 @@ type CollectionCard = {
 	type: string;
 };
 
-type PressedCollectionType = {
+type DCRFrontCard = {
+	format: ArticleFormat;
+	isLiveBlog: boolean;
+	url: string;
+	headline: string;
+	webPublicationDate?: string;
+	image?: string;
+	kickerText?: string;
+};
+
+type CollectionType = {
 	id: string;
 	displayName: string;
-	curated: CollectionCard[];
-	backfill: CollectionCard[];
-	treats: CollectionCard[];
+	curated: FrontCard[];
+	backfill: FrontCard[];
+	treats: FrontCard[];
 	lastUpdate?: number;
 	href?: string;
 	groups?: string[];
-	collectionType: CollectionType;
+	collectionType: ContainerType;
 	uneditable: boolean;
 	showTags: boolean;
 	showSections: boolean;
@@ -690,7 +731,7 @@ type PressedCollectionType = {
 	config: {
 		displayName: string;
 		metadata?: { type: string }[];
-		collectionType: CollectionType;
+		collectionType: ContainerType;
 		href?: string;
 		groups?: string[];
 		uneditable: boolean;
@@ -705,6 +746,14 @@ type PressedCollectionType = {
 		platform: string;
 	};
 	hasMore: boolean;
+};
+
+type DCRCollectionType = {
+	id: string;
+	displayName: string;
+	curated: DCRFrontCard[];
+	backfill: DCRFrontCard[];
+	treats: DCRFrontCard[];
 };
 
 type FrontConfigType = {
@@ -1057,7 +1106,7 @@ interface BaseTrailType {
 	url: string;
 	headline: string;
 	isLiveBlog: boolean;
-	webPublicationDate: string;
+	webPublicationDate?: string;
 	image?: string;
 	carouselImages?: CarouselImagesMap;
 	avatarUrl?: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -515,8 +515,8 @@ interface CAPIArticleType {
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
-interface FrontType {
-	pressedPage: PressedPageType;
+interface FEFrontType {
+	pressedPage: FEPressedPageType;
 	nav: CAPINavType;
 	editionId: Edition;
 	editionLongForm: string;
@@ -524,7 +524,7 @@ interface FrontType {
 	pageId: string;
 	webTitle: string;
 	webURL: string;
-	config: FrontConfigType;
+	config: FEFrontConfigType;
 	commercialProperties: Record<string, unknown>;
 }
 
@@ -533,36 +533,36 @@ type DCRFrontType = {
 	nav: CAPINavType;
 	editionId: Edition;
 	webTitle: string;
-	config: FrontConfigType;
+	config: FEFrontConfigType;
 };
 
-type PressedPageType = {
+type FEPressedPageType = {
 	id: string;
-	seoData: SeoDataType;
-	frontProperties: FrontPropertiesType;
-	collections: CollectionType[];
+	seoData: FESeoDataType;
+	frontProperties: FEFrontPropertiesType;
+	collections: FECollectionType[];
 };
 
 type DCRPressedPageType = {
 	id: string;
-	seoData: SeoDataType;
-	frontProperties: FrontPropertiesType;
+	seoData: FESeoDataType;
+	frontProperties: FEFrontPropertiesType;
 	collections: DCRCollectionType[];
 };
 
-type SeoDataType = {
+type FESeoDataType = {
 	id: string;
 	navSection: string;
 	webTitle: string;
 	description: string;
 };
 
-type FrontPropertiesType = {
+type FEFrontPropertiesType = {
 	isImageDisplayed: boolean;
 	commercial: Record<string, unknown>;
 };
 
-type ContainerType =
+type FEContainerType =
 	| 'dynamic/fast'
 	| 'dynamic/package'
 	| 'dynamic/slow'
@@ -586,7 +586,7 @@ type ContainerType =
 	| 'nav/media-list'
 	| 'news/most-popular';
 
-type FrontCard = {
+type FEFrontCard = {
 	properties: {
 		isBreaking: boolean;
 		showMainVideo: boolean;
@@ -712,16 +712,16 @@ type DCRFrontCard = {
 	kickerText?: string;
 };
 
-type CollectionType = {
+type FECollectionType = {
 	id: string;
 	displayName: string;
-	curated: FrontCard[];
-	backfill: FrontCard[];
-	treats: FrontCard[];
+	curated: FEFrontCard[];
+	backfill: FEFrontCard[];
+	treats: FEFrontCard[];
 	lastUpdate?: number;
 	href?: string;
 	groups?: string[];
-	collectionType: ContainerType;
+	collectionType: FEContainerType;
 	uneditable: boolean;
 	showTags: boolean;
 	showSections: boolean;
@@ -731,7 +731,7 @@ type CollectionType = {
 	config: {
 		displayName: string;
 		metadata?: { type: string }[];
-		collectionType: ContainerType;
+		collectionType: FEContainerType;
 		href?: string;
 		groups?: string[];
 		uneditable: boolean;
@@ -756,7 +756,7 @@ type DCRCollectionType = {
 	treats: DCRFrontCard[];
 };
 
-type FrontConfigType = {
+type FEFrontConfigType = {
 	avatarApiUrl: string;
 	externalEmbedHost: string;
 	ajaxUrl: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -515,6 +515,7 @@ interface CAPIArticleType {
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
+// FE* types are coming from Frontend
 interface FEFrontType {
 	pressedPage: FEPressedPageType;
 	nav: CAPINavType;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,7 +1,7 @@
 import { ArticleDesign } from '@guardian/libs';
 import { decideFormat } from '../web/lib/decideFormat';
 
-const enhanceCards = (collections: FrontCard[]): DCRFrontCard[] => {
+const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] => {
 	const enhanced: DCRFrontCard[] = [];
 	collections.forEach((faciaCard) => {
 		if (faciaCard.format) {
@@ -27,7 +27,7 @@ const enhanceCards = (collections: FrontCard[]): DCRFrontCard[] => {
 };
 
 export const enhanceCollections = (
-	collections: CollectionType[],
+	collections: FECollectionType[],
 ): DCRCollectionType[] => {
 	return collections.map((collection) => {
 		return {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,0 +1,40 @@
+import { ArticleDesign } from '@guardian/libs';
+import { decideFormat } from '../web/lib/decideFormat';
+
+const enhanceCards = (collections: FrontCard[]): DCRFrontCard[] => {
+	const enhanced: DCRFrontCard[] = [];
+	collections.forEach((faciaCard) => {
+		if (faciaCard.format) {
+			const format = decideFormat(faciaCard.format);
+			enhanced.push({
+				format,
+				isLiveBlog: format.design === ArticleDesign.LiveBlog,
+				url: faciaCard.header.url,
+				headline: faciaCard.header.headline,
+				webPublicationDate: faciaCard.card.webPublicationDateOption
+					? new Date(
+							faciaCard.card.webPublicationDateOption,
+					  ).toISOString()
+					: undefined,
+				image: faciaCard.properties.maybeContent?.trail.trailPicture
+					?.allImages[0].url,
+				kickerText:
+					faciaCard.header.kicker?.item?.properties.kickerText,
+			});
+		}
+	});
+	return enhanced;
+};
+
+export const enhanceCollections = (
+	collections: CollectionType[],
+): DCRCollectionType[] => {
+	return collections.map((collection) => {
+		return {
+			...collection,
+			curated: enhanceCards(collection.curated),
+			backfill: enhanceCards(collection.backfill),
+			treats: enhanceCards(collection.treats),
+		};
+	});
+};

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -128,7 +128,6 @@
                                                                                             }
                                                                                         },
                                                                                         "required": [
-                                                                                            "altText",
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
@@ -327,6 +326,67 @@
                                                 },
                                                 "isAudio": {
                                                     "type": "boolean"
+                                                },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
                                                 },
                                                 "headline": {
                                                     "type": "string"
@@ -566,7 +626,6 @@
                                                                                             }
                                                                                         },
                                                                                         "required": [
-                                                                                            "altText",
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
@@ -765,6 +824,67 @@
                                                 },
                                                 "isAudio": {
                                                     "type": "boolean"
+                                                },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
                                                 },
                                                 "headline": {
                                                     "type": "string"
@@ -1004,7 +1124,6 @@
                                                                                             }
                                                                                         },
                                                                                         "required": [
-                                                                                            "altText",
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
@@ -1204,6 +1323,67 @@
                                                 "isAudio": {
                                                     "type": "boolean"
                                                 },
+                                                "kicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "kickerText": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "kickerText"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "properties"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "seriesOrBlogKicker": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "properties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "kickerText": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kickerText"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "url": {
+                                                            "type": "string"
+                                                        },
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "name",
+                                                        "properties",
+                                                        "url"
+                                                    ]
+                                                },
                                                 "headline": {
                                                     "type": "string"
                                                 },
@@ -1383,7 +1563,7 @@
                                 }
                             },
                             "collectionType": {
-                                "$ref": "#/definitions/CollectionType"
+                                "$ref": "#/definitions/ContainerType"
                             },
                             "uneditable": {
                                 "type": "boolean"
@@ -1424,7 +1604,7 @@
                                         }
                                     },
                                     "collectionType": {
-                                        "$ref": "#/definitions/CollectionType"
+                                        "$ref": "#/definitions/ContainerType"
                                     },
                                     "href": {
                                         "type": "string"
@@ -1940,7 +2120,7 @@
             ],
             "type": "string"
         },
-        "CollectionType": {
+        "ContainerType": {
             "enum": [
                 "dynamic/fast",
                 "dynamic/package",

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -37,7 +37,7 @@ export const validateAsCAPIType = (data: {
 
 export const validateAsFrontType = (
 	data: Record<string, unknown>,
-): FrontType => {
+): FEFrontType => {
 	const isValid = validateFront(data);
 
 	if (!isValid) {
@@ -50,5 +50,5 @@ export const validateAsFrontType = (
 		);
 	}
 
-	return data as unknown as FrontType;
+	return data as unknown as FEFrontType;
 };

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -133,7 +133,7 @@ export const makeWindowGuardian = (
 const makeFrontWindowGuardianConfig = ({
 	config,
 	editionId,
-}: FrontType): WindowGuardianFrontConfig => {
+}: DCRFrontType): WindowGuardianFrontConfig => {
 	return {
 		// This indicates to the client side code that we are running a dotcom-rendering rendered page.
 		isDotcomRendering: true,
@@ -169,7 +169,7 @@ const makeFrontWindowGuardianConfig = ({
 };
 
 export const makeFrontWindowGuardian = (
-	front: FrontType,
+	front: DCRFrontType,
 ): {
 	// The 'config' attribute is derived from DCRServerDocumentData and contains
 	// all the data that, for legacy reasons, for instance compatibility

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -667,6 +667,9 @@ export const Carousel: React.FC<OnwardsType> = ({
 							carouselImages,
 							kickerText,
 						} = trail;
+						// Don't try to render cards that have no publication date. This property is technically optional
+						// but we rarely if ever expect it not to exist
+						if (!webPublicationDate) return;
 						const imageUrl =
 							isFullCardImage && carouselImages
 								? carouselImages['460']

--- a/dotcom-rendering/src/web/components/FrontPage.tsx
+++ b/dotcom-rendering/src/web/components/FrontPage.tsx
@@ -9,7 +9,7 @@ import { CoreVitals } from './CoreVitals.importable';
 import { FrontLayout } from '../layouts/FrontLayout';
 
 type Props = {
-	front: FrontType;
+	front: DCRFrontType;
 	NAV: NavType;
 };
 

--- a/dotcom-rendering/src/web/components/FrontPage.tsx
+++ b/dotcom-rendering/src/web/components/FrontPage.tsx
@@ -18,7 +18,7 @@ type Props = {
  * Article is a high level wrapper for pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
- * @param {FrontType} props.front - The article JSON data
+ * @param {DCRFrontType} props.front - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * */
 export const FrontPage = ({ front, NAV }: Props) => {

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -13,7 +13,7 @@ import { ContainerLayout } from '../components/ContainerLayout';
 import { Header } from '../components/Header';
 
 interface Props {
-	front: FrontType;
+	front: DCRFrontType;
 	NAV: NavType;
 }
 
@@ -105,10 +105,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<main>
 				{front.pressedPage.collections.map((collection, index) => {
+					// TODO: We also need to support backfill and treats containers
+					const trails = collection.curated;
+					// There are some containers that have zero trails. We don't want to render these
+					if (trails.length === 0) return null;
 					return (
 						<ContainerLayout
 							title={collection.displayName}
-							showTopBorder={index !== 0}
+							showTopBorder={index > 1}
 							sideBorders={true}
 							centralBorder="partial"
 						/>

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -11,7 +11,7 @@ import { escapeData } from '../../lib/escapeData';
 import { makeFrontWindowGuardian } from '../../model/window-guardian';
 
 interface Props {
-	front: FrontType;
+	front: DCRFrontType;
 	NAV: NavType;
 }
 

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -4,6 +4,7 @@ import { extractNAV } from '../../model/extract-nav';
 import { articleToHtml } from './articleToHtml';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
+import { enhanceCollections } from '../../model/enhanceCollections';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import { extract as extractGA } from '../../model/extract-ga';
 import { blocksToHtml } from './blocksToHtml';
@@ -25,12 +26,15 @@ const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 	return CAPIArticle;
 };
 
-const enhanceFront = (body: Record<string, unknown>): FrontType => {
-	const enhanced = validateAsFrontType(body);
-	const front: FrontType = {
-		...enhanced,
+const enhanceFront = (body: Record<string, unknown>): DCRFrontType => {
+	const data: FrontType = validateAsFrontType(body);
+	return {
+		...data,
+		pressedPage: {
+			...data.pressedPage,
+			collections: enhanceCollections(data.pressedPage.collections),
+		},
 	};
-	return front;
 };
 
 export const renderArticle = (

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -27,7 +27,7 @@ const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 };
 
 const enhanceFront = (body: Record<string, unknown>): DCRFrontType => {
-	const data: FrontType = validateAsFrontType(body);
+	const data: FEFrontType = validateAsFrontType(body);
 	return {
 		...data,
 		pressedPage: {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the enhancer pattern to Fronts. We now have a type for the data before it is enhanced - what gets sent to us from Frontend - and then a type for the version that DCR uses afterwards - the actual data we use for rendering

## Why?
The enhancer pattern allows us to put mutations in one place. This is better for comprehension and also serves to make moving these mutations at a later stage easier if we choose to do so.

In addition, having tighter types for the data that is actually used makes reading and learning the code a lot simpler.

### `DCR...` prefix
Previously, we used the `CAPI...` prefix the denote data that had been sent to use from Frontend and then subsequent types were named normally. Here, I'm adding a prefix to denote that a type is DCR specific. I don't think this needs to be slavishly followed (we don't need to prefix _all_ types with 'DCR') but it is useful to have some form of naming convention that helps explain at which end of the enhancer pattern a type is.