### PR TITLE
Fix margins on `DynamicFast`

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -133,7 +133,7 @@ export const DynamicFast = ({ trails }: Props) => {
 												linkTo={card.url}
 												format={card.format}
 												headlineText={card.headline}
-												headlineSize="medium"
+												headlineSize="small"
 												byline={card.byline}
 												showByline={card.showByline}
 												showQuotes={

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -121,9 +121,9 @@ export const DynamicFast = ({ trails }: Props) => {
 							padSides={true}
 						>
 							<UL direction="column">
-								{group.map((card, groupIndex) => {
+								{group.map((card, cardIndex) => {
 									const isLastCard =
-										groupIndex === group.length - 1;
+										cardIndex === group.length - 1;
 									return (
 										<LI
 											stretch={true}

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -122,7 +122,7 @@ export const DynamicFast = ({ trails }: Props) => {
 					<UL direction="column">
 						{groupOne.map((card) => {
 							return (
-								<LI bottomMargin={true} stretch={true}>
+								<LI stretch={true}>
 									<Card
 										linkTo={card.url}
 										format={card.format}
@@ -166,7 +166,7 @@ export const DynamicFast = ({ trails }: Props) => {
 					<UL direction="column">
 						{groupTwo.map((card) => {
 							return (
-								<LI bottomMargin={true} stretch={true}>
+								<LI stretch={true}>
 									<Card
 										linkTo={card.url}
 										format={card.format}

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -17,8 +17,7 @@ export const DynamicFast = ({ trails }: Props) => {
 	// - The middle column has exactly three items
 	// - The last column has exactly three items
 	const third = trails[2];
-	const groupOne = trails.slice(3, 6);
-	const groupTwo = trails.slice(7, 12);
+	const groups = [trails.slice(3, 6), trails.slice(7, 12)];
 
 	return (
 		<>
@@ -85,8 +84,8 @@ export const DynamicFast = ({ trails }: Props) => {
 					/>
 				</LI>
 			</UL>
-			<UL direction="row">
-				<LI percentage="50%" padSides={true}>
+			<UL direction="row" bottomMargin={true}>
+				<LI percentage="50%" padSides={true} bottomMargin={false}>
 					<Card
 						linkTo={third.url}
 						format={third.format}
@@ -113,94 +112,61 @@ export const DynamicFast = ({ trails }: Props) => {
 						branding={third.branding}
 					/>
 				</LI>
-				<LI
-					percentage="25%"
-					showDivider={true}
-					showTopMarginWhenStacked={true}
-					padSides={true}
-				>
-					<UL direction="column">
-						{groupOne.map((card) => {
-							return (
-								<LI stretch={true}>
-									<Card
-										linkTo={card.url}
-										format={card.format}
-										headlineText={card.headline}
-										headlineSize="medium"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										commentCount={card.commentCount}
-										starRating={card.starRating}
-										branding={card.branding}
-									/>
-								</LI>
-							);
-						})}
-					</UL>
-				</LI>
-				<LI
-					percentage="25%"
-					showDivider={true}
-					showTopMarginWhenStacked={true}
-					padSides={true}
-				>
-					<UL direction="column">
-						{groupTwo.map((card) => {
-							return (
-								<LI stretch={true}>
-									<Card
-										linkTo={card.url}
-										format={card.format}
-										headlineText={card.headline}
-										headlineSize="small"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										commentCount={card.commentCount}
-										starRating={card.starRating}
-										branding={card.branding}
-									/>
-								</LI>
-							);
-						})}
-					</UL>
-				</LI>
+				{groups.map((group) => {
+					return (
+						<LI
+							percentage="25%"
+							showDivider={true}
+							showTopMarginWhenStacked={true}
+							padSides={true}
+						>
+							<UL direction="column">
+								{group.map((card, groupIndex) => {
+									const isLastCard =
+										groupIndex === group.length - 1;
+									return (
+										<LI
+											stretch={true}
+											bottomMargin={!isLastCard}
+										>
+											<Card
+												linkTo={card.url}
+												format={card.format}
+												headlineText={card.headline}
+												headlineSize="medium"
+												byline={card.byline}
+												showByline={card.showByline}
+												showQuotes={
+													card.format.design ===
+														ArticleDesign.Comment ||
+													card.format.design ===
+														ArticleDesign.Letter
+												}
+												webPublicationDate={
+													card.webPublicationDate
+												}
+												kickerText={card.kickerText}
+												showPulsingDot={
+													card.format.design ===
+													ArticleDesign.LiveBlog
+												}
+												showSlash={true}
+												showClock={false}
+												mediaType={card.mediaType}
+												mediaDuration={
+													card.mediaDuration
+												}
+												commentCount={card.commentCount}
+												starRating={card.starRating}
+												branding={card.branding}
+											/>
+										</LI>
+									);
+								})}
+							</UL>
+						</LI>
+					);
+				})}
 			</UL>
 		</>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Set the `bottomMargin` prop consistently

## Why?
@ajbreuer [spotted this](https://github.com/guardian/dotcom-rendering/pull/4572#issuecomment-1095070490) when it was implemented 

### Before
<img width="766" alt="Screenshot 2022-04-11 at 15 03 29" src="https://user-images.githubusercontent.com/1336821/162756740-9a0c3ef3-b99b-4ee8-94a2-aba6ad398361.png">


### After
<img width="766" alt="Screenshot 2022-04-11 at 15 02 11" src="https://user-images.githubusercontent.com/1336821/162756744-541c0509-4b0a-430b-a6aa-6e1a3ebb915b.png">
