### PR TITLE
add front to lighthouse

### DIFF
--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -1,7 +1,10 @@
 module.exports = {
   ci: {
     collect: {
-      url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'],
+      url: [
+        'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads',
+        'http://localhost:9000/Front?url=https://www.theguardian.com/uk'
+      ],
       startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
       numberOfRuns: '10',
       puppeteerScript: './scripts/lighthouse/puppeteer-script.js',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?
Part of https://github.com/guardian/dotcom-rendering/issues/4415

Adds a front to our lighthouse checks to help us identify where we might make improvements to our CWVs.

It will also give us a second example so we can consider this when working on [exposing our lighthouse scores](https://github.com/guardian/dotcom-rendering/issues/4584).