### PR TITLE
add blinking dot for mobile and update desktop version

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleLastUpdated.tsx
+++ b/dotcom-rendering/src/web/components/ArticleLastUpdated.tsx
@@ -6,14 +6,14 @@ import { PulsingDot } from './PulsingDot.importable';
 import { Island } from './Island';
 
 const lastUpdatedStyles = (palette: Palette) => css`
-	${textSans.xxsmall()}
+	${textSans.small()}
 	padding-bottom: 0.125rem;
 	padding-top: 0.125rem;
 	color: ${palette.text.standfirst};
 `;
 
 const livePulseIconStyles = css`
-	${textSans.xxsmall({ fontWeight: 'bold' })}
+	${textSans.small({ fontWeight: 'bold' })}
 `;
 
 type Props = {

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -1,9 +1,12 @@
 import { css } from '@emotion/react';
 
-import { from, until } from '@guardian/source-foundations';
+import { from, textSans, until } from '@guardian/source-foundations';
 import { ArticleDisplay, ArticleDesign } from '@guardian/libs';
 import { Badge } from './Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
+import { Island } from './Island';
+import { PulsingDot } from './PulsingDot.importable';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
@@ -16,7 +19,7 @@ type Props = {
 
 const sectionStyles = css`
 	padding-top: 8px;
-	display: flex;
+	display: inline-flex;
 	flex-direction: row;
 	${from.leftCol} {
 		flex-direction: column;
@@ -56,6 +59,14 @@ const immersiveMargins = css`
 	}
 `;
 
+const livePulseIconStyles = css`
+	${textSans.xxsmall({ fontWeight: 'bold' })}
+	padding-top: 0.25em;
+	${from.desktop} {
+		display: none;
+	}
+`;
+
 export const ArticleTitle = ({
 	format,
 	tags,
@@ -63,29 +74,49 @@ export const ArticleTitle = ({
 	sectionUrl,
 	guardianBaseURL,
 	badge,
-}: Props) => (
-	<div css={[sectionStyles, badge && badgeContainer]}>
-		{badge && format.display !== ArticleDisplay.Immersive && (
-			<div css={titleBadgeWrapper}>
-				<Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
+}: Props) => {
+	const palette = decidePalette(format);
+	return (
+		<div css={[sectionStyles, badge && badgeContainer]}>
+			{format.design === ArticleDesign.LiveBlog && (
+				<span
+					css={[
+						livePulseIconStyles,
+						css`
+							color: ${palette.text.seriesTitle};
+						`,
+					]}
+				>
+					<Island deferUntil="idle">
+						<PulsingDot />
+					</Island>
+				</span>
+			)}
+			{badge && format.display !== ArticleDisplay.Immersive && (
+				<div css={titleBadgeWrapper}>
+					<Badge
+						imageUrl={badge.imageUrl}
+						seriesTag={badge.seriesTag}
+					/>
+				</div>
+			)}
+			<div
+				css={[
+					badge && marginTop,
+					format.display === ArticleDisplay.Immersive &&
+						format.design !== ArticleDesign.PrintShop &&
+						immersiveMargins,
+				]}
+			>
+				<SeriesSectionLink
+					format={format}
+					tags={tags}
+					sectionLabel={sectionLabel}
+					sectionUrl={sectionUrl}
+					guardianBaseURL={guardianBaseURL}
+					badge={badge}
+				/>
 			</div>
-		)}
-		<div
-			css={[
-				badge && marginTop,
-				format.display === ArticleDisplay.Immersive &&
-					format.design !== ArticleDesign.PrintShop &&
-					immersiveMargins,
-			]}
-		>
-			<SeriesSectionLink
-				format={format}
-				tags={tags}
-				sectionLabel={sectionLabel}
-				sectionUrl={sectionUrl}
-				guardianBaseURL={guardianBaseURL}
-				badge={badge}
-			/>
 		</div>
-	</div>
-);
+	);
+};

--- a/dotcom-rendering/src/web/components/PulsingDot.importable.tsx
+++ b/dotcom-rendering/src/web/components/PulsingDot.importable.tsx
@@ -1,17 +1,23 @@
 import { css, keyframes } from '@emotion/react';
 
 import { storage } from '@guardian/libs';
+import { until } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 
 const dotStyles = (colour?: string) => css`
 	color: ${colour && colour};
+	vertical-align: middle;
 	:before {
 		border-radius: 62.5rem;
 		display: inline-block;
 		position: relative;
 		background-color: currentColor;
-		width: 0.75em;
-		height: 0.75em;
+		width: 0.917em;
+		height: 0.917em;
+		${until.desktop} {
+			width: 1.084em;
+			height: 1.084em;
+		}
 		content: '';
 		margin-right: 0.1875rem;
 		vertical-align: initial;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR does the following:
- Add blinking dot to liveblogs article title section on below desktop 
- update the size of the blinking dot and the article last updated text on desktop breakpoint

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
