### PR TITLE
Remove `isliveblog`

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -8,7 +8,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Julia Kollewe',
 		image: 'https://i.guim.co.uk/img/media/d4124d7bb89be381cbe9d72c849fad136f843086/0_84_4974_2985/master/4974.jpg?width=900&quality=85&s=4bdf16831b01b6fcc649992c52e6011b',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.Opinion,
@@ -22,7 +21,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Shaun Walker in Budapest',
 		image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=900&quality=85&s=f27d36b8e7563f226cb5c22049559569',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -38,7 +36,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: 'https://i.guim.co.uk/img/media/e8de0c5e27a2d92ced64f690daf48fd9b3b5c079/0_0_5101_3061/master/5101.jpg?width=900&quality=85&s=6c1cec769f59569c150794ae5f3d6c44',
-		isLiveBlog: true,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -53,7 +50,6 @@ export const trails: TrailType[] = [
 		showByline: true,
 		byline: 'Damian Carrington Environment editor',
 		image: 'https://i.guim.co.uk/img/media/1774967ff6b9127a43b06c0685d1fd499c965141/98_0_3413_2048/master/3413.jpg?width=900&quality=85&s=7332d70e260400883bfdcb5b1453ef10',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.Opinion,
@@ -67,7 +63,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: 'https://i.guim.co.uk/img/media/6db4a6d23e6e8d78ca6893f14b03e79869b2fef1/0_220_3500_2101/master/3500.jpg?width=900&quality=85&s=c212dd884c83237b2a1f24349bd9973b',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -82,7 +77,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Simon Murphy',
 		image: 'https://i.guim.co.uk/img/media/deb1f0b7f61ebbed2086a55dc34fecb2433a04bc/0_0_6000_3600/master/6000.jpg?width=900&quality=85&s=52aefcb20c15c279b6a6d360f5af9828',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -97,7 +91,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Leyland Cecco',
 		image: 'https://i.guim.co.uk/img/media/5e8ea90ae9f503aa1c98fd35dbf13235b1207fea/0_490_3264_1958/master/3264.jpg?width=900&quality=85&s=80890967a26cab02bd524331818e6e23',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -112,7 +105,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Larry Elliott  in Washington',
 		image: 'https://i.guim.co.uk/img/media/2905d1c09d1a27de1c183dfa5cdcc10c869932d9/0_124_5472_3284/master/5472.jpg?width=900&quality=85&s=88c182d909be33c918fc17f26778d0c1',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.News,
@@ -127,7 +119,6 @@ export const trails: TrailType[] = [
 		byline: 'Yohannes Lowe',
 		image: 'https://i.guim.co.uk/img/media/77e960298d4339e047eac5c1986d0f3214f6285d/419_447_4772_2863/master/4772.jpg?width=300&quality=85&auto=format&fit=max&s=9a17ef5d7a6240caa29965407ef912e0',
 
-		isLiveBlog: true,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -143,7 +134,6 @@ export const trails: TrailType[] = [
 		byline: 'Nicola Davis and agency',
 		image: 'https://i.guim.co.uk/img/media/56d554a7c453dc1040f70453a01fefcb227f2055/0_0_3060_1836/master/3060.jpg?width=300&quality=85&auto=format&fit=max&s=501112ecfd78672fc4a19133053fe04a',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -159,7 +149,6 @@ export const trails: TrailType[] = [
 		byline: 'Libby Brooks Scotland correspondent',
 		image: 'https://i.guim.co.uk/img/media/df5aea6391e21b5a5d2d25fd9aad81d497f99d42/0_45_3062_1837/master/3062.jpg?width=300&quality=85&auto=format&fit=max&s=4de26576c2388e49ee9c9414d5c46d6d',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -175,7 +164,6 @@ export const trails: TrailType[] = [
 		byline: 'Anna Leach, Ashley Kirk and Pamela Duncan',
 		image: 'https://i.guim.co.uk/img/media/5ebec1a8d662f0da39887dae16e4b2720379246e/0_0_5000_3000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=51c9ef2f26b312a7c057d86e9a53f365',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -191,7 +179,6 @@ export const trails: TrailType[] = [
 		byline: 'Nicola Davis and Natalie Grover',
 		image: 'https://i.guim.co.uk/img/media/046002abfc13c8cf7f0c40454349eb0e95d842b2/0_147_3884_2331/master/3884.jpg?width=300&quality=85&auto=format&fit=max&s=63ca0f0e218f3c7d886231b544a82cbd',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -207,7 +194,6 @@ export const trails: TrailType[] = [
 		byline: 'Sarah Boseley Health editor and Aamna Mohdin Community affairs correspondent',
 		image: 'https://i.guim.co.uk/img/media/9e47ac13c7ffc63ee56235e8ef64301d6ed96d03/0_90_3520_2111/master/3520.jpg?width=300&quality=85&auto=format&fit=max&s=206ae21754ca45db0f098b08091562ef',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -223,7 +209,6 @@ export const trails: TrailType[] = [
 		byline: 'Nicola Slawson',
 		image: 'https://i.guim.co.uk/img/media/c01ad5ee63034e0f478959fc7a705c93debf8ba7/0_220_4104_2462/master/4104.jpg?width=300&quality=85&auto=format&fit=max&s=5dbe0a813852f2ce7304f2eddd0b6e45',
 
-		isLiveBlog: true,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -239,7 +224,6 @@ export const trails: TrailType[] = [
 		byline: 'Sarah Boseley Health editor',
 		image: 'https://i.guim.co.uk/img/media/6d152e60fdb37dbbc063a68e2cffccf97cdab183/0_40_5458_3275/master/5458.jpg?width=300&quality=85&auto=format&fit=max&s=de76d3ccfb81477fa0ec3e24a93a0daf',
 
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -255,7 +239,6 @@ export const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: 'https://i.guim.co.uk/img/media/e8de0c5e27a2d92ced64f690daf48fd9b3b5c079/0_0_5101_3061/master/5101.jpg?width=900&quality=85&s=6c1cec769f59569c150794ae5f3d6c44',
-		isLiveBlog: true,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: ArticlePillar.Sport,

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -705,7 +705,6 @@ type FEFrontCard = {
 
 type DCRFrontCard = {
 	format: ArticleFormat;
-	isLiveBlog: boolean;
 	url: string;
 	headline: string;
 	webPublicationDate?: string;
@@ -1100,7 +1099,6 @@ interface DCRServerDocumentData {
 interface BaseTrailType {
 	url: string;
 	headline: string;
-	isLiveBlog: boolean;
 	webPublicationDate?: string;
 	image?: string;
 	avatarUrl?: string;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,4 +1,3 @@
-import { ArticleDesign } from '@guardian/libs';
 import { decideFormat } from '../web/lib/decideFormat';
 
 const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] => {
@@ -8,7 +7,6 @@ const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] => {
 			const format = decideFormat(faciaCard.format);
 			enhanced.push({
 				format,
-				isLiveBlog: format.design === ArticleDesign.LiveBlog,
 				url: faciaCard.header.url,
 				headline: faciaCard.header.headline,
 				webPublicationDate: faciaCard.card.webPublicationDateOption

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -39,7 +39,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Yohannes Lowe',
 		image: 'https://i.guim.co.uk/img/media/77e960298d4339e047eac5c1986d0f3214f6285d/419_447_4772_2863/master/4772.jpg?width=300&quality=85&auto=format&fit=max&s=9a17ef5d7a6240caa29965407ef912e0',
-		isLiveBlog: true,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -57,7 +56,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Nicola Davis and agency',
 		image: 'https://i.guim.co.uk/img/media/56d554a7c453dc1040f70453a01fefcb227f2055/0_0_3060_1836/master/3060.jpg?width=300&quality=85&auto=format&fit=max&s=501112ecfd78672fc4a19133053fe04a',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -75,7 +73,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Libby Brooks Scotland correspondent',
 		image: 'https://i.guim.co.uk/img/media/df5aea6391e21b5a5d2d25fd9aad81d497f99d42/0_45_3062_1837/master/3062.jpg?width=300&quality=85&auto=format&fit=max&s=4de26576c2388e49ee9c9414d5c46d6d',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -93,7 +90,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Anna Leach, Ashley Kirk and Pamela Duncan',
 		image: 'https://i.guim.co.uk/img/media/5ebec1a8d662f0da39887dae16e4b2720379246e/0_0_5000_3000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=51c9ef2f26b312a7c057d86e9a53f365',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -111,7 +107,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Nicola Davis and Natalie Grover',
 		image: 'https://i.guim.co.uk/img/media/046002abfc13c8cf7f0c40454349eb0e95d842b2/0_147_3884_2331/master/3884.jpg?width=300&quality=85&auto=format&fit=max&s=63ca0f0e218f3c7d886231b544a82cbd',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -129,7 +124,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Sarah Boseley Health editor and Aamna Mohdin Community affairs correspondent',
 		image: 'https://i.guim.co.uk/img/media/9e47ac13c7ffc63ee56235e8ef64301d6ed96d03/0_90_3520_2111/master/3520.jpg?width=300&quality=85&auto=format&fit=max&s=206ae21754ca45db0f098b08091562ef',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -147,7 +141,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Nicola Slawson',
 		image: 'https://i.guim.co.uk/img/media/c01ad5ee63034e0f478959fc7a705c93debf8ba7/0_220_4104_2462/master/4104.jpg?width=300&quality=85&auto=format&fit=max&s=5dbe0a813852f2ce7304f2eddd0b6e45',
-		isLiveBlog: true,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
@@ -165,7 +158,6 @@ const trails: TrailType[] = [
 		showByline: false,
 		byline: 'Sarah Boseley Health editor',
 		image: 'https://i.guim.co.uk/img/media/6d152e60fdb37dbbc063a68e2cffccf97cdab183/0_40_5458_3275/master/5458.jpg?width=300&quality=85&auto=format&fit=max&s=de76d3ccfb81477fa0ec3e24a93a0daf',
-		isLiveBlog: false,
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,

--- a/dotcom-rendering/src/web/components/MostViewed.mocks.ts
+++ b/dotcom-rendering/src/web/components/MostViewed.mocks.ts
@@ -8,7 +8,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: true,
 			byline: 'Jennifer Rankin and Daniel Boffey',
 			image: 'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
-			isLiveBlog: true,
 			format: {
 				design: 'LiveBlogDesign',
 				theme: 'NewsPillar',
@@ -24,7 +23,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: true,
 			byline: 'Martin Pengelly',
 			image: 'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'OpinionPillar',
@@ -42,7 +40,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Vic Marks at the Oval',
 			image: 'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
-			isLiveBlog: true,
 			format: {
 				design: 'LiveBlogDesign',
 				theme: 'SportPillar',
@@ -59,7 +56,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Simon Murphy',
 			image: 'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
-			isLiveBlog: true,
 			format: {
 				design: 'LiveBlogDesign',
 				theme: 'CulturePillar',
@@ -76,7 +72,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Caroline Davies',
 			image: 'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'LifestylePillar',
@@ -94,7 +89,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Tanya Aldred,  Geoff Lemon  & Jonathan Howcroft',
 			image: 'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -111,7 +105,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Sarah Johnson',
 			image: 'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -128,7 +121,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Aaron Hicklin',
 			image: 'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -145,7 +137,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Jess Cartner-Morley',
 			image: 'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -162,7 +153,6 @@ export const mockTab1: CAPITrailTabType = {
 			showByline: true,
 			byline: 'Matthew d’Ancona',
 			image: 'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -185,7 +175,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Bridget Christie',
 			image: 'https://i.guim.co.uk/img/media/eef1ed43631aa9088f26fca4a138f6e4250d9319/0_297_5400_3240/master/5400.jpg?width=300&quality=85&auto=format&fit=max&s=90f779a1a1ca85348a47ff19ccc50b12',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -202,7 +191,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Lauren Martin',
 			image: 'https://i.guim.co.uk/img/media/ff131761ef56456073d4edfb52af4ec8b8b953c2/0_290_6355_3813/master/6355.jpg?width=300&quality=85&auto=format&fit=max&s=6f1d869f447a6389e1e4a05b457c2289',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -218,7 +206,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Ben Beaumont-Thomas (1-50); Laura Snapes and April Curtin (51-100)',
 			image: 'https://i.guim.co.uk/img/media/1ce9e4ae33c1be975ab83fdabc267fc081c9d73c/0_0_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=16240604b766e11e7d5846fa13c43102',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -235,7 +222,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Dorian Lynskey',
 			image: 'https://i.guim.co.uk/img/media/6de53bbc2260febc167488209afe81844c47ecaa/0_225_5352_3211/master/5352.jpg?width=300&quality=85&auto=format&fit=max&s=d7da55f1e5f9d6b3a11f0c97237f3992',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'CulturePillar',
@@ -252,7 +238,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Mattha Busby',
 			image: 'https://i.guim.co.uk/img/media/5ee2bea12b92b28eff10b84d22e952c2681cb5f5/0_479_2239_1343/master/2239.jpg?width=300&quality=85&auto=format&fit=max&s=7b5cfb46f6a84b663d94a83c35acfe81',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -268,7 +253,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Killian Fox',
 			image: 'https://i.guim.co.uk/img/media/981e17d90b401754aae355d2e56bfedbe5b359b5/0_1000_2480_1488/master/2480.jpg?width=300&quality=85&auto=format&fit=max&s=facd8591d83abd4b0019370b6031be6e',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -285,7 +269,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Laura Snapes',
 			image: 'https://i.guim.co.uk/img/media/ff17da45e26064e2666106902a90655e4db49ea4/955_135_1467_880/master/1467.jpg?width=300&quality=85&auto=format&fit=max&s=f6c5f055f7614d73f65ec193bb30c054',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -302,7 +285,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Phil Mongredien',
 			image: 'https://i.guim.co.uk/img/media/b819ca05b59cdbe5ee59684740d1d9fe181b5a22/0_69_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=2f001df53652440f4be489b695c03ad2',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -319,7 +301,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'John Hind',
 			image: 'https://i.guim.co.uk/img/media/1e518e0996861201a7350f91f46d1f573ed2ea9c/0_823_6206_3724/master/6206.jpg?width=300&quality=85&auto=format&fit=max&s=149bde7a6699e526903598c690c214d0',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -336,7 +317,6 @@ export const mockTab2: CAPITrailTabType = {
 			showByline: false,
 			byline: 'Fiona Maddocks',
 			image: 'https://i.guim.co.uk/img/media/478dcff6eee2cbd753f1956e420c4caaf7b00fdd/0_1208_8095_4859/master/8095.jpg?width=300&quality=85&auto=format&fit=max&s=44effc5b2ab10b9a588be02c55a0620a',
-			isLiveBlog: false,
 			format: {
 				design: 'ArticleDesign',
 				theme: 'NewsPillar',
@@ -356,7 +336,6 @@ export const mockMostCommented = {
 	showByline: true,
 	byline: 'Jennifer Rankin and Daniel Boffey',
 	image: 'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
-	isLiveBlog: false,
 	format: {
 		theme: 'OpinionPillar',
 		design: 'CommentDesign',
@@ -374,7 +353,6 @@ export const mockMostShared = {
 	showByline: false,
 	byline: 'Martin Pengelly',
 	image: 'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
-	isLiveBlog: false,
 	format: {
 		design: 'ArticleDesign',
 		theme: 'OpinionPillar',

--- a/dotcom-rendering/src/web/components/Onwards.mocks.ts
+++ b/dotcom-rendering/src/web/components/Onwards.mocks.ts
@@ -15,7 +15,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Julia Kollewe',
 		image: 'https://i.guim.co.uk/img/media/d4124d7bb89be381cbe9d72c849fad136f843086/0_84_4974_2985/master/4974.jpg?width=900&quality=85&s=4bdf16831b01b6fcc649992c52e6011b',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'OpinionPillar',
@@ -31,7 +30,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Shaun Walker in Budapest',
 		image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=900&quality=85&s=f27d36b8e7563f226cb5c22049559569',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -49,7 +47,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: 'https://i.guim.co.uk/img/media/e8de0c5e27a2d92ced64f690daf48fd9b3b5c079/0_0_5101_3061/master/5101.jpg?width=900&quality=85&s=6c1cec769f59569c150794ae5f3d6c44',
-		isLiveBlog: true,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -66,7 +63,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Damian Carrington Environment editor',
 		image: 'https://i.guim.co.uk/img/media/1774967ff6b9127a43b06c0685d1fd499c965141/98_0_3413_2048/master/3413.jpg?width=900&quality=85&s=7332d70e260400883bfdcb5b1453ef10',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'SportPillar',
@@ -82,7 +78,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: 'https://i.guim.co.uk/img/media/6db4a6d23e6e8d78ca6893f14b03e79869b2fef1/0_220_3500_2101/master/3500.jpg?width=900&quality=85&s=c212dd884c83237b2a1f24349bd9973b',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -99,7 +94,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Simon Murphy',
 		image: 'https://i.guim.co.uk/img/media/deb1f0b7f61ebbed2086a55dc34fecb2433a04bc/0_0_6000_3600/master/6000.jpg?width=900&quality=85&s=52aefcb20c15c279b6a6d360f5af9828',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -116,7 +110,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Leyland Cecco',
 		image: 'https://i.guim.co.uk/img/media/5e8ea90ae9f503aa1c98fd35dbf13235b1207fea/0_490_3264_1958/master/3264.jpg?width=900&quality=85&s=80890967a26cab02bd524331818e6e23',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -133,7 +126,6 @@ const CAPITrails: CAPITrailType[] = [
 		showByline: false,
 		byline: 'Larry Elliott  in Washington',
 		image: 'https://i.guim.co.uk/img/media/2905d1c09d1a27de1c183dfa5cdcc10c869932d9/0_124_5472_3284/master/5472.jpg?width=900&quality=85&s=88c182d909be33c918fc17f26778d0c1',
-		isLiveBlog: false,
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: 'NewsPillar',
@@ -153,7 +145,6 @@ const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 		showByline: thisTrail.showByline,
 		byline: thisTrail.byline,
 		image: thisTrail.image,
-		isLiveBlog: thisTrail.isLiveBlog,
 		webPublicationDate: thisTrail.webPublicationDate,
 		mediaType: thisTrail.mediaType,
 		mediaDuration: thisTrail.mediaDuration,

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -85,19 +85,19 @@ type Props = {
 // updateRole modifies the role of an element in a way appropriate for most
 // article types.
 const updateRole = (el: CAPIElement, format: ArticleFormat): CAPIElement => {
-	const isLiveBlog =
+	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
 	switch (el._type) {
 		case 'model.dotcomrendering.pageElements.ImageBlockElement':
-			if (isLiveBlog && el.role !== 'thumbnail') {
+			if (isBlog && el.role !== 'thumbnail') {
 				el.role = 'inline';
 			}
 
 			return el;
 		case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
-			if (isLiveBlog) {
+			if (isBlog) {
 				el.role = 'inline';
 			} else {
 				el.role = 'richLink';
@@ -105,7 +105,7 @@ const updateRole = (el: CAPIElement, format: ArticleFormat): CAPIElement => {
 
 			return el;
 		default:
-			if (isLiveBlog && 'role' in el) {
+			if (isBlog && 'role' in el) {
 				el.role = 'inline';
 			}
 
@@ -136,7 +136,7 @@ export const renderElement = ({
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
 
-	const isLiveBlog =
+	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
@@ -731,7 +731,7 @@ export const renderElement = ({
 						mediaTitle={element.mediaTitle}
 						altText={element.altText}
 						origin={host}
-						stickyVideos={isLiveBlog && switches.stickyVideos}
+						stickyVideos={isBlog && switches.stickyVideos}
 					/>
 				</Island>,
 			];

--- a/dotcom-rendering/src/web/lib/useComments.test.tsx
+++ b/dotcom-rendering/src/web/lib/useComments.test.tsx
@@ -79,7 +79,6 @@ describe('buildUrl', () => {
 						showByline: true,
 						byline: 'Zoe Williams',
 						image: 'https://i.guim.co.uk/img/media/8ffbd3dc5aedfd502ca5ddd5f91f82c767cd28ea/0_0_3442_2065/master/3442.jpg?width=300&quality=85&auto=format&fit=max&s=52292233df8e95c6308e01f4222e25b3',
-						isLiveBlog: false,
 						format: {
 							display: ArticleDisplay.Standard,
 							theme: ArticlePillar.Opinion,
@@ -97,7 +96,6 @@ describe('buildUrl', () => {
 						showByline: true,
 						byline: 'Bill McKibben',
 						image: 'https://i.guim.co.uk/img/media/5dfdcb80828f014e04054ab626750cc112e92364/0_129_5065_3039/master/5065.jpg?width=300&quality=85&auto=format&fit=max&s=c108e8f88f55b627161b8f1827c93698',
-						isLiveBlog: false,
 						format: {
 							display: ArticleDisplay.Standard,
 							theme: ArticlePillar.Opinion,
@@ -134,7 +132,6 @@ describe('buildUrl', () => {
 						showByline: true,
 						byline: 'David Feldman, Ben Gidley and Brendan McGeever',
 						image: 'https://i.guim.co.uk/img/media/637243d90e93683dd13234ff543ab9b93da3d8d0/0_161_3926_2355/master/3926.jpg?width=300&quality=85&auto=format&fit=max&s=4f1ca464b3b4e7c498acd29d548ecae0',
-						isLiveBlog: false,
 						format: {
 							display: ArticleDisplay.Standard,
 							theme: ArticlePillar.Opinion,
@@ -152,7 +149,6 @@ describe('buildUrl', () => {
 						showByline: true,
 						byline: 'Arthur Goldhammer',
 						image: 'https://i.guim.co.uk/img/media/1f18d9b3ee4a6d38ff5a5544651f6cc382fdf480/0_203_5184_3110/master/5184.jpg?width=300&quality=85&auto=format&fit=max&s=ebc79b062b7f7f72582f8480a548eacb',
-						isLiveBlog: false,
 						format: {
 							display: ArticleDisplay.Standard,
 							theme: ArticlePillar.Opinion,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the `isLiveBlog` property from `TrailType`

## Why?
We don't need this. We can use `format` to determine this status