### PR TITLE
Only fallback to display headline on live/deadblogs

### DIFF
--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -44,25 +44,31 @@ export const GetMatchNav = ({
 		// Send the error to Sentry and then render the headline in its place as a fallback
 		window.guardian?.modules?.sentry?.reportError?.(error, 'match-nav');
 
-		return (
-			<div
-				css={css`
-					${from.leftCol} {
-						margin-left: 10px;
-					}
-					${from.desktop} {
-						max-width: 700px;
-					}
-				`}
-			>
-				<ArticleHeadline
-					headlineString={headlineString}
-					format={format}
-					tags={tags}
-					webPublicationDateDeprecated={webPublicationDateDeprecated}
-				/>
-			</div>
-		);
+		if (
+			format.design === ArticleDesign.LiveBlog ||
+			format.design === ArticleDesign.DeadBlog
+		)
+			return (
+				<div
+					css={css`
+						${from.leftCol} {
+							margin-left: 10px;
+						}
+						${from.desktop} {
+							max-width: 700px;
+						}
+					`}
+				>
+					<ArticleHeadline
+						headlineString={headlineString}
+						format={format}
+						tags={tags}
+						webPublicationDateDeprecated={
+							webPublicationDateDeprecated
+						}
+					/>
+				</div>
+			);
 	}
 	if (data) {
 		return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes https://github.com/guardian/dotcom-rendering/issues/4597

We replace the headline with the match nav on liveblogs & deadblogs, so we want to fallback to it there - but on articles the headline appears below the match nav, so we don't want the fallback!

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |



[before]: https://user-images.githubusercontent.com/9575458/162941878-52b6f0dd-c76a-4d0f-9ee5-1cb2b4e1ab33.png
[after]: https://user-images.githubusercontent.com/9575458/162941807-e9dd4c30-fd4d-4291-b558-221b42f19643.png
[before2]: https://user-images.githubusercontent.com/9575458/162942020-7263cf48-0722-4fe6-b445-1252578610b0.png
[after2]: https://user-images.githubusercontent.com/9575458/162941944-259b4369-7b62-436d-8866-03f098da2dd8.png



