### PR TITLE
Remove left padding in meta in Liveblogs and Deadblogs

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
 import {
 	between,
-	from,
-	until,
 	border,
+	from,
 	space,
+	until,
 } from '@guardian/source-foundations';
-import { ArticleDisplay, ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { Contributor } from './Contributor';
@@ -38,28 +38,48 @@ type Props = {
 	showShareCount: boolean;
 };
 
-const meta = css`
-	${between.tablet.and.leftCol} {
-		order: 3;
-	}
+const meta = (format: ArticleFormat) => {
+	if (
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
+	) {
+		return css`
+			${between.tablet.and.leftCol} {
+				order: 3;
+			}
 
-	${until.mobileLandscape} {
-		padding-left: 10px;
-		padding-right: 10px;
-	}
+			${from.phablet} {
+				padding-left: 0px;
+				padding-right: 0px;
+			}
 
-	${from.mobileLandscape} {
-		padding-left: 20px;
-		padding-right: 20px;
-	}
+			padding-top: 2px;
+		`;
+	} else {
+		return css`
+			${between.tablet.and.leftCol} {
+				order: 3;
+			}
 
-	${from.phablet} {
-		padding-left: 0px;
-		padding-right: 0px;
-	}
+			${until.mobileLandscape} {
+				padding-left: 10px;
+				padding-right: 10px;
+			}
 
-	padding-top: 2px;
-`;
+			${from.mobileLandscape} {
+				padding-left: 20px;
+				padding-right: 20px;
+			}
+
+			${from.phablet} {
+				padding-left: 0px;
+				padding-right: 0px;
+			}
+
+			padding-top: 2px;
+		`;
+	}
+};
 
 const metaFlex = css`
 	margin-bottom: 6px;
@@ -328,7 +348,7 @@ export const ArticleMeta = ({
 			}
 			css={metaContainer(format)}
 		>
-			<div css={meta}>
+			<div css={meta(format)}>
 				{branding && (
 					<Island deferUntil="visible">
 						<Branding branding={branding} palette={palette} />

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -55,30 +55,30 @@ const meta = (format: ArticleFormat) => {
 
 			padding-top: 2px;
 		`;
-	} else {
-		return css`
-			${between.tablet.and.leftCol} {
-				order: 3;
-			}
-
-			${until.mobileLandscape} {
-				padding-left: 10px;
-				padding-right: 10px;
-			}
-
-			${from.mobileLandscape} {
-				padding-left: 20px;
-				padding-right: 20px;
-			}
-
-			${from.phablet} {
-				padding-left: 0px;
-				padding-right: 0px;
-			}
-
-			padding-top: 2px;
-		`;
 	}
+
+	return css`
+		${between.tablet.and.leftCol} {
+			order: 3;
+		}
+
+		${until.mobileLandscape} {
+			padding-left: 10px;
+			padding-right: 10px;
+		}
+
+		${from.mobileLandscape} {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
+
+		${from.phablet} {
+			padding-left: 0px;
+			padding-right: 0px;
+		}
+
+		padding-top: 2px;
+	`;
 };
 
 const metaFlex = css`

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -48,11 +48,6 @@ const meta = (format: ArticleFormat) => {
 				order: 3;
 			}
 
-			${from.phablet} {
-				padding-left: 0px;
-				padding-right: 0px;
-			}
-
 			padding-top: 2px;
 		`;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #4153 

## What does this change?
Removes unnecessary left padding from metadata in Liveblogs and Deadblogs below phablet breakpoint (660px).

## Why?
To match the designs.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="479" alt="image" src="https://user-images.githubusercontent.com/19683595/163021348-9b3b564a-6521-4da7-8fe8-ad2e4b9fb8ae.png"> | <img width="477" alt="image" src="https://user-images.githubusercontent.com/19683595/163020818-6c5b9d57-8499-4025-8bed-da422cd1b3f7.png"> |
| <img width="481" alt="image" src="https://user-images.githubusercontent.com/19683595/163021189-866ada47-27f3-4fb0-b027-169e7dff22d2.png"> | <img width="481" alt="image" src="https://user-images.githubusercontent.com/19683595/163021038-1c2b216f-be20-49f3-96cc-f09915cade3e.png"> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
