### PR TITLE
Remove sticky videos switch from renderElement

### DIFF
--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -731,7 +731,7 @@ export const renderElement = ({
 						mediaTitle={element.mediaTitle}
 						altText={element.altText}
 						origin={host}
-						stickyVideos={isBlog && switches.stickyVideos}
+						stickyVideos={isBlog}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
## What does this change?

Removes the sticky videos switch from the `stickyVideos` conditional in `renderElement`. **Once merged the Sticky Videos will be available to all users on PROD.**

The companion PR in Frontend is [here](https://github.com/guardian/frontend/pull/24889).

