### PR TITLE
refactor(toast): scroll with JS only

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -281,7 +281,7 @@ export const Liveness = ({
 			document.getElementById(placeToScrollTo)?.scrollIntoView({
 				behavior: 'smooth',
 			});
-			window.location.href = `#${placeToScrollTo}`;
+			window.history.replaceState({}, '', `#${placeToScrollTo}`);
 			revealPendingBlocks();
 			setNumHiddenBlocks(0);
 		} else {

--- a/dotcom-rendering/src/web/server/articleTemplate.ts
+++ b/dotcom-rendering/src/web/server/articleTemplate.ts
@@ -1,6 +1,5 @@
 import { resets, brandBackground } from '@guardian/source-foundations';
 import he from 'he';
-import { ArticleDesign } from '@guardian/libs';
 import { getFontsCss } from '../../lib/fonts-css';
 import { ASSET_ORIGIN } from '../../lib/assets';
 
@@ -19,7 +18,6 @@ export const articleTemplate = ({
 	openGraphData,
 	twitterData,
 	keywords,
-	format,
 }: {
 	title?: string;
 	description: string;
@@ -35,7 +33,6 @@ export const articleTemplate = ({
 	openGraphData: { [key: string]: string };
 	twitterData: { [key: string]: string };
 	keywords: string;
-	format: ArticleFormat;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -112,8 +109,6 @@ export const articleTemplate = ({
 		(src) => `<link rel="dns-prefetch" href="${src}">`,
 	);
 
-	const smoothScrolling = `style="scroll-behavior: smooth;"`;
-
 	const weAreHiringMessage = `
 <!--
 
@@ -159,10 +154,7 @@ https://workforus.theguardian.com/careers/product-engineering/
 --->`;
 
 	return `<!doctype html>
-        <html lang="en" ${
-			// Used when taking the reader to the top of the blog on toast click
-			format.design === ArticleDesign.LiveBlog && smoothScrolling
-		}>
+        <html lang="en">
             <head>
 			    ${weAreHiringMessage}
                 <title>${title}</title>

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -193,6 +193,5 @@ export const articleToHtml = ({ data }: Props): string => {
 		openGraphData,
 		twitterData,
 		keywords,
-		format,
 	});
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updating window.location.href required adding the smooth behaviour to all liveblogs, which meant that direct link to a blocks were animated. This change keeps smooth scrolling only when clicking the Toast (n updates available)

## Why?

Fixes #4624

## Screenshots

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
