### PR TITLE
Fix dev server query url

### DIFF
--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -72,6 +72,13 @@ const parseURL = (requestURL, requestPath) => {
 	 * This happens because the url query param isn't serialised. But we actually want everything
 	 * after 'url=' including '?filterKeyEvents=true' and we'd rather not serialise so we just
 	 * split the string instead
+	 *
+	 *
+	 * When in DEV, any params after 'url' are considered additional params and so are preceded by an ampersand.
+	 * If our url includes an '&' but not a '?' then we are within the DEV environment and the first ampersand
+	 * should be replaced by a question mark to indicate the start of the query string.
+	 * In order to achieve this, we are first decoding the URL so that we can read any special characters.
+	 *
 	 */
 
 	let url = decodeURIComponent(requestURL.split('url=')[1]);

--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -81,7 +81,11 @@ const parseURL = (requestURL, requestPath) => {
 	 *
 	 */
 
-	let url = decodeURIComponent(requestURL.split('url=')[1]);
+	let url = requestURL.includes('url=')
+		? requestURL.split('url=')[1]
+		: requestURL;
+
+	url = decodeURIComponent(url);
 
 	if (url.includes('&') && !url.includes('?')) {
 		url = url.replace('&', '?');

--- a/dotcom-rendering/src/server/lib/get-content-from-url.js
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.js
@@ -71,7 +71,12 @@ exports.getContentFromURLMiddleware = async (req, res, next) => {
 		 * after 'url=' including '?filterKeyEvents=true' and we'd rather not serialise so we just
 		 * split the string instead
 		 */
-		let url = req.url.split('url=')[1];
+
+		let url = decodeURIComponent(req.url.split('url=')[1]);
+
+		if (url.includes('&') && !url.includes('?')) {
+			url = url.replace('&', '?');
+		}
 		if (req.path.startsWith('/AMP')) {
 			url = url.replace('www', 'amp');
 		}

--- a/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
@@ -26,4 +26,30 @@ describe('URL parser', () => {
 
 		expect(url).toEqual(parsedURL);
 	});
+
+
+	test('parse PROD env query params correctly when multiple queries are present', async () => {
+		const req = {
+			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
+			path: '',
+		};
+		const parsedURL =
+			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true';
+
+		const url = parseURL(req.url, req.path);
+		expect(url).toEqual(parsedURL);
+	});
+
+	test('parse URL when there are no params', async () => {
+		const req = {
+			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown',
+			path: '',
+		};
+		const parsedURL =
+			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown';
+
+		const url = parseURL(req.url, req.path);
+
+		expect(url).toEqual(parsedURL);
+	});
 });

--- a/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
@@ -1,7 +1,7 @@
 import { parseURL } from './get-content-from-url';
 
 describe('URL parser', () => {
-	test('parse DEV env query params correctly when one query is present', async () => {
+	test('parse DEV URL when one query is present', async () => {
 		const req = {
 			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true',
 			path: '/Article',
@@ -14,7 +14,7 @@ describe('URL parser', () => {
 		expect(url).toEqual(parsedURL);
 	});
 
-	test('parse DEV env query params correctly when multiple queries are present', async () => {
+	test('parse DEV URL when multiple queries are present', async () => {
 		const req = {
 			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
 			path: '/Article',
@@ -27,8 +27,19 @@ describe('URL parser', () => {
 		expect(url).toEqual(parsedURL);
 	});
 
+	test('parse URL when there are 2 query string', async () => {
+		const req = {
+			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true',
+			path: '/Article',
+		};
+		const parsedURL =
+			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true';
 
-	test('parse PROD env query params correctly when multiple queries are present', async () => {
+		const url = parseURL(req.url, req.path);
+		expect(url).toEqual(parsedURL);
+	});
+
+	test('parse URL when there is a query but no query string', async () => {
 		const req = {
 			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
 			path: '',
@@ -40,7 +51,7 @@ describe('URL parser', () => {
 		expect(url).toEqual(parsedURL);
 	});
 
-	test('parse URL when there are no params', async () => {
+	test('parse URL when there are no queries', async () => {
 		const req = {
 			url: 'https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown',
 			path: '',

--- a/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
@@ -1,0 +1,24 @@
+import { parseURL } from "./get-content-from-url";
+
+describe('URL parser', () => {
+	test('parse DEV env query params correctly when one query is present', async () => {
+		const req = { url: "/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true", path: "/Article" }
+		const parsedURL =
+			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true';
+
+		const url = parseURL(req.url, req.path);
+
+		expect(url).toEqual(parsedURL);
+	})
+
+	test('parse DEV env query params correctly when multiple queries are present', async () => {
+		const req = { url: "/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true", path: "/Article" }
+		const parsedURL =
+			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true';
+
+		const url = parseURL(req.url, req.path);
+
+		expect(url).toEqual(parsedURL);
+	})
+
+});

--- a/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.test.ts
@@ -1,24 +1,29 @@
-import { parseURL } from "./get-content-from-url";
+import { parseURL } from './get-content-from-url';
 
 describe('URL parser', () => {
 	test('parse DEV env query params correctly when one query is present', async () => {
-		const req = { url: "/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true", path: "/Article" }
+		const req = {
+			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true',
+			path: '/Article',
+		};
 		const parsedURL =
 			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true';
 
 		const url = parseURL(req.url, req.path);
 
 		expect(url).toEqual(parsedURL);
-	})
+	});
 
 	test('parse DEV env query params correctly when multiple queries are present', async () => {
-		const req = { url: "/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true", path: "/Article" }
+		const req = {
+			url: '/Article?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Flive%2F2022%2Fapr%2F13%2Fboris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown&filterKeyEvents=true&dcr=true&live=true',
+			path: '/Article',
+		};
 		const parsedURL =
 			'https://www.theguardian.com/politics/live/2022/apr/13/boris-johnson-uk-politics-live-rishi-sunak-partygate-lockdown?filterKeyEvents=true&dcr=true&live=true';
 
 		const url = parseURL(req.url, req.path);
 
 		expect(url).toEqual(parsedURL);
-	})
-
+	});
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds additional url parsing logic to the replace the first `&` in the url with a `?` if we are in the DEV environment.

## Why?
When in DEV environment, we start each query string with `?url=`. This means that when we set additional query params on the client side (such as `filterKeyEvents`), they are added to the existing query string with an `&` when, actually, not query string exists within the url itself. This breaks the build as our url is passed back as `https://www.theguardian.com/my/article&filterKeyEvents=true` instead of `https://www.theguardian.com/my/article?filterKeyEvents=true`. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-04-13 at 17 01 41](https://user-images.githubusercontent.com/20416599/163222352-899766af-c713-42c8-948f-3dca8b7eef35.png) | ![Screenshot 2022-04-13 at 16 47 49](https://user-images.githubusercontent.com/20416599/163222416-47acba32-2a6c-46c2-9399-d155bd49d64f.png)
