### PR TITLE
Disable `LiveBlogEpic` for permalinks

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -146,7 +146,8 @@ export const ArticleBody = ({
 						globalH3Styles(format.display),
 						globalLinkStyles(palette),
 						// revealStyles is used to animate the reveal of new blocks
-						format.design === ArticleDesign.LiveBlog &&
+						(format.design === ArticleDesign.DeadBlog ||
+							format.design === ArticleDesign.LiveBlog) &&
 							revealStyles,
 					]}
 				>

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -276,8 +276,22 @@ export const LiveBlogEpic = ({
 		isPaidContent,
 		tags,
 	});
-
 	if (!payload) return null;
+
+	/**
+	 * Because this epic is loaded client side it will cause CLS (it will shift the
+	 * blocks down after the page has already loaded). This is a poor reader experience
+	 * in general because it moves the content whilst they are trying to read it but
+	 * it is especially problematic where a permalink is being used, so we're disabling
+	 * this element in those cases.
+	 */
+	if (window.location.href.includes('#block-')) {
+		log(
+			'dotcom',
+			'A permalink was detected so the LiveBlogEpic will not show',
+		);
+		return null;
+	}
 
 	// Using the payload, make a fetch request to contributions
 	return (

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
@@ -201,6 +202,12 @@ const Render = ({
 	);
 };
 
+/**
+ * Using the payload, make a fetch request to contributions service
+ *
+ * @param payload - unknown
+ * @param contributionsServiceUrl - string
+ */
 const Fetch = ({
 	payload,
 	contributionsServiceUrl,
@@ -251,6 +258,10 @@ const Fetch = ({
 	);
 };
 
+function insertAfter(referenceNode: HTMLElement, newNode: Element) {
+	referenceNode.parentNode?.insertBefore(newNode, referenceNode.nextSibling);
+}
+
 /**
  * LiveBlogEpic is the support epic which appears in-between blocks in blogs
  *
@@ -279,25 +290,44 @@ export const LiveBlogEpic = ({
 	if (!payload) return null;
 
 	/**
-	 * Because this epic is loaded client side it will cause CLS (it will shift the
-	 * blocks down after the page has already loaded). This is a poor reader experience
-	 * in general because it moves the content whilst they are trying to read it but
-	 * it is especially problematic where a permalink is being used, so we're disabling
-	 * this element in those cases.
+	 * Here we decide where to insert the epic.
+	 *
+	 * If the url contains a permalink then we
+	 * want to insert it immediately after that block to prevent any CLS issues.
+	 *
+	 * Otherwise, we choose a random position near the top of the blog
 	 */
+	const epicPlaceholder = document.createElement('article');
 	if (window.location.href.includes('#block-')) {
-		log(
-			'dotcom',
-			'A permalink was detected so the LiveBlogEpic will not show',
-		);
-		return null;
+		// Because we're using a permalink there's a possibility the epic will render in
+		// view. To prevent confusing layout shift we initially hide the message so that
+		// we can reveal (animate in) it once it has been rendered
+		epicPlaceholder.classList.add('pending');
+		const blockId = window.location.hash.slice(1);
+		const blockLinkedTo = document.getElementById(blockId);
+		if (blockLinkedTo) {
+			insertAfter(blockLinkedTo, epicPlaceholder);
+		}
+		epicPlaceholder.classList.add('reveal');
+		epicPlaceholder.classList.remove('pending');
+	} else {
+		// This is a simple page load so we simply insert the epic somewhere near the top
+		// of the blog
+		const randomPosition = Math.floor(Math.random() * 3) + 1; // 1, 2 or 3
+		const aBlockNearTheTop =
+			document.querySelectorAll<HTMLElement>('article.block')[
+				randomPosition
+			];
+		if (aBlockNearTheTop) {
+			insertAfter(aBlockNearTheTop, epicPlaceholder);
+		}
 	}
 
-	// Using the payload, make a fetch request to contributions
-	return (
+	return createPortal(
 		<Fetch
 			payload={payload}
 			contributionsServiceUrl={contributionsServiceUrl}
-		/>
+		/>,
+		epicPlaceholder,
 	);
 };

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -45,9 +45,6 @@ export const LiveBlogRenderer = ({
 	contributionsServiceUrl,
 	onFirstPage,
 }: Props) => {
-	const thereAreMoreThanFourBlocks = blocks.length > 4;
-	const positionToInsertEpic = Math.floor(Math.random() * 3) + 1; // 1, 2 or 3
-
 	return (
 		<>
 			{pinnedPost && onFirstPage && (
@@ -74,44 +71,36 @@ export const LiveBlogRenderer = ({
 				</>
 			)}
 			<div id="top-of-blog" />
-			{blocks.map((block, index) => {
+			{blocks.map((block) => {
 				return (
-					<>
-						{!isLiveUpdate &&
-							thereAreMoreThanFourBlocks &&
-							index === positionToInsertEpic && (
-								<Island clientOnly={true}>
-									<LiveBlogEpic
-										section={section}
-										shouldHideReaderRevenue={
-											shouldHideReaderRevenue
-										}
-										tags={tags}
-										isPaidContent={isPaidContent}
-										contributionsServiceUrl={
-											contributionsServiceUrl
-										}
-									/>
-								</Island>
-							)}
-						<LiveBlock
-							format={format}
-							block={block}
-							pageId={pageId}
-							webTitle={webTitle}
-							adTargeting={adTargeting}
-							host={host}
-							ajaxUrl={ajaxUrl}
-							isLiveUpdate={isLiveUpdate}
-							switches={switches}
-							isAdFreeUser={isAdFreeUser}
-							isSensitive={isSensitive}
-							isPinnedPost={false}
-							pinnedPostId={pinnedPost?.id}
-						/>
-					</>
+					<LiveBlock
+						format={format}
+						block={block}
+						pageId={pageId}
+						webTitle={webTitle}
+						adTargeting={adTargeting}
+						host={host}
+						ajaxUrl={ajaxUrl}
+						isLiveUpdate={isLiveUpdate}
+						switches={switches}
+						isAdFreeUser={isAdFreeUser}
+						isSensitive={isSensitive}
+						isPinnedPost={false}
+						pinnedPostId={pinnedPost?.id}
+					/>
 				);
 			})}
+			{blocks.length > 4 && (
+				<Island clientOnly={true}>
+					<LiveBlogEpic
+						section={section}
+						shouldHideReaderRevenue={shouldHideReaderRevenue}
+						tags={tags}
+						isPaidContent={isPaidContent}
+						contributionsServiceUrl={contributionsServiceUrl}
+					/>
+				</Island>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This prevents the `LiveBlogEpic` from rendering when the reader is using a permalink

## Why?
Because this epic will cause content to shift down unexpectedly after the page has already appeared on the screen. This is a poor experience in general but it is especially problematic for readers that are using permalinks where they justifiably expect the page to show them the block they are requesting (instead of showing it to them and then snatching it away as it gets pushed down the page)

## But... 💲 ?!
There's a balance to be made here. It is true in an absolute sense that if you show more banners then you get more money. But this is simplistic and does not take into account other factors that also impact how readers choose to behave. If the product you are giving people is unpleasant to use and does not work well then ultimately, you will get fewer dollars. I can't measure this and prove it to you though so if you only allow things that can be easily measured to influence decisions then we should not merge this PR and we should cover the site in banners. But if you allow for more subjective reasoning then my argument here is we should reduce the volume of these banners (by a bit) in favour of a giving people a better experience when reading our content

| Before 😠       | After 😃       |
|-------------|------------|
| ![2022-04-14 10 12 01](https://user-images.githubusercontent.com/1336821/163353546-648dcb48-1b23-4a24-bae1-8886e5aa8347.gif) | ![2022-04-14 10 07 40](https://user-images.githubusercontent.com/1336821/163352833-59311869-8ca9-4110-ab69-19e54fac8310.gif) |


