### PR TITLE
Add support for href on front containers

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -758,6 +758,7 @@ type DCRCollectionType = {
 	curated: DCRFrontCard[];
 	backfill: DCRFrontCard[];
 	treats: DCRFrontCard[];
+	href?: string;
 };
 
 type FEFrontConfigType = {

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -122,6 +122,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							sideBorders={true}
 							padContent={false}
 							centralBorder="partial"
+							url={collection.href}
 						>
 							<DecideContainer
 								trails={trails}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for href property to be passed through

## Why?

Another step of the migration

## Screenshots

| Before (hover)      | After (hover)      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/163387444-807f84d9-3f25-43a1-a912-74ce9397b806.png
[after]: https://user-images.githubusercontent.com/9575458/163387332-176495ba-e0fb-49e2-8148-796550b499e0.png