### PR TITLE
feat: Add margin to liveblog main media captions when on a tablet display

### DIFF
--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -28,6 +28,7 @@ type Props = {
 	isOverlayed?: boolean;
 	isLeftCol?: boolean;
 	mediaType?: MediaType;
+	isMainMedia?: boolean;
 };
 
 type IconProps = {
@@ -116,6 +117,12 @@ const veryLimitedWidth = css`
 const captionPadding = css`
 	padding-left: 8px;
 	padding-right: 8px;
+`;
+
+const mobileCaptionPadding = css`
+	${until.desktop} {
+		${captionPadding}
+	}
 `;
 
 const videoPadding = css`
@@ -231,6 +238,7 @@ export const Caption = ({
 	isOverlayed,
 	isLeftCol,
 	mediaType = 'Gallery',
+	isMainMedia = false,
 }: Props) => {
 	// Sometimes captions come thorough as a single blank space, so we trim here to ignore those
 	const noCaption = !captionText?.trim();
@@ -239,6 +247,9 @@ export const Caption = ({
 	if (noCaption && (noCredit || hideCredit)) return null;
 
 	const palette = decidePalette(format);
+	const isLiveblog =
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog;
 
 	const defaultCaption = (
 		<figcaption
@@ -247,6 +258,7 @@ export const Caption = ({
 				shouldLimitWidth && limitedWidth,
 				!isOverlayed && bottomMargin,
 				isOverlayed && overlayedStyles(palette, format),
+				isMainMedia && isLiveblog && mobileCaptionPadding,
 				padCaption && captionPadding,
 				mediaType === 'Video' && videoPadding,
 			]}

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -247,7 +247,7 @@ export const Caption = ({
 	if (noCaption && (noCredit || hideCredit)) return null;
 
 	const palette = decidePalette(format);
-	const isLiveblog =
+	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
@@ -258,7 +258,7 @@ export const Caption = ({
 				shouldLimitWidth && limitedWidth,
 				!isOverlayed && bottomMargin,
 				isOverlayed && overlayedStyles(palette, format),
-				isMainMedia && isLiveblog && tabletCaptionPadding,
+				isMainMedia && isBlog && tabletCaptionPadding,
 				padCaption && captionPadding,
 				mediaType === 'Video' && videoPadding,
 			]}

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -119,7 +119,7 @@ const captionPadding = css`
 	padding-right: 8px;
 `;
 
-const mobileCaptionPadding = css`
+const tabletCaptionPadding = css`
 	${until.desktop} {
 		${captionPadding}
 	}
@@ -258,7 +258,7 @@ export const Caption = ({
 				shouldLimitWidth && limitedWidth,
 				!isOverlayed && bottomMargin,
 				isOverlayed && overlayedStyles(palette, format),
-				isMainMedia && isLiveblog && mobileCaptionPadding,
+				isMainMedia && isLiveblog && tabletCaptionPadding,
 				padCaption && captionPadding,
 				mediaType === 'Video' && videoPadding,
 			]}

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -881,6 +881,7 @@ export const VimeoBlockComponentStory = () => {
 							caption={vimeoVideoEmbed.caption}
 							credit={vimeoVideoEmbed.credit}
 							title={vimeoVideoEmbed.title}
+							isMainMedia={false}
 						/>
 					</ClickToView>
 				</Figure>

--- a/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
@@ -4,12 +4,21 @@ import { css } from '@emotion/react';
 import { unescapeData } from '../../lib/escapeData';
 import { Caption } from './Caption';
 
-export const GuVideoBlockComponent: React.FC<{
+type Props = {
 	html: string;
 	format: ArticleFormat;
 	credit: string;
+	isMainMedia: boolean;
 	caption?: string;
-}> = ({ html, format, credit, caption }) => {
+};
+
+export const GuVideoBlockComponent = ({
+	html,
+	format,
+	credit,
+	isMainMedia,
+	caption,
+}: Props) => {
 	const embedContainer = css`
 		width: 100%;
 		margin-bottom: ${caption ? `0px` : `6px`};
@@ -28,6 +37,7 @@ export const GuVideoBlockComponent: React.FC<{
 					format={format}
 					credit={credit}
 					mediaType="Video"
+					isMainMedia={isMainMedia}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -368,7 +368,7 @@ export const ImageComponent = ({
 										displayCredit={element.displayCredit}
 										shouldLimitWidth={shouldLimitWidth}
 										isOverlayed={true}
-										isMainMedia={true}
+										isMainMedia={isMainMedia}
 									/>
 								</div>
 							</div>
@@ -388,7 +388,7 @@ export const ImageComponent = ({
 						credit={element.data.credit}
 						displayCredit={element.displayCredit}
 						shouldLimitWidth={shouldLimitWidth}
-						isMainMedia={true}
+						isMainMedia={isMainMedia}
 					/>
 				</Hide>
 			) : (
@@ -398,7 +398,7 @@ export const ImageComponent = ({
 					credit={element.data.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={shouldLimitWidth}
-					isMainMedia={false}
+					isMainMedia={isMainMedia}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -368,6 +368,7 @@ export const ImageComponent = ({
 										displayCredit={element.displayCredit}
 										shouldLimitWidth={shouldLimitWidth}
 										isOverlayed={true}
+										isMainMedia={true}
 									/>
 								</div>
 							</div>
@@ -387,6 +388,7 @@ export const ImageComponent = ({
 						credit={element.data.credit}
 						displayCredit={element.displayCredit}
 						shouldLimitWidth={shouldLimitWidth}
+						isMainMedia={true}
 					/>
 				</Hide>
 			) : (
@@ -396,6 +398,7 @@ export const ImageComponent = ({
 					credit={element.data.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={shouldLimitWidth}
+					isMainMedia={false}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
@@ -18,6 +18,7 @@ type Props = {
 	caption?: string;
 	format: ArticleFormat;
 	elementId?: string;
+	isMainMedia: boolean;
 };
 
 /*
@@ -233,6 +234,7 @@ export const InteractiveBlockComponent = ({
 	caption,
 	format,
 	elementId = '',
+	isMainMedia,
 }: Props) => {
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
@@ -321,7 +323,13 @@ export const InteractiveBlockComponent = ({
 					</>
 				)}
 			</figure>
-			{caption && <Caption captionText={caption} format={format} />}
+			{caption && (
+				<Caption
+					captionText={caption}
+					format={format}
+					isMainMedia={isMainMedia}
+				/>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.stories.tsx
@@ -51,6 +51,7 @@ export const Default = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<SomeText />
 			<SomeText />
@@ -75,6 +76,7 @@ export const InlineMap = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<SomeText />
 			<SomeText />
@@ -98,6 +100,7 @@ export const Showcase = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<SomeText />
 			<SomeText />
@@ -123,6 +126,7 @@ export const WithCaption = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<SomeText />
 			<SomeText />
@@ -147,6 +151,7 @@ export const NonBootJs = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<SomeText />
 			<SomeText />

--- a/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
@@ -73,6 +73,7 @@ export const MapEmbedBlockComponent = ({
 						captionText={caption}
 						format={format}
 						credit={credit}
+						isMainMedia={isMainMedia}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
@@ -66,6 +66,7 @@ export const SpotifyBlockComponent = ({
 						captionText={caption}
 						format={format}
 						credit={credit}
+						isMainMedia={isMainMedia}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
@@ -72,6 +72,7 @@ export const VideoFacebookBlockComponent = ({
 						format={format}
 						credit={credit}
 						mediaType="Video"
+						isMainMedia={isMainMedia}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.stories.tsx
@@ -35,6 +35,7 @@ export const smallAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<p>abc</p>
 		</Container>
@@ -58,6 +59,7 @@ export const largeAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<p>abc</p>
 		</Container>
@@ -84,6 +86,7 @@ export const verticalAspectRatio = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticlePillar.News,
 				}}
+				isMainMedia={false}
 			/>
 			<p>abc</p>
 		</Container>

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
@@ -13,7 +13,8 @@ const responsiveAspectRatio = (height: number, width: number) => css`
 		left: 0;
 	}
 `;
-export const VimeoBlockComponent: React.FC<{
+
+type Props = {
 	format: ArticleFormat;
 	embedUrl?: string;
 	height: number;
@@ -21,7 +22,19 @@ export const VimeoBlockComponent: React.FC<{
 	caption?: string;
 	credit?: string;
 	title?: string;
-}> = ({ embedUrl, caption, title, format, width, height, credit }) => {
+	isMainMedia: boolean;
+};
+
+export const VimeoBlockComponent = ({
+	embedUrl,
+	caption,
+	title,
+	format,
+	width,
+	height,
+	credit,
+	isMainMedia,
+}: Props) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -54,6 +67,7 @@ export const VimeoBlockComponent: React.FC<{
 					format={format}
 					credit={credit}
 					mediaType="Video"
+					isMainMedia={isMainMedia}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -148,6 +148,7 @@ export const YoutubeBlockComponent = ({
 						displayCredit={false}
 						shouldLimitWidth={shouldLimitWidth}
 						mediaType="Video"
+						isMainMedia={isMainMedia}
 					/>
 				)}
 			</figure>
@@ -224,6 +225,7 @@ export const YoutubeBlockComponent = ({
 					displayCredit={false}
 					shouldLimitWidth={shouldLimitWidth}
 					mediaType="Video"
+					isMainMedia={isMainMedia}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { ArticleDisplay, ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { decidePalette } from '../lib/decidePalette';
 
 import { YoutubeEmbedBlockComponent } from './YoutubeEmbedBlockComponent';
 
@@ -37,16 +36,12 @@ export const standardAspectRatio = () => {
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
 				}}
-				palette={decidePalette({
-					theme: ArticlePillar.News,
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-				})}
 				height={259}
 				width={460}
 				caption="blah"
 				credit=""
 				title=""
+				isMainMedia={false}
 			/>
 			<p>abc</p>
 		</Container>

--- a/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
@@ -3,16 +3,27 @@ import { css } from '@emotion/react';
 import { Caption } from './Caption';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 
-export const YoutubeEmbedBlockComponent: React.FC<{
+type Props = {
 	format: ArticleFormat;
-	palette: Palette;
 	embedUrl?: string;
 	height: number;
 	width: number;
 	caption?: string;
 	credit?: string;
 	title?: string;
-}> = ({ embedUrl, caption, title, format, width, height, credit }) => {
+	isMainMedia: boolean;
+};
+
+export const YoutubeEmbedBlockComponent = ({
+	embedUrl,
+	caption,
+	title,
+	format,
+	width,
+	height,
+	credit,
+	isMainMedia,
+}: Props) => {
 	// 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
 	// Constrain iframe embeds with a width to their natural width
 	// rather than stretch them to the container using
@@ -45,6 +56,7 @@ export const YoutubeEmbedBlockComponent: React.FC<{
 					format={format}
 					credit={credit}
 					mediaType="Video"
+					isMainMedia={isMainMedia}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -320,6 +320,7 @@ export const renderElement = ({
 					html={element.html}
 					format={format}
 					credit={element.source}
+					isMainMedia={isMainMedia}
 					caption={element.caption}
 				/>,
 			];
@@ -392,6 +393,7 @@ export const renderElement = ({
 						format={format}
 						elementId={element.elementId}
 						caption={element.caption}
+						isMainMedia={isMainMedia}
 					/>
 				</Island>,
 			];
@@ -640,6 +642,7 @@ export const renderElement = ({
 					caption={element.caption}
 					credit={element.credit}
 					title={element.title}
+					isMainMedia={isMainMedia}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
@@ -647,13 +650,13 @@ export const renderElement = ({
 				true,
 				<YoutubeEmbedBlockComponent
 					format={format}
-					palette={palette}
 					embedUrl={element.embedUrl}
 					height={element.height}
 					width={element.width}
 					caption={element.caption}
 					credit={element.credit}
 					title={element.title}
+					isMainMedia={isMainMedia}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.VineBlockElement':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds left and right padding to main media captions on Liveblogs when on a tablet display.

## Why?

Closes #4150 

## Screenshots

| Before  / After     |
|-------------|
| ![before][] | 
| ![after][] |

[before]:  https://user-images.githubusercontent.com/21217225/163406438-c1df2758-38b9-415e-b95d-685912c746e2.png
[after]: https://user-images.githubusercontent.com/21217225/163405928-e7281644-6641-409e-a069-af99bd6ae2fe.png

