### PR TITLE
Make culture liveblog subMeta accessible

### DIFF
--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -47,16 +47,20 @@ const topMarginStlyes = css`
 const decideIconColor = (format: ArticleFormat, context: Context) => {
 	const palette = decidePalette(format);
 	if (format.design === ArticleDesign.LiveBlog) {
-		return context === 'ArticleMeta'
-			? css`
-					fill: ${palette.fill.shareIconGrayBackground};
-					${until.desktop} {
-						fill: ${palette.text.standfirst};
-					}
-			  `
-			: css`
-					fill: ${palette.fill.shareIconGrayBackground};
-			  `;
+		if (context === 'ArticleMeta') {
+			return css`
+				fill: ${palette.fill.shareIconGrayBackground};
+				${until.desktop} {
+					fill: ${palette.text.standfirst};
+				}
+			`;
+		}
+
+		if (context === 'SubMeta') {
+			return css`
+				fill: ${palette.fill.shareIconGrayBackground};
+			`;
+		}
 	}
 	if (
 		format.design === ArticleDesign.DeadBlog &&

--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -46,13 +46,17 @@ const topMarginStlyes = css`
 
 const decideIconColor = (format: ArticleFormat, context: Context) => {
 	const palette = decidePalette(format);
-	if (format.design === ArticleDesign.LiveBlog && context === 'ArticleMeta') {
-		return css`
-			fill: ${palette.fill.shareIconGrayBackground};
-			${until.desktop} {
-				fill: ${palette.text.standfirst};
-			}
-		`;
+	if (format.design === ArticleDesign.LiveBlog) {
+		return context === 'ArticleMeta'
+			? css`
+					fill: ${palette.fill.shareIconGrayBackground};
+					${until.desktop} {
+						fill: ${palette.text.standfirst};
+					}
+			  `
+			: css`
+					fill: ${palette.fill.shareIconGrayBackground};
+			  `;
 	}
 	if (
 		format.design === ArticleDesign.DeadBlog &&

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1,24 +1,24 @@
-import {
-	ArticleDisplay,
-	ArticleDesign,
-	ArticleSpecial,
-	ArticlePillar,
-} from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
-	neutral,
-	text,
-	specialReport,
-	opinion,
-	news,
-	sport,
-	brandAltBackground,
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import {
 	border,
 	brand,
 	brandAlt,
-	lifestyle,
+	brandAltBackground,
 	culture,
 	labs,
+	lifestyle,
+	neutral,
+	news,
+	opinion,
+	specialReport,
+	sport,
+	text,
 } from '@guardian/source-foundations';
 
 // Here is the one place where we use `pillarPalette`
@@ -180,7 +180,10 @@ const textSubMeta = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
-	if (format.design === ArticleDesign.DeadBlog)
+	if (
+		format.design === ArticleDesign.DeadBlog ||
+		format.design === ArticleDesign.LiveBlog
+	)
 		return blogsGrayBackgroundPalette(format);
 	return pillarPalette[format.theme].main;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #4524 

## What does this change?
Changes subMeta culture liveblog colour to pillar 300.

## Why?
To make it accessible.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="727" alt="image" src="https://user-images.githubusercontent.com/19683595/163437045-9f1bcdff-c647-4af5-b583-e2f0d98f98a3.png"> | <img width="728" alt="image" src="https://user-images.githubusercontent.com/19683595/163436927-31bf04e3-a1d0-437a-b661-0a96042e4cc7.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
