### PR TITLE
fix: Fixes odd alignment of bullets on keyEvents in firefox.

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -97,6 +97,7 @@ const listStyles = (
 `;
 
 const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	position: initial;
 	text-decoration: none;
 
 	&:hover::before {


### PR DESCRIPTION
## What does this change?

Sets the link for key events to use `position: initial;` instead of `position: relative;`

## Why?

This _should_ resolve an issue on Firefox where the bullets on key events would sometimes be mis-aligned due to a long standing layout bug with Firefox. More details can be found on this bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=1763663

Thank you @emilio for the workaround!

Fixes #4550

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/163624476-dbfebe30-c8ed-4fb0-8af1-6755e77010d6.png
[after]: https://user-images.githubusercontent.com/21217225/163624526-706e8ab9-899a-470e-a3fb-05717bd5a17f.png