### PR TITLE
Refactor `DynamicFast` columns

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -93,7 +93,7 @@ export const DynamicFast = ({ trails }: Props) => {
 								linkTo={card.url}
 								format={card.format}
 								headlineText={card.headline}
-								headlineSize="large"
+								headlineSize="medium"
 								byline={card.byline}
 								showByline={card.showByline}
 								showQuotes={

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -80,12 +80,14 @@ export const DynamicFast = ({ trails }: Props) => {
 				</LI>
 			</UL>
 			<UL direction="row" bottomMargin={true}>
-				{bigCards.map((card) => {
+				{bigCards.map((card, cardIndex) => {
 					return (
 						<LI
 							percentage="25%"
 							padSides={true}
 							bottomMargin={false}
+							showTopMarginWhenStacked={cardIndex > 0}
+							showDivider={cardIndex > 0}
 						>
 							<Card
 								linkTo={card.url}

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -11,13 +11,8 @@ type Props = {
 export const DynamicFast = ({ trails }: Props) => {
 	const primary = trails[0];
 	const secondary = trails[1];
-	// TODO: These divisions are based on assunmed rules for how content is placed in these columns but this needs confirmation
-	// Current assumptions
-	// - The boosted third card is standalone
-	// - The middle column has exactly three items
-	// - The last column has exactly three items
-	const third = trails[2];
-	const groups = [trails.slice(3, 6), trails.slice(7, 12)];
+	const bigCards = trails.slice(2, 4);
+	const smallCards = [trails.slice(4, 7), trails.slice(7, 10)];
 
 	return (
 		<>
@@ -85,34 +80,44 @@ export const DynamicFast = ({ trails }: Props) => {
 				</LI>
 			</UL>
 			<UL direction="row" bottomMargin={true}>
-				<LI percentage="50%" padSides={true} bottomMargin={false}>
-					<Card
-						linkTo={third.url}
-						format={third.format}
-						headlineText={third.headline}
-						headlineSize="large"
-						byline={third.byline}
-						showByline={third.showByline}
-						showQuotes={
-							third.format.design === ArticleDesign.Comment ||
-							third.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={third.webPublicationDate}
-						kickerText={third.kickerText}
-						showPulsingDot={
-							third.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={third.image}
-						mediaType={third.mediaType}
-						mediaDuration={third.mediaDuration}
-						commentCount={third.commentCount}
-						starRating={third.starRating}
-						branding={third.branding}
-					/>
-				</LI>
-				{groups.map((group) => {
+				{bigCards.map((card) => {
+					return (
+						<LI
+							percentage="25%"
+							padSides={true}
+							bottomMargin={false}
+						>
+							<Card
+								linkTo={card.url}
+								format={card.format}
+								headlineText={card.headline}
+								headlineSize="large"
+								byline={card.byline}
+								showByline={card.showByline}
+								showQuotes={
+									card.format.design ===
+										ArticleDesign.Comment ||
+									card.format.design === ArticleDesign.Letter
+								}
+								webPublicationDate={card.webPublicationDate}
+								kickerText={card.kickerText}
+								showPulsingDot={
+									card.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								showSlash={true}
+								showClock={false}
+								imageUrl={card.image}
+								mediaType={card.mediaType}
+								mediaDuration={card.mediaDuration}
+								commentCount={card.commentCount}
+								starRating={card.starRating}
+								branding={card.branding}
+							/>
+						</LI>
+					);
+				})}
+				{smallCards.map((group) => {
 					return (
 						<LI
 							percentage="25%"


### PR DESCRIPTION
## What
This refactors the `DynamicFast` container to show two large cards at the start of the second row, not just one

| Before      | After      |
|-------------|------------|
|<img width="952" alt="Screenshot 2022-04-18 at 10 22 43" src="https://user-images.githubusercontent.com/1336821/163787593-18bbccbe-fa7c-431e-99c3-9d529e0550a1.png"> | <img width="953" alt="Screenshot 2022-04-18 at 10 21 53" src="https://user-images.githubusercontent.com/1336821/163787491-85daf475-3859-4807-a787-855aa69dce47.png"> |



