### PR TITLE
Added `imagePositionOnMobile`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -889,7 +889,7 @@ interface BadgeType {
 	imageUrl: string;
 }
 
-type ImagePositionType = 'left' | 'top' | 'right';
+type ImagePositionType = 'left' | 'top' | 'right' | 'bottom';
 
 type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -37,6 +37,7 @@ type Props = {
 	webPublicationDate?: string;
 	imageUrl?: string;
 	imagePosition?: ImagePositionType;
+	imagePositionOnMobile?: ImagePositionType;
 	imageSize?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
 	standfirst?: string;
 	avatar?: AvatarType;
@@ -49,7 +50,6 @@ type Props = {
 	showSlash?: boolean;
 	commentCount?: number;
 	starRating?: number;
-	alwaysVertical?: boolean;
 	minWidthInPixels?: number;
 	// Ophan tracking
 	dataLinkName?: string;
@@ -124,7 +124,8 @@ export const Card = ({
 	showByline,
 	webPublicationDate,
 	imageUrl,
-	imagePosition,
+	imagePosition = 'top',
+	imagePositionOnMobile = 'left',
 	imageSize,
 	standfirst,
 	avatar,
@@ -136,7 +137,6 @@ export const Card = ({
 	showSlash,
 	commentCount,
 	starRating,
-	alwaysVertical,
 	minWidthInPixels,
 	dataLinkName,
 	branding,
@@ -162,14 +162,14 @@ export const Card = ({
 			<TopBar palette={cardPalette}>
 				<CardLayout
 					imagePosition={imagePosition}
-					alwaysVertical={alwaysVertical}
+					imagePositionOnMobile={imagePositionOnMobile}
 					minWidthInPixels={minWidthInPixels}
 				>
 					<>
 						{imageUrl && (
 							<ImageWrapper
 								percentage={imageCoverage}
-								alwaysVertical={alwaysVertical}
+								imagePositionOnMobile={imagePositionOnMobile}
 							>
 								<img
 									src={imageUrl}

--- a/dotcom-rendering/src/web/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLayout.tsx
@@ -4,8 +4,8 @@ import { until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
-	imagePosition?: ImagePositionType;
-	alwaysVertical?: boolean;
+	imagePosition: ImagePositionType;
+	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
 };
 
@@ -13,6 +13,8 @@ const decideDirection = (imagePosition?: ImagePositionType) => {
 	switch (imagePosition) {
 		case 'top':
 			return 'column';
+		case 'bottom':
+			return 'column-reverse';
 		case 'left':
 			return 'row';
 		case 'right':
@@ -35,20 +37,13 @@ const decideWidth = (minWidthInPixels?: number) => {
 };
 
 const decidePosition = (
-	imagePosition?: ImagePositionType,
-	alwaysVertical?: boolean,
+	imagePosition: ImagePositionType,
+	imagePositionOnMobile: ImagePositionType,
 ) => {
-	const direction = decideDirection(imagePosition);
-	if (alwaysVertical) {
-		return css`
-			flex-direction: ${direction};
-		`;
-	}
 	return css`
-		flex-direction: ${direction};
-		/* Force horizontal view for mobile cards */
+		flex-direction: ${decideDirection(imagePosition)};
 		${until.tablet} {
-			flex-direction: row;
+			flex-direction: ${decideDirection(imagePositionOnMobile)};
 		}
 	`;
 };
@@ -56,7 +51,7 @@ const decidePosition = (
 export const CardLayout = ({
 	children,
 	imagePosition,
-	alwaysVertical,
+	imagePositionOnMobile,
 	minWidthInPixels,
 }: Props) => (
 	<div
@@ -65,7 +60,7 @@ export const CardLayout = ({
 				display: flex;
 			`,
 			decideWidth(minWidthInPixels),
-			decidePosition(imagePosition, alwaysVertical),
+			decidePosition(imagePosition, imagePositionOnMobile),
 		]}
 	>
 		{children}

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -4,15 +4,17 @@ import { until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
-	alwaysVertical?: boolean;
+	imagePositionOnMobile: ImagePositionType;
 	percentage?: CardPercentageType;
 };
 
 export const ImageWrapper = ({
 	children,
 	percentage,
-	alwaysVertical,
+	imagePositionOnMobile,
 }: Props) => {
+	const notVertical =
+		imagePositionOnMobile !== 'top' && imagePositionOnMobile !== 'bottom';
 	return (
 		<div
 			css={[
@@ -20,7 +22,7 @@ export const ImageWrapper = ({
 					/* position relative is required here to bound the image overlay */
 					position: relative;
 					flex-basis: ${percentage && percentage};
-					${!alwaysVertical && until.tablet} {
+					${notVertical && until.tablet} {
 						/* Below tablet, we fix the size of the image and add a margin
                        around it. The corresponding content flex grows to fill the space */
 						margin-left: 6px;

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -356,7 +356,7 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 			kickerText={kickerText || ''}
 			imageUrl={imageUrl || ''}
 			showClock={true}
-			alwaysVertical={true}
+			imagePositionOnMobile="top"
 			minWidthInPixels={220}
 			showQuotes={
 				format.design === ArticleDesign.Comment ||

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -43,6 +43,7 @@ export const DynamicFast = ({ trails }: Props) => {
 						showClock={false}
 						imageUrl={primary.image}
 						imagePosition="right"
+						imagePositionOnMobile="top"
 						imageSize="large"
 						mediaType={primary.mediaType}
 						mediaDuration={primary.mediaDuration}

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -41,6 +41,7 @@ export const FixedLargeSlowXIV = ({ trails }: Props) => {
 						showClock={false}
 						imageUrl={primary.image}
 						imagePosition="right"
+						imagePositionOnMobile="bottom"
 						imageSize="large"
 						mediaType={primary.mediaType}
 						mediaDuration={primary.mediaDuration}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4607 by adding

1) The `imagePositionOnMobile` prop to `Card` and
2) Extending `ImagePositionType` to include `bottom`

Along the way I refactored the code to remove the `alwaysVertical` prop

## Why
We want to be able to render the headline above the image to support some front layouts.

I removed `alwaysVertical` as this was added for the specific use case of carousels where we no longer wanted to default to showing the image on the left at mobile. But now that we have two new use cases where this default no longer works I felt there was justification for a different api so I replaced

```ts
type Props = {
  imagePosition: ImagePositionType;
  alwayVertical: boolean;
  ...
}
```

with

```ts
type Props = {
  imagePosition: ImagePositionType;
  imagePositionOnMobile: ImagePositionType;
  ...
}
```

| Before      | After      |
|-------------|------------|
| <img width="413" alt="Screenshot 2022-04-18 at 10 50 37" src="https://user-images.githubusercontent.com/1336821/163791939-37a2748a-304c-4e7c-8559-c13a25a51a88.png"> | <img width="413" alt="Screenshot 2022-04-18 at 10 49 57" src="https://user-images.githubusercontent.com/1336821/163791948-6c71da75-a2c0-4901-ae38-4361a4874ba8.png"> |



