### PR TITLE
Fix twitter handle colour in liveblogs below desktop

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -85,7 +85,7 @@ type Palette = {
 		matchTitle: Colour;
 		byline: Colour;
 		twitterHandle: Colour;
-		twitterHandleLiveBackground: Colour;
+		twitterHandleBelowDesktop: Colour;
 		caption: Colour;
 		captionLink: Colour;
 		subMeta: Colour;
@@ -157,6 +157,7 @@ type Palette = {
 		richLink: Colour;
 		quoteIcon: Colour;
 		blockquoteIcon: Colour;
+		twitterHandleBelowDesktop: Colour;
 	};
 	border: {
 		syndicationButton: Colour;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -85,6 +85,7 @@ type Palette = {
 		matchTitle: Colour;
 		byline: Colour;
 		twitterHandle: Colour;
+		twitterHandleLiveBackground: Colour;
 		caption: Colour;
 		captionLink: Colour;
 		subMeta: Colour;

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -6,6 +6,7 @@ import {
 	headline,
 	textSans,
 	until,
+	from,
 } from '@guardian/source-foundations';
 
 import { BylineLink } from './BylineLink';
@@ -15,25 +16,59 @@ import TwitterIcon from '../../static/icons/twitter.svg';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 
-const twitterHandleStyles = (palette: Palette) => css`
-	${textSans.xxsmall()};
-	font-weight: bold;
+const defaultTwitterHandleColour = (palette: Palette) => css`
 	color: ${palette.text.twitterHandle};
 
-	padding-right: 10px;
-	display: inline-block;
-
 	svg {
-		height: 10px;
-		max-width: 12px;
-		margin-right: 0px;
 		fill: ${neutral[46]};
 	}
 
 	a {
 		color: ${palette.text.twitterHandle};
+	}
+`;
+
+const twitterHandleColour = (palette: Palette, format: ArticleFormat) => {
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			return css`
+				color: ${palette.text.twitterHandleLiveBackground};
+
+				svg {
+					fill: ${neutral[100]};
+				}
+
+				a {
+					color: ${palette.text.twitterHandleLiveBackground};
+				}
+
+				${from.desktop} {
+					${defaultTwitterHandleColour(palette)}
+				}
+			`;
+		}
+		default: {
+			return defaultTwitterHandleColour(palette);
+		}
+	}
+};
+
+const twitterHandleStyles = css`
+	${textSans.xxsmall()};
+	font-weight: bold;
+
+	svg {
+		height: 10px;
+		max-width: 12px;
+		margin-right: 0px;
+	}
+
+	a {
 		text-decoration: none;
 	}
+
+	padding-right: 10px;
+	display: inline-block;
 `;
 
 // for liveblog smaller breakpoints article meta is located in the same
@@ -120,7 +155,12 @@ export const Contributor: React.FC<{
 				</div>
 			)}
 			{onlyOneContributor && author.twitterHandle && (
-				<div css={twitterHandleStyles(palette)}>
+				<div
+					css={[
+						twitterHandleStyles,
+						twitterHandleColour(palette, format),
+					]}
+				>
 					<TwitterIcon />
 					<a
 						href={`https://www.twitter.com/${author.twitterHandle}`}

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -16,42 +16,29 @@ import TwitterIcon from '../../static/icons/twitter.svg';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 
-const defaultTwitterHandleColour = (palette: Palette) => css`
-	color: ${palette.text.twitterHandle};
+const twitterHandleColour = (palette: Palette) => css`
+	color: ${palette.text.twitterHandleBelowDesktop};
 
 	svg {
-		fill: ${neutral[46]};
+		fill: ${palette.fill.twitterHandleBelowDesktop};
 	}
 
 	a {
+		color: ${palette.text.twitterHandleBelowDesktop};
+	}
+
+	${from.desktop} {
 		color: ${palette.text.twitterHandle};
+
+		svg {
+			fill: ${neutral[46]};
+		}
+
+		a {
+			color: ${palette.text.twitterHandle};
+		}
 	}
 `;
-
-const twitterHandleColour = (palette: Palette, format: ArticleFormat) => {
-	switch (format.design) {
-		case ArticleDesign.LiveBlog: {
-			return css`
-				color: ${palette.text.twitterHandleLiveBackground};
-
-				svg {
-					fill: ${neutral[100]};
-				}
-
-				a {
-					color: ${palette.text.twitterHandleLiveBackground};
-				}
-
-				${from.desktop} {
-					${defaultTwitterHandleColour(palette)}
-				}
-			`;
-		}
-		default: {
-			return defaultTwitterHandleColour(palette);
-		}
-	}
-};
 
 const twitterHandleStyles = css`
 	${textSans.xxsmall()};
@@ -155,12 +142,7 @@ export const Contributor: React.FC<{
 				</div>
 			)}
 			{onlyOneContributor && author.twitterHandle && (
-				<div
-					css={[
-						twitterHandleStyles,
-						twitterHandleColour(palette, format),
-					]}
-				>
+				<div css={[twitterHandleStyles, twitterHandleColour(palette)]}>
 					<TwitterIcon />
 					<a
 						href={`https://www.twitter.com/${author.twitterHandle}`}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -157,6 +157,10 @@ const textTwitterHandle = (format: ArticleFormat): string => {
 	return text.supporting;
 };
 
+const textTwitterHandleLiveBackground = (): string => {
+	return WHITE;
+};
+
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
@@ -1055,6 +1059,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			matchTitle: textMatchTitle(),
 			byline: textByline(format),
 			twitterHandle: textTwitterHandle(format),
+			twitterHandleLiveBackground: textTwitterHandleLiveBackground(),
 			caption: textCaption(format),
 			captionLink: textCaptionLink(format),
 			subMeta: textSubMeta(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -157,8 +157,10 @@ const textTwitterHandle = (format: ArticleFormat): string => {
 	return text.supporting;
 };
 
-const textTwitterHandleLiveBackground = (): string => {
-	return WHITE;
+const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	return textTwitterHandle(format);
 };
 
 const textCaption = (format: ArticleFormat): string => {
@@ -739,6 +741,11 @@ const fillCaptionCamera = (format: ArticleFormat): string =>
 const fillBlockquoteIcon = (format: ArticleFormat): string =>
 	pillarPalette[format.theme].main;
 
+const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	return neutral[46];
+};
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;
@@ -1059,7 +1066,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			matchTitle: textMatchTitle(),
 			byline: textByline(format),
 			twitterHandle: textTwitterHandle(format),
-			twitterHandleLiveBackground: textTwitterHandleLiveBackground(),
+			twitterHandleBelowDesktop: textTwitterHandleBelowDesktop(format),
 			caption: textCaption(format),
 			captionLink: textCaptionLink(format),
 			subMeta: textSubMeta(format),
@@ -1131,6 +1138,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			richLink: fillRichLink(format),
 			quoteIcon: fillQuoteIcon(format),
 			blockquoteIcon: fillBlockquoteIcon(format),
+			twitterHandleBelowDesktop: fillTwitterHandleBelowDesktop(format),
 		},
 		border: {
 			syndicationButton: borderSyndicationButton(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #4482 

## What does this change?
Adds colour logic for twitter handle. This fixes the colour in liveblogs for breakpoints below desktop (980px).

## Why?
To match the liveblog designs.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="738" alt="image" src="https://user-images.githubusercontent.com/19683595/163989863-a40abcd2-21ff-411e-9c0f-c49780fbc7ba.png"> | <img width="737" alt="image" src="https://user-images.githubusercontent.com/19683595/163989173-6a6270ba-8f69-44b9-acbf-8c222f3995a3.png"> |
| <img width="658" alt="image" src="https://user-images.githubusercontent.com/19683595/163989806-8e21d8d6-107a-4026-9a41-ead0fbd483a7.png"> | <img width="661" alt="image" src="https://user-images.githubusercontent.com/19683595/163989246-748537c9-5b5d-4712-a425-57158dbdee82.png"> |
| <img width="476" alt="image" src="https://user-images.githubusercontent.com/19683595/163989739-a037c0cc-b605-493b-be00-a1a752bd7fe8.png"> | <img width="480" alt="image" src="https://user-images.githubusercontent.com/19683595/163989353-b775e21b-6112-4c2d-a1be-d0db89745ce9.png"> |
| <img width="373" alt="image" src="https://user-images.githubusercontent.com/19683595/163989690-fe68f209-935e-4dbe-832c-0c6da618f93b.png"> | <img width="370" alt="image" src="https://user-images.githubusercontent.com/19683595/163989417-f73271c5-d220-4f8b-9155-1467476abab7.png"> |
| <img width="318" alt="image" src="https://user-images.githubusercontent.com/19683595/163989601-840112bf-b36b-4fcd-b03f-3b77b093d846.png"> | <img width="319" alt="image" src="https://user-images.githubusercontent.com/19683595/163989528-a3c68823-291e-4c96-aaf7-ae60a0a72409.png"> |
| <img width="737" alt="image" src="https://user-images.githubusercontent.com/19683595/163990603-7a42c551-191d-46e5-b503-19c77c34430a.png"> | <img width="735" alt="image" src="https://user-images.githubusercontent.com/19683595/163990442-2376970f-5382-4c4f-ae8b-59ba383c39fe.png"> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
