### PR TITLE
docs(ophan): add Ophan tracking information and logs

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1300,7 +1300,7 @@ declare namespace JSX {
 		 * to server-rendered HTML.
 		 *
 		 * Add `data-component="component-name"` to the element you want
-		 * to track. Then add data-link-name="link-name" to the anchor for which
+		 * to track. Then `add data-link-name="link-name"` to the anchor for which
 		 * clicks will be tracked.
 		 *
 		 * The page views table will then contain `link-name` when the

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1274,4 +1274,38 @@ declare namespace JSX {
 			children: React.ReactNode;
 		};
 	}
+
+	interface IntrinsicAttributes {
+		/**
+		 * **Rendered Components – Ophan**
+		 *
+		 * The Ophan client automatically tracks components on the page
+		 * that have the `data-component` attribute.
+		 * To avoid race conditions, it is best to add this attribute only
+		 * to server-rendered HTML.
+		 *
+		 * Add `data-component="component-name"` to the element you want
+		 * to track.
+		 *
+		 * The page views table will then contain `component-name` when the
+		 * element is present on the page.
+		 */
+		'data-component'?: string;
+		/**
+		 * **Component Clicks – Ophan**
+		 *
+		 * The Ophan client automatically tracks click interactions
+		 * on components that have the `data-link-name` attribute.
+		 * To avoid race conditions, it is best to add this attribute only
+		 * to server-rendered HTML.
+		 *
+		 * Add `data-component="component-name"` to the element you want
+		 * to track. Then add data-link-name="link-name" to the anchor for which
+		 * clicks will be tracked.
+		 *
+		 * The page views table will then contain `link-name` when the
+		 * link is clicked.
+		 */
+		'data-link-name'?: string;
+	}
 }

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -8,22 +8,27 @@ import type {
 	OphanProduct,
 	OphanABTestMeta,
 } from '@guardian/libs';
+import { log } from '@guardian/libs';
 
-export type OphanRecordFunction = (event: { [key: string]: any }) => void;
+export type OphanRecordFunction = (
+	event: { [key: string]: any },
+	callback?: () => void,
+) => void;
 
 export const getOphanRecordFunction = (): OphanRecordFunction => {
 	const record = window?.guardian?.ophan?.record;
 
-	if (record) {
-		return record;
-	}
-	console.log('window.guardian.ophan.record is not available');
+	if (record) return record;
+
+	console.warn('window.guardian.ophan.record is not available');
 	return () => {};
 };
 
 export const record: OphanRecordFunction = (event) => {
 	if (window?.guardian?.ophan?.record) {
-		window.guardian.ophan.record(event);
+		window.guardian.ophan.record(event, () =>
+			log('dotcom', '🧿 Ophan event recorded:', event),
+		);
 	} else {
 		throw new Error("window.guardian.ophan.record doesn't exist");
 	}

--- a/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
@@ -1,4 +1,4 @@
-import { OphanComponent, OphanComponentEvent } from '../../browser/ophan/ophan';
+import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
 import { CurrentSignInGateABTest } from './types';
 
 type ABTestVariant = {
@@ -25,13 +25,11 @@ type ComponentEventWithoutAction = {
 	abTest?: ABTestVariant;
 };
 
-const ophan = isServer ? { record: () => {} } : window?.guardian?.ophan;
+const ophan = isServer ? undefined : window?.guardian?.ophan;
 
 // ophan helper methods
-export const submitComponentEventTracking = (
-	componentEvent: OphanComponentEvent,
-) => {
-	ophan.record({ componentEvent });
+const submitComponentEventTracking = (componentEvent: OphanComponentEvent) => {
+	ophan?.record({ componentEvent });
 };
 
 export const submitViewEventTracking = (

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -5,6 +5,7 @@ import type {
 	VendorName,
 } from '@guardian/consent-management-platform/dist/types';
 import { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+import { OphanRecordFunction } from './src/web/browser/ophan/ophan';
 import { WindowGuardianConfig } from './src/model/window-guardian';
 import { ReaderRevenueDevUtils } from './src/web/lib/readerRevenueDevUtils';
 import { DailyArticleHistory } from './src/web/lib/dailyArticleCount';
@@ -20,14 +21,14 @@ declare global {
 			onPolyfilled: () => void;
 			queue: Array<() => void>;
 			config: WindowGuardianConfig;
-			ophan: {
+			ophan?: {
 				setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
 				trackComponentAttention: (
 					name: string,
 					el: Element,
 					visiblityThreshold: number,
 				) => void;
-				record: ({}) => void;
+				record: OphanRecordFunction;
 				viewId: string;
 				pageViewId: string;
 			};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds logs when the Ophan tracker `record` function is called. Improve types based on an analysis of the [`transmit.coffee` source][transmit.coffee] to indicate the presence of this callback.

Adds JSDocs to the `data-component` and `data-link-name` attributes in JSX to gain Intellisense info. Based on [**Tracking components in the Data Lake**] from `frontend`.

[transmit.coffee]: https://github.com/guardian/ophan/blob/ccaa57bcee3f5f3f83ec28973074c9b3f98f1438/tracker-js/assets/coffee/ophan/transmit.coffee#L43-L50
[**Tracking components in the Data Lake**]: https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/docs/03-dev-howtos/19-tracking-components-in-the-data-lake.md#tracking-components-in-the-data-lake

## Why?

@jlieb10 and I have been discovering a lot of things, and we want to share these findings to make them as visible as possible for all. Part of #4662 

## Intellisense for attributes

| data-link-name      | data-component      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/164194321-03e5c0a4-db1a-424b-aabf-4398043f78b4.png
[after]: https://user-images.githubusercontent.com/76776/164194460-f7313381-547e-49f5-a5ae-01cd4286bd89.png
