### PR TITLE
Update styling for key events carousel cards

### DIFF
--- a/common-rendering/src/components/KeyEventsCards.stories.tsx
+++ b/common-rendering/src/components/KeyEventsCards.stories.tsx
@@ -1,0 +1,106 @@
+import { css } from '@emotion/react';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleTheme,
+} from '@guardian/libs';
+import type { KeyEvent } from './keyEvents';
+import KeyEvents from './keyEventsCards';
+import KeyEventsCard from './keyEventsCards';
+
+const getDate = (milliSeconds = 1, seconds = 1, minutes = 1, hours = 1) =>
+	new Date(Date.now() - milliSeconds * seconds * minutes * hours);
+
+const events: KeyEvent[] = [
+	{
+		date: getDate(),
+		text: 'Biden heads to Europe to announce new sanctions on Russian Duma',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 30),
+		text: `Pope 'embarrassed' by West's increased military spending`,
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 60, 30),
+		text: 'Kremlin: sending peacekeepers to Ukraine would be ‘reckless and extremely dangerous’',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 60, 30, 3),
+		text: 'Pentagon condemns Kremlin refusal to rule out use of nuclear weapons',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 60, 60, 10),
+		text: 'Biden heads to Europe to announce new sanctions on Russian Duma',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 60, 60, 24),
+		text: `Mariupol under 'constant bombing', Russia seizes humanitarian convoy, Zelenskiy says`,
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: getDate(1000, 60, 60, 48),
+		text: 'Summary and welcome',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+];
+
+const getFormat = (theme: ArticleTheme) => {
+	return {
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
+		theme: theme,
+	};
+};
+
+const wrapperStyles = css`
+	ul {
+		overflow-x: scroll;
+		margin: 20px 0;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+`;
+
+const keyEventWithTheme = (dark: boolean, events: KeyEvent[]) => () =>
+	(
+		<div css={wrapperStyles}>
+			<KeyEvents
+				supportsDarkMode={dark}
+				keyEvents={events}
+				format={getFormat(ArticlePillar.News)}
+			/>
+			<KeyEvents
+				supportsDarkMode={dark}
+				keyEvents={events}
+				format={getFormat(ArticlePillar.Sport)}
+			/>
+			<KeyEvents
+				supportsDarkMode={dark}
+				keyEvents={events}
+				format={getFormat(ArticlePillar.Culture)}
+			/>
+			<KeyEvents
+				supportsDarkMode={dark}
+				keyEvents={events}
+				format={getFormat(ArticlePillar.Lifestyle)}
+			/>
+		</div>
+	);
+
+const SingleCard = keyEventWithTheme(false, events.slice(0, 1));
+const MultipleCards = keyEventWithTheme(false, events.slice(0, 2));
+
+export default {
+	component: KeyEventsCard,
+	title: 'Common/Components/KeyEventsCard',
+};
+
+export { SingleCard, MultipleCards };

--- a/common-rendering/src/components/keyEventsCards.tsx
+++ b/common-rendering/src/components/keyEventsCards.tsx
@@ -59,23 +59,6 @@ const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
 	}
 };
 
-const keyEventWrapperStyles = (
-	format: ArticleFormat,
-	supportsDarkMode: boolean,
-): SerializedStyles => css`
-	width: 100%;
-
-	${from.desktop} {
-		border-top: 1px solid ${neutral[86]};
-		padding-top: ${remSpace[2]};
-	}
-
-	${darkModeCss(supportsDarkMode)`
-		border-top-color: ${neutral[20]};
-		background-color: ${background.articleContentDark(format)};
-	`}
-`;
-
 const listStyles = (
 	format: ArticleFormat,
 	supportsDarkMode: boolean,
@@ -238,7 +221,11 @@ const ListItem = ({ keyEvent, format, supportsDarkMode }: ListItemProps) => {
 	);
 };
 
-const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
+const KeyEventsCards = ({
+	keyEvents,
+	format,
+	supportsDarkMode,
+}: KeyEventsProps) => {
 	return (
 		<nav id="keyevents" aria-label="Key Events">
 			<ul css={listStyles(format, supportsDarkMode)}>
@@ -257,5 +244,5 @@ const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
 
 // ----- Exports ----- //
 
-export default KeyEvents;
+export default KeyEventsCards;
 export type { KeyEvent };

--- a/common-rendering/src/components/keyEventsCards.tsx
+++ b/common-rendering/src/components/keyEventsCards.tsx
@@ -1,0 +1,261 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import {
+	textSans,
+	sport,
+	culture,
+	lifestyle,
+	opinion,
+	news,
+	neutral,
+	remSpace,
+	from,
+} from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
+import {
+	ArticleFormat,
+	ArticlePillar,
+	ArticleTheme,
+	timeAgo,
+} from '@guardian/libs';
+import { darkModeCss } from '../lib';
+import { background, text } from '../editorialPalette';
+
+// ----- Component ----- //
+type paletteId = 300 | 400 | 500;
+
+interface KeyEvent {
+	date: Date;
+	text: string;
+	url: string;
+}
+
+interface KeyEventsProps {
+	keyEvents: KeyEvent[];
+	format: ArticleFormat;
+	supportsDarkMode: boolean;
+}
+
+interface ListItemProps {
+	keyEvent: KeyEvent;
+	format: ArticleFormat;
+	supportsDarkMode: boolean;
+}
+
+const getColor = (theme: ArticleTheme, paletteId: paletteId) => {
+	switch (theme) {
+		case ArticlePillar.Sport:
+			return sport[paletteId];
+		case ArticlePillar.Culture:
+			return culture[paletteId];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[paletteId];
+		case ArticlePillar.Opinion:
+			return opinion[paletteId];
+		default:
+			return news[paletteId];
+	}
+};
+
+const keyEventWrapperStyles = (
+	format: ArticleFormat,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
+	width: 100%;
+
+	${from.desktop} {
+		border-top: 1px solid ${neutral[86]};
+		padding-top: ${remSpace[2]};
+	}
+
+	${darkModeCss(supportsDarkMode)`
+		border-top-color: ${neutral[20]};
+		background-color: ${background.articleContentDark(format)};
+	`}
+`;
+
+const listStyles = (
+	format: ArticleFormat,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
+	padding: ${remSpace[5]};
+	display: flex;
+	background-color: ${background.keyEvents(format)};
+
+	${from.desktop} {
+		background-color: ${background.keyEventsWide(format)};
+	}
+
+	${darkModeCss(supportsDarkMode)`
+		background-color: ${background.keyEventsDark(format)};
+
+		${from.desktop} {
+			background-color: ${background.keyEventsWideDark(format)};
+		}
+	`}
+`;
+
+const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	position: initial;
+	text-decoration: none;
+
+	&:hover::before {
+		background-color: ${neutral[0]};
+	}
+
+	&::before {
+		content: '';
+		display: block;
+		position: relative;
+		height: 13px;
+		width: 13px;
+		border-radius: 50%;
+		background-color: ${neutral[46]};
+		margin-bottom: ${remSpace[2]};
+		z-index: 2;
+
+		${from.tablet} {
+			height: 15px;
+			width: 15px;
+		}
+	}
+
+	${darkModeCss(supportsDarkMode)`
+		&:hover::before {
+			background-color: ${neutral[100]};
+		}
+
+		&::before {
+			border-color: transparent ${neutral[60]};
+			background-color: ${neutral[60]};
+		}
+	`}
+`;
+
+const listItemStyles = (format: ArticleFormat): SerializedStyles => css`
+	padding-bottom: ${remSpace[3]};
+	position: relative;
+	background-color: ${background.keyEvents(format)};
+	padding-right: ${remSpace[5]};
+
+	${from.desktop} {
+		background-color: ${background.keyEventsWide(format)};
+	}
+
+	&::before {
+		content: '';
+		display: block;
+		position: absolute;
+		border-top: 1px dotted ${neutral[46]};
+		left: 0;
+		right: 0;
+		top: 6px;
+
+		${from.tablet} {
+			top: ${remSpace[2]};
+		}
+	}
+
+	&:last-child::before {
+		border-top: 0;
+	}
+`;
+
+const textStyles = (
+	format: ArticleFormat,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
+	width: 150px;
+	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
+
+	color: ${text.keyEventsInline(format)};
+	display: block;
+	text-decoration: none;
+
+	&:hover {
+		color: ${text.keyEventsInline(format)};
+		text-decoration: underline;
+	}
+
+	${from.desktop} {
+		color: ${text.keyEventsLeftColumn(format)};
+
+		&:hover {
+			color: ${text.keyEventsLeftColumn(format)};
+			text-decoration: underline;
+		}
+	}
+
+	${darkModeCss(supportsDarkMode)`
+		color: ${getColor(format.theme, 500)};
+		&:hover {
+			color: ${getColor(format.theme, 500)};
+		}
+	`}
+`;
+
+const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
+	color: ${neutral[7]};
+	display: block;
+
+	${darkModeCss(supportsDarkMode)`
+		color: ${neutral[60]};
+	`}
+`;
+
+const ListItem = ({ keyEvent, format, supportsDarkMode }: ListItemProps) => {
+	return (
+		<li css={listItemStyles(format)}>
+			<Link
+				priority="secondary"
+				css={linkStyles(supportsDarkMode)}
+				href={keyEvent.url}
+			>
+				<time
+					dateTime={keyEvent.date.toISOString()}
+					data-relativeformat="med"
+					title={`${keyEvent.date.toLocaleDateString('en-GB', {
+						hour: '2-digit',
+						minute: '2-digit',
+						weekday: 'long',
+						year: 'numeric',
+						month: 'long',
+						day: 'numeric',
+						timeZoneName: 'long',
+					})}`}
+					css={timeStyles(supportsDarkMode)}
+				>
+					{timeAgo(keyEvent.date.getTime())}
+				</time>
+				<span css={textStyles(format, supportsDarkMode)}>
+					{keyEvent.text}
+				</span>
+			</Link>
+		</li>
+	);
+};
+
+const KeyEvents = ({ keyEvents, format, supportsDarkMode }: KeyEventsProps) => {
+	return (
+		<nav id="keyevents" aria-label="Key Events">
+			<ul css={listStyles(format, supportsDarkMode)}>
+				{keyEvents.map((event, index) => (
+					<ListItem
+						key={`${event.url}${index}`}
+						keyEvent={event}
+						format={format}
+						supportsDarkMode={supportsDarkMode}
+					/>
+				))}
+			</ul>
+		</nav>
+	);
+};
+
+// ----- Exports ----- //
+
+export default KeyEvents;
+export type { KeyEvent };

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -187,9 +187,9 @@ const avatar = (format: ArticleFormat): string => {
 			return news[500];
 	}
 };
-const keyEvents = (_format: ArticleFormat): Colour => neutral[100];
+const keyEvents = (_format: ArticleFormat): Colour => neutral[97];
 
-const keyEventsWide = (_format: ArticleFormat): Colour => neutral[97];
+const keyEventsWide = (_format: ArticleFormat): Colour => neutral[93];
 
 const keyEventsDark = (_format: ArticleFormat): Colour => neutral[10];
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
