### PR TITLE
reduce mobile immersive header to 80vh

### DIFF
--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -259,12 +259,12 @@ export const ImageComponent = ({
 					width: 100%;
 
 					${from.desktop} {
-		height: 100vh;
-		min-height: 31.25rem;
-	}
-	${from.wide} {
-		min-height: 50rem;
-	}
+						height: 100vh;
+						min-height: 31.25rem;
+					}
+					${from.wide} {
+						min-height: 50rem;
+					}
 					img {
 						object-fit: cover;
 					}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -259,8 +259,12 @@ export const ImageComponent = ({
 					width: 100%;
 
 					${from.desktop} {
-						height: 100vh;
-					}
+		height: 100vh;
+		min-height: 31.25rem;
+	}
+	${from.wide} {
+		min-height: 50rem;
+	}
 					img {
 						object-fit: cover;
 					}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -255,9 +255,12 @@ export const ImageComponent = ({
 					/* These styles depend on the containing layout component wrapping the main media
                     with a div set to 100vh. This is the case for ImmersiveLayout which should
                     always be used if display === 'immersive' */
-					height: 100vh;
+					height: 80vh;
 					width: 100%;
 
+					${from.desktop} {
+						height: 100vh;
+					}
 					img {
 						object-fit: cover;
 					}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -276,7 +276,6 @@ export const ImageComponent = ({
 					isLazy={!isMainMedia}
 					isMainMedia={isMainMedia}
 				/>
-				{starRating && <PositionStarRating rating={starRating} />}
 				{title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -257,6 +257,7 @@ export const ImageComponent = ({
                     always be used if display === 'immersive' */
 					height: 80vh;
 					width: 100%;
+					min-height: 25rem;
 
 					${from.desktop} {
 						height: 100vh;

--- a/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Immersive.stories.tsx
@@ -107,7 +107,14 @@ ReviewStory.story = {
 	name: 'Review',
 	parameters: {
 		viewport: { defaultViewport: 'phablet' },
-		chromatic: { viewports: [660] },
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.wide,
+			],
+		},
 	},
 };
 

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -27,13 +27,14 @@ import { Island } from '../../components/Island';
 import { decidePalette } from '../../lib/decidePalette';
 
 const hasMainMediaStyles = css`
-	height: 100vh;
+	height: 80vh;
 	/**
     100vw is normally enough but don't let the content shrink vertically too
     much just in case
     */
 	min-height: 25rem;
 	${from.desktop} {
+		height: 100vh;
 		min-height: 31.25rem;
 	}
 	${from.wide} {

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -29,7 +29,7 @@ import { decidePalette } from '../../lib/decidePalette';
 const hasMainMediaStyles = css`
 	height: 80vh;
 	/**
-    100vw is normally enough but don't let the content shrink vertically too
+    80vh is normally enough but don't let the content shrink vertically too
     much just in case
     */
 	min-height: 25rem;

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -35,10 +35,10 @@ const hasMainMediaStyles = css`
 	min-height: 25rem;
 	${from.desktop} {
 		height: 100vh;
-		min-height: 31.25rem;
+		/* min-height: 31.25rem; */
 	}
 	${from.wide} {
-		min-height: 50rem;
+		/* min-height: 50rem; */
 	}
 `;
 

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -35,10 +35,10 @@ const hasMainMediaStyles = css`
 	min-height: 25rem;
 	${from.desktop} {
 		height: 100vh;
-		/* min-height: 31.25rem; */
+		min-height: 31.25rem;
 	}
 	${from.wide} {
-		/* min-height: 50rem; */
+		min-height: 50rem;
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Reduces height of immersive header until desktop - was 100vh now 80vh
## Why?
@ajbreuer @Bryony-Szekeres request
## Screenshots

| Before      | After      |
|-------------|------------|
|  ![image](https://user-images.githubusercontent.com/20658471/164249875-e442a157-ce0f-4ff4-b340-de025777057e.png) |  ![image](https://user-images.githubusercontent.com/20658471/164249966-d72b6ae8-b91e-4ed4-b638-072a213c6d9f.png) |
|  ![image](https://user-images.githubusercontent.com/20658471/164250237-fd2531f1-ada2-48a2-ad1c-4f18adfeab09.png) |  ![image](https://user-images.githubusercontent.com/20658471/164250166-cbc425dc-7290-452d-b8ac-bc2eeab8774b.png) |


