### PR TITLE
Drop caps

### DIFF
--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -1,7 +1,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
-import { background, neutral, remSpace } from '@guardian/source-foundations';
+import { text } from '@guardian/common-rendering/src/editorialPalette/text';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+import { background, neutral, remSpace, space } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 
@@ -11,7 +12,21 @@ interface ArticleBodyProps {
 	format: ArticleFormat;
 }
 
-const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
+const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
+	switch (format.design) {
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return css`font-weight: 200;
+			`;
+		default:
+			return css`
+				font-weight: 700;
+			`;
+	}
+}
+const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {
+	const baseStyles = css`
 	position: relative;
 	clear: both;
 
@@ -28,7 +43,34 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 		clear: both;
 		display: inline-block;
 	}
-`;
+	`;
+
+	const dropCap = css`
+		p:first-child:first-letter {
+		color: ${text.dropCap(format)};
+		${dropCapWeight(format)};
+		float: left;
+		font-size: 7.375rem;
+		line-height: 6.188rem;
+		vertical-align: text-top;
+		pointer-events: none;
+		margin-right: ${space[1]}px;
+		}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.Interview:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+			return css`
+				${baseStyles}
+				${dropCap}
+			`;
+		default:
+			return baseStyles;
+			}
+};
 
 const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     background: ${background.inverse};

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import type { ArticleFormat } from '@guardian/libs';
+import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import {
 	background,
@@ -18,19 +18,19 @@ interface ArticleBodyProps {
 	format: ArticleFormat;
 }
 
-const shouldShowDropCap = (format: ArticleFormat): boolean => {
-	if (format.display === ArticleDisplay.Immersive) {
-		return true;
-	} else {
-		switch (format.design) {
-			case ArticleDesign.Interview:
-			case ArticleDesign.Comment:
-			case ArticleDesign.Editorial:
-			case ArticleDesign.Letter:
-				return true;
-			default:
-				return false;
-		}
+const allowsDropCaps = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.Labs) return false;
+	if (format.display === ArticleDisplay.Immersive) return true;
+	switch (format.design) {
+		case ArticleDesign.Feature:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Review:
+		case ArticleDesign.Interview:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.Recipe:
+			return true;
+		default:
+			return false;
 	}
 };
 
@@ -91,7 +91,7 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {
 		}
 	`;
 
-	if (shouldShowDropCap(format)) {
+	if (allowsDropCaps(format)) {
 		return css`
 			${baseStyles}
 			${dropCap(format)}

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -1,8 +1,14 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import { ArticleDesign, ArticleFormat } from '@guardian/libs';
-import { background, headline, neutral, remSpace } from '@guardian/source-foundations';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import {
+	background,
+	headline,
+	neutral,
+	remSpace,
+} from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 
@@ -12,65 +18,80 @@ interface ArticleBodyProps {
 	format: ArticleFormat;
 }
 
+const shouldShowDropCap = (format: ArticleFormat): boolean => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return true;
+	} else {
+		switch (format.design) {
+			case ArticleDesign.Interview:
+			case ArticleDesign.Comment:
+			case ArticleDesign.Editorial:
+			case ArticleDesign.Letter:
+				return true;
+			default:
+				return false;
+		}
+	}
+};
+
 const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
-			return css`font-weight: 200;
+			return css`
+				font-weight: 200;
 			`;
 		default:
 			return css`
 				font-weight: 700;
 			`;
 	}
-}
+};
+
+const dropCap = (format: ArticleFormat): SerializedStyles => css`
+	p:first-of-type:first-letter,
+	hr + p:first-letter {
+		${headline.large({ fontWeight: 'bold' })}
+		${dropCapWeight(format)};
+		color: ${text.dropCap(format)};
+		float: left;
+		font-size: 7.375rem;
+		line-height: 6.188rem;
+		vertical-align: text-top;
+		pointer-events: none;
+		margin-right: ${remSpace[1]};
+	}
+`;
+
 const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {
 	const baseStyles = css`
-	position: relative;
-	clear: both;
-
-	iframe {
-		width: 100%;
-		border: none;
-	}
-
-	${adStyles(format)}
-
-	twitter-widget,
-    figure[data-atom-type="explainer"] {
-		margin: ${remSpace[4]} 0;
+		position: relative;
 		clear: both;
-		display: inline-block;
-	}
-	`;
 
-	const dropCap = css`
-		p:first-child:first-letter {
-			${headline.large({ fontWeight: 'bold' })}
-			${dropCapWeight(format)};
-			color: ${text.dropCap(format)};
-			float: left;
-			font-size: 7.375rem;
-			line-height: 6.188rem;
-			vertical-align: text-top;
-			pointer-events: none;
-			margin-right: ${remSpace[1]};
+		iframe {
+			width: 100%;
+			border: none;
+		}
+
+		${adStyles(format)}
+
+		twitter-widget,
+    figure[data-atom-type="explainer"] {
+			margin: ${remSpace[4]} 0;
+			clear: both;
+			display: inline-block;
 		}
 	`;
 
-	switch (format.design) {
-		case ArticleDesign.Interview:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-			return css`
-				${baseStyles}
-				${dropCap}
-			`;
-		default:
-			return baseStyles;
-			}
+	if (shouldShowDropCap(format)) {
+		return css`
+			${baseStyles}
+			${dropCap(format)}
+		`;
+	} else {
+		return baseStyles;
+	}
 };
 
 const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -1,14 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
-import {
-	background,
-	headline,
-	neutral,
-	remSpace,
-} from '@guardian/source-foundations';
+import type { ArticleFormat } from '@guardian/libs';
+import { background, neutral, remSpace } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 
@@ -18,88 +11,24 @@ interface ArticleBodyProps {
 	format: ArticleFormat;
 }
 
-const allowsDropCaps = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.Labs) return false;
-	if (format.display === ArticleDisplay.Immersive) return true;
-	switch (format.design) {
-		case ArticleDesign.Feature:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Review:
-		case ArticleDesign.Interview:
-		case ArticleDesign.PhotoEssay:
-		case ArticleDesign.Recipe:
-			return true;
-		default:
-			return false;
-	}
-};
+const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
+	position: relative;
+	clear: both;
 
-const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
-	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return css`
-				font-weight: 200;
-			`;
-		default:
-			return css`
-				font-weight: 700;
-			`;
-	}
-};
-
-const dropCap = (format: ArticleFormat): SerializedStyles => css`
-	p:first-of-type:first-letter,
-	hr + p:first-letter {
-		${headline.large({ fontWeight: 'bold' })}
-		${dropCapWeight(format)};
-		color: ${text.dropCap(format)};
-		float: left;
-		font-size: 7.375rem;
-		line-height: 6.188rem;
-		vertical-align: text-top;
-		pointer-events: none;
-		margin-right: ${remSpace[1]};
+	iframe {
+		width: 100%;
+		border: none;
 	}
 
-	${darkModeCss`
-		p:first-of-type:first-letter,
-		hr + p:first-letter {
-			color: ${text.dropCapDark(format)};
-		}
-	`};
-`;
+	${adStyles(format)}
 
-const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {
-	const baseStyles = css`
-		position: relative;
-		clear: both;
-
-		iframe {
-			width: 100%;
-			border: none;
-		}
-
-		${adStyles(format)}
-
-		twitter-widget,
+	twitter-widget,
     figure[data-atom-type="explainer"] {
-			margin: ${remSpace[4]} 0;
-			clear: both;
-			display: inline-block;
-		}
-	`;
-
-	if (allowsDropCaps(format)) {
-		return css`
-			${baseStyles}
-			${dropCap(format)}
-		`;
-	} else {
-		return baseStyles;
+		margin: ${remSpace[4]} 0;
+		clear: both;
+		display: inline-block;
 	}
-};
+`;
 
 const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     background: ${background.inverse};

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
-import { background, neutral, remSpace, space } from '@guardian/source-foundations';
+import { background, headline, neutral, remSpace } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
 import { adStyles, darkModeCss } from 'styles';
 
@@ -47,14 +47,15 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {
 
 	const dropCap = css`
 		p:first-child:first-letter {
-		color: ${text.dropCap(format)};
-		${dropCapWeight(format)};
-		float: left;
-		font-size: 7.375rem;
-		line-height: 6.188rem;
-		vertical-align: text-top;
-		pointer-events: none;
-		margin-right: ${space[1]}px;
+			${headline.large({ fontWeight: 'bold' })}
+			${dropCapWeight(format)};
+			color: ${text.dropCap(format)};
+			float: left;
+			font-size: 7.375rem;
+			line-height: 6.188rem;
+			vertical-align: text-top;
+			pointer-events: none;
+			margin-right: ${remSpace[1]};
 		}
 	`;
 

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -62,6 +62,13 @@ const dropCap = (format: ArticleFormat): SerializedStyles => css`
 		pointer-events: none;
 		margin-right: ${remSpace[1]};
 	}
+
+	${darkModeCss`
+		p:first-of-type:first-letter,
+		hr + p:first-letter {
+			color: ${text.dropCapDark(format)};
+		}
+	`};
 `;
 
 const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => {

--- a/apps-rendering/src/components/blockquote.stories.tsx
+++ b/apps-rendering/src/components/blockquote.stories.tsx
@@ -11,7 +11,7 @@ const standard = {
 
 const Default: FC = () => (
 	<Blockquote format={standard}>
-		<Paragraph format={standard}>
+		<Paragraph format={standard} showDropCap={false}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eu
 			nunc dolor. Suspendisse vestibulum non turpis eget porta. Duis
 			pretium est pretium tellus facilisis, eget tempor nibh condimentum.
@@ -19,12 +19,12 @@ const Default: FC = () => (
 			felis nunc. Phasellus a dui tellus. Suspendisse vel tellus porta,
 			tincidunt massa id, tincidunt erat.
 		</Paragraph>
-		<Paragraph format={standard}>
+		<Paragraph format={standard} showDropCap={false}>
 			Donec congue rutrum justo. Mauris condimentum tellus sit amet purus
 			euismod, ac eleifend tortor tempor. Maecenas tristique auctor est,
 			vitae hendrerit dolor elementum non.
 		</Paragraph>
-		<Paragraph format={standard}>
+		<Paragraph format={standard} showDropCap={false}>
 			Pellentesque porttitor finibus interdum. Etiam hendrerit purus quis
 			risus auctor porttitor quis ut nibh. Sed dictum ex non diam
 			vestibulum aliquet. Ut vel enim at diam suscipit sodales eu sed leo.

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -1,14 +1,11 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { ArticleDisplay } from '@guardian/libs';
 import {
 	background,
 	breakpoints,
 	from,
 	neutral,
-	remSpace,
 } from '@guardian/source-foundations';
 import { Lines } from '@guardian/source-react-components-development-kitchen';
 import { map, none, withDefault } from '@guardian/types';
@@ -26,7 +23,6 @@ import Standfirst from 'components/standfirst';
 import Tags from 'components/tags';
 import HeaderMedia from 'headerMedia';
 import type {
-	Item,
 	MatchReport as MatchReportItem,
 	Review as ReviewItem,
 	Standard as StandardItem,
@@ -39,7 +35,7 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
-import { getThemeStyles, themeToPillarString } from 'themeStyles';
+import { themeToPillarString } from 'themeStyles';
 
 // ----- Styles ----- //
 
@@ -60,35 +56,6 @@ const BorderStyles = css`
 		margin: 0 auto;
 	}
 `;
-
-const itemStyles = (item: Item): SerializedStyles => {
-	const { kicker, inverted } = getThemeStyles(item.theme);
-
-	switch (item.display) {
-		case ArticleDisplay.Immersive:
-			return css`
-				> p:first-of-type:first-letter,
-				> hr + p:first-letter {
-					color: ${kicker};
-					display: inline-block;
-					vertical-align: text-top;
-					line-height: 5.625rem;
-					font-size: 6.8125rem;
-					display: inline-block;
-					font-weight: 900;
-					float: left;
-					margin-right: ${remSpace[3]};
-
-					${darkModeCss`
-                        color: ${inverted};
-                    `}
-				}
-			`;
-
-		default:
-			return css``;
-	}
-};
 
 interface Props {
 	item: StandardItem | ReviewItem | MatchReportItem;
@@ -151,10 +118,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 						<Logo item={item} />
 					</section>
 				</header>
-				<Body
-					className={[articleWidthStyles, itemStyles(item)]}
-					format={item}
-				>
+				<Body className={[articleWidthStyles]} format={item}>
 					{children}
 				</Body>
 				{epicContainer}

--- a/apps-rendering/src/components/paragraph.stories.tsx
+++ b/apps-rendering/src/components/paragraph.stories.tsx
@@ -24,7 +24,7 @@ const labs = {
 };
 
 const Default: FC = () => (
-	<Paragraph format={standard}>
+	<Paragraph format={standard} showDropCap={false}>
 		Ever since Mexico City was founded on an island in the lake of Texcoco
 		its inhabitants have dreamed of water: containing it, draining it and
 		now retaining it.
@@ -32,7 +32,7 @@ const Default: FC = () => (
 );
 
 const Labs: FC = () => (
-	<Paragraph format={labs}>
+	<Paragraph format={labs} showDropCap={false}>
 		Ever since Mexico City was founded on an island in the lake of Texcoco
 		its inhabitants have dreamed of water: containing it, draining it and
 		now retaining it.

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -2,33 +2,82 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import { text } from '@guardian/common-rendering/src/editorialPalette/text';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import { ArticleSpecial } from '@guardian/libs';
-import { body, remSpace, textSans } from '@guardian/source-foundations';
+import {
+	body,
+	headline,
+	remSpace,
+	textSans,
+} from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
 interface Props {
 	children?: ReactNode;
 	format: ArticleFormat;
-	dropCapStyles?: SerializedStyles;
+	showDropCap?: boolean;
 }
 
-const styles = (theme: ArticleTheme): SerializedStyles => {
-	const labs = theme === ArticleSpecial.Labs ? textSans.medium() : null;
+const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
+	switch (format.design) {
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return css`
+				font-weight: 200;
+			`;
+		default:
+			return css`
+				font-weight: 700;
+			`;
+	}
+};
+
+const styles = (
+	format: ArticleFormat,
+	showDropCap: boolean = false,
+): SerializedStyles => {
+	const labs =
+		format.theme === ArticleSpecial.Labs ? textSans.medium() : null;
+
+	const dropCap = showDropCap
+		? css`
+				&:first-of-type:first-letter,
+				hr + &:first-letter {
+					${headline.large({ fontWeight: 'bold' })}
+					${dropCapWeight(format)}
+				color: ${text.dropCap(format)};
+					float: left;
+					font-size: 7.375rem;
+					line-height: 6.188rem;
+					vertical-align: text-top;
+					pointer-events: none;
+					margin-right: ${remSpace[1]};
+				}
+
+				${darkModeCss`
+				&:first-of-type:first-letter,
+				hr + &:first-letter {
+					color: ${text.dropCapDark(format)};
+				}`}
+		  `
+		: null;
 
 	return css`
 		${body.medium()}
 		overflow-wrap: break-word;
 		margin: 0 0 ${remSpace[3]};
-
+		${dropCap}
 		${labs}
 	`;
 };
 
-const Paragraph: FC<Props> = ({ children, format, dropCapStyles }: Props) => (
-	<p css={[styles(format.theme), dropCapStyles]}>{children}</p>
+const Paragraph: FC<Props> = ({ children, format, showDropCap }: Props) => (
+	<p css={styles(format, showDropCap)}>{children}</p>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -3,8 +3,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import {
 	body,
 	headline,

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -3,8 +3,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import { ArticleDesign, ArticleFormat } from '@guardian/libs';
-import { ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import {
 	body,
 	headline,
@@ -19,7 +19,7 @@ import { darkModeCss } from 'styles';
 interface Props {
 	children?: ReactNode;
 	format: ArticleFormat;
-	showDropCap?: boolean;
+	showDropCap: boolean;
 }
 
 const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
@@ -39,7 +39,7 @@ const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
 
 const styles = (
 	format: ArticleFormat,
-	showDropCap: boolean = false,
+	showDropCap: boolean,
 ): SerializedStyles => {
 	const labs =
 		format.theme === ArticleSpecial.Labs ? textSans.medium() : null;

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -12,6 +12,7 @@ import type { FC, ReactNode } from 'react';
 interface Props {
 	children?: ReactNode;
 	format: ArticleFormat;
+	dropCapStyles?: SerializedStyles;
 }
 
 const styles = (theme: ArticleTheme): SerializedStyles => {
@@ -26,8 +27,8 @@ const styles = (theme: ArticleTheme): SerializedStyles => {
 	`;
 };
 
-const Paragraph: FC<Props> = ({ children, format }: Props) => (
-	<p css={styles(format.theme)}>{children}</p>
+const Paragraph: FC<Props> = ({ children, format, dropCapStyles }: Props) => (
+	<p css={[styles(format.theme), dropCapStyles]}>{children}</p>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -3,7 +3,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import { ArticleDesign, ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	body,
 	headline,

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -177,43 +177,6 @@ const allowsDropCaps = (format: ArticleFormat): boolean => {
 	}
 };
 
-const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
-	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return css`
-				font-weight: 200;
-			`;
-		default:
-			return css`
-				font-weight: 700;
-			`;
-	}
-};
-
-const dropCapStyles = (format: ArticleFormat): SerializedStyles => css`
-	&:first-of-type:first-letter,
-	hr + &:first-letter {
-		${headline.large({ fontWeight: 'bold' })}
-		${dropCapWeight(format)}
-		color: ${text.dropCap(format)};
-		float: left;
-		font-size: 7.375rem;
-		line-height: 6.188rem;
-		vertical-align: text-top;
-		pointer-events: none;
-		margin-right: ${remSpace[1]};
-	}
-
-	${darkModeCss`
-		&:first-of-type:first-letter,
-		hr + &:first-letter {
-			color: ${text.dropCapDark(format)};
-		}
-	`};
-`;
-
 //Elements rendered by this function should contain no styles.
 // For example in callout form and interactives we want to exclude styles.
 const plainTextElement = (node: Node, key: number): ReactNode => {
@@ -271,15 +234,7 @@ const textElement =
 				const showDropCap =
 					allowsDropCaps(format) && text.length >= 200;
 				return showDropCap
-					? styledH(
-							Paragraph,
-							{
-								key,
-								format,
-								dropCapStyles: dropCapStyles(format),
-							},
-							children,
-					  )
+					? h(Paragraph, { key, format, showDropCap }, children)
 					: h(Paragraph, { key, format }, children);
 			}
 			case '#text':

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -233,9 +233,7 @@ const textElement =
 			case 'P': {
 				const showDropCap =
 					allowsDropCaps(format) && text.length >= 200;
-				return showDropCap
-					? h(Paragraph, { key, format, showDropCap }, children)
-					: h(Paragraph, { key, format }, children);
+				return h(Paragraph, { key, format, showDropCap }, children);
 			}
 			case '#text':
 				return transform(text, format);

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -222,6 +222,19 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 	}
 };
 
+/**
+ * This regular expression checks that a string begins with a word that is at least
+ * three characters long.
+ * ["'\u2018\u201c]? matches an optional quotation mark, apostrophe, open single quote
+ * or open double quote.
+ * The rest of the expression matches any character in the Latin-1 Unicode block,
+ * which includes diacritics (e.g. å, č, Ë, etc.).
+ * The regex sits outside the rendering function so it is only compiled once
+ * for better performance.
+ */
+const dropCapRegex =
+	/^["'\u2018\u201c]?[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
+
 const textElement =
 	(format: ArticleFormat, isEditions = false) =>
 	(node: Node, key: number): ReactNode => {
@@ -232,7 +245,9 @@ const textElement =
 		switch (node.nodeName) {
 			case 'P': {
 				const showDropCap =
-					allowsDropCaps(format) && text.length >= 200;
+					allowsDropCaps(format) &&
+					text.length >= 200 &&
+					dropCapRegex.test(text);
 				return h(Paragraph, { key, format, showDropCap }, children);
 			}
 			case '#text':

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -24,11 +24,11 @@ import { Colour } from '.';
 
 const branding = (_format: ArticleFormat): Colour => {
 	return neutral[20];
-}
+};
 
 const brandingDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
-}
+};
 
 const dropCap = (format: ArticleFormat): Colour => {
 	switch (format.theme) {

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -62,7 +62,7 @@ const dropCapDark = (format: ArticleFormat): Colour => {
 		case ArticlePillar.News:
 			return news[500];
 		case ArticleSpecial.Labs:
-			return labs[500];
+			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
 	}

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -30,6 +30,25 @@ const brandingDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
 }
 
+const dropCap = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.News:
+			return news[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+	}
+};
+
 const headline = (format: ArticleFormat): Colour => {
 	if (
 		format.display === ArticleDisplay.Immersive ||
@@ -589,6 +608,7 @@ const text = {
 	bylineLeftColumn,
 	bylineInline,
 	bylineDark,
+	dropCap,
 	follow,
 	followDark,
 	headline,

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -49,6 +49,25 @@ const dropCap = (format: ArticleFormat): Colour => {
 	}
 };
 
+const dropCapDark = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.Opinion:
+			return opinion[500];
+		case ArticlePillar.Culture:
+			return culture[500];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[500];
+		case ArticlePillar.Sport:
+			return sport[500];
+		case ArticlePillar.News:
+			return news[500];
+		case ArticleSpecial.Labs:
+			return labs[500];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[500];
+	}
+};
+
 const headline = (format: ArticleFormat): Colour => {
 	if (
 		format.display === ArticleDisplay.Immersive ||
@@ -609,6 +628,7 @@ const text = {
 	bylineInline,
 	bylineDark,
 	dropCap,
+	dropCapDark,
 	follow,
 	followDark,
 	headline,


### PR DESCRIPTION
## Why?
Some formats require drop caps to be applied to paragraphs. 
This PR introduces a pure CSS solution for AR to render them.

The logic is as follow:

1) The CAPI response is parsed in `renderer.ts`
2) If the element is a text element, and specifically a paragraph, perform the drop cap check against the format (i.e. allow drop caps if the display is immersive or the design is any of Feature, Comment, Review, Interview, PhotoEssay, Recipe)
3) If drop caps are allowed, apply the drop cap styling to the `Paragraph` component but only if the text content of the paragraph is longer than 200 characters, and only to the first paragraph of an article (or the first paragraph following an `<hr>` tag)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="638" alt="image" src="https://user-images.githubusercontent.com/57295823/164263753-6f20d475-6bb6-4c2b-b51e-c125d77371c0.png"> | <img width="633" alt="image" src="https://user-images.githubusercontent.com/57295823/164263944-2a45826f-e103-4993-9f86-a0032f3e1536.png"> |
| <img width="635" alt="image" src="https://user-images.githubusercontent.com/57295823/164264107-958c958a-4f4f-415d-9678-050a87db8e55.png"> | <img width="639" alt="image" src="https://user-images.githubusercontent.com/57295823/164264197-55a08e73-a9a6-4641-ad92-38b51aebec80.png"> |
| <img width="637" alt="image" src="https://user-images.githubusercontent.com/57295823/164264353-72ab799e-f3b0-468b-8240-ffe585adc78a.png"> | <img width="638" alt="image" src="https://user-images.githubusercontent.com/57295823/164264418-5751797c-2a27-490a-a1ad-02cb1583d12b.png"> |
|  <img width="643" alt="image" src="https://user-images.githubusercontent.com/57295823/164265178-2f5b216c-6a36-4944-baf5-c3c0dcc9f0f6.png"> | <img width="638" alt="image" src="https://user-images.githubusercontent.com/57295823/164265320-417f2853-6f5c-443e-8aa4-cadb15c439e0.png"> |
## Darkmode
I have applied the same dark mode colours as `text.followDark` (i.e.`500` for every pillar). @HarryFischer can you confirm this is correct? 

| Before | After |
|----|----|
| <img width="627" alt="image" src="https://user-images.githubusercontent.com/57295823/164265770-9380f333-2e79-4c0e-a8a9-7b9ac689974d.png"> | <img width="640" alt="image" src="https://user-images.githubusercontent.com/57295823/164265844-c62b6236-ec4f-45af-a31d-f68476e30b91.png"> |
