### PR TITLE
Fix ad label max-height

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -27,6 +27,7 @@ const adSlotLabelStyles = css`
 	${textSans.xxsmall()};
 	position: relative;
 	height: ${labelHeight}px;
+	max-height: ${labelHeight}px;
 	background-color: ${neutral[97]};
 	padding: 0 8px;
 	border-top: 1px solid ${border.secondary};


### PR DESCRIPTION
## What does this change?

We have seen issues where the ad label has its width and height set to that of its related advert.

Until we track down the cause of this we have decided to add a `max-height` to the ad label.

## Screenshots

### Before

<img width="112" alt="Screenshot 2022-04-20 at 16 53 03" src="https://user-images.githubusercontent.com/7014230/164277164-6af2125d-5020-47d9-b757-8180e2cce8da.png">



