### PR TITLE
Pass ad slot props down into `<TopRightAdSlot />`

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -200,7 +200,12 @@ const AdSlotLabelToggled: React.FC = () => (
 	</div>
 );
 
-export const AdSlot: React.FC<Props> = ({ position, display }) => {
+export const AdSlot: React.FC<Props> = ({
+	position,
+	display,
+	shouldHideReaderRevenue = false,
+	isPaidContent = false,
+}) => {
 	switch (position) {
 		case 'right':
 			switch (display) {
@@ -240,8 +245,10 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 					return (
 						<Island>
 							<TopRightAdSlot
-								shouldHideReaderRevenue={false}
-								isPaidContent={false}
+								shouldHideReaderRevenue={
+									shouldHideReaderRevenue
+								}
+								isPaidContent={isPaidContent}
 								adStyles={adStyles}
 							/>
 						</Island>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Pass the props `shouldHideReaderRevenue` and `isPaidContent` down from the ad slot into the top right ad slot component.

## Why?

These props were previously being ignored, with the values passed hardcoded as `false`. These values should be passed in and used to decide when to render a shady pie.
