### PR TITLE
Apply 300px `max-width` to ad slot containers

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -86,7 +86,7 @@ const articleAdStyles = css`
 			margin-left: 20px;
 		}
 	}
-	.ad-slot--inline:not(.ad-slot--inline1):not(.ad-slot--top-above-nav):not(.ad-slot--fluid) {
+	.ad-slot-container {
 		max-width: 300px;
 	}
 	.ad-slot--offset-right {


### PR DESCRIPTION
## What does this change?

Applies a `max-width` of 300px to ad slot containers, instead of the ad slots themselves.

We use ad slot containers to wrap `inline2+` ads in an attempt to stop Google performing [ad expansion](https://support.google.com/admanager/answer/9117822?hl=en). 

Ad slot containers are introduced in this PR: https://github.com/guardian/frontend/pull/24917

## Why?

Our [previous attempt at addressing this problem](https://github.com/guardian/dotcom-rendering/pull/4441), which involved applying the `max-size` to the ad slot itself, didn't work. When we asked Google about this, they recommended applying the `max-size` to the parent element instead.