### PR TITLE
Changes leftCol on Comments layout to use wide size on Liveblogs

### DIFF
--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
+import { ArticleDisplay } from '@guardian/libs';
 import { ContainerLayout } from './ContainerLayout';
 import { Flex } from './Flex';
 import { RightColumn } from './RightColumn';
@@ -47,7 +48,11 @@ export const DiscussionLayout = ({
 						/>
 					</Island>
 				}
-				leftColSize="wide"
+				leftColSize={
+					format.display === ArticleDisplay.Standard
+						? 'wide'
+						: 'compact'
+				}
 			>
 				<Flex>
 					<div

--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -47,6 +47,7 @@ export const DiscussionLayout = ({
 						/>
 					</Island>
 				}
+				leftColSize="wide"
 			>
 				<Flex>
 					<div


### PR DESCRIPTION

## What does this change?

Sets the leftCol size of the comments meta on liveblogs to "wide" to make it align with the onwards containers above

## Why?

This fixes #4488

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/164464597-10e66373-194e-4ef2-aefe-2c8040ad74d6.png
[after]: https://user-images.githubusercontent.com/21217225/164464695-308036c1-764c-4975-93cc-544092c56a3a.png
