### PR TITLE
Ophan Components parity tracking

### DIFF
--- a/.github/workflows/fronts.yml
+++ b/.github/workflows/fronts.yml
@@ -1,0 +1,58 @@
+name: DCR Fronts Ophan tag status
+on:
+  push:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  data-link-name:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: v1.21.0
+
+      - name: Compare components "data-link-name"
+        id: text
+        run: |
+          echo "About to run Deno script"
+          TEXT=$(deno run --allow-net ./scripts/deno/ophan-components.ts data-link-name)
+          echo "::set-output text=$TEXT"
+
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@v2.0.0
+        with:
+          comment-id: 1211151898
+          body: "{{ steps.text.outputs }}"
+          edit-mode: replace
+
+  data-component:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: v1.21.0
+
+      - name: Compare components "data-component"
+        id: text
+        run: |
+          echo "About to run Deno script"
+          TEXT=$(deno run --allow-net ./scripts/deno/ophan-components.ts data-component)
+          echo "::set-output name=text::$TEXT"
+
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@v2.0.0
+        with:
+          comment-id: 1212191944
+          body: "{{ steps.text.outputs }}"
+          edit-mode: replace

--- a/.github/workflows/fronts.yml
+++ b/.github/workflows/fronts.yml
@@ -1,7 +1,11 @@
-name: DCR Fronts Ophan tag status
+name: DCR Fronts–Ophan Components
 on:
   push:
     branches: [main]
+
+  schedule:
+    # Every work day of the week at 08:08
+    - cron: "8 8 * * MON-FRI"
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.github/workflows/fronts.yml
+++ b/.github/workflows/fronts.yml
@@ -1,8 +1,5 @@
 name: DCR Fronts–Ophan Components
 on:
-  push:
-    branches: [main]
-
   schedule:
     # Every work day of the week at 08:08
     - cron: "8 8 * * MON-FRI"

--- a/.github/workflows/fronts.yml
+++ b/.github/workflows/fronts.yml
@@ -19,18 +19,7 @@ jobs:
           deno-version: v1.21.0
 
       - name: Compare components "data-link-name"
-        id: text
-        run: |
-          echo "About to run Deno script"
-          TEXT=$(deno run --allow-net ./scripts/deno/ophan-components.ts data-link-name)
-          echo "::set-output text=$TEXT"
-
-      - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v2.0.0
-        with:
-          comment-id: 1211151898
-          body: "{{ steps.text.outputs }}"
-          edit-mode: replace
+        run: deno run --allow-env="GITHUB_TOKEN" --no-check=remote --allow-net=www.theguardian.com,api.github.com  scripts/deno/ophan-components.ts data-link-name
 
   data-component:
     runs-on: ubuntu-20.04
@@ -44,15 +33,4 @@ jobs:
           deno-version: v1.21.0
 
       - name: Compare components "data-component"
-        id: text
-        run: |
-          echo "About to run Deno script"
-          TEXT=$(deno run --allow-net ./scripts/deno/ophan-components.ts data-component)
-          echo "::set-output name=text::$TEXT"
-
-      - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v2.0.0
-        with:
-          comment-id: 1212191944
-          body: "{{ steps.text.outputs }}"
-          edit-mode: replace
+        run: run: deno run --allow-env="GITHUB_TOKEN" --no-check=remote --allow-net=www.theguardian.com,api.github.com  scripts/deno/ophan-components.ts data-component

--- a/.github/workflows/fronts.yml
+++ b/.github/workflows/fronts.yml
@@ -20,7 +20,7 @@ jobs:
           deno-version: v1.21.0
 
       - name: Compare components "data-link-name"
-        run: deno run --allow-env="GITHUB_TOKEN" --no-check=remote --allow-net=www.theguardian.com,api.github.com  scripts/deno/ophan-components.ts data-link-name
+        run: scripts/ci-ophan.sh
 
   data-component:
     runs-on: ubuntu-20.04

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
         "styled-components.vscode-styled-components",
         "stylelint.vscode-stylelint",
         "eamodio.gitlens",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "denoland.vscode-deno"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+	"deno.enablePaths": ["scripts/deno"],
+	"deno.lint": true,
+	"deno.unstable": false,
     "eslint.validate": ["typescript", "typescriptreact"],
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true

--- a/scripts/ci-ophan.sh
+++ b/scripts/ci-ophan.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+deno run \
+	--no-check=remote \
+	--allow-net=www.theguardian.com,api.github.com \
+	--allow-env="GITHUB_TOKEN" \
+	scripts/deno/ophan-components.ts

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -1,0 +1,111 @@
+const tags = ["data-link-name", "data-component"] as const;
+type OphanAttribute = typeof tags[number];
+const isOphanAttribute = (tag?: string): tag is OphanAttribute =>
+	tags.includes(tag as OphanAttribute);
+
+const attribute = Deno.args[0];
+if (!isOphanAttribute(attribute)) {
+	console.warn(`invalid tag: ${attribute}`);
+	console.info(`Use one of [${tags.join(", ")}] instead.`);
+	Deno.exit(1);
+}
+
+const URLS = {
+	frontend: "https://www.theguardian.com/international?dcr=false",
+	dcr: "https://www.theguardian.com/international?dcr=true",
+};
+
+const regexLinkName = /<([a-zA-Z]+)[^>]+?\bdata-link-name="(.+?)"/gi;
+const regexComponent = /<([a-zA-Z]+)[^>]+?\bdata-component="(.+?)"/gi;
+const tagMatch = (tag: OphanAttribute) =>
+	tag === "data-link-name" ? regexLinkName : regexComponent;
+
+const getOphanTags = (url: string, tag: OphanAttribute) =>
+	fetch(url)
+		.then((response) => response.text())
+		.then((html) => html.matchAll(tagMatch(tag)))
+		.then((matches) => [...matches].map((match) => [match[2], match[1]]));
+
+const frontend = await getOphanTags(URLS.frontend, attribute);
+const dcr = await getOphanTags(URLS.dcr, attribute);
+
+type ExistsOnDcr = "identical" | "tag-mismatch" | "missing";
+type Issue<T extends ExistsOnDcr = ExistsOnDcr> = {
+	name: string;
+	tag: string;
+	dcrTag?: string;
+	existsOnDcr: T;
+};
+
+const issues: Issue[] = frontend
+	.reduce<[Set<string>, [string, string][]]>(
+		([set, array], [name, tag]) => {
+			if (!set.has(name)) array.push([name, tag]);
+			set.add(name);
+			return [set, array];
+		},
+		[new Set(), []]
+	)[1]
+	.map(([name, tag]) => {
+		const fullMatch = dcr.find(
+			([nameDcr, tagDcr]) => nameDcr === name && tagDcr === tag
+		);
+		if (fullMatch) return { name, tag, existsOnDcr: "identical" };
+
+		const partialMatch = dcr.find(([nameDcr]) => nameDcr === name);
+
+		if (partialMatch)
+			return {
+				name,
+				tag,
+				dcrTag: partialMatch[1],
+				existsOnDcr: "tag-mismatch",
+			};
+
+		return { name, tag, existsOnDcr: "missing" };
+	});
+
+const isIssueType =
+	<T extends ExistsOnDcr>(existsOnDcr: T) =>
+	(issue: Issue): issue is Issue<T> =>
+		issue.existsOnDcr === existsOnDcr;
+
+const missing = issues.filter(isIssueType("missing"));
+const mismatches = issues.filter(isIssueType("tag-mismatch"));
+const identical = issues.filter(isIssueType("identical"));
+
+const output = `
+## Remaining Front components mismatches
+
+Comparing the international Front between [Frontend][] & [DCR][].
+
+Component attribute: **\`${attribute}\`**
+
+[Frontend]: ${URLS.frontend}
+[DCR]: ${URLS.dcr}
+
+### Missing from DCR (${missing.length} / ${issues.length})
+
+${missing
+	.map(({ tag, name }) => `- [ ] **\`${name}\`** &rarr; \`<${tag}/>\``)
+	.join("\n")}
+
+### Tag mismatch (${mismatches.length} / ${issues.length})
+
+${mismatches
+	.map(
+		({ tag, name, dcrTag }) =>
+			`- [X] **\`${name}\`** : \`<${dcrTag} />\` &cross; should be &rarr; \`<${tag}/>\``
+	)
+	.join("\n")}
+
+---
+
+### Identical match (${identical.length} / ${issues.length})
+
+${identical
+	.map(({ tag, name }) => `- [X] **\`${name}\`** &rarr; \`<${tag}/>\``)
+	.join("\n")}
+`;
+
+await Deno.stdout.write(new TextEncoder().encode(output));


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Introduce a workflow that runs a script every work day morning to check the parity of [Ophan Components][].

The script is written in Deno / Typescript. It checks the [`/international`][] Front on both rendering platforms, and compares the presence of `data-link-name` and `data-component` attributes. The action uses the `GITHUB_TOKEN` and Octokit to update issues with the latest comparison.

As of this writing, there are only 74 / 302 of  `data-link-name`, and 1 / 30 `data-component` parity in DCR.

A neat feature of issues is that updating with identical text will not register as a new edit. This means that we can also track the progress over time without too much noise. I’ve tested this by running the script locally several times–using a Personal Access Token to gain issue editing rights.

## Why?

Parity on Fronts between `frontend` and `dotcom-rendering` is an essential part of launching fronts. It’s easy to forget invisible elements, so running this script regularly ensures there’s visibility on these components.

For the parity progress, see:
- #4692
- #4698

For docs on [Ophan Components][]
- #4664 

[`/international`]: https://www.theguardian.com/international
[Ophan Components]: https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/track-user-behaviour.md

## Screenshots

It’s possible to enable [a pure CSS viewer](https://gist.github.com/mxdvl/b17f344678ed34d45683896e208ecdc1) to what components are one a page:

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/76776/164814489-54671ed4-9359-46b9-8a3a-ea9e509cf19e.png">
