### PR TITLE
Don't render drop cap if the first character of a paragraph is "I"

### DIFF
--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -226,12 +226,12 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
  * This regular expression checks that a string begins with a word that is at least
  * three characters long, ignoring the initial quotation mark.
  *
- * - The regex can be broken down as follows:
+ *  The regex can be broken down as follows:
  *
- * - ["'\u2018\u201c]? matches an optional quotation mark, apostrophe, open single quote
+ * - `["'\u2018\u201c]?` matches an optional quotation mark, apostrophe, open single quote
  * or open double quote.
  *
- * - (?!I) is a negative lookahead checking that the first letter is not "I".
+ * - `(?!I)` is a negative lookahead checking that the first letter is not "I".
  *
  * - The rest of the expression matches 3 or more characters in the Latin-1 Unicode block,
  * which includes diacritics (e.g. å, č, Ë, etc.).
@@ -242,6 +242,9 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 const dropCapRegex =
 	/^["'\u2018\u201c]?(?!I)[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
 
+const shouldShowDropCap = (text: string, format: ArticleFormat): boolean =>
+	allowsDropCaps(format) && text.length >= 200 && dropCapRegex.test(text);
+
 const textElement =
 	(format: ArticleFormat, isEditions = false) =>
 	(node: Node, key: number): ReactNode => {
@@ -251,10 +254,7 @@ const textElement =
 		);
 		switch (node.nodeName) {
 			case 'P': {
-				const showDropCap =
-					allowsDropCaps(format) &&
-					text.length >= 200 &&
-					dropCapRegex.test(text);
+				const showDropCap = shouldShowDropCap(text, format);
 				return h(Paragraph, { key, format, showDropCap }, children);
 			}
 			case '#text':
@@ -840,4 +840,5 @@ export {
 	transformHref,
 	plainTextElement,
 	renderCaption,
+	shouldShowDropCap,
 };

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -224,16 +224,23 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 
 /**
  * This regular expression checks that a string begins with a word that is at least
- * three characters long.
- * ["'\u2018\u201c]? matches an optional quotation mark, apostrophe, open single quote
+ * three characters long, ignoring the initial quotation mark.
+ *
+ * - The regex can be broken down as follows:
+ *
+ * - ["'\u2018\u201c]? matches an optional quotation mark, apostrophe, open single quote
  * or open double quote.
- * The rest of the expression matches any character in the Latin-1 Unicode block,
+ *
+ * - (?!) is a negative lookahead checking that the first letter is not "I".
+ *
+ * - The rest of the expression matches 3 or more characters in the Latin-1 Unicode block,
  * which includes diacritics (e.g. å, č, Ë, etc.).
+ *
  * The regex sits outside the rendering function so it is only compiled once
  * for better performance.
  */
 const dropCapRegex =
-	/^["'\u2018\u201c]?[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
+	/^["'\u2018\u201c]?(?!I)[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
 
 const textElement =
 	(format: ArticleFormat, isEditions = false) =>

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -231,7 +231,7 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
  * - ["'\u2018\u201c]? matches an optional quotation mark, apostrophe, open single quote
  * or open double quote.
  *
- * - (?!) is a negative lookahead checking that the first letter is not "I".
+ * - (?!I) is a negative lookahead checking that the first letter is not "I".
  *
  * - The rest of the expression matches 3 or more characters in the Latin-1 Unicode block,
  * which includes diacritics (e.g. å, č, Ë, etc.).


### PR DESCRIPTION
## Why?
As per title.

I understand regular expressions are not everyone's cup of tea, and the tradeoff is readability.

If people are really against it, I've come up with a more traditional solution here: https://gist.github.com/MarSavar/164b689fb3f37ebcc983e93c68f3e4e9 but personally I don't love it because I feel like manipulating strings is always a bit of a mystery in JS. I actually had to go and check that slicing with an index bigger than the length of the string doesn't throw an out-of-bounds exception or unintended behaviour.
Also, it's several times slower than the regex. And we are performing this check on every single paragraph in every eligible article, so to me it makes sense to optimise this code. (I have deliberately made sure it is the rightmost logical check in order to skip it altogether if the previous checks fail),

I have improved the JS doc of the regex explaining it in the clearest possible terms so hovering over it gives a pretty understandable (I hope) explanation of what is going on.

<img width="521" alt="image" src="https://user-images.githubusercontent.com/57295823/164481985-69d3ac80-c7b6-4028-a85d-53247a77d1db.png">

