### PR TITLE
fix: Change analysis underlines to use the line heights provided by S…

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -78,7 +78,7 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 };
 
 const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
-	function generateUnderlinedCss(baseSize: number) {
+	function underlinedCss(baseSize: number) {
 		return css`
 			background-image: linear-gradient(
 				to bottom,
@@ -94,28 +94,28 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 		`;
 	}
 
-	function screenSizedUnderlinedCss(
+	function underlinedCssWithMediaQuery(
 		baseSize: number,
 		untilDesktopSize: number,
 	) {
 		return css`
 			${until.desktop} {
-				${generateUnderlinedCss(untilDesktopSize)}
+				${underlinedCss(untilDesktopSize)}
 			}
 
-			${generateUnderlinedCss(baseSize)}
+			${underlinedCss(baseSize)}
 		`;
 	}
 
 	switch (size) {
 		case 'large':
-			return screenSizedUnderlinedCss(29, 25);
+			return underlinedCssWithMediaQuery(29, 29);
 		case 'medium':
-			return screenSizedUnderlinedCss(25, 22);
+			return underlinedCssWithMediaQuery(25, 25);
 		case 'small':
-			return generateUnderlinedCss(22);
+			return underlinedCss(22);
 		case 'tiny':
-			return generateUnderlinedCss(24);
+			return underlinedCss(24);
 	}
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -1,14 +1,7 @@
 import { css } from '@emotion/react';
 
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import {
-	headline,
-	textSans,
-	until,
-	space,
-	headlineSizes,
-	lineHeights,
-} from '@guardian/source-foundations';
+import { headline, textSans, until, space } from '@guardian/source-foundations';
 
 import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
@@ -116,21 +109,13 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 
 	switch (size) {
 		case 'large':
-			return screenSizedUnderlinedCss(
-				Math.round(headlineSizes.xsmall * lineHeights.tight),
-				Math.round(headlineSizes.xxsmall * lineHeights.tight),
-			);
+			return screenSizedUnderlinedCss(29, 25);
 		case 'medium':
-			return screenSizedUnderlinedCss(
-				Math.round(headlineSizes.xxsmall * lineHeights.tight),
-				Math.round(headlineSizes.xxxsmall * lineHeights.tight),
-			);
+			return screenSizedUnderlinedCss(25, 22);
 		case 'small':
-			return generateUnderlinedCss(
-				Math.round(headlineSizes.xxxsmall * lineHeights.tight),
-			);
+			return generateUnderlinedCss(22);
 		case 'tiny':
-			return generateUnderlinedCss(Math.round(14 * lineHeights.tight));
+			return generateUnderlinedCss(24);
 	}
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -116,20 +116,20 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 	switch (size) {
 		case 'large':
 			return screenSizedUnderlinedCss(
-				headlineSizes.xsmall * lineHeights.tight,
-				headlineSizes.xxsmall * lineHeights.tight,
+				Math.round(headlineSizes.xsmall * lineHeights.tight),
+				Math.round(headlineSizes.xxsmall * lineHeights.tight),
 			);
 		case 'medium':
 			return screenSizedUnderlinedCss(
-				headlineSizes.xxsmall * lineHeights.tight,
-				headlineSizes.xxxsmall * lineHeights.tight,
+				Math.round(headlineSizes.xxsmall * lineHeights.tight),
+				Math.round(headlineSizes.xxxsmall * lineHeights.tight),
 			);
 		case 'small':
 			return generateUnderlinedCss(
-				headlineSizes.xxxsmall * lineHeights.tight,
+				Math.round(headlineSizes.xxxsmall * lineHeights.tight),
 			);
 		case 'tiny':
-			return generateUnderlinedCss(14 * lineHeights.tight);
+			return generateUnderlinedCss(Math.round(14 * lineHeights.tight));
 	}
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -1,7 +1,14 @@
 import { css } from '@emotion/react';
 
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { headline, textSans, until, space } from '@guardian/source-foundations';
+import {
+	headline,
+	textSans,
+	until,
+	space,
+	headlineSizes,
+	lineHeights,
+} from '@guardian/source-foundations';
 
 import { QuoteIcon } from './QuoteIcon';
 import { Kicker } from './Kicker';
@@ -86,22 +93,43 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 				transparent ${baseSize - 1}px,
 				${colour}
 			);
-			line-height: ${baseSize}px;
 			background-size: 1px ${baseSize}px;
 			background-origin: content-box;
 			background-clip: content-box;
 			margin-right: -5px;
 		`;
 	}
+
+	function screenSizedUnderlinedCss(
+		baseSize: number,
+		untilDesktopSize: number,
+	) {
+		return css`
+			${until.desktop} {
+				${generateUnderlinedCss(untilDesktopSize)}
+			}
+
+			${generateUnderlinedCss(baseSize)}
+		`;
+	}
+
 	switch (size) {
-		case 'small':
-			return generateUnderlinedCss(22);
-		case 'medium':
-			return generateUnderlinedCss(25);
 		case 'large':
-			return generateUnderlinedCss(29);
-		default:
-			return generateUnderlinedCss(24);
+			return screenSizedUnderlinedCss(
+				headlineSizes.xsmall * lineHeights.tight,
+				headlineSizes.xxsmall * lineHeights.tight,
+			);
+		case 'medium':
+			return screenSizedUnderlinedCss(
+				headlineSizes.xxsmall * lineHeights.tight,
+				headlineSizes.xxxsmall * lineHeights.tight,
+			);
+		case 'small':
+			return generateUnderlinedCss(
+				headlineSizes.xxxsmall * lineHeights.tight,
+			);
+		case 'tiny':
+			return generateUnderlinedCss(14 * lineHeights.tight);
 	}
 };
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -93,6 +93,7 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 				transparent ${baseSize - 1}px,
 				${colour}
 			);
+			line-height: ${baseSize}px;
 			background-size: 1px ${baseSize}px;
 			background-origin: content-box;
 			background-clip: content-box;


### PR DESCRIPTION
## What does this change?

Updates underline styles of analysis cards to have a `until.desktop` media query to set line-height. Theres another media query that is replacing the line height set by the underline CSS which causes the underlines to overlay over the text.

## Why?

Stop underlines from intersecting through text on analysis cards.
Part of #4191 

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/164747524-92b2499b-472a-45ca-81d5-e470e07588e5.png

[after]: https://user-images.githubusercontent.com/21217225/164747563-f6dbce88-e469-4f43-9f02-416997c21700.png



