### PR TITLE
Update ad slot copy

### DIFF
--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -41,9 +41,9 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 			h(
 				'div',
 				{ className: 'upgrade-banner' },
-				h('h1', null, 'Upgrade to Premium and enjoy the app ad-free.'),
+				h('h1', null, 'Support the Guardian and enjoy the app ad-free.'),
 				<ThemeProvider theme={buttonThemeBrandAlt}>
-					<Button>Upgrade to Premium</Button>
+					<Button>Support the Guardian</Button>
 				</ThemeProvider>,
 			),
 		);

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -41,7 +41,11 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 			h(
 				'div',
 				{ className: 'upgrade-banner' },
-				h('h1', null, 'Support the Guardian and enjoy the app ad-free.'),
+				h(
+					'h1',
+					null,
+					'Support the Guardian and enjoy the app ad-free.',
+				),
 				<ThemeProvider theme={buttonThemeBrandAlt}>
 					<Button>Support the Guardian</Button>
 				</ThemeProvider>,


### PR DESCRIPTION
## Why?
This PR changes the phrase "Upgrade to Premium" to "Support the Guardian" in Apps Rendering to match the ad copy of the app templates.

Relevant PR: 
- https://github.com/guardian/mobile-apps-article-templates/pull/1527