### PR TITLE
change to textSans to improve legibility

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import {
 	textSans,
-	headline,
 	sport,
 	culture,
 	lifestyle,
@@ -149,7 +148,7 @@ const textStyles = (
 	format: ArticleFormat,
 	supportsDarkMode: boolean,
 ): SerializedStyles => css`
-	${headline.xxxsmall({ fontWeight: 'regular', lineHeight: 'regular' })};
+	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
 	/* TODO update with Source value when it's added */
 	${from.desktop} {
 		font-size: 15px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Swap KeyEvents font to use Sans
## Why?
Had some comments about Headline font being hard to read at this size.
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20658471/164728967-f4c77bc5-8ef8-4d28-b901-d526696261b9.png
[after]: https://user-images.githubusercontent.com/20658471/164728500-90b5145a-fef3-4125-89d8-a7ecacfdeabb.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
