### PR TITLE
Card SubLinks

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -175,6 +175,7 @@ type Palette = {
 		lines: Colour;
 		matchTab: Colour;
 		activeMatchTab: Colour;
+		cardSupporting: Colour;
 	};
 	topBar: {
 		card: Colour;
@@ -567,6 +568,30 @@ type FEFrontPropertiesType = {
 	commercial: Record<string, unknown>;
 };
 
+type FESupportingContent = {
+	properties: {
+		href: string;
+	};
+	header?: {
+		kicker?: {
+			item: {
+				properties: {
+					kickerText: string;
+				};
+			};
+		};
+		headline: string;
+	};
+	format?: CAPIFormat;
+};
+
+type DCRSupportingContent = {
+	headline: string;
+	url: string;
+	kickerText?: string;
+	format: ArticleFormat;
+};
+
 type FEContainerType =
 	| 'dynamic/fast'
 	| 'dynamic/package'
@@ -703,7 +728,7 @@ type FEFrontCard = {
 	};
 	format?: CAPIFormat;
 	enriched?: Record<string, unknown>;
-	supportingContent?: unknown[];
+	supportingContent?: FESupportingContent[];
 	cardStyle?: {
 		type: string;
 	};
@@ -906,7 +931,7 @@ type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
 type LeftColSize = 'compact' | 'wide';
 
-type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
+type CardPercentageType = '25%' | '34%' | '50%' | '66%' | '75%' | '100%';
 
 type HeadlineLink = {
 	to: string; // the href for the anchor tag
@@ -1126,6 +1151,7 @@ interface BaseTrailType {
 interface TrailType extends BaseTrailType {
 	palette?: never;
 	format: ArticleFormat;
+	supportingContent?: DCRSupportingContent[];
 }
 
 interface CAPITrailType extends BaseTrailType {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,5 +1,18 @@
 import { decideFormat } from '../web/lib/decideFormat';
 
+const enhanceSupportingContent = (
+	supportingContent: FESupportingContent[],
+	format: ArticleFormat,
+): DCRSupportingContent[] => {
+	return supportingContent.map((subLink) => ({
+		// Some sublinks are to fronts and so don't have a `format` property
+		format: (subLink.format && decideFormat(subLink.format)) || format,
+		headline: subLink.header?.headline || '',
+		url: subLink.properties.href,
+		kickerText: subLink.header?.kicker?.item?.properties.kickerText,
+	}));
+};
+
 const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
 	collections
 		.filter(
@@ -21,6 +34,12 @@ const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
 					?.allImages[0].url,
 				kickerText:
 					faciaCard.header.kicker?.item?.properties.kickerText,
+				supportingContent: faciaCard.supportingContent
+					? enhanceSupportingContent(
+							faciaCard.supportingContent,
+							format,
+					  )
+					: undefined,
 			};
 		});
 

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -160,12 +160,10 @@ export const Card = ({
 
 	const cardPalette = decidePalette(format);
 
-	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
 	const moreThanTwoSubLinks =
 		supportingContent &&
 		supportingContent.length &&
 		supportingContent.length > 2;
-	const showFooterInColumn = isHorizontal && !moreThanTwoSubLinks;
 
 	const renderFooter = ({
 		renderAge = true,
@@ -320,12 +318,14 @@ export const Card = ({
 									</AvatarContainer>
 								</Hide>
 							)}
-							{showFooterInColumn &&
+							{/* Show the card footer in the same column as the headline content */}
+							{!moreThanTwoSubLinks &&
 								renderFooter({ forceVertical: true })}
 						</div>
 					</ContentWrapper>
 				</CardLayout>
-				{!showFooterInColumn && renderFooter({})}
+				{/* If there are more than two sublinks break footer out of the headline column into a row below */}
+				{moreThanTwoSubLinks && renderFooter({})}
 			</TopBar>
 		</CardLink>
 	);

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -161,8 +161,7 @@ export const Card = ({
 	const cardPalette = decidePalette(format);
 
 	const moreThanTwoSubLinks =
-		supportingContent &&
-		supportingContent.length &&
+		supportingContent?.length &&
 		supportingContent.length > 2;
 
 	const renderFooter = ({

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -320,9 +320,9 @@ export const Card = ({
 									</AvatarContainer>
 								</Hide>
 							)}
+							{showFooterInColumn &&
+								renderFooter({ forceVertical: true })}
 						</div>
-						{showFooterInColumn &&
-							renderFooter({ forceVertical: true })}
 					</ContentWrapper>
 				</CardLayout>
 				{!showFooterInColumn && renderFooter({})}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -160,6 +160,84 @@ export const Card = ({
 
 	const cardPalette = decidePalette(format);
 
+	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
+	const moreThanTwoSubLinks =
+		supportingContent &&
+		supportingContent.length &&
+		supportingContent.length > 2;
+	const showFooterInColumn = isHorizontal && !moreThanTwoSubLinks;
+
+	const renderFooter = ({
+		renderAge = true,
+		renderMediaMeta = true,
+		renderCommentCount = true,
+		renderCardBranding = true,
+		renderSupportingContent = true,
+		forceVertical = false,
+	}: {
+		renderAge?: boolean;
+		renderMediaMeta?: boolean;
+		renderCommentCount?: boolean;
+		renderCardBranding?: boolean;
+		renderSupportingContent?: boolean;
+		forceVertical?: boolean;
+	}) => {
+		return (
+			<CardFooter
+				format={format}
+				age={
+					renderAge && webPublicationDate ? (
+						<CardAge
+							format={format}
+							webPublicationDate={webPublicationDate}
+							showClock={showClock}
+						/>
+					) : undefined
+				}
+				mediaMeta={
+					renderMediaMeta &&
+					format.design === ArticleDesign.Media &&
+					mediaType ? (
+						<MediaMeta
+							palette={cardPalette}
+							mediaType={mediaType}
+							mediaDuration={mediaDuration}
+						/>
+					) : undefined
+				}
+				commentCount={
+					renderCommentCount &&
+					showCommentCount &&
+					longCount &&
+					shortCount ? (
+						<CardCommentCount
+							palette={cardPalette}
+							long={longCount}
+							short={shortCount}
+						/>
+					) : undefined
+				}
+				cardBranding={
+					renderCardBranding && branding ? (
+						<CardBranding branding={branding} format={format} />
+					) : undefined
+				}
+				supportingContent={
+					renderSupportingContent &&
+					supportingContent &&
+					supportingContent.length > 0 ? (
+						<SupportingContent
+							supportingContent={supportingContent}
+							imagePosition={
+								forceVertical ? 'top' : imagePosition
+							}
+						/>
+					) : undefined
+				}
+			/>
+		);
+	};
+
 	return (
 		<CardLink linkTo={linkTo} format={format} dataLinkName={dataLinkName}>
 			<TopBar palette={cardPalette}>
@@ -239,52 +317,11 @@ export const Card = ({
 								</Hide>
 							)}
 						</div>
-						{}
+						{showFooterInColumn &&
+							renderFooter({ forceVertical: true })}
 					</ContentWrapper>
 				</CardLayout>
-				<CardFooter
-					format={format}
-					age={
-						webPublicationDate ? (
-							<CardAge
-								format={format}
-								webPublicationDate={webPublicationDate}
-								showClock={showClock}
-							/>
-						) : undefined
-					}
-					mediaMeta={
-						format.design === ArticleDesign.Media && mediaType ? (
-							<MediaMeta
-								palette={cardPalette}
-								mediaType={mediaType}
-								mediaDuration={mediaDuration}
-							/>
-						) : undefined
-					}
-					commentCount={
-						showCommentCount && longCount && shortCount ? (
-							<CardCommentCount
-								palette={cardPalette}
-								long={longCount}
-								short={shortCount}
-							/>
-						) : undefined
-					}
-					cardBranding={
-						branding ? (
-							<CardBranding branding={branding} format={format} />
-						) : undefined
-					}
-					supportingContent={
-						supportingContent && supportingContent.length > 0 ? (
-							<SupportingContent
-								supportingContent={supportingContent}
-								imagePosition={imagePosition}
-							/>
-						) : undefined
-					}
-				/>
+				{!showFooterInColumn && renderFooter({})}
 			</TopBar>
 		</CardLink>
 	);

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -161,8 +161,7 @@ export const Card = ({
 	const cardPalette = decidePalette(format);
 
 	const moreThanTwoSubLinks =
-		supportingContent?.length &&
-		supportingContent.length > 2;
+		supportingContent?.length && supportingContent.length > 2;
 
 	const renderFooter = ({
 		renderAge = true,

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -81,13 +81,13 @@ const coverages: CoveragesType = {
 	image: {
 		small: '25%',
 		medium: '50%',
-		large: '67%',
+		large: '66%',
 		jumbo: '75%',
 	},
 	content: {
 		small: '75%',
 		medium: '50%',
-		large: '33%',
+		large: '34%',
 		jumbo: '25%',
 	},
 };

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -25,6 +25,7 @@ import { TopBar } from './components/TopBar';
 import { CardLink } from './components/CardLink';
 import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
+import { SupportingContent } from '../SupportingContent';
 
 export type Props = {
 	linkTo: string;
@@ -55,6 +56,7 @@ export type Props = {
 	dataLinkName?: string;
 	// Labs
 	branding?: Branding;
+	supportingContent?: DCRSupportingContent[];
 };
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
@@ -140,6 +142,7 @@ export const Card = ({
 	minWidthInPixels,
 	dataLinkName,
 	branding,
+	supportingContent,
 }: Props) => {
 	// Decide how we position the image on the card
 	let imageCoverage: CardPercentageType | undefined;
@@ -165,76 +168,48 @@ export const Card = ({
 					imagePositionOnMobile={imagePositionOnMobile}
 					minWidthInPixels={minWidthInPixels}
 				>
-					<>
-						{imageUrl && (
-							<ImageWrapper
-								percentage={imageCoverage}
-								imagePositionOnMobile={imagePositionOnMobile}
-							>
-								<img
-									src={imageUrl}
-									alt=""
-									role="presentation"
+					{imageUrl && (
+						<ImageWrapper
+							percentage={imageCoverage}
+							imagePositionOnMobile={imagePositionOnMobile}
+						>
+							<img src={imageUrl} alt="" role="presentation" />
+							<>
+								{starRating !== undefined ? (
+									<StarRatingComponent rating={starRating} />
+								) : null}
+							</>
+						</ImageWrapper>
+					)}
+					<ContentWrapper percentage={contentCoverage}>
+						<Flex>
+							<HeadlineWrapper>
+								<CardHeadline
+									headlineText={headlineText}
+									format={format}
+									size={headlineSize}
+									showQuotes={showQuotes}
+									kickerText={
+										format.design === ArticleDesign.LiveBlog
+											? 'Live'
+											: kickerText
+									}
+									showPulsingDot={
+										format.design ===
+											ArticleDesign.LiveBlog ||
+										showPulsingDot
+									}
+									showSlash={
+										format.design ===
+											ArticleDesign.LiveBlog || showSlash
+									}
+									byline={byline}
+									showByline={showByline}
 								/>
-								<>
-									{starRating !== undefined ? (
-										<StarRatingComponent
-											rating={starRating}
-										/>
-									) : null}
-								</>
-							</ImageWrapper>
-						)}
-						<ContentWrapper percentage={contentCoverage}>
-							<Flex>
-								<HeadlineWrapper>
-									<CardHeadline
-										headlineText={headlineText}
-										format={format}
-										size={headlineSize}
-										showQuotes={showQuotes}
-										kickerText={
-											format.design ===
-											ArticleDesign.LiveBlog
-												? 'Live'
-												: kickerText
-										}
-										showPulsingDot={
-											format.design ===
-												ArticleDesign.LiveBlog ||
-											showPulsingDot
-										}
-										showSlash={
-											format.design ===
-												ArticleDesign.LiveBlog ||
-											showSlash
-										}
-										byline={byline}
-										showByline={showByline}
-									/>
-								</HeadlineWrapper>
-								<>
-									{avatar && (
-										<Hide when="above" breakpoint="tablet">
-											<AvatarContainer>
-												<Avatar
-													imageSrc={avatar.src}
-													imageAlt={avatar.alt}
-													palette={cardPalette}
-												/>
-											</AvatarContainer>
-										</Hide>
-									)}
-								</>
-							</Flex>
-							<div>
-								{standfirst && (
-									<StandfirstWrapper palette={cardPalette}>
-										{standfirst}
-									</StandfirstWrapper>
-								)}
+							</HeadlineWrapper>
+							<>
 								{avatar && (
-									<Hide when="below" breakpoint="tablet">
+									<Hide when="above" breakpoint="tablet">
 										<AvatarContainer>
 											<Avatar
 												imageSrc={avatar.src}
@@ -244,53 +219,72 @@ export const Card = ({
 										</AvatarContainer>
 									</Hide>
 								)}
-								<CardFooter
-									format={format}
-									age={
-										webPublicationDate ? (
-											<CardAge
-												format={format}
-												webPublicationDate={
-													webPublicationDate
-												}
-												showClock={showClock}
-											/>
-										) : undefined
-									}
-									mediaMeta={
-										format.design === ArticleDesign.Media &&
-										mediaType ? (
-											<MediaMeta
-												palette={cardPalette}
-												mediaType={mediaType}
-												mediaDuration={mediaDuration}
-											/>
-										) : undefined
-									}
-									commentCount={
-										showCommentCount &&
-										longCount &&
-										shortCount ? (
-											<CardCommentCount
-												palette={cardPalette}
-												long={longCount}
-												short={shortCount}
-											/>
-										) : undefined
-									}
-									cardBranding={
-										branding ? (
-											<CardBranding
-												branding={branding}
-												format={format}
-											/>
-										) : undefined
-									}
-								/>
-							</div>
-						</ContentWrapper>
-					</>
+							</>
+						</Flex>
+						<div>
+							{standfirst && (
+								<StandfirstWrapper palette={cardPalette}>
+									{standfirst}
+								</StandfirstWrapper>
+							)}
+							{avatar && (
+								<Hide when="below" breakpoint="tablet">
+									<AvatarContainer>
+										<Avatar
+											imageSrc={avatar.src}
+											imageAlt={avatar.alt}
+											palette={cardPalette}
+										/>
+									</AvatarContainer>
+								</Hide>
+							)}
+						</div>
+						{}
+					</ContentWrapper>
 				</CardLayout>
+				<CardFooter
+					format={format}
+					age={
+						webPublicationDate ? (
+							<CardAge
+								format={format}
+								webPublicationDate={webPublicationDate}
+								showClock={showClock}
+							/>
+						) : undefined
+					}
+					mediaMeta={
+						format.design === ArticleDesign.Media && mediaType ? (
+							<MediaMeta
+								palette={cardPalette}
+								mediaType={mediaType}
+								mediaDuration={mediaDuration}
+							/>
+						) : undefined
+					}
+					commentCount={
+						showCommentCount && longCount && shortCount ? (
+							<CardCommentCount
+								palette={cardPalette}
+								long={longCount}
+								short={shortCount}
+							/>
+						) : undefined
+					}
+					cardBranding={
+						branding ? (
+							<CardBranding branding={branding} format={format} />
+						) : undefined
+					}
+					supportingContent={
+						supportingContent && supportingContent.length > 0 ? (
+							<SupportingContent
+								supportingContent={supportingContent}
+								imagePosition={imagePosition}
+							/>
+						) : undefined
+					}
+				/>
 			</TopBar>
 		</CardLink>
 	);

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -9,6 +9,7 @@ type Props = {
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
+	supportingContent?: JSX.Element;
 };
 
 const spaceBetween = css`
@@ -35,6 +36,7 @@ export const CardFooter = ({
 	mediaMeta,
 	commentCount,
 	cardBranding,
+	supportingContent,
 }: Props) => {
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer>{cardBranding}</footer>;
@@ -46,38 +48,50 @@ export const CardFooter = ({
 		format.design === ArticleDesign.Letter
 	) {
 		return (
-			<footer css={spaceBetween}>
-				{age}
-				<div css={linesWrapperStyles}>
-					<Lines count={4} />
+			<footer>
+				<div>{supportingContent}</div>
+				<div css={spaceBetween}>
+					{age}
+					<div css={linesWrapperStyles}>
+						<Lines count={4} />
+					</div>
+					{commentCount}
 				</div>
-				{commentCount}
 			</footer>
 		);
 	}
 
 	if (format.design === ArticleDesign.Media) {
 		return (
-			<footer css={spaceBetween}>
-				{mediaMeta}
-				{/* Show age if we have it otherwise try for commentCount */}
-				{age || commentCount}
+			<footer>
+				<div>{supportingContent}</div>
+				<div css={spaceBetween}>
+					{mediaMeta}
+					{/* Show age if we have it otherwise try for commentCount */}
+					{age || commentCount}
+				</div>
 			</footer>
 		);
 	}
 
 	if (age) {
 		return (
-			<footer css={spaceBetween}>
-				{age}
-				{commentCount}
+			<footer>
+				<div>{supportingContent}</div>
+				<div css={spaceBetween}>
+					{age}
+					{commentCount}
+				</div>
 			</footer>
 		);
 	}
 
 	return (
-		<footer css={flexEnd}>
-			<>{commentCount}</>
+		<footer>
+			<div>{supportingContent}</div>
+			<div css={flexEnd}>
+				<>{commentCount}</>
+			</div>
 		</footer>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLayout.tsx
@@ -58,6 +58,7 @@ export const CardLayout = ({
 		css={[
 			css`
 				display: flex;
+				flex-basis: 100%;
 			`,
 			decideWidth(minWidthInPixels),
 			decidePosition(imagePosition, imagePositionOnMobile),

--- a/dotcom-rendering/src/web/components/Card/components/TopBar.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TopBar.tsx
@@ -9,6 +9,8 @@ export const TopBar = ({ children, palette }: Props) => (
 	<div
 		css={css`
 			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
 			width: 100%;
 			/* We absolutely position the 1 pixel top bar below
                so this is required here */

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -18,6 +18,7 @@ type Props = {
 	size?: SmallHeadlineSize;
 	byline?: string;
 	showByline?: boolean;
+	showLine?: boolean; // If true a short line is displayed above, used for sublinks
 };
 
 const fontStyles = (size: SmallHeadlineSize) => {
@@ -105,6 +106,18 @@ const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
 	}
 };
 
+const lineStyles = (palette: Palette) => css`
+	:before {
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
+		content: '';
+		width: 120px;
+		border-top: 1px solid ${palette.border.cardSupporting};
+	}
+`;
+
 export const CardHeadline = ({
 	headlineText,
 	format,
@@ -115,6 +128,7 @@ export const CardHeadline = ({
 	size = 'medium',
 	byline,
 	showByline,
+	showLine,
 }: Props) => {
 	const palette = decidePalette(format);
 	return (
@@ -129,6 +143,7 @@ export const CardHeadline = ({
 							size,
 							palette.background.analysisUnderline,
 						),
+					showLine && lineStyles(palette),
 				]}
 			>
 				<span>

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -45,6 +45,7 @@ export const DynamicFast = ({ trails }: Props) => {
 						commentCount={primary.commentCount}
 						starRating={primary.starRating}
 						branding={primary.branding}
+						supportingContent={primary.supportingContent}
 					/>
 				</LI>
 				<LI
@@ -77,6 +78,7 @@ export const DynamicFast = ({ trails }: Props) => {
 						commentCount={secondary.commentCount}
 						starRating={secondary.starRating}
 						branding={secondary.branding}
+						supportingContent={secondary.supportingContent}
 					/>
 				</LI>
 			</UL>
@@ -116,6 +118,7 @@ export const DynamicFast = ({ trails }: Props) => {
 								commentCount={card.commentCount}
 								starRating={card.starRating}
 								branding={card.branding}
+								supportingContent={card.supportingContent}
 							/>
 						</LI>
 					);
@@ -164,6 +167,9 @@ export const DynamicFast = ({ trails }: Props) => {
 										commentCount={card.commentCount}
 										starRating={card.starRating}
 										branding={card.branding}
+										supportingContent={
+											card.supportingContent
+										}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/ExactlyFive.tsx
+++ b/dotcom-rendering/src/web/components/ExactlyFive.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const ExactlyFive = ({ content }: Props) => (
 	<>
 		<UL direction="row" padBottom={true}>
-			<LI padSides={true} percentage="33%">
+			<LI padSides={true} percentage="34%">
 				<Card
 					linkTo={content[0].url}
 					format={content[0].format}
@@ -44,7 +44,7 @@ export const ExactlyFive = ({ content }: Props) => (
 				padSides={true}
 				showDivider={true}
 				showTopMarginWhenStacked={true}
-				percentage="33%"
+				percentage="34%"
 			>
 				<Card
 					linkTo={content[1].url}
@@ -76,7 +76,7 @@ export const ExactlyFive = ({ content }: Props) => (
 				padSides={true}
 				showDivider={true}
 				showTopMarginWhenStacked={true}
-				percentage="33%"
+				percentage="34%"
 			>
 				<UL direction="column">
 					<LI padBottom={true} stretch={true}>

--- a/dotcom-rendering/src/web/components/FourOrLess.tsx
+++ b/dotcom-rendering/src/web/components/FourOrLess.tsx
@@ -17,7 +17,7 @@ const decidePercentage = (length: number) => {
 		case 2:
 			return '50%';
 		case 3:
-			return '33%';
+			return '34%';
 		case 4:
 		default:
 			return '25%';

--- a/dotcom-rendering/src/web/components/MoreThanFive.tsx
+++ b/dotcom-rendering/src/web/components/MoreThanFive.tsx
@@ -16,7 +16,7 @@ const decidePercentage = (length: number) => {
 		case 6:
 			return '50%';
 		case 7:
-			return '33%';
+			return '34%';
 		case 8:
 			return '25%';
 		default:

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -23,7 +23,7 @@ const basicCardProps: CardProps = {
 		theme: ArticlePillar.News,
 	},
 	headlineText: 'Headline text',
-	standfirst:
+	trailText:
 		'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
 	headlineSize: 'medium',
 	kickerText: '',

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -348,3 +348,68 @@ export const MoreThanThree = () => {
 		</div>
 	);
 };
+
+export const OneSublink = () => {
+	return (
+		<div
+			css={css`
+				width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Headline',
+						kickerText: 'Kicker',
+					},
+				]}
+				imagePosition="left"
+				trailText="When the image is positioned horizontally and there is only one sublink, it appears under the headline"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="With one link"
+			/>
+		</div>
+	);
+};
+
+export const TwoSublinks = () => {
+	return (
+		<div
+			css={css`
+				width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Headline 1',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'Headline 2',
+						kickerText: 'Kicker',
+					},
+				]}
+				imagePosition="left"
+				trailText="When there are only two sublinks they appear under the headline vertically stacked"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="With two links"
+			/>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -1,0 +1,350 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import {
+	ArticleDesign,
+	ArticlePillar,
+	ArticleDisplay,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { css } from '@emotion/react';
+import { breakpoints } from '@guardian/source-foundations';
+import { SupportingContent } from './SupportingContent';
+import { Card, Props as CardProps } from './Card/Card';
+
+export default {
+	component: SupportingContent,
+	title: 'Components/SupportingContent',
+};
+
+const basicCardProps: CardProps = {
+	linkTo: '',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+	headlineText: 'Headline text',
+	standfirst:
+		'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
+	headlineSize: 'medium',
+	kickerText: '',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/6537e163c9164d25ec6102641f6a04fa5ba76560/0_0_5472_3648/master/5472.jpg?width=1140&quality=85&s=15053eb16d6829d670fb348d8d26aabd',
+	imagePosition: 'top',
+};
+
+const aBasicLink = {
+	headline: 'Headline',
+	url: '',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+};
+
+export const Default = () => {
+	return (
+		<SupportingContent
+			supportingContent={[aBasicLink]}
+			imagePosition="top"
+		/>
+	);
+};
+
+export const WithKicker = () => {
+	return (
+		<SupportingContent
+			supportingContent={[{ ...aBasicLink, kickerText: 'Kicket text' }]}
+			imagePosition="top"
+		/>
+	);
+};
+
+export const Themes = () => {
+	return (
+		<div
+			css={css`
+				width: 300px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						kickerText: 'News',
+						format: {
+							...aBasicLink.format,
+							theme: ArticlePillar.News,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'Sport',
+						format: {
+							...aBasicLink.format,
+							theme: ArticlePillar.Sport,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'Lifestyle',
+						format: {
+							...aBasicLink.format,
+							theme: ArticlePillar.Lifestyle,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'Opinion',
+						format: {
+							...aBasicLink.format,
+							theme: ArticlePillar.Opinion,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'Culture',
+						format: {
+							...aBasicLink.format,
+							theme: ArticlePillar.Culture,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'SpecialReport',
+						format: {
+							...aBasicLink.format,
+							theme: ArticleSpecial.SpecialReport,
+						},
+					},
+					{
+						...aBasicLink,
+						kickerText: 'Labs',
+						format: {
+							...aBasicLink.format,
+							theme: ArticleSpecial.Labs,
+						},
+					},
+				]}
+				imagePosition="top"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="Different themes"
+			/>
+		</div>
+	);
+};
+
+export const Vertical = () => {
+	return (
+		<div
+			css={css`
+				width: 300px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Vertical 1',
+					},
+					{
+						...aBasicLink,
+						headline: 'Vertical 2',
+					},
+					{
+						...aBasicLink,
+						headline: 'Vertical 3',
+					},
+				]}
+				imagePosition="top"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="Vertical"
+			/>
+		</div>
+	);
+};
+
+export const Horizontal = () => {
+	return (
+		<div
+			css={css`
+				width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Horizontal 1',
+					},
+					{
+						...aBasicLink,
+						headline: 'Horizontal 2',
+					},
+					{
+						...aBasicLink,
+						headline: 'Horizontal 3',
+					},
+				]}
+				imagePosition="right"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="Horizontal"
+			/>
+		</div>
+	);
+};
+
+export const HorizontalOnMobile = () => {
+	return (
+		<div
+			css={css`
+				max-width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Horizontal 1',
+					},
+					{
+						...aBasicLink,
+						headline: 'Horizontal 2',
+					},
+					{
+						...aBasicLink,
+						headline: 'Horizontal 3',
+					},
+				]}
+				imagePosition="right"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="Horizontal"
+			/>
+		</div>
+	);
+};
+HorizontalOnMobile.story = {
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+		viewport: {
+			defaultViewport: 'mobileMedium',
+		},
+	},
+};
+
+export const LongText = () => {
+	return (
+		<div
+			css={css`
+				width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline:
+							'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
+						kickerText: 'Long',
+					},
+					{
+						...aBasicLink,
+						headline:
+							'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
+						kickerText: 'Long',
+					},
+					{
+						...aBasicLink,
+						headline:
+							'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
+						kickerText: 'Long',
+					},
+				]}
+				imagePosition="left"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="Very long sublinks"
+			/>
+		</div>
+	);
+};
+
+export const MoreThanThree = () => {
+	return (
+		<div
+			css={css`
+				width: 700px;
+			`}
+		>
+			<Card
+				{...basicCardProps}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'Lots of links',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'Lots of links',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'Lots of links',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'Lots of links',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'Lots of links',
+						kickerText: 'Kicker',
+					},
+				]}
+				imagePosition="left"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+				linkTo=""
+				headlineText="With five links"
+			/>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,0 +1,100 @@
+import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
+import { from, until } from '@guardian/source-foundations';
+import { CardHeadline } from './CardHeadline';
+
+type Props = {
+	supportingContent: DCRSupportingContent[];
+	imagePosition: ImagePositionType;
+};
+
+const wrapperStyles = css`
+	position: relative;
+	display: flex;
+	margin-left: 5px;
+	margin-right: 5px;
+`;
+
+const directionStyles = (imagePosition: ImagePositionType) => {
+	switch (imagePosition) {
+		case 'left':
+		case 'right':
+			return css`
+				flex-direction: column;
+				${from.phablet} {
+					flex-direction: row;
+				}
+			`;
+		case 'top':
+		case 'bottom':
+			return css`
+				flex-direction: column;
+			`;
+	}
+};
+
+const liStyles = css`
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	padding-top: 2px;
+	position: relative;
+	margin-top: 8px;
+	${from.phablet} {
+		margin-bottom: 4px;
+	}
+`;
+
+const leftMargin = css`
+	${from.desktop} {
+		margin-left: 10px;
+	}
+`;
+
+const bottomMargin = css`
+	${until.phablet} {
+		margin-bottom: 8px;
+	}
+`;
+
+export const SupportingContent = ({
+	supportingContent,
+	imagePosition,
+}: Props) => {
+	return (
+		<ul css={[wrapperStyles, directionStyles(imagePosition)]}>
+			{supportingContent.map((subLink: DCRSupportingContent, index) => {
+				// The model has this property as optional but it is very likely
+				// to exist
+				if (!subLink.headline) return <></>;
+				// The kicker defaults to 'Live' when the article is a liveblog
+				const kickerText =
+					subLink.format.design === ArticleDesign.LiveBlog
+						? 'Live'
+						: subLink.kickerText;
+				const shouldPadLeft =
+					index > 0 &&
+					(imagePosition === 'left' || imagePosition === 'right');
+				return (
+					<li
+						css={[
+							liStyles,
+							shouldPadLeft && leftMargin,
+							index === supportingContent.length - 1 &&
+								bottomMargin,
+						]}
+					>
+						<CardHeadline
+							headlineText={subLink.headline}
+							kickerText={kickerText}
+							format={subLink.format}
+							size="tiny"
+							showSlash={false}
+							showLine={true}
+						/>
+					</li>
+				);
+			})}
+		</ul>
+	);
+};

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -838,6 +838,59 @@ const activeMatchTab = (): string => {
 	return sport[300];
 };
 
+const borderCardSupporting = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return opinion[550];
+				default:
+					return neutral[46];
+			}
+		case ArticleDesign.LiveBlog:
+			switch (format.theme) {
+				case ArticlePillar.News:
+					return news[600];
+				case ArticlePillar.Sport:
+					return sport[600];
+				case ArticlePillar.Opinion:
+					return WHITE;
+				case ArticlePillar.Culture:
+					return culture[600];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
+				case ArticleSpecial.SpecialReport:
+					return brandAlt[400];
+				case ArticleSpecial.Labs:
+				default:
+					return BLACK;
+			}
+		case ArticleDesign.Media:
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return brandAlt[400];
+				case ArticlePillar.News:
+					return news[600];
+				case ArticlePillar.Sport:
+					return sport[600];
+				case ArticlePillar.Opinion:
+					return opinion[550];
+				case ArticlePillar.Lifestyle:
+				case ArticlePillar.Culture:
+				default:
+					return pillarPalette[format.theme][500];
+			}
+		default:
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return brandAltBackground.primary;
+				default:
+					return neutral[86];
+			}
+	}
+};
+
 const backgroundMatchNav = (): string => {
 	return '#FFE500';
 };
@@ -1156,6 +1209,7 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			lines: borderLines(format),
 			matchTab: matchTab(),
 			activeMatchTab: activeMatchTab(),
+			cardSupporting: borderCardSupporting(format),
 		},
 		topBar: {
 			card: topBarCard(format),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,7 +4605,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^7.28.1", "@testing-library/dom@^7.31.2":
+"@testing-library/dom@^7.28.1":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
   integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
@@ -4618,6 +4618,20 @@
     dom-accessibility-api "^0.5.6"
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
+
+"@testing-library/dom@^8.13.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
 
 "@testing-library/react@^11.2.6":
   version "11.2.7"
@@ -5362,12 +5376,12 @@
   resolved "https://registry.yarnpkg.com/@types/youtube/-/youtube-0.0.46.tgz#925afdf741f35279114da7c58c98013868a949f5"
   integrity sha512-Yf1Y4bDj/QIn8v+zdy0l7+OW6s1uoUvzVn5cGqPNCsL4iUW4gYUlIdQIRtH9NOHVgwZNLbVeeRDEn6N4RMq6Nw==
 
-"@typescript-eslint/eslint-plugin-tslint@^4.22.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-4.33.0.tgz#c0f2a5a8a53a915d6c24983888013b7e78e75b44"
-  integrity sha512-o3ujMErtZJPgiNRETRJefo1bFNrloocOa5dMU49OW/G+Rq92IbXTY6FSF5MOwrdQK1X+VBEcA8y6PhUPWGlYqA==
+"@typescript-eslint/eslint-plugin-tslint@^5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-5.20.0.tgz#a9c27efaa024674ad527fa1bbf376b9c255e5be7"
+  integrity sha512-lfp0bUbAnqPHNc0bKvdQ/lo1KAuz590h9yH7FuplaYypvBGuqSJrWm6FDm2aOX8fj4WaztJi4fiikKnbpwoNCw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/utils" "5.20.0"
     lodash "^4.17.21"
 
 "@typescript-eslint/eslint-plugin@5.9.1":
@@ -5473,6 +5487,14 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz#79c7fb8598d2942e45b3c881ced95319818c7980"
+  integrity sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==
+  dependencies:
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
+
 "@typescript-eslint/scope-manager@5.9.1":
   version "5.9.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz#6c27be89f1a9409f284d95dfa08ee3400166fe69"
@@ -5499,6 +5521,11 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.20.0.tgz#fa39c3c2aa786568302318f1cb51fcf64258c20c"
+  integrity sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==
 
 "@typescript-eslint/types@5.9.1":
   version "5.9.1"
@@ -5532,6 +5559,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz#ab73686ab18c8781bbf249c9459a55dc9417d6b0"
+  integrity sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==
+  dependencies:
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/typescript-estree@5.9.1":
   version "5.9.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz#d5b996f49476495070d2b8dd354861cf33c005d6"
@@ -5544,6 +5584,18 @@
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.20.0.tgz#b8e959ed11eca1b2d5414e12417fd94cae3517a5"
+  integrity sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.20.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/typescript-estree" "5.20.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/visitor-keys@3.10.1":
   version "3.10.1"
@@ -5559,6 +5611,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz#70236b5c6b67fbaf8b2f58bf3414b76c1e826c2a"
+  integrity sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==
+  dependencies:
+    "@typescript-eslint/types" "5.20.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@typescript-eslint/visitor-keys@5.9.1":
   version "5.9.1"
@@ -6237,6 +6297,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -8931,6 +8996,11 @@ dom-accessibility-api@^0.5.6:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
   integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
+  integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -16391,7 +16461,7 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.5.1:
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds support for sublinks in cards

<img width="704" alt="Screenshot 2022-04-25 at 10 00 12" src="https://user-images.githubusercontent.com/1336821/165056498-80e28e04-6185-4b45-8d5f-c41dc2258c3c.png">
<img width="493" alt="Screenshot 2022-04-25 at 10 00 36" src="https://user-images.githubusercontent.com/1336821/165056504-fb91991a-a6ce-4111-bf55-3d788512a048.png">

### Still pending
The styling for sublinks needs to vary based on the format of the _container_ that they exist in

Here we see links to standard news articles looking broken because they exist in a card with the `LiveBlog` format
<img width="704" alt="Screenshot 2022-04-25 at 09 59 48" src="https://user-images.githubusercontent.com/1336821/165056709-71a2292c-60e0-4216-b272-b5d92cc8c827.png">

Here we see a link to a liveblog looking broken because the container is standard
<img width="704" alt="Screenshot 2022-04-25 at 09 59 32" src="https://user-images.githubusercontent.com/1336821/165056720-72d1e17b-08cd-46f1-a3bf-4d9c3a289565.png">

The work to vary styles based on container type / palette is pending and will be completed in a different PR

### `66/34` vs. `67/33`
I've slightly adjusted the positioning of content when a card is horizontal by changing the percentages used by one point. I did this because, 1) this aligns us with Frontend and 2) this means the sublinks will vertically align with the image now
<img width="700" alt="Screenshot 2022-04-25 at 10 07 26" src="https://user-images.githubusercontent.com/1336821/165058037-2a9a5d1b-9928-4403-94a5-189faf6d40cc.png">

