### PR TITLE
refactor(Lines): use new SVG lines

### DIFF
--- a/apps-rendering/src/components/editions/lines.tsx
+++ b/apps-rendering/src/components/editions/lines.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { FC } from 'react';
 import { borderWidthStyles } from './styles';
 
@@ -19,7 +19,7 @@ interface Props {
 
 const EditionsLines: FC<Props> = ({ className }) => (
 	<div css={[styles, className]}>
-		<Lines />
+		<StraightLines />
 	</div>
 );
 

--- a/apps-rendering/src/components/layout/comment.tsx
+++ b/apps-rendering/src/components/layout/comment.tsx
@@ -9,7 +9,7 @@ import {
 	opinion,
 	remSpace,
 } from '@guardian/source-foundations';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import ArticleBody from 'components/articleBody';
 import Byline from 'components/byline';
 import Cutout from 'components/cutout';
@@ -89,7 +89,7 @@ const Comment: FC<Props> = ({ item, children }) => (
 					format={item}
 				/>
 				<div css={[commentLineStylePosition, lineStyles]}>
-					<Lines count={8} />
+					<StraightLines count={8} />
 				</div>
 
 				<div css={articleWidthStyles}>

--- a/apps-rendering/src/components/layout/comment.tsx
+++ b/apps-rendering/src/components/layout/comment.tsx
@@ -88,10 +88,10 @@ const Comment: FC<Props> = ({ item, children }) => (
 					className={articleWidthStyles}
 					format={item}
 				/>
-				<div css={[commentLineStylePosition, lineStyles]}>
-					<StraightLines count={8} />
-				</div>
-
+				<StraightLines
+					cssOverrides={[commentLineStylePosition, lineStyles]}
+					count={8}
+				/>
 				<div css={articleWidthStyles}>
 					<Standfirst item={item} />
 				</div>

--- a/apps-rendering/src/components/layout/interactiveimmersive.tsx
+++ b/apps-rendering/src/components/layout/interactiveimmersive.tsx
@@ -81,9 +81,7 @@ const InteractiveImmersive: FC<Props> = ({ item, children }) => {
 						<Standfirst item={item} />
 						<ImmersiveCaption item={item} />
 					</div>
-					<div css={lineStyles}>
-						<StraightLines count={4} />
-					</div>
+						<StraightLines count={4} cssOverrides={lineStyles} />
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						<Logo item={item} />

--- a/apps-rendering/src/components/layout/interactiveimmersive.tsx
+++ b/apps-rendering/src/components/layout/interactiveimmersive.tsx
@@ -81,7 +81,7 @@ const InteractiveImmersive: FC<Props> = ({ item, children }) => {
 						<Standfirst item={item} />
 						<ImmersiveCaption item={item} />
 					</div>
-						<StraightLines count={4} cssOverrides={lineStyles} />
+					<StraightLines count={4} cssOverrides={lineStyles} />
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						<Logo item={item} />

--- a/apps-rendering/src/components/layout/interactiveimmersive.tsx
+++ b/apps-rendering/src/components/layout/interactiveimmersive.tsx
@@ -7,7 +7,7 @@ import {
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import Body from 'components/articleBody';
 import Epic from 'components/epic';
 import Footer from 'components/footer';
@@ -82,7 +82,7 @@ const InteractiveImmersive: FC<Props> = ({ item, children }) => {
 						<ImmersiveCaption item={item} />
 					</div>
 					<div css={lineStyles}>
-						<Lines count={4} />
+						<StraightLines count={4} />
 					</div>
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />

--- a/apps-rendering/src/components/layout/labs.tsx
+++ b/apps-rendering/src/components/layout/labs.tsx
@@ -7,7 +7,7 @@ import {
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { map, withDefault } from '@guardian/types';
 import Body from 'components/articleBody';
 import Footer from 'components/footer';
@@ -73,7 +73,7 @@ const Labs: FC<Props> = ({ item, children }) => {
 						</div>
 					</div>
 					<div css={lineStyles}>
-						<Lines count={4} />
+						<StraightLines count={4} />
 					</div>
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />

--- a/apps-rendering/src/components/layout/labs.tsx
+++ b/apps-rendering/src/components/layout/labs.tsx
@@ -7,7 +7,7 @@ import {
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { DottedLines } from '@guardian/source-react-components-development-kitchen';
 import { map, withDefault } from '@guardian/types';
 import Body from 'components/articleBody';
 import Footer from 'components/footer';
@@ -72,9 +72,7 @@ const Labs: FC<Props> = ({ item, children }) => {
 							<Standfirst item={item} />
 						</div>
 					</div>
-					<div css={lineStyles}>
-						<StraightLines count={4} />
-					</div>
+					<DottedLines count={1} cssOverrides={lineStyles} />
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						{pipe(

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -1,13 +1,19 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import {
 	background,
 	breakpoints,
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { DottedLines, SquigglyLines, StraightLines } from '@guardian/source-react-components-development-kitchen';
+import {
+	DottedLines,
+	SquigglyLines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { map, none, withDefault } from '@guardian/types';
 import Body from 'components/articleBody';
 import Epic from 'components/epic';
@@ -21,8 +27,9 @@ import RelatedContent from 'components/relatedContent';
 import Series from 'components/series';
 import Standfirst from 'components/standfirst';
 import Tags from 'components/tags';
-import { getFormat, Item } from 'item';
+import { getFormat } from 'item';
 import type {
+	Item,
 	MatchReport as MatchReportItem,
 	Review as ReviewItem,
 	Standard as StandardItem,
@@ -37,7 +44,6 @@ import {
 	onwardStyles,
 } from 'styles';
 import { themeToPillarString } from 'themeStyles';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 
 // ----- Styles ----- //
 
@@ -59,7 +65,10 @@ const BorderStyles = css`
 	}
 `;
 
-const decideLines = (item: Item, cssOverrides?: SerializedStyles | SerializedStyles[]): JSX.Element => {
+const decideLines = (
+	item: Item,
+	cssOverrides?: SerializedStyles | SerializedStyles[],
+): JSX.Element => {
 	const count = item.design === ArticleDesign.Comment ? 8 : 4;
 
 	if (item.theme === ArticlePillar.Sport) {

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -7,7 +7,7 @@ import {
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { map, none, withDefault } from '@guardian/types';
 import Body from 'components/articleBody';
 import Epic from 'components/epic';
@@ -115,7 +115,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 						<ImmersiveCaption item={item} />
 					</div>
 					<div css={lineStyles}>
-						<Lines count={4} />
+						<StraightLines count={4} />
 					</div>
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />

--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -1,13 +1,13 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import {
 	background,
 	breakpoints,
 	from,
 	neutral,
 } from '@guardian/source-foundations';
-import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { DottedLines, SquigglyLines, StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { map, none, withDefault } from '@guardian/types';
 import Body from 'components/articleBody';
 import Epic from 'components/epic';
@@ -21,7 +21,7 @@ import RelatedContent from 'components/relatedContent';
 import Series from 'components/series';
 import Standfirst from 'components/standfirst';
 import Tags from 'components/tags';
-import { getFormat } from 'item';
+import { getFormat, Item } from 'item';
 import type {
 	MatchReport as MatchReportItem,
 	Review as ReviewItem,
@@ -37,6 +37,7 @@ import {
 	onwardStyles,
 } from 'styles';
 import { themeToPillarString } from 'themeStyles';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 
 // ----- Styles ----- //
 
@@ -57,6 +58,22 @@ const BorderStyles = css`
 		margin: 0 auto;
 	}
 `;
+
+const decideLines = (item: Item, cssOverrides?: SerializedStyles | SerializedStyles[]): JSX.Element => {
+	const count = item.design === ArticleDesign.Comment ? 8 : 4;
+
+	if (item.theme === ArticlePillar.Sport) {
+		return <DottedLines cssOverrides={cssOverrides} count={count} />;
+	}
+
+	switch (item.design) {
+		case ArticleDesign.Feature:
+		case ArticleDesign.Recipe:
+			return <SquigglyLines cssOverrides={cssOverrides} count={count} />;
+		default:
+			return <StraightLines cssOverrides={cssOverrides} count={count} />;
+	}
+};
 
 interface Props {
 	item: StandardItem | ReviewItem | MatchReportItem;
@@ -114,9 +131,7 @@ const Standard: FC<Props> = ({ item, children }) => {
 						<Standfirst item={item} />
 						<ImmersiveCaption item={item} />
 					</div>
-					<div css={lineStyles}>
-						<StraightLines count={4} />
-					</div>
+					{decideLines(item, lineStyles)}
 					<section css={articleWidthStyles}>
 						<Metadata item={item} />
 						<Logo item={item} />

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -13,7 +13,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import {
-	Lines,
+	StraightLines,
 	ToggleSwitch,
 } from '@guardian/source-react-components-development-kitchen';
 import Avatar from 'components/avatar';
@@ -185,7 +185,7 @@ const tempraryBackgroundStyle = (format: ArticleFormat): SerializedStyles => {
 
 const BlogLines: FC<Item> = (item: Item) => (
 	<>
-		<Lines
+		<StraightLines
 			color={
 				isLive(item.design)
 					? 'rgba(255, 255, 255, 0.4)'
@@ -193,8 +193,8 @@ const BlogLines: FC<Item> = (item: Item) => (
 			}
 			cssOverrides={linesStyles}
 		/>
-		<Lines color={neutral[86]} cssOverrides={linesDesktopStyles} />
-		<Lines
+		<StraightLines color={neutral[86]} cssOverrides={linesDesktopStyles} />
+		<StraightLines
 			color={
 				isLive(item.design) ? neutral[20] : 'rgba(237, 237, 237, 0.4)'
 			}

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -86,22 +86,23 @@ export const liveblogWidthStyles: SerializedStyles = css`
 `;
 
 export const lineStyles = css`
+	display: block;
+
 	${from.wide} {
 		width: ${wideContentWidth}px;
 		margin-left: auto;
 		margin-right: auto;
 	}
-	div {
-		${darkModeCss`
-        background-image: repeating-linear-gradient(
-            to bottom,
-            ${neutral[20]},
-            ${neutral[20]} 1px,
-            transparent 1px,
-            transparent 3px
-            );
+
+	${darkModeCss`
+		[stroke] {
+			stroke: ${neutral[20]}
+		}
+
+		defs pattern [fill]  {
+			fill: ${neutral[20]}
+		}
     `}
-	}
 `;
 
 export const onwardStyles: SerializedStyles = css`

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -95,11 +95,13 @@ export const lineStyles = css`
 	}
 
 	${darkModeCss`
-		[stroke] {
+		// Straight, Dashed, Squiggly
+		&[stroke], defs pattern[stroke], defs pattern g[stroke] {
 			stroke: ${neutral[20]}
 		}
 
-		defs pattern [fill]  {
+		// Dotted
+		defs pattern circle[fill]  {
 			fill: ${neutral[20]}
 		}
     `}

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -97,12 +97,12 @@ export const lineStyles = css`
 	${darkModeCss`
 		// Straight, Dashed, Squiggly
 		&[stroke], defs pattern[stroke], defs pattern g[stroke] {
-			stroke: ${neutral[20]}
+			stroke: ${neutral[20]};
 		}
 
 		// Dotted
 		defs pattern circle[fill]  {
-			fill: ${neutral[20]}
+			fill: ${neutral[20]};
 		}
     `}
 `;

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -84,6 +84,8 @@ const metaFlex = css`
 `;
 
 const stretchLines = css`
+	display: block;
+
 	${until.phablet} {
 		margin-left: -20px;
 		margin-right: -20px;
@@ -350,8 +352,12 @@ export const ArticleMeta = ({
 					</Island>
 				)}
 				{format.theme === ArticleSpecial.Labs ? (
-					<div css={stretchLines}>
-						<StraightLines count={1} color={border.primary} />
+					<div>
+						<StraightLines
+							cssOverrides={stretchLines}
+							count={1}
+							color={border.primary}
+						/>
 						<div
 							css={css`
 								height: ${space[1]}px;

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -9,7 +9,7 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { Contributor } from './Contributor';
 import { Avatar } from './Avatar';
 import { Counts } from './Counts';
@@ -351,11 +351,7 @@ export const ArticleMeta = ({
 				)}
 				{format.theme === ArticleSpecial.Labs ? (
 					<div css={stretchLines}>
-						<Lines
-							count={1}
-							effect="straight"
-							color={border.primary}
-						/>
+						<StraightLines count={1} color={border.primary} />
 						<div
 							css={css`
 								height: ${space[1]}px;

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -25,9 +25,8 @@ const flexEnd = css`
 
 const linesWrapperStyles = css`
 	/* Fill the container */
-	flex-grow: 1;
-	/* Push the lines down to align with the bottom of the card */
-	margin-top: 5px;
+	flex: 1;
+	align-self: flex-end;
 `;
 
 export const CardFooter = ({
@@ -52,7 +51,10 @@ export const CardFooter = ({
 				<div>{supportingContent}</div>
 				<div css={spaceBetween}>
 					{age}
-					<StraightLines cssOverrides={linesWrapperStyles} count={4} />
+					<StraightLines
+						cssOverrides={linesWrapperStyles}
+						count={4}
+					/>
 					{commentCount}
 				</div>
 			</footer>

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 
 type Props = {
 	format: ArticleFormat;
@@ -52,9 +52,7 @@ export const CardFooter = ({
 				<div>{supportingContent}</div>
 				<div css={spaceBetween}>
 					{age}
-					<div css={linesWrapperStyles}>
-						<Lines count={4} />
-					</div>
+					<StraightLines cssOverrides={linesWrapperStyles} count={4} />
 					{commentCount}
 				</div>
 			</footer>

--- a/dotcom-rendering/src/web/components/GuardianLabsLines.tsx
+++ b/dotcom-rendering/src/web/components/GuardianLabsLines.tsx
@@ -1,15 +1,18 @@
 import { css } from '@emotion/react';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	DottedLines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { border, space } from '@guardian/source-foundations';
 
 export const GuardianLabsLines = () => (
 	<>
-		<Lines count={1} effect="straight" color={border.primary} />
+		<StraightLines count={1} color={border.primary} />
 		<div
 			css={css`
 				height: ${space[2]}px;
 			`}
 		/>
-		<Lines count={1} effect="dotted" color={border.primary} />
+		<DottedLines count={1} color={border.primary} />
 	</>
 );

--- a/dotcom-rendering/src/web/components/GuardianLabsLines.tsx
+++ b/dotcom-rendering/src/web/components/GuardianLabsLines.tsx
@@ -5,14 +5,18 @@ import {
 } from '@guardian/source-react-components-development-kitchen';
 import { border, space } from '@guardian/source-foundations';
 
+const block = css`
+	display: block;
+`;
+
 export const GuardianLabsLines = () => (
 	<>
-		<StraightLines count={1} color={border.primary} />
+		<StraightLines cssOverrides={block} count={1} color={border.primary} />
 		<div
 			css={css`
 				height: ${space[2]}px;
 			`}
 		/>
-		<DottedLines count={1} color={border.primary} />
+		<DottedLines cssOverrides={block} count={1} color={border.primary} />
 	</>
 );

--- a/dotcom-rendering/src/web/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import { headline } from '@guardian/source-foundations';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 
 import { useApi } from '../lib/useApi';
 import { decideTrail } from '../lib/decideTrail';
@@ -56,7 +56,7 @@ export const MostViewedRight = ({
 				css={[wrapperStyles, stickToTop && stickyStyles]}
 				data-component="geo-most-popular"
 			>
-				<Lines count={4} effect="straight" />
+				<StraightLines count={4} />
 				<h3 css={headingStyles}>Most viewed</h3>
 				<ul data-link-name="Right hand most popular geo GB">
 					{trails.map((trail, index) => (

--- a/dotcom-rendering/src/web/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.tsx
@@ -56,7 +56,12 @@ export const MostViewedRight = ({
 				css={[wrapperStyles, stickToTop && stickyStyles]}
 				data-component="geo-most-popular"
 			>
-				<StraightLines count={4} />
+				<StraightLines
+					cssOverrides={css`
+						display: block;
+					`}
+					count={4}
+				/>
 				<h3 css={headingStyles}>Most viewed</h3>
 				<ul data-link-name="Right hand most popular geo GB">
 					{trails.map((trail, index) => (

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -47,6 +47,7 @@ import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
+import { Hide } from '../components/Hide';
 
 const StandardGrid = ({
 	children,
@@ -211,6 +212,7 @@ const avatarPositionStyles = css`
 	display: flex;
 	justify-content: flex-end;
 	overflow: hidden;
+	position: relative;
 	margin-bottom: -29px;
 	margin-top: -50px;
 	pointer-events: none;
@@ -405,7 +407,12 @@ export const CommentLayout = ({
 						padded={false}
 						showTopBorder={false}
 					>
-						<StraightLines count={4} />
+						<StraightLines
+							count={4}
+							cssOverrides={css`
+								display: block;
+							`}
+						/>
 					</ElementContainer>
 				</SendToBack>
 			</div>
@@ -466,14 +473,26 @@ export const CommentLayout = ({
 												/>
 											</div>
 										)}
-										<StraightLines count={8} />
+										<StraightLines
+											count={8}
+											cssOverrides={css`
+												display: block;
+											`}
+										/>
 									</div>
 								</div>
 							</div>
 						</GridItem>
 						<GridItem area="lines">
 							<div css={pushToBottom}>
-								<StraightLines count={8} />
+								<Hide when="below" breakpoint="desktop">
+									<StraightLines
+										count={8}
+										cssOverrides={css`
+											display: block;
+										`}
+									/>
+								</Hide>
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
@@ -613,7 +632,12 @@ export const CommentLayout = ({
 											/>
 										</Island>
 									)}
-									<StraightLines count={4} />
+									<StraightLines
+										count={4}
+										cssOverrides={css`
+											display: block;
+										`}
+									/>
 									<SubMeta
 										format={format}
 										subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -11,7 +11,7 @@ import {
 import { ArticleDisplay, ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 
 import { ArticleBody } from '../components/ArticleBody';
 import { RightColumn } from '../components/RightColumn';
@@ -405,7 +405,7 @@ export const CommentLayout = ({
 						padded={false}
 						showTopBorder={false}
 					>
-						<Lines count={4} effect="straight" />
+						<StraightLines count={4} />
 					</ElementContainer>
 				</SendToBack>
 			</div>
@@ -466,14 +466,14 @@ export const CommentLayout = ({
 												/>
 											</div>
 										)}
-										<Lines count={8} effect="straight" />
+										<StraightLines count={8} />
 									</div>
 								</div>
 							</div>
 						</GridItem>
 						<GridItem area="lines">
 							<div css={pushToBottom}>
-								<Lines count={8} effect="straight" />
+								<StraightLines count={8} />
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
@@ -613,7 +613,7 @@ export const CommentLayout = ({
 											/>
 										</Island>
 									)}
-									<Lines count={4} effect="straight" />
+									<StraightLines count={4} />
 									<SubMeta
 										format={format}
 										subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -1,6 +1,6 @@
 import { brandBackground, brandLine } from '@guardian/source-foundations';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { DecideContainer } from '../lib/DecideContainer';
 
 import { SubNav } from '../components/SubNav.importable';
@@ -96,7 +96,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								padded={false}
 								showTopBorder={false}
 							>
-								<Lines count={4} effect="straight" />
+								<StraightLines count={4} />
 							</ElementContainer>
 						</>
 					)}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -1,6 +1,7 @@
 import { brandBackground, brandLine } from '@guardian/source-foundations';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { css } from '@emotion/react';
 import { DecideContainer } from '../lib/DecideContainer';
 
 import { SubNav } from '../components/SubNav.importable';
@@ -96,7 +97,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								padded={false}
 								showTopBorder={false}
 							>
-								<StraightLines count={4} />
+								<StraightLines
+									cssOverrides={css`
+										display: block;
+									`}
+									count={4}
+								/>
 							</ElementContainer>
 						</>
 					)}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -348,6 +348,9 @@ export const ImmersiveLayout = ({
 											<GuardianLabsLines />
 										) : (
 											<Lines
+												cssOverrides={css`
+													display: block;
+												`}
 												effect={decideLineEffect(
 													ArticleDesign.Standard,
 													format.theme,

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -11,7 +11,10 @@ import {
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	Lines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { ArticleBody } from '../components/ArticleBody';
 import { RightColumn } from '../components/RightColumn';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -454,7 +457,7 @@ export const ImmersiveLayout = ({
 										/>
 									</Island>
 								)}
-								<Lines count={4} effect="straight" />
+								<StraightLines count={4} />
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -408,6 +408,9 @@ export const InteractiveImmersiveLayout = ({
 											<GuardianLabsLines />
 										) : (
 											<Lines
+												cssOverrides={css`
+													display: block;
+												`}
 												effect={decideLineEffect(
 													ArticleDesign.Standard,
 													format.theme,

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -470,6 +470,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<div css={maxWidth}>
 									<div css={stretchLines}>
 										<Lines
+											cssOverrides={css`
+												display: block;
+											`}
 											count={decideLineCount(
 												format.design,
 											)}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -354,7 +354,12 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						padded={false}
 						showTopBorder={false}
 					>
-						<StraightLines count={4} />
+						<StraightLines
+							cssOverrides={css`
+								display: block;
+							`}
+							count={4}
+						/>
 					</ElementContainer>
 				)}
 			</div>
@@ -556,6 +561,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<StraightLines
 											count={4}
 											data-print-layout="hide"
+											cssOverrides={css`
+												display: block;
+											`}
 										/>
 									</div>
 									<SubMeta

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -15,7 +15,10 @@ import {
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	Lines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 
 import { StarRating } from '../components/StarRating/StarRating';
 import { ArticleBody } from '../components/ArticleBody';
@@ -351,7 +354,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						padded={false}
 						showTopBorder={false}
 					>
-						<Lines count={4} effect="straight" />
+						<StraightLines count={4} />
 					</ElementContainer>
 				)}
 			</div>
@@ -545,9 +548,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isDev={!!CAPIArticle.config.isDev}
 									/>
 
-									{/* <Lines data-print-layout="hide" count={4} /> */}
+									{/* <StraightLines data-print-layout="hide" count={4} /> */}
 									<div css={stretchMetaLines}>
-										<Lines
+										<StraightLines
 											count={4}
 											data-print-layout="hide"
 										/>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -389,7 +389,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showTopBorder={false}
 						borderColour={palette.border.article}
 					>
-						<StraightLines count={4} />
+						<StraightLines
+							count={4}
+							cssOverrides={css`
+								display: block;
+							`}
+						/>
 					</ElementContainer>
 				</SendToBack>
 			</div>
@@ -943,6 +948,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											<StraightLines
 												data-print-layout="hide"
 												count={4}
+												cssOverrides={css`
+													display: block;
+												`}
 											/>
 											<SubMeta
 												format={format}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -537,6 +537,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<Hide from="desktop">
 									<div css={sidePaddingDesktop}>
 										<Lines
+											cssOverrides={css`
+												display: block;
+											`}
 											count={decideLineCount(
 												format.design,
 											)}
@@ -647,6 +650,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<Hide until="desktop">
 									<div css={[maxWidth, sidePaddingDesktop]}>
 										<Lines
+											cssOverrides={css`
+												display: block;
+											`}
 											count={decideLineCount(
 												format.design,
 											)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -11,7 +11,10 @@ import {
 	space,
 } from '@guardian/source-foundations';
 import { ArticleDesign, ArticleFormat } from '@guardian/libs';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	Lines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { Pagination } from '@guardian/common-rendering/src/components/Pagination';
 import Accordion from '@guardian/common-rendering/src/components/accordion';
 import { Hide } from '@guardian/source-react-components';
@@ -386,7 +389,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showTopBorder={false}
 						borderColour={palette.border.article}
 					>
-						<Lines count={4} effect="straight" />
+						<StraightLines count={4} />
 					</ElementContainer>
 				</SendToBack>
 			</div>
@@ -931,10 +934,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													/>
 												</Island>
 											)}
-											<Lines
+											<StraightLines
 												data-print-layout="hide"
 												count={4}
-												effect="straight"
 											/>
 											<SubMeta
 												format={format}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -13,7 +13,10 @@ import {
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	Lines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { ArticleBody } from '../components/ArticleBody';
 import { RightColumn } from '../components/RightColumn';
 import { ArticleTitle } from '../components/ArticleTitle';
@@ -349,7 +352,7 @@ export const ShowcaseLayout = ({
 								padded={false}
 								showTopBorder={false}
 							>
-								<Lines count={4} effect="straight" />
+								<StraightLines count={4} />
 							</ElementContainer>
 						</SendToBack>
 					</div>
@@ -586,7 +589,7 @@ export const ShowcaseLayout = ({
 										/>
 									</Island>
 								)}
-								<Lines count={4} effect="straight" />
+								<StraightLines count={4} />
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -484,6 +484,9 @@ export const ShowcaseLayout = ({
 							<div css={maxWidth}>
 								<div css={stretchLines}>
 									<Lines
+										cssOverrides={css`
+											display: block;
+										`}
 										count={decideLineCount(format.design)}
 										effect={decideLineEffect(
 											format.design,

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -352,7 +352,12 @@ export const ShowcaseLayout = ({
 								padded={false}
 								showTopBorder={false}
 							>
-								<StraightLines count={4} />
+								<StraightLines
+									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
+								/>
 							</ElementContainer>
 						</SendToBack>
 					</div>
@@ -592,7 +597,12 @@ export const ShowcaseLayout = ({
 										/>
 									</Island>
 								)}
-								<StraightLines count={4} />
+								<StraightLines
+									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
+								/>
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -14,7 +14,10 @@ import {
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import {
+	Lines,
+	StraightLines,
+} from '@guardian/source-react-components-development-kitchen';
 import { StarRating } from '../components/StarRating/StarRating';
 import { ArticleBody } from '../components/ArticleBody';
 import { RightColumn } from '../components/RightColumn';
@@ -438,7 +441,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									padded={false}
 									showTopBorder={false}
 								>
-									<Lines count={4} effect="straight" />
+									<StraightLines count={4} />
 								</ElementContainer>
 							</>
 						)}
@@ -713,10 +716,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										/>
 									</Island>
 								)}
-								<Lines
+								<StraightLines
 									data-print-layout="hide"
 									count={4}
-									effect="straight"
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -441,7 +441,12 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									padded={false}
 									showTopBorder={false}
 								>
-									<StraightLines count={4} />
+									<StraightLines
+										count={4}
+										cssOverrides={css`
+											display: block;
+										`}
+									/>
 								</ElementContainer>
 							</>
 						)}
@@ -722,6 +727,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								<StraightLines
 									data-print-layout="hide"
 									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -593,6 +593,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<GuardianLabsLines />
 									) : (
 										<Lines
+											cssOverrides={css`
+												display: block;
+											`}
 											count={decideLineCount(
 												format.design,
 											)}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@guardian/eslint-plugin-source-react-components": "^4.0.2",
 		"@guardian/source-foundations": "^4.0.3",
 		"@guardian/source-react-components": "^4.0.2",
-		"@guardian/source-react-components-development-kitchen": "^0.0.33",
+		"@guardian/source-react-components-development-kitchen": "0.0.35",
 		"@storybook/addon-essentials": "^6.3.7",
 		"@storybook/addon-knobs": "^6.3.1",
 		"@storybook/builder-webpack5": "^6.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,10 +2878,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@^0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-0.0.33.tgz#d785992f833f6072072848f1d748d6f9b1e82cb7"
-  integrity sha512-/jpVvjzWxbnhf7Of7lVRv67SAa2i2bQGsvTz+JsZIjgllmZKSLfuwn8SoYzJnQIiRhJhPzRY6PZFhMhZOtcPDw==
+"@guardian/source-react-components-development-kitchen@0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-0.0.35.tgz#fe3b7f3abac0a0612618ba62647c3a739eaf3e40"
+  integrity sha512-i76aDzboAaMJLPso0+mqCrC8zvZHzEb1tOzofOUVtd0LCCc4G70KsqpVDcLOSX0dTmMD4XmEJJbrtPrqB/Va6w==
 
 "@guardian/source-react-components@^4.0.2":
   version "4.2.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bump `@guardian/source-react-components-development-kitchen` to 0.0.35 which introduces a new type of lines component, which are SVG-only.
- `StraightLines`
- `SquigglyLines`
- `DottedLines`
- `DashedLines`

As these are SVG components, some css styling needed to be adjusted so they display as `block` rather than `inline-block`.

## Why?

So we don’t have to change our CSP policy in #4519 

## Screenshots (DCR)

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

## Screenshots (AR)

| Before      | After      |
|-------------|------------|
| ![ar-before-1][] | ![ar-after-1][] |
| ![ar-before-2][] | ![ar-after-2][] |
| ![ar-before-3][] | ![ar-after-3][] |

[before]: https://user-images.githubusercontent.com/76776/165064740-fe7dc629-7726-40bc-b7d9-9e7c2a1e1a37.png
[after]: https://user-images.githubusercontent.com/76776/165075463-7252bc97-7dcd-4f5a-a921-5edd67089f7e.png
[ar-before-1]: https://user-images.githubusercontent.com/57295823/165348543-b56f2bfa-8b4c-4ae9-8677-83fa44837ea5.png
[ar-after-1]: https://user-images.githubusercontent.com/57295823/165348494-ce3a6c75-959c-4d22-986f-9f0011fbed0d.png
[ar-before-2]: https://user-images.githubusercontent.com/57295823/165348885-4083de07-300d-42c6-8e8f-ec24d3ce9473.png
[ar-after-2]: https://user-images.githubusercontent.com/57295823/165348985-db013c7a-845f-4545-8923-b82912815a73.png
[ar-before-3]: https://user-images.githubusercontent.com/57295823/165349280-a8c546d8-7d57-4a97-b216-30206167de41.png
[ar-after-3]: https://user-images.githubusercontent.com/57295823/165349353-10aeb79d-93ec-4b41-b08b-1f1cd5e98758.png





