### PR TITLE
Move `EmailEmbed` caption from underneath to above

### DIFF
--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { textSans, text } from '@guardian/source-foundations';
+import { textSans, text, space } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import { ClickToView } from './ClickToView';
 
@@ -17,6 +17,7 @@ const emailCaptionStyle = css`
 	${textSans.xxsmall()};
 	word-break: break-all;
 	color: ${text.supporting};
+	padding-bottom: ${space[1]}px;
 `;
 
 const embedContainerStyles = (isEmailEmbed: boolean) => css`
@@ -48,10 +49,10 @@ export const EmbedBlockComponent = ({
 			sourceDomain={sourceDomain}
 		>
 			<div data-cy="embed-block" css={embedContainerStyles(isEmailEmbed)}>
-				<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
 				{isEmailEmbed && caption && (
 					<div css={emailCaptionStyle}>{caption}</div>
 				)}
+				<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
 			</div>
 		</ClickToView>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves the caption shown under email embeds from below the input to above it

Fixes #4704 

## Why?
So it better describes the content being seen

| Before      | After      |
|-------------|------------|
|<img width="725" alt="Screenshot 2022-04-25 at 16 36 48" src="https://user-images.githubusercontent.com/1336821/165123478-247ed42c-000a-4f4c-b8b7-5d54fdaa72b4.png"> | <img width="725" alt="Screenshot 2022-04-25 at 16 36 08" src="https://user-images.githubusercontent.com/1336821/165123427-678a7608-8af6-4b54-bb5e-928ba8f6736e.png"> |
