### PR TITLE
Rename `Topbar` to `CardWrapper`

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -21,7 +21,7 @@ import { ImageWrapper } from './components/ImageWrapper';
 import { AvatarContainer } from './components/AvatarContainer';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
 import { CardFooter } from './components/CardFooter';
-import { TopBar } from './components/TopBar';
+import { CardWrapper } from './components/CardWrapper';
 import { CardLink } from './components/CardLink';
 import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
@@ -236,7 +236,7 @@ export const Card = ({
 
 	return (
 		<CardLink linkTo={linkTo} format={format} dataLinkName={dataLinkName}>
-			<TopBar palette={cardPalette}>
+			<CardWrapper palette={cardPalette}>
 				<CardLayout
 					imagePosition={imagePosition}
 					imagePositionOnMobile={imagePositionOnMobile}
@@ -324,7 +324,7 @@ export const Card = ({
 				</CardLayout>
 				{/* If there are more than two sublinks break footer out of the headline column into a row below */}
 				{moreThanTwoSubLinks && renderFooter({})}
-			</TopBar>
+			</CardWrapper>
 		</CardLink>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -5,7 +5,7 @@ type Props = {
 	palette: Palette;
 };
 
-export const TopBar = ({ children, palette }: Props) => (
+export const CardWrapper = ({ children, palette }: Props) => (
 	<div
 		css={css`
 			display: flex;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR renames `Topbar` to `CardWrapper`

## Why?
Because this is now, after growth and refactors, what this component actually is