### PR TITLE
Fix `o` on fronts

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -160,8 +160,9 @@ export const Card = ({
 
 	const cardPalette = decidePalette(format);
 
-	const moreThanTwoSubLinks =
-		supportingContent?.length && supportingContent.length > 2;
+	const moreThanTwoSubLinks: boolean = !!(
+		supportingContent?.length && supportingContent.length > 2
+	);
 
 	const renderFooter = ({
 		renderAge = true,

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -317,13 +317,16 @@ export const Card = ({
 								</Hide>
 							)}
 							{/* Show the card footer in the same column as the headline content */}
-							{!moreThanTwoSubLinks &&
-								renderFooter({ forceVertical: true })}
+							{!moreThanTwoSubLinks ? (
+								renderFooter({ forceVertical: true })
+							) : (
+								<></>
+							)}
 						</div>
 					</ContentWrapper>
 				</CardLayout>
 				{/* If there are more than two sublinks break footer out of the headline column into a row below */}
-				{moreThanTwoSubLinks && renderFooter({})}
+				{moreThanTwoSubLinks ? renderFooter({}) : <></>}
 			</TopBar>
 		</CardLink>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Don't try to render false

## Why?
It ends up as a zero in the html


| Before      | After      |
|-------------|------------|
| <img width="226" alt="Screenshot 2022-04-25 at 17 23 48" src="https://user-images.githubusercontent.com/1336821/165131850-2ad0827b-e354-46cb-87e4-0d6286fba21f.png"> | <img width="226" alt="Screenshot 2022-04-25 at 17 23 14" src="https://user-images.githubusercontent.com/1336821/165131773-a41c1c5b-9e41-4ae2-a88b-d911132c78b2.png">|
