### PR TITLE
Show which container types we don't support

### DIFF
--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -13,9 +13,6 @@ export const DecideContainer = ({ trails, containerType }: Props) => {
 		case 'fixed/large/slow-XIV':
 			return <FixedLargeSlowXIV trails={trails} />;
 		default:
-			// TODO: This default allows us to render fronts in-development where we might
-			// not support all the container types, but it should be removed / re-investigated
-			// before fronts are released
-			return <DynamicFast trails={trails} />;
+			return <p>{containerType} is not yet supported</p>;
 	}
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the `DynamicFast` default and replaces it with some debug text
<img width="1162" alt="Screenshot 2022-04-25 at 17 58 28" src="https://user-images.githubusercontent.com/1336821/165137587-f3d51110-1261-4172-9293-2604f24aace4.png">


## Why?
It doesn't look as exciting but it more useful for development