### PR TITLE
Only render key event toggle if some exist

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -773,21 +773,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											</Island>
 										</>
 									)}
-									<Hide below="desktop">
-										<Island deferUntil="visible">
-											<FilterKeyEventsToggle
-												filterKeyEvents={
-													CAPIArticle.filterKeyEvents
-												}
-											/>
-										</Island>
-									</Hide>
-									<Accordion
-										supportsDarkMode={false}
-										accordionTitle="Live feed"
-										context="liveFeed"
-									>
-										<Hide above="desktop">
+									{CAPIArticle.keyEvents?.length && (
+										<Hide below="desktop">
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
 													filterKeyEvents={
@@ -796,6 +783,23 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												/>
 											</Island>
 										</Hide>
+									)}
+									<Accordion
+										supportsDarkMode={false}
+										accordionTitle="Live feed"
+										context="liveFeed"
+									>
+										{CAPIArticle.keyEvents?.length && (
+											<Hide above="desktop">
+												<Island deferUntil="visible">
+													<FilterKeyEventsToggle
+														filterKeyEvents={
+															CAPIArticle.filterKeyEvents
+														}
+													/>
+												</Island>
+											</Hide>
+										)}
 										<ArticleContainer format={format}>
 											{pagination.currentPage !== 1 && (
 												<Pagination

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -773,7 +773,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											</Island>
 										</>
 									)}
-									{CAPIArticle.keyEvents?.length && (
+									{CAPIArticle.keyEvents?.length ? (
 										<Hide below="desktop">
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
@@ -783,13 +783,15 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												/>
 											</Island>
 										</Hide>
+									) : (
+										<></>
 									)}
 									<Accordion
 										supportsDarkMode={false}
 										accordionTitle="Live feed"
 										context="liveFeed"
 									>
-										{CAPIArticle.keyEvents?.length && (
+										{CAPIArticle.keyEvents?.length ? (
 											<Hide above="desktop">
 												<Island deferUntil="visible">
 													<FilterKeyEventsToggle
@@ -799,6 +801,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													/>
 												</Island>
 											</Hide>
+										) : (
+											<></>
 										)}
 										<ArticleContainer format={format}>
 											{pagination.currentPage !== 1 && (

--- a/dotcom-rendering/src/web/layouts/Liveblog.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Liveblog.stories.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+
+import { breakpoints } from '@guardian/source-foundations';
+
+import { decideFormat } from '../lib/decideFormat';
+
+import { Live } from '../../../fixtures/generated/articles/Live';
+
+import { embedIframe } from '../browser/embedIframe/embedIframe';
+import { mockRESTCalls } from '../lib/mockRESTCalls';
+import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
+
+import { extractNAV } from '../../model/extract-nav';
+import { DecideLayout } from './DecideLayout';
+import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
+
+mockRESTCalls();
+
+export default {
+	title: 'FullPage/LiveBlog',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.wide],
+			pauseAnimationAtEnd: true,
+		},
+	},
+};
+
+// HydratedLayout is used here to simulated the hydration that happens after we init react on
+// the client. We need a separate component so that we can make use of useEffect to ensure
+// the hydrate step only runs once the dom has been rendered.
+const HydratedLayout = ({
+	ServerCAPI,
+	modifyPage,
+}: {
+	ServerCAPI: CAPIArticleType;
+	modifyPage?: () => void;
+}) => {
+	const NAV = extractNAV(ServerCAPI.nav);
+	const format: ArticleFormat = decideFormat(ServerCAPI.format);
+
+	useEffect(() => {
+		embedIframe().catch((e) =>
+			console.error(`HydratedLayout embedIframe - error: ${e}`),
+		);
+		// Manually updates the footer DOM because it's not hydrated
+		injectPrivacySettingsLink();
+		doStorybookHydration();
+	}, [ServerCAPI]);
+	if (modifyPage) {
+		modifyPage();
+	}
+	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
+};
+
+export const NoKeyEvents = (): React.ReactNode => {
+	const BlogWithoutKeyEvents = {
+		...Live,
+		format: {
+			...Live.format,
+			display: 'StandardDisplay' as CAPIDisplay,
+			design: 'LiveBlogDesign' as CAPIDesign,
+		},
+		keyEvents: [],
+	};
+	return <HydratedLayout ServerCAPI={BlogWithoutKeyEvents} />;
+};

--- a/dotcom-rendering/src/web/layouts/Liveblog.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Liveblog.stories.tsx
@@ -26,9 +26,11 @@ export default {
 	},
 };
 
-// HydratedLayout is used here to simulated the hydration that happens after we init react on
-// the client. We need a separate component so that we can make use of useEffect to ensure
-// the hydrate step only runs once the dom has been rendered.
+/**
+ * HydratedLayout is used here to simulated the hydration that happens after we init react on
+ * the client. We need a separate component so that we can make use of `useEffect` to ensure
+ * the hydrate step only runs once the DOM has been rendered.
+ */
 const HydratedLayout = ({
 	ServerCAPI,
 	modifyPage,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides the key event toggle if there are no key events

This fixes #4523 

## Why?
It's pointless to show it when there are no events

| Before      | After      |
|-------------|------------|
|<img width="975" alt="Screenshot 2022-04-26 at 08 38 24" src="https://user-images.githubusercontent.com/1336821/165247522-dff04b8a-61e2-4694-9a42-a4c6b3b24406.png">|<img width="975" alt="Screenshot 2022-04-26 at 08 37 34" src="https://user-images.githubusercontent.com/1336821/165247535-fcdb211e-afb2-42ae-98e7-0ccd6b8161af.png">|


