### PR TITLE
Replace hex code with imported source-foundation code

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -366,9 +366,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
 	)
-		// TODO: Pull this in from source as opinion[550]
-		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-		return '#ff9941';
+		return opinion[550];
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -394,9 +392,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 				case ArticlePillar.Sport:
 					return sport[600];
 				case ArticlePillar.Opinion:
-					// TODO: Pull this in from source as opinion[550]
-					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-					return '#ff9941';
+					return opinion[550];
 				case ArticlePillar.Lifestyle:
 				case ArticlePillar.Culture:
 				default:
@@ -413,9 +409,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 		case ArticleDesign.Letter:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:
-					// TODO: Pull this in from souce once we see it here:
-					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-					return '#ff9941';
+					return opinion[550];
 				default:
 					return neutral[46];
 			}
@@ -446,9 +440,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 				case ArticlePillar.Sport:
 					return sport[600];
 				case ArticlePillar.Opinion:
-					// TODO: Pull this in from source as opinion[550]
-					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
-					return '#ff9941';
+					return opinion[550];
 				case ArticlePillar.Lifestyle:
 				case ArticlePillar.Culture:
 				default:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces a hard-coded hex value with a reference to a colour property defined in source-foundation. If successful there should be no visible changes to the site. Should close [#4709](https://github.com/guardian/dotcom-rendering/issues/4709).

## Why?
This will make it easier to update colours in the future.

## Screenshots

(The affected element is the colour of the `Opinion /` kicker text.)

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/37048459/165296130-d3db8898-e70a-4a91-87e5-fe1338e20479.png) | ![after](https://user-images.githubusercontent.com/37048459/165294952-6bc6b052-46aa-4fec-84e5-5f3aca61f58e.png) |