### PR TITLE
Track epic events in liveblog

### DIFF
--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -250,6 +250,7 @@ const Fetch = ({
 	}
 	log('dotcom', 'LiveBlogEpic has a module');
 
+	// Add submitComponentEvent function to props to enable Ophan tracking in the component
 	const props = {
 		...response.data.module.props,
 		submitComponentEvent,

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -15,6 +15,7 @@ import {
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
 import { useApi } from '../lib/useApi';
+import { submitComponentEvent } from '../browser/ophan/ophan';
 
 type Props = {
 	section: string;
@@ -249,12 +250,17 @@ const Fetch = ({
 	}
 	log('dotcom', 'LiveBlogEpic has a module');
 
+	const props = {
+		...response.data.module.props,
+		submitComponentEvent,
+	};
+
 	// Take any returned module and render it
 	return (
 		<Render
 			url={response.data.module.url}
 			name={response.data.module.name}
-			props={response.data.module.props}
+			props={props}
 		/>
 	);
 };


### PR DESCRIPTION
This was missed in the migration to dcr. The epic component needs a `submitComponentEvent` function in its props to support ophan tracking - https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/support/epic.ts#L100

Tested locally:
![Screen Shot 2022-04-27 at 09 53 58](https://user-images.githubusercontent.com/1513454/165480980-f62ffaba-1bf5-4d46-80f4-68f0c11af8c0.png)
