### PR TITLE
fix: resolve git.io link

### DIFF
--- a/dotcom-rendering/scripts/env/check-node.js
+++ b/dotcom-rendering/scripts/env/check-node.js
@@ -22,7 +22,9 @@ const ensure = require('./ensure');
 			);
 			if (process.env.NVM_DIR) {
 				prompt('Run `nvm install` and try again.');
-				log('See also: https://git.io/vKTnK');
+				log(
+					'See also: https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb',
+				);
 			} else {
 				prompt(
 					`NVM can make managing Node versions a lot easier:`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Resolves git.io links, which is sunset this Friday.

[github.blog/changelog/2022-04-25-git-io-deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation)