### PR TITLE
Single front door v3 updates

### DIFF
--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -14,8 +14,6 @@ import { ArticleDisplay } from '@guardian/libs';
 import { clearFix } from '../../lib/mixins';
 import { Pillars, pillarWidth, firstPillarWidth } from './Pillars';
 import { BackToTop } from './BackToTop';
-import { Island } from './Island';
-import { ReaderRevenueLinks } from './ReaderRevenueLinks.importable';
 
 // CSS vars
 const emailSignupSideMargins = 10;
@@ -135,19 +133,6 @@ const footerList = css`
 	}
 `;
 
-const readerRevenueLinks = css`
-	border-left: ${footerBorders};
-	flex: 1;
-	padding: 12px 0 0 10px;
-	margin: 0 10px 36px 0;
-	width: calc(50% - 10px);
-
-	${until.tablet} {
-		width: 50%;
-		border-top: ${footerBorders};
-	}
-`;
-
 const copyright = css`
 	${textSans.xxsmall()};
 	padding-left: 20px;
@@ -183,17 +168,7 @@ const bttPosition = css`
 	right: 20px;
 `;
 
-const FooterLinks = ({
-	pageFooter,
-	urls,
-	edition,
-	contributionsServiceUrl,
-}: {
-	pageFooter: FooterType;
-	urls: ReaderRevenueCategories;
-	edition: Edition;
-	contributionsServiceUrl: string;
-}) => {
+const FooterLinks = ({ pageFooter }: { pageFooter: FooterType }) => {
 	const linkGroups = pageFooter.footerLinks.map((linkGroup) => {
 		const linkList = linkGroup.map((l: FooterLink, index: number) => (
 			<li key={`${l.url}${index}`}>
@@ -210,27 +185,7 @@ const FooterLinks = ({
 		return <ul key={key}>{linkList}</ul>;
 	});
 
-	const rrLinks = (
-		<div css={readerRevenueLinks}>
-			<Island deferUntil="visible" clientOnly={true}>
-				<ReaderRevenueLinks
-					urls={urls}
-					edition={edition}
-					dataLinkNamePrefix="footer : "
-					inHeader={false}
-					remoteHeader={false}
-					contributionsServiceUrl={contributionsServiceUrl}
-				/>
-			</Island>
-		</div>
-	);
-
-	return (
-		<div css={footerList}>
-			{linkGroups}
-			{rrLinks}
-		</div>
-	);
+	return <div css={footerList}>{linkGroups}</div>;
 };
 
 const year = new Date().getFullYear();
@@ -239,16 +194,10 @@ export const Footer = ({
 	pillars,
 	pillar,
 	pageFooter,
-	urls,
-	edition,
-	contributionsServiceUrl,
 }: {
 	pillars: PillarType[];
 	pillar: ArticleTheme;
 	pageFooter: FooterType;
-	urls: ReaderRevenueCategories;
-	edition: Edition;
-	contributionsServiceUrl: string;
 }) => (
 	<div
 		data-print-layout="hide"
@@ -276,12 +225,7 @@ export const Footer = ({
 				height="100"
 			/>
 
-			<FooterLinks
-				pageFooter={pageFooter}
-				urls={urls}
-				edition={edition}
-				contributionsServiceUrl={contributionsServiceUrl}
-			/>
+			<FooterLinks pageFooter={pageFooter} />
 			<div css={bttPosition}>
 				<BackToTop />
 			</div>

--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -21,7 +21,6 @@ type Props = {
 	idUrl?: string;
 	mmaUrl?: string;
 	isAnniversary?: boolean; // Temporary for G200 anniversary
-	supporterCTA: string;
 	discussionApiUrl: string;
 	urls: ReaderRevenueCategories;
 	remoteHeader: boolean;
@@ -33,7 +32,6 @@ export const Header = ({
 	idUrl,
 	mmaUrl,
 	isAnniversary,
-	supporterCTA,
 	discussionApiUrl,
 	urls,
 	remoteHeader,
@@ -62,7 +60,6 @@ export const Header = ({
 		<div id="links-root">
 			<Island>
 				<Links
-					supporterCTA={supporterCTA}
 					idUrl={idUrl}
 					mmaUrl={mmaUrl}
 					discussionApiUrl={discussionApiUrl}

--- a/dotcom-rendering/src/web/components/Links.importable.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.tsx
@@ -18,7 +18,6 @@ import { useApi } from '../lib/useApi';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
-	supporterCTA: string;
 	discussionApiUrl: string;
 	idUrl?: string;
 	mmaUrl?: string;
@@ -222,7 +221,6 @@ const MyAccount = ({
 };
 
 export const Links = ({
-	supporterCTA,
 	discussionApiUrl: discussionApiUrlFromConfig,
 	idUrl: idUrlServerFromConfig,
 	mmaUrl: mmaUrlServerFromConfig,
@@ -236,13 +234,6 @@ export const Links = ({
 
 	const isServer = typeof window === 'undefined';
 
-	const showSupporterCTA =
-		!isServer &&
-		getCookie({
-			name: 'gu_hide_support_messaging',
-			shouldMemoize: true,
-		}) === 'true';
-
 	const isSignedIn =
 		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
 
@@ -251,21 +242,14 @@ export const Links = ({
 			{/* Since 'subscriptions' is only rendered on the client, rendering it within
 				a div is required to prevent DOM elements getting mis-matched during hydration  */}
 			<div css={linkWrapperStyles}>
-				{showSupporterCTA && supporterCTA !== '' && (
-					<>
-						<div css={seperatorStyles} id="supporter" />
-						<a
-							href={supporterCTA}
-							css={[
-								linkTablet({ showAtTablet: false }),
-								linkStyles,
-							]}
-							data-link-name="nav2 : supporter-cta"
-						>
-							Subscriptions
-						</a>
-					</>
-				)}
+				<div css={seperatorStyles} id="supporter" />
+				<a
+					href="https://support.theguardian.com/subscribe/weekly?INTCMP=header_supporter_cta&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_supporter_cta%22%7D"
+					css={[linkTablet({ showAtTablet: false }), linkStyles]}
+					data-link-name="nav2 : supporter-cta"
+				>
+					Print subscriptions
+				</a>
 			</div>
 
 			<div css={seperatorStyles} />

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -73,7 +73,7 @@ export const ReaderRevenueLinks: React.FC<{
 			longTitle: 'Subscribe',
 			title: 'Subscribe',
 			mobileOnly: true,
-			url: readerRevenueLinks.sideMenu.subscribe,
+			url: 'https://support.theguardian.com/subscribe/weekly?INTCMP=side_menu_support_subscribe&acquisitionData=%7B"source"%3A"GUARDIAN_WEB"%2C"componentType"%3A"ACQUISITIONS_HEADER"%2C"componentId"%3A"side_menu_support_subscribe"%7D',
 		},
 	];
 

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -340,10 +340,6 @@ export const CommentLayout = ({
 								edition={CAPIArticle.editionId}
 								idUrl={CAPIArticle.config.idUrl}
 								mmaUrl={CAPIArticle.config.mmaUrl}
-								supporterCTA={
-									CAPIArticle.nav.readerRevenueLinks.header
-										.supporter
-								}
 								discussionApiUrl={
 									CAPIArticle.config.discussionApiUrl
 								}
@@ -803,11 +799,6 @@ export const CommentLayout = ({
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -47,9 +47,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							edition={front.editionId}
 							idUrl={front.config.idUrl}
 							mmaUrl={front.config.mmaUrl}
-							supporterCTA={
-								front.nav.readerRevenueLinks.header.supporter
-							}
 							discussionApiUrl={front.config.discussionApiUrl}
 							isAnniversary={
 								front.config.switches.anniversaryHeaderSvg

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -209,10 +209,6 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props): JSX.Element => {
 							edition={CAPIArticle.editionId}
 							idUrl={CAPIArticle.config.idUrl}
 							mmaUrl={CAPIArticle.config.mmaUrl}
-							supporterCTA={
-								CAPIArticle.nav.readerRevenueLinks.header
-									.supporter
-							}
 							discussionApiUrl={
 								CAPIArticle.config.discussionApiUrl
 							}
@@ -370,11 +366,6 @@ export const FullPageInteractiveLayout = ({
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -640,11 +640,6 @@ export const ImmersiveLayout = ({
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -506,11 +506,6 @@ export const InteractiveImmersiveLayout = ({
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -285,10 +285,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								edition={CAPIArticle.editionId}
 								idUrl={CAPIArticle.config.idUrl}
 								mmaUrl={CAPIArticle.config.mmaUrl}
-								supporterCTA={
-									CAPIArticle.nav.readerRevenueLinks.header
-										.supporter
-								}
 								discussionApiUrl={
 									CAPIArticle.config.discussionApiUrl
 								}
@@ -708,11 +704,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -323,10 +323,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							edition={CAPIArticle.editionId}
 							idUrl={CAPIArticle.config.idUrl}
 							mmaUrl={CAPIArticle.config.mmaUrl}
-							supporterCTA={
-								CAPIArticle.nav.readerRevenueLinks.header
-									.supporter
-							}
 							discussionApiUrl={
 								CAPIArticle.config.discussionApiUrl
 							}
@@ -1137,11 +1133,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -281,10 +281,6 @@ export const ShowcaseLayout = ({
 									edition={CAPIArticle.editionId}
 									idUrl={CAPIArticle.config.idUrl}
 									mmaUrl={CAPIArticle.config.mmaUrl}
-									supporterCTA={
-										CAPIArticle.nav.readerRevenueLinks
-											.header.supporter
-									}
 									discussionApiUrl={
 										CAPIArticle.config.discussionApiUrl
 									}
@@ -775,11 +771,6 @@ export const ShowcaseLayout = ({
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -374,10 +374,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								edition={CAPIArticle.editionId}
 								idUrl={CAPIArticle.config.idUrl}
 								mmaUrl={CAPIArticle.config.mmaUrl}
-								supporterCTA={
-									CAPIArticle.nav.readerRevenueLinks.header
-										.supporter
-								}
 								discussionApiUrl={
 									CAPIArticle.config.discussionApiUrl
 								}
@@ -918,11 +914,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					pageFooter={CAPIArticle.pageFooter}
 					pillar={format.theme}
 					pillars={NAV.pillars}
-					urls={CAPIArticle.nav.readerRevenueLinks.header}
-					edition={CAPIArticle.editionId}
-					contributionsServiceUrl={
-						CAPIArticle.contributionsServiceUrl
-					}
 				/>
 			</ElementContainer>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Currently we only show the the "Subscriptions" link in the main navigation to supporters. For the duration of the Single Front Door AB Test we will display a "Print Subscriptions" link which isn't dependant on the user's supporter status and whether they're in the AB test. 

We will also hide the Supporter Revenue links in the footer for all users.

## Changes
- Hide Supporter Revenue links in the footer
- Update "Subscriptions" link in desktop navigation
- Update "Subscriptions" link in mobile navigation

These changes have been reproduced in frontend here: https://github.com/guardian/frontend/pull/24952

## Screenshots
| Before | After |
|-- | -- |
| <img width="587" alt="Screenshot 2022-01-14 at 13 05 20" src="https://user-images.githubusercontent.com/44685872/149520117-e69e17c8-52d4-4c1e-999d-9d5c01bde0d6.png"> | <img width="587" alt="Screenshot 2022-01-14 at 12 57 39" src="https://user-images.githubusercontent.com/44685872/149520132-d97b0290-4bfe-4b1b-bec9-ced757e17434.png"> |
| <img width="829" alt="Screenshot 2022-01-14 at 13 16 49" src="https://user-images.githubusercontent.com/44685872/149521375-474d35ab-c561-4621-baf0-c754a24a82d2.png"> | <img width="829" alt="Screenshot 2022-01-14 at 13 16 36" src="https://user-images.githubusercontent.com/44685872/149521355-525cda32-d2bc-4d3e-b1de-28680afb2ae2.png"> |

## Why
To support the new product proposition work we are going to run an ABC test to measure the effect of the current contribute/subscribe split messaging vs a single 'support the guardian' call to action. This will be done in combination with benefits messaging on the support site.
