### PR TITLE
feat: add Ophan component data to fronts

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -48,8 +48,11 @@ export const enhanceCollections = (
 	collections: FECollectionType[],
 ): DCRCollectionType[] => {
 	return collections.map((collection) => {
+		const { id, displayName, collectionType } = collection;
 		return {
-			...collection,
+			id,
+			displayName,
+			collectionType,
 			curated: enhanceCards(collection.curated),
 			backfill: enhanceCards(collection.backfill),
 			treats: enhanceCards(collection.treats),

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -27,6 +27,8 @@ type Props = {
 	stretchRight?: boolean;
 	leftColSize?: LeftColSize;
 	format?: ArticleFormat;
+	ophanComponentName?: string;
+	ophanComponentLink?: string;
 };
 
 const containerStyles = css`
@@ -113,6 +115,8 @@ export const ContainerLayout = ({
 	stretchRight = false,
 	leftColSize,
 	format,
+	ophanComponentLink,
+	ophanComponentName,
 }: Props) => (
 	<ElementContainer
 		sectionId={sectionId}
@@ -121,6 +125,9 @@ export const ContainerLayout = ({
 		padded={padSides}
 		borderColour={borderColour}
 		backgroundColour={backgroundColour}
+		element="section"
+		ophanComponentLink={ophanComponentLink}
+		ophanComponentName={ophanComponentName}
 	>
 		<Flex>
 			<LeftColumn

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -1,9 +1,8 @@
 import { ClassNames, css as emoCss } from '@emotion/react';
 
 import { border, from } from '@guardian/source-foundations';
-// @ts-ignore-start
+// @ts-ignore
 import { jsx as _jsx } from 'react/jsx-runtime';
-// @ts-ignore-end
 import { center } from '../lib/center';
 
 const padding = emoCss`
@@ -48,6 +47,8 @@ type Props = {
 		| 'section'
 		| 'footer'; // ElementContainer is generally a top-level wrapper
 	className?: string;
+	ophanComponentName?: string;
+	ophanComponentLink?: string;
 };
 
 export const ElementContainer = ({
@@ -61,6 +62,8 @@ export const ElementContainer = ({
 	children,
 	element = 'div',
 	className,
+	ophanComponentName,
+	ophanComponentLink,
 }: Props) => (
 	<ClassNames>
 		{({ css }) => {
@@ -83,6 +86,8 @@ export const ElementContainer = ({
 			// Create a react element from the tagName passed in OR
 			// default to <div>
 			return _jsx(`${element}`, {
+				'data-link-name': ophanComponentLink,
+				'data-component': ophanComponentName,
 				className: className ? `${style} ${className}` : style,
 				children: child,
 			});

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -17,6 +17,11 @@ interface Props {
 	NAV: NavType;
 }
 
+const spaces = / /g;
+/** TODO: Confirm with is a valid way to generate component IDs. */
+const ophanComponentId = (name: string) =>
+	name.toLowerCase().replace(spaces, '-');
+
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
 		config: { isPaidContent },
@@ -113,6 +118,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (trails.length === 0) return null;
 
+					const ophanName = ophanComponentId(collection.displayName);
+
 					return (
 						<ContainerLayout
 							title={collection.displayName}
@@ -123,6 +130,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							padContent={false}
 							centralBorder="partial"
 							url={collection.href}
+							// same as above re 'palette styles' for index increment
+							ophanComponentLink={`container-${
+								index + 1
+							} | ${ophanName}`}
+							ophanComponentName={`${ophanName}`}
 						>
 							<DecideContainer
 								trails={trails}


### PR DESCRIPTION
## What does this change?

Adds Ophan components data to front. These are both `data-component` and `data-link-name`.

Changes the containers tag from `div` to `section`.

See #4693 and #4664 for prior art.

## Why?

These attributes are essential to get accurate reporting in Ophan
for sections present on fronts, and tracking of clicks to sections.

Mirrors the existing setup in Frontend.

see also docs/track-user-behaviour.md

## Screenshots

<img width="969" alt="image" src="https://user-images.githubusercontent.com/76776/165510883-321f3053-79b7-4767-90cc-0041dd71b1d0.png">
