### PR TITLE
`DynamicSlow` adjustments

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -106,7 +106,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 										linkTo={card.url}
 										format={card.format}
 										headlineText={card.headline}
-										headlineSize="medium"
+										headlineSize="small"
 										byline={card.byline}
 										showByline={card.showByline}
 										showQuotes={

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -157,7 +157,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 										format={card.format}
 										trailText={card.trailText}
 										headlineText={card.headline}
-										headlineSize="small"
+										headlineSize="medium"
 										byline={card.byline}
 										showByline={card.showByline}
 										showQuotes={

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -106,6 +106,9 @@ export const DynamicSlow = ({ trails }: Props) => {
 										linkTo={card.url}
 										format={card.format}
 										headlineText={card.headline}
+										imageUrl={card.image}
+										imagePosition="left"
+										imageSize="small"
 										headlineSize="small"
 										byline={card.byline}
 										showByline={card.showByline}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adjusts the cards in `DynamicSlow` to better align with intentions

| Before      | After      |
|-------------|------------|
| <img width="951" alt="Screenshot 2022-04-27 at 12 47 31" src="https://user-images.githubusercontent.com/1336821/165511625-5b79420e-e366-4551-b422-ca1563456594.png"> | <img width="951" alt="Screenshot 2022-04-27 at 12 47 03" src="https://user-images.githubusercontent.com/1336821/165511576-8ab22d3a-abdd-48af-83fe-b7aa1ac3cf72.png"> |
