### PR TITLE
refactor: Move front containers to their own subfolder

### DIFF
--- a/dotcom-rendering/src/web/components/FrontContainer/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/DynamicFast.stories.tsx
@@ -1,12 +1,12 @@
 import { breakpoints } from '@guardian/source-foundations';
-import { ContainerLayout } from './ContainerLayout';
-import { DynamicSlow } from './DynamicSlow';
+import { ContainerLayout } from '../ContainerLayout';
+import { DynamicFast } from './DynamicFast';
 
-import { trails } from '../../../fixtures/manual/trails';
+import { trails } from '../../../../fixtures/manual/trails';
 
 export default {
-	component: DynamicSlow,
-	title: 'Components/DynamicSlow',
+	component: DynamicFast,
+	title: 'Components/DynamicFast',
 	parameters: {
 		chromatic: {
 			viewports: [
@@ -25,13 +25,13 @@ export default {
 
 export const Default = () => (
 	<ContainerLayout
-		title="DynamicSlow"
+		title="DynamicFast"
 		showTopBorder={true}
 		sideBorders={true}
 		padContent={false}
 		centralBorder="partial"
 	>
-		<DynamicSlow trails={trails} />
+		<DynamicFast trails={trails} />
 	</ContainerLayout>
 );
-Default.story = { name: 'DynamicSlow' };
+Default.story = { name: 'DynamicFast' };

--- a/dotcom-rendering/src/web/components/FrontContainer/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/DynamicFast.tsx
@@ -1,8 +1,8 @@
 import { ArticleDesign } from '@guardian/libs';
 
-import { Card } from './Card/Card';
-import { UL } from './Card/components/UL';
-import { LI } from './Card/components/LI';
+import { Card } from '../Card/Card';
+import { UL } from '../Card/components/UL';
+import { LI } from '../Card/components/LI';
 
 type Props = {
 	trails: TrailType[];

--- a/dotcom-rendering/src/web/components/FrontContainer/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/DynamicSlow.stories.tsx
@@ -1,12 +1,12 @@
 import { breakpoints } from '@guardian/source-foundations';
-import { ContainerLayout } from './ContainerLayout';
-import { FixedLargeSlowXIV } from './FixedLargeSlowXIV';
+import { ContainerLayout } from '../ContainerLayout';
+import { DynamicSlow } from './DynamicSlow';
 
-import { trails } from '../../../fixtures/manual/trails';
+import { trails } from '../../../../fixtures/manual/trails';
 
 export default {
-	component: FixedLargeSlowXIV,
-	title: 'Components/FixedLargeSlowXIV',
+	component: DynamicSlow,
+	title: 'Components/DynamicSlow',
 	parameters: {
 		chromatic: {
 			viewports: [
@@ -25,13 +25,13 @@ export default {
 
 export const Default = () => (
 	<ContainerLayout
-		title="FixedLargeSlowXIV"
+		title="DynamicSlow"
 		showTopBorder={true}
 		sideBorders={true}
 		padContent={false}
 		centralBorder="partial"
 	>
-		<FixedLargeSlowXIV trails={trails} />
+		<DynamicSlow trails={trails} />
 	</ContainerLayout>
 );
-Default.story = { name: 'FixedLargeSlowXIV' };
+Default.story = { name: 'DynamicSlow' };

--- a/dotcom-rendering/src/web/components/FrontContainer/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/DynamicSlow.tsx
@@ -1,8 +1,8 @@
 import { ArticleDesign } from '@guardian/libs';
 
-import { Card } from './Card/Card';
-import { UL } from './Card/components/UL';
-import { LI } from './Card/components/LI';
+import { Card } from '../Card/Card';
+import { UL } from '../Card/components/UL';
+import { LI } from '../Card/components/LI';
 
 type Props = {
 	trails: TrailType[];

--- a/dotcom-rendering/src/web/components/FrontContainer/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/FixedLargeSlowXIV.stories.tsx
@@ -1,12 +1,12 @@
 import { breakpoints } from '@guardian/source-foundations';
-import { ContainerLayout } from './ContainerLayout';
-import { DynamicFast } from './DynamicFast';
+import { ContainerLayout } from '../ContainerLayout';
+import { FixedLargeSlowXIV } from './FixedLargeSlowXIV';
 
-import { trails } from '../../../fixtures/manual/trails';
+import { trails } from '../../../../fixtures/manual/trails';
 
 export default {
-	component: DynamicFast,
-	title: 'Components/DynamicFast',
+	component: FixedLargeSlowXIV,
+	title: 'Components/FixedLargeSlowXIV',
 	parameters: {
 		chromatic: {
 			viewports: [
@@ -25,13 +25,13 @@ export default {
 
 export const Default = () => (
 	<ContainerLayout
-		title="DynamicFast"
+		title="FixedLargeSlowXIV"
 		showTopBorder={true}
 		sideBorders={true}
 		padContent={false}
 		centralBorder="partial"
 	>
-		<DynamicFast trails={trails} />
+		<FixedLargeSlowXIV trails={trails} />
 	</ContainerLayout>
 );
-Default.story = { name: 'DynamicFast' };
+Default.story = { name: 'FixedLargeSlowXIV' };

--- a/dotcom-rendering/src/web/components/FrontContainer/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FrontContainer/FixedLargeSlowXIV.tsx
@@ -1,8 +1,8 @@
 import { ArticleDesign } from '@guardian/libs';
 
-import { Card } from './Card/Card';
-import { UL } from './Card/components/UL';
-import { LI } from './Card/components/LI';
+import { Card } from '../Card/Card';
+import { UL } from '../Card/components/UL';
+import { LI } from '../Card/components/LI';
 
 type Props = {
 	trails: TrailType[];

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -1,6 +1,6 @@
-import { DynamicFast } from '../components/DynamicFast';
-import { DynamicSlow } from '../components/DynamicSlow';
-import { FixedLargeSlowXIV } from '../components/FixedLargeSlowXIV';
+import { DynamicFast } from '../components/FrontContainer/DynamicFast';
+import { DynamicSlow } from '../components/FrontContainer/DynamicSlow';
+import { FixedLargeSlowXIV } from '../components/FrontContainer/FixedLargeSlowXIV';
 
 type Props = {
 	trails: DCRFrontCard[];


### PR DESCRIPTION
## What does this change?

Move all front containers to a `FrontContainer` sub folder

## Why?

We're going to end up with quite a lot of different front containers, it might be helpful to group all of these in a single folder.
