### PR TITLE
Add `row-reverse` to `UL`

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/UL.tsx
@@ -4,7 +4,9 @@ import { until, from } from '@guardian/source-foundations';
 
 import { verticalDivider } from '../../../lib/verticalDivider';
 
-const ulStyles = (direction?: 'row' | 'column') => css`
+type Direction = 'row' | 'column' | 'row-reverse';
+
+const ulStyles = (direction?: Direction) => css`
 	position: relative;
 	display: flex;
 	flex-direction: ${direction};
@@ -26,7 +28,7 @@ const wrapStyles = css`
 
 type Props = {
 	children: React.ReactNode;
-	direction?: 'row' | 'column'; // Passed to flex-direction
+	direction?: Direction; // Passed to flex-direction
 	showDivider?: boolean; // If this UL is a column and not the left most column
 	padBottom?: boolean; // If this UL is a row, add spacing below
 	wrapCards?: boolean; // Used to keep cards aligned in adjacent columns

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -88,7 +88,59 @@ export const DynamicSlow = ({ trails }: Props) => {
 					/>
 				</LI>
 			</UL>
-			<UL direction="row" padBottom={true}>
+			<UL direction="row-reverse" padBottom={true}>
+				<LI percentage="50%" showTopMarginWhenStacked={true}>
+					<UL direction="row" wrapCards={true} showDivider={true}>
+						{bigCards.map((card, cardIndex) => {
+							return (
+								<LI
+									percentage="50%"
+									showDivider={cardIndex !== 0}
+									padSides={true}
+									padBottom={false}
+									padBottomOnMobile={
+										cardIndex < bigCards.length
+									}
+								>
+									<Card
+										linkTo={card.url}
+										format={card.format}
+										trailText={card.trailText}
+										headlineText={card.headline}
+										headlineSize="medium"
+										byline={card.byline}
+										showByline={card.showByline}
+										showQuotes={
+											card.format.design ===
+												ArticleDesign.Comment ||
+											card.format.design ===
+												ArticleDesign.Letter
+										}
+										webPublicationDate={
+											card.webPublicationDate
+										}
+										kickerText={card.kickerText}
+										showPulsingDot={
+											card.format.design ===
+											ArticleDesign.LiveBlog
+										}
+										showSlash={true}
+										showClock={false}
+										imageUrl={card.image}
+										mediaType={card.mediaType}
+										mediaDuration={card.mediaDuration}
+										commentCount={card.commentCount}
+										starRating={card.starRating}
+										branding={card.branding}
+										supportingContent={
+											card.supportingContent
+										}
+									/>
+								</LI>
+							);
+						})}
+					</UL>
+				</LI>
 				<LI percentage="50%" showTopMarginWhenStacked={false}>
 					<UL direction="column" wrapCards={true}>
 						{smallCards.map((card, cardIndex) => {
@@ -128,58 +180,6 @@ export const DynamicSlow = ({ trails }: Props) => {
 										}
 										showSlash={true}
 										showClock={false}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										commentCount={card.commentCount}
-										starRating={card.starRating}
-										branding={card.branding}
-										supportingContent={
-											card.supportingContent
-										}
-									/>
-								</LI>
-							);
-						})}
-					</UL>
-				</LI>
-				<LI percentage="50%" showTopMarginWhenStacked={true}>
-					<UL direction="row" wrapCards={true} showDivider={true}>
-						{bigCards.map((card, cardIndex) => {
-							return (
-								<LI
-									percentage="50%"
-									showDivider={cardIndex !== 0}
-									padSides={true}
-									padBottom={false}
-									padBottomOnMobile={
-										cardIndex < bigCards.length
-									}
-								>
-									<Card
-										linkTo={card.url}
-										format={card.format}
-										trailText={card.trailText}
-										headlineText={card.headline}
-										headlineSize="medium"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										imageUrl={card.image}
 										mediaType={card.mediaType}
 										mediaDuration={card.mediaDuration}
 										commentCount={card.commentCount}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the ability to use `row-reverse` when setting the flex direction for children

## Why?
Because the `DynamicSlow` container has this requirement to position the two large cards that sit on the right at desktop, at the top of the list when at mobile. In other words, look at where the 'Glacial rivers...' and 'UK urges...' cards sit at tablet and mobile below. This PR allows that card to move to the top of the stack when at mobile.


| Before      | After      |
|-------------|------------|
| <img width="761" alt="t-before" src="https://user-images.githubusercontent.com/1336821/165548897-56f0b08f-c3dd-4149-a94c-90eab7fb5815.png"> |<img width="761" alt="t-after" src="https://user-images.githubusercontent.com/1336821/165548960-edaea5c8-45d3-41bd-87fe-f9514aae1a3c.png"> |
| <img width="399" alt="m-before" src="https://user-images.githubusercontent.com/1336821/165548990-d4ef4d25-d821-4641-a194-316ce816cf3b.png"> | <img width="399" alt="m-after" src="https://user-images.githubusercontent.com/1336821/165549029-583c52b2-02ae-455e-a57a-e985495bfb70.png"> |
