### PR TITLE
Ad placeholder as a React component

### DIFF
--- a/apps-rendering/src/adSlot.stories.tsx
+++ b/apps-rendering/src/adSlot.stories.tsx
@@ -1,0 +1,27 @@
+// ----- Imports ----- //
+
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import AdSlot from 'adSlot';
+import type { ReactElement } from 'react';
+
+// ----- Stories ----- //
+
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+};
+
+const Default = (): ReactElement => (
+	<AdSlot className={'ad-placeholder'} paragraph={0} format={mockFormat} />
+);
+
+// ----- Exports ----- //
+
+export default {
+	component: AdSlot,
+	title: 'AR/AdSlot',
+};
+
+export { Default };

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -84,16 +84,6 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 		margin: 1em -${remSpace[3]};
 	}
 
-	// This class is applied in the nativeCommunication module
-	// to the first ad slot if Teads ads are enabled.
-	&.ad-slot-square {
-		height: 344px;
-		width: 320px;
-		margin-left: auto;
-		margin-right: auto;
-		padding-bottom: 0;
-	}
-
 	// This class is applied if the article has fewer than 15 paragraphs.
 	&.short:nth-of-type(1) {
 		${from.desktop} {
@@ -107,6 +97,16 @@ const adHeight = '258px';
 const adSlotStyles = css`
 	clear: both;
 	padding-bottom: ${adHeight};
+
+	// This class is applied in the nativeCommunication module
+	// to the first ad slot if Teads ads are enabled.
+	&.ad-slot-square {
+		height: 344px;
+		width: 320px;
+		margin-left: auto;
+		margin-right: auto;
+		padding-bottom: 0;
+	}
 `;
 
 const AdSlot: FC<Props> = ({ className, paragraph, format }): ReactElement => (

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -1,0 +1,25 @@
+import { ThemeProvider } from '@emotion/react';
+import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
+import { FC, ReactElement } from 'react';
+
+type Props = {
+	className: string;
+	paragraph: number;
+};
+
+const AdSlot: FC<Props> = ({ className, paragraph }): ReactElement => (
+	<aside className={className} key={`ad-after-${paragraph}-para`}>
+		<div className="ad-labels">
+			<h1>Advertisement</h1>
+		</div>
+		<div className="ad-slot"></div>
+		<div className="upgrade-banner">
+			<h1>Support the Guardian and enjoy the app ad-free.</h1>
+			<ThemeProvider theme={buttonThemeBrandAlt}>
+				<Button>Support the Guardian</Button>
+			</ThemeProvider>
+		</div>
+	</aside>
+);
+
+export default AdSlot;

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -27,7 +27,8 @@ const adLabelsStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.adLabel(format)};
 	padding: ${remSpace[3]};
 	float: left;
-	width: calc(100% - ${remSpace[6]});
+	// We need to account for padding on both sides
+	width: calc(100% - 2 * ${remSpace[3]});
 
 	h1 {
 		margin: 0;

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -1,19 +1,124 @@
-import { ThemeProvider } from '@emotion/react';
+import { css, SerializedStyles, ThemeProvider } from '@emotion/react';
+import {
+	background,
+	text,
+} from '@guardian/common-rendering/src/editorialPalette';
+import { ArticleFormat } from '@guardian/libs';
+import {
+	from,
+	headline,
+	remSpace,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
 import type { FC, ReactElement } from 'react';
+import { darkModeCss, wideContentWidth } from 'styles';
 
 type Props = {
 	className: string;
 	paragraph: number;
+	format: ArticleFormat;
 };
 
-const AdSlot: FC<Props> = ({ className, paragraph }): ReactElement => (
-	<aside className={className} key={`ad-after-${paragraph}-para`}>
-		<div className="ad-labels">
+const adLabelsStyles = (format: ArticleFormat): SerializedStyles => css`
+	${textSans.xsmall()}
+	color: ${text.adLabel(format)};
+	padding: ${remSpace[3]};
+	float: left;
+	width: calc(100% - ${remSpace[3]} - ${remSpace[3]});
+
+	h1 {
+		margin: 0;
+		float: left;
+		font-size: 16px;
+		font-weight: 400;
+
+		${darkModeCss`
+		color: ${text.adLabelDark(format)};
+	`}
+	}
+`;
+
+const supportBannerStyles = (format: ArticleFormat): SerializedStyles => css`
+	padding: ${remSpace[3]};
+	background-color: ${background.supportBanner(format)};
+
+	h1 {
+		${headline.xxxsmall()};
+		margin-top: 0;
+	}
+
+	button {
+		margin-top: ${remSpace[3]};
+	}
+
+	${darkModeCss`
+		background-color: ${background.supportBannerDark(format)};
+	`}
+`;
+
+const styles = (format: ArticleFormat): SerializedStyles => css`
+	clear: both;
+	margin: ${remSpace[4]} 0;
+	color: ${text.adSlot(format)};
+	background: ${background.adSlot(format)};
+
+	&.hidden {
+		display: none;
+	}
+
+	${darkModeCss`
+		background-color: ${background.adSlotDark(format)};
+	`}
+
+	${from.desktop} {
+		position: absolute;
+		margin-left: calc(${wideContentWidth}px + ${remSpace[4]});
+		min-width: 300px;
+		margin-bottom: ${remSpace[6]};
+	}
+
+	${until.phablet} {
+		margin: 1em -${remSpace[3]};
+	}
+
+	// This class is applied in the nativeCommunication module
+	// to the first ad slot if Teads ads are enabled.
+	&.ad-slot-square {
+		height: 344px;
+		width: 320px;
+		margin-left: auto;
+		margin-right: auto;
+		padding-bottom: 0;
+	}
+
+	// This class is applied if the article has fewer than 15 paragraphs.
+	&.short:nth-of-type(1) {
+		${from.desktop} {
+			top: 0;
+		}
+	}
+`;
+
+const adHeight = '258px';
+
+const adSlotStyles = css`
+	clear: both;
+	padding-bottom: ${adHeight};
+`;
+
+const AdSlot: FC<Props> = ({ className, paragraph, format }): ReactElement => (
+	<aside
+		css={styles(format)}
+		className={className}
+		key={`ad-after-${paragraph}-para`}
+	>
+		<div css={adLabelsStyles(format)} className="ad-labels">
 			<h1>Advertisement</h1>
 		</div>
-		<div className="ad-slot"></div>
-		<div className="upgrade-banner">
+		<div css={adSlotStyles} className="ad-slot"></div>
+		<div css={supportBannerStyles(format)} className="support-banner">
 			<h1>Support the Guardian and enjoy the app ad-free.</h1>
 			<ThemeProvider theme={buttonThemeBrandAlt}>
 				<Button>Support the Guardian</Button>

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -27,7 +27,7 @@ const adLabelsStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.adLabel(format)};
 	padding: ${remSpace[3]};
 	float: left;
-	width: calc(100% - ${remSpace[3]} - ${remSpace[3]});
+	width: calc(100% - ${remSpace[6]});
 
 	h1 {
 		margin: 0;

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -1,9 +1,10 @@
-import { css, SerializedStyles, ThemeProvider } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import {
 	background,
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,
 	headline,

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@emotion/react';
 import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
-import { FC, ReactElement } from 'react';
+import type { FC, ReactElement } from 'react';
 
 type Props = {
 	className: string;

--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -2,7 +2,12 @@ import { getAdPlaceholderInserter } from './ads';
 import { ReactNode } from 'react';
 import { renderAll } from 'renderer';
 import { JSDOM } from 'jsdom';
-import {ArticlePillar, ArticleFormat, ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import {
+	ArticlePillar,
+	ArticleFormat,
+	ArticleDesign,
+	ArticleDisplay,
+} from '@guardian/libs';
 import { compose } from 'lib';
 import { ElementKind, BodyElement } from 'bodyElement';
 
@@ -32,19 +37,28 @@ const renderTextElement = compose(render, textElement);
 describe('Adds the correct number of ad placeholders', () => {
 	test('Adds no placeholders for 2 paragraphs', () => {
 		const twoParagraphs = renderParagraphs(2);
-		const twoParagraphsAndNoAds = insertAdPlaceholders(twoParagraphs);
+		const twoParagraphsAndNoAds = insertAdPlaceholders(
+			twoParagraphs,
+			mockFormat,
+		);
 		expect(twoParagraphsAndNoAds.length).toBe(2);
 	});
 
 	test('Adds one placeholder for 5 paragraphs', () => {
 		const fiveParagraphs = renderParagraphs(5);
-		const fiveParagraphsAndOneAd = insertAdPlaceholders(fiveParagraphs);
+		const fiveParagraphsAndOneAd = insertAdPlaceholders(
+			fiveParagraphs,
+			mockFormat,
+		);
 		expect(fiveParagraphsAndOneAd.length).toBe(6);
 	});
 
 	test('Adds two placeholders for 9 paragraphs', () => {
 		const nineParagraphs = renderParagraphs(9);
-		const nineParagraphsAndTwoAds = insertAdPlaceholders(nineParagraphs);
+		const nineParagraphsAndTwoAds = insertAdPlaceholders(
+			nineParagraphs,
+			mockFormat,
+		);
 		expect(nineParagraphsAndTwoAds.length).toBe(11);
 	});
 
@@ -52,6 +66,7 @@ describe('Adds the correct number of ad placeholders', () => {
 		const fiftyParagraphs = renderParagraphs(50);
 		const fiftyParagraphsAndEightAds = insertAdPlaceholders(
 			fiftyParagraphs,
+			mockFormat,
 		);
 		expect(fiftyParagraphsAndEightAds.length).toBe(58);
 	});
@@ -60,13 +75,17 @@ describe('Adds the correct number of ad placeholders', () => {
 		const ninetyParagraphs = renderParagraphs(90);
 		const ninetyParagraphsAndFifteenAds = insertAdPlaceholders(
 			ninetyParagraphs,
+			mockFormat,
 		);
 		expect(ninetyParagraphsAndFifteenAds.length).toBe(105);
 	});
 
 	test('Adds fifteen placeholders for 150 paragraphs', () => {
 		const hundredFifty = renderParagraphs(150);
-		const hundredFiftyAndFifteenAds = insertAdPlaceholders(hundredFifty);
+		const hundredFiftyAndFifteenAds = insertAdPlaceholders(
+			hundredFifty,
+			mockFormat,
+		);
 		expect(hundredFiftyAndFifteenAds.length).toBe(165);
 	});
 });
@@ -76,13 +95,17 @@ describe('Adds placholders at the correct indexes', () => {
 		const fiveParagraphs = renderParagraphs(5);
 		const fiveParagraphsAndOneAd: any = insertAdPlaceholders(
 			fiveParagraphs,
+			mockFormat,
 		);
 		expect(fiveParagraphsAndOneAd[3].type).toBe('aside');
 	});
 
 	test('Adds second placeholder after 9th paragraph', () => {
 		const tenParagraphs = renderParagraphs(10);
-		const tenParagraphsAndTwoAds: any = insertAdPlaceholders(tenParagraphs);
+		const tenParagraphsAndTwoAds: any = insertAdPlaceholders(
+			tenParagraphs,
+			mockFormat,
+		);
 		expect(tenParagraphsAndTwoAds[10].type).toBe('aside');
 	});
 });
@@ -92,6 +115,7 @@ describe('Adds short classname correctly', () => {
 		const fourteenParagraphs = renderParagraphs(14);
 		const fourteenParagraphsAndTwoAds: any = insertAdPlaceholders(
 			fourteenParagraphs,
+			mockFormat,
 		);
 		expect(fourteenParagraphsAndTwoAds[3].props.className).toBe(
 			'ad-placeholder hidden short',
@@ -105,6 +129,7 @@ describe('Adds short classname correctly', () => {
 		const fifteenParagraphs = renderParagraphs(15);
 		const fifteenParagraphsAndTwoAds: any = insertAdPlaceholders(
 			fifteenParagraphs,
+			mockFormat,
 		);
 		expect(fifteenParagraphsAndTwoAds[3].props.className).toBe(
 			'ad-placeholder hidden',
@@ -126,7 +151,7 @@ describe('Handles different DOM structures', () => {
 			'<div></div>',
 		]);
 
-		const sixTagsWithNoAds = insertAdPlaceholders(text);
+		const sixTagsWithNoAds = insertAdPlaceholders(text, mockFormat);
 		expect(sixTagsWithNoAds.length).toBe(6);
 	});
 
@@ -140,7 +165,7 @@ describe('Handles different DOM structures', () => {
 			'<a href="foo"></a>',
 		]);
 
-		const sixTagsWithOneAd: any = insertAdPlaceholders(text);
+		const sixTagsWithOneAd: any = insertAdPlaceholders(text, mockFormat);
 		expect(sixTagsWithOneAd.length).toBe(7);
 		expect(
 			sixTagsWithOneAd[5].props.className ===

--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@guardian/libs';
 import { compose } from 'lib';
 import { ElementKind, BodyElement } from 'bodyElement';
+import AdSlot from 'adSlot';
 
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);
@@ -97,7 +98,7 @@ describe('Adds placholders at the correct indexes', () => {
 			fiveParagraphs,
 			mockFormat,
 		);
-		expect(fiveParagraphsAndOneAd[3].type).toBe('aside');
+		expect(fiveParagraphsAndOneAd[3].type).toBe(AdSlot);
 	});
 
 	test('Adds second placeholder after 9th paragraph', () => {
@@ -106,7 +107,8 @@ describe('Adds placholders at the correct indexes', () => {
 			tenParagraphs,
 			mockFormat,
 		);
-		expect(tenParagraphsAndTwoAds[10].type).toBe('aside');
+		console.log(JSON.stringify(tenParagraphsAndTwoAds[10]));
+		expect(tenParagraphsAndTwoAds[10].type).toBe(AdSlot);
 	});
 });
 

--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -107,7 +107,6 @@ describe('Adds placholders at the correct indexes', () => {
 			tenParagraphs,
 			mockFormat,
 		);
-		console.log(JSON.stringify(tenParagraphsAndTwoAds[10]));
 		expect(tenParagraphsAndTwoAds[10].type).toBe(AdSlot);
 	});
 });

--- a/apps-rendering/src/ads.ts
+++ b/apps-rendering/src/ads.ts
@@ -2,7 +2,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import AdSlot from 'adSlot';
 import Paragraph from 'components/paragraph';
 import type { ReactNode } from 'react';
-import { isValidElement } from 'react';
+import { createElement as h, isValidElement } from 'react';
 
 function getAdIndices(): number[] {
 	const adEveryNParagraphs = 6;
@@ -31,17 +31,9 @@ function insertPlaceholders(
 	const className =
 		numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
 
-	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
-		adIndices.includes(para)
-			? [
-					...nodes,
-					<AdSlot
-						className={className}
-						paragraph={para}
-						format={format}
-						key={para}
-					/>,
-			  ]
+	const insertAd = (paragraph: number, nodes: ReactNode[]): ReactNode[] =>
+		adIndices.includes(paragraph)
+			? [...nodes, h(AdSlot, { className, paragraph, format })]
 			: nodes;
 
 	return flattenedNodes.reduce<{ paraNum: number; nodes: ReactNode[] }>(

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -28,7 +28,8 @@ function insertPlaceholders(
 
 	const numParas = flattenedNodes.filter(isPara).length;
 
-	const className = numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
+	const className =
+		numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
 
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
 		adIndices.includes(para)

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -1,3 +1,4 @@
+import { ArticleFormat } from '@guardian/libs';
 import AdSlot from 'adSlot';
 import Paragraph from 'components/paragraph';
 import type { ReactNode } from 'react';
@@ -14,7 +15,7 @@ function getAdIndices(): number[] {
 	return [firstAdIndex, ...indicesAfterFirstAd];
 }
 
-function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
+function insertPlaceholders(reactNodes: ReactNode[], format: ArticleFormat): ReactNode[] {
 	const adIndices = getAdIndices();
 
 	const flattenedNodes = reactNodes.flat();
@@ -25,7 +26,7 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 	const numParas = flattenedNodes.filter(isPara).length;
 
 	const className =
-		numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
+		numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';
 
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
 		adIndices.includes(para)
@@ -34,6 +35,7 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 					<AdSlot
 						className={className}
 						paragraph={para}
+						format={format}
 						key={para}
 					/>,
 			  ]
@@ -59,7 +61,7 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 
 const getAdPlaceholderInserter = (
 	shouldHideAdverts: boolean,
-): ((reactNodes: ReactNode[]) => ReactNode[]) =>
+): ((reactNodes: ReactNode[], format: ArticleFormat) => ReactNode[]) =>
 	shouldHideAdverts
 		? (reactNodes: ReactNode[]): ReactNode[] => reactNodes
 		: insertPlaceholders;

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -29,7 +29,14 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
 		adIndices.includes(para)
-			? [...nodes, <AdSlot className={className} paragraph={para} />]
+			? [
+					...nodes,
+					<AdSlot
+						className={className}
+						paragraph={para}
+						key={para}
+					/>,
+			  ]
 			: nodes;
 
 	return flattenedNodes.reduce<{ paraNum: number; nodes: ReactNode[] }>(

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -1,4 +1,4 @@
-import { ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import AdSlot from 'adSlot';
 import Paragraph from 'components/paragraph';
 import type { ReactNode } from 'react';
@@ -15,7 +15,10 @@ function getAdIndices(): number[] {
 	return [firstAdIndex, ...indicesAfterFirstAd];
 }
 
-function insertPlaceholders(reactNodes: ReactNode[], format: ArticleFormat): ReactNode[] {
+function insertPlaceholders(
+	reactNodes: ReactNode[],
+	format: ArticleFormat,
+): ReactNode[] {
 	const adIndices = getAdIndices();
 
 	const flattenedNodes = reactNodes.flat();
@@ -25,8 +28,7 @@ function insertPlaceholders(reactNodes: ReactNode[], format: ArticleFormat): Rea
 
 	const numParas = flattenedNodes.filter(isPara).length;
 
-	const className =
-		numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';
+	const className = numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';
 
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
 		adIndices.includes(para)

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -1,18 +1,17 @@
-import { ThemeProvider } from '@emotion/react';
-import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
+import AdSlot from 'adSlot';
 import Paragraph from 'components/paragraph';
-import type { ReactElement, ReactNode } from 'react';
-import { createElement as h, isValidElement } from 'react';
+import type { ReactNode } from 'react';
+import { isValidElement } from 'react';
 
 function getAdIndices(): number[] {
 	const adEveryNParagraphs = 6;
 	const firstAdIndex = 3;
 	const totalAds = 15;
 
-	const indiciesAfterFirstAd = [...Array(totalAds - 1).keys()].map(
+	const indicesAfterFirstAd = [...Array(totalAds - 1).keys()].map(
 		(index) => firstAdIndex + adEveryNParagraphs * ++index,
 	);
-	return [firstAdIndex, ...indiciesAfterFirstAd];
+	return [firstAdIndex, ...indicesAfterFirstAd];
 }
 
 function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
@@ -28,32 +27,10 @@ function insertPlaceholders(reactNodes: ReactNode[]): ReactNode[] {
 	const className =
 		numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
 
-	const ad = (para: number): ReactElement =>
-		h(
-			'aside',
-			{ className, key: `ad-after-${para}-para` },
-			h(
-				'div',
-				{ className: 'ad-labels' },
-				h('h1', null, 'Advertisement'),
-			),
-			h('div', { className: 'ad-slot' }, null),
-			h(
-				'div',
-				{ className: 'upgrade-banner' },
-				h(
-					'h1',
-					null,
-					'Support the Guardian and enjoy the app ad-free.',
-				),
-				<ThemeProvider theme={buttonThemeBrandAlt}>
-					<Button>Support the Guardian</Button>
-				</ThemeProvider>,
-			),
-		);
-
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
-		adIndices.includes(para) ? [...nodes, ad(para)] : nodes;
+		adIndices.includes(para)
+			? [...nodes, <AdSlot className={className} paragraph={para} />]
+			: nodes;
 
 	return flattenedNodes.reduce<{ paraNum: number; nodes: ReactNode[] }>(
 		({ paraNum, nodes: prevNodes }, node) => {

--- a/apps-rendering/src/ads.tsx
+++ b/apps-rendering/src/ads.tsx
@@ -28,7 +28,7 @@ function insertPlaceholders(
 
 	const numParas = flattenedNodes.filter(isPara).length;
 
-	const className = numParas < 15 ? 'ad-placeholder short' : 'ad-placeholder';
+	const className = numParas < 15 ? 'ad-placeholder hidden short' : 'ad-placeholder hidden';
 
 	const insertAd = (para: number, nodes: ReactNode[]): ReactNode[] =>
 		adIndices.includes(para)

--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -126,7 +126,7 @@ function ads(): void {
 
 			insertAds();
 			Array.from(
-				document.querySelectorAll('.ad-labels, .upgrade-banner button'),
+				document.querySelectorAll('.ad-labels, .support-banner button'),
 			).forEach((adLabel) => {
 				adLabel.addEventListener('click', () => {
 					void acquisitionsClient.launchPurchaseScreen(

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { background, neutral, remSpace } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
-import { adStyles, darkModeCss } from 'styles';
+import { darkModeCss } from 'styles';
 
 interface ArticleBodyProps {
 	className?: SerializedStyles[];
@@ -20,8 +20,6 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 		border: none;
 	}
 
-	${adStyles(format)}
-
 	twitter-widget,
     figure[data-atom-type="explainer"] {
 		margin: ${remSpace[4]} 0;
@@ -29,7 +27,6 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 		display: inline-block;
 	}
 `;
-
 const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     background: ${background.inverse};
     color: ${neutral[86]};

--- a/apps-rendering/src/components/articleBody.tsx
+++ b/apps-rendering/src/components/articleBody.tsx
@@ -21,7 +21,7 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	}
 
 	twitter-widget,
-    figure[data-atom-type="explainer"] {
+	figure[data-atom-type='explainer'] {
 		margin: ${remSpace[4]} 0;
 		clear: both;
 		display: inline-block;

--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -23,7 +23,10 @@ import Live from './live';
 const renderWithAds =
 	(shouldHide: boolean) =>
 	(format: ArticleFormat, elements: BodyElement[]): ReactNode[] =>
-		getAdPlaceholderInserter(shouldHide)(renderAll(format, elements), format);
+		getAdPlaceholderInserter(shouldHide)(
+			renderAll(format, elements),
+			format,
+		);
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/layout/index.tsx
+++ b/apps-rendering/src/components/layout/index.tsx
@@ -23,7 +23,7 @@ import Live from './live';
 const renderWithAds =
 	(shouldHide: boolean) =>
 	(format: ArticleFormat, elements: BodyElement[]): ReactNode[] =>
-		getAdPlaceholderInserter(shouldHide)(renderAll(format, elements));
+		getAdPlaceholderInserter(shouldHide)(renderAll(format, elements), format);
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/media/articleBody.tsx
+++ b/apps-rendering/src/components/media/articleBody.tsx
@@ -12,7 +12,6 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	clear: both;
 	background: ${background.inverse};
 	color: ${neutral[86]};
-
 `;
 //	${adStyles(format)}
 

--- a/apps-rendering/src/components/media/articleBody.tsx
+++ b/apps-rendering/src/components/media/articleBody.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
 import { background, neutral, remSpace } from '@guardian/source-foundations';
 import type { FC, ReactNode } from 'react';
-import { adStyles, darkModeCss } from 'styles';
+import { darkModeCss } from 'styles';
 import type { ThemeStyles } from 'themeStyles';
 import { getThemeStyles } from 'themeStyles';
 
@@ -13,8 +13,8 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	background: ${background.inverse};
 	color: ${neutral[86]};
 
-	${adStyles(format)}
 `;
+//	${adStyles(format)}
 
 const ArticleBodyDarkStyles = ({
 	inverted,

--- a/apps-rendering/src/components/media/articleBody.tsx
+++ b/apps-rendering/src/components/media/articleBody.tsx
@@ -13,7 +13,6 @@ const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
 	background: ${background.inverse};
 	color: ${neutral[86]};
 `;
-//	${adStyles(format)}
 
 const ArticleBodyDarkStyles = ({
 	inverted,

--- a/apps-rendering/src/styles.ts
+++ b/apps-rendering/src/styles.ts
@@ -4,13 +4,9 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import {
 	background,
-	brandAltBackground,
 	from,
-	headline,
 	neutral,
 	remSpace,
-	textSans,
-	until,
 } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { map, none, some, withDefault } from '@guardian/types';
@@ -118,101 +114,12 @@ export const onwardStyles: SerializedStyles = css`
 	}
 `;
 
-const adHeight = '258px';
-
 export const backgroundColor = (format: ArticleFormat): string =>
 	format.design === ArticleDesign.Comment ||
 	format.design === ArticleDesign.Letter ||
 	format.design === ArticleDesign.Editorial
 		? neutral[86]
 		: neutral[97];
-
-export const adStyles = (format: ArticleFormat): SerializedStyles => {
-	return css`
-		.ad-placeholder {
-			margin: ${remSpace[4]} 0;
-
-			&.hidden {
-				display: none;
-			}
-
-			color: ${neutral[20]};
-			background: ${backgroundColor(format)};
-
-			${darkModeCss`
-            background-color: ${neutral[20]};
-        `}
-
-			clear: both;
-
-			.ad-labels {
-				${textSans.xsmall()}
-				padding: ${remSpace[3]};
-				float: left;
-				width: calc(100% - ${remSpace[3]} - ${remSpace[3]});
-
-				h1 {
-					margin: 0;
-					float: left;
-					font-size: 16px;
-					font-weight: 400;
-
-					${darkModeCss`
-                    color: ${neutral[60]};
-                `}
-				}
-			}
-
-			.ad-slot {
-				clear: both;
-				padding-bottom: ${adHeight};
-			}
-
-			.ad-slot-square {
-				height: 344px;
-				width: 320px;
-				margin-left: auto;
-				margin-right: auto;
-				padding-bottom: 0;
-			}
-
-			.upgrade-banner {
-				padding: ${remSpace[3]};
-				background-color: ${brandAltBackground.primary};
-
-				h1 {
-					${headline.xxxsmall()};
-					margin-top: 0;
-				}
-
-				button {
-					margin-top: ${remSpace[3]};
-				}
-
-				${darkModeCss`
-                background-color: ${brandAltBackground.ctaSecondary};
-            `}
-			}
-
-			${until.phablet} {
-				margin: 1em -${remSpace[3]};
-			}
-
-			${from.desktop} {
-				position: absolute;
-				margin-left: calc(${wideContentWidth}px + ${remSpace[4]});
-				min-width: 300px;
-				margin-bottom: ${remSpace[6]};
-			}
-		}
-
-		.ad-placeholder.short:nth-of-type(1) {
-			${from.desktop} {
-				top: 0;
-			}
-		}
-	`;
-};
 
 export const fontFace = (
 	family: string,

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -22,6 +22,17 @@ import { Colour } from '.';
 
 // ----- Functions ----- //
 
+const adSlot = (format: ArticleFormat): Colour => {
+	if (format.design === ArticleDesign.Comment ||
+	format.design === ArticleDesign.Letter ||
+	format.design === ArticleDesign.Editorial) {
+		return neutral[86];
+	}
+	return  neutral[97];
+}
+
+const adSlotDark = (_format: ArticleFormat) => neutral[20];
+
 const headline = (format: ArticleFormat): Colour => {
 	if (format.display === ArticleDisplay.Immersive) {
 		return neutral[7];
@@ -219,10 +230,22 @@ const headlineTag = (format: ArticleFormat): Colour => {
 	}
 };
 
+const supportBanner = (_format: ArticleFormat): Colour => {
+	return brandAlt[400];
+};
+
+const supportBannerDark = (_format: ArticleFormat): Colour => {
+	return brandAlt[200];
+};
+
 // ----- API ----- //
 
 const background = {
+	adSlot,
+	adSlotDark,
+	articleContentDark,
 	avatar,
+	bulletDark,
 	headline,
 	headlineByline,
 	headlineDark,
@@ -233,8 +256,8 @@ const background = {
 	keyEventsWideDark,
 	standfirst,
 	standfirstDark,
-	articleContentDark,
-	bulletDark,
+	supportBanner,
+	supportBannerDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -23,12 +23,14 @@ import { Colour } from '.';
 // ----- Functions ----- //
 
 const adSlot = (format: ArticleFormat): Colour => {
-	if (format.design === ArticleDesign.Comment ||
-	format.design === ArticleDesign.Letter ||
-	format.design === ArticleDesign.Editorial) {
-		return neutral[86];
+	switch (format.design) {
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			return neutral[86];
+		default:
+			return neutral[97];
 	}
-	return  neutral[97];
 }
 
 const adSlotDark = (_format: ArticleFormat) => neutral[20];

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -22,6 +22,17 @@ import { Colour } from '.';
 
 // ----- Functions ----- //
 
+const adLabel = (_format: ArticleFormat): Colour => {
+	return neutral[20];
+};
+
+const adLabelDark = (_format: ArticleFormat): Colour => {
+	return neutral[60];
+};
+
+const adSlot = (_format: ArticleFormat): Colour => {
+	return neutral[20];
+};
 const branding = (_format: ArticleFormat): Colour => {
 	return neutral[20];
 };
@@ -627,6 +638,9 @@ const pagination = (format: ArticleFormat): Colour => {
 // ----- API ----- //
 
 const text = {
+	adLabel,
+	adLabelDark,
+	adSlot,
 	articleLink,
 	branding,
 	brandingDark,


### PR DESCRIPTION
## Why?
Ad slots in AR were defined in `ads.tsx` as a mix of React's `createElement` (aliased as `h`) and JSX. This prevented the file from having a `.ts` extension (which we reserve for logic only).
`ads.tsx` handled both the ad insertion logic and the implementation of the placeholder component. Additionally, CSS styles were being pulled from the `adStyles` function in the `ArticleBody` component, which made the ad placeholder styles dependant on the body of an article.

This PR attempts to simplify how we reason about ads in AR by:

1) Creating a separate `AdSlot` React component.
2) Decoupling the CSS styles from `ArticleBody` and `AdSlots`: instead of being declared in the `ArticleBody` component, all styles now live in the `AdSlot` component and make use of `editorialPalette` to decide the colours.

As a result of 1. and 2., the component can be visually tested in isolation because styles are no longer applied in the article body (I've created a Storybook story to reflect this).

Also, because JSX is no longer used in the ad logic, the file previously known as `ads.tsx` is now `ads.ts`, and the placeholder component lives separately in `adSlot.tsx`, which should hopefully be an easier mental model to follow.

**NOTE**: class names are still needed in the component itself because of how placeholders are injected between paragraphs.

cc @guardian/commercial-dev

## Screenshots
*There is no visual difference between the old way of rendering ad placeholders and the new one*
| Before      | After      |
|-------------|------------|
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://user-images.githubusercontent.com/57295823/165552817-612c6321-ac27-4d18-bebb-257b3b62b869.png
[after1]: https://user-images.githubusercontent.com/57295823/165551589-159a70ef-d8e3-4814-b2e6-6af0c83197f0.png
[before2]: https://user-images.githubusercontent.com/57295823/165553080-b8aab50c-d5be-4963-a896-a6ca039d93ae.png
[after2]: https://user-images.githubusercontent.com/57295823/165551213-496c9bac-4c41-4913-be26-aac599abeab6.png

## Storybook

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/57295823/165553552-1f346699-d3e5-4daf-8e7d-332f7fbab07d.png">
