### PR TITLE
chore: Use new prannouncer repository

### DIFF
--- a/.github/workflows/prannouncer.yml
+++ b/.github/workflows/prannouncer.yml
@@ -9,6 +9,6 @@ jobs:
   prnouncer:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/google-chats-pr-announcer@main
+      - uses: guardian/prnouncer@main
         with:
           google-webhook-url: ${{ secrets.GOOGLE_WEBHOOK_URL }}


### PR DESCRIPTION
## What does this change?

Use https://github.com/guardian/actions-prnouncer instead of https://github.com/guardian/google-chats-pr-announcer

## Why?

Apparently theres a standard to prefix action repos with `actions-`, I've taken the chance to do a quick switcheroo.
