### PR TITLE
Refactor reveal styles

### DIFF
--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -49,7 +49,7 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 						animation: ${keyframes`
 							0% { opacity: 0; }
 							100% { opacity: 1; }
-						`} 2s ease-out;
+						`} 1s ease-out;
 					}
 					.reveal-slowly {
 						animation: ${keyframes`

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { Global, css } from '@emotion/react';
+import { Global, css, keyframes } from '@emotion/react';
 import { focusHalo, brandAlt, neutral } from '@guardian/source-foundations';
 import { ArticleDesign } from '@guardian/libs';
 import { filterABTestSwitches } from '../../model/enhance-switches';
@@ -42,6 +42,23 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 					::selection {
 						background: ${brandAlt[400]};
 						color: ${neutral[7]};
+					}
+					/* We're using classnames here because we add and remove these classes
+	   				   using plain javascript */
+					.reveal {
+						animation: ${keyframes`
+							0% { opacity: 0; }
+							100% { opacity: 1; }
+						`} 2s ease-out;
+					}
+					.reveal-slowly {
+						animation: ${keyframes`
+							0% { opacity: 0; }
+							100% { opacity: 1; }
+						`} 4s ease-out;
+					}
+					.pending {
+						display: none;
 					}
 				`}
 			/>

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -1,4 +1,4 @@
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 
 import { headline, body, between, space } from '@guardian/source-foundations';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
@@ -87,20 +87,6 @@ const globalLinkStyles = (palette: Palette) => css`
 	}
 `;
 
-const revealStyles = css`
-	/* We're using classnames here because we add and remove these classes
-	   using plain javascript */
-	.reveal {
-		animation: ${keyframes`
-			0% { opacity: 0; }
-			100% { opacity: 1; }
-		`} 4s ease-out;
-	}
-	.pending {
-		display: none;
-	}
-`;
-
 export const ArticleBody = ({
 	format,
 	blocks,
@@ -145,10 +131,6 @@ export const ArticleBody = ({
 						globalH2Styles(format.display),
 						globalH3Styles(format.display),
 						globalLinkStyles(palette),
-						// revealStyles is used to animate the reveal of new blocks
-						(format.design === ArticleDesign.DeadBlog ||
-							format.design === ArticleDesign.LiveBlog) &&
-							revealStyles,
 					]}
 				>
 					<LiveBlogRenderer

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 
 import { joinUrl } from '@guardian/libs';
 import { neutral, space } from '@guardian/source-foundations';
@@ -35,20 +35,6 @@ const overlayStyles = css`
 	right: 0;
 	width: 100%;
 	display: block;
-`;
-
-const revealStyles = css`
-	/* We're using classnames here because we add and remove these classes
-   using plain javascript */
-	.reveal {
-		animation: ${keyframes`
-		0% { opacity: 0; }
-		100% { opacity: 1; }
-	`} 2s ease-out;
-	}
-	.pending {
-		display: none;
-	}
 `;
 
 const fixHeight = css`
@@ -152,7 +138,7 @@ export const Discussion = ({
 	return (
 		<>
 			<div
-				css={[positionRelative, revealStyles, !isExpanded && fixHeight]}
+				css={[positionRelative, !isExpanded && fixHeight]}
 				className="discussion"
 			>
 				<div className="pending">

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -87,7 +87,7 @@ function revealPendingBlocks() {
 		'article .pending.block',
 	);
 	pendingBlocks?.forEach((block) => {
-		block.classList.add('reveal');
+		block.classList.add('reveal-slowly');
 		block.classList.remove('pending');
 	});
 

--- a/dotcom-rendering/src/web/components/OnwardsData.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsData.tsx
@@ -1,4 +1,4 @@
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 import { useEffect } from 'react';
 import { useApi } from '../lib/useApi';
 
@@ -23,20 +23,6 @@ type OnwardsResponse = {
 
 const minHeight = css`
 	min-height: 300px;
-`;
-
-const revealStyles = css`
-	/* We're using classnames here because we add and remove these classes
-	   using plain javascript */
-	.reveal {
-		animation: ${keyframes`
-			0% { opacity: 0; }
-			100% { opacity: 1; }
-		`} 2s ease-out;
-	}
-	.pending {
-		display: none;
-	}
 `;
 
 export const OnwardsData = ({
@@ -87,7 +73,7 @@ export const OnwardsData = ({
 
 	if (data?.trails) {
 		return (
-			<div css={[minHeight, revealStyles]} className="onwards">
+			<div css={[minHeight]} className="onwards">
 				<div className="pending">
 					<Container
 						heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We use similar `reveal` and `pending` classes in three different places in the code. This PR centralises this styling logic as globals

## Why?
This creates a contract that can be re-used
