### PR TITLE
Fix the height of the merchandising containers

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -453,6 +453,7 @@ export const AdSlot: React.FC<Props> = ({
 					css={[
 						css`
 							position: relative;
+							min-height: 332px;
 						`,
 						adStyles,
 						fluidFullWidthAdStyles,
@@ -484,6 +485,7 @@ export const AdSlot: React.FC<Props> = ({
 					css={[
 						css`
 							position: relative;
+							min-height: 332px;
 						`,
 						adStyles,
 						fluidFullWidthAdStyles,

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -453,7 +453,6 @@ export const AdSlot: React.FC<Props> = ({
 					css={[
 						css`
 							position: relative;
-							min-height: 332px;
 						`,
 						adStyles,
 						fluidFullWidthAdStyles,
@@ -485,7 +484,6 @@ export const AdSlot: React.FC<Props> = ({
 					css={[
 						css`
 							position: relative;
-							min-height: 332px;
 						`,
 						adStyles,
 						fluidFullWidthAdStyles,

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -28,6 +28,10 @@ const setBackgroundColour = (colour: string) => emoCss`
 	background-color: ${colour};
 `;
 
+const setHeight = (height: number) => emoCss`
+	min-height: ${height}px;
+`;
+
 type Props = {
 	sectionId?: string;
 	showSideBorders?: boolean;
@@ -49,6 +53,7 @@ type Props = {
 	className?: string;
 	ophanComponentName?: string;
 	ophanComponentLink?: string;
+	fixedHeight?: number;
 };
 
 export const ElementContainer = ({
@@ -64,6 +69,7 @@ export const ElementContainer = ({
 	className,
 	ophanComponentName,
 	ophanComponentLink,
+	fixedHeight,
 }: Props) => (
 	<ClassNames>
 		{({ css }) => {
@@ -75,6 +81,7 @@ export const ElementContainer = ({
 						showSideBorders && sideBorders(borderColour),
 						showTopBorder && topBorder(borderColour),
 						padded && padding,
+						fixedHeight && setHeight(fixedHeight),
 					]}
 				>
 					{children && children}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -791,6 +791,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
 					element="aside"
+					fixedHeight={248}
 				>
 					<AdSlot
 						data-print-layout="hide"
@@ -885,6 +886,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
 					element="aside"
+					fixedHeight={248}
 				>
 					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds a `fixedHeight` prop to `ElementContainer` allowing the height to be fixed and then uses it for the merchandising ad slots at the bottom of the page.

## Why?
This allows us to hold open a container at a fixed value ahead of any client content that might be loaded into it. For merchandising, this ameliorates the CLS caused by the advert loading in and shifting content on the page. The content that gets rendered can be of different heights so we do still get some layout shift but this is greatly reduced with this change.

## Why not?
This will now hold this space open permanently. If a reader is using an ad blocker they will be left with a grey box on the page.

And potentially, there are other circumstances where an unwanted grey box may remain - this is being investigated.

## 248?
This is the height of the narrowest content I saw but it is possible narrower content will be loaded in in which case the slot will remain at 248 pixels high, with grey space below

## Why not set the height on `AdSlot`?
I think that the commercial code is removing this div prior to rendering the ad which seems to cause a flash and subsequent CLS spike

### Scores
These CLS scores are for the particular area of the page where one of the slots is loaded

| Before      | After      |
|-------------|------------|
| <img width="426" alt="bb" src="https://user-images.githubusercontent.com/1336821/165693486-a745bdac-5310-456b-8add-6d4e7fa7b137.png"> | <img width="426" alt="aa" src="https://user-images.githubusercontent.com/1336821/165693537-d39993f9-853a-455b-b7a9-b3a16e81df62.png"> |
