### PR TITLE
Increase size of Prebid price granularity test to 5%

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/prebid-price-granularity.ts
+++ b/dotcom-rendering/src/web/experiments/tests/prebid-price-granularity.ts
@@ -7,8 +7,8 @@ export const prebidPriceGranularity: ABTest = {
 	author: 'Chris Jones (@chrislomaxjones)',
 	description:
 		'Test the commercial impact of changing Prebid Price granularity for Ozone',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 5 / 100,
+	audienceOffset: 25 / 100,
 	successMeasure:
 		'No significant negative impact on CPM when using a granularity that permits fewer line items',
 	audienceCriteria: 'n/a',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increase the participation of our AB test to `5%`. See the [Frontend PR](https://github.com/guardian/frontend/pull/24965) for more details.