### PR TITLE
Stop dependabot from rebasing its open PRs every time `main` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,17 @@ updates:
       directory: '/'
       schedule:
           interval: 'daily'
+      # Minimise the number of chromatic runs.
+      # We've enabled 'Require branches to be up to date before merging',
+      # so you won't be able to merge a dependabot PR unless you rebase manually anyway.
+      rebase-strategy: "disabled"
     - package-ecosystem: 'npm'
       directory: '/apps-rendering'
       schedule:
           interval: 'daily'
       labels:
         - "AR Dependency"
+      rebase-strategy: "disabled"
     - package-ecosystem: "npm" 
       directory: "/dotcom-rendering"
       schedule:
@@ -22,7 +27,9 @@ updates:
       labels:
         - "DCR Dependency"
       open-pull-requests-limit: 10
+      rebase-strategy: "disabled"
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
           interval: 'daily'
+      rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,7 @@ updates:
       directory: '/'
       schedule:
           interval: 'daily'
-      # Minimise the number of chromatic runs.
-      # We've enabled 'Require branches to be up to date before merging',
-      # so you won't be able to merge a dependabot PR unless you rebase manually anyway.
+      # Set to minimise the number of chromatic runs.
       rebase-strategy: "disabled"
     - package-ecosystem: 'npm'
       directory: '/apps-rendering'
@@ -20,7 +18,7 @@ updates:
       labels:
         - "AR Dependency"
       rebase-strategy: "disabled"
-    - package-ecosystem: "npm" 
+    - package-ecosystem: "npm"
       directory: "/dotcom-rendering"
       schedule:
         interval: "daily"


### PR DESCRIPTION
## why?
following on from the $10-per-build cost @AshCorr identified in #4768, i had a look in chromatic usage stats. for april this year, dotcom accounts for entire excess (i.e. all other repos cover the allowance by themselves)

<img width="816" alt="image" src="https://user-images.githubusercontent.com/867233/165785645-14656eda-aa3b-4883-a5d1-f86b0177c096.png">

at the time of writing, there are 26 open dependabot PRs open in this repo. every time `main` changes, dependabot will rebase those PRs triggering a full set of chromatic tests. 

this means every merge to `main` currently costs us 26 x $10 = $260!

unless dependabot PRs are about to be merged, those tests don't need to be run right then. this PR will stop dependabot from doing that.

to make this safe, it would probably be a good idea enable [Require branches to be up to date before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging). this should give you the same confidence merging dependabot PRs as before, but without the multiple chromatic tests being run before the PR is ready to merge

