### PR TITLE
Only run chromatic tests when a review is requested

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,10 @@
 name: Chromatic 👓
 on: push
-
+  branches:
+    - main
+  pull_request:
+    types: ['review_requested']
+    
 jobs:
   chromatic:
     name: Chromatic


### PR DESCRIPTION
following on from #4775, this PR will stop chromatic tests from running unless a PR has a review requested.

the codeowners will automatically add a review request for most new PRs. but any subsequent pushing the branch will _also_ trigger chromatic tests, even if the PR is not ready.

this PR will remove the pass check for any previous chromatic runs if new commits are added, meaning that once you're happy the PR is good to go, you can formally (re)request a review and chromatic will kick off again.

this repo already requires an approval to merge, so it shouldn't change the PR workflow too much but could save a good few chromatic snapshots 🙏 

it might be worth enabling 
<img width="585" alt="image" src="https://user-images.githubusercontent.com/867233/165791103-249b0e22-4b53-4969-9bc5-fee66ee3830c.png"> 
on the repo too if you decide to merge this