### PR TITLE
Series colour for match features

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -82,7 +82,7 @@ type Palette = {
 		headline: Colour;
 		seriesTitle: Colour;
 		sectionTitle: Colour;
-		matchTitle: Colour;
+		seriesTitleWhenMatch: Colour;
 		byline: Colour;
 		twitterHandle: Colour;
 		twitterHandleBelowDesktop: Colour;

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -195,11 +195,11 @@ export const SeriesSectionLink = ({
 	const palette = decidePalette(format);
 
 	const seriesTitleColour = isMatch
-		? palette.text.matchTitle
+		? palette.text.seriesTitleWhenMatch
 		: palette.text.seriesTitle;
 
 	const sectionTitleColour = isMatch
-		? palette.text.matchTitle
+		? palette.text.seriesTitleWhenMatch
 		: palette.text.sectionTitle;
 
 	switch (format.display) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -72,10 +72,6 @@ const textHeadline = (format: ArticleFormat): string => {
 	}
 };
 
-const textMatchTitle = (): string => {
-	return BLACK;
-};
-
 const textSeriesTitle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -108,6 +104,10 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 		default:
 			return BLACK;
 	}
+};
+
+const textSeriesTitleWhenMatch = (format: ArticleFormat): string => {
+			return BLACK;
 };
 
 const textSectionTitle = textSeriesTitle;
@@ -1128,8 +1128,8 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 		text: {
 			headline: textHeadline(format),
 			seriesTitle: textSeriesTitle(format),
+			seriesTitleWhenMatch: textSeriesTitleWhenMatch(format),
 			sectionTitle: textSectionTitle(format),
-			matchTitle: textMatchTitle(),
 			byline: textByline(format),
 			twitterHandle: textTwitterHandle(format),
 			twitterHandleBelowDesktop: textTwitterHandleBelowDesktop(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -109,6 +109,7 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 const textSeriesTitleWhenMatch = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.MatchReport:
+		case ArticleDesign.LiveBlog:
 			return BLACK;
 		default:
 			return textSeriesTitle(format);

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -107,7 +107,12 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 };
 
 const textSeriesTitleWhenMatch = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.MatchReport:
 			return BLACK;
+		default:
+			return textSeriesTitle(format);
+	}
 };
 
 const textSectionTitle = textSeriesTitle;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This changes the colour of the series title when an article with a `matchUrl` is not a `MatchReport`

Fixes #4749 

## Why?
In [this example](https://www.theguardian.com/football/2022/apr/26/henderson-emery-and-night-in-a-bar-that-launched-klopps-new-liverpool) we see a case where an article has a `matchUrl` value but the feature tag has taken precedence and so we should be using the pillar colour for styling instead of black.

Checking [other](https://www.theguardian.com/football/live/2022/apr/29/newcastle-liverpool-leeds-manchester-city-weekend-football-countdown-live) [examples](https://www.theguardian.com/sport/live/2022/apr/07/golf-the-masters-2022-augusta-tiger-woods-live-updates?live) I do not see any regression

| Before      | After      |
|-------------|------------|
| <img width="449" alt="Screenshot 2022-04-29 at 14 13 03" src="https://user-images.githubusercontent.com/1336821/165951223-ab7417ab-37d3-4de4-bd0f-8ebbff187d9b.png"> | <img width="449" alt="Screenshot 2022-04-29 at 14 12 36" src="https://user-images.githubusercontent.com/1336821/165951351-a9f58fa8-a634-4905-8135-b68a8a970845.png"> |
