### PR TITLE
`standfirst` > `trailText`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -741,7 +741,7 @@ type DCRFrontCard = {
 	format: ArticleFormat;
 	url: string;
 	headline: string;
-	standfirst?: string;
+	trailText?: string;
 	webPublicationDate?: string;
 	image?: string;
 	kickerText?: string;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -25,7 +25,7 @@ const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
 				format,
 				url: faciaCard.header.url,
 				headline: faciaCard.header.headline,
-				standfirst: faciaCard.card.trailText,
+				trailText: faciaCard.card.trailText,
 				webPublicationDate: faciaCard.card.webPublicationDateOption
 					? new Date(
 							faciaCard.card.webPublicationDateOption,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes an issue where the refactor from `standfirst` to `trailText` on Cards was not fully completed

## Why?
So we show the trail text on cards

| Before      | After      |
|-------------|------------|
| <img width="714" alt="Screenshot 2022-05-02 at 09 51 01" src="https://user-images.githubusercontent.com/1336821/166209040-8c5cb961-9963-401b-bfec-b6b1292f01d2.png"> | <img width="714" alt="Screenshot 2022-05-02 at 09 50 06" src="https://user-images.githubusercontent.com/1336821/166208962-f2d6799a-228a-4d33-b08d-4381276c633e.png">|
