### PR TITLE
Choose the right cards

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -16,8 +16,8 @@ type Props = {
 export const DynamicSlow = ({ trails }: Props) => {
 	const primary = trails[0];
 	const secondary = trails[1];
-	const smallCards = trails.slice(2, 6);
-	const bigCards = trails.slice(6, 8);
+	const bigCards = trails.slice(2, 4);
+	const smallCards = trails.slice(4, 8);
 
 	return (
 		<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR changes the cards that we pick for the different sections of `DynamicSlow`

## Why?
We were using the last two, not the first two

| Before      | After      |
|-------------|------------|
| <img width="959" alt="Screenshot 2022-05-02 at 10 00 33" src="https://user-images.githubusercontent.com/1336821/166210275-56085ff2-b27b-476d-92d0-bb0195d9af2d.png">| <img width="959" alt="Screenshot 2022-05-02 at 10 00 08" src="https://user-images.githubusercontent.com/1336821/166210230-0d891b84-576b-4be5-a18d-b40fc1367f40.png">|