### PR TITLE
Hide sublinks on small cards

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -186,9 +186,6 @@ export const DynamicSlow = ({ trails }: Props) => {
 										commentCount={card.commentCount}
 										starRating={card.starRating}
 										branding={card.branding}
-										supportingContent={
-											card.supportingContent
-										}
 									/>
 								</LI>
 							);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides siblinks on small cards that don't have enough space to show them

## Why?
This is the convention in place at the moment and we want to respect this, even if the card has `supportingContent` added to it

| Before      | After      |
|-------------|------------|
| <img width="959" alt="Screenshot 2022-05-02 at 10 01 43" src="https://user-images.githubusercontent.com/1336821/166210734-6affede9-a0bb-4a7c-bda3-534d16641ebb.png"> | <img width="959" alt="Screenshot 2022-05-02 at 10 02 52" src="https://user-images.githubusercontent.com/1336821/166210722-a0410eb5-b1aa-4ddf-ad7e-cbcb0b5fd3fa.png">|

