### PR TITLE
Fix `inline1ContainerSizing` float right CSS

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -107,6 +107,18 @@ const articleAdStyles = (isInline1ContainerSizingVariant: boolean) => {
 				width: 100%;
 			}
 		}
+		/** ad-slot-offset-right is only added to inline2+ slots */
+		.ad-slot--offset-right {
+			${from.desktop} {
+				float: right;
+				width: auto;
+				margin-right: -318px;
+			}
+
+			${from.wide} {
+				margin-right: -398px;
+			}
+		}
 	`;
 	const controlCSS = css`
 		.ad-slot--inline,
@@ -132,17 +144,6 @@ const articleAdStyles = (isInline1ContainerSizingVariant: boolean) => {
 				margin-left: 20px;
 			}
 		}
-		.ad-slot--offset-right {
-			${from.desktop} {
-				float: right;
-				width: auto;
-				margin-right: -318px;
-			}
-
-			${from.wide} {
-				margin-right: -398px;
-			}
-		}
 		.ad-slot--outstream {
 			${from.tablet} {
 				margin-left: 0;
@@ -158,7 +159,7 @@ const articleAdStyles = (isInline1ContainerSizingVariant: boolean) => {
 		.ad-slot--inline1 {
 			margin: 12px auto;
 			text-align: center;
-			/* Unlike other inlines we don't float right inline1 */
+			/* Unlike other inlines do not float right inline1 */
 			/* Prevent merger with any nearby float left elements e.g. rich-links */
 			${until.tablet} {
 				clear: left;
@@ -189,17 +190,6 @@ const articleAdStyles = (isInline1ContainerSizingVariant: boolean) => {
 				margin: 0;
 				margin-top: 4px;
 				margin-left: 20px;
-			}
-			&.ad-slot--offset-right {
-				${from.desktop} {
-					float: right;
-					width: auto;
-					margin-right: -318px;
-				}
-
-				${from.wide} {
-					margin-right: -398px;
-				}
 			}
 		}
 	`;

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -48,156 +48,152 @@ const articleWrapper = css`
 	z-index: 1;
 `;
 
-const articleAdStyles = (isInline1ContainerSizingVariant: boolean) => {
-	const sharedCSS = css`
-		.ad-slot {
-			@media print {
-				/* stylelint-disable-next-line declaration-no-important */
-				display: none !important;
-			}
-			&.ad-slot--collapse {
-				display: none;
+const adSharedCSS = css`
+	.ad-slot {
+		@media print {
+			/* stylelint-disable-next-line declaration-no-important */
+			display: none !important;
+		}
+		&.ad-slot--collapse {
+			display: none;
+		}
+	}
+	.ad-slot--mostpop {
+		${from.desktop} {
+			margin: 0;
+			width: auto;
+		}
+	}
+	.ad-slot-container {
+		max-width: 300px;
+	}
+	.ad-slot--fluid {
+		width: 100%;
+	}
+	.ad-slot--liveblog-inline {
+		margin: 0 auto ${space[3]}px;
+
+		.ad-slot__label {
+			color: ${neutral[46]};
+			border-top-color: ${neutral[86]};
+		}
+
+		&.ad-slot--outstream {
+			${from.tablet} {
+				width: 620px;
 			}
 		}
-		.ad-slot--mostpop {
-			${from.desktop} {
-				margin: 0;
-				width: auto;
+
+		&:not(.ad-slot--outstream) {
+			width: 300px;
+			background-color: ${neutral[93]};
+			text-align: center;
+
+			${from.tablet} {
+				width: 100%;
+				padding-bottom: ${space[6]}px;
+
+				& > div:not(.ad-slot__label) {
+					width: 300px;
+					margin-left: auto;
+					margin-right: auto;
+				}
 			}
 		}
-		.ad-slot-container {
-			max-width: 300px;
-		}
-		.ad-slot--fluid {
+
+		&.ad-slot--fluid {
+			background-color: green;
 			width: 100%;
 		}
-		.ad-slot--liveblog-inline {
-			margin: 0 auto ${space[3]}px;
-
-			.ad-slot__label {
-				color: ${neutral[46]};
-				border-top-color: ${neutral[86]};
-			}
-
-			&.ad-slot--outstream {
-				${from.tablet} {
-					width: 620px;
-				}
-			}
-
-			&:not(.ad-slot--outstream) {
-				width: 300px;
-				background-color: ${neutral[93]};
-				text-align: center;
-
-				${from.tablet} {
-					width: 100%;
-					padding-bottom: ${space[6]}px;
-
-					& > div:not(.ad-slot__label) {
-						width: 300px;
-						margin-left: auto;
-						margin-right: auto;
-					}
-				}
-			}
-
-			&.ad-slot--fluid {
-				background-color: green;
-				width: 100%;
-			}
-		}
-		/** ad-slot-offset-right is only added to inline2+ slots */
-		.ad-slot--offset-right {
-			${from.desktop} {
-				float: right;
-				width: auto;
-				margin-right: -318px;
-			}
-
-			${from.wide} {
-				margin-right: -398px;
-			}
-		}
-	`;
-	const controlCSS = css`
-		.ad-slot--inline,
-		.ad-slot-liveblog--inline {
-			width: 300px;
-			margin: 12px auto;
-			min-width: 160px;
-			min-height: 274px;
-			text-align: center;
-
-			${from.tablet} {
-				margin-right: -100px;
-				width: auto;
-				float: right;
-				margin-top: 4px;
-				margin-left: 20px;
-			}
-			${from.desktop} {
-				width: auto;
-				float: right;
-				margin: 0;
-				margin-top: 4px;
-				margin-left: 20px;
-			}
-		}
-		.ad-slot--outstream {
-			${from.tablet} {
-				margin-left: 0;
-				width: 100%;
-				.ad-slot__label {
-					margin-left: 35px;
-					margin-right: 35px;
-				}
-			}
-		}
-	`;
-	const variantCSS = css`
-		.ad-slot--inline1 {
-			margin: 12px auto;
-			text-align: center;
-			/* Unlike other inlines do not float right inline1 */
-			/* Prevent merger with any nearby float left elements e.g. rich-links */
-			${until.tablet} {
-				clear: left;
-				width: 300px;
-			}
-			/* Reserve full width with a background colour */
-			${from.tablet} {
-				background-color: ${neutral[97]};
-			}
-		}
-		.ad-slot--inline:not(.ad-slot--inline1),
-		.ad-slot-liveblog--inline:not(.ad-slot--inline1) {
-			width: 300px;
-			margin: 12px auto;
-			min-width: 300px;
-			min-height: 274px;
-			text-align: center;
-			${from.tablet} {
-				margin-right: -100px;
-				width: auto;
-				float: right;
-				margin-top: 4px;
-				margin-left: 20px;
-			}
-			${from.desktop} {
-				width: auto;
-				float: right;
-				margin: 0;
-				margin-top: 4px;
-				margin-left: 20px;
-			}
-		}
-	`;
-	if (isInline1ContainerSizingVariant) {
-		return [sharedCSS, variantCSS];
 	}
-	return [sharedCSS, controlCSS];
-};
+	/** ad-slot-offset-right is only added to inline2+ slots */
+	.ad-slot--offset-right {
+		${from.desktop} {
+			float: right;
+			width: auto;
+			margin-right: -318px;
+		}
+
+		${from.wide} {
+			margin-right: -398px;
+		}
+	}
+`;
+
+const adControlCSS = css`
+	.ad-slot--inline,
+	.ad-slot-liveblog--inline {
+		width: 300px;
+		margin: 12px auto;
+		min-width: 160px;
+		min-height: 274px;
+		text-align: center;
+
+		${from.tablet} {
+			margin-right: -100px;
+			width: auto;
+			float: right;
+			margin-top: 4px;
+			margin-left: 20px;
+		}
+		${from.desktop} {
+			width: auto;
+			float: right;
+			margin: 0;
+			margin-top: 4px;
+			margin-left: 20px;
+		}
+	}
+	.ad-slot--outstream {
+		${from.tablet} {
+			margin-left: 0;
+			width: 100%;
+			.ad-slot__label {
+				margin-left: 35px;
+				margin-right: 35px;
+			}
+		}
+	}
+`;
+
+const adVariantCSS = css`
+	.ad-slot--inline1 {
+		margin: 12px auto;
+		text-align: center;
+		/* Unlike other inlines do not float right inline1 */
+		/* Prevent merger with any nearby float left elements e.g. rich-links */
+		${until.tablet} {
+			clear: left;
+			width: 300px;
+		}
+		/* Reserve full width with a background colour */
+		${from.tablet} {
+			background-color: ${neutral[97]};
+		}
+	}
+	.ad-slot--inline:not(.ad-slot--inline1),
+	.ad-slot-liveblog--inline:not(.ad-slot--inline1) {
+		width: 300px;
+		margin: 12px auto;
+		min-width: 300px;
+		min-height: 274px;
+		text-align: center;
+		${from.tablet} {
+			margin-right: -100px;
+			width: auto;
+			float: right;
+			margin-top: 4px;
+			margin-left: 20px;
+		}
+		${from.desktop} {
+			width: auto;
+			float: right;
+			margin: 0;
+			margin-top: 4px;
+			margin-left: 20px;
+		}
+	}
+`;
 
 export const ArticleContainer = ({ children, format, abTests }: Props) => {
 	const isInline1ContainerSizingVariant =
@@ -207,7 +203,8 @@ export const ArticleContainer = ({ children, format, abTests }: Props) => {
 			css={[
 				articleWrapper,
 				articleWidth(format),
-				articleAdStyles(isInline1ContainerSizingVariant),
+				adSharedCSS,
+				isInline1ContainerSizingVariant ? adVariantCSS : adControlCSS,
 				carrotAdStyles,
 				labelStyles,
 			]}


### PR DESCRIPTION
## What does this change?

In the previous PR: #4506 we introduced an AB test to _not_ float right inline1 slots and take up the column full width.

However because of a concurrent change to add new ad slot containers, the _variant_ float right behaviour of inline2+ was not applied correctly to the new containers. This PR fixes that.

The switch for the test has been off so there has been no user impact.

ps - some prettier noise so it's easier to look at the commits diffs.

 ## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:https://user-images.githubusercontent.com/7014230/166289930-4fe6801f-ca57-4a30-83e1-a12d24cebb25.png

[after]:https://user-images.githubusercontent.com/7014230/166289950-6d478d77-48d7-41db-a64b-5ec6d48d0d93.png

