### PR TITLE
Set chromatic params first

### DIFF
--- a/dotcom-rendering/src/web/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Layout.stories.tsx
@@ -164,6 +164,12 @@ for (const [displayName] of Object.entries(ArticleDisplay)) {
 }
 
 storiesOf(`Layouts/Liveblog`, module)
+	.addParameters({
+		chromatic: {
+			diffThreshold: 0.2,
+			pauseAnimationAtEnd: true,
+		},
+	})
 	.add('With no key events', () => {
 		return (
 			<HydratedLayout
@@ -173,10 +179,4 @@ storiesOf(`Layouts/Liveblog`, module)
 				}}
 			/>
 		);
-	})
-	.addParameters({
-		chromatic: {
-			diffThreshold: 0.2,
-			pauseAnimationAtEnd: true,
-		},
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR moves the statement where we set the chromatic params for the liveblog (with no key events) story up one level of the chain so that it gets set prior to the story being added

## Why?
I hoping this will address the continued false negatives we get. It's a bit of a punt but this is how the params are set above so it seems like a reasonable assumption.
