### PR TITLE
feat(github): add octokit abstraction

### DIFF
--- a/scripts/deno/github.ts
+++ b/scripts/deno/github.ts
@@ -1,0 +1,22 @@
+import { Octokit } from "https://cdn.skypack.dev/octokit";
+import type { RestEndpointMethodTypes } from "https://cdn.skypack.dev/@octokit/plugin-rest-endpoint-methods?dts";
+
+/** Github token for Authentication */
+const token = Deno.env.get("GITHUB_TOKEN");
+if (!token) throw new Error("Missing GITHUB_TOKEN");
+
+type OctokitWithRest = {
+	rest: {
+		issues: {
+			[Method in keyof RestEndpointMethodTypes["issues"]]: (
+				arg: RestEndpointMethodTypes["issues"][Method]["parameters"]
+			) => Promise<RestEndpointMethodTypes["issues"][Method]["response"]>;
+		};
+	};
+};
+
+/**
+ * A hydrated Octokit with types for the rest API.
+ */
+// @ts-expect-error -- Octokit’s own types are not as good as ours
+export const octokit = new Octokit({ auth: token }) as OctokitWithRest;

--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -1,12 +1,4 @@
-import { Octokit } from "https://cdn.skypack.dev/octokit";
-import type { RestEndpointMethodTypes } from "https://cdn.skypack.dev/@octokit/plugin-rest-endpoint-methods?dts";
-
-const token = Deno.env.get("GITHUB_TOKEN");
-if (!token) {
-	console.warn("Missing GITHUB_TOKEN");
-	Deno.exit(1);
-}
-const octokit = new Octokit({ auth: token });
+import { octokit } from "./github.ts";
 
 type Platform = "frontend" | "dcr";
 type OphanAttribute = "data-link-name" | "data-component";
@@ -140,26 +132,20 @@ ${
 
 	const {
 		data: { body: previousBody },
-	}: RestEndpointMethodTypes["issues"]["update"]["response"] = await octokit.request(
-		"GET /repos/{owner}/{repo}/issues/{issue_number}",
-		{
-			owner: "guardian",
-			repo: "dotcom-rendering",
-			issue_number,
-		}
-	);
+	} = await octokit.rest.issues.get({
+		owner: "guardian",
+		repo: "dotcom-rendering",
+		issue_number,
+	});
 
 	const {
 		data: { body: newBody, html_url },
-	}: RestEndpointMethodTypes["issues"]["update"]["response"] = await octokit.request(
-		"PATCH /repos/{owner}/{repo}/issues/{issue_number}",
-		{
-			owner: "guardian",
-			repo: "dotcom-rendering",
-			issue_number,
-			body,
-		}
-	);
+	} = await octokit.rest.issues.update({
+		owner: "guardian",
+		repo: "dotcom-rendering",
+		issue_number,
+		body,
+	});
 
 	const change: string =
 		previousBody === newBody ? "[no change]" : `[some changes]`;

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -1,23 +1,8 @@
-import { Octokit } from "https://cdn.skypack.dev/octokit";
-import type { RestEndpointMethodTypes } from "https://cdn.skypack.dev/@octokit/plugin-rest-endpoint-methods?dts";
+import { octokit } from "./github.ts";
 import type { EventPayloadMap } from "https://cdn.skypack.dev/@octokit/webhooks-types?dts";
 import "https://raw.githubusercontent.com/GoogleChrome/lighthouse-ci/v0.8.2/types/assert.d.ts";
 
 /* -- Setup -- */
-
-type OctokitWithRest = {
-	rest: {
-		issues: {
-			[Method in keyof RestEndpointMethodTypes["issues"]]: (
-				arg: RestEndpointMethodTypes["issues"][Method]["parameters"]
-			) => Promise<RestEndpointMethodTypes["issues"][Method]["response"]>;
-		};
-	};
-};
-
-/** Github token for Authentication */
-const token = Deno.env.get("GITHUB_TOKEN");
-if (!token) throw new Error("Missing GITHUB_TOKEN");
 
 /** Path for workflow event */
 const path = Deno.env.get("GITHUB_EVENT_PATH");
@@ -92,9 +77,6 @@ const GIHUB_PARAMS = {
 	repo: "dotcom-rendering",
 	issue_number,
 } as const;
-
-// @ts-expect-error -- Octokit’s own types are not as good as ours
-const octokit = new Octokit({ auth: token }) as OctokitWithRest;
 
 /* -- Methods -- */
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Improve the Ophan Components tracker info by creating an `Octokit` abstraction.

## Why?

We learned from the work in #4773 