### PR TITLE
`decideSubLinkFormat`

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,19 +1,65 @@
+import { ArticleSpecial, ArticleDesign } from '@guardian/libs';
 import { decideFormat } from '../web/lib/decideFormat';
+
+/**
+ *
+ * This function makes the decision about when we use the parent's (the
+ * container's) format property to override the styling of a sublink, and
+ * when we allow the sublink to express its own styling.
+ *
+ * Eg. If you had a sublink to a lifestyle article, when should it use pink for
+ * the kicker and when would that not look right
+ *
+ * @returns the format property that we will use to style the sublink
+ */
+const decideSubLinkFormat = ({
+	linkFormat,
+	containerFormat,
+	containerPalette,
+}: {
+	linkFormat?: CAPIFormat;
+	containerFormat: ArticleFormat;
+	containerPalette?: DCRContainerPalette;
+}): ArticleFormat => {
+	// Some sublinks are to fronts and so don't have a `format` property
+	if (!linkFormat) return containerFormat;
+	// If the container has a special palette, use the container format
+	if (containerPalette) return containerFormat;
+	// Convert from CAPI to DCR format
+	const dcrLinkFormat = decideFormat(linkFormat);
+	// These types of article styles have background styles that sublinks
+	// need to respect so we use the container format here
+	if (
+		dcrLinkFormat.design === ArticleDesign.LiveBlog ||
+		dcrLinkFormat.design === ArticleDesign.Media ||
+		dcrLinkFormat.theme === ArticleSpecial.SpecialReport
+	)
+		return containerFormat;
+	// Otherwise, we can allow the sublink to express its own styling
+	return dcrLinkFormat;
+};
 
 const enhanceSupportingContent = (
 	supportingContent: FESupportingContent[],
 	format: ArticleFormat,
+	containerPalette?: DCRContainerPalette,
 ): DCRSupportingContent[] => {
 	return supportingContent.map((subLink) => ({
-		// Some sublinks are to fronts and so don't have a `format` property
-		format: (subLink.format && decideFormat(subLink.format)) || format,
+		format: decideSubLinkFormat({
+			linkFormat: subLink.format,
+			containerFormat: format,
+			containerPalette,
+		}),
 		headline: subLink.header?.headline || '',
 		url: subLink.properties.href || subLink.header?.url,
 		kickerText: subLink.header?.kicker?.item?.properties.kickerText,
 	}));
 };
 
-const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
+const enhanceCards = (
+	collections: FEFrontCard[],
+	containerPalette?: DCRContainerPalette,
+): DCRFrontCard[] =>
 	collections
 		.filter(
 			(card: FEFrontCard): card is FEFrontCard & { format: CAPIFormat } =>
@@ -39,6 +85,7 @@ const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
 					? enhanceSupportingContent(
 							faciaCard.supportingContent,
 							format,
+							containerPalette,
 					  )
 					: undefined,
 			};
@@ -55,16 +102,17 @@ export const enhanceCollections = (
 ): DCRCollectionType[] => {
 	return collections.map((collection) => {
 		const { id, displayName, collectionType } = collection;
+		const containerPalette = decideContainerPalette(
+			collection.config.metadata,
+		);
 		return {
 			id,
 			displayName,
 			collectionType,
-			containerPalette: decideContainerPalette(
-				collection.config.metadata,
-			),
-			curated: enhanceCards(collection.curated),
-			backfill: enhanceCards(collection.backfill),
-			treats: enhanceCards(collection.treats),
+			containerPalette,
+			curated: enhanceCards(collection.curated, containerPalette),
+			backfill: enhanceCards(collection.backfill, containerPalette),
+			treats: enhanceCards(collection.treats, containerPalette),
 		};
 	});
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -30,7 +30,8 @@ const decideSubLinkFormat = ({
 	if (
 		linkFormat.design === ArticleDesign.LiveBlog ||
 		linkFormat.design === ArticleDesign.Media ||
-		linkFormat.theme === ArticleSpecial.SpecialReport
+		linkFormat.theme === ArticleSpecial.SpecialReport ||
+		linkFormat.design === ArticleDesign.Analysis
 	)
 		return containerFormat;
 	// Otherwise, we can allow the sublink to express its own styling

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -17,7 +17,7 @@ const decideSubLinkFormat = ({
 	containerFormat,
 	containerPalette,
 }: {
-	linkFormat?: CAPIFormat;
+	linkFormat?: ArticleFormat;
 	containerFormat: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
 }): ArticleFormat => {
@@ -25,18 +25,16 @@ const decideSubLinkFormat = ({
 	if (!linkFormat) return containerFormat;
 	// If the container has a special palette, use the container format
 	if (containerPalette) return containerFormat;
-	// Convert from CAPI to DCR format
-	const dcrLinkFormat = decideFormat(linkFormat);
 	// These types of article styles have background styles that sublinks
 	// need to respect so we use the container format here
 	if (
-		dcrLinkFormat.design === ArticleDesign.LiveBlog ||
-		dcrLinkFormat.design === ArticleDesign.Media ||
-		dcrLinkFormat.theme === ArticleSpecial.SpecialReport
+		linkFormat.design === ArticleDesign.LiveBlog ||
+		linkFormat.design === ArticleDesign.Media ||
+		linkFormat.theme === ArticleSpecial.SpecialReport
 	)
 		return containerFormat;
 	// Otherwise, we can allow the sublink to express its own styling
-	return dcrLinkFormat;
+	return linkFormat;
 };
 
 const enhanceSupportingContent = (
@@ -46,7 +44,9 @@ const enhanceSupportingContent = (
 ): DCRSupportingContent[] => {
 	return supportingContent.map((subLink) => ({
 		format: decideSubLinkFormat({
-			linkFormat: subLink.format,
+			linkFormat: subLink.format
+				? decideFormat(subLink.format)
+				: undefined,
 			containerFormat: format,
 			containerPalette,
 		}),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the function `decideSubLinkFormat` which is where we make the decision about which `format` property to use for sublinks.

## Why?
On fronts, a Card can have sublinks along the bottom. In some situations we want to style these sublinks according to the container that they sit in. A good example of this is where the container is for a liveblog, with the red background. In this case the sublink text should be white, regardless of the format of the article they link to. But if the container format is a simple news article and the sublink points to a lifestyle article then we would not want to style the link using the news tone, that would be inaccurate.

This variation in design logic is encompassed in this function.


| Before      | After      |
|-------------|------------|
| <img width="710" alt="Screenshot 2022-05-03 at 16 14 27" src="https://user-images.githubusercontent.com/1336821/166482196-b1cb1fe9-9c26-4dcf-ba0c-c797ac5c50b7.png"> | <img width="710" alt="Screenshot 2022-05-03 at 16 13 53" src="https://user-images.githubusercontent.com/1336821/166482091-85daf33e-68f3-4caa-b044-1fff84585435.png"> |

