### PR TITLE
fix: Wait until fonts have loaded before rendering storybooks

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -61,6 +61,13 @@ window.guardian = {
 }
 setCookie({name:'bwid', value: 'mockBrowserId'});
 
+// See https://www.chromatic.com/docs/resource-loading
+// Seems like chromatic isn't super great at loading font's correctly.
+// This might help reduce the false positives we get when running chromatic tests.
+const fontLoader = async () => ({
+	fonts: await document.fonts.ready,
+});
+
 const guardianViewports = {
 	mobileMedium: {
 		name: 'mobileMedium',
@@ -122,3 +129,5 @@ export const parameters = {
 	},
 	layout: 'fullscreen',
 };
+
+export const loaders = isChromatic() && document.fonts ? [fontLoader] : [];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Force chromatic to wait for fonts to be loaded before taking a screenshot.

## Why?

This is also a bit of a punt and may or may not do anything at all. 

When I was looking at the footer https://5dfcbf3012392c0020e7140b-ubkpogwarw.chromatic.com/?path=/story/layouts-format-variations-immersive-interactive--labs of this storybook I noticed the "Obituary" link would overflow to the next line on first page load but on subsequent loads it would render without overflowing. By clearing the cache I was able to make this happen consistently.

I couldn't really find any difference in CSS or DOM for that particular section of the page between the two page loads, so it seemed like it could potentially be a seperate issue. Furthermore, blocking all fronts from loading seemed to make the footer load consistently (although not correctly).

Chromatic does apparently  have some issues with fronts causing false negatives according to this page https://www.chromatic.com/docs/resource-loading and this is one of their suggested solutions.
