### PR TITLE
Footer position

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -164,6 +164,11 @@ export const Card = ({
 		supportingContent?.length && supportingContent.length > 2
 	);
 
+	const cardIsVertical =
+		imagePosition === 'top' || imagePosition === 'bottom';
+
+	const positionFooterUnderContent = !moreThanTwoSubLinks && cardIsVertical;
+
 	const renderFooter = ({
 		renderAge = true,
 		renderMediaMeta = true,
@@ -313,7 +318,7 @@ export const Card = ({
 							</Hide>
 						)}
 						{/* Show the card footer in the same column as the headline content */}
-						{!moreThanTwoSubLinks ? (
+						{positionFooterUnderContent ? (
 							renderFooter({ forceVertical: true })
 						) : (
 							<></>
@@ -322,7 +327,7 @@ export const Card = ({
 				</ContentWrapper>
 			</CardLayout>
 			{/* If there are more than two sublinks break footer out of the headline column into a row below */}
-			{moreThanTwoSubLinks ? renderFooter({}) : <></>}
+			{!positionFooterUnderContent ? renderFooter({}) : <></>}
 		</CardWrapper>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -48,7 +48,7 @@ export const CardFooter = ({
 	) {
 		return (
 			<footer>
-				<div>{supportingContent}</div>
+				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
 					<StraightLines
@@ -64,7 +64,7 @@ export const CardFooter = ({
 	if (format.design === ArticleDesign.Media) {
 		return (
 			<footer>
-				<div>{supportingContent}</div>
+				{supportingContent}
 				<div css={spaceBetween}>
 					{mediaMeta}
 					{/* Show age if we have it otherwise try for commentCount */}
@@ -77,7 +77,7 @@ export const CardFooter = ({
 	if (age) {
 		return (
 			<footer>
-				<div>{supportingContent}</div>
+				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
 					{commentCount}
@@ -88,7 +88,7 @@ export const CardFooter = ({
 
 	return (
 		<footer>
-			<div>{supportingContent}</div>
+			{supportingContent}
 			<div css={flexEnd}>
 				<>{commentCount}</>
 			</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We no longer position the footer in the same column as the headline and trail text if the image is positioned to the left or right

## Why?
The footer should go full width in these circumstances

| Before      | After      |
|-------------|------------|
| <img width="472" alt="Screenshot 2022-05-04 at 09 18 14" src="https://user-images.githubusercontent.com/1336821/166645245-7538f3a0-cc50-4f75-b9a4-6fd18e441be9.png"> | <img width="472" alt="Screenshot 2022-05-04 at 09 15 55" src="https://user-images.githubusercontent.com/1336821/166645285-cf7c42cd-aabb-4c3b-ad2b-ea7fa7ddf7bd.png"> |