### PR TITLE
Bump `commercial-core`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.1.2",
     "@guardian/braze-components": "^7.2.0",
-    "@guardian/commercial-core": "^3.3.0",
+    "@guardian/commercial-core": "^3.4.0",
     "@guardian/consent-management-platform": "^10.5.0",
     "@guardian/discussion-rendering": "^10.1.0",
     "@guardian/libs": "^4.0.0",

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -61,15 +61,20 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 			browserId: browserId || undefined,
 			isDev,
 			adBlockerInUse,
-		});
-
-		if (
-			userInClientSideTestToForceMetrics ||
-			userInServerSideTestToForceMetrics
-		) {
-			// TODO: rename this in commercial-core and update here
-			switchOffSampling();
-		}
+		})
+			.then(() => {
+				if (
+					userInClientSideTestToForceMetrics ||
+					userInServerSideTestToForceMetrics
+				) {
+					// TODO: rename this in commercial-core and update here
+					// eslint-disable-next-line no-void
+					void switchOffSampling();
+				}
+			})
+			.catch((e) =>
+				console.error(`Error initialising commercial metrics: ${e}`),
+			);
 	}, [ABTestAPI, adBlockerInUse, enabled]);
 
 	// We don’t render anything

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,10 +2815,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
   integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
 
-"@guardian/commercial-core@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.3.0.tgz#c859a49a0949a864df97a5c23b21e641ef18d93e"
-  integrity sha512-F0vMNO9Rud7eLgtivz1YWOBvgHuAP1IgI98aJrnD9iPdeiX8Cf79ApinvdT46/p/rNgOEwn2UhoJq9MkhtyqXg==
+"@guardian/commercial-core@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.4.0.tgz#30fa768df0ca77ae912a1d55c4de2427d8608654"
+  integrity sha512-r/JPn0MpUUOZ/gy0E0NJOBwGDM0fga1nXxXiwY60Ya8S2fOdqrtGJfcnfDOd55wDbQQ0VbRWnO3SO/J6ZA9icw==
 
 "@guardian/consent-management-platform@^10.5.0":
   version "10.5.0"


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to `3.4.0`.

## Why?

To pull in changes to `commercial-core` which require consent to be given before sending commercial metrics:

https://github.com/guardian/commercial-core/pull/535
