### PR TITLE
Split Up Media Designs - Stage One: Temporarily Parse New Designs To `Design.Media`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -27,7 +27,11 @@ type CAPITheme = ThemePillar | ThemeSpecial;
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
 type CAPIDesign =
 	| 'ArticleDesign'
+	// Temporarily accept both the old MediaDesign and the new ones
 	| 'MediaDesign'
+	| 'GalleryDesign'
+	| 'AudioDesign'
+	| 'VideoDesign'
 	| 'ReviewDesign'
 	| 'AnalysisDesign'
 	| 'CommentDesign'

--- a/dotcom-rendering/src/web/lib/decideDesign.ts
+++ b/dotcom-rendering/src/web/lib/decideDesign.ts
@@ -11,7 +11,11 @@ export const decideDesign = ({
 	switch (design) {
 		case 'ArticleDesign':
 			return ArticleDesign.Standard;
+		// Temporarily accept both the old MediaDesign and the new ones
 		case 'MediaDesign':
+		case 'GalleryDesign':
+		case 'AudioDesign':
+		case 'VideoDesign':
 			return ArticleDesign.Media;
 		case 'ReviewDesign':
 			return ArticleDesign.Review;


### PR DESCRIPTION
## Why?

We're splitting `Design.Media` into `Design.Gallery`, `Design.Audio` and `Design.Video`; for the reason why see https://github.com/guardian/libs/pull/332

At the moment, for dotcom, `Design` is modelled in two places: `libs` and the CAPI client. Frontend uses the CAPI client representation and passes it on to DCR, and DCR parses that representation into the `libs` representation, which it uses from then on. Therefore we have to make the change to both libraries (CAPI client change here: https://github.com/guardian/content-api-scala-client/pull/353 ) and make sure frontend and DCR are synchronised.

Because frontend and DCR are deployed independently and speak via an API, we can't ship the changes to both at exactly the same time. There will be a point where the same instance of DCR is receiving requests from both the old frontend version and the new frontend version. Therefore we have to migrate in stages, allowing DCR to understand both versions of the frontend API simultaneously. The stages are as follows, with a PR for each:

1. Update DCR to accept the three new CAPI client designs, and parse them into the old `libs` representation: `Design.Media`
2. Update the CAPI client in frontend, to switch from the old `Design.MediaDesign` to the three new CAPI client designs
3. Update `libs` in DCR, parse the new CAPI client designs into the new `libs` designs, and remove the old `Design.MediaDesign`.

This PR represents stage one.

## Changes

- Add new CAPI media Designs
- Parse new CAPI media Designs to old libs `Design.Media`