### PR TITLE
Allow client-side JS to run on Interview articles for rich link support

### DIFF
--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -56,6 +56,7 @@ const scriptName = ({ design, display }: ArticleFormat): Option<string> => {
 		case ArticleDesign.Standard:
 		case ArticleDesign.Quiz:
 		case ArticleDesign.Media:
+		case ArticleDesign.Interview:
 			return some('article.js');
 		default:
 			return none;


### PR DESCRIPTION
## Why?
Rich link images and pillars are fetched client-side because the CAPI response doesn't include information about the articles that rich links point to. At the moment, the client-side JS that performs this fetch request doesn't run on Interview articles, meaning that rich links won't be displayed correctly in AR (boo!).

Therefore, this PR adds `ArticleDesign.Interview` to the list of designs where `article.js` is allowed to run.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/57295823/166699371-c84ac7cb-0b84-4f2c-aa02-f1b66990b0f0.png
[after]: https://user-images.githubusercontent.com/57295823/166699460-a57d83ad-d8bd-411f-9cdf-fd656c2a28e6.png
[before2]: https://user-images.githubusercontent.com/57295823/166719876-3b0192c4-0656-4e89-92ea-93f3bfae4dda.png
[after2]: https://user-images.githubusercontent.com/57295823/166719404-b05fcd5f-fbe3-432a-b2db-4d99f910ce94.png