### PR TITLE
Add `data-link-name` to Front Cards

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -800,6 +800,8 @@ type DCRFrontCard = {
 	webPublicationDate?: string;
 	image?: string;
 	kickerText?: string;
+	/** @see JSX.IntrinsicAttributes["data-link-name"] */
+	dataLinkName: string;
 };
 
 type FECollectionType = {
@@ -1213,6 +1215,8 @@ interface TrailType extends BaseTrailType {
 	format: ArticleFormat;
 	supportingContent?: DCRSupportingContent[];
 	trailText?: string;
+	/** @see JSX.IntrinsicAttributes["data-link-name"] */
+	dataLinkName?: string;
 }
 
 interface CAPITrailType extends BaseTrailType {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,4 +1,5 @@
 import { decideFormat } from '../web/lib/decideFormat';
+import { getDataLinkNameCard } from '../web/lib/getDataLinkName';
 
 const enhanceSupportingContent = (
 	supportingContent: FESupportingContent[],
@@ -19,10 +20,15 @@ const enhanceCards = (collections: FEFrontCard[]): DCRFrontCard[] =>
 			(card: FEFrontCard): card is FEFrontCard & { format: CAPIFormat } =>
 				!!card.format,
 		)
-		.map((faciaCard) => {
+		.map((faciaCard, index) => {
 			const format = decideFormat(faciaCard.format);
+			const group = `${faciaCard.card.group}${
+				faciaCard.display.isBoosted ? '+' : ''
+			}`;
+			const dataLinkName = getDataLinkNameCard(format, group, index + 1);
 			return {
 				format,
+				dataLinkName,
 				url: faciaCard.header.url,
 				headline: faciaCard.header.headline,
 				trailText: faciaCard.card.trailText,

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -52,7 +52,7 @@ export type Props = {
 	commentCount?: number;
 	starRating?: number;
 	minWidthInPixels?: number;
-	// Ophan tracking
+	/** Used for Ophan tracking */
 	dataLinkName?: string;
 	// Labs
 	branding?: Branding;

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -4,7 +4,6 @@ import { getZIndex } from '../../../lib/getZIndex';
 const fauxLinkStyles = css`
 	position: absolute;
 	${getZIndex('card-link')};
-	opacity: 0;
 	top: 0;
 	right: 0;
 	bottom: 0;
@@ -17,7 +16,6 @@ type Props = {
 };
 
 export const CardLink = ({ linkTo, dataLinkName = 'article' }: Props) => (
-	<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName}>
-		{linkTo}
-	</a>
+	// eslint-disable-next-line -- we’ve got an empty link floating: see #4798
+	<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName} />
 );

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -47,6 +47,7 @@ export const DynamicFast = ({ trails }: Props) => {
 						starRating={primary.starRating}
 						branding={primary.branding}
 						supportingContent={primary.supportingContent}
+						dataLinkName={primary.dataLinkName}
 					/>
 				</LI>
 				<LI
@@ -80,6 +81,7 @@ export const DynamicFast = ({ trails }: Props) => {
 						starRating={secondary.starRating}
 						branding={secondary.branding}
 						supportingContent={secondary.supportingContent}
+						dataLinkName={secondary.dataLinkName}
 					/>
 				</LI>
 			</UL>
@@ -120,6 +122,7 @@ export const DynamicFast = ({ trails }: Props) => {
 								starRating={card.starRating}
 								branding={card.branding}
 								supportingContent={card.supportingContent}
+								dataLinkName={card.dataLinkName}
 							/>
 						</LI>
 					);
@@ -171,6 +174,7 @@ export const DynamicFast = ({ trails }: Props) => {
 										supportingContent={
 											card.supportingContent
 										}
+										dataLinkName={card.dataLinkName}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -52,6 +52,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 						starRating={primary.starRating}
 						branding={primary.branding}
 						supportingContent={primary.supportingContent}
+						dataLinkName={primary.dataLinkName}
 					/>
 				</LI>
 				<LI
@@ -85,6 +86,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 						starRating={secondary.starRating}
 						branding={secondary.branding}
 						supportingContent={secondary.supportingContent}
+						dataLinkName={secondary.dataLinkName}
 					/>
 				</LI>
 			</UL>
@@ -136,6 +138,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 											card.supportingContent
 										}
 										imagePositionOnMobile="none"
+										dataLinkName={card.dataLinkName}
 									/>
 								</LI>
 							);
@@ -186,6 +189,7 @@ export const DynamicSlow = ({ trails }: Props) => {
 										commentCount={card.commentCount}
 										starRating={card.starRating}
 										branding={card.branding}
+										dataLinkName={card.dataLinkName}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -128,6 +128,7 @@ export const FixedLargeSlowXIV = ({ trails }: Props) => {
 										commentCount={card.commentCount}
 										starRating={card.starRating}
 										branding={card.branding}
+										dataLinkName={card.dataLinkName}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign } from '@guardian/libs';
+
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -47,6 +48,7 @@ export const FixedSmallSlowIV = ({ trails }: Props) => {
 							commentCount={trail.commentCount}
 							starRating={trail.starRating}
 							branding={trail.branding}
+							dataLinkName={trail.dataLinkName}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/web/lib/getDataLinkName.ts
+++ b/dotcom-rendering/src/web/lib/getDataLinkName.ts
@@ -1,0 +1,49 @@
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+
+/**
+ * TODO: missing "podcast" and "external"
+ */
+const getLinkType = ({ theme, design }: ArticleFormat): RichLinkCardType => {
+	switch (theme) {
+		case ArticleSpecial.SpecialReport:
+			return 'special-report';
+		default:
+			switch (design) {
+				case ArticleDesign.Analysis:
+					return 'analysis';
+				case ArticleDesign.LiveBlog:
+					return 'live';
+				case ArticleDesign.DeadBlog:
+					return 'dead';
+				case ArticleDesign.Feature:
+					return 'feature';
+				case ArticleDesign.Editorial:
+					return 'editorial';
+				case ArticleDesign.Comment:
+					return 'comment';
+				case ArticleDesign.Media:
+					return 'media';
+				case ArticleDesign.Review:
+					return 'review';
+				case ArticleDesign.Letter:
+					return 'letters';
+
+				default:
+					return 'news';
+			}
+	}
+};
+
+/**
+ * Get the `data-link-name` attribute for a card.
+ * Used by Ophan for understanding reader journeys. E.g:
+ * - `feature | card-2+ | card-@1`
+ * - `news | group-0 | card-@5`
+ *
+ * @see {JSX.IntrinsicAttributes}
+ */
+export const getDataLinkNameCard = (
+	format: ArticleFormat,
+	group: string | number,
+	index: number,
+) => [getLinkType(format), `group-${group}`, `card-@${index}`].join(' | ');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

All trails now have an optional `dataLinkName` key that may contain the Ophan component attribute.

A new helper method `getDataLinkNameCard` helps retrieve a `data-link-name` attribute for a card given its format, group and index.


## Why?

`data-link-name` attributes are missing on Front cards.

Part of #4692 & #4662 

## Screenshots

Using the [Ophan component bookarklet](https://gist.github.com/mxdvl/b17f344678ed34d45683896e208ecdc1).

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/76776/166717771-7a4e4ca2-ee15-426c-bdf8-37e838d5001a.png">
