### PR TITLE
Refactor image width decisions

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -978,6 +978,8 @@ interface BadgeType {
 
 type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
 
+type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
+
 type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
 type AvatarType = {

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -268,74 +268,86 @@ cardStories.add('with media type', () => {
 	);
 });
 
-cardStories.add('with different image positions', () => {
-	return (
-		<>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="left"
-					imageSize="large"
-					headlineText="left"
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="right"
-					imageSize="large"
-					headlineText="right"
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="top"
-					headlineText="top"
-				/>
-			</CardWrapper>
-		</>
-	);
-});
+cardStories
+	.add('with different image positions', () => {
+		return (
+			<>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="left"
+						imageSize="large"
+						headlineText="left"
+					/>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="right"
+						imageSize="large"
+						headlineText="right"
+					/>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="top"
+						headlineText="top"
+					/>
+				</CardWrapper>
+			</>
+		);
+	})
+	.addParameters({
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.wide],
+		},
+	});
 
-cardStories.add('with different image sizes', () => {
-	return (
-		<>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="left"
-					headlineText="small"
-					imageSize="small"
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="left"
-					headlineText="medium"
-					imageSize="medium"
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="left"
-					headlineText="large"
-					imageSize="large"
-				/>
-			</CardWrapper>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					imagePosition="left"
-					headlineText="jumbo"
-					imageSize="jumbo"
-				/>
-			</CardWrapper>
-		</>
-	);
-});
+cardStories
+	.add('with different image sizes', () => {
+		return (
+			<>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="left"
+						headlineText="small"
+						imageSize="small"
+					/>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="left"
+						headlineText="medium"
+						imageSize="medium"
+					/>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="left"
+						headlineText="large"
+						imageSize="large"
+					/>
+				</CardWrapper>
+				<CardWrapper>
+					<Card
+						{...basicCardProps}
+						imagePosition="left"
+						headlineText="jumbo"
+						imageSize="jumbo"
+					/>
+				</CardWrapper>
+			</>
+		);
+	})
+	.addParameters({
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.wide],
+		},
+	});
 
 cardStories.add('with pulsing dot', () => {
 	return (

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -275,6 +275,7 @@ cardStories.add('with different image positions', () => {
 				<Card
 					{...basicCardProps}
 					imagePosition="left"
+					imageSize="large"
 					headlineText="left"
 				/>
 			</CardWrapper>
@@ -282,6 +283,7 @@ cardStories.add('with different image positions', () => {
 				<Card
 					{...basicCardProps}
 					imagePosition="right"
+					imageSize="large"
 					headlineText="right"
 				/>
 			</CardWrapper>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -59,41 +59,6 @@ export type Props = {
 	supportingContent?: DCRSupportingContent[];
 };
 
-type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
-
-type CoveragesType = {
-	image: {
-		small: CardPercentageType;
-		medium: CardPercentageType;
-		large: CardPercentageType;
-		jumbo: CardPercentageType;
-	};
-	content: {
-		small: CardPercentageType;
-		medium: CardPercentageType;
-		large: CardPercentageType;
-		jumbo: CardPercentageType;
-	};
-};
-
-const coverages: CoveragesType = {
-	// coverages is how we set the image size relative to the space given
-	// to the headline. These percentages are passed to flex-basis inside the
-	// wrapper components
-	image: {
-		small: '25%',
-		medium: '50%',
-		large: '66%',
-		jumbo: '75%',
-	},
-	content: {
-		small: '75%',
-		medium: '50%',
-		large: '34%',
-		jumbo: '25%',
-	},
-};
-
 const starWrapper = css`
 	background-color: ${brandAltBackground.primary};
 	position: absolute;
@@ -144,17 +109,6 @@ export const Card = ({
 	branding,
 	supportingContent,
 }: Props) => {
-	// Decide how we position the image on the card
-	let imageCoverage: CardPercentageType | undefined;
-	let contentCoverage: CardPercentageType | undefined;
-	if (imageSize && imagePosition !== 'top') {
-		// We only specifiy an explicit width for the image when
-		// we're positioning left or right, not top. Top positioned
-		// images flow naturally
-		imageCoverage = coverages.image[imageSize];
-		contentCoverage = coverages.content[imageSize];
-	}
-
 	const showCommentCount = commentCount || commentCount === 0;
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
@@ -245,7 +199,8 @@ export const Card = ({
 			>
 				{imageUrl && (
 					<ImageWrapper
-						percentage={imageCoverage}
+						imageSize={imageSize}
+						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
 					>
 						<img src={imageUrl} alt="" role="presentation" />
@@ -254,7 +209,10 @@ export const Card = ({
 						) : null}
 					</ImageWrapper>
 				)}
-				<ContentWrapper percentage={contentCoverage}>
+				<ContentWrapper
+					imageSize={imageSize}
+					imagePosition={imagePosition}
+				>
 					<Flex>
 						<HeadlineWrapper>
 							<CardHeadline

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -8,6 +8,11 @@ const sizingStyles = css`
 	justify-content: space-between;
 `;
 
+/**
+ * This function works in partnership with its sibling in `ImageWrapper`. If you
+ * change any values here be sure to update that file as well.
+ *
+ */
 const flexBasisStyles = ({
 	imagePosition,
 	imageSize,

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -49,7 +49,7 @@ const flexBasisStyles = ({
 						flex-basis: 25%;
 					`;
 			}
-		// eslint-disable-next-line no-fallthrough
+		// eslint-disable-next-line no-fallthrough -- we know fallthrough will never happen here but eslint isn't so sure
 		case 'none':
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -33,7 +33,7 @@ const flexBasisStyles = ({
 							flex-basis: 60%;
 						}
 						${from.desktop} {
-							flex-basis: 67%;
+							flex-basis: 70%;
 						}
 					`;
 				case 'medium':

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 
-import { until } from '@guardian/source-foundations';
+import { between, from } from '@guardian/source-foundations';
 
 const sizingStyles = css`
 	display: flex;
@@ -8,24 +8,65 @@ const sizingStyles = css`
 	justify-content: space-between;
 `;
 
-const coverageStyles = (percentage?: string) => {
-	return percentage
-		? css`
-				flex-basis: ${percentage};
-				${until.tablet} {
-					flex-basis: unset;
-				}
-		  `
-		: css`
+const flexBasisStyles = ({
+	imagePosition,
+	imageSize,
+}: {
+	imagePosition: ImagePositionType;
+	imageSize: ImageSizeType;
+}): SerializedStyles | null => {
+	switch (imagePosition) {
+		case 'top':
+		case 'bottom':
+			// If the image is top or bottom positioned then it takes 100% of the width and
+			// we want the content to grow into the remaining vertical space
+			return css`
 				flex-grow: 1;
-		  `;
+			`;
+		case 'left':
+		case 'right':
+			switch (imageSize) {
+				case 'small':
+					return css`
+						flex-basis: 75%;
+						${between.tablet.and.desktop} {
+							flex-basis: 60%;
+						}
+						${from.desktop} {
+							flex-basis: 67%;
+						}
+					`;
+				case 'medium':
+					return css`
+						flex-basis: 50%;
+					`;
+				case 'large':
+					return css`
+						flex-basis: 34%;
+					`;
+				case 'jumbo':
+					return css`
+						flex-basis: 25%;
+					`;
+			}
+		// eslint-disable-next-line no-fallthrough
+		case 'none':
+			return null;
+	}
 };
 
 type Props = {
 	children: React.ReactNode;
-	percentage?: CardPercentageType;
+	imageSize?: ImageSizeType;
+	imagePosition: ImagePositionType;
 };
 
-export const ContentWrapper = ({ children, percentage }: Props) => (
-	<div css={[sizingStyles, coverageStyles(percentage)]}>{children}</div>
+export const ContentWrapper = ({
+	children,
+	imageSize = 'small',
+	imagePosition,
+}: Props) => (
+	<div css={[sizingStyles, flexBasisStyles({ imageSize, imagePosition })]}>
+		{children}
+	</div>
 );

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -14,49 +14,33 @@ const sizingStyles = css`
  *
  */
 const flexBasisStyles = ({
-	imagePosition,
 	imageSize,
 }: {
-	imagePosition: ImagePositionType;
 	imageSize: ImageSizeType;
-}): SerializedStyles | null => {
-	switch (imagePosition) {
-		case 'top':
-		case 'bottom':
-			// If the image is top or bottom positioned then it takes 100% of the width and
-			// we want the content to grow into the remaining vertical space
+}): SerializedStyles => {
+	switch (imageSize) {
+		case 'small':
 			return css`
-				flex-grow: 1;
+				flex-basis: 75%;
+				${between.tablet.and.desktop} {
+					flex-basis: 60%;
+				}
+				${from.desktop} {
+					flex-basis: 70%;
+				}
 			`;
-		case 'left':
-		case 'right':
-			switch (imageSize) {
-				case 'small':
-					return css`
-						flex-basis: 75%;
-						${between.tablet.and.desktop} {
-							flex-basis: 60%;
-						}
-						${from.desktop} {
-							flex-basis: 70%;
-						}
-					`;
-				case 'medium':
-					return css`
-						flex-basis: 50%;
-					`;
-				case 'large':
-					return css`
-						flex-basis: 34%;
-					`;
-				case 'jumbo':
-					return css`
-						flex-basis: 25%;
-					`;
-			}
-		// eslint-disable-next-line no-fallthrough -- we know fallthrough will never happen here but eslint isn't so sure
-		case 'none':
-			return null;
+		case 'medium':
+			return css`
+				flex-basis: 50%;
+			`;
+		case 'large':
+			return css`
+				flex-basis: 34%;
+			`;
+		case 'jumbo':
+			return css`
+				flex-basis: 25%;
+			`;
 	}
 };
 
@@ -70,8 +54,23 @@ export const ContentWrapper = ({
 	children,
 	imageSize = 'small',
 	imagePosition,
-}: Props) => (
-	<div css={[sizingStyles, flexBasisStyles({ imageSize, imagePosition })]}>
-		{children}
-	</div>
-);
+}: Props) => {
+	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
+	const isVertical = imagePosition === 'top' || imagePosition === 'bottom';
+	return (
+		<div
+			css={[
+				sizingStyles,
+				isHorizontal && flexBasisStyles({ imageSize }),
+				/* If the image is top or bottom positioned then it takes 100% of the width and
+				   we want the content to grow into the remaining vertical space */
+				isVertical &&
+					css`
+						flex-grow: 1;
+					`,
+			]}
+		>
+			{children}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -33,7 +33,7 @@ const flexBasisStyles = ({
 							flex-basis: 40%;
 						}
 						${from.desktop} {
-							flex-basis: 33%;
+							flex-basis: 30%;
 						}
 					`;
 				case 'medium':

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -1,16 +1,64 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 
-import { until } from '@guardian/source-foundations';
+import { between, from, until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
+	imageSize?: ImageSizeType;
+	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
-	percentage?: CardPercentageType;
+};
+
+const flexBasisStyles = ({
+	imagePosition,
+	imageSize,
+}: {
+	imagePosition: ImagePositionType;
+	imageSize: ImageSizeType;
+}): SerializedStyles | null => {
+	switch (imagePosition) {
+		case 'top':
+		case 'bottom':
+			// We only specifiy an explicit width for the image when
+			// we're positioning left or right, not top. Top positioned
+			// images flow naturally
+			return null;
+		case 'left':
+		case 'right':
+			switch (imageSize) {
+				case 'small':
+					return css`
+						flex-basis: 25%;
+						${between.tablet.and.desktop} {
+							flex-basis: 40%;
+						}
+						${from.desktop} {
+							flex-basis: 33%;
+						}
+					`;
+				case 'medium':
+					return css`
+						flex-basis: 50%;
+					`;
+				case 'large':
+					return css`
+						flex-basis: 66%;
+					`;
+				case 'jumbo':
+					return css`
+						flex-basis: 75%;
+					`;
+			}
+		// eslint-disable-next-line no-fallthrough
+		case 'none':
+			return null;
+	}
 };
 
 export const ImageWrapper = ({
 	children,
-	percentage,
+	imageSize = 'large',
+	imagePosition,
 	imagePositionOnMobile,
 }: Props) => {
 	const notVertical =
@@ -18,10 +66,13 @@ export const ImageWrapper = ({
 	return (
 		<div
 			css={[
+				flexBasisStyles({
+					imageSize,
+					imagePosition,
+				}),
 				css`
 					/* position relative is required here to bound the image overlay */
 					position: relative;
-					flex-basis: ${percentage && percentage};
 					/* If no image position for mobile is provided then hide the image */
 					${imagePositionOnMobile === 'none' && until.tablet} {
 						display: none;

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -15,48 +15,33 @@ type Props = {
  *
  */
 const flexBasisStyles = ({
-	imagePosition,
 	imageSize,
 }: {
-	imagePosition: ImagePositionType;
 	imageSize: ImageSizeType;
 }): SerializedStyles | null => {
-	switch (imagePosition) {
-		case 'top':
-		case 'bottom':
-			// We only specifiy an explicit width for the image when
-			// we're positioning left or right, not top. Top positioned
-			// images flow naturally
-			return null;
-		case 'left':
-		case 'right':
-			switch (imageSize) {
-				case 'small':
-					return css`
-						flex-basis: 25%;
-						${between.tablet.and.desktop} {
-							flex-basis: 40%;
-						}
-						${from.desktop} {
-							flex-basis: 30%;
-						}
-					`;
-				case 'medium':
-					return css`
-						flex-basis: 50%;
-					`;
-				case 'large':
-					return css`
-						flex-basis: 66%;
-					`;
-				case 'jumbo':
-					return css`
-						flex-basis: 75%;
-					`;
-			}
-		// eslint-disable-next-line no-fallthrough
-		case 'none':
-			return null;
+	switch (imageSize) {
+		case 'small':
+			return css`
+				flex-basis: 25%;
+				${between.tablet.and.desktop} {
+					flex-basis: 40%;
+				}
+				${from.desktop} {
+					flex-basis: 30%;
+				}
+			`;
+		case 'medium':
+			return css`
+				flex-basis: 50%;
+			`;
+		case 'large':
+			return css`
+				flex-basis: 66%;
+			`;
+		case 'jumbo':
+			return css`
+				flex-basis: 75%;
+			`;
 	}
 };
 
@@ -66,33 +51,37 @@ export const ImageWrapper = ({
 	imagePosition,
 	imagePositionOnMobile,
 }: Props) => {
-	const notVertical =
-		imagePositionOnMobile !== 'top' && imagePositionOnMobile !== 'bottom';
+	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
 	return (
 		<div
 			css={[
-				flexBasisStyles({
-					imageSize,
-					imagePosition,
-				}),
+				isHorizontal &&
+					flexBasisStyles({
+						imageSize,
+					}),
+				/* If no image position for mobile is provided then hide the image */
+				imagePositionOnMobile === 'none' &&
+					css`
+						${until.tablet} {
+							display: none;
+						}
+					`,
+				/* Below tablet, we fix the size of the image and add a margin
+				   around it. The corresponding content flex grows to fill the space */
+				isHorizontal &&
+					css`
+						${until.tablet} {
+							margin-left: 6px;
+							width: 119px;
+							flex-shrink: 0;
+							margin-top: 6px;
+							margin-bottom: 6px;
+							flex-basis: unset;
+						}
+					`,
 				css`
 					/* position relative is required here to bound the image overlay */
 					position: relative;
-					/* If no image position for mobile is provided then hide the image */
-					${imagePositionOnMobile === 'none' && until.tablet} {
-						display: none;
-					}
-					${notVertical && until.tablet} {
-						/* Below tablet, we fix the size of the image and add a margin
-                       around it. The corresponding content flex grows to fill the space */
-						margin-left: 6px;
-						width: 119px;
-						flex-shrink: 0;
-						margin-top: 6px;
-						margin-bottom: 6px;
-						flex-basis: unset;
-					}
-
 					img {
 						width: 100%;
 						display: block;

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -9,6 +9,11 @@ type Props = {
 	imagePositionOnMobile: ImagePositionType;
 };
 
+/**
+ * This function works in partnership with its sibling in `ContentWrapper`. If you
+ * change any values here be sure to update that file as well.
+ *
+ */
 const flexBasisStyles = ({
 	imagePosition,
 	imageSize,

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -18,7 +18,7 @@ const flexBasisStyles = ({
 	imageSize,
 }: {
 	imageSize: ImageSizeType;
-}): SerializedStyles | null => {
+}): SerializedStyles => {
 	switch (imageSize) {
 		case 'small':
 			return css`
@@ -52,6 +52,8 @@ export const ImageWrapper = ({
 	imagePositionOnMobile,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';
+	const isHorizontalOnMobile =
+		imagePositionOnMobile === 'left' || imagePositionOnMobile === 'right';
 	return (
 		<div
 			css={[
@@ -68,7 +70,7 @@ export const ImageWrapper = ({
 					`,
 				/* Below tablet, we fix the size of the image and add a margin
 				   around it. The corresponding content flex grows to fill the space */
-				isHorizontal &&
+				isHorizontalOnMobile &&
 					css`
 						${until.tablet} {
 							margin-left: 6px;

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -200,6 +200,7 @@ export const Horizontal = () => {
 					},
 				]}
 				imagePosition="right"
+				imageSize="large"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -288,6 +289,7 @@ export const LongText = () => {
 					},
 				]}
 				imagePosition="left"
+				imageSize="large"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -337,6 +339,7 @@ export const MoreThanThree = () => {
 					},
 				]}
 				imagePosition="left"
+				imageSize="large"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -366,6 +369,7 @@ export const OneSublink = () => {
 					},
 				]}
 				imagePosition="left"
+				imageSize="large"
 				trailText="When the image is positioned horizontally and there is only one sublink, it appears under the headline"
 				format={{
 					display: ArticleDisplay.Standard,
@@ -401,6 +405,7 @@ export const TwoSublinks = () => {
 					},
 				]}
 				imagePosition="left"
+				imageSize="large"
 				trailText="When there are only two sublinks they appear under the headline vertically stacked"
 				format={{
 					display: ArticleDisplay.Standard,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR refactors how we decide the width of an image. It does this by extending the decision logic we had before to take into account breakpoint, image orientation and the requested size of image when making the choice about how to space things.

At the same time, I've refactored the code to push the decision down into the `ImageWrapper` and `ContentWrapper` components themselves. There are pros and cons here. It's arguably better if the left and right flex basis values are tied together somehow but on the other hand having the decision logic for each wrapper locally helps keep things simple.

## Why?
We had some issues where DCR was making the wrong decisions about the size of image to render. In particular, the 'small' size of the image when a card is horizontal but rendered at a wider breakpoint was not correct previously, it's now a bit bigger.

| Before      | After      |
|-------------|------------|
| <img width="956" alt="Screenshot 2022-05-05 at 14 15 14" src="https://user-images.githubusercontent.com/1336821/166930794-6890fa6e-dce9-4d33-be02-fc6cfe66db45.png"> | <img width="956" alt="Screenshot 2022-05-05 at 14 14 38" src="https://user-images.githubusercontent.com/1336821/166930840-9afc8b39-689a-4ed5-ae24-8904bec2252c.png"> |
