### PR TITLE
Style Opinion comment blockquotes

### DIFF
--- a/dotcom-rendering/src/web/components/CommentBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CommentBlockComponent.stories.tsx
@@ -26,3 +26,40 @@ export const defaultStory = () => {
 	);
 };
 defaultStory.story = { name: 'default' };
+
+export const embeddedBlockquoteStory = () => {
+	const bodyContent = `
+		<blockquote>
+			<p>
+				Children and youth are striking to demand action. But many of not most are
+				themselves involved in one of the most damaging practices towards earth's
+				climate, I mean consuming massive amounts of meat and diary in their diets.
+			</p>
+			<p>What is their thought on this regard ?</p>
+		</blockquote>
+		<p>
+			Are they? I see young people leading on this. There's been a massive surge
+			towards veganism by young people, which has resulted in a sevenfold increase
+			in the UK within 5 years. Quite remarkable. And it should be recognised.
+		</p>
+	`;
+	return (
+		<div
+			css={css`
+				padding: 20px;
+			`}
+		>
+			<CommentBlockComponent
+				profileURL="https://profile.theguardian.com/user/id/1395989"
+				profileName="George Monbiot"
+				dateTime="15 March 2019 11:00am"
+				avatarURL="https://avatar.guim.co.uk/user/1395989"
+				body={bodyContent}
+				permalink="https://www.theguardian.com/commentisfree/live/2019/mar/15/webchat-share-questions-for-george-monbiot-and-climate-strike-activists?dcr&page=with:block-5c8b9709e4b0cf92e5a57a5f#block-5c8b9709e4b0cf92e5a57a5f"
+			/>
+		</div>
+	);
+};
+embeddedBlockquoteStory.story = {
+	name: 'Comment block which contains a blockquote',
+};

--- a/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
@@ -33,9 +33,9 @@ const bodyContentStyles = css`
 	}
 
 	blockquote {
-		font-style: italic; /* would something like "textSans({FontStyle: 'italic'})" work here..? */
+		font-style: italic;
 		color: ${textColor.supporting};
-		border-left: ${remSpace[1]} ${neutral[86]} solid; /* is this the right way to refer to the colour here..? */
+		border-left: ${remSpace[1]} ${neutral[86]} solid;
 		margin-top: ${remSpace[1]};
 		margin-right: 0;
 		margin-bottom: ${remSpace[4]};

--- a/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { textSans, neutral, space, remSpace, text as textColor } from '@guardian/source-foundations';
+import {
+	textSans,
+	neutral,
+	space,
+	remSpace,
+	text as textColor,
+} from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CommentBlockComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { textSans, neutral, space } from '@guardian/source-foundations';
+import { textSans, neutral, space, remSpace, text as textColor } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 
 type Props = {
@@ -24,6 +24,17 @@ const bodyContentStyles = css`
 	p {
 		word-break: break-word;
 		margin-bottom: ${space[2]}px;
+	}
+
+	blockquote {
+		font-style: italic; /* would something like "textSans({FontStyle: 'italic'})" work here..? */
+		color: ${textColor.supporting};
+		border-left: ${remSpace[1]} ${neutral[86]} solid; /* is this the right way to refer to the colour here..? */
+		margin-top: ${remSpace[1]};
+		margin-right: 0;
+		margin-bottom: ${remSpace[4]};
+		margin-left: 0;
+		padding-left: ${remSpace[3]};
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

It adds styling to `<blockquote>` elements when they are contained in embedded comments.


## Why?

There was no visual differentiation between the main text of the embedded comment, and the text that was being quoted in that comment (#4826)

## Screenshots

| Before      | After      |
|-------------|------------|
| !['before' screenshot, desktop display](https://user-images.githubusercontent.com/37048459/166962575-eb08a960-e3c2-48af-b8d3-5f8c5e831e18.png) | !['after' screenshot, desktop display](https://user-images.githubusercontent.com/37048459/166962391-9a186c81-ce88-4bb1-9638-177781dae33f.png) |
| !['before' screenshot, mobile display](https://user-images.githubusercontent.com/37048459/166962813-23eaa3a1-dec4-4093-8dba-59af9f708261.png) | !['after' screenshot, mobile display](https://user-images.githubusercontent.com/37048459/166962137-c96b8e09-52c4-414f-80db-0ea863fac74a.png) |
