### PR TITLE
Update sign in gate display rule to use cmp ConsentState.canTarget

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -1,6 +1,5 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
 import { onConsentChange } from '@guardian/consent-management-platform';
-import { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { getLocale } from '@guardian/libs';
 import {
 	DailyArticle,
@@ -69,38 +68,8 @@ export const isValidTag = (tags: TagType[]): boolean => {
 };
 
 export const hasRequiredConsents = (): Promise<boolean> => {
-	const hasConsentedToAll = (state: ConsentState) => {
-		const consentFlags = state.tcfv2?.consents
-			? Object.values(state.tcfv2.consents)
-			: [];
-		const vendorConsentFlags = state.tcfv2?.vendorConsents
-			? Object.values(state.tcfv2.vendorConsents)
-			: [];
-		const isEmpty =
-			consentFlags.length === 0 || vendorConsentFlags.length === 0;
-
-		return (
-			!isEmpty && [...consentFlags, ...vendorConsentFlags].every(Boolean)
-		);
-	};
-
 	return new Promise((resolve) => {
-		onConsentChange((state) => {
-			if (state.tcfv2) {
-				return resolve(hasConsentedToAll(state));
-			}
-
-			if (state.ccpa) {
-				return resolve(state.ccpa.doNotSell === false);
-			}
-
-			if (state.aus) {
-				return resolve(state.aus.personalisedAdvertising);
-			}
-
-			// this shouldn't ever be hit, but this is here as safety
-			return resolve(false);
-		});
+		onConsentChange((state) => resolve(state.canTarget));
 	});
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
