### PR TITLE
feat(KeyEventsContainer): add type predicate

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
@@ -8,20 +8,30 @@ type Props = {
 	filterKeyEvents: boolean;
 };
 
+type ValidBlock = Block & {
+	title: string;
+	blockFirstPublished: number;
+};
+
+const isValidKeyEvent = (keyEvent: Block): keyEvent is ValidBlock => {
+	return (
+		typeof keyEvent.title === 'string' &&
+		typeof keyEvent.blockFirstPublished === 'number'
+	);
+};
+
 export const KeyEventsContainer = ({
 	keyEvents,
 	format,
 	filterKeyEvents,
 }: Props) => {
 	const transformedKeyEvents: KeyEvent[] = keyEvents
-		.filter((keyEvent) => {
-			return keyEvent.title && keyEvent.blockFirstPublished;
-		})
+		.filter(isValidKeyEvent)
 		.map((keyEvent) => {
 			return {
-				text: keyEvent.title || '', // We fallback to '' here purely to keep ts happy
+				text: keyEvent.title,
 				url: `?filterKeyEvents=${filterKeyEvents}&page=with:block-${keyEvent.id}#block-${keyEvent.id}`,
-				date: new Date(keyEvent.blockFirstPublished || ''), // We fallback to '' here purely to keep ts happy
+				date: new Date(keyEvent.blockFirstPublished),
 			};
 		});
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use a type predicate to figure out if a key event is valid.

An alternative would be to filter the data upstream an never pass Blocks without a `title` and a `blockFirstPublished` key.

## Why?

Work with Typescript, not against it.