### PR TITLE
Support Jest VSCode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "titleBar.activeBackground": "#648FFF",
         "titleBar.activeForeground": "#000000"
 	},
+	"jest.jestCommandLine": "fnm use; yarn workspace @guardian/dotcom-rendering test",
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
         "titleBar.activeBackground": "#648FFF",
         "titleBar.activeForeground": "#000000"
 	},
-	"jest.jestCommandLine": "fnm use; yarn workspace @guardian/dotcom-rendering test",
+	"jest.jestCommandLine": "yarn workspaces run test",
     "typescript.tsdk": "node_modules/typescript/lib",
     "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Enable the Jest VSCode extension for `dotcom-rendering` and `apps-rendering`, by providing a 

## Why?

We use Jest extensively, and getting visual feedback as you work is invaluable.

## Screenshots

<img width="447" alt="image" src="https://user-images.githubusercontent.com/76776/167162210-71e57e90-04f1-45a0-b3bb-b95d61a4f3bc.png">
