### PR TITLE
Reduce passing around of 'switches' object - Islands

### DIFF
--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -11,7 +11,7 @@ type Props = {
 	ajaxUrl: string;
 	filterKeyEvents: boolean;
 	format: ArticleFormat;
-	switches: Switches;
+	enhanceTweetsSwitch: boolean;
 	onFirstPage: boolean;
 	webURL: string;
 	mostRecentBlockId: string;
@@ -41,7 +41,7 @@ const toastRoot: Element | null = !isServer
  * @param {string} html The block html to be inserted
  * @returns void
  */
-function insert(html: string, switches: Switches) {
+function insert(html: string, enhanceTweetsSwitch: boolean) {
 	// Create
 	// ------
 	const template = document.createElement('template');
@@ -65,7 +65,7 @@ function insert(html: string, switches: Switches) {
 
 	// Enhance
 	// -----------
-	if (switches.enhanceTweets) {
+	if (enhanceTweetsSwitch) {
 		const pendingBlocks = blogBody.querySelectorAll<HTMLElement>(
 			'article .pending.block',
 		);
@@ -139,7 +139,7 @@ export const Liveness = ({
 	ajaxUrl,
 	filterKeyEvents,
 	format,
-	switches,
+	enhanceTweetsSwitch,
 	onFirstPage,
 	webURL,
 	mostRecentBlockId,
@@ -161,7 +161,7 @@ export const Liveness = ({
 				// Insert the new blocks in the dom (but hidden)
 				if (onFirstPage) {
 					try {
-						insert(data.html, switches);
+						insert(data.html, enhanceTweetsSwitch);
 					} catch (e) {
 						console.log('>> failed >>', e);
 					}
@@ -191,7 +191,7 @@ export const Liveness = ({
 				}
 			}
 		},
-		[onFirstPage, topOfBlogVisible, numHiddenBlocks, switches],
+		[onFirstPage, topOfBlogVisible, numHiddenBlocks, enhanceTweetsSwitch],
 	);
 
 	/**

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -846,7 +846,12 @@ export const CommentLayout = ({
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -388,7 +388,12 @@ export const FullPageInteractiveLayout = ({
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -669,7 +669,12 @@ export const ImmersiveLayout = ({
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -531,7 +531,12 @@ export const InteractiveImmersiveLayout = ({
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -743,7 +743,12 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -779,9 +779,10 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														CAPIArticle.filterKeyEvents
 													}
 													format={format}
-													switches={
+													enhanceTweetsSwitch={
 														CAPIArticle.config
 															.switches
+															.enhanceTweets
 													}
 													onFirstPage={
 														pagination.currentPage ===
@@ -1190,7 +1191,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -810,7 +810,12 @@ export const ShowcaseLayout = ({
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -953,7 +953,12 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						shouldHideReaderRevenue={
 							CAPIArticle.shouldHideReaderRevenue
 						}
-						switches={CAPIArticle.config.switches}
+						remoteBannerSwitch={
+							CAPIArticle.config.switches.remoteBanner
+						}
+						puzzleBannerSwitch={
+							CAPIArticle.config.switches.puzzleBanner
+						}
 						tags={CAPIArticle.tags}
 					/>
 				</Island>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

In some components we take the whole 'switches' object as props, and then consume just 1 or 2 keys from it. This a problem especially in Island components because this entire object must be serialised onto the DOM, downloaded, then unserialised by the client!

```ts
interface Switches {
	[key: string]: boolean;
}
```
As seen above, switches is an untyped object where the size and exact contents are inherently unknown, this is not great for dev experience!

Where possible then, it'd likely be preferred to pass around the individual switches, rather than the whole object!

This PR updates `Liveness` and `StickyBottomBanner` (the two island components which consume switches) to use the specific switches required as props rather than the entire object.

