### PR TITLE
Fix drop cap alignment in Firefox

### DIFF
--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -60,7 +60,7 @@ const styles = (
 				}
 
 				// This fixes drop cap misalignment in Firefox
-				@supports (-moz-appearance:none) {
+				@supports (-moz-appearance: none) {
 					&:first-of-type:first-letter,
 					hr + &:first-letter {
 						margin-top: ${remSpace[3]};

--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -59,6 +59,14 @@ const styles = (
 					margin-right: ${remSpace[1]};
 				}
 
+				// This fixes drop cap misalignment in Firefox
+				@supports (-moz-appearance:none) {
+					&:first-of-type:first-letter,
+					hr + &:first-letter {
+						margin-top: ${remSpace[3]};
+					}
+				}
+
 				${darkModeCss`
 				&:first-of-type:first-letter,
 				hr + &:first-letter {


### PR DESCRIPTION
## Why?
From #4811:

> There seems to be an alignment issue with dropcaps in Firefox: they're higher than they should be relative to the text.
> 
> Note: App webviews are based on Safari or Chrome, so this is unlikely to impact production users if it doesn't affect those browsers. It's probably only an issue for those of us who use Firefox for development.

This PR fixes the alignment issue in Firefox. Other browsers should be unaffected (tested locally on Chrome and Safari).

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/167178334-cdd14bca-ada7-43cb-abdb-bf2acf9161a9.png
[after]: https://user-images.githubusercontent.com/57295823/167178383-081ca946-5b8c-4940-adb0-50318c35bcc6.png
