### PR TITLE
Sign in after checkout prompts (header / banner)

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -67,7 +67,7 @@
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/libs": "^5.0.0",
     "@guardian/shimport": "^1.0.2",
-    "@guardian/support-dotcom-components": "^1.0.3",
+    "@guardian/support-dotcom-components": "^1.0.4",
     "@percy/cli": "^1.4.0",
     "@percy/cypress": "^3.1.2",
     "@sentry/browser": "^5.30.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -67,7 +67,7 @@
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/libs": "^5.0.0",
     "@guardian/shimport": "^1.0.2",
-    "@guardian/support-dotcom-components": "^1.0.2",
+    "@guardian/support-dotcom-components": "^1.0.3",
     "@percy/cli": "^1.4.0",
     "@percy/cypress": "^3.1.2",
     "@sentry/browser": "^5.30.0",

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -30,6 +30,7 @@ import {
 	getLastOneOffContributionDate,
 	MODULES_VERSION,
 	shouldHideSupportMessaging,
+	getPurchaseInfo,
 } from '../lib/contributions';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
@@ -173,6 +174,7 @@ const ReaderRevenueLinksRemote: React.FC<{
 	useOnce((): void => {
 		setAutomat();
 
+		const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
 		const requestData: HeaderPayload = {
 			tracking: {
 				ophanPageId: pageViewId,
@@ -189,6 +191,8 @@ const ReaderRevenueLinksRemote: React.FC<{
 					getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
 				),
 				lastOneOffContributionDate: getLastOneOffContributionDate(),
+				purchaseInfo: getPurchaseInfo(),
+				isSignedIn,
 			},
 		};
 		getHeader(contributionsServiceUrl, requestData)

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -191,9 +191,6 @@ const ReaderRevenueLinksRemote: React.FC<{
 					getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
 				),
 				lastOneOffContributionDate: getLastOneOffContributionDate(),
-				// TODO: remove this once PR in support-dotcom-components is merged and released
-				// https://github.com/guardian/support-dotcom-components/pull/665
-				// @ts-ignore
 				purchaseInfo: getPurchaseInfo(),
 				isSignedIn,
 			},

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -28,9 +28,9 @@ import {
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
 import {
 	getLastOneOffContributionDate,
+	getPurchaseInfo,
 	MODULES_VERSION,
 	shouldHideSupportMessaging,
-	getPurchaseInfo,
 } from '../lib/contributions';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -191,6 +191,9 @@ const ReaderRevenueLinksRemote: React.FC<{
 					getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
 				),
 				lastOneOffContributionDate: getLastOneOffContributionDate(),
+				// TODO: remove this once PR in support-dotcom-components is merged and released
+				// https://github.com/guardian/support-dotcom-components/pull/665
+				// @ts-ignore
 				purchaseInfo: getPurchaseInfo(),
 				isSignedIn,
 			},

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -147,6 +147,9 @@ const buildRRBannerConfigWith = ({
 						subscriptionBannerLastClosedAt: getBannerLastClosedAt(
 							'subscriptionBannerLastClosedAt',
 						),
+						signInBannerLastClosedAt: getBannerLastClosedAt(
+							'signInBannerLastClosedAt',
+						),
 						section,
 						isPreview,
 						idApiUrl,

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -14,6 +14,7 @@ import type { ArticleCounts } from '../../../lib/article-count';
 import { trackNonClickInteraction } from '../../browser/ga/ga';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import {
+	getPurchaseInfo,
 	hasCmpConsentForBrowserId,
 	hasOptedOutOfArticleCount,
 	lazyFetchEmailWithTimeout,
@@ -42,6 +43,7 @@ type BaseProps = {
 	alreadyVisitedCount: number;
 	engagementBannerLastClosedAt?: string;
 	subscriptionBannerLastClosedAt?: string;
+	signInBannerLastClosedAt?: string;
 };
 
 type BuildPayloadProps = BaseProps & {
@@ -89,6 +91,7 @@ const buildPayload = async ({
 	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
+	signInBannerLastClosedAt,
 	countryCode,
 	optedOutOfArticleCount,
 	asyncArticleCounts,
@@ -116,6 +119,9 @@ const buildPayload = async ({
 			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
+			// eslint-disable-next-line -- i continue do do as i wish
+			// @ts-ignore
+			signInBannerLastClosedAt,
 			mvtId: Number(
 				getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
 			),
@@ -130,6 +136,10 @@ const buildPayload = async ({
 			browserId: (await hasCmpConsentForBrowserId())
 				? browserId || undefined
 				: undefined,
+			// eslint-disable-next-line -- because i do what i like
+			// @ts-ignore
+			purchaseInfo: getPurchaseInfo(),
+			isSignedIn,
 		},
 	};
 };
@@ -149,6 +159,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 	alreadyVisitedCount,
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
+	signInBannerLastClosedAt,
 	isPreview,
 	idApiUrl,
 	signInGateWillShow,
@@ -166,7 +177,12 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		return { show: false };
 	}
 
+	const purchaseInfo = getPurchaseInfo();
+	const showSignInPrompt =
+		purchaseInfo && !isSignedIn && !signInBannerLastClosedAt;
+
 	if (
+		!showSignInPrompt &&
 		engagementBannerLastClosedAt &&
 		subscriptionBannerLastClosedAt &&
 		withinLocalNoBannerCachePeriod()
@@ -190,6 +206,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		alreadyVisitedCount,
 		engagementBannerLastClosedAt,
 		subscriptionBannerLastClosedAt,
+		signInBannerLastClosedAt,
 		optedOutOfArticleCount,
 		asyncArticleCounts,
 	});

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -119,8 +119,6 @@ const buildPayload = async ({
 			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
-			// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
-			// @ts-ignore
 			signInBannerLastClosedAt,
 			mvtId: Number(
 				getCookie({ name: 'GU_mvt_id', shouldMemoize: true }),
@@ -136,8 +134,6 @@ const buildPayload = async ({
 			browserId: (await hasCmpConsentForBrowserId())
 				? browserId || undefined
 				: undefined,
-			// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
-			// @ts-ignore
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn,
 		},

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -119,7 +119,7 @@ const buildPayload = async ({
 			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
-			// eslint-disable-next-line -- i continue do do as i wish
+			// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
 			// @ts-ignore
 			signInBannerLastClosedAt,
 			mvtId: Number(
@@ -136,7 +136,7 @@ const buildPayload = async ({
 			browserId: (await hasCmpConsentForBrowserId())
 				? browserId || undefined
 				: undefined,
-			// eslint-disable-next-line -- because i do what i like
+			// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
 			// @ts-ignore
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn,

--- a/dotcom-rendering/src/web/lib/contributions.test.ts
+++ b/dotcom-rendering/src/web/lib/contributions.test.ts
@@ -142,3 +142,37 @@ describe('lazyFetchEmailWithTimeout', () => {
 		expect(getIdApiUserData).toHaveBeenCalledWith('https://idapi-url.com');
 	});
 });
+
+describe('getPurchaseInfo', () => {
+	let getPurchaseInfo: () => any;
+
+	beforeEach(() => {
+		clearAllCookies();
+		// Reset modules to avoid memoized cookies affecting tests
+		jest.resetModules();
+		({ getPurchaseInfo } = require('./contributions'));
+	});
+
+	it('returns decoded cookie data', () => {
+		setCookie({
+			name: 'GU_CO_COMPLETE',
+			value: '%7B%22userType%22%3A%22guest%22%2C%22product%22%3A%22DigitalPack%22%7D',
+		});
+		expect(getPurchaseInfo()).toEqual({
+			userType: 'guest',
+			product: 'DigitalPack',
+		});
+	});
+
+	it('returns undefined if cookie unset', () => {
+		expect(getPurchaseInfo()).toBeUndefined();
+	});
+
+	it('returns undefined if cookie data invalid', () => {
+		setCookie({
+			name: 'GU_CO_COMPLETE',
+			value: 'utter-nonsense',
+		});
+		expect(getPurchaseInfo()).toBeUndefined();
+	});
+});

--- a/dotcom-rendering/src/web/lib/contributions.test.ts
+++ b/dotcom-rendering/src/web/lib/contributions.test.ts
@@ -150,7 +150,7 @@ describe('getPurchaseInfo', () => {
 		clearAllCookies();
 		// Reset modules to avoid memoized cookies affecting tests
 		jest.resetModules();
-		({ getPurchaseInfo } = require('./contributions'));
+		({ getPurchaseInfo } = jest.requireActual('./contributions'));
 	});
 
 	it('returns decoded cookie data', () => {

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -246,9 +246,6 @@ export const getContributionsServiceUrl = (
 	CAPIArticle: CAPIArticleType,
 ): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
 
-// TODO: remove this once PR in support-dotcom-components is merged and released
-// https://github.com/guardian/support-dotcom-components/pull/665
-// @ts-ignore
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
 export const getPurchaseInfo = () => {
 	const purchaseInfoRaw = getCookie({

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -1,5 +1,6 @@
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { getCookie } from '@guardian/libs';
+import { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
 
@@ -244,3 +245,18 @@ export const lazyFetchEmailWithTimeout =
 export const getContributionsServiceUrl = (
 	CAPIArticle: CAPIArticleType,
 ): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
+
+type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
+export const getPurchaseInfo = () => {
+	const purchaseInfoRaw = getCookie({
+		name: 'GU_CO_COMPLETE',
+		shouldMemoize: true,
+	});
+	let purchaseInfo: PurchaseInfo;
+
+	try {
+		purchaseInfo = purchaseInfoRaw && JSON.parse(purchaseInfoRaw);
+	} catch {} // eslint-disable-line no-empty
+
+	return purchaseInfo;
+};

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -1,6 +1,6 @@
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { getCookie } from '@guardian/libs';
-import { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
 
@@ -247,7 +247,7 @@ export const getContributionsServiceUrl = (
 ): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
-export const getPurchaseInfo = () => {
+export const getPurchaseInfo = (): PurchaseInfo => {
 	const purchaseInfoRaw = getCookie({
 		name: 'GU_CO_COMPLETE',
 		shouldMemoize: true,
@@ -261,7 +261,7 @@ export const getPurchaseInfo = () => {
 
 	try {
 		purchaseInfo = JSON.parse(decodeURIComponent(purchaseInfoRaw));
-	} catch {} // eslint-disable-line no-empty
+	} catch {} // eslint-disable-line no-empty -- silently handle error
 
 	return purchaseInfo;
 };

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -246,16 +246,24 @@ export const getContributionsServiceUrl = (
 	CAPIArticle: CAPIArticleType,
 ): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
 
+// TODO: remove this once PR in support-dotcom-components is merged and released
+// https://github.com/guardian/support-dotcom-components/pull/665
+// @ts-ignore
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
 export const getPurchaseInfo = () => {
 	const purchaseInfoRaw = getCookie({
 		name: 'GU_CO_COMPLETE',
 		shouldMemoize: true,
 	});
+
+	if (!purchaseInfoRaw) {
+		return undefined;
+	}
+
 	let purchaseInfo: PurchaseInfo;
 
 	try {
-		purchaseInfo = purchaseInfoRaw && JSON.parse(purchaseInfoRaw);
+		purchaseInfo = JSON.parse(decodeURIComponent(purchaseInfoRaw));
 	} catch {} // eslint-disable-line no-empty
 
 	return purchaseInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,10 +2893,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.4.0.tgz#69cf404b56db3ca507702d29dae6a40eeb145cf4"
   integrity sha512-5Q4Vl8ek0UV0Y9ob5y3Smq5xHs1d3lEzLynv5qqlYqVBlhze5Ypg5IzrPcEpKtcUaCIQeI9d5FevHM9fmm18sQ==
 
-"@guardian/support-dotcom-components@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.3.tgz#1880eb83191757be4936c0ba838646fc407cc8f2"
-  integrity sha512-KxNhZtH6uS6oO5DOOpBBb0cdcDzHMVkCY8ldwie5R8elBUzISNYfAttOPbFbSBD9juFICMOkbvPe2CWH8kDw7Q==
+"@guardian/support-dotcom-components@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.4.tgz#1d09ce408bcfa435eb2411255688e22a2eede032"
+  integrity sha512-g23KJoJiJVIC75DZW87zyblmNMnjujCgCKntLVLblKoSxIzOBLhzkPUnJqzPtG3aztTPRbqmhLzqgzm6M56/qw==
 
 "@guardian/types@^9.0.1":
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2893,10 +2893,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.4.0.tgz#69cf404b56db3ca507702d29dae6a40eeb145cf4"
   integrity sha512-5Q4Vl8ek0UV0Y9ob5y3Smq5xHs1d3lEzLynv5qqlYqVBlhze5Ypg5IzrPcEpKtcUaCIQeI9d5FevHM9fmm18sQ==
 
-"@guardian/support-dotcom-components@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.2.tgz#56bfb7cf7aef6d859b6f97b3986188af687f8a16"
-  integrity sha512-NqAxmegwQ1ltBH4EmfXwJHxRXGJzlZMSFDkK+5fkReL4XtACX3ZzR2rMbl7SN5RxSbeSzr5nGElRZ0TWkAYRJw==
+"@guardian/support-dotcom-components@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.3.tgz#1880eb83191757be4936c0ba838646fc407cc8f2"
+  integrity sha512-KxNhZtH6uS6oO5DOOpBBb0cdcDzHMVkCY8ldwie5R8elBUzISNYfAttOPbFbSBD9juFICMOkbvPe2CWH8kDw7Q==
 
 "@guardian/types@^9.0.1":
   version "9.0.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

So we can prompt users have contributed to sign in, so that they may get the benefits.

~~This is in draft, the CI will fail until guardian/support-dotcom-components#665 has been merged, as the types have changed.~~

Back in draft, now waiting for guardian/support-dotcom-components#723.



## Screenshots
Revised Designs here - https://github.com/guardian/support-dotcom-components/pull/738


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
