### PR TITLE
Display the toast over a wider area

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -400,6 +400,39 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			</div>
 
 			<main>
+				{format.design === ArticleDesign.LiveBlog && (
+					<>
+						{/* The Toast component is inserted into this div using a Portal */}
+						<div
+							id="toast-root"
+							css={css`
+								position: sticky;
+								top: 0;
+								${getZIndex('toast')};
+								display: flex;
+								justify-content: center;
+							`}
+						/>
+						<Island clientOnly={true} deferUntil="idle">
+							<Liveness
+								pageId={CAPIArticle.pageId}
+								webTitle={CAPIArticle.webTitle}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								filterKeyEvents={CAPIArticle.filterKeyEvents}
+								format={format}
+								switches={CAPIArticle.config.switches}
+								onFirstPage={pagination.currentPage === 1}
+								webURL={CAPIArticle.webURL}
+								// We default to string here because the property is optional but we
+								// know it will exist for all blogs
+								mostRecentBlockId={
+									CAPIArticle.mostRecentBlockId || ''
+								}
+								hasPinnedPost={!!CAPIArticle.pinnedPost}
+							/>
+						</Island>
+					</>
+				)}
 				<article>
 					{footballMatchUrl ? (
 						<ContainerLayout
@@ -745,59 +778,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</GridItem>
 							<GridItem area="body">
 								<div id="maincontent" css={bodyWrapper}>
-									{format.design ===
-										ArticleDesign.LiveBlog && (
-										<>
-											{/* The Toast component is inserted into this div using a Portal */}
-											<div
-												id="toast-root"
-												css={css`
-													position: sticky;
-													top: 0;
-													${getZIndex('toast')};
-													display: flex;
-													justify-content: center;
-												`}
-											/>
-											<Island
-												clientOnly={true}
-												deferUntil="idle"
-											>
-												<Liveness
-													pageId={CAPIArticle.pageId}
-													webTitle={
-														CAPIArticle.webTitle
-													}
-													ajaxUrl={
-														CAPIArticle.config
-															.ajaxUrl
-													}
-													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
-													}
-													format={format}
-													switches={
-														CAPIArticle.config
-															.switches
-													}
-													onFirstPage={
-														pagination.currentPage ===
-														1
-													}
-													webURL={CAPIArticle.webURL}
-													// We default to string here because the property is optional but we
-													// know it will exist for all blogs
-													mostRecentBlockId={
-														CAPIArticle.mostRecentBlockId ||
-														''
-													}
-													hasPinnedPost={
-														!!CAPIArticle.pinnedPost
-													}
-												/>
-											</Island>
-										</>
-									)}
 									{CAPIArticle.keyEvents?.length ? (
 										<Hide below="desktop">
 											<Island deferUntil="visible">


### PR DESCRIPTION
## What does this change?
This PR fixes #4852 by displaying the toast over the whole `main` component, not just inside the article space.

I initially thought to conditionally place the toast over a larger area for blogs that have discussion on them only but I think there is benefit here in doing this in all situations. We should be displaying this information about updates over a wider area in all cases.

## Why?
A reader wrote in pointing out that the '5 new updates' button that appears when new content is available was no longer showing when they were reading discussion posts. This made navigating the liveblog difficult. This was a regression introduced as part of the work to migrate to the new DCR platform.

### The button now shows _above_ the article as well as below?
By moving the toast container up to `main` we are now showing it over both the standfirst and the headline. Previously we kept it inside the body of the article so it sat underneath main media. Using `main` as the container is the natural solution if we want to also show this button over content at the bottom of the page but that also means we will show the button further up as well. I think this is a positive change, it is surfacing this information more. @HarryFischer what do you think?

## Top
| Before      | After      |
|-------------|------------|
| ![top_before](https://user-images.githubusercontent.com/1336821/167397343-c88aa6dd-9ca6-4441-9470-173857310654.gif) | ![top_after](https://user-images.githubusercontent.com/1336821/167397382-17f40c85-e048-4297-add5-7303721934b2.gif) |


## Bottom
| Before      | After      |
|-------------|------------|
| ![bottom_before](https://user-images.githubusercontent.com/1336821/167397458-2cb8450f-8b22-4698-aea9-53538bb6fff2.gif) | ![bottom_after](https://user-images.githubusercontent.com/1336821/167397505-33233412-dc71-49e0-8b9c-4a6e2e7e326f.gif) |
