### PR TITLE
Do not italicise drop caps

### DIFF
--- a/apps-rendering/src/components/paragraph.tsx
+++ b/apps-rendering/src/components/paragraph.tsx
@@ -50,13 +50,14 @@ const styles = (
 				hr + &:first-letter {
 					${headline.large({ fontWeight: 'bold' })}
 					${dropCapWeight(format)}
-				color: ${text.dropCap(format)};
+					color: ${text.dropCap(format)};
 					float: left;
 					font-size: 7.375rem;
 					line-height: 6.188rem;
 					vertical-align: text-top;
 					pointer-events: none;
 					margin-right: ${remSpace[1]};
+					font-style: normal;
 				}
 
 				${darkModeCss`


### PR DESCRIPTION
## Why?
If a paragraph that is eligible for drop cap is in italics, the drop cap is also italicised, which looks odd.
@ajbreuer confirmed it looks much better if the drop cap is not italicised, hence this PR.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/167427600-a6d3d681-3798-4ad0-8d93-bfb20e2852b4.png
[after]: https://user-images.githubusercontent.com/57295823/167427565-3cb795e3-4e75-48e5-84f3-3fc99e31ffa1.png
