### PR TITLE
Fix `FilterKeyEventsToggle` scroll issue

### DIFF
--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -22,12 +22,12 @@ const toggleWrapperStyles = css`
 
 interface Props {
 	filterKeyEvents: boolean;
-	breakpoint: 'mobile' | 'desktop';
+	id: 'filter-toggle-mobile' | 'filter-toggle-desktop';
 }
 
 export const FilterKeyEventsToggle = ({
 	filterKeyEvents,
-	breakpoint,
+	id,
 }: Props) => {
 	const [checked, setChecked] = useState(filterKeyEvents);
 
@@ -38,13 +38,13 @@ export const FilterKeyEventsToggle = ({
 		urlParams.delete('page'); // direct to the first page
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
-		window.location.hash = `filter-toggle-${breakpoint}`;
+		window.location.hash = id;
 		window.location.search = urlParams.toString();
 	};
 
 	return (
 		<>
-			<span id={`filter-toggle-${breakpoint}`} />
+			<span id={id} />
 			<div css={toggleWrapperStyles}>
 				<ToggleSwitch
 					label="Show key events only"

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -25,10 +25,7 @@ interface Props {
 	id: 'filter-toggle-mobile' | 'filter-toggle-desktop';
 }
 
-export const FilterKeyEventsToggle = ({
-	filterKeyEvents,
-	id,
-}: Props) => {
+export const FilterKeyEventsToggle = ({ filterKeyEvents, id }: Props) => {
 	const [checked, setChecked] = useState(filterKeyEvents);
 
 	const handleClick = () => {

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -22,10 +22,13 @@ const toggleWrapperStyles = css`
 
 interface Props {
 	filterKeyEvents: boolean;
-	breakpoint: "mobile" | "desktop";
+	breakpoint: 'mobile' | 'desktop';
 }
 
-export const FilterKeyEventsToggle = ({ filterKeyEvents, breakpoint }: Props) => {
+export const FilterKeyEventsToggle = ({
+	filterKeyEvents,
+	breakpoint,
+}: Props) => {
 	const [checked, setChecked] = useState(filterKeyEvents);
 
 	const handleClick = () => {

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -22,10 +22,10 @@ const toggleWrapperStyles = css`
 
 interface Props {
 	filterKeyEvents: boolean;
-	id: string;
+	breakpoint: "mobile" | "desktop";
 }
 
-export const FilterKeyEventsToggle = ({ filterKeyEvents, id }: Props) => {
+export const FilterKeyEventsToggle = ({ filterKeyEvents, breakpoint }: Props) => {
 	const [checked, setChecked] = useState(filterKeyEvents);
 
 	const handleClick = () => {
@@ -35,13 +35,13 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents, id }: Props) => {
 		urlParams.delete('page'); // direct to the first page
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
-		window.location.hash = `filter-toggle-${id}`;
+		window.location.hash = `filter-toggle-${breakpoint}`;
 		window.location.search = urlParams.toString();
 	};
 
 	return (
 		<>
-			<span id={`filter-toggle-${id}`} />
+			<span id={`filter-toggle-${breakpoint}`} />
 			<div css={toggleWrapperStyles}>
 				<ToggleSwitch
 					label="Show key events only"

--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -22,9 +22,10 @@ const toggleWrapperStyles = css`
 
 interface Props {
 	filterKeyEvents: boolean;
+	id: string;
 }
 
-export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
+export const FilterKeyEventsToggle = ({ filterKeyEvents, id }: Props) => {
 	const [checked, setChecked] = useState(filterKeyEvents);
 
 	const handleClick = () => {
@@ -34,13 +35,13 @@ export const FilterKeyEventsToggle = ({ filterKeyEvents }: Props) => {
 		urlParams.delete('page'); // direct to the first page
 		urlParams.set('filterKeyEvents', checked ? 'false' : 'true');
 
-		window.location.hash = 'filter-toggle';
+		window.location.hash = `filter-toggle-${id}`;
 		window.location.search = urlParams.toString();
 	};
 
 	return (
 		<>
-			<span id="filter-toggle" />
+			<span id={`filter-toggle-${id}`} />
 			<div css={toggleWrapperStyles}>
 				<ToggleSwitch
 					label="Show key events only"

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -805,7 +805,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													breakpoint="desktop"
+													id="filter-toggle-desktop"
 												/>
 											</Island>
 										</Hide>
@@ -824,7 +824,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														filterKeyEvents={
 															CAPIArticle.filterKeyEvents
 														}
-														breakpoint="mobile"
+														id="filter-toggle-mobile"
 													/>
 												</Island>
 											</Hide>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -805,7 +805,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													id='1'
+													id="1"
 												/>
 											</Island>
 										</Hide>
@@ -824,7 +824,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														filterKeyEvents={
 															CAPIArticle.filterKeyEvents
 														}
-														id='2'
+														id="2"
 													/>
 												</Island>
 											</Hide>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -805,7 +805,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													id="desktop"
+													breakpoint="desktop"
 												/>
 											</Island>
 										</Hide>
@@ -824,7 +824,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														filterKeyEvents={
 															CAPIArticle.filterKeyEvents
 														}
-														id="mobile"
+														breakpoint="mobile"
 													/>
 												</Island>
 											</Hide>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -805,7 +805,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													id="1"
+													id="desktop"
 												/>
 											</Island>
 										</Hide>
@@ -824,7 +824,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														filterKeyEvents={
 															CAPIArticle.filterKeyEvents
 														}
-														id="2"
+														id="mobile"
 													/>
 												</Island>
 											</Hide>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -805,6 +805,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
+													id='1'
 												/>
 											</Island>
 										</Hide>
@@ -823,6 +824,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														filterKeyEvents={
 															CAPIArticle.filterKeyEvents
 														}
+														id='2'
 													/>
 												</Island>
 											</Hide>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a `breakpoint` prop to FilterKeyEventsToggle to fix a scroll issue caused by two components sharing the same ID.

## Why?
Giving each of the two filters a unique ID ensures that the `window.location.hash` navigates to the correct place on the page.

## Videos

### Before:
https://user-images.githubusercontent.com/55602675/167612549-0061a67f-e070-4748-b80f-4b3adc8990e9.mov

### After:
https://user-images.githubusercontent.com/55602675/167613337-d85eb16c-b08a-4dd7-bddb-c647194e89cd.mov


