### PR TITLE
Fix `KeyEventCard` widths

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.stories.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.stories.tsx
@@ -5,7 +5,7 @@ import {
 	ArticleDisplay,
 	ArticlePillar,
 } from '@guardian/libs';
-import { neutral } from '@guardian/source-foundations';
+import { from, neutral } from '@guardian/source-foundations';
 import { events } from '../../../fixtures/manual/key-events';
 import { KeyEventCard } from './KeyEventCard';
 
@@ -19,9 +19,13 @@ const getFormat = (theme: ArticleTheme) => {
 
 const wrapperStyles = css`
 	padding-left: 20px;
-	display: flex;
-	background-color: ${neutral[93]};
+	display: inline-flex;
+	background-color: ${neutral[97]};
 	margin: 10px 0;
+
+	${from.desktop} {
+		background-color: ${neutral[93]};
+	}
 
 	ul {
 		overflow-x: scroll;

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -47,15 +47,16 @@ const listItemStyles = css`
 	position: relative;
 	padding-bottom: ${space[5]}px;
 	padding-top: ${space[3]}px;
-	padding-right: ${space[5]}px;
+	padding-right: ${space[3]}px;
 	background-color: ${neutral[97]};
 	list-style: none;
 	display: block;
-	width: 150px;
+	width: 162px;
 
 	${from.desktop} {
 		background-color: ${neutral[93]};
-		width: 180px;
+		width: 200px;
+		padding-right: ${space[5]}px;
 	}
 
 	&::before {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Updates the widths to the correct sizes for the KeyEventCard.
- Fixes storybook multiple card layout and background colours

## Why?

@benwuersching provided us with new design specs.

## Screenshots

### Before
<img width="300" alt="Screenshot 2022-05-09 at 15 38 40" src="https://user-images.githubusercontent.com/77005274/167444863-12839a2c-56b1-41eb-bfd9-f6b52c463ace.png">

### After
<img width="300" alt="Screenshot 2022-05-09 at 15 38 53" src="https://user-images.githubusercontent.com/77005274/167444970-a7369b70-c1c9-4f00-941e-55ab0bd896fc.png">




