### PR TITLE
`Footer` on fronts

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -601,6 +601,7 @@ interface FEFrontType {
 	webURL: string;
 	config: FEFrontConfigType;
 	commercialProperties: Record<string, unknown>;
+	pageFooter: FooterType;
 }
 
 type DCRFrontType = {
@@ -609,6 +610,7 @@ type DCRFrontType = {
 	editionId: Edition;
 	webTitle: string;
 	config: FEFrontConfigType;
+	pageFooter: FooterType;
 };
 
 type FEPressedPageType = {

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -1,4 +1,8 @@
-import { brandBackground, brandLine } from '@guardian/source-foundations';
+import {
+	brandBackground,
+	brandBorder,
+	brandLine,
+} from '@guardian/source-foundations';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { css } from '@emotion/react';
@@ -11,6 +15,7 @@ import { Island } from '../components/Island';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { decidePalette } from '../lib/decidePalette';
 import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
 import { ContainerLayout } from '../components/ContainerLayout';
 
 interface Props {
@@ -172,6 +177,21 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					</Island>
 				</ElementContainer>
 			)}
+
+			<ElementContainer
+				data-print-layout="hide"
+				padded={false}
+				backgroundColour={brandBackground.primary}
+				borderColour={brandBorder.primary}
+				showSideBorders={false}
+				element="footer"
+			>
+				<Footer
+					pageFooter={front.pageFooter}
+					pillar={format.theme}
+					pillars={NAV.pillars}
+				/>
+			</ElementContainer>
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the page footer to front pages

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1437" alt="Screenshot 2022-05-10 at 12 30 48" src="https://user-images.githubusercontent.com/1336821/167618836-7b2dbfab-838f-4804-a75f-1783e8689886.png"> | <img width="1437" alt="Screenshot 2022-05-10 at 12 30 15" src="https://user-images.githubusercontent.com/1336821/167618776-49748e92-fbcc-4d32-9338-2aee6eb84257.png"> |