### PR TITLE
Don't show toast over headline

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-5/liveblog.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/liveblog.interactivity.spec.js
@@ -202,7 +202,7 @@ describe('Liveblogs', function () {
 			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e').should(
 				'not.be.visible',
 			);
-			cy.scrollTo(0, 900);
+			cy.get('#maincontent').scrollIntoView();
 			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e').should(
 				'be.visible',
 			);

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -66,9 +66,8 @@ function insert(html: string, switches: Switches) {
 	// Enhance
 	// -----------
 	if (switches.enhanceTweets) {
-		const pendingBlocks = blogBody.querySelectorAll<HTMLElement>(
-			'article .pending.block',
-		);
+		const pendingBlocks =
+			blogBody.querySelectorAll<HTMLElement>('.pending.block');
 		// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
 		if (typeof twttr !== 'undefined') {
 			twttr.ready((twitter) => {
@@ -83,9 +82,8 @@ function insert(html: string, switches: Switches) {
  */
 function revealPendingBlocks() {
 	const blogBody = document.querySelector<HTMLElement>('#liveblog-body');
-	const pendingBlocks = blogBody?.querySelectorAll<HTMLElement>(
-		'article .pending.block',
-	);
+	const pendingBlocks =
+		blogBody?.querySelectorAll<HTMLElement>('.pending.block');
 	pendingBlocks?.forEach((block) => {
 		block.classList.add('reveal-slowly');
 		block.classList.remove('pending');

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -400,404 +400,392 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			</div>
 
 			<main>
-				{format.design === ArticleDesign.LiveBlog && (
-					<>
-						{/* The Toast component is inserted into this div using a Portal */}
-						<div
-							id="toast-root"
-							css={css`
-								position: sticky;
-								top: 0;
-								${getZIndex('toast')};
-								display: flex;
-								justify-content: center;
-							`}
-						/>
-						<Island clientOnly={true} deferUntil="idle">
-							<Liveness
-								pageId={CAPIArticle.pageId}
-								webTitle={CAPIArticle.webTitle}
-								ajaxUrl={CAPIArticle.config.ajaxUrl}
-								filterKeyEvents={CAPIArticle.filterKeyEvents}
+				{footballMatchUrl ? (
+					<ContainerLayout
+						showTopBorder={false}
+						backgroundColour={palette.background.matchNav}
+						borderColour={palette.border.headline}
+						leftContent={
+							<ArticleTitle
 								format={format}
-								switches={CAPIArticle.config.switches}
-								onFirstPage={pagination.currentPage === 1}
-								webURL={CAPIArticle.webURL}
-								// We default to string here because the property is optional but we
-								// know it will exist for all blogs
-								mostRecentBlockId={
-									CAPIArticle.mostRecentBlockId || ''
-								}
-								hasPinnedPost={!!CAPIArticle.pinnedPost}
+								tags={CAPIArticle.tags}
+								sectionLabel={CAPIArticle.sectionLabel}
+								sectionUrl={CAPIArticle.sectionUrl}
+								guardianBaseURL={CAPIArticle.guardianBaseURL}
+								badge={CAPIArticle.badge}
+								isMatch={true}
 							/>
-						</Island>
-					</>
-				)}
-				<article>
-					{footballMatchUrl ? (
-						<ContainerLayout
-							showTopBorder={false}
-							backgroundColour={palette.background.matchNav}
-							borderColour={palette.border.headline}
-							leftContent={
-								<ArticleTitle
-									format={format}
-									tags={CAPIArticle.tags}
-									sectionLabel={CAPIArticle.sectionLabel}
-									sectionUrl={CAPIArticle.sectionUrl}
-									guardianBaseURL={
-										CAPIArticle.guardianBaseURL
-									}
-									badge={CAPIArticle.badge}
-									isMatch={true}
-								/>
-							}
-							leftColSize="wide"
-							sideBorders={true}
-							padContent={false}
-							verticalMargins={false}
-						>
-							<Hide above="leftCol">
-								<ArticleTitle
-									format={format}
-									tags={CAPIArticle.tags}
-									sectionLabel={CAPIArticle.sectionLabel}
-									sectionUrl={CAPIArticle.sectionUrl}
-									guardianBaseURL={
-										CAPIArticle.guardianBaseURL
-									}
-									badge={CAPIArticle.badge}
-									isMatch={true}
-								/>
-							</Hide>
-
-							<Island
-								deferUntil="visible"
-								clientOnly={true}
-								placeholderHeight={230}
-							>
-								<GetMatchNav
-									matchUrl={footballMatchUrl}
-									format={format}
-									headlineString={CAPIArticle.headline}
-									tags={CAPIArticle.tags}
-									webPublicationDateDeprecated={
-										CAPIArticle.webPublicationDateDeprecated
-									}
-								/>
-							</Island>
-						</ContainerLayout>
-					) : (
-						<ElementContainer
-							showTopBorder={false}
-							backgroundColour={palette.background.header}
-							borderColour={palette.border.headline}
-						>
-							<HeadlineGrid>
-								<GridItem area="title">
-									<ArticleTitle
-										format={format}
-										tags={CAPIArticle.tags}
-										sectionLabel={CAPIArticle.sectionLabel}
-										sectionUrl={CAPIArticle.sectionUrl}
-										guardianBaseURL={
-											CAPIArticle.guardianBaseURL
-										}
-										badge={CAPIArticle.badge}
-									/>
-								</GridItem>
-								<GridItem area="headline">
-									<div css={maxWidth}>
-										{!footballMatchUrl && (
-											<ArticleHeadline
-												format={format}
-												headlineString={
-													CAPIArticle.headline
-												}
-												tags={CAPIArticle.tags}
-												byline={
-													CAPIArticle.author.byline
-												}
-												webPublicationDateDeprecated={
-													CAPIArticle.webPublicationDateDeprecated
-												}
-												hasStarRating={
-													!!CAPIArticle.starRating ||
-													CAPIArticle.starRating === 0
-												}
-											/>
-										)}
-									</div>
-									{CAPIArticle.starRating ||
-									CAPIArticle.starRating === 0 ? (
-										<div css={starWrapper}>
-											<StarRating
-												rating={CAPIArticle.starRating}
-												size="large"
-											/>
-										</div>
-									) : (
-										<></>
-									)}
-								</GridItem>
-							</HeadlineGrid>
-						</ElementContainer>
-					)}
-
-					<ElementContainer
-						showTopBorder={false}
-						backgroundColour={palette.background.standfirst}
-						borderColour={palette.border.standfirst}
+						}
+						leftColSize="wide"
+						sideBorders={true}
+						padContent={false}
+						verticalMargins={false}
 					>
-						<StandFirstGrid>
-							<GridItem area="standfirst">
-								<Standfirst
-									format={format}
-									standfirst={CAPIArticle.standfirst}
-								/>
-							</GridItem>
-							<GridItem area="lastupdated">
-								<Hide until="desktop">
-									{CAPIArticle.blocks.length &&
-										CAPIArticle.blocks[0]
-											.blockLastUpdated && (
-											<ArticleLastUpdated
-												format={format}
-												lastUpdated={
-													CAPIArticle.blocks[0]
-														.blockLastUpdated
-												}
-											/>
-										)}
-								</Hide>
-							</GridItem>
-							<GridItem area="lines">
-								<Hide from="desktop">
-									<div css={sidePaddingDesktop}>
-										<Lines
-											cssOverrides={css`
-												display: block;
-											`}
-											count={decideLineCount(
-												format.design,
-											)}
-											effect={decideLineEffect(
-												format.design,
-												format.theme,
-											)}
-											color={
-												format.design ===
-												ArticleDesign.LiveBlog
-													? 'rgba(255, 255, 255, 0.4)'
-													: undefined
-											}
-										/>
-									</div>
-								</Hide>
-							</GridItem>
-							<GridItem area="meta">
-								<Hide from="desktop">
-									<div css={sidePaddingDesktop}>
-										<ArticleMeta
-											branding={branding}
-											format={format}
-											pageId={CAPIArticle.pageId}
-											webTitle={CAPIArticle.webTitle}
-											author={CAPIArticle.author}
-											tags={CAPIArticle.tags}
-											primaryDateline={
-												CAPIArticle.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												CAPIArticle.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												CAPIArticle.isCommentable
-											}
-											discussionApiUrl={
-												CAPIArticle.config
-													.discussionApiUrl
-											}
-											shortUrlId={
-												CAPIArticle.config.shortUrlId
-											}
-											ajaxUrl={CAPIArticle.config.ajaxUrl}
-											showShareCount={
-												CAPIArticle.config.switches
-													.serverShareCounts
-											}
-										/>
-									</div>
-								</Hide>
-							</GridItem>
-						</StandFirstGrid>
-					</ElementContainer>
-
-					<ElementContainer
-						showTopBorder={false}
-						borderColour={palette.border.article}
-						backgroundColour={palette.background.article}
-					>
-						<Hide until="desktop">
-							<div
-								css={css`
-									height: ${space[4]}px;
-								`}
+						<Hide above="leftCol">
+							<ArticleTitle
+								format={format}
+								tags={CAPIArticle.tags}
+								sectionLabel={CAPIArticle.sectionLabel}
+								sectionUrl={CAPIArticle.sectionUrl}
+								guardianBaseURL={CAPIArticle.guardianBaseURL}
+								badge={CAPIArticle.badge}
+								isMatch={true}
 							/>
 						</Hide>
-					</ElementContainer>
 
+						<Island
+							deferUntil="visible"
+							clientOnly={true}
+							placeholderHeight={230}
+						>
+							<GetMatchNav
+								matchUrl={footballMatchUrl}
+								format={format}
+								headlineString={CAPIArticle.headline}
+								tags={CAPIArticle.tags}
+								webPublicationDateDeprecated={
+									CAPIArticle.webPublicationDateDeprecated
+								}
+							/>
+						</Island>
+					</ContainerLayout>
+				) : (
 					<ElementContainer
 						showTopBorder={false}
-						backgroundColour={palette.background.article}
-						borderColour={palette.border.article}
-						padded={false}
+						backgroundColour={palette.background.header}
+						borderColour={palette.border.headline}
 					>
-						<LiveGrid>
-							<GridItem area="media">
+						<HeadlineGrid>
+							<GridItem area="title">
+								<ArticleTitle
+									format={format}
+									tags={CAPIArticle.tags}
+									sectionLabel={CAPIArticle.sectionLabel}
+									sectionUrl={CAPIArticle.sectionUrl}
+									guardianBaseURL={
+										CAPIArticle.guardianBaseURL
+									}
+									badge={CAPIArticle.badge}
+								/>
+							</GridItem>
+							<GridItem area="headline">
 								<div css={maxWidth}>
+									{!footballMatchUrl && (
+										<ArticleHeadline
+											format={format}
+											headlineString={
+												CAPIArticle.headline
+											}
+											tags={CAPIArticle.tags}
+											byline={CAPIArticle.author.byline}
+											webPublicationDateDeprecated={
+												CAPIArticle.webPublicationDateDeprecated
+											}
+											hasStarRating={
+												!!CAPIArticle.starRating ||
+												CAPIArticle.starRating === 0
+											}
+										/>
+									)}
+								</div>
+								{CAPIArticle.starRating ||
+								CAPIArticle.starRating === 0 ? (
+									<div css={starWrapper}>
+										<StarRating
+											rating={CAPIArticle.starRating}
+											size="large"
+										/>
+									</div>
+								) : (
+									<></>
+								)}
+							</GridItem>
+						</HeadlineGrid>
+					</ElementContainer>
+				)}
+
+				<ElementContainer
+					showTopBorder={false}
+					backgroundColour={palette.background.standfirst}
+					borderColour={palette.border.standfirst}
+				>
+					<StandFirstGrid>
+						<GridItem area="standfirst">
+							<Standfirst
+								format={format}
+								standfirst={CAPIArticle.standfirst}
+							/>
+						</GridItem>
+						<GridItem area="lastupdated">
+							<Hide until="desktop">
+								{CAPIArticle.blocks.length &&
+									CAPIArticle.blocks[0].blockLastUpdated && (
+										<ArticleLastUpdated
+											format={format}
+											lastUpdated={
+												CAPIArticle.blocks[0]
+													.blockLastUpdated
+											}
+										/>
+									)}
+							</Hide>
+						</GridItem>
+						<GridItem area="lines">
+							<Hide from="desktop">
+								<div css={sidePaddingDesktop}>
+									<Lines
+										cssOverrides={css`
+											display: block;
+										`}
+										count={decideLineCount(format.design)}
+										effect={decideLineEffect(
+											format.design,
+											format.theme,
+										)}
+										color={
+											format.design ===
+											ArticleDesign.LiveBlog
+												? 'rgba(255, 255, 255, 0.4)'
+												: undefined
+										}
+									/>
+								</div>
+							</Hide>
+						</GridItem>
+						<GridItem area="meta">
+							<Hide from="desktop">
+								<div css={sidePaddingDesktop}>
+									<ArticleMeta
+										branding={branding}
+										format={format}
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										author={CAPIArticle.author}
+										tags={CAPIArticle.tags}
+										primaryDateline={
+											CAPIArticle.webPublicationDateDisplay
+										}
+										secondaryDateline={
+											CAPIArticle.webPublicationSecondaryDateDisplay
+										}
+										isCommentable={
+											CAPIArticle.isCommentable
+										}
+										discussionApiUrl={
+											CAPIArticle.config.discussionApiUrl
+										}
+										shortUrlId={
+											CAPIArticle.config.shortUrlId
+										}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										showShareCount={
+											CAPIArticle.config.switches
+												.serverShareCounts
+										}
+									/>
+								</div>
+							</Hide>
+						</GridItem>
+					</StandFirstGrid>
+				</ElementContainer>
+
+				<ElementContainer
+					showTopBorder={false}
+					borderColour={palette.border.article}
+					backgroundColour={palette.background.article}
+				>
+					<Hide until="desktop">
+						<div
+							css={css`
+								height: ${space[4]}px;
+							`}
+						/>
+					</Hide>
+				</ElementContainer>
+				<div>
+					{format.design === ArticleDesign.LiveBlog && (
+						<>
+							{/* The Toast component is inserted into this div using a Portal */}
+							<div
+								id="toast-root"
+								css={css`
+									position: sticky;
+									top: 0;
+									${getZIndex('toast')};
+									display: flex;
+									justify-content: center;
+								`}
+							/>
+							<Island clientOnly={true} deferUntil="idle">
+								<Liveness
+									pageId={CAPIArticle.pageId}
+									webTitle={CAPIArticle.webTitle}
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									filterKeyEvents={
+										CAPIArticle.filterKeyEvents
+									}
+									format={format}
+									switches={CAPIArticle.config.switches}
+									onFirstPage={pagination.currentPage === 1}
+									webURL={CAPIArticle.webURL}
+									// We default to string here because the property is optional but we
+									// know it will exist for all blogs
+									mostRecentBlockId={
+										CAPIArticle.mostRecentBlockId || ''
+									}
+									hasPinnedPost={!!CAPIArticle.pinnedPost}
+								/>
+							</Island>
+						</>
+					)}
+
+					<article>
+						<ElementContainer
+							showTopBorder={false}
+							backgroundColour={palette.background.article}
+							borderColour={palette.border.article}
+							padded={false}
+						>
+							<LiveGrid>
+								<GridItem area="media">
+									<div css={maxWidth}>
+										{footballMatchUrl && (
+											<Island
+												clientOnly={true}
+												placeholderHeight={40}
+											>
+												<GetMatchTabs
+													matchUrl={footballMatchUrl}
+													format={format}
+												/>
+											</Island>
+										)}
+										{cricketMatchUrl && (
+											<Island
+												clientOnly={true}
+												placeholderHeight={172}
+											>
+												<GetCricketScoreboard
+													matchUrl={cricketMatchUrl}
+													format={format}
+												/>
+											</Island>
+										)}
+										<MainMedia
+											format={format}
+											elements={
+												CAPIArticle.mainMediaElements
+											}
+											adTargeting={adTargeting}
+											host={host}
+											pageId={CAPIArticle.pageId}
+											webTitle={CAPIArticle.webTitle}
+											ajaxUrl={CAPIArticle.config.ajaxUrl}
+											switches={
+												CAPIArticle.config.switches
+											}
+											isSensitive={
+												CAPIArticle.config.isSensitive
+											}
+											isAdFreeUser={
+												CAPIArticle.isAdFreeUser
+											}
+										/>
+									</div>
+								</GridItem>
+								<GridItem area="info" element="aside">
+									{/* Lines */}
+									<Hide until="desktop">
+										<div
+											css={[maxWidth, sidePaddingDesktop]}
+										>
+											<Lines
+												cssOverrides={css`
+													display: block;
+												`}
+												count={decideLineCount(
+													format.design,
+												)}
+												effect={decideLineEffect(
+													format.design,
+													format.theme,
+												)}
+											/>
+										</div>
+									</Hide>
+									{/* Meta */}
+									<Hide until="desktop">
+										<div
+											css={[maxWidth, sidePaddingDesktop]}
+										>
+											<ArticleMeta
+												branding={branding}
+												format={format}
+												pageId={CAPIArticle.pageId}
+												webTitle={CAPIArticle.webTitle}
+												author={CAPIArticle.author}
+												tags={CAPIArticle.tags}
+												primaryDateline={
+													CAPIArticle.webPublicationDateDisplay
+												}
+												secondaryDateline={
+													CAPIArticle.webPublicationSecondaryDateDisplay
+												}
+												isCommentable={
+													CAPIArticle.isCommentable
+												}
+												discussionApiUrl={
+													CAPIArticle.config
+														.discussionApiUrl
+												}
+												shortUrlId={
+													CAPIArticle.config
+														.shortUrlId
+												}
+												ajaxUrl={
+													CAPIArticle.config.ajaxUrl
+												}
+												showShareCount={
+													CAPIArticle.config.switches
+														.serverShareCounts
+												}
+											/>
+										</div>
+									</Hide>
+									{/* Key events */}
+									<div
+										css={[
+											!footballMatchUrl && sticky,
+											keyEventsMargins,
+											sidePaddingDesktop,
+										]}
+									>
+										<KeyEventsContainer
+											format={format}
+											keyEvents={CAPIArticle.keyEvents}
+											filterKeyEvents={
+												CAPIArticle.filterKeyEvents
+											}
+										/>
+									</div>
+									{/* Match stats */}
 									{footballMatchUrl && (
 										<Island
+											deferUntil="visible"
 											clientOnly={true}
-											placeholderHeight={40}
+											placeholderHeight={800}
 										>
-											<GetMatchTabs
+											<GetMatchStats
 												matchUrl={footballMatchUrl}
 												format={format}
 											/>
 										</Island>
 									)}
-									{cricketMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={172}
-										>
-											<GetCricketScoreboard
-												matchUrl={cricketMatchUrl}
-												format={format}
-											/>
-										</Island>
-									)}
-									<MainMedia
-										format={format}
-										elements={CAPIArticle.mainMediaElements}
-										adTargeting={adTargeting}
-										host={host}
-										pageId={CAPIArticle.pageId}
-										webTitle={CAPIArticle.webTitle}
-										ajaxUrl={CAPIArticle.config.ajaxUrl}
-										switches={CAPIArticle.config.switches}
-										isSensitive={
-											CAPIArticle.config.isSensitive
-										}
-										isAdFreeUser={CAPIArticle.isAdFreeUser}
-									/>
-								</div>
-							</GridItem>
-							<GridItem area="info" element="aside">
-								{/* Lines */}
-								<Hide until="desktop">
-									<div css={[maxWidth, sidePaddingDesktop]}>
-										<Lines
-											cssOverrides={css`
-												display: block;
-											`}
-											count={decideLineCount(
-												format.design,
-											)}
-											effect={decideLineEffect(
-												format.design,
-												format.theme,
-											)}
-										/>
-									</div>
-								</Hide>
-								{/* Meta */}
-								<Hide until="desktop">
-									<div css={[maxWidth, sidePaddingDesktop]}>
-										<ArticleMeta
-											branding={branding}
-											format={format}
-											pageId={CAPIArticle.pageId}
-											webTitle={CAPIArticle.webTitle}
-											author={CAPIArticle.author}
-											tags={CAPIArticle.tags}
-											primaryDateline={
-												CAPIArticle.webPublicationDateDisplay
-											}
-											secondaryDateline={
-												CAPIArticle.webPublicationSecondaryDateDisplay
-											}
-											isCommentable={
-												CAPIArticle.isCommentable
-											}
-											discussionApiUrl={
-												CAPIArticle.config
-													.discussionApiUrl
-											}
-											shortUrlId={
-												CAPIArticle.config.shortUrlId
-											}
-											ajaxUrl={CAPIArticle.config.ajaxUrl}
-											showShareCount={
-												CAPIArticle.config.switches
-													.serverShareCounts
-											}
-										/>
-									</div>
-								</Hide>
-								{/* Key events */}
-								<div
-									css={[
-										!footballMatchUrl && sticky,
-										keyEventsMargins,
-										sidePaddingDesktop,
-									]}
-								>
-									<KeyEventsContainer
-										format={format}
-										keyEvents={CAPIArticle.keyEvents}
-										filterKeyEvents={
-											CAPIArticle.filterKeyEvents
-										}
-									/>
-								</div>
-								{/* Match stats */}
-								{footballMatchUrl && (
-									<Island
-										deferUntil="visible"
-										clientOnly={true}
-										placeholderHeight={800}
-									>
-										<GetMatchStats
-											matchUrl={footballMatchUrl}
-											format={format}
-										/>
-									</Island>
-								)}
-							</GridItem>
-							<GridItem area="body">
-								<div id="maincontent" css={bodyWrapper}>
-									{CAPIArticle.keyEvents?.length ? (
-										<Hide below="desktop">
-											<Island deferUntil="visible">
-												<FilterKeyEventsToggle
-													filterKeyEvents={
-														CAPIArticle.filterKeyEvents
-													}
-												/>
-											</Island>
-										</Hide>
-									) : (
-										<></>
-									)}
-									<Accordion
-										supportsDarkMode={false}
-										accordionTitle="Live feed"
-										context="liveFeed"
-									>
+								</GridItem>
+								<GridItem area="body">
+									<div id="maincontent" css={bodyWrapper}>
 										{CAPIArticle.keyEvents?.length ? (
-											<Hide above="desktop">
+											<Hide below="desktop">
 												<Island deferUntil="visible">
 													<FilterKeyEventsToggle
 														filterKeyEvents={
@@ -809,314 +797,372 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										) : (
 											<></>
 										)}
-										<ArticleContainer
-											format={format}
-											abTests={CAPIArticle.config.abTests}
+										<Accordion
+											supportsDarkMode={false}
+											accordionTitle="Live feed"
+											context="liveFeed"
 										>
-											{pagination.currentPage !== 1 && (
-												<Pagination
-													currentPage={
-														pagination.currentPage
-													}
-													totalPages={
-														pagination.totalPages
-													}
-													newest={pagination.newest}
-													oldest={pagination.oldest}
-													newer={pagination.newer}
-													older={pagination.older}
-													format={format}
-												/>
+											{CAPIArticle.keyEvents?.length ? (
+												<Hide above="desktop">
+													<Island deferUntil="visible">
+														<FilterKeyEventsToggle
+															filterKeyEvents={
+																CAPIArticle.filterKeyEvents
+															}
+														/>
+													</Island>
+												</Hide>
+											) : (
+												<></>
 											)}
-											<ArticleBody
+											<ArticleContainer
 												format={format}
-												blocks={CAPIArticle.blocks}
-												pinnedPost={
-													CAPIArticle.pinnedPost
+												abTests={
+													CAPIArticle.config.abTests
 												}
-												adTargeting={adTargeting}
-												host={host}
-												pageId={CAPIArticle.pageId}
-												webTitle={CAPIArticle.webTitle}
-												ajaxUrl={
-													CAPIArticle.config.ajaxUrl
-												}
-												section={
-													CAPIArticle.config.section
-												}
-												switches={
-													CAPIArticle.config.switches
-												}
-												isSensitive={
-													CAPIArticle.config
-														.isSensitive
-												}
-												isAdFreeUser={
-													CAPIArticle.isAdFreeUser
-												}
+											>
+												{pagination.currentPage !==
+													1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
+													/>
+												)}
+												<ArticleBody
+													format={format}
+													blocks={CAPIArticle.blocks}
+													pinnedPost={
+														CAPIArticle.pinnedPost
+													}
+													adTargeting={adTargeting}
+													host={host}
+													pageId={CAPIArticle.pageId}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													ajaxUrl={
+														CAPIArticle.config
+															.ajaxUrl
+													}
+													section={
+														CAPIArticle.config
+															.section
+													}
+													switches={
+														CAPIArticle.config
+															.switches
+													}
+													isSensitive={
+														CAPIArticle.config
+															.isSensitive
+													}
+													isAdFreeUser={
+														CAPIArticle.isAdFreeUser
+													}
+													shouldHideReaderRevenue={
+														CAPIArticle.shouldHideReaderRevenue
+													}
+													tags={CAPIArticle.tags}
+													isPaidContent={
+														!!CAPIArticle.config
+															.isPaidContent
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													contentType={
+														CAPIArticle.contentType
+													}
+													sectionName={
+														CAPIArticle.sectionName ||
+														''
+													}
+													isPreview={
+														CAPIArticle.config
+															.isPreview
+													}
+													idUrl={
+														CAPIArticle.config
+															.idUrl || ''
+													}
+													isDev={
+														!!CAPIArticle.config
+															.isDev
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+												/>
+												{pagination.totalPages > 1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
+													/>
+												)}
+												{showBodyEndSlot && (
+													<Island clientOnly={true}>
+														<SlotBodyEnd
+															contentType={
+																CAPIArticle.contentType
+															}
+															contributionsServiceUrl={
+																contributionsServiceUrl
+															}
+															idApiUrl={
+																CAPIArticle
+																	.config
+																	.idApiUrl
+															}
+															isMinuteArticle={
+																CAPIArticle
+																	.pageType
+																	.isMinuteArticle
+															}
+															isPaidContent={
+																CAPIArticle
+																	.pageType
+																	.isPaidContent
+															}
+															keywordsId={
+																CAPIArticle
+																	.config
+																	.keywordIds
+															}
+															pageId={
+																CAPIArticle.pageId
+															}
+															sectionId={
+																CAPIArticle
+																	.config
+																	.section
+															}
+															sectionName={
+																CAPIArticle.sectionName
+															}
+															shouldHideReaderRevenue={
+																CAPIArticle.shouldHideReaderRevenue
+															}
+															stage={
+																CAPIArticle
+																	.config
+																	.stage
+															}
+															tags={
+																CAPIArticle.tags
+															}
+														/>
+													</Island>
+												)}
+												<StraightLines
+													data-print-layout="hide"
+													count={4}
+													cssOverrides={css`
+														display: block;
+													`}
+												/>
+												<SubMeta
+													format={format}
+													subMetaKeywordLinks={
+														CAPIArticle.subMetaKeywordLinks
+													}
+													subMetaSectionLinks={
+														CAPIArticle.subMetaSectionLinks
+													}
+													pageId={CAPIArticle.pageId}
+													webUrl={CAPIArticle.webURL}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													showBottomSocialButtons={
+														CAPIArticle.showBottomSocialButtons
+													}
+													badge={CAPIArticle.badge}
+												/>
+											</ArticleContainer>
+										</Accordion>
+									</div>
+								</GridItem>
+								<GridItem area="right-column">
+									<div
+										css={css`
+											height: 100%;
+											${from.desktop} {
+												/* above 980 */
+												margin-left: 20px;
+												margin-right: -20px;
+												display: none;
+											}
+											${from.leftCol} {
+												/* above 1140 */
+												margin-left: 0px;
+												margin-right: 0px;
+											}
+											${from.wide} {
+												display: block;
+											}
+										`}
+									>
+										<RightColumn>
+											<AdSlot
+												position="right"
+												display={format.display}
 												shouldHideReaderRevenue={
 													CAPIArticle.shouldHideReaderRevenue
 												}
-												tags={CAPIArticle.tags}
 												isPaidContent={
-													!!CAPIArticle.config
+													CAPIArticle.pageType
 														.isPaidContent
 												}
-												contributionsServiceUrl={
-													contributionsServiceUrl
-												}
-												contentType={
-													CAPIArticle.contentType
-												}
-												sectionName={
-													CAPIArticle.sectionName ||
-													''
-												}
-												isPreview={
-													CAPIArticle.config.isPreview
-												}
-												idUrl={
-													CAPIArticle.config.idUrl ||
-													''
-												}
-												isDev={
-													!!CAPIArticle.config.isDev
-												}
-												onFirstPage={
-													pagination.currentPage === 1
-												}
 											/>
-											{pagination.totalPages > 1 && (
-												<Pagination
-													currentPage={
-														pagination.currentPage
-													}
-													totalPages={
-														pagination.totalPages
-													}
-													newest={pagination.newest}
-													oldest={pagination.oldest}
-													newer={pagination.newer}
-													older={pagination.older}
-													format={format}
-												/>
-											)}
-											{showBodyEndSlot && (
-												<Island clientOnly={true}>
-													<SlotBodyEnd
-														contentType={
-															CAPIArticle.contentType
-														}
-														contributionsServiceUrl={
-															contributionsServiceUrl
-														}
-														idApiUrl={
-															CAPIArticle.config
-																.idApiUrl
-														}
-														isMinuteArticle={
-															CAPIArticle.pageType
-																.isMinuteArticle
-														}
-														isPaidContent={
-															CAPIArticle.pageType
-																.isPaidContent
-														}
-														keywordsId={
-															CAPIArticle.config
-																.keywordIds
-														}
-														pageId={
-															CAPIArticle.pageId
-														}
-														sectionId={
-															CAPIArticle.config
-																.section
-														}
-														sectionName={
-															CAPIArticle.sectionName
-														}
-														shouldHideReaderRevenue={
-															CAPIArticle.shouldHideReaderRevenue
-														}
-														stage={
-															CAPIArticle.config
-																.stage
-														}
-														tags={CAPIArticle.tags}
-													/>
-												</Island>
-											)}
-											<StraightLines
-												data-print-layout="hide"
-												count={4}
-												cssOverrides={css`
-													display: block;
-												`}
-											/>
-											<SubMeta
-												format={format}
-												subMetaKeywordLinks={
-													CAPIArticle.subMetaKeywordLinks
-												}
-												subMetaSectionLinks={
-													CAPIArticle.subMetaSectionLinks
-												}
-												pageId={CAPIArticle.pageId}
-												webUrl={CAPIArticle.webURL}
-												webTitle={CAPIArticle.webTitle}
-												showBottomSocialButtons={
-													CAPIArticle.showBottomSocialButtons
-												}
-												badge={CAPIArticle.badge}
-											/>
-										</ArticleContainer>
-									</Accordion>
-								</div>
-							</GridItem>
-							<GridItem area="right-column">
-								<div
-									css={css`
-										height: 100%;
-										${from.desktop} {
-											/* above 980 */
-											margin-left: 20px;
-											margin-right: -20px;
-											display: none;
-										}
-										${from.leftCol} {
-											/* above 1140 */
-											margin-left: 0px;
-											margin-right: 0px;
-										}
-										${from.wide} {
-											display: block;
-										}
-									`}
-								>
-									<RightColumn>
-										<AdSlot
-											position="right"
-											display={format.display}
-											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
-											}
-											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
-											}
-										/>
-									</RightColumn>
-								</div>
-							</GridItem>
-						</LiveGrid>
-					</ElementContainer>
-				</article>
+										</RightColumn>
+									</div>
+								</GridItem>
+							</LiveGrid>
+						</ElementContainer>
+					</article>
 
-				<ElementContainer
-					data-print-layout="hide"
-					padded={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot
-						data-print-layout="hide"
-						position="merchandising-high"
-						display={format.display}
-					/>
-				</ElementContainer>
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						edition={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
-
-				{showOnwardsLower && (
 					<ElementContainer
-						sectionId="onwards-lower"
-						element="section"
-					>
-						<Island clientOnly={true} deferUntil="visible">
-							<OnwardsLower
-								ajaxUrl={CAPIArticle.config.ajaxUrl}
-								hasStoryPackage={CAPIArticle.hasStoryPackage}
-								tags={CAPIArticle.tags}
-								format={format}
-							/>
-						</Island>
-					</ElementContainer>
-				)}
-
-				{!isPaidContent && CAPIArticle.isCommentable && (
-					<ElementContainer
-						sectionId="comments"
 						data-print-layout="hide"
-						element="section"
+						padded={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
 					>
-						<DiscussionLayout
-							discussionApiUrl={
-								CAPIArticle.config.discussionApiUrl
-							}
-							shortUrlId={CAPIArticle.config.shortUrlId}
-							format={format}
-							discussionD2Uid={CAPIArticle.config.discussionD2Uid}
-							discussionApiClientHeader={
-								CAPIArticle.config.discussionApiClientHeader
-							}
-							enableDiscussionSwitch={
-								CAPIArticle.config.switches
-									.enableDiscussionSwitch
-							}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							shouldHideAds={CAPIArticle.shouldHideAds}
+						<AdSlot
+							data-print-layout="hide"
+							position="merchandising-high"
+							display={format.display}
 						/>
 					</ElementContainer>
-				)}
 
-				{!isPaidContent && (
-					<ElementContainer data-print-layout="hide" element="aside">
-						<MostViewedFooterLayout
-							format={format}
-							sectionName={CAPIArticle.sectionName}
+					<Island
+						clientOnly={true}
+						deferUntil="visible"
+						placeholderHeight={600}
+					>
+						<OnwardsUpper
 							ajaxUrl={CAPIArticle.config.ajaxUrl}
+							hasRelated={CAPIArticle.hasRelated}
+							hasStoryPackage={CAPIArticle.hasStoryPackage}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							pageId={CAPIArticle.pageId}
+							isPaidContent={
+								CAPIArticle.config.isPaidContent || false
+							}
+							showRelatedContent={
+								CAPIArticle.config.showRelatedContent
+							}
+							keywordIds={CAPIArticle.config.keywordIds}
+							contentType={CAPIArticle.contentType}
+							tags={CAPIArticle.tags}
+							format={format}
+							pillar={format.theme}
+							edition={CAPIArticle.editionId}
+							shortUrlId={CAPIArticle.config.shortUrlId}
+						/>
+					</Island>
+
+					{showOnwardsLower && (
+						<ElementContainer
+							sectionId="onwards-lower"
+							element="section"
+						>
+							<Island clientOnly={true} deferUntil="visible">
+								<OnwardsLower
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									hasStoryPackage={
+										CAPIArticle.hasStoryPackage
+									}
+									tags={CAPIArticle.tags}
+									format={format}
+								/>
+							</Island>
+						</ElementContainer>
+					)}
+
+					{!isPaidContent && CAPIArticle.isCommentable && (
+						<ElementContainer
+							sectionId="comments"
+							data-print-layout="hide"
+							element="section"
+						>
+							<DiscussionLayout
+								discussionApiUrl={
+									CAPIArticle.config.discussionApiUrl
+								}
+								shortUrlId={CAPIArticle.config.shortUrlId}
+								format={format}
+								discussionD2Uid={
+									CAPIArticle.config.discussionD2Uid
+								}
+								discussionApiClientHeader={
+									CAPIArticle.config.discussionApiClientHeader
+								}
+								enableDiscussionSwitch={
+									CAPIArticle.config.switches
+										.enableDiscussionSwitch
+								}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								shouldHideAds={CAPIArticle.shouldHideAds}
+							/>
+						</ElementContainer>
+					)}
+
+					{!isPaidContent && (
+						<ElementContainer
+							data-print-layout="hide"
+							element="aside"
+						>
+							<MostViewedFooterLayout
+								format={format}
+								sectionName={CAPIArticle.sectionName}
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+							/>
+						</ElementContainer>
+					)}
+
+					<ElementContainer
+						data-print-layout="hide"
+						padded={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising"
+							display={format.display}
 						/>
 					</ElementContainer>
-				)}
-
-				<ElementContainer
-					data-print-layout="hide"
-					padded={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot position="merchandising" display={format.display} />
-				</ElementContainer>
+				</div>
 			</main>
 
 			{NAV.subNavSections && (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -602,6 +602,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						/>
 					</Hide>
 				</ElementContainer>
+
+				{/* This div is used to contain the Toast */}
 				<div>
 					{format.design === ArticleDesign.LiveBlog && (
 						<>
@@ -639,153 +641,157 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</>
 					)}
 
-					<article>
-						<ElementContainer
-							showTopBorder={false}
-							backgroundColour={palette.background.article}
-							borderColour={palette.border.article}
-							padded={false}
-						>
-							<LiveGrid>
-								<GridItem area="media">
-									<div css={maxWidth}>
-										{footballMatchUrl && (
-											<Island
-												clientOnly={true}
-												placeholderHeight={40}
-											>
-												<GetMatchTabs
-													matchUrl={footballMatchUrl}
-													format={format}
-												/>
-											</Island>
-										)}
-										{cricketMatchUrl && (
-											<Island
-												clientOnly={true}
-												placeholderHeight={172}
-											>
-												<GetCricketScoreboard
-													matchUrl={cricketMatchUrl}
-													format={format}
-												/>
-											</Island>
-										)}
-										<MainMedia
-											format={format}
-											elements={
-												CAPIArticle.mainMediaElements
-											}
-											adTargeting={adTargeting}
-											host={host}
-											pageId={CAPIArticle.pageId}
-											webTitle={CAPIArticle.webTitle}
-											ajaxUrl={CAPIArticle.config.ajaxUrl}
-											switches={
-												CAPIArticle.config.switches
-											}
-											isSensitive={
-												CAPIArticle.config.isSensitive
-											}
-											isAdFreeUser={
-												CAPIArticle.isAdFreeUser
-											}
-										/>
-									</div>
-								</GridItem>
-								<GridItem area="info" element="aside">
-									{/* Lines */}
-									<Hide until="desktop">
-										<div
-											css={[maxWidth, sidePaddingDesktop]}
-										>
-											<Lines
-												cssOverrides={css`
-													display: block;
-												`}
-												count={decideLineCount(
-													format.design,
-												)}
-												effect={decideLineEffect(
-													format.design,
-													format.theme,
-												)}
-											/>
-										</div>
-									</Hide>
-									{/* Meta */}
-									<Hide until="desktop">
-										<div
-											css={[maxWidth, sidePaddingDesktop]}
-										>
-											<ArticleMeta
-												branding={branding}
-												format={format}
-												pageId={CAPIArticle.pageId}
-												webTitle={CAPIArticle.webTitle}
-												author={CAPIArticle.author}
-												tags={CAPIArticle.tags}
-												primaryDateline={
-													CAPIArticle.webPublicationDateDisplay
-												}
-												secondaryDateline={
-													CAPIArticle.webPublicationSecondaryDateDisplay
-												}
-												isCommentable={
-													CAPIArticle.isCommentable
-												}
-												discussionApiUrl={
-													CAPIArticle.config
-														.discussionApiUrl
-												}
-												shortUrlId={
-													CAPIArticle.config
-														.shortUrlId
-												}
-												ajaxUrl={
-													CAPIArticle.config.ajaxUrl
-												}
-												showShareCount={
-													CAPIArticle.config.switches
-														.serverShareCounts
-												}
-											/>
-										</div>
-									</Hide>
-									{/* Key events */}
-									<div
-										css={[
-											!footballMatchUrl && sticky,
-											keyEventsMargins,
-											sidePaddingDesktop,
-										]}
-									>
-										<KeyEventsContainer
-											format={format}
-											keyEvents={CAPIArticle.keyEvents}
-											filterKeyEvents={
-												CAPIArticle.filterKeyEvents
-											}
-										/>
-									</div>
-									{/* Match stats */}
+					<ElementContainer
+						showTopBorder={false}
+						backgroundColour={palette.background.article}
+						borderColour={palette.border.article}
+						padded={false}
+					>
+						<LiveGrid>
+							<GridItem area="media">
+								<div css={maxWidth}>
 									{footballMatchUrl && (
 										<Island
-											deferUntil="visible"
 											clientOnly={true}
-											placeholderHeight={800}
+											placeholderHeight={40}
 										>
-											<GetMatchStats
+											<GetMatchTabs
 												matchUrl={footballMatchUrl}
 												format={format}
 											/>
 										</Island>
 									)}
-								</GridItem>
-								<GridItem area="body">
-									<div id="maincontent" css={bodyWrapper}>
+									{cricketMatchUrl && (
+										<Island
+											clientOnly={true}
+											placeholderHeight={172}
+										>
+											<GetCricketScoreboard
+												matchUrl={cricketMatchUrl}
+												format={format}
+											/>
+										</Island>
+									)}
+									<MainMedia
+										format={format}
+										elements={CAPIArticle.mainMediaElements}
+										adTargeting={adTargeting}
+										host={host}
+										pageId={CAPIArticle.pageId}
+										webTitle={CAPIArticle.webTitle}
+										ajaxUrl={CAPIArticle.config.ajaxUrl}
+										switches={CAPIArticle.config.switches}
+										isSensitive={
+											CAPIArticle.config.isSensitive
+										}
+										isAdFreeUser={CAPIArticle.isAdFreeUser}
+									/>
+								</div>
+							</GridItem>
+							<GridItem area="info" element="aside">
+								{/* Lines */}
+								<Hide until="desktop">
+									<div css={[maxWidth, sidePaddingDesktop]}>
+										<Lines
+											cssOverrides={css`
+												display: block;
+											`}
+											count={decideLineCount(
+												format.design,
+											)}
+											effect={decideLineEffect(
+												format.design,
+												format.theme,
+											)}
+										/>
+									</div>
+								</Hide>
+								{/* Meta */}
+								<Hide until="desktop">
+									<div css={[maxWidth, sidePaddingDesktop]}>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={CAPIArticle.pageId}
+											webTitle={CAPIArticle.webTitle}
+											author={CAPIArticle.author}
+											tags={CAPIArticle.tags}
+											primaryDateline={
+												CAPIArticle.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												CAPIArticle.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												CAPIArticle.isCommentable
+											}
+											discussionApiUrl={
+												CAPIArticle.config
+													.discussionApiUrl
+											}
+											shortUrlId={
+												CAPIArticle.config.shortUrlId
+											}
+											ajaxUrl={CAPIArticle.config.ajaxUrl}
+											showShareCount={
+												CAPIArticle.config.switches
+													.serverShareCounts
+											}
+										/>
+									</div>
+								</Hide>
+								{/* Key events */}
+								<div
+									css={[
+										!footballMatchUrl && sticky,
+										keyEventsMargins,
+										sidePaddingDesktop,
+									]}
+								>
+									<KeyEventsContainer
+										format={format}
+										keyEvents={CAPIArticle.keyEvents}
+										filterKeyEvents={
+											CAPIArticle.filterKeyEvents
+										}
+									/>
+								</div>
+								{/* Match stats */}
+								{footballMatchUrl && (
+									<Island
+										deferUntil="visible"
+										clientOnly={true}
+										placeholderHeight={800}
+									>
+										<GetMatchStats
+											matchUrl={footballMatchUrl}
+											format={format}
+										/>
+									</Island>
+								)}
+							</GridItem>
+							<GridItem area="body">
+								<div id="maincontent" css={bodyWrapper}>
+									{CAPIArticle.keyEvents?.length ? (
+										<Hide below="desktop">
+											<Island deferUntil="visible">
+												<FilterKeyEventsToggle
+													filterKeyEvents={
+														CAPIArticle.filterKeyEvents
+													}
+												/>
+											</Island>
+										</Hide>
+									) : (
+										<></>
+									)}
+									<Accordion
+										supportsDarkMode={false}
+										accordionTitle="Live feed"
+										context="liveFeed"
+									>
 										{CAPIArticle.keyEvents?.length ? (
-											<Hide below="desktop">
+											<Hide above="desktop">
 												<Island deferUntil="visible">
 													<FilterKeyEventsToggle
 														filterKeyEvents={
@@ -797,256 +803,208 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										) : (
 											<></>
 										)}
-										<Accordion
-											supportsDarkMode={false}
-											accordionTitle="Live feed"
-											context="liveFeed"
+										<ArticleContainer
+											format={format}
+											abTests={CAPIArticle.config.abTests}
 										>
-											{CAPIArticle.keyEvents?.length ? (
-												<Hide above="desktop">
-													<Island deferUntil="visible">
-														<FilterKeyEventsToggle
-															filterKeyEvents={
-																CAPIArticle.filterKeyEvents
-															}
-														/>
-													</Island>
-												</Hide>
-											) : (
-												<></>
+											{pagination.currentPage !== 1 && (
+												<Pagination
+													currentPage={
+														pagination.currentPage
+													}
+													totalPages={
+														pagination.totalPages
+													}
+													newest={pagination.newest}
+													oldest={pagination.oldest}
+													newer={pagination.newer}
+													older={pagination.older}
+													format={format}
+												/>
 											)}
-											<ArticleContainer
+											<ArticleBody
 												format={format}
-												abTests={
-													CAPIArticle.config.abTests
+												blocks={CAPIArticle.blocks}
+												pinnedPost={
+													CAPIArticle.pinnedPost
 												}
-											>
-												{pagination.currentPage !==
-													1 && (
-													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
-														newer={pagination.newer}
-														older={pagination.older}
-														format={format}
-													/>
-												)}
-												<ArticleBody
-													format={format}
-													blocks={CAPIArticle.blocks}
-													pinnedPost={
-														CAPIArticle.pinnedPost
-													}
-													adTargeting={adTargeting}
-													host={host}
-													pageId={CAPIArticle.pageId}
-													webTitle={
-														CAPIArticle.webTitle
-													}
-													ajaxUrl={
-														CAPIArticle.config
-															.ajaxUrl
-													}
-													section={
-														CAPIArticle.config
-															.section
-													}
-													switches={
-														CAPIArticle.config
-															.switches
-													}
-													isSensitive={
-														CAPIArticle.config
-															.isSensitive
-													}
-													isAdFreeUser={
-														CAPIArticle.isAdFreeUser
-													}
-													shouldHideReaderRevenue={
-														CAPIArticle.shouldHideReaderRevenue
-													}
-													tags={CAPIArticle.tags}
-													isPaidContent={
-														!!CAPIArticle.config
-															.isPaidContent
-													}
-													contributionsServiceUrl={
-														contributionsServiceUrl
-													}
-													contentType={
-														CAPIArticle.contentType
-													}
-													sectionName={
-														CAPIArticle.sectionName ||
-														''
-													}
-													isPreview={
-														CAPIArticle.config
-															.isPreview
-													}
-													idUrl={
-														CAPIArticle.config
-															.idUrl || ''
-													}
-													isDev={
-														!!CAPIArticle.config
-															.isDev
-													}
-													onFirstPage={
-														pagination.currentPage ===
-														1
-													}
-												/>
-												{pagination.totalPages > 1 && (
-													<Pagination
-														currentPage={
-															pagination.currentPage
-														}
-														totalPages={
-															pagination.totalPages
-														}
-														newest={
-															pagination.newest
-														}
-														oldest={
-															pagination.oldest
-														}
-														newer={pagination.newer}
-														older={pagination.older}
-														format={format}
-													/>
-												)}
-												{showBodyEndSlot && (
-													<Island clientOnly={true}>
-														<SlotBodyEnd
-															contentType={
-																CAPIArticle.contentType
-															}
-															contributionsServiceUrl={
-																contributionsServiceUrl
-															}
-															idApiUrl={
-																CAPIArticle
-																	.config
-																	.idApiUrl
-															}
-															isMinuteArticle={
-																CAPIArticle
-																	.pageType
-																	.isMinuteArticle
-															}
-															isPaidContent={
-																CAPIArticle
-																	.pageType
-																	.isPaidContent
-															}
-															keywordsId={
-																CAPIArticle
-																	.config
-																	.keywordIds
-															}
-															pageId={
-																CAPIArticle.pageId
-															}
-															sectionId={
-																CAPIArticle
-																	.config
-																	.section
-															}
-															sectionName={
-																CAPIArticle.sectionName
-															}
-															shouldHideReaderRevenue={
-																CAPIArticle.shouldHideReaderRevenue
-															}
-															stage={
-																CAPIArticle
-																	.config
-																	.stage
-															}
-															tags={
-																CAPIArticle.tags
-															}
-														/>
-													</Island>
-												)}
-												<StraightLines
-													data-print-layout="hide"
-													count={4}
-													cssOverrides={css`
-														display: block;
-													`}
-												/>
-												<SubMeta
-													format={format}
-													subMetaKeywordLinks={
-														CAPIArticle.subMetaKeywordLinks
-													}
-													subMetaSectionLinks={
-														CAPIArticle.subMetaSectionLinks
-													}
-													pageId={CAPIArticle.pageId}
-													webUrl={CAPIArticle.webURL}
-													webTitle={
-														CAPIArticle.webTitle
-													}
-													showBottomSocialButtons={
-														CAPIArticle.showBottomSocialButtons
-													}
-													badge={CAPIArticle.badge}
-												/>
-											</ArticleContainer>
-										</Accordion>
-									</div>
-								</GridItem>
-								<GridItem area="right-column">
-									<div
-										css={css`
-											height: 100%;
-											${from.desktop} {
-												/* above 980 */
-												margin-left: 20px;
-												margin-right: -20px;
-												display: none;
-											}
-											${from.leftCol} {
-												/* above 1140 */
-												margin-left: 0px;
-												margin-right: 0px;
-											}
-											${from.wide} {
-												display: block;
-											}
-										`}
-									>
-										<RightColumn>
-											<AdSlot
-												position="right"
-												display={format.display}
+												adTargeting={adTargeting}
+												host={host}
+												pageId={CAPIArticle.pageId}
+												webTitle={CAPIArticle.webTitle}
+												ajaxUrl={
+													CAPIArticle.config.ajaxUrl
+												}
+												section={
+													CAPIArticle.config.section
+												}
+												switches={
+													CAPIArticle.config.switches
+												}
+												isSensitive={
+													CAPIArticle.config
+														.isSensitive
+												}
+												isAdFreeUser={
+													CAPIArticle.isAdFreeUser
+												}
 												shouldHideReaderRevenue={
 													CAPIArticle.shouldHideReaderRevenue
 												}
+												tags={CAPIArticle.tags}
 												isPaidContent={
-													CAPIArticle.pageType
+													!!CAPIArticle.config
 														.isPaidContent
 												}
+												contributionsServiceUrl={
+													contributionsServiceUrl
+												}
+												contentType={
+													CAPIArticle.contentType
+												}
+												sectionName={
+													CAPIArticle.sectionName ||
+													''
+												}
+												isPreview={
+													CAPIArticle.config.isPreview
+												}
+												idUrl={
+													CAPIArticle.config.idUrl ||
+													''
+												}
+												isDev={
+													!!CAPIArticle.config.isDev
+												}
+												onFirstPage={
+													pagination.currentPage === 1
+												}
 											/>
-										</RightColumn>
-									</div>
-								</GridItem>
-							</LiveGrid>
-						</ElementContainer>
-					</article>
+											{pagination.totalPages > 1 && (
+												<Pagination
+													currentPage={
+														pagination.currentPage
+													}
+													totalPages={
+														pagination.totalPages
+													}
+													newest={pagination.newest}
+													oldest={pagination.oldest}
+													newer={pagination.newer}
+													older={pagination.older}
+													format={format}
+												/>
+											)}
+											{showBodyEndSlot && (
+												<Island clientOnly={true}>
+													<SlotBodyEnd
+														contentType={
+															CAPIArticle.contentType
+														}
+														contributionsServiceUrl={
+															contributionsServiceUrl
+														}
+														idApiUrl={
+															CAPIArticle.config
+																.idApiUrl
+														}
+														isMinuteArticle={
+															CAPIArticle.pageType
+																.isMinuteArticle
+														}
+														isPaidContent={
+															CAPIArticle.pageType
+																.isPaidContent
+														}
+														keywordsId={
+															CAPIArticle.config
+																.keywordIds
+														}
+														pageId={
+															CAPIArticle.pageId
+														}
+														sectionId={
+															CAPIArticle.config
+																.section
+														}
+														sectionName={
+															CAPIArticle.sectionName
+														}
+														shouldHideReaderRevenue={
+															CAPIArticle.shouldHideReaderRevenue
+														}
+														stage={
+															CAPIArticle.config
+																.stage
+														}
+														tags={CAPIArticle.tags}
+													/>
+												</Island>
+											)}
+											<StraightLines
+												data-print-layout="hide"
+												count={4}
+												cssOverrides={css`
+													display: block;
+												`}
+											/>
+											<SubMeta
+												format={format}
+												subMetaKeywordLinks={
+													CAPIArticle.subMetaKeywordLinks
+												}
+												subMetaSectionLinks={
+													CAPIArticle.subMetaSectionLinks
+												}
+												pageId={CAPIArticle.pageId}
+												webUrl={CAPIArticle.webURL}
+												webTitle={CAPIArticle.webTitle}
+												showBottomSocialButtons={
+													CAPIArticle.showBottomSocialButtons
+												}
+												badge={CAPIArticle.badge}
+											/>
+										</ArticleContainer>
+									</Accordion>
+								</div>
+							</GridItem>
+							<GridItem area="right-column">
+								<div
+									css={css`
+										height: 100%;
+										${from.desktop} {
+											/* above 980 */
+											margin-left: 20px;
+											margin-right: -20px;
+											display: none;
+										}
+										${from.leftCol} {
+											/* above 1140 */
+											margin-left: 0px;
+											margin-right: 0px;
+										}
+										${from.wide} {
+											display: block;
+										}
+									`}
+								>
+									<RightColumn>
+										<AdSlot
+											position="right"
+											display={format.display}
+											shouldHideReaderRevenue={
+												CAPIArticle.shouldHideReaderRevenue
+											}
+											isPaidContent={
+												CAPIArticle.pageType
+													.isPaidContent
+											}
+										/>
+									</RightColumn>
+								</div>
+							</GridItem>
+						</LiveGrid>
+					</ElementContainer>
 
 					<ElementContainer
 						data-print-layout="hide"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR refactors [an earlier change](https://github.com/guardian/dotcom-rendering/pull/4858) to allow the toast to display over a larger area. We still keep the ability to show the toast over any discussion but we now no longer show the toast above the headline or standfirst

## Why?
We never want to obscure the article headline

### What happened to the `article` tag?
I've removed the `article` tag that was being used to contain the headline, standfirst and article body. Having this element there made it impossible to wrap the article body and discussion in one div. I initially considered pushing it down so it only wrapped the article body but then @mxdvl pointed out that each block is an article anyway and having nested articles is not ideal.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="736" alt="Screenshot 2022-05-10 at 14 49 36" src="https://user-images.githubusercontent.com/1336821/167645207-be91d635-89ec-4d0a-950e-330a559bfb9f.png"> | <img width="736" alt="Screenshot 2022-05-10 at 14 49 03" src="https://user-images.githubusercontent.com/1336821/167645246-aecf8ea2-ec0e-4bdd-8bb2-f88eadfa2cd4.png"> |

