### PR TITLE
HAPPY - offline reading spike

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.dev-server.js
@@ -73,6 +73,20 @@ module.exports = {
 				);
 			});
 
+			devServer.app.get('/service-worker.js', (req, res) => {
+				res.sendFile(
+					path.join(
+						__dirname,
+						'..',
+						'..',
+						'src',
+						'static',
+						'js',
+						'service-worker.js',
+					),
+				)
+			})
+
 			// webpack-hot-server-middleware needs to run after webpack-dev-middleware
 			middlewares.push({
 				name: 'server',

--- a/dotcom-rendering/src/static/js/happy-offline.js
+++ b/dotcom-rendering/src/static/js/happy-offline.js
@@ -1,0 +1,28 @@
+window.addEventListener('DOMContentLoaded', (event) => {
+	domreadyHandler();
+});
+
+const domreadyHandler = async (event) => {
+	const cache = await caches.open('GU-HAPPY-OFFLINE-v1');
+
+	const containers = document.querySelectorAll('section[data-link-name^=container-]');
+	containers.forEach((container) => {
+		const sectionName = container.getAttribute('data-component');
+		const links = container.querySelectorAll('ul li a');
+
+		const fixedUrls = Array.from(links).map((link) => {
+			const fixedUrl = rewriteArticleUrl(link.href);
+			link.setAttribute('href', fixedUrl);
+			return fixedUrl;
+		});
+
+		console.log('caching', sectionName, fixedUrls);
+		cache.addAll(fixedUrls);
+	});
+}
+
+const rewriteArticleUrl = (url) => {
+	const path = url.match(/^http:\/\/(.*?)\/(.*)/)[2];
+	const sourceUrl = `https://www.theguardian.com/${path}`
+	return `/Article?url=${sourceUrl}`;
+}

--- a/dotcom-rendering/src/static/js/happy-offline.js
+++ b/dotcom-rendering/src/static/js/happy-offline.js
@@ -16,7 +16,6 @@ const domreadyHandler = async (event) => {
 			return fixedUrl;
 		});
 
-		console.log('caching', sectionName, fixedUrls);
 		cache.addAll(fixedUrls);
 	});
 }

--- a/dotcom-rendering/src/static/js/service-worker.js
+++ b/dotcom-rendering/src/static/js/service-worker.js
@@ -1,0 +1,56 @@
+console.log('Hello from service-worker.js');
+
+const CACHE_NAMESPACE = 'GU-HAPPY-OFFLINE-v1'
+
+/*, INSTALL */
+
+self.addEventListener("install", (event) => {
+  installHandler(event);
+});
+
+const installHandler = async (event) => {
+  console.log('install event');
+  event.waitUntil(self.skipWaiting());
+};
+
+/* ACTIVATE */
+
+self.addEventListener('activate', (event) => {
+  console.log('activate event');
+  event.waitUntil(enableNavigationPreload());
+});
+
+const enableNavigationPreload = async () => {
+  if (self.registration.navigationPreload) {
+    // Enable navigation preloads!
+    await self.registration.navigationPreload.enable();
+  }
+};
+
+/* FETCH */
+
+self.addEventListener('fetch', (event) => {
+  console.log('fetch event');
+  event.respondWith(
+    cacheFirst(event.request)
+  );
+});
+
+const cacheFirst = async (request) => {
+  // return new Response('<p>From service worker</p>');
+  console.log(request.url, request.destination);
+  const responseFromCache = await caches.match(request);
+  if (responseFromCache) {
+    console.log('serving out of cache');
+    return responseFromCache;
+  }
+  console.log('serving from network');
+  const responseFromNetwork = await fetch(request);
+  await putInCache(request, responseFromNetwork.clone());
+  return responseFromNetwork;
+};
+
+const putInCache = async (request, response) => {
+  const cache = await caches.open(CACHE_NAMESPACE);
+  await cache.put(request, response);
+}

--- a/dotcom-rendering/src/static/js/service-worker.js
+++ b/dotcom-rendering/src/static/js/service-worker.js
@@ -30,27 +30,33 @@ const enableNavigationPreload = async () => {
 /* FETCH */
 
 self.addEventListener('fetch', (event) => {
-  console.log('fetch event');
   event.respondWith(
     cacheFirst(event.request)
   );
 });
 
 const cacheFirst = async (request) => {
-  // return new Response('<p>From service worker</p>');
-  console.log(request.url, request.destination);
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
-    console.log('serving out of cache');
     return responseFromCache;
   }
-  console.log('serving from network');
-  const responseFromNetwork = await fetch(request);
-  await putInCache(request, responseFromNetwork.clone());
-  return responseFromNetwork;
+  try {
+	const responseFromNetwork = await fetch(request);
+	putInCache(request, responseFromNetwork.clone());
+	return responseFromNetwork;
+  } catch (e) {
+	if (request.destination === 'image') {
+      const fallbackImage = '<svg xmlns="http://www.w3.org/2000/svg" width="680.765" height="528.355" viewBox="0 0 180.119 139.794" xmlns:v="https://vecta.io/nano"><path d="M0 0h180.119v139.794H0z" fill="#d0d0d0" paint-order="fill markers stroke"/><g fill="#fff"><path d="M104.916 66.875l-34.249 34.249-15.968-15.968-41.938 41.938h31.936 51.939 68.498z" opacity=".675" paint-order="fill markers stroke"/><circle cx="44.626" cy="41.916" r="11.773" opacity=".675" paint-order="fill markers stroke"/></g></svg>'
+      return new Response(fallbackImage, { headers: {'Content-Type': 'image/svg+xml'}});
+	} else {
+      return new Response('', { headers: request.headers });
+	}
+  }
 };
 
 const putInCache = async (request, response) => {
   const cache = await caches.open(CACHE_NAMESPACE);
-  await cache.put(request, response);
+  if (request.method === 'GET') {
+	await cache.put(request, response);
+  }
 }

--- a/dotcom-rendering/src/static/js/service-worker.js
+++ b/dotcom-rendering/src/static/js/service-worker.js
@@ -5,58 +5,58 @@ const CACHE_NAMESPACE = 'GU-HAPPY-OFFLINE-v1'
 /*, INSTALL */
 
 self.addEventListener("install", (event) => {
-  installHandler(event);
+	installHandler(event);
 });
 
 const installHandler = async (event) => {
-  console.log('install event');
-  event.waitUntil(self.skipWaiting());
+	console.log('install event');
+	event.waitUntil(self.skipWaiting());
 };
 
 /* ACTIVATE */
 
 self.addEventListener('activate', (event) => {
-  console.log('activate event');
-  event.waitUntil(enableNavigationPreload());
+	console.log('activate event');
+	event.waitUntil(enableNavigationPreload());
 });
 
 const enableNavigationPreload = async () => {
-  if (self.registration.navigationPreload) {
-    // Enable navigation preloads!
-    await self.registration.navigationPreload.enable();
-  }
+	if (self.registration.navigationPreload) {
+		// Enable navigation preloads!
+		await self.registration.navigationPreload.enable();
+	}
 };
 
 /* FETCH */
 
 self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    cacheFirst(event.request)
-  );
+	event.respondWith(
+		cacheFirst(event.request)
+	);
 });
 
 const cacheFirst = async (request) => {
-  const responseFromCache = await caches.match(request);
-  if (responseFromCache) {
-    return responseFromCache;
-  }
-  try {
-	const responseFromNetwork = await fetch(request);
-	putInCache(request, responseFromNetwork.clone());
-	return responseFromNetwork;
-  } catch (e) {
-	if (request.destination === 'image') {
-      const fallbackImage = '<svg xmlns="http://www.w3.org/2000/svg" width="680.765" height="528.355" viewBox="0 0 180.119 139.794" xmlns:v="https://vecta.io/nano"><path d="M0 0h180.119v139.794H0z" fill="#d0d0d0" paint-order="fill markers stroke"/><g fill="#fff"><path d="M104.916 66.875l-34.249 34.249-15.968-15.968-41.938 41.938h31.936 51.939 68.498z" opacity=".675" paint-order="fill markers stroke"/><circle cx="44.626" cy="41.916" r="11.773" opacity=".675" paint-order="fill markers stroke"/></g></svg>'
-      return new Response(fallbackImage, { headers: {'Content-Type': 'image/svg+xml'}});
-	} else {
-      return new Response('', { headers: request.headers });
+	const responseFromCache = await caches.match(request);
+	if (responseFromCache) {
+		return responseFromCache;
 	}
-  }
+	try {
+		const responseFromNetwork = await fetch(request);
+		putInCache(request, responseFromNetwork.clone());
+		return responseFromNetwork;
+	} catch (e) {
+		if (request.destination === 'image') {
+			const fallbackImage = '<svg xmlns="http://www.w3.org/2000/svg" width="680.765" height="528.355" viewBox="0 0 180.119 139.794" xmlns:v="https://vecta.io/nano"><path d="M0 0h180.119v139.794H0z" fill="#d0d0d0" paint-order="fill markers stroke"/><g fill="#fff"><path d="M104.916 66.875l-34.249 34.249-15.968-15.968-41.938 41.938h31.936 51.939 68.498z" opacity=".675" paint-order="fill markers stroke"/><circle cx="44.626" cy="41.916" r="11.773" opacity=".675" paint-order="fill markers stroke"/></g></svg>'
+			return new Response(fallbackImage, { headers: { 'Content-Type': 'image/svg+xml' } });
+		} else {
+			return new Response('', { headers: request.headers });
+		}
+	}
 };
 
 const putInCache = async (request, response) => {
-  const cache = await caches.open(CACHE_NAMESPACE);
-  if (request.method === 'GET') {
-	await cache.put(request, response);
-  }
+	const cache = await caches.open(CACHE_NAMESPACE);
+	if (request.method === 'GET') {
+		await cache.put(request, response);
+	}
 }

--- a/dotcom-rendering/src/web/server/frontTemplate.ts
+++ b/dotcom-rendering/src/web/server/frontTemplate.ts
@@ -229,6 +229,24 @@ https://workforus.theguardian.com/careers/product-engineering/
 					window.curl = window.curlConfig;
 				</script>
 
+				<!-- offline support -->
+				<script>
+					const registerServiceWorker = async () => {
+						if ('serviceWorker' in navigator) {
+							try {
+								const registration = await navigator.serviceWorker.register(
+									'/service-worker.js',
+									{scope: '/'}
+								);
+							} catch (error) {
+								console.error(\`Registration failed with \${error}\`);
+							}
+						}
+					};
+					registerServiceWorker()
+				</script>
+				<script src='${ASSET_ORIGIN}static/frontend/js/happy-offline.js'><script>
+
 
                 <noscript>
                     <img src="https://sb.scorecardresearch.com/p?${new URLSearchParams(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds offline articles to the Guardian website.

## Why?

Offline access to Guardian content is important, especially if the apps won't always be so easy to use. This will make our users...

![happy-green-transparent](https://user-images.githubusercontent.com/29761/167853584-f19c2f14-75f6-492a-82c2-2d6262deef0d.png)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/29761/167853786-c4d4328a-9faf-434a-8878-7eb9f1537e0a.png) | ![after](https://user-images.githubusercontent.com/29761/167854000-42e1f475-6c5a-4c70-bc5f-9aa539d31989.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

## What?

This spike shows how it would be possible to add offline support to the website, using a Service Worker. This implementation hacks a service worker into the local dev server, and injects a content script to add caching support to the website. A real implementation would wire caching support properly into the Fronts react components.

### Ideas

#### Opt-in

Because this behaviour isn't super common for websites, it should be-opt in, or a manually triggered process. The UI should expose a control for downloading all the articles on a front.

#### Tidy up

The news is "new", we should be very proactive about clearing up old cached resources.

#### Target specific resource types

It probably isn't necessary to cache *everything*! What needs to be there?

#### Fetch article assets

Once articles are downloaded, we can inspect their response and fetch any inline image assets they require, rather than showing a placeholder like we do now.

### Gotchas

The service worker has to be served from the root of the site!
