### PR TITLE
Add em handler to editions image caption

### DIFF
--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -73,7 +73,11 @@ const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
 				details.location = node.textContent
 					? some(node.textContent)
 					: none;
-			} else if (node.nodeName === '#text' || node.nodeName === 'A') {
+			} else if (
+				node.nodeName === '#text' ||
+				node.nodeName === 'A' ||
+				node.nodeName === 'EM'
+			) {
 				details = pushToDescription(details, node);
 			}
 			return details;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Expanded the conditional that reduces html nodes into plain text for image captions to include EM elements
## Why?
Currently, anything that is wrapped in EM tags is missed in the reducer that parses the caption
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="767" alt="image" src="https://user-images.githubusercontent.com/99400613/167896753-3a5fa5e0-461b-4d86-b1b0-bb8a164c9589.png"> | <img width="759" alt="image" src="https://user-images.githubusercontent.com/99400613/167896899-f4787f5e-4e73-4757-be5a-37696ddda23a.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
