### PR TITLE
Remove drop cap styles from editions

### DIFF
--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -16,7 +16,6 @@ import type { Item } from 'item';
 import { isPicture } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
-import { getThemeStyles } from 'themeStyles';
 import Header from '../header';
 import {
 	articleMarginStyles,
@@ -123,31 +122,6 @@ const headerBackgroundStyles = (format: ArticleFormat): SerializedStyles => css`
 	background-color: ${headerBackgroundColour(format)};
 `;
 
-const itemStyles = (item: Item): SerializedStyles => {
-	const { kicker } = getThemeStyles(item.theme);
-
-	switch (item.display) {
-		case ArticleDisplay.Immersive:
-			return css`
-				> p:first-of-type:first-letter,
-				> hr + p:first-letter {
-					color: ${kicker};
-					display: inline-block;
-					vertical-align: text-top;
-					line-height: 5.625rem;
-					font-size: 6.8125rem;
-					display: inline-block;
-					font-weight: 900;
-					float: left;
-					margin-right: ${remSpace[3]};
-				}
-			`;
-
-		default:
-			return css``;
-	}
-};
-
 const getSectionStyles = (item: ArticleFormat): SerializedStyles[] => {
 	if (
 		item.design === ArticleDesign.Interview ||
@@ -194,10 +168,7 @@ const Layout: FC<Props> = ({ item }) => {
 								: null,
 						]}
 					>
-						<section
-							className={'body-content'}
-							css={[bodyStyles, itemStyles(item)]}
-						>
+						<section className={'body-content'} css={bodyStyles}>
 							{renderEditionsAll(item, partition(item.body).oks)}
 						</section>
 					</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes drop cap styling from editions layout component
## Why?
Dropcaps are being applied without the rules that are used on DCR and AR and are therefor appearing all too often. We should put them back eventually by expanding @MarSavar's work on dropcaps for interviews but for now the editions team are happier not to have them.
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="658" alt="image" src="https://user-images.githubusercontent.com/99400613/167898108-962e828d-07a9-4d44-807d-728972a8b349.png"> | <img width="656" alt="image" src="https://user-images.githubusercontent.com/99400613/167898044-085964b1-3489-437f-b41e-1a062b7349cc.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
