### PR TITLE
Module Implementing Guardian Grid Using CSS Grid

### DIFF
--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -8,22 +8,26 @@ import { from } from '@guardian/source-foundations';
  * Named CSS grid lines, based on the three columns commonly used for Guardian
  * layouts.
  */
-type Line
-    = 'viewport-start'
-    | 'left-column-start'
-    | 'left-column-end'
-    | 'centre-column-start'
-    | 'centre-column-end'
-    | 'right-column-start'
-    | 'right-column-end'
-    | 'viewport-end'
-    ;
+type Line =
+	| 'viewport-start'
+	| 'left-column-start'
+	| 'left-column-end'
+	| 'centre-column-start'
+	| 'centre-column-end'
+	| 'right-column-start'
+	| 'right-column-end'
+	| 'viewport-end';
 
-const mobileColumns = '[viewport-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [viewport-end]';
-const tabletColumns = '[viewport-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [viewport-end]';
-const desktopColumns = '[viewport-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
-const leftColColumns = '[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
-const wideColumns = '[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const mobileColumns =
+	'[viewport-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [viewport-end]';
+const tabletColumns =
+	'[viewport-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [viewport-end]';
+const desktopColumns =
+	'[viewport-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const leftColColumns =
+	'[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const wideColumns =
+	'[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
 const mobileColumnGap = '12px';
 const columnGap = '20px';
 
@@ -53,7 +57,7 @@ const container = `
     ${from.wide} {
         grid-template-columns: ${wideColumns};
     }
-`
+`;
 
 // ----- Grid Item Styles ----- //
 
@@ -81,12 +85,12 @@ const allColumns = `
  * @param from The grid line to start from, either a `Line` name or a number.
  * @param to The grid line to end at, either a `Line` name or a number.
  * @returns {string} CSS to place the element on the grid.
- * 
+ *
  * @example <caption>Will place the element in the centre column.</caption>
  * const styles = css`
  *   ${grid.between('centre-column-start', 'centre-column-end')}
  * `;
- * 
+ *
  * @example <caption>Will place the element between lines 3 and 5.</caption>
  * const styles = css`
  *   ${grid.between(3, 5)}
@@ -102,7 +106,7 @@ const between = (from: Line | number, to: Line | number): string => `
  * @param start The grid line to start from, either a `Line` name or a number.
  * @param span The number of columns to span.
  * @returns {string} CSS to place the element on the grid.
- * 
+ *
  * @example <caption>The element will span 3 columns from the line.</caption>
  * const styles = css`
  *   ${grid.span('centre-column-start', 3)}
@@ -117,64 +121,62 @@ const span = (start: Line | number, span: number): string => `
  * on the Guardian Grid see https://theguardian.design/2a1e5182b/p/41be19-grids
  */
 const grid = {
-    /**
-     * CSS to set up the grid container. It applies `display: grid;` etc.
-     * 
-     * @example
-     * const Component = () =>
-     *   <div css={css`${grid.container}`}>
-     *     <h1 css={css`grid-row: 1;`}>Headline</h1>
-     *     <p css={css`grid-row: 2;`}>Standfirst</p>
-     *   </div>
-     */
-    container,
-    /**
-     * Place the element into one of the common Guardian layout columns. The
-     * breakpoints at which they're available are as follows:
-     * 
-     * - **Centre** exists for all breakpoints
-     * - **Left** exists from the `leftCol` breakpoint up
-     * - **Right** exists from the `desktop` breakpoint up
-     * - **All** means take up the entire width of the viewport, "all" columns,
-     * and exists for every breakpoint
-     */
-    column: {
-        /**
-         * Place the element into the centre column. Available for all
-         * breakpoints.
-         */
-        centre: centreColumn,
-        /**
-         * Place the element into the left column. Available for `leftCol`
-         * and above breakpoints.
-         */
-        left: leftColumn,
-        /**
-         * Place the element into the right column. Available for `desktop`
-         * and above breakpoints.
-         */
-        right: rightColumn,
-        /**
-         * Ask the element to take up the entire width of the viewport.
-         * Available for all breakpoints.
-         */
-        all: allColumns,
-    },
-    between,
-    span,
-    /**
-     * The gap between grid columns from the `mobileLandscape` breakpoint up.
-     */
-    columnGap,
-    /**
-     * The gap between grid columns when below the `mobileLandscape`
-     * breakpoint.
-     */
-    mobileColumnGap,
-}
+	/**
+	 * CSS to set up the grid container. It applies `display: grid;` etc.
+	 *
+	 * @example
+	 * const Component = () =>
+	 *   <div css={css`${grid.container}`}>
+	 *     <h1 css={css`grid-row: 1;`}>Headline</h1>
+	 *     <p css={css`grid-row: 2;`}>Standfirst</p>
+	 *   </div>
+	 */
+	container,
+	/**
+	 * Place the element into one of the common Guardian layout columns. The
+	 * breakpoints at which they're available are as follows:
+	 *
+	 * - **Centre** exists for all breakpoints
+	 * - **Left** exists from the `leftCol` breakpoint up
+	 * - **Right** exists from the `desktop` breakpoint up
+	 * - **All** means take up the entire width of the viewport, "all" columns,
+	 * and exists for every breakpoint
+	 */
+	column: {
+		/**
+		 * Place the element into the centre column. Available for all
+		 * breakpoints.
+		 */
+		centre: centreColumn,
+		/**
+		 * Place the element into the left column. Available for `leftCol`
+		 * and above breakpoints.
+		 */
+		left: leftColumn,
+		/**
+		 * Place the element into the right column. Available for `desktop`
+		 * and above breakpoints.
+		 */
+		right: rightColumn,
+		/**
+		 * Ask the element to take up the entire width of the viewport.
+		 * Available for all breakpoints.
+		 */
+		all: allColumns,
+	},
+	between,
+	span,
+	/**
+	 * The gap between grid columns from the `mobileLandscape` breakpoint up.
+	 */
+	columnGap,
+	/**
+	 * The gap between grid columns when below the `mobileLandscape`
+	 * breakpoint.
+	 */
+	mobileColumnGap,
+};
 
 // ----- Exports ----- //
 
-export {
-    grid,
-}
+export { grid };

--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -1,0 +1,180 @@
+// ----- Imports ----- //
+
+import { from } from '@guardian/source-foundations';
+
+// ----- Columns & Lines ----- //
+
+/**
+ * Named CSS grid lines, based on the three columns commonly used for Guardian
+ * layouts.
+ */
+type Line
+    = 'viewport-start'
+    | 'left-column-start'
+    | 'left-column-end'
+    | 'centre-column-start'
+    | 'centre-column-end'
+    | 'right-column-start'
+    | 'right-column-end'
+    | 'viewport-end'
+    ;
+
+const mobileColumns = '[viewport-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [viewport-end]';
+const tabletColumns = '[viewport-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [viewport-end]';
+const desktopColumns = '[viewport-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const leftColColumns = '[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const wideColumns = '[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+const mobileColumnGap = '12px';
+const columnGap = '20px';
+
+// ----- Grid Styles ----- //
+
+const container = `
+    display: grid;
+    grid-template-columns: ${mobileColumns};
+    column-gap: ${mobileColumnGap};
+
+    ${from.mobileLandscape} {
+        column-gap: ${columnGap};
+    }
+
+    ${from.tablet} {
+        grid-template-columns: ${tabletColumns};
+    }
+
+    ${from.desktop} {
+        grid-template-columns: ${desktopColumns};
+    }
+
+    ${from.leftCol} {
+        grid-template-columns: ${leftColColumns};
+    }
+
+    ${from.wide} {
+        grid-template-columns: ${wideColumns};
+    }
+`
+
+// ----- Grid Item Styles ----- //
+
+const centreColumn = `
+    grid-column: centre-column-start / centre-column-end;
+`;
+
+const leftColumn = `
+    grid-column: left-column-start / left-column-end;
+`;
+
+const rightColumn = `
+    grid-column: right-column-start / right-column-end;
+`;
+
+const allColumns = `
+    grid-column: viewport-start / viewport-end;
+`;
+
+// ----- API ----- //
+
+/**
+ * Ask the element to span all grid columns between two grid lines. The lines
+ * can be specified either by `Line` name or by number.
+ * @param from The grid line to start from, either a `Line` name or a number.
+ * @param to The grid line to end at, either a `Line` name or a number.
+ * @returns {string} CSS to place the element on the grid.
+ * 
+ * @example <caption>Will place the element in the centre column.</caption>
+ * const styles = css`
+ *   ${grid.between('centre-column-start', 'centre-column-end')}
+ * `;
+ * 
+ * @example <caption>Will place the element between lines 3 and 5.</caption>
+ * const styles = css`
+ *   ${grid.between(3, 5)}
+ * `;
+ */
+const between = (from: Line | number, to: Line | number): string => `
+    grid-column: ${from} / ${to};
+`;
+
+/**
+ * Ask the element to span a number of grid columns, starting at a specific
+ * grid line. The line can be specified either by `Line` name or by number.
+ * @param start The grid line to start from, either a `Line` name or a number.
+ * @param span The number of columns to span.
+ * @returns {string} CSS to place the element on the grid.
+ * 
+ * @example <caption>The element will span 3 columns from the line.</caption>
+ * const styles = css`
+ *   ${grid.span('centre-column-start', 3)}
+ * `;
+ */
+const span = (start: Line | number, span: number): string => `
+    grid-column: ${start} / span ${span};
+`;
+
+/**
+ * An API implementing the Guardian Grid using CSS grid. For more information
+ * on the Guardian Grid see https://theguardian.design/2a1e5182b/p/41be19-grids
+ */
+const grid = {
+    /**
+     * CSS to set up the grid container. It applies `display: grid;` etc.
+     * 
+     * @example
+     * const Component = () =>
+     *   <div css={css`${grid.container}`}>
+     *     <h1 css={css`grid-row: 1;`}>Headline</h1>
+     *     <p css={css`grid-row: 2;`}>Standfirst</p>
+     *   </div>
+     */
+    container,
+    /**
+     * Place the element into one of the common Guardian layout columns. The
+     * breakpoints at which they're available are as follows:
+     * 
+     * - **Centre** exists for all breakpoints
+     * - **Left** exists from the `leftCol` breakpoint up
+     * - **Right** exists from the `desktop` breakpoint up
+     * - **All** means take up the entire width of the viewport, "all" columns,
+     * and exists for every breakpoint
+     */
+    column: {
+        /**
+         * Place the element into the centre column. Available for all
+         * breakpoints.
+         */
+        centre: centreColumn,
+        /**
+         * Place the element into the left column. Available for `leftCol`
+         * and above breakpoints.
+         */
+        left: leftColumn,
+        /**
+         * Place the element into the right column. Available for `desktop`
+         * and above breakpoints.
+         */
+        right: rightColumn,
+        /**
+         * Ask the element to take up the entire width of the viewport.
+         * Available for all breakpoints.
+         */
+        all: allColumns,
+    },
+    between,
+    span,
+    /**
+     * The gap between grid columns from the `mobileLandscape` breakpoint up.
+     */
+    columnGap,
+    /**
+     * The gap between grid columns when below the `mobileLandscape`
+     * breakpoint.
+     */
+    mobileColumnGap,
+}
+
+// ----- Exports ----- //
+
+export {
+    grid,
+}


### PR DESCRIPTION
## Why?

For a long time we've had design grids that have provided a foundation for laying out the designs of several products, including dotcom, apps, some of the supporter revenue sites and so on. The documentation for these grids is here: https://theguardian.design/2a1e5182b/p/41be19-grids

To summarise, these grids are made up of a series of equal width columns, interspersed with equal width gutters. Here's an example of what this looks like, taken from the docs above:

<img src="https://user-images.githubusercontent.com/53781962/167900391-05703866-7e09-4538-be3d-f7b55a8ec88f.jpg" width=500 />

This model seems to map very well onto the [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout), which allows you to specify a series of (equal or varied width) columns separated by an equal width gap. This PR is an attempt at an API implementing the Guardian grid using CSS grid.

**Note:** In case people are worried this PR introduces a new module appearing in isolation with no concrete usage 🙈, I've built a couple of app layouts with this already (standard and immersive) for testing purposes. If this PR goes through OK I plan to open a follow-up for the immersive layout, but I didn't want to do it all in one go because the resulting PR would be _huge_.

## What?

I think this API models the grid described in the above design docs fairly closely, with one exception and one additional feature.

### The Extra Feature

The definition of the Guardian grid describes a flat layout of grid columns across different breakpoints. For this API I've also included a model of the two-and-three "layout" columns that are common across several of our designs, most prominently on dotcom. These three layout columns are:

- **The Centre Column:** This is the only column available for all the narrower breakpoints up to and including `tablet`.
- **The Right Column:** This appears for the `desktop` breakpoint and above. On dotcom it's commonly used to display adverts and the "most viewed" container.
- **The Left Column:** This appears for the `leftCol` breakpoint (the name is no coincidence 🙂). On dotcom it's commonly used for metadata, series tags and rich links (it's also used for rich links on apps).

These layout columns are optional, this API will also work for designs that don't use them.

### The Exception

The above docs on the grid say that:

> The gutter between columns is a consistent 20px across all grid sizes with a 20px space to the left and right of the layout.

I've adhered to this for all breakpoints _except_ for `mobile` and `mobileMedium`. For those I've switched the gutter to `12px` to match the spaces to the left and the right of the layout. I've done this because I found it difficult to model these spaces separately from the gutter using CSS grid's `gap` property. However, I don't _think_ many designs rely heavily on the exactness of these gutters at the narrowest breakpoints, so I'm hoping this is an acceptable compromise.

## How?

To start with I've tried to keep the API fairly minimal and low level. I'm hoping this will help to keep it flexible and applicable to a wider range of use cases. It's currently made up of a few CSS strings, provided via a handful of constants and functions.

The basic premise of CSS grid is that you have a grid "container", which specifies a grid layout, and grid "children" which are positioned on that grid (similar in concept to flexbox, but in two dimensions).

In the API in this PR you apply `grid.container` to the element you want to be your grid container. This does most of the heavy lifting to set up the grids across all breakpoints. It creates the grid columns specified by the Guardian grid, sets up line names to use for the two-and-three-column layouts described above, and specifies the flexible spaces on either side. The rest of the API is used to position children on this grid.

The `grid.column` API is slightly higher level, and is used to place elements in the two-and-three-column layouts as follows: `grid.column.centre`, `grid.column.left` and `grid.column.right` will position in one of the three layout columns, `grid.column.all` will spread an element across the full width of the viewport ("all" three columns). In might make sense in future to split `all` into versions that explicitly include and exclude the page margins on either side, but for now I've only found a use for this "entire viewport" version (immersive main media).

The `grid.between` API is used to place an element to span all the columns between two grid lines. This can be useful when an element needs to span multiple "layout" columns, and so can't use one of the pre-defined columns in `grid.column`. For example, an immersive headline that runs all the way to the right of the screen across multiple "layout" columns and the page margins.

The `grid.span` API is used to place an element starting at a specific grid line and spanning a limited number of grid columns. This is useful when we have elements whose widths don't start and end on named grid lines. For example, body copy doesn't always span the full width of the centre column because that would make it too wide for comfortable legibility. This API is inspired by the `span` keyword in the CSS grid API.

### Example

```tsx

const ImmersiveLayout = () => (
  // The grid container
  <main css={css`${grid.container}`}>
    // The full-width immersive image
    <img css={css`${grid.column.all}`} />
    // The headline, with a black background that runs to the right of the screen
    <h1 css={css`${grid.between('centre-column-start', 'viewport-end')}`}>
      A headline
    </h1>
    // The standfirst, which has a limited width
    <p css={css`${grid.span('centre-column-start', 9)}`}>
      The standfirst copy, which may be several lines long, hence the need
      to limit the width to aid legibility
    </p>
  </main>
)
```

### A Note On Rows

Much of the variation in our design layout is concerned with widths and breakpoints - in other words: columns. Therefore this API focuses on abstracting that aspect. When building a couple of layouts I couldn't find any particular value in also abstracting away grid rows, so I haven't attempted this. To position on rows in this API the standard CSS properties, such as `grid-row`, can be used.

## Changes

- Added the `grid.ts` module to implement the Guardian Grid using CSS grid, and documented with JSDoc
