### PR TITLE
Fix overflow on header image caption

### DIFF
--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -40,7 +40,7 @@ const fullWidthStyles = css`
 	width: 100%;
 	display: flex;
 	justify-content: center;
-	overflow-x: hidden;
+	overflow: hidden;
 `;
 
 const captionStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides overflow on full size image captions on editions
## Why?
The absolute position on the image caption is causing an overflow and adding a scroll
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="375" alt="image" src="https://user-images.githubusercontent.com/99400613/167911988-4414f993-7f1e-4bc7-8065-622543672c7d.png"> | <img width="374" alt="image" src="https://user-images.githubusercontent.com/99400613/167911926-e624d1e8-309f-40e4-b789-f802b2014be9.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
