### PR TITLE
Liveblogs - SpecialReport palette

### DIFF
--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -31,7 +31,7 @@ const adSlot = (format: ArticleFormat): Colour => {
 		default:
 			return neutral[97];
 	}
-}
+};
 
 const adSlotDark = (_format: ArticleFormat) => neutral[20];
 
@@ -211,7 +211,14 @@ const avatar = (format: ArticleFormat): string => {
 };
 const keyEvents = (_format: ArticleFormat): Colour => neutral[100];
 
-const keyEventsWide = (_format: ArticleFormat): Colour => neutral[97];
+const keyEventsWide = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticleSpecial.SpecialReport:
+			return specialReport[800];
+		default:
+			return neutral[97];
+	}
+};
 
 const keyEventsDark = (_format: ArticleFormat): Colour => neutral[10];
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -171,8 +171,10 @@ const textLastUpdated = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[600];
 			case ArticleSpecial.Labs:
-			case ArticleSpecial.SpecialReport:
+				// We don't support liveblogs on labs ye
 				return news[600];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[700];
 		}
 	}
 	return BLACK;
@@ -259,7 +261,7 @@ const textArticleLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.Labs:
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
-				return specialReport[400];
+				return specialReport[300];
 		}
 	}
 
@@ -306,7 +308,7 @@ const textKeyEvent = (format: ArticleFormat): string => {
 		case ArticleSpecial.Labs:
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
-			return specialReport[400];
+			return specialReport[300];
 	}
 };
 
@@ -651,10 +653,11 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[500];
 			case ArticleSpecial.Labs:
-			case ArticleSpecial.SpecialReport:
-				// We don't have designs for Special Report or Labs liveblogs yet
+				// We don't have designs for Labs liveblogs yet
 				// so we default to news
 				return news[600];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[700];
 		}
 	}
 
@@ -666,10 +669,11 @@ const backgroundHeader = (format: ArticleFormat): string => {
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
-				case ArticleSpecial.SpecialReport:
 					// We don't have designs for Special Report or Labs liveblogs yet
 					// so we default to news
 					return news[200];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[700];
 				default:
 					return pillarPalette[format.theme][300];
 			}
@@ -693,10 +697,11 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 				case ArticlePillar.Opinion:
 					return opinion[200];
 				case ArticleSpecial.Labs:
-				case ArticleSpecial.SpecialReport:
-					// We don't have designs for Special Report or Labs liveblogs yet
+					// We don't have designs for Labs liveblogs yet
 					// so we default to news
 					return news[200];
+				case ArticleSpecial.SpecialReport:
+					return specialReport[300];
 			}
 			break;
 		case ArticleDesign.DeadBlog:
@@ -828,7 +833,7 @@ const borderPinnedPost = (format: ArticleFormat): string => {
 const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[400];
+		return specialReport[300];
 	return border.secondary;
 };
 
@@ -846,10 +851,11 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[500];
 			case ArticleSpecial.Labs:
-			case ArticleSpecial.SpecialReport:
 				// We don't have designs for Special Report or Labs liveblogs yet
 				// so we default to news
 				return news[600];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[450];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -265,8 +265,9 @@ const textArticleLink = (format: ArticleFormat): string => {
 	}
 
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[400];
+	if (format.theme === ArticleSpecial.SpecialReport) {
+		return specialReport[300];
+	}
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -513,9 +514,11 @@ const textCricketScoreboardLink = (): string => {
 };
 
 const backgroundArticle = (format: ArticleFormat): string => {
+	// specialreport blogs should have specialreport background
 	if (
-		format.design === ArticleDesign.LiveBlog ||
-		format.design === ArticleDesign.DeadBlog
+		(format.design === ArticleDesign.LiveBlog ||
+			format.design === ArticleDesign.DeadBlog) &&
+		format.theme !== ArticleSpecial.SpecialReport
 	)
 		return neutral[97];
 	// Order matters. We want comment special report pieces to have the opinion background
@@ -698,7 +701,13 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 			}
 			break;
 		case ArticleDesign.DeadBlog:
-			return neutral[93];
+			switch (format.theme) {
+				case ArticleSpecial.SpecialReport:
+					return specialReport[700];
+				default:
+					return neutral[93];
+			}
+
 		default:
 			return backgroundArticle(format);
 	}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -171,7 +171,6 @@ const textLastUpdated = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[600];
 			case ArticleSpecial.Labs:
-				// We don't support liveblogs on labs ye
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
@@ -653,8 +652,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[500];
 			case ArticleSpecial.Labs:
-				// We don't have designs for Labs liveblogs yet
-				// so we default to news
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
@@ -669,8 +666,6 @@ const backgroundHeader = (format: ArticleFormat): string => {
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
-					// We don't have designs for Special Report or Labs liveblogs yet
-					// so we default to news
 					return news[200];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[700];
@@ -697,8 +692,6 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 				case ArticlePillar.Opinion:
 					return opinion[200];
 				case ArticleSpecial.Labs:
-					// We don't have designs for Labs liveblogs yet
-					// so we default to news
 					return news[200];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
@@ -851,8 +844,6 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticlePillar.Opinion:
 				return opinion[500];
 			case ArticleSpecial.Labs:
-				// We don't have designs for Special Report or Labs liveblogs yet
-				// so we default to news
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];


### PR DESCRIPTION
Co-Authored-By: Joshua <joshuathomaslieberman@gmail.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Update our palette to 'complete' support for special report liveblogs. 

> Note: In a few places we also changed the link colour to be darker for special reports, this was to try and get it to pass WCAG contrast guidelines!

## Why?

As our existing article palette is partially resused for liveblogs, we had a half supported half not supported type deal going on, so it makes more sense to complete the special report palette, than move all the way back to news styles!

## Screenshots

| type   | Before      | After      |
|-----------|-------------|------------|
| Live | ![before][] | ![after][] |
| Dead | ![before2][] | ![after2][] |


[before]: https://user-images.githubusercontent.com/3300789/168848579-0ea5ba25-ab05-4d30-9dc3-d60e9793a9b8.png
[after]: https://user-images.githubusercontent.com/3300789/168848168-a845a433-4c24-4555-9dac-064f813f0fed.png
[before2]: https://user-images.githubusercontent.com/3300789/168848678-3cd6d42f-ecc7-4146-af6a-2a55f72fe947.png
[after2]: https://user-images.githubusercontent.com/3300789/168848090-55a44366-e85a-427a-bf4a-59a6a87b729d.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

Example Articles to test with:
https://www.theguardian.com/news/live/2021/oct/05/pandora-papers-expose-eu-plans-on-tax-havens-as-absurd-meps-claim-live?dcr&live
https://www.theguardian.com/news/live/2021/oct/04/pandora-papers-live-sunak-says-hmrc-will-review-leaked-documents?dcr&live