### PR TITLE
Extract Caption From Renderer

### DIFF
--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -36,7 +36,7 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles | undefined =>
 		: undefined;
 
 const textStyles = css`
-	${textSans.xsmall()}
+	${textSans.xxsmall()}
 	color: ${neutral[46]};
 `;
 

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -42,6 +42,7 @@ const textStyles = css`
 
 const captionElement =
 	(format: ArticleFormat) =>
+	// eslint-disable-next-line react/display-name -- not a normal React component
 	(node: Node, key: number): ReactNode => {
 		const text = node.textContent ?? '';
 		const children = Array.from(node.childNodes).map(

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -1,0 +1,103 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
+import {
+	headline,
+	neutral,
+	remSpace,
+	textSans,
+} from '@guardian/source-foundations';
+import { withDefault } from '@guardian/types';
+import Anchor from 'components/anchor';
+import type { FC, ReactNode } from 'react';
+import { getHref, renderTextElement } from 'renderer';
+
+// ----- Caption Elements ----- //
+
+const headingStyles = css`
+	${headline.xxxsmall()}
+	color: ${neutral[86]};
+	margin: 0 0 ${remSpace[3]};
+	display: block;
+`;
+
+const emStyles = css`
+	${textSans.xsmall({ fontStyle: 'italic', fontWeight: 'bold' })}
+`;
+
+const anchorStyles = (format: ArticleFormat): SerializedStyles | undefined =>
+	format.design === ArticleDesign.Media
+		? css`
+				color: ${neutral[86]};
+		  `
+		: undefined;
+
+const textStyles = css`
+	${textSans.xsmall()}
+	color: ${neutral[46]};
+`;
+
+const captionElement =
+	(format: ArticleFormat) =>
+	(node: Node, key: number): ReactNode => {
+		const text = node.textContent ?? '';
+		const children = Array.from(node.childNodes).map(
+			captionElement(format),
+		);
+
+		switch (node.nodeName) {
+			case 'STRONG':
+				return format.design === ArticleDesign.Media ? (
+					<h2 css={headingStyles} key={key}>
+						{children}
+					</h2>
+				) : (
+					children
+				);
+			case 'BR':
+				return null;
+			case 'EM':
+				return (
+					<em css={emStyles} key={key}>
+						{children}
+					</em>
+				);
+			case 'A':
+				return (
+					<Anchor
+						href={withDefault('')(getHref(node))}
+						className={anchorStyles(format)}
+						format={format}
+						key={key}
+					>
+						{children}
+					</Anchor>
+				);
+			case '#text':
+				return (
+					<span css={textStyles} key={key}>
+						{text}
+					</span>
+				);
+			default:
+				return renderTextElement(format)(node, key);
+		}
+	};
+
+// ----- Component ----- //
+
+type Props = {
+	caption: DocumentFragment;
+	format: ArticleFormat;
+};
+
+const Caption: FC<Props> = ({ caption, format }) => (
+	<>{Array.from(caption.childNodes).map(captionElement(format))}</>
+);
+
+// ----- Exports ----- //
+
+export default Caption;

--- a/apps-rendering/src/components/caption/index.tsx
+++ b/apps-rendering/src/components/caption/index.tsx
@@ -1,0 +1,3 @@
+import Caption from './caption';
+
+export { Caption };

--- a/apps-rendering/src/components/immersiveCaption.tsx
+++ b/apps-rendering/src/components/immersiveCaption.tsx
@@ -4,11 +4,11 @@ import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import { OptionKind } from '@guardian/types';
 import type { Option } from '@guardian/types';
+import { Caption } from 'components/caption';
 import type { Item } from 'item';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
 import type { FC, ReactElement } from 'react';
-import { renderCaption } from 'renderer';
 
 interface Props {
 	item: Item;
@@ -30,7 +30,7 @@ const buildCaption = (
 	if (cap.kind === OptionKind.Some && credit.kind === OptionKind.Some) {
 		return (
 			<p css={captionHeadingStyles}>
-				{renderCaption(cap.value, format)} {credit.value}
+				<Caption caption={cap.value} format={format} /> {credit.value}
 			</p>
 		);
 	} else if (
@@ -38,7 +38,9 @@ const buildCaption = (
 		credit.kind === OptionKind.None
 	) {
 		return (
-			<p css={captionHeadingStyles}>{renderCaption(cap.value, format)}</p>
+			<p css={captionHeadingStyles}>
+				<Caption caption={cap.value} format={format} />
+			</p>
 		);
 	} else if (
 		cap.kind === OptionKind.None &&

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -53,6 +53,7 @@ import Quiz from 'components/atoms/quiz';
 import Blockquote from 'components/blockquote';
 import Bullet from 'components/bullet';
 import CalloutForm from 'components/calloutForm';
+import { Caption } from 'components/caption';
 import Credit from 'components/credit';
 import GalleryImage from 'components/editions/galleryImage';
 import EditionsPullquote from 'components/editions/pullquote';
@@ -405,82 +406,6 @@ const Tweet = (props: {
 		...Array.from(props.content).map(textElement(props.format)),
 	);
 
-const captionHeadingStyles = css`
-	${headline.xxxsmall()}
-	color: ${neutral[86]};
-	margin: 0 0 ${remSpace[3]};
-	display: block;
-`;
-
-const captionElement =
-	(format: ArticleFormat) =>
-	(node: Node, key: number): ReactNode => {
-		const text = node.textContent ?? '';
-		const children = Array.from(node.childNodes).map(
-			captionElement(format),
-		);
-		switch (node.nodeName) {
-			case 'STRONG':
-				return format.design === ArticleDesign.Media
-					? styledH(
-							'h2',
-							{ css: captionHeadingStyles, key },
-							children,
-					  )
-					: children;
-			case 'BR':
-				return null;
-			case 'EM':
-				return styledH(
-					'em',
-					{
-						css: css`
-							${textSans.xsmall({
-								fontStyle: 'italic',
-								fontWeight: 'bold',
-							})}
-						`,
-						key,
-					},
-					children,
-				);
-			case 'A':
-				return styledH(
-					Anchor,
-					{
-						href: withDefault('')(getHref(node)),
-						className:
-							format.design === ArticleDesign.Media
-								? css`
-										color: ${neutral[86]};
-								  `
-								: undefined,
-						format,
-						key,
-					},
-					children,
-				);
-			case '#text':
-				return styledH(
-					'span',
-					{
-						css: css`
-							${textSans.xxsmall()}
-						`,
-						key,
-					},
-					text,
-				);
-			default:
-				return textElement(format)(node, key);
-		}
-	};
-
-const renderCaption = (
-	doc: DocumentFragment,
-	format: ArticleFormat,
-): ReactNode[] => Array.from(doc.childNodes).map(captionElement(format));
-
 const imageRenderer = (
 	format: ArticleFormat,
 	element: Image,
@@ -489,7 +414,7 @@ const imageRenderer = (
 	const { caption, credit, nativeCaption } = element;
 	return h(BodyImage, {
 		caption: map<DocumentFragment, ReactNode>((cap) => [
-			renderCaption(cap, format),
+			h(Caption, { format, caption: cap }),
 			h(Credit, { credit, format, key }),
 		])(caption),
 		format: format,
@@ -652,9 +577,9 @@ const mediaAtomRenderer = (
 	const figcaption = h(FigCaption, {
 		format: format,
 		supportsDarkMode: true,
-		children: map((cap: DocumentFragment) => renderCaption(cap, format))(
-			caption,
-		),
+		children: map((cap: DocumentFragment) =>
+			h(Caption, { caption: cap, format }),
+		)(caption),
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions
@@ -839,6 +764,5 @@ export {
 	getHref,
 	transformHref,
 	plainTextElement,
-	renderCaption,
 	shouldShowDropCap,
 };


### PR DESCRIPTION
## Why?

There are a few advantages:

- It's arguably easier to understand the component in isolation
- This migrates to JSX, which people seem to find easier to read
- It's useful to break JavaScript down into small files to avoid accidental side effects
- It follows a component structure that's common elsewhere in the codebase, and can have stories written for it more easily
- The renderer file has less in it, which may make it easier to reason about

## Changes

- Extracted the caption rendering code into standalone component file
- Updated usages to use new component
