### PR TITLE
Observer Opinion series title - show 'Observer'

### DIFF
--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -170,29 +170,6 @@ const immersiveTitleBadgeStyle = (palette: Palette) => css`
 		6px 0 0 0 ${palette.background.seriesTitle};
 `;
 
-const pickSeriesTag = (tags: TagType[]): TagType | undefined => {
-	const observerTag = tags.find(
-		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
-	);
-
-	// Observer opinion (commentisfree) articles should prioritise
-	// the publication tag over the commentisfree tag.
-	if (
-		observerTag &&
-		tags.find((tag) => tag.id === 'commentisfree/commentisfree')
-	) {
-		return observerTag;
-	}
-
-	return tags.find(
-		(thisTag) =>
-			thisTag.type === 'Blog' ||
-			thisTag.type === 'Series' ||
-			(thisTag.type === 'Publication' &&
-				thisTag.title === 'The Observer'),
-	);
-};
-
 export const SeriesSectionLink = ({
 	format,
 	tags,
@@ -202,8 +179,23 @@ export const SeriesSectionLink = ({
 	badge,
 	isMatch,
 }: Props) => {
+	const observerTag = tags.find(
+		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
+	);
+	const isCommentIsFree = tags.some(
+		(tag) => tag.id === 'commentisfree/commentisfree',
+	);
+	const seriesTag = tags.find(
+		(tag) =>
+			tag.type === 'Blog' ||
+			tag.type === 'Series' ||
+			(tag.type === 'Publication' && tag.title === 'The Observer'),
+	);
+
 	// If we have a tag, use it to show 2 section titles
-	const tag: TagType | undefined = pickSeriesTag(tags);
+	// Observer opinion (commentisfree) articles should prioritise
+	// the publication tag over the commentisfree tag.
+	const tag = observerTag && isCommentIsFree ? observerTag : seriesTag;
 
 	const hasSeriesTag = tag && tag.type === 'Series';
 

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -203,7 +203,7 @@ export const SeriesSectionLink = ({
 	isMatch,
 }: Props) => {
 	// If we have a tag, use it to show 2 section titles
-	const tag = pickSeriesTag(tags);
+	const tag: TagType | undefined = pickSeriesTag(tags);
 
 	const hasSeriesTag = tag && tag.type === 'Series';
 

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -170,6 +170,29 @@ const immersiveTitleBadgeStyle = (palette: Palette) => css`
 		6px 0 0 0 ${palette.background.seriesTitle};
 `;
 
+const pickSeriesTag = (tags: TagType[]): TagType | undefined => {
+	const observerTag = tags.find(
+		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
+	);
+
+	// Observer opinion (commentisfree) articles should prioritise
+	// the publication tag over the commentisfree tag.
+	if (
+		observerTag &&
+		tags.find((tag) => tag.id === 'commentisfree/commentisfree')
+	) {
+		return observerTag;
+	}
+
+	return tags.find(
+		(thisTag) =>
+			thisTag.type === 'Blog' ||
+			thisTag.type === 'Series' ||
+			(thisTag.type === 'Publication' &&
+				thisTag.title === 'The Observer'),
+	);
+};
+
 export const SeriesSectionLink = ({
 	format,
 	tags,
@@ -180,13 +203,7 @@ export const SeriesSectionLink = ({
 	isMatch,
 }: Props) => {
 	// If we have a tag, use it to show 2 section titles
-	const tag = tags.find(
-		(thisTag) =>
-			thisTag.type === 'Blog' ||
-			thisTag.type === 'Series' ||
-			(thisTag.type === 'Publication' &&
-				thisTag.title === 'The Observer'),
-	);
+	const tag = pickSeriesTag(tags);
 
 	const hasSeriesTag = tag && tag.type === 'Series';
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When we have an opinion observer piece, show the Observer tag instead of commentisfree (Opinion)

## Why?

Request from CP & Johnathon Haynes

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |



[before]: https://user-images.githubusercontent.com/9575458/168071656-c9941972-bf24-48cc-8627-e0970464206b.png
[after]: https://user-images.githubusercontent.com/9575458/168071615-431f5255-55fc-4630-bf4b-ae5a0aa2bdd5.png
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
