### PR TITLE
Follow takes format

### DIFF
--- a/apps-rendering/src/components/follow.tsx
+++ b/apps-rendering/src/components/follow.tsx
@@ -14,8 +14,9 @@ import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-interface Props extends ArticleFormat {
+interface Props {
 	contributors: Contributor[];
+	format: ArticleFormat;
 }
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
@@ -46,7 +47,7 @@ const followStatusStyles = css`
 	column-gap: 0.2em;
 `;
 
-const Follow: FC<Props> = ({ contributors, ...format }) => {
+const Follow: FC<Props> = ({ contributors, format }) => {
 	const [contributor] = contributors;
 
 	if (

--- a/apps-rendering/src/components/metadata.tsx
+++ b/apps-rendering/src/components/metadata.tsx
@@ -23,6 +23,7 @@ import Dateline from 'components/dateline';
 import Follow from 'components/follow';
 import Logo from 'components/logo';
 import type { Item } from 'item';
+import { getFormat } from 'item';
 import type { FC } from 'react';
 import { useState } from 'react';
 import { darkModeCss } from 'styles';
@@ -209,7 +210,7 @@ const MetadataWithByline: FC<Props> = ({ item }: Props) => (
 		<div css={css(textStyles, withBylineTextStyles)}>
 			<Byline {...item} />
 			<Dateline date={item.publishDate} format={item} />
-			<Follow {...item} />
+			<Follow format={getFormat(item)} contributors={item.contributors} />
 		</div>
 		<CommentCount count={item.commentCount} {...item} />
 	</div>
@@ -219,7 +220,7 @@ const ShortMetadata: FC<Props> = ({ item }: Props) => (
 	<div css={styles}>
 		<div css={textStyles}>
 			<Dateline date={item.publishDate} format={item} />
-			<Follow {...item} />
+			<Follow format={getFormat(item)} contributors={item.contributors} />
 		</div>
 		<CommentCount count={item.commentCount} {...item} />
 	</div>
@@ -245,7 +246,10 @@ const MetadataWithAlertSwitch: FC<Props> = ({ item }: Props) => {
 					<Byline {...item} />
 				</div>
 				<Dateline date={item.publishDate} format={item} />
-				<Follow {...item} />
+				<Follow
+					format={getFormat(item)}
+					contributors={item.contributors}
+				/>
 			</div>
 			<div css={metaBottomStyles(isLive(design))}>
 				{isLive(design) && (


### PR DESCRIPTION
## Why?

This doesn't change the breadth of inputs (the domain) of the `Follow` component, but it does hopefully make the props a bit easier to understand, and similar to other components in the codebase. It also narrows the amount of information being passed at the call site.

## Changes

- Stop passing the whole `Item` to `Follow`
