### PR TITLE
Refactor Card Footer

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -15,6 +15,39 @@ export const trails: TrailType[] = [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@1',
+
+		supportingContent: [
+			{
+				url: 'https://www.theguardian.com',
+				format: {
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				},
+				headline: 'Headline 1',
+				kickerText: 'Kicker',
+			},
+			{
+				url: 'https://www.theguardian.com',
+				format: {
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				},
+				headline: 'Headline 2',
+				kickerText: 'Kicker',
+			},
+			{
+				url: 'https://www.theguardian.com',
+				format: {
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				},
+				headline: 'Headline 3',
+				kickerText: 'Kicker',
+			},
+		],
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -357,9 +357,37 @@ cardStories.add('with no slash', () => {
 	);
 });
 
-cardStories.add('with an avatar', () => {
+cardStories.add('with an avatar when vertical', () => {
 	return (
-		<CardGroup>
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 260px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						imageUrl=""
+						avatar={{
+							src: 'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
+							alt: '',
+						}}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Comment,
+							theme: ArticlePillar.Opinion,
+						}}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('with an avatar when horizontal', () => {
+	return (
+		<>
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
@@ -368,9 +396,14 @@ cardStories.add('with an avatar', () => {
 						src: 'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
 						alt: '',
 					}}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
 				/>
 			</CardWrapper>
-		</CardGroup>
+		</>
 	);
 });
 

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -268,86 +268,74 @@ cardStories.add('with media type', () => {
 	);
 });
 
-cardStories
-	.add('with different image positions', () => {
-		return (
-			<>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="left"
-						imageSize="large"
-						headlineText="left"
-					/>
-				</CardWrapper>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="right"
-						imageSize="large"
-						headlineText="right"
-					/>
-				</CardWrapper>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="top"
-						headlineText="top"
-					/>
-				</CardWrapper>
-			</>
-		);
-	})
-	.addParameters({
-		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
-		},
-	});
+cardStories.add('with different image positions', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="left"
+					imageSize="large"
+					headlineText="left"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="right"
+					imageSize="large"
+					headlineText="right"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="top"
+					headlineText="top"
+				/>
+			</CardWrapper>
+		</>
+	);
+});
 
-cardStories
-	.add('with different image sizes', () => {
-		return (
-			<>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="left"
-						headlineText="small"
-						imageSize="small"
-					/>
-				</CardWrapper>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="left"
-						headlineText="medium"
-						imageSize="medium"
-					/>
-				</CardWrapper>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="left"
-						headlineText="large"
-						imageSize="large"
-					/>
-				</CardWrapper>
-				<CardWrapper>
-					<Card
-						{...basicCardProps}
-						imagePosition="left"
-						headlineText="jumbo"
-						imageSize="jumbo"
-					/>
-				</CardWrapper>
-			</>
-		);
-	})
-	.addParameters({
-		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
-		},
-	});
+cardStories.add('with different image sizes', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="left"
+					headlineText="small"
+					imageSize="small"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="left"
+					headlineText="medium"
+					imageSize="medium"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="left"
+					headlineText="large"
+					imageSize="large"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="left"
+					headlineText="jumbo"
+					imageSize="jumbo"
+				/>
+			</CardWrapper>
+		</>
+	);
+});
 
 cardStories.add('with pulsing dot', () => {
 	return (

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -29,11 +29,21 @@ const basicCardProps: CardProps = {
 	imagePosition: 'top',
 };
 
+const aBasicLink = {
+	headline: 'Headline',
+	url: 'https://www.theguardian.com',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+};
+
 const CardWrapper = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<div
 			css={css`
-				max-height: 300px;
+				max-height: 360px;
 				max-width: 600px;
 				flex-basis: 100%;
 				${from.tablet} {
@@ -407,12 +417,280 @@ cardStories.add('with an avatar when horizontal', () => {
 	);
 });
 
-cardStories.add('with comments', () => {
+cardStories.add('when vertical and theme opinion', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="top"
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when vertical, opinion and with comments', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="top"
+					commentCount={99}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('with sublinks when vertical and opinion', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="top"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline: 'Headline 1',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline: 'Headline 2',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline: 'Headline 3',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal and opinion', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					commentCount={99}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="right"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					commentCount={99}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="right"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					commentCount={99}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="right"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when news, with comments', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="right"
+					imageSize="large"
+					commentCount={99}
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="right"
+					imageSize="large"
+					commentCount={99}
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when news, with more than two sublinks', () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				imagePosition="right"
+				imageSize="large"
+				commentCount={99}
+				supportingContent={[
+					{
+						...aBasicLink,
+						headline: 'A longer headline to see how wrapping works',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'A longer headline to see how wrapping works',
+						kickerText: 'Kicker',
+					},
+					{
+						...aBasicLink,
+						headline: 'A longer headline to see how wrapping works',
+						kickerText: 'Kicker',
+					},
+				]}
+			/>
+		</CardWrapper>
+	);
+});
+
+cardStories.add('when vertical, news and with comments', () => {
 	return (
 		<CardGroup>
 			<CardWrapper>
 				<Card {...basicCardProps} commentCount={894} />
 			</CardWrapper>
 		</CardGroup>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a small image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="small"
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when opinion, with the image at the bottom', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="bottom"
+					commentCount={99}
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
 	);
 });

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { brandAltBackground } from '@guardian/source-foundations';
 
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { StarRating } from '../StarRating/StarRating';
 import { CardHeadline } from '../CardHeadline';
 import { Avatar } from '../Avatar';
@@ -25,6 +26,7 @@ import { CardLink } from './components/CardLink';
 import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { SupportingContent } from '../SupportingContent';
+import { decidePalette } from '../../lib/decidePalette';
 
 export type Props = {
 	linkTo: string;
@@ -111,91 +113,16 @@ export const Card = ({
 	containerPalette,
 }: Props) => {
 	const showCommentCount = commentCount || commentCount === 0;
+	const palette = decidePalette(format, containerPalette);
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
-	const moreThanTwoSubLinks: boolean = !!(
-		supportingContent?.length && supportingContent.length > 2
-	);
+	const hasSublinks = supportingContent && supportingContent.length > 0;
+	const noOfSublinks = (supportingContent && supportingContent.length) || 0;
 
-	const cardIsVertical =
-		imagePosition === 'top' || imagePosition === 'bottom';
-
-	const positionFooterUnderContent = !moreThanTwoSubLinks && cardIsVertical;
-
-	const renderFooter = ({
-		renderAge = true,
-		renderMediaMeta = true,
-		renderCommentCount = true,
-		renderCardBranding = true,
-		renderSupportingContent = true,
-		forceVertical = false,
-	}: {
-		renderAge?: boolean;
-		renderMediaMeta?: boolean;
-		renderCommentCount?: boolean;
-		renderCardBranding?: boolean;
-		renderSupportingContent?: boolean;
-		forceVertical?: boolean;
-	}) => {
-		return (
-			<CardFooter
-				format={format}
-				containerPalette={containerPalette}
-				age={
-					renderAge && webPublicationDate ? (
-						<CardAge
-							format={format}
-							containerPalette={containerPalette}
-							webPublicationDate={webPublicationDate}
-							showClock={showClock}
-						/>
-					) : undefined
-				}
-				mediaMeta={
-					renderMediaMeta &&
-					format.design === ArticleDesign.Media &&
-					mediaType ? (
-						<MediaMeta
-							containerPalette={containerPalette}
-							format={format}
-							mediaType={mediaType}
-							mediaDuration={mediaDuration}
-						/>
-					) : undefined
-				}
-				commentCount={
-					renderCommentCount &&
-					showCommentCount &&
-					longCount &&
-					shortCount ? (
-						<CardCommentCount
-							containerPalette={containerPalette}
-							format={format}
-							long={longCount}
-							short={shortCount}
-						/>
-					) : undefined
-				}
-				cardBranding={
-					renderCardBranding && branding ? (
-						<CardBranding branding={branding} format={format} />
-					) : undefined
-				}
-				supportingContent={
-					renderSupportingContent &&
-					supportingContent &&
-					supportingContent.length > 0 ? (
-						<SupportingContent
-							supportingContent={supportingContent}
-							imagePosition={
-								forceVertical ? 'top' : imagePosition
-							}
-						/>
-					) : undefined
-				}
-			/>
-		);
-	};
+	const isOpinion =
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Editorial ||
+		format.design === ArticleDesign.Letter;
 
 	return (
 		<CardWrapper format={format} containerPalette={containerPalette}>
@@ -289,17 +216,74 @@ export const Card = ({
 								</AvatarContainer>
 							</Hide>
 						)}
-						{/* Show the card footer in the same column as the headline content */}
-						{positionFooterUnderContent ? (
-							renderFooter({ forceVertical: true })
+						<CardFooter
+							format={format}
+							age={
+								webPublicationDate ? (
+									<CardAge
+										format={format}
+										containerPalette={containerPalette}
+										webPublicationDate={webPublicationDate}
+										showClock={showClock}
+									/>
+								) : undefined
+							}
+							mediaMeta={
+								format.design === ArticleDesign.Media &&
+								mediaType ? (
+									<MediaMeta
+										containerPalette={containerPalette}
+										format={format}
+										mediaType={mediaType}
+										mediaDuration={mediaDuration}
+									/>
+								) : undefined
+							}
+							commentCount={
+								showCommentCount && longCount && shortCount ? (
+									<CardCommentCount
+										containerPalette={containerPalette}
+										format={format}
+										long={longCount}
+										short={shortCount}
+									/>
+								) : undefined
+							}
+							cardBranding={
+								branding ? (
+									<CardBranding
+										branding={branding}
+										format={format}
+									/>
+								) : undefined
+							}
+						/>
+						{hasSublinks && noOfSublinks <= 2 ? (
+							<SupportingContent
+								supportingContent={supportingContent}
+								alignment="vertical"
+							/>
 						) : (
 							<></>
 						)}
 					</div>
 				</ContentWrapper>
 			</CardLayout>
-			{/* If there are more than two sublinks break footer out of the headline column into a row below */}
-			{!positionFooterUnderContent ? renderFooter({}) : <></>}
+			{hasSublinks && noOfSublinks > 2 ? (
+				<SupportingContent
+					supportingContent={supportingContent}
+					alignment={
+						imagePosition === 'top' || imagePosition === 'bottom'
+							? 'vertical'
+							: 'horizontal'
+					}
+				/>
+			) : (
+				<></>
+			)}
+			{isOpinion && (
+				<StraightLines color={palette.border.lines} count={4} />
+			)}
 		</CardWrapper>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -1,12 +1,9 @@
 import { css } from '@emotion/react';
 
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { StraightLines } from '@guardian/source-react-components-development-kitchen';
-import { decidePalette } from '../../../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
-	containerPalette?: DCRContainerPalette;
 	age?: JSX.Element;
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
@@ -25,45 +22,16 @@ const flexEnd = css`
 	justify-content: flex-end;
 `;
 
-const linesWrapperStyles = css`
-	/* Fill the container */
-	flex: 1;
-	align-self: flex-end;
-`;
-
 export const CardFooter = ({
 	format,
-	containerPalette,
 	age,
 	mediaMeta,
 	commentCount,
 	cardBranding,
 	supportingContent,
 }: Props) => {
-	const palette = decidePalette(format, containerPalette);
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer>{cardBranding}</footer>;
-	}
-
-	if (
-		format.design === ArticleDesign.Comment ||
-		format.design === ArticleDesign.Editorial ||
-		format.design === ArticleDesign.Letter
-	) {
-		return (
-			<footer>
-				{supportingContent}
-				<div css={spaceBetween}>
-					{age}
-					<StraightLines
-						cssOverrides={linesWrapperStyles}
-						color={palette.border.lines}
-						count={4}
-					/>
-					{commentCount}
-				</div>
-			</footer>
-		);
 	}
 
 	if (format.design === ArticleDesign.Media) {

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -12,6 +12,7 @@ type Props = {
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	supportingContent?: JSX.Element;
+	renderLines?: boolean;
 };
 
 const spaceBetween = css`
@@ -39,6 +40,7 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	supportingContent,
+	renderLines,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
@@ -55,11 +57,13 @@ export const CardFooter = ({
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
-					<StraightLines
-						cssOverrides={linesWrapperStyles}
-						color={palette.border.lines}
-						count={4}
-					/>
+					{renderLines && (
+						<StraightLines
+							cssOverrides={linesWrapperStyles}
+							color={palette.border.lines}
+							count={4}
+						/>
+					)}
 					{commentCount}
 				</div>
 			</footer>

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -12,7 +12,6 @@ type Props = {
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	supportingContent?: JSX.Element;
-	renderLines?: boolean;
 };
 
 const spaceBetween = css`
@@ -40,7 +39,6 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	supportingContent,
-	renderLines,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
@@ -57,13 +55,11 @@ export const CardFooter = ({
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
-					{renderLines && (
-						<StraightLines
-							cssOverrides={linesWrapperStyles}
-							color={palette.border.lines}
-							count={4}
-						/>
-					)}
+					<StraightLines
+						cssOverrides={linesWrapperStyles}
+						color={palette.border.lines}
+						count={4}
+					/>
 					{commentCount}
 				</div>
 			</footer>

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -46,7 +46,7 @@ export const Default = () => {
 	return (
 		<SupportingContent
 			supportingContent={[aBasicLink]}
-			imagePosition="top"
+			alignment="horizontal"
 		/>
 	);
 };
@@ -55,7 +55,7 @@ export const WithKicker = () => {
 	return (
 		<SupportingContent
 			supportingContent={[{ ...aBasicLink, kickerText: 'Kicket text' }]}
-			imagePosition="top"
+			alignment="horizontal"
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -3,9 +3,11 @@ import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
 import { CardHeadline } from './CardHeadline';
 
+type Alignment = 'vertical' | 'horizontal';
+
 type Props = {
 	supportingContent: DCRSupportingContent[];
-	imagePosition: ImagePositionType;
+	alignment: Alignment;
 };
 
 const wrapperStyles = css`
@@ -15,19 +17,16 @@ const wrapperStyles = css`
 	margin-right: 5px;
 `;
 
-const directionStyles = (imagePosition: ImagePositionType) => {
-	switch (imagePosition) {
-		case 'left':
-		case 'right':
+const directionStyles = (alignment: Alignment) => {
+	switch (alignment) {
+		case 'horizontal':
 			return css`
 				flex-direction: column;
 				${from.phablet} {
 					flex-direction: row;
 				}
 			`;
-		case 'none':
-		case 'top':
-		case 'bottom':
+		case 'vertical':
 			return css`
 				flex-direction: column;
 			`;
@@ -58,12 +57,9 @@ const bottomMargin = css`
 	}
 `;
 
-export const SupportingContent = ({
-	supportingContent,
-	imagePosition,
-}: Props) => {
+export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 	return (
-		<ul css={[wrapperStyles, directionStyles(imagePosition)]}>
+		<ul css={[wrapperStyles, directionStyles(alignment)]}>
 			{supportingContent.map((subLink: DCRSupportingContent, index) => {
 				// The model has this property as optional but it is very likely
 				// to exist
@@ -73,9 +69,7 @@ export const SupportingContent = ({
 					subLink.format.design === ArticleDesign.LiveBlog
 						? 'Live'
 						: subLink.kickerText;
-				const shouldPadLeft =
-					index > 0 &&
-					(imagePosition === 'left' || imagePosition === 'right');
+				const shouldPadLeft = index > 0 && alignment === 'horizontal';
 				return (
 					<li
 						css={[


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This refactors the layout of the Card footer to break the article meta data out from the `Lines` and position it directly under the trailText instead. If you open the before and after images below and squint you will see the comment count and card date are in new positions.

## Why?
We're now adding more meta data to cards (specifically, the article date, maybe) and with this extra information showing we wanted to revisit how things are positioned.

This work was done in collaboration with @HarryFischer but is still a work in progress in terms of design. But by making this change we simplify the code and also make it possible to share how different combinations of cards look using this changed layout using the `?dcr` param.

### Headlines
| Before      | After      |
|-------------|------------|
| <img width="1327" alt="headline-before" src="https://user-images.githubusercontent.com/1336821/168096756-293f694c-c57d-46c0-b969-16139d38d91b.png"> | <img width="1327" alt="healines-after" src="https://user-images.githubusercontent.com/1336821/168096800-fc8264eb-08b6-401f-a7eb-0f97576acc84.png"> |


### Opinion
| Before      | After      |
|-------------|------------|
| <img width="1327" alt="opinion-before" src="https://user-images.githubusercontent.com/1336821/168096849-49706892-51fe-48e3-b035-697c312ed8c0.png"> | <img width="1327" alt="opinion-after" src="https://user-images.githubusercontent.com/1336821/168096879-89e0427a-f0bf-41c6-bf92-27a8599dcaf3.png"> |
