### PR TITLE
Inline fluid slots can take full width

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -143,6 +143,9 @@ const adControlCSS = css`
 			margin-top: 4px;
 			margin-left: 20px;
 		}
+		&.ad-slot--fluid {
+			width: 100%;
+		}
 	}
 	.ad-slot--outstream {
 		${from.tablet} {
@@ -170,6 +173,9 @@ const adVariantCSS = css`
 		${from.tablet} {
 			background-color: ${neutral[97]};
 		}
+		&.ad-slot--fluid {
+			width: 100%;
+		}
 	}
 	.ad-slot--inline:not(.ad-slot--inline1),
 	.ad-slot-liveblog--inline:not(.ad-slot--inline1) {
@@ -191,6 +197,9 @@ const adVariantCSS = css`
 			margin: 0;
 			margin-top: 4px;
 			margin-left: 20px;
+		}
+		&.ad-slot--fluid {
+			width: 100%;
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

Allows custom templates and fluid ads to take the full width.

With the new container styling for `inline1` the `.ad-slot--fluid` class lost out on specificity.

This change ensures full width if `.ad-slot--fluid` is present on inline slots.

## Why?

Our colleagues in DAP reported an issue with interscrollers not being able to take the full column width on mobile.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/7014230/168104192-de997d8c-96f1-4f7c-9af4-6a048a3a3931.png

[after]: https://user-images.githubusercontent.com/7014230/168106179-6c54af3c-5c3a-4127-ab22-4aa4579d6403.png



