### PR TITLE
Fix: Scroll to comment multiple times

### DIFF
--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -92,7 +92,7 @@ export const Discussion = ({
 		window.location.hash = `#comment-${commentId}`;
 		// Put this comment id into the hashCommentId state which will
 		// trigger an api call to get the comment context and then expand
-		// and reload the discussion based on the resuts
+		// and reload the discussion based on the results
 		setHashCommentId(commentId);
 		return false;
 	};

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -89,7 +89,20 @@ export const Discussion = ({
 
 	const handlePermalink = (commentId: number) => {
 		if (typeof window === 'undefined') return false;
-		window.location.hash = `#comment-${commentId}`;
+
+		const newHash = `#comment-${commentId}`
+
+		// If the comment is already on the page, scroll to
+		// it directly. (If comment is not loaded, updating the hashCommentId
+		// should trigger setCommentPage, which will trigger a page load in
+		// discussion rendering.) We're adding scrolling here because React
+		// doesn't register a click as a change of state, if the same link is
+		// clicked twice. (Problem still persists for edge case of user navigating
+		// to a different page of comments without changing the comment id.)
+		document.querySelector(newHash)?.scrollIntoView();
+
+		window.location.hash = newHash;
+
 		// Put this comment id into the hashCommentId state which will
 		// trigger an api call to get the comment context and then expand
 		// and reload the discussion based on the results

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -90,7 +90,7 @@ export const Discussion = ({
 	const handlePermalink = (commentId: number) => {
 		if (typeof window === 'undefined') return false;
 
-		const newHash = `#comment-${commentId}`
+		const newHash = `#comment-${commentId}`;
 
 		// If the comment is already on the page, scroll to
 		// it directly. (If comment is not loaded, updating the hashCommentId


### PR DESCRIPTION
Code co-authored with @mxdvl 

## What does this change?
It adds a call to `scrollToView` in the permalink click handler that DCR passes to discussion-rendering.

## Why?
If a user clicked 'Jump to comment', scrolled away, then clicked it again, then the page wouldn't scroll back to the comment the second time (at least on Chrome). See issue #4836.

Our hypothesis is that previously, the scroll behaviour was triggered by a useEffect hook which watched the selected comment id in the URL. But when the same comment was 'jumped to' twice in a row, React wasn't recognising the updated as a change, and so wasn't triggering the hook.

We looked at ways of triggering a re-render in these circumstances, but we felt as though these added an extra dependency on state which might not be obvious to a reader of the codebase. Our chosen solution (triggering scroll directly from the click handler) also goes somewhat against the implicit contract between DCR and discussion-rendering. However, we felt that it makes some sense insofar as what we need to react to here is an event, rather than a state change as such. It would be good to hear from others, though, whether this reasoning makes sense to them.

## Drawbacks and potential further steps
Our solution leaves open an existing edge case: if you jump to a comment, navigate to another page of comments, then try to jump to the original comment again, this won't work. We thought that this case was fairly niche, and also that it might be better addressed by a more thorough refactoring of the navigation logic for discussion-rendering.

Specifically, the logic governing jump to comments is currently quite complicated, and the division of labour between the discussion-rendering app and DCR is also quite complex. It looks like this is an area of the codebase that has been revisited a few times recently, so we thought it would be good to discuss with previous contributors (e.g. @oliverlloyd ?) before deciding whether a slightly larger refactor would make sense, and if so what it might look like.