### PR TITLE
Do not render generic embeds in Editions

### DIFF
--- a/apps-rendering/src/components/embed.tsx
+++ b/apps-rendering/src/components/embed.tsx
@@ -51,7 +51,7 @@ const EmbedComponent: FC<Props> = ({ embed, editions }) => {
 			return !editions ? <GenericEmbed embed={embed} /> : null;
 
 		case EmbedKind.Generic:
-			return <GenericEmbed embed={embed} />;
+			return !editions ? <GenericEmbed embed={embed} /> : null;
 
 		default:
 			return null;

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -533,9 +533,8 @@ describe('Renders different types of Editions elements', () => {
 	test('ElementKind.Embed', () => {
 		const nodes = renderEditions(embedElement);
 		const embed = nodes.flat()[0];
-		expect(getHtml(embed)).toContain(
-			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322"></iframe>',
-		);
+		// Editions shouldn't render generic embeds
+		expect(getHtml(embed)).toBeNull;
 	});
 
 	test('ElementKind.Video', () => {


### PR DESCRIPTION
## Why?
Previously, there was no check in place for generic embeds in Editions, causing to all sorts of visual bugs, as per screenshot below (an iframe with an SVG in it). The official line is that embeds shouldn't be supported by Editions with the exception of videos. 

Therefore, this PR prevents generic embeds from being rendered in Editions altogether.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/168299726-5c38e501-b982-4d72-8224-bf83cc79e4c0.png
[after]: https://user-images.githubusercontent.com/57295823/168299649-993761fa-11bf-4dd4-898c-dd575ba23c8c.png

