### PR TITLE
Run chromatic action on PRs and main branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,9 @@
 name: Chromatic 👓
-on: push
-
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   chromatic:
     name: Chromatic


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?
We run Chromatic on all pushes to any branch. The only places we use and confirm these tests are PRs and merges to main. This should be a no-op in terms of process and hopefully run Chromatic less in places where we never use it.

We've used something similar in Source:
https://github.com/guardian/source/blob/main/.github/workflows/chromatic.yml#L2-L6

Co-authored-by: @sndrs <alex.sanders@theguardian.com>

## Screenshots

| Before      | After      |
|-------------|------------|
| 💰 💰 💰 | 💰 💰  |
