### PR TITLE
Do not render drop caps in Editions

### DIFF
--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -605,6 +605,7 @@ describe('Transforms hrefs', () => {
 
 describe('Shows drop caps', () => {
 	const paragraph = new Array(50).fill('word').join(' ');
+	const isEditions = true;
 	const format = {
 		display: ArticleDisplay.Standard,
 		theme: ArticlePillar.Culture,
@@ -612,31 +613,31 @@ describe('Shows drop caps', () => {
 	};
 
 	test('Shows drop cap if the paragraph is at least 200 characters long, the first word is longer than three chars, and the article has the correct design', () => {
-		const showDropCap = shouldShowDropCap(paragraph, format);
+		const showDropCap = shouldShowDropCap(paragraph, format, !isEditions);
 		expect(showDropCap).toBe(true);
 	});
 
 	test('Shows drop cap if the first word is at least three characters long', () => {
 		const threeChars = `One ${paragraph}`;
-		const showDropCap = shouldShowDropCap(threeChars, format);
+		const showDropCap = shouldShowDropCap(threeChars, format, !isEditions);
 		expect(showDropCap).toBe(true);
 	});
 
 	test('Shows drop cap for eligible paragraphs including Unicode Latin-1 characters', () => {
 		const unicodeLatin = `Česká ${paragraph}`;
-		const showDropCap = shouldShowDropCap(unicodeLatin, format);
+		const showDropCap = shouldShowDropCap(unicodeLatin, format, !isEditions);
 		expect(showDropCap).toBe(true);
 	});
 
 	test('Does not show drop cap if the paragraph starts with an "I", despite being at least 200 characters long', () => {
 		const startsWithI = `Inevitably, ${paragraph}`;
-		const showDropCap = shouldShowDropCap(startsWithI, format);
+		const showDropCap = shouldShowDropCap(startsWithI, format, !isEditions);
 		expect(showDropCap).toBe(false);
 	});
 
 	test('Does not show drop cap if the first word is shorter than three characters', () => {
 		const twoChars = `On ${paragraph}`;
-		const showDropCap = shouldShowDropCap(twoChars, format);
+		const showDropCap = shouldShowDropCap(twoChars, format, !isEditions);
 		expect(showDropCap).toBe(false);
 	});
 
@@ -645,6 +646,7 @@ describe('Shows drop caps', () => {
 		const showDropCap = shouldShowDropCap(
 			twoCharsWithQuotationMark,
 			format,
+			!isEditions,
 		);
 		expect(showDropCap).toBe(false);
 	});
@@ -652,12 +654,17 @@ describe('Shows drop caps', () => {
 	test('Does not show drop cap if the paragraph is shorter than 200 characters', () => {
 		const shortParagraph =
 			'The pen might not be mightier than the sword, but maybe the printing press was heavier than the siege weapon. Just a few words can change everything.';
-		const showDropCap = shouldShowDropCap(shortParagraph, format);
+		const showDropCap = shouldShowDropCap(shortParagraph, format, !isEditions);
 		expect(showDropCap).toBe(false);
 	});
 
 	test('Does not show drop cap if the article is not an allowed design (e.g. standard design)', () => {
-		const showDropCap = shouldShowDropCap(paragraph, mockFormat);
+		const showDropCap = shouldShowDropCap(paragraph, mockFormat, !isEditions);
+		expect(showDropCap).toBe(false);
+	});
+
+	test('Does not show drop cap if the article is an Editions article', () => {
+		const showDropCap = shouldShowDropCap(paragraph, mockFormat, isEditions);
 		expect(showDropCap).toBe(false);
 	});
 });

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -242,8 +242,18 @@ const plainTextElement = (node: Node, key: number): ReactNode => {
 const dropCapRegex =
 	/^["'\u2018\u201c]?(?!I)[a-zA-Z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u024F]{3,}/;
 
-const shouldShowDropCap = (text: string, format: ArticleFormat): boolean =>
-	allowsDropCaps(format) && text.length >= 200 && dropCapRegex.test(text);
+const shouldShowDropCap = (
+	text: string,
+	format: ArticleFormat,
+	isEditions: boolean,
+): boolean => {
+	if (isEditions) {
+		return false;
+	}
+	return (
+		allowsDropCaps(format) && text.length >= 200 && dropCapRegex.test(text)
+	);
+};
 
 const textElement =
 	(format: ArticleFormat, isEditions = false) =>
@@ -254,7 +264,7 @@ const textElement =
 		);
 		switch (node.nodeName) {
 			case 'P': {
-				const showDropCap = shouldShowDropCap(text, format);
+				const showDropCap = shouldShowDropCap(text, format, isEditions);
 				return h(Paragraph, { key, format, showDropCap }, children);
 			}
 			case '#text':


### PR DESCRIPTION
## What does this change?
Stops rendering drop caps in Editions.

## Why?
To prevent unexpected behaviour.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/168306740-0974bf5a-8224-45a7-abc8-2055e4b0db80.png
[after]: https://user-images.githubusercontent.com/57295823/168306645-ccedef3b-2609-44db-9707-93a307e33ec7.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
