### PR TITLE
Stop relying on star rating to parse Design.Review

### DIFF
--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -48,9 +48,6 @@ const isPhotoEssay = (content: Content): boolean =>
 const isFeature = (content: Content): boolean =>
 	content.tags.some((tag) => tag.id === 'tone/features');
 
-const isReview = (content: Content): boolean =>
-	[0, 1, 2, 3, 4, 5].includes(content.fields?.starRating ?? -1);
-
 const isAnalysis = (content: Content): boolean =>
 	content.tags.some((tag) => tag.id === 'tone/analysis');
 
@@ -227,7 +224,6 @@ export {
 	isImmersive,
 	isInteractive,
 	isFeature,
-	isReview,
 	isAnalysis,
 	articleSeries,
 	articleContributors,

--- a/apps-rendering/src/components/editions/starRating/index.tsx
+++ b/apps-rendering/src/components/editions/starRating/index.tsx
@@ -5,6 +5,7 @@ import { ArticleDesign } from '@guardian/libs';
 import { brandAltBackground, brandAltLine } from '@guardian/source-foundations';
 import { SvgStar } from '@guardian/source-react-components';
 import type { Item } from 'item';
+import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
 
 // ----- Subcomponents ----- //
@@ -54,9 +55,11 @@ const containerStyles = css`
 `;
 
 const StarRating: FC<Props> = ({ item }) =>
-	item.design === ArticleDesign.Review ? (
-		<div css={containerStyles}>{stars(item.starRating)}</div>
-	) : null;
+	item.design === ArticleDesign.Review
+		? maybeRender(item.starRating, (starRating) => (
+				<div css={containerStyles}>{stars(starRating)}</div>
+		  ))
+		: null;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
+++ b/apps-rendering/src/components/editions/starRating/starRating.stories.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import { some } from '@guardian/types';
 import { radios, withKnobs } from '@storybook/addon-knobs';
 import { article, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -15,7 +16,7 @@ const Default = (): ReactElement => (
 	<StarRating
 		item={{
 			...review,
-			starRating: radios('Rating', starRating, 3),
+			starRating: some(radios('Rating', starRating, 3)),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/headline.stories.tsx
+++ b/apps-rendering/src/components/headline.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { some } from '@guardian/types';
 import { boolean, radios, withKnobs } from '@storybook/addon-knobs';
 import { analysis, article, feature, labs, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -52,7 +53,7 @@ const Review = (): ReactElement => (
 	<Headline
 		item={{
 			...review,
-			starRating: radios('Rating', starRating, 3),
+			starRating: some(radios('Rating', starRating, 3)),
 			display: boolean('Immersive', false)
 				? ArticleDisplay.Immersive
 				: ArticleDisplay.Standard,

--- a/apps-rendering/src/components/starRating.stories.tsx
+++ b/apps-rendering/src/components/starRating.stories.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import { some } from '@guardian/types';
 import { radios, withKnobs } from '@storybook/addon-knobs';
 import { article, review } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -15,7 +16,7 @@ const Default = (): ReactElement => (
 	<StarRating
 		item={{
 			...review,
-			starRating: radios('Rating', starRating, 3),
+			starRating: some(radios('Rating', starRating, 3)),
 		}}
 	/>
 );

--- a/apps-rendering/src/components/starRating.tsx
+++ b/apps-rendering/src/components/starRating.tsx
@@ -5,6 +5,7 @@ import { ArticleDesign } from '@guardian/libs';
 import { brandAltBackground, brandAltLine } from '@guardian/source-foundations';
 import { SvgStar } from '@guardian/source-react-components';
 import type { Item } from 'item';
+import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from 'styles';
 
@@ -55,9 +56,11 @@ interface Props {
 }
 
 const StarRating: FC<Props> = ({ item }) =>
-	item.design === ArticleDesign.Review ? (
-		<div>{stars(item.starRating)}</div>
-	) : null;
+	item.design === ArticleDesign.Review
+		? maybeRender(item.starRating, (starRating) => (
+				<div>{stars(starRating)}</div>
+		  ))
+		: null;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -372,7 +372,7 @@ const feature: Feature = {
 
 const review: Review = {
 	design: ArticleDesign.Review,
-	starRating: 4,
+	starRating: some(4),
 	...fields,
 	theme: ArticlePillar.Culture,
 };

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -16,8 +16,8 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import type { Option } from '@guardian/types';
 import { fromNullable, map } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import type { Logo } from 'capi';
@@ -94,7 +94,7 @@ interface DeadBlog extends Fields {
 interface Review extends Fields {
 	design: ArticleDesign.Review;
 	body: Body;
-	starRating: number;
+	starRating: Option<number>;
 }
 
 interface Comment extends Fields {
@@ -396,10 +396,10 @@ const fromCapi =
 				design: ArticleDesign.Media,
 				...itemFieldsWithBody(context, request),
 			};
-		} else if (fields?.starRating !== undefined && isReview(tags)) {
+		} else if (isReview(tags)) {
 			return {
 				design: ArticleDesign.Review,
-				starRating: fields.starRating,
+				starRating: fromNullable(fields?.starRating),
 				...itemFieldsWithBody(context, request),
 			};
 		} else if (isAnalysis(tags)) {
@@ -512,4 +512,5 @@ export {
 	isPicture,
 	isLetter,
 	isObituary,
+	isReview,
 };

--- a/apps-rendering/src/relatedContent.test.ts
+++ b/apps-rendering/src/relatedContent.test.ts
@@ -164,8 +164,9 @@ describe('parseRelatedItemType', () => {
 		expect(actual.relatedItems[0].type).toEqual(RelatedItemType.LIVE);
 	});
 
-	it('returns Type REVIEW given a content field with 0-5 star rating', () => {
+	it('returns Type REVIEW given a content with a reviews tone', () => {
 		defaultContent.fields = { starRating: 4 };
+		addTagToTagsList('tone/reviews', TagType.TONE);
 		const actual = parseRelatedContent([defaultContent]);
 		expect(actual.relatedItems[0].type).toEqual(RelatedItemType.REVIEW);
 		expect(actual.relatedItems[0].starRating).toBe('4');

--- a/apps-rendering/src/relatedContent.ts
+++ b/apps-rendering/src/relatedContent.ts
@@ -14,7 +14,6 @@ import {
 	articleMainImage,
 	isAnalysis,
 	isFeature,
-	isReview,
 } from 'capi';
 import {
 	isAudio,
@@ -23,6 +22,7 @@ import {
 	isLabs,
 	isLetter,
 	isLive,
+	isReview,
 	isVideo,
 } from 'item';
 import { compose, index, pipe } from 'lib';
@@ -33,7 +33,7 @@ const parseRelatedItemType = (content: Content): RelatedItemType => {
 		return RelatedItemType.FEATURE;
 	} else if (isLive(tags) && content.fields?.liveBloggingNow) {
 		return RelatedItemType.LIVE;
-	} else if (isReview(content)) {
+	} else if (isReview(tags)) {
 		return RelatedItemType.REVIEW;
 	} else if (isAnalysis(content)) {
 		return RelatedItemType.ANALYSIS;


### PR DESCRIPTION
## Why?
Currently, AR uses star rating to determine whether an article is of type `Review`. However, there are articles with no star rating that should still be rendered with the `Review` design and aren't being captured by the current logic.

This PR changes the way we parse `ArticleDesign.Review` using tags instead of star rating. Closes #4539 

## Screenshots
Here is an example of a review article with no star rating.
| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/168320066-0251b091-0fae-45c1-8bcc-9664385a556a.png
[after]: https://user-images.githubusercontent.com/57295823/168320120-e24f905a-0de0-417c-8bed-ce3bce508647.png



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
