### PR TITLE
Increase Review headline font weight

### DIFF
--- a/apps-rendering/src/components/headline.tsx
+++ b/apps-rendering/src/components/headline.tsx
@@ -125,6 +125,14 @@ const featureStyles = css`
 	}
 `;
 
+const reviewStyles = css`
+	${headline.small({ fontWeight: 'bold' })}
+
+	${from.tablet} {
+		${headline.medium({ fontWeight: 'bold' })}
+	}
+`;
+
 const interviewStyles = css`
 	${headline.small({ fontWeight: 'bold' })}
 	line-height: 1.25;
@@ -187,7 +195,8 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 			return css(styles(format), commentStyles);
 		case ArticleDesign.Media:
 			return css(styles(format), mediaStyles);
-
+		case ArticleDesign.Review:
+			return css(styles(format), reviewStyles);
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 			return css(styles(format), liveblogStyles);


### PR DESCRIPTION
## Why?
Review headlines should be bold, to match DCR styling.

Closes #4540 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/168323284-014cb11e-a978-4fbe-832c-cb45297bcd7d.png
[after]: https://user-images.githubusercontent.com/57295823/168323334-4053a611-cc84-4ee8-af4d-70a905d783b1.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
