### PR TITLE
Add "schema check" action

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -1,0 +1,26 @@
+name: DCR Schema Check
+on:
+  push:
+    paths-ignore:
+      - "apps-rendering/**"
+
+jobs:
+  build_check:
+    name: DCR Schema Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: guardian/actions-setup-node@main
+
+      # Cache npm dependencies using https://github.com/bahmutov/npm-install
+      - uses: bahmutov/npm-install@v1
+
+      - name: Install
+        run: yarn
+
+      - name: Run check-schema script
+        run: make check-schema
+        working-directory: dotcom-rendering

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -163,6 +163,10 @@ check-env: # private
 clear: # private
 	@clear
 
+check-schema:
+	$(call log, "Checking schemas")
+	@node scripts/json-schema/check-schema
+
 gen-schema:
 	$(call log, "Generating new schemas")
 	@node scripts/json-schema/gen-schema.js

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -68,7 +68,6 @@
     "@guardian/prettier": "^0.5.0",
     "@guardian/shimport": "^1.0.2",
     "@guardian/support-dotcom-components": "^1.0.2",
-    "@hkdobrev/run-if-changed": "^0.3.1",
     "@sentry/browser": "^5.30.0",
     "@sentry/integrations": "^5.30.0",
     "@testing-library/dom": "^8.13.0",
@@ -249,9 +248,5 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
     ]
-  },
-  "run-if-changed": {
-    "dotcom-rendering/src/lib/content.d.ts": "make gen-schema && make gen-fixtures",
-    "dotcom-rendering/src/lib/index.d.ts": "make gen-schema && make gen-fixtures"
   }
 }

--- a/dotcom-rendering/scripts/json-schema/check-schema.js
+++ b/dotcom-rendering/scripts/json-schema/check-schema.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const fs = require('fs');
+
+const root = path.resolve(__dirname, '..', '..');
+const { generateArticleSchema, generateFrontSchema } = require('./schema');
+
+const existingArticleSchema = fs.readFileSync(
+	`${root}/src/model/json-schema.json`,
+	{ encoding: 'utf-8' },
+);
+const existingFrontSchema = fs.readFileSync(
+	`${root}/src/model/front-schema.json`,
+	{ encoding: 'utf-8' },
+);
+
+const articleSchema = generateArticleSchema();
+const frontSchema = generateFrontSchema();
+
+if (
+	existingArticleSchema !== articleSchema ||
+	existingFrontSchema !== frontSchema
+) {
+	throw new Error('Schemas do not match ... please run "make gen-schema"');
+} else {
+	console.log('Schemas match!');
+}

--- a/dotcom-rendering/scripts/json-schema/check-schema.js
+++ b/dotcom-rendering/scripts/json-schema/check-schema.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 
 const root = path.resolve(__dirname, '..', '..');
-const { generateArticleSchema, generateFrontSchema } = require('./schema');
+const { getArticleSchema, getFrontSchema } = require('./get-schema');
 
 const existingArticleSchema = fs.readFileSync(
 	`${root}/src/model/json-schema.json`,
@@ -13,8 +13,8 @@ const existingFrontSchema = fs.readFileSync(
 	{ encoding: 'utf-8' },
 );
 
-const articleSchema = generateArticleSchema();
-const frontSchema = generateFrontSchema();
+const articleSchema = getArticleSchema();
+const frontSchema = getFrontSchema();
 
 if (
 	existingArticleSchema !== articleSchema ||

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -2,10 +2,10 @@ const path = require('path');
 
 const root = path.resolve(__dirname, '..', '..');
 const fs = require('fs');
-const { generateArticleSchema, generateFrontSchema } = require('./schema');
+const { getArticleSchema, getFrontSchema } = require('./get-schema');
 
-const articleSchema = generateArticleSchema();
-const frontSchema = generateFrontSchema();
+const articleSchema = getArticleSchema();
+const frontSchema = getFrontSchema();
 
 fs.writeFile(
 	`${root}/src/model/json-schema.json`,

--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -1,23 +1,15 @@
-const TJS = require('typescript-json-schema');
-const { resolve } = require('path');
+const path = require('path');
 
-const root = resolve(__dirname, '..', '..');
+const root = path.resolve(__dirname, '..', '..');
 const fs = require('fs');
+const { generateArticleSchema, generateFrontSchema } = require('./schema');
 
-const program = TJS.getProgramFromFiles(
-	[resolve(`${root}/src/lib/content.d.ts`), resolve(`${root}/index.d.ts`)],
-	{
-		skipLibCheck: true,
-	},
-);
-
-const settings = { rejectDateType: true, required: true };
-const schema = TJS.generateSchema(program, 'CAPIArticleType', settings);
-const frontSchema = TJS.generateSchema(program, 'FEFrontType', settings);
+const articleSchema = generateArticleSchema();
+const frontSchema = generateFrontSchema();
 
 fs.writeFile(
 	`${root}/src/model/json-schema.json`,
-	JSON.stringify(schema, null, 4),
+	articleSchema,
 	'utf8',
 	(err) => {
 		if (err) {
@@ -29,7 +21,7 @@ fs.writeFile(
 
 fs.writeFile(
 	`${root}/src/model/front-schema.json`,
-	JSON.stringify(frontSchema, null, 4),
+	frontSchema,
 	'utf8',
 	(err) => {
 		if (err) {

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -16,14 +16,14 @@ const program = TJS.getProgramFromFiles(
 const settings = { rejectDateType: true, required: true };
 
 module.exports = {
-	generateArticleSchema: () => {
+	getArticleSchema: () => {
 		return JSON.stringify(
 			TJS.generateSchema(program, 'CAPIArticleType', settings),
 			null,
 			4,
 		);
 	},
-	generateFrontSchema: () => {
+	getFrontSchema: () => {
 		return JSON.stringify(
 			TJS.generateSchema(program, 'FEFrontType', settings),
 			null,

--- a/dotcom-rendering/scripts/json-schema/schema.js
+++ b/dotcom-rendering/scripts/json-schema/schema.js
@@ -1,0 +1,33 @@
+const TJS = require('typescript-json-schema');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..', '..');
+
+const program = TJS.getProgramFromFiles(
+	[
+		path.resolve(`${root}/src/lib/content.d.ts`),
+		path.resolve(`${root}/index.d.ts`),
+	],
+	{
+		skipLibCheck: true,
+	},
+);
+
+const settings = { rejectDateType: true, required: true };
+
+module.exports = {
+	generateArticleSchema: () => {
+		return JSON.stringify(
+			TJS.generateSchema(program, 'CAPIArticleType', settings),
+			null,
+			4,
+		);
+	},
+	generateFrontSchema: () => {
+		return JSON.stringify(
+			TJS.generateSchema(program, 'FEFrontType', settings),
+			null,
+			4,
+		);
+	},
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,17 +2910,6 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hkdobrev/run-if-changed@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@hkdobrev/run-if-changed/-/run-if-changed-0.3.1.tgz#69b670ba346118cb04ddc3772376f4b352b9a987"
-  integrity sha512-kxu18zdSoTwYpTuwIw4Zsc/cWa+1c/HayXA290TSD97WKBzodntiqm6pPCoXhGDZu2F6/yg5VChJNSjrfMiTSA==
-  dependencies:
-    cosmiconfig "^5.0.7"
-    execa "^1.0.0"
-    micromatch "^3.1.10"
-    npm-which "^3.0.1"
-    string-argv "^0.1.1"
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -7968,7 +7957,7 @@ commander@7.2.0, commander@^7.0.0, commander@^7.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-commander@^2.12.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
+commander@^2.12.1, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -8211,7 +8200,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^5.0.7, cosmiconfig@^5.2.1:
+cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -15228,13 +15217,6 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
-npm-path@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
-  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
-  dependencies:
-    which "^1.2.10"
-
 npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
@@ -15263,15 +15245,6 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-npm-which@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
-  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
-  dependencies:
-    commander "^2.9.0"
-    npm-path "^2.0.2"
-    which "^1.2.10"
 
 npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
@@ -18588,11 +18561,6 @@ streamroller@^3.0.6:
     debug "^4.3.4"
     fs-extra "^10.0.1"
 
-string-argv@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.2.tgz#c5b7bc03fb2b11983ba3a72333dd0559e77e4738"
-  integrity sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==
-
 string-argv@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -20841,7 +20809,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@^1.2.10, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
Adds an action which compares a newly generated schema to the existing one. 

This ensures that a user would be notified on their PR if they'd made a change to any types in `index.d.ts` which would change our json schemas, but hasn't run `make gen-schema` to update them.

Removes run-if-changed as this didn't work anyway and the action will replace it.