### PR TITLE
`InnerBackgroundColour`

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
@@ -95,19 +95,39 @@ export const BackgroundStory = () => {
 	return (
 		<ContainerLayout
 			title="Background Colour"
-			description="About this content"
+			description="When fullWidthBackground is false, the background colour is contained"
 			fontColour={brandBackground.ctaPrimary}
 			showTopBorder={true}
 			sideBorders={true}
 			centralBorder="full"
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
+			fullWidthBackground={false}
 		>
 			<Grey />
 		</ContainerLayout>
 	);
 };
 BackgroundStory.story = { name: 'with a blue background' };
+
+export const FullWidthBackgroundStory = () => {
+	return (
+		<ContainerLayout
+			title="Background Colour"
+			description="When fullWidthBackground is true (default), then the background colour stretches all the way to the viewport edges, left and right"
+			fontColour={brandBackground.ctaPrimary}
+			showTopBorder={true}
+			sideBorders={true}
+			centralBorder="full"
+			backgroundColour={brandBackground.primary}
+			borderColour={brandBorder.primary}
+			fullWidthBackground={true}
+		>
+			<Grey />
+		</ContainerLayout>
+	);
+};
+FullWidthBackgroundStory.story = { name: 'with a full width blue background' };
 
 export const StretchRightStory = () => {
 	return (

--- a/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
@@ -95,14 +95,13 @@ export const BackgroundStory = () => {
 	return (
 		<ContainerLayout
 			title="Background Colour"
-			description="When fullWidthBackground is false, the background colour is contained"
+			description="About this content"
 			fontColour={brandBackground.ctaPrimary}
 			showTopBorder={true}
 			sideBorders={true}
 			centralBorder="full"
 			backgroundColour={brandBackground.primary}
 			borderColour={brandBorder.primary}
-			fullWidthBackground={false}
 		>
 			<Grey />
 		</ContainerLayout>
@@ -110,24 +109,26 @@ export const BackgroundStory = () => {
 };
 BackgroundStory.story = { name: 'with a blue background' };
 
-export const FullWidthBackgroundStory = () => {
+export const InnerBackgroundStory = () => {
 	return (
 		<ContainerLayout
-			title="Background Colour"
-			description="When fullWidthBackground is true (default), then the background colour stretches all the way to the viewport edges, left and right"
-			fontColour={brandBackground.ctaPrimary}
+			title="Tip us off"
 			showTopBorder={true}
 			sideBorders={true}
 			centralBorder="full"
-			backgroundColour={brandBackground.primary}
+			backgroundColour="#FFF280"
 			borderColour={brandBorder.primary}
-			fullWidthBackground={true}
+			innerBackgroundColour="#FFE501"
 		>
-			<Grey />
+			<h1>
+				👀 Share stories with the Guardian securely and confidentially
+			</h1>
 		</ContainerLayout>
 	);
 };
-FullWidthBackgroundStory.story = { name: 'with a full width blue background' };
+InnerBackgroundStory.story = {
+	name: 'with inner background different to main background',
+};
 
 export const StretchRightStory = () => {
 	return (

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -31,6 +31,7 @@ type Props = {
 	ophanComponentName?: string;
 	ophanComponentLink?: string;
 	containerPalette?: DCRContainerPalette;
+	fullWidthBackground?: boolean;
 };
 
 const containerStyles = css`
@@ -120,6 +121,7 @@ export const ContainerLayout = ({
 	ophanComponentLink,
 	ophanComponentName,
 	containerPalette,
+	fullWidthBackground,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -136,6 +138,7 @@ export const ContainerLayout = ({
 			element="section"
 			ophanComponentLink={ophanComponentLink}
 			ophanComponentName={ophanComponentName}
+			fullWidthBackground={fullWidthBackground}
 		>
 			<Flex>
 				<LeftColumn

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -31,7 +31,7 @@ type Props = {
 	ophanComponentName?: string;
 	ophanComponentLink?: string;
 	containerPalette?: DCRContainerPalette;
-	fullWidthBackground?: boolean;
+	innerBackgroundColour?: string;
 };
 
 const containerStyles = css`
@@ -121,7 +121,7 @@ export const ContainerLayout = ({
 	ophanComponentLink,
 	ophanComponentName,
 	containerPalette,
-	fullWidthBackground,
+	innerBackgroundColour,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -138,7 +138,7 @@ export const ContainerLayout = ({
 			element="section"
 			ophanComponentLink={ophanComponentLink}
 			ophanComponentName={ophanComponentName}
-			fullWidthBackground={fullWidthBackground}
+			innerBackgroundColour={innerBackgroundColour}
 		>
 			<Flex>
 				<LeftColumn

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -34,10 +34,10 @@ type Props = {
 	showTopBorder?: boolean;
 	padded?: boolean;
 	backgroundColour?: string;
+	innerBackgroundColour?: string;
 	borderColour?: string;
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
-	fullWidthBackground?: boolean;
 	element?:
 		| 'div'
 		| 'article'
@@ -59,8 +59,8 @@ export const ElementContainer = ({
 	padded = true,
 	borderColour = border.secondary,
 	backgroundColour,
+	innerBackgroundColour,
 	shouldCenter = true,
-	fullWidthBackground = true,
 	children,
 	element = 'div',
 	className,
@@ -76,21 +76,17 @@ export const ElementContainer = ({
 						shouldCenter && center,
 						showSideBorders && sideBorders(borderColour),
 						showTopBorder && topBorder(borderColour),
-						backgroundColour &&
-							!fullWidthBackground &&
-							setBackgroundColour(backgroundColour),
+						innerBackgroundColour &&
+							setBackgroundColour(innerBackgroundColour),
 						padded && padding,
 					]}
 				>
 					{children && children}
 				</div>
 			);
-			const style =
-				fullWidthBackground &&
-				css`
-					${backgroundColour &&
-					setBackgroundColour(backgroundColour)};
-				`;
+			const style = css`
+				${backgroundColour && setBackgroundColour(backgroundColour)};
+			`;
 			// Create a react element from the tagName passed in OR
 			// default to <div>
 			return _jsx(`${element}`, {

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -37,6 +37,7 @@ type Props = {
 	borderColour?: string;
 	children?: React.ReactNode;
 	shouldCenter?: boolean;
+	fullWidthBackground?: boolean;
 	element?:
 		| 'div'
 		| 'article'
@@ -59,6 +60,7 @@ export const ElementContainer = ({
 	borderColour = border.secondary,
 	backgroundColour,
 	shouldCenter = true,
+	fullWidthBackground = true,
 	children,
 	element = 'div',
 	className,
@@ -74,15 +76,21 @@ export const ElementContainer = ({
 						shouldCenter && center,
 						showSideBorders && sideBorders(borderColour),
 						showTopBorder && topBorder(borderColour),
+						backgroundColour &&
+							!fullWidthBackground &&
+							setBackgroundColour(backgroundColour),
 						padded && padding,
 					]}
 				>
 					{children && children}
 				</div>
 			);
-			const style = css`
-				${backgroundColour && setBackgroundColour(backgroundColour)};
-			`;
+			const style =
+				fullWidthBackground &&
+				css`
+					${backgroundColour &&
+					setBackgroundColour(backgroundColour)};
+				`;
 			// Create a react element from the tagName passed in OR
 			// default to <div>
 			return _jsx(`${element}`, {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the `innerBackgroundColour` prop on `ContainerLayout`. This prop allows the background of the inner container to be set independently of the main, full width, `backgroundColour`

![2022-05-16 15 34 22](https://user-images.githubusercontent.com/1336821/168621831-5c258da2-1dfd-43f6-bcfa-58dafa37dba1.gif)


## Why?
We are seeing designs that call for the ability to set the background colour differently to how `ContainerLayout` currently works so we need more flexibility here. We want to be able to sometimes set just the inner background by itself and also to set both at the same time

