### PR TITLE
Make the top right ad sticky on immersive pages

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -209,7 +209,6 @@ export const AdSlot: React.FC<Props> = ({
 	switch (position) {
 		case 'right':
 			switch (display) {
-				case ArticleDisplay.Immersive:
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
@@ -234,7 +233,8 @@ export const AdSlot: React.FC<Props> = ({
 						/>
 					);
 				}
-				case ArticleDisplay.Standard: {
+				case ArticleDisplay.Standard:
+				case ArticleDisplay.Immersive: {
 					return (
 						<Island>
 							<TopRightAdSlot


### PR DESCRIPTION
## What does this change?

Makes the top right ad sticky on immersive pages.

## Why?

There's no reason they shouldn't behave the same way as standard article pages.

## Screenshots

Oh no, what happened to my gifs. You get the idea...

| Before      | After      |
|-------------|------------|
| ![before (1)](https://user-images.githubusercontent.com/7423751/168777909-e53de7ff-e36a-413a-92d2-2eb4fde12947.gif) | ![after (1)](https://user-images.githubusercontent.com/7423751/168777942-f3260104-8b6b-4db9-937f-faa862105017.gif) |