### PR TITLE
DCR Fronts Show/Hide containers

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
@@ -196,6 +196,19 @@ export const SidesStory = () => {
 };
 SidesStory.story = { name: 'with a full border divider' };
 
+export const ToggleableStory = () => {
+	return (
+		<ContainerLayout
+			title="Toggleable Container"
+			toggleable={true}
+			sectionId="sectionId"
+		>
+			<Grey />
+		</ContainerLayout>
+	);
+};
+ToggleableStory.story = { name: 'toggleable container' };
+
 export const MarginsStory = () => {
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -1,14 +1,16 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { from, space } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source-foundations';
 import type { DCRContainerPalette } from '../../types/front';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import { hiddenStyles } from '../lib/hiddenStyles';
 import { ContainerTitle } from './ContainerTitle';
 import { ElementContainer } from './ElementContainer';
 import { Flex } from './Flex';
 import { Hide } from './Hide';
 import { LeftColumn } from './LeftColumn';
+import { ShowHideButton } from './ShowHideButton';
 
 type Props = {
 	title?: string;
@@ -32,6 +34,7 @@ type Props = {
 	ophanComponentName?: string;
 	ophanComponentLink?: string;
 	containerPalette?: DCRContainerPalette;
+	toggleable?: boolean;
 	innerBackgroundColour?: string;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
@@ -42,6 +45,15 @@ const containerStyles = css`
 	flex-grow: 1;
 	flex-direction: column;
 	width: 100%;
+`;
+
+const headlineContainerStyles = css`
+	display: flex;
+	justify-content: flex-end;
+
+	${until.leftCol} {
+		justify-content: space-between;
+	}
 `;
 
 const margins = css`
@@ -124,12 +136,14 @@ export const ContainerLayout = ({
 	ophanComponentLink,
 	ophanComponentName,
 	containerPalette,
+	toggleable = false,
 	innerBackgroundColour,
 	showDateHeader,
 	editionId,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
+
 	return (
 		<ElementContainer
 			sectionId={sectionId}
@@ -170,18 +184,32 @@ export const ContainerLayout = ({
 					stretchRight={stretchRight}
 					format={format}
 				>
-					<Hide when="above" breakpoint="leftCol">
-						<ContainerTitle
-							title={title}
-							fontColour={fontColour || overrides?.text.container}
-							description={description}
-							url={url}
-							containerPalette={containerPalette}
-							showDateHeader={showDateHeader}
-							editionId={editionId}
-						/>
-					</Hide>
-					{children}
+					<div css={headlineContainerStyles}>
+						<Hide when="above" breakpoint="leftCol">
+							<ContainerTitle
+								title={title}
+								fontColour={
+									fontColour || overrides?.text.container
+								}
+								description={description}
+								url={url}
+								containerPalette={containerPalette}
+								showDateHeader={showDateHeader}
+								editionId={editionId}
+							/>
+						</Hide>
+						{toggleable && sectionId !== undefined && (
+							<ShowHideButton
+								sectionId={sectionId}
+								overrideContainerToggleColour={
+									overrides?.text.containerToggle
+								}
+							/>
+						)}
+					</div>
+					<div css={hiddenStyles} id={`container-${sectionId}`}>
+						{children}
+					</div>
 				</Container>
 			</Flex>
 		</ElementContainer>

--- a/dotcom-rendering/src/web/components/FrontPage.tsx
+++ b/dotcom-rendering/src/web/components/FrontPage.tsx
@@ -8,6 +8,7 @@ import { CoreVitals } from './CoreVitals.importable';
 import { FetchCommentCounts } from './FetchCommentCounts.importable';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
+import { ShowHideContainers } from './ShowHideContainers.importable';
 import { SkipTo } from './SkipTo';
 
 type Props = {
@@ -52,6 +53,9 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<FetchCommentCounts repeat={true} />
+			</Island>
+			<Island clientOnly={true} expediteLoading={true}>
+				<ShowHideContainers />
 			</Island>
 			<FrontLayout front={front} NAV={NAV} />
 		</StrictMode>

--- a/dotcom-rendering/src/web/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/web/components/ShowHideButton.tsx
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import { ButtonLink } from '@guardian/source-react-components';
+
+type Props = {
+	sectionId: string;
+	overrideContainerToggleColour?: string;
+};
+
+const showHideButtonCss = (
+	overrideContainerToggleColour: string | undefined,
+) => css`
+	color: ${overrideContainerToggleColour ?? neutral[46]};
+	${textSans.xsmall()};
+
+	margin-top: ${space[2]}px;
+	margin-right: 10px;
+	margin-bottom: ${space[2]}px;
+	position: relative;
+	align-items: bottom;
+
+	${from.wide} {
+		position: absolute;
+		top: 0;
+		right: 0;
+	}
+`;
+
+/**
+ * This component creates the styled button for showing & hiding a container,
+ * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
+ **/
+export const ShowHideButton = ({
+	sectionId,
+	overrideContainerToggleColour,
+}: Props) => {
+	return (
+		<ButtonLink
+			priority="secondary"
+			subdued={true}
+			cssOverrides={showHideButtonCss(overrideContainerToggleColour)}
+			data-link-name="Hide"
+			data-show-hide-button={sectionId}
+			aria-controls={`container-${sectionId}`}
+			aria-expanded={true}
+		>
+			Hide
+		</ButtonLink>
+	);
+};

--- a/dotcom-rendering/src/web/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowHideContainers.importable.tsx
@@ -1,0 +1,59 @@
+import { storage } from '@guardian/libs';
+import { useOnce } from '../lib/useOnce';
+
+type ContainerStates = { [id: string]: string };
+
+const getContainerStates = (): ContainerStates => {
+	const item = storage.local.get(`gu.prefs.container-states`);
+
+	if (!item) {
+		return {};
+	}
+
+	return item;
+};
+
+export const ShowHideContainers = () => {
+	useOnce(() => {
+		const containerStates = getContainerStates();
+
+		const toggleContainer = (sectionId: string, element: HTMLElement) => {
+			const isExpanded = element.getAttribute('aria-expanded') === 'true';
+
+			const section: Element | null = window.document.getElementById(
+				`container-${sectionId}`,
+			);
+
+			if (isExpanded) {
+				containerStates[sectionId] = 'closed';
+				section?.classList.add('hidden');
+				element.innerHTML = 'Show';
+				element.setAttribute('aria-expanded', 'false');
+				element.setAttribute('data-link-name', 'Show');
+			} else {
+				containerStates[sectionId] = 'opened';
+				section?.classList.remove('hidden');
+				element.innerHTML = 'Hide';
+				element.setAttribute('aria-expanded', 'true');
+				element.setAttribute('data-link-name', 'Hide');
+			}
+
+			storage.local.set(`gu.prefs.container-states`, containerStates);
+		};
+
+		window.document
+			.querySelectorAll<HTMLElement>('[data-show-hide-button]')
+			.forEach((e) => {
+				const sectionId = e.getAttribute('data-show-hide-button');
+				if (!sectionId) return;
+
+				e.onclick = () => toggleContainer(sectionId, e);
+
+				if (containerStates[sectionId] === 'closed') {
+					toggleContainer(sectionId, e);
+				}
+			});
+	}, []);
+
+	return <></>;
+};

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -163,6 +163,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							ophanComponentLink={ophanComponentLink}
 							ophanComponentName={ophanName}
 							containerPalette={collection.containerPalette}
+							toggleable={true}
+							sectionId={collection.id}
 							showDateHeader={collection.config.showDateHeader}
 							editionId={front.editionId}
 						>

--- a/dotcom-rendering/src/web/lib/hiddenStyles.tsx
+++ b/dotcom-rendering/src/web/lib/hiddenStyles.tsx
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const hiddenStyles = css`
+	&.hidden {
+		display: none;
+	}
+`;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the Show / Hide button to containers on fronts to allow users to toggle seeing containers they don't want to see.

### What this PR does not do

 - Disable the show hide button on Labs containers
 - Disable the show hide button on containers with the weather widget
 - Disable the show hide button on special containers such as Thrasher

## Screenshots (currently out of date)
### Before
![before][]
### After
![after][]

[before]: https://user-images.githubusercontent.com/21217225/168631807-5b8c5ca6-d0c7-48a8-97b5-ac6d28594232.png
[after]: https://user-images.githubusercontent.com/21217225/168632288-2375feb1-c0f0-49f3-bf32-af98fa317d4c.png
<!--
### DCR Screenshots
<details>
  <summary>Opened</summary>

#### DCR Mobile
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Mobile)](https://user-images.githubusercontent.com/21217225/168833000-d031f32a-bebf-4151-b1b8-d117f1323255.png)

#### DCR Tablet
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Tablet)](https://user-images.githubusercontent.com/21217225/168833015-1f92b71d-2b9d-42e0-b71c-a115834973f0.png)

#### DCR Desktop
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Desktop)](https://user-images.githubusercontent.com/21217225/168833027-bcf322e9-9f6f-425b-81da-de3b77293566.png)

#### DCR Left Col
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Left Col)](https://user-images.githubusercontent.com/21217225/168833038-dd1eeb2c-306e-4f1a-bebc-400fa35f0702.png)

#### DCR Wide
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Wide)](https://user-images.githubusercontent.com/21217225/168833057-acf790a6-6018-4222-a32b-2d7d224c946d.png)
</details>

<details>
  <summary>Closed</summary>

#### DCR Mobile
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Mobile) (2)](https://user-images.githubusercontent.com/21217225/168834378-19677783-470d-4c38-bfe3-b903d35c1ef4.png)

#### DCR Tablet
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Tablet) (1)](https://user-images.githubusercontent.com/21217225/168834384-42c11009-bd85-44f8-a9bf-ceb43057ea5d.png)

#### DCR Desktop
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Desktop) (1)](https://user-images.githubusercontent.com/21217225/168834394-14bc4362-8f21-4c86-b83a-d2e38c101cea.png)

#### DCR Left Col
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Left Col) (1)](https://user-images.githubusercontent.com/21217225/168834420-9cda129b-aa02-424c-a966-f012279987fc.png)

#### DCR Wide
![3030 code ashleigh rocks_Front_url=https___www theguardian com_uk(Guardian Wide) (1)](https://user-images.githubusercontent.com/21217225/168834436-4f30e18e-ce3d-4075-9bc1-df0c14db1a85.png)

</details

-->