### PR TITLE
Fix standfirst background colour for Editorial and Letter designs

### DIFF
--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -121,8 +121,8 @@ const standfirst = ({ design, theme }: ArticleFormat): Colour => {
 
 	if (
 		design === ArticleDesign.Comment ||
-		ArticleDesign.Letter ||
-		ArticleDesign.Editorial
+		design === ArticleDesign.Letter ||
+		design === ArticleDesign.Editorial
 	) {
 		return opinion[800];
 	}

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -31,7 +31,7 @@ const adSlot = (format: ArticleFormat): Colour => {
 		default:
 			return neutral[97];
 	}
-}
+};
 
 const adSlotDark = (_format: ArticleFormat) => neutral[20];
 
@@ -119,7 +119,11 @@ const standfirst = ({ design, theme }: ArticleFormat): Colour => {
 		}
 	}
 
-	if (design === ArticleDesign.Comment) {
+	if (
+		design === ArticleDesign.Comment ||
+		ArticleDesign.Letter ||
+		ArticleDesign.Editorial
+	) {
 		return opinion[800];
 	}
 


### PR DESCRIPTION
## Why?
These two designs weren't accounted for in the palette, so the background was white instead of peach.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/168634502-e83458cc-7832-49e4-978b-d85707e88df7.png
[after]: https://user-images.githubusercontent.com/57295823/168634571-1c0d9ede-1633-4ee6-bc88-dfbac5ef9a57.png