### PR TITLE
Fix  `PinnedPost` content height with long embeds

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -17,6 +17,10 @@ const pinnedPostContent: HTMLElement | null = !isServer
 	? window.document.querySelector('#collapsible-body')
 	: null;
 
+const contentFitsContainer = () =>
+	pinnedPostContent &&
+	pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
+
 /**
  * hide show more button and overlay on pinned post
  */
@@ -78,11 +82,16 @@ export const EnhancePinnedPost = () => {
 
 	const pinnedPostTiming = useRef<ReturnType<typeof initPerf>>();
 
-	const contentFitsContainer =
-		pinnedPostContent &&
-		pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
+	/**
+	 * Timeout allows embeds to load before calculating content height
+	 */
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			if (contentFitsContainer()) hideShowMore();
+		}, 1000);
 
-	if (contentFitsContainer) hideShowMore();
+		return () => clearTimeout(timeout);
+	}, []);
 
 	useEffect(() => {
 		pinnedPostCheckBox?.addEventListener('change', handleClickTracking);

--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -17,10 +17,6 @@ const pinnedPostContent: HTMLElement | null = !isServer
 	? window.document.querySelector('#collapsible-body')
 	: null;
 
-const contentFitsContainer = () =>
-	pinnedPostContent &&
-	pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
-
 /**
  * hide show more button and overlay on pinned post
  */
@@ -82,15 +78,24 @@ export const EnhancePinnedPost = () => {
 
 	const pinnedPostTiming = useRef<ReturnType<typeof initPerf>>();
 
+	const checkContentHeight = () => {
+		const contentFitsContainer =
+			pinnedPostContent &&
+			pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
+
+		if (contentFitsContainer) hideShowMore();
+	};
+
 	/**
-	 * Timeout allows embeds to load before calculating content height
+	 * Checks for dom updates (embeds loading etc) and updates content height
 	 */
 	useEffect(() => {
-		const timeout = setTimeout(() => {
-			if (contentFitsContainer()) hideShowMore();
-		}, 1000);
+		if (!pinnedPost) return;
 
-		return () => clearTimeout(timeout);
+		const observer = new MutationObserver(checkContentHeight);
+		observer.observe(pinnedPost);
+
+		return () => observer.disconnect();
 	}, []);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -82,7 +82,6 @@ export const EnhancePinnedPost = () => {
 		const contentFitsContainer =
 			pinnedPostContent &&
 			pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
-
 		if (contentFitsContainer) hideShowMore();
 	};
 
@@ -93,7 +92,9 @@ export const EnhancePinnedPost = () => {
 		if (!pinnedPost) return;
 
 		const observer = new MutationObserver(checkContentHeight);
-		observer.observe(pinnedPost);
+		const config = { childList: true };
+
+		observer.observe(pinnedPost, config);
 
 		return () => observer.disconnect();
 	}, []);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

~Wraps the check for block content height in a `setTimeout` to allow twitter embeds to load before the height is calculated.~

Wraps the check for block content height in a `MutationObserver` so the height is recalculated when changes are made to the target elements. 

## Why?

Previously the content height was only calculated before the embed was loaded, meaning the `showMore` button would not be shown. This meant if a post contained a long embed the post could not be expanded and some of the post was not visible.

@paperboyo reported this as a bug.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/77005274/168791984-825fe97d-36a3-4652-abbe-008891d8e12c.png
[after]: https://user-images.githubusercontent.com/77005274/168792086-e633970f-9118-4f9d-bb0b-dd9ae5527d7d.png



