### PR TITLE
Fix missing gallery image location

### DIFF
--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -29,7 +29,7 @@ type CaptionProps = {
 };
 
 type CaptionDetails = {
-	location: Option<string>;
+	location: Option<string[]>;
 	description: Option<string[]>;
 };
 
@@ -52,17 +52,20 @@ const styles = css`
 
 const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
 	const details: CaptionDetails = {
-		location: none,
+		location: some([]),
 		description: some([]),
 	};
 
-	const pushToDescription = (
+	const pushToDetails = (
+		section: 'location' | 'description',
 		details: CaptionDetails,
 		node: Node,
 	): CaptionDetails => {
+		const detailsSection = details[section];
+
 		node.textContent &&
-			details.description.kind === OptionKind.Some &&
-			details.description.value.push(node.textContent);
+			detailsSection.kind === OptionKind.Some &&
+			detailsSection.value.push(node.textContent);
 
 		return details;
 	};
@@ -70,15 +73,13 @@ const getCaptionDetails = (oDoc: Option<DocumentFragment>): CaptionDetails => {
 	const parseCaptionNode = (doc: DocumentFragment): CaptionDetails =>
 		Array.from(doc.childNodes).reduce((details, node) => {
 			if (node.nodeName === 'STRONG') {
-				details.location = node.textContent
-					? some(node.textContent)
-					: none;
+				details = pushToDetails('location', details, node);
 			} else if (
 				node.nodeName === '#text' ||
 				node.nodeName === 'A' ||
 				node.nodeName === 'EM'
 			) {
-				details = pushToDescription(details, node);
+				details = pushToDetails('description', details, node);
 			}
 			return details;
 		}, details);
@@ -107,7 +108,7 @@ const Triangle: FC<{ color: string }> = ({ color }) => (
 	</svg>
 );
 
-const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
+const CaptionLocation: FC<{ location: string[]; triangleColor: string }> = ({
 	location,
 	triangleColor,
 }) => {
@@ -127,7 +128,7 @@ const CaptionLocation: FC<{ location: string; triangleColor: string }> = ({
 	return (
 		<h2 css={styles}>
 			<Triangle color={triangleColor} />
-			{location}
+			{location.join(', ')}
 		</h2>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changed the location field in the GalleryImage details to an array, same as description

## Why?
The `GalleryImage` component currently looks for any strong tags and assumes they are the images location data and puts it in bold below the image. In some cases there are empty `<strong>` tags and as the value of `location` is set as a standard string, the last strong tag found in the markup will be set as the location regardless of whether it's empty. The description uses an array which various values can be pushed to. This changes the location to use the same method so that all strong tags' contents will be put together instead of overwriting each other.



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
