### PR TITLE
Fix top padding on cards on fronts

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -17,7 +17,7 @@ const cardStyles = (format: ArticleFormat, palette?: Palette) => {
 		flex-direction: column;
 		justify-content: space-between;
 		width: 100%;
-		/* We absolutely position both the 1 pixel top bar below and the faux link
+		/* We absolutely position the faux link
 		so this is required here */
 		position: relative;
 

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -25,6 +25,10 @@ const cardStyles = (format: ArticleFormat, palette?: Palette) => {
 		:before {
 			background-color: ${cardPalette.topBar.card};
 			content: '';
+			position: absolute;
+			top: -1px;
+			left: 0;
+			right: 0;
 			height: 1px;
 			z-index: 2;
 		}

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -25,10 +25,6 @@ const cardStyles = (format: ArticleFormat, palette?: Palette) => {
 		:before {
 			background-color: ${cardPalette.topBar.card};
 			content: '';
-			position: absolute;
-			top: -1px;
-			left: 0;
-			right: 0;
 			height: 1px;
 			z-index: 2;
 		}

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -17,7 +17,7 @@ const cardStyles = (format: ArticleFormat, palette?: Palette) => {
 		flex-direction: column;
 		justify-content: space-between;
 		width: 100%;
-		/* We absolutely position bioth the 1 pixel top bar below and the faux link
+		/* We absolutely position both the 1 pixel top bar below and the faux link
 		so this is required here */
 		position: relative;
 

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -26,7 +26,7 @@ const cardStyles = (format: ArticleFormat, palette?: Palette) => {
 			background-color: ${cardPalette.topBar.card};
 			content: '';
 			position: absolute;
-			top: 0;
+			top: -1px;
 			left: 0;
 			right: 0;
 			height: 1px;

--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -10,6 +10,7 @@ export const HeadlineWrapper = ({ children }: Props) => (
 			padding-bottom: 8px;
 			padding-left: 5px;
 			padding-right: 5px;
+			padding-top: 1px;
 			flex-grow: 1;
 		`}
 	>

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -73,11 +73,12 @@ export const ImageWrapper = ({
 				isHorizontalOnMobile &&
 					css`
 						${until.tablet} {
-							margin-left: 6px;
 							width: 119px;
 							flex-shrink: 0;
-							margin-top: 6px;
-							margin-bottom: 6px;
+							margin-top: 4px;
+							margin-right: 0;
+							margin-bottom: 4px;
+							margin-left: 4px;
 							flex-basis: unset;
 						}
 					`,


### PR DESCRIPTION
Fixes part of: #4705
Bottom padding will be fixed as part of the work for https://github.com/guardian/dotcom-rendering/issues/4869

Co-authored-by: Harry Fischer <harry.fischer@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
It modifies padding in `CardWrapper`, `HeadlineWrapper` and `ImageWrapper`.

## Why?
To fix the top padding on cards on fronts and match Figma designs.

## Screenshots

The change is applied to the `CardWrapper` so it affects all breakpoints (hence the 839 chromatic diffs I had to accept!) but it will be mostly visible in mobile breakpoints.

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/168869241-e4c9de3a-6eec-41d6-8246-ac4924355fc8.png) | ![image](https://user-images.githubusercontent.com/19683595/168868412-fbf80f78-1ae1-45a6-8b7d-b857114c162d.png) |
| ![image](https://user-images.githubusercontent.com/19683595/168869031-245192bb-e3b4-46bf-8497-5cd998121261.png) | ![image](https://user-images.githubusercontent.com/19683595/168868643-44bacf35-84a7-4102-94aa-51baca2c208b.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
