### PR TITLE
Increase spacing between header image and text in Comment, Letter, Editorial designs

### DIFF
--- a/apps-rendering/src/components/HeaderImage/index.tsx
+++ b/apps-rendering/src/components/HeaderImage/index.tsx
@@ -68,6 +68,16 @@ const immersiveStyles = css`
 	left: 0;
 `;
 
+const commentStyles = css`
+	margin: 0 0 ${remSpace[5]} 0;
+	position: relative;
+	${from.wide} {
+		width: ${wideContentWidth}px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
+
 const interviewStyles = css`
 	position: relative;
 	margin: 0;
@@ -103,6 +113,10 @@ const getStyles = ({ design, display }: ArticleFormat): SerializedStyles => {
 			return liveStyles;
 		case ArticleDesign.Interview:
 			return interviewStyles;
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return commentStyles;
 		default:
 			if (display === ArticleDisplay.Immersive) {
 				return immersiveStyles;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?
Non comment/editorial/letter articles have a spacing of `1.25rem` above the body of the article. This margin is defined in the Metadata component.

In Comment/Editorial/Letter pieces, the metadata sits below the standfirst, resulting in almost no space between the header image and the text. This PR addresses the issue.

See a regular article: 

![image](https://user-images.githubusercontent.com/57295823/169086732-fbd6af89-5871-4ca8-96e4-ec498c377674.png)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/169087825-ef719dd6-e4c7-4c79-b29e-556ef7426715.png
[after]: https://user-images.githubusercontent.com/57295823/169087704-8100d26b-ac18-496a-ab0e-7f8d84927880.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
