### PR TITLE
Remove wavy lines from Feature and Recipe designs in AR

### DIFF
--- a/apps-rendering/src/components/layout/standard.tsx
+++ b/apps-rendering/src/components/layout/standard.tsx
@@ -11,7 +11,6 @@ import {
 } from '@guardian/source-foundations';
 import {
 	DottedLines,
-	SquigglyLines,
 	StraightLines,
 } from '@guardian/source-react-components-development-kitchen';
 import { map, none, withDefault } from '@guardian/types';
@@ -75,13 +74,7 @@ const decideLines = (
 		return <DottedLines cssOverrides={cssOverrides} count={count} />;
 	}
 
-	switch (item.design) {
-		case ArticleDesign.Feature:
-		case ArticleDesign.Recipe:
-			return <SquigglyLines cssOverrides={cssOverrides} count={count} />;
-		default:
-			return <StraightLines cssOverrides={cssOverrides} count={count} />;
-	}
+	return <StraightLines cssOverrides={cssOverrides} count={count} />;
 };
 
 interface Props {


### PR DESCRIPTION
## Why?
As per discussion in https://github.com/guardian/dotcom-rendering/issues/4848, all wavy lines are to replaced with straight lines.

The only two designs that currently use them are `Feature` and `Recipe`. This PR gets rid of them in both.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/169270382-bdd31cdc-16e5-47b2-924e-029f9a8e7090.png
[after]: https://user-images.githubusercontent.com/57295823/169270447-d6989457-4ad1-416b-b521-8705e3a81af8.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
