### PR TITLE
Make source optional for trial picture

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -738,7 +738,7 @@ type FEFrontCard = {
 						index: number;
 						fields: {
 							displayCredit?: string;
-							source: string;
+							source?: string;
 							photographer?: string;
 							isMaster?: string;
 							altText?: string;

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -131,7 +131,6 @@
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
-                                                                                            "source",
                                                                                             "width"
                                                                                         ]
                                                                                     },
@@ -702,7 +701,6 @@
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
-                                                                                            "source",
                                                                                             "width"
                                                                                         ]
                                                                                     },
@@ -1273,7 +1271,6 @@
                                                                                             "credit",
                                                                                             "height",
                                                                                             "mediaId",
-                                                                                            "source",
                                                                                             "width"
                                                                                         ]
                                                                                     },


### PR DESCRIPTION
Seems the `/uk` front has been updated and this type should be optional: https://www.theguardian.com/uk?dcr

This will break our lighhouse ... etc