### PR TITLE
Load interactives on page idle

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -30,6 +30,7 @@ type Props = {
 	isSensitive: boolean;
 	isDev: boolean;
 	onFirstPage?: boolean;
+	abTests?: ServerSideTests;
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -110,6 +111,7 @@ export const ArticleBody = ({
 	isSensitive,
 	isDev,
 	onFirstPage,
+	abTests,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const palette = decidePalette(format);
@@ -191,6 +193,7 @@ export const ArticleBody = ({
 				isDev={isDev}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
+				abTests={abTests}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -39,6 +39,8 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 
 		const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 			/* keep array multi-line */
+			'interactivesIdleLoadingVariant',
+			'interactivesIdleLoadingControl',
 		];
 
 		const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -30,6 +30,8 @@ export const CoreVitals = () => {
 
 	const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 		/* linter, please keep this array multi-line */
+		'interactivesIdleLoadingVariant',
+		'interactivesIdleLoadingControl',
 	];
 
 	const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -584,6 +584,7 @@ export const CommentLayout = ({
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
+										abTests={CAPIArticle.config.abTests}
 									/>
 									{showBodyEndSlot && (
 										<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -417,6 +417,7 @@ export const ImmersiveLayout = ({
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -546,6 +546,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
+										abTests={CAPIArticle.config.abTests}
 									/>
 
 									{/* <StraightLines data-print-layout="hide" count={4} /> */}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -883,6 +883,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												onFirstPage={
 													pagination.currentPage === 1
 												}
+												abTests={
+													CAPIArticle.config.abTests
+												}
 											/>
 											{pagination.totalPages > 1 && (
 												<Pagination

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -551,6 +551,7 @@ export const ShowcaseLayout = ({
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -667,6 +667,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -64,6 +64,7 @@ export const ArticleRenderer: React.FC<{
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests?: ServerSideTests;
 }> = ({
 	format,
 	elements,
@@ -82,6 +83,7 @@ export const ArticleRenderer: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	isDev,
+	abTests,
 }) => {
 	const renderedElements = elements.map((element, index) => {
 		return renderArticleElement({
@@ -97,6 +99,7 @@ export const ArticleRenderer: React.FC<{
 			isAdFreeUser,
 			isSensitive,
 			switches,
+			abTests,
 		});
 	});
 

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -138,6 +138,8 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
+	const shouldLazyLoadInteractives = isAdFreeUser;
+
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return [
@@ -382,7 +384,9 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return [
 				true,
-				<Island deferUntil="idle">
+				<Island
+					deferUntil={shouldLazyLoadInteractives ? 'visible' : 'idle'}
+				>
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -78,6 +78,7 @@ type Props = {
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: { [key: string]: boolean };
+	abTests?: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -131,6 +132,7 @@ export const renderElement = ({
 	isAdFreeUser,
 	switches,
 	isSensitive,
+	abTests,
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
 
@@ -138,7 +140,11 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
-	const shouldLazyLoadInteractives = isAdFreeUser;
+	const isInteractivesIdleLoadingVariant =
+		abTests?.interactivesIdleLoadingVariant === 'variant';
+
+	const shouldIdleLoadInteractives =
+		!isAdFreeUser && isInteractivesIdleLoadingVariant;
 
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
@@ -385,7 +391,7 @@ export const renderElement = ({
 			return [
 				true,
 				<Island
-					deferUntil={shouldLazyLoadInteractives ? 'visible' : 'idle'}
+					deferUntil={shouldIdleLoadInteractives ? 'idle' : 'visible'}
 				>
 					<InteractiveBlockComponent
 						url={element.url}
@@ -791,6 +797,7 @@ export const renderArticleElement = ({
 	isAdFreeUser,
 	isSensitive,
 	switches,
+	abTests,
 }: Props): JSX.Element => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -809,6 +816,7 @@ export const renderArticleElement = ({
 		isAdFreeUser,
 		isSensitive,
 		switches,
+		abTests,
 	});
 
 	if (!ok) {

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -382,7 +382,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return [
 				true,
-				<Island deferUntil="visible">
+				<Island deferUntil="idle">
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}


### PR DESCRIPTION
## What does this change?

Configures interactives to load on page idle instead of when they become visible.

## Why?

Since [10th March](https://github.com/guardian/dotcom-rendering/pull/4077/files#diff-bfe01c729b02a7387fbe09422851114b59f1445c1785129940980a3d0aaebb16R367), interactive elements have been configured to load only when they become visible in the viewport. This makes sense from an efficiency standpoint but presents issues for spacefinder which has to wait for all interactives to load before running. This is because interactives have a variable height which cannot be anticipated in advance, and spacefinder needs to know this to make sensible decisions about where to place ads.

Consequently, any article containing interactives won't show inline ads until either the user scrolls to them, or until spacefinder times out. This happens after 5 seconds for `inline1` ads and after 10 seconds for `inline2+` ads.

It also means the following scenario is possible:

1) Article loads. Interactives do not load. Interactives [occupy a placeholder of 500px in height](https://github.com/guardian/dotcom-rendering/blob/3e89f4fa67bd8671b17b2fdbf79544bb6fcfc54a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx#L312) before they are loaded.
2) Spacefinder times out after waiting 10 seconds for interactives to load
3) Spacefinder runs and inserts ads accordingly
4) User scrolls to interactive, which loads. The actual height is less than 500px and the adverts are pulled up, clashing with the "Most viewed" element.

To reproduce: https://www.theguardian.com/politics/2022/apr/08/rishi-sunak-akshata-murty-us-green-cards

## Screenshot

![Screenshot 2022-05-19 at 14 54 05](https://user-images.githubusercontent.com/7423751/169310350-26c9a9e5-b96d-473e-9424-9a5645c79d3e.png)

(in this case, the interactive is the "Contact Guardian Politics" block)

## A/B test

To test the impact of this change, we've put the fix behind a server-side A/B test. 

The configuration is here: https://github.com/guardian/frontend/pull/25049

## Testing on CODE (mostly for my own future reference!)

### Step 1

Enable the [switch](https://frontend.code.dev-gutools.co.uk/dev/switchboard#Server-side%20Experiments):

![Screenshot 2022-05-26 at 11 54 52](https://user-images.githubusercontent.com/7423751/170474427-84c405a0-75aa-4c76-ac6d-250a8fc437be.png)

### Step 2

Visit the [CAPI object](https://m.code.dev-theguardian.com/politics/2022/apr/08/rishi-sunak-akshata-murty-us-green-cards.json?dcr) and note:

![Screenshot 2022-05-26 at 11 51 29](https://user-images.githubusercontent.com/7423751/170473959-a925e68b-6116-437e-8677-ff4333569310.png)

Visit the [article](https://m.code.dev-theguardian.com/politics/2022/apr/08/rishi-sunak-akshata-murty-us-green-cards) and note:

![Screenshot 2022-05-26 at 11 49 40](https://user-images.githubusercontent.com/7423751/170473658-82042181-cf5d-4a59-a029-64067d4311af.png)

### Step 3

Opt into the test: 

https://m.code.dev-theguardian.com/opt/in/interactives-idle-loading

> **Note**
> This doesn't work on localhost. Instead use the following "Header Hacker" configuration:
> ![Screenshot 2022-05-26 at 13 57 34](https://user-images.githubusercontent.com/7423751/170492120-62365771-7653-452e-9be9-8e6953b00a88.png)
> ![Screenshot 2022-05-26 at 13 56 16](https://user-images.githubusercontent.com/7423751/170491942-99ae2014-7ca7-4f8d-8d95-6d300475d5ac.png)

### Step 4

Visit the [CAPI object](https://m.code.dev-theguardian.com/politics/2022/apr/08/rishi-sunak-akshata-murty-us-green-cards.json?dcr) and note:

![Screenshot 2022-05-26 at 11 47 06](https://user-images.githubusercontent.com/7423751/170473295-7ed6c43a-0d36-4706-add7-66d3eb137dce.png)

Visit the [article](https://m.code.dev-theguardian.com/politics/2022/apr/08/rishi-sunak-akshata-murty-us-green-cards) and note:

![Screenshot 2022-05-26 at 11 50 19](https://user-images.githubusercontent.com/7423751/170473746-41e3416a-97a0-4b54-9933-1955a1c15ee3.png)

