### PR TITLE
Default sublink kicker text

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -47,15 +47,19 @@ const enhanceSupportingContent = (
 	containerPalette?: DCRContainerPalette,
 ): DCRSupportingContent[] => {
 	return supportingContent.map((subLink) => {
+		// This is the actual DCR format for this sublink
 		const linkFormat = subLink.format
 			? decideFormat(subLink.format)
 			: undefined;
+		// This is the format used to decide how the sublink looks (we vary this based
+		// on the container background colour)
+		const presentationFormat = decidePresentationFormat({
+			linkFormat,
+			containerFormat: format,
+			containerPalette,
+		});
 		return {
-			format: decidePresentationFormat({
-				linkFormat,
-				containerFormat: format,
-				containerPalette,
-			}),
+			format: presentationFormat,
 			headline: subLink.header?.headline || '',
 			url: subLink.properties.href || subLink.header?.url,
 			kickerText:

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -13,7 +13,7 @@ import { getDataLinkNameCard } from '../web/lib/getDataLinkName';
  *
  * @returns the format property that we will use to style the sublink
  */
-const decideSubLinkFormat = ({
+const decidePresentationFormat = ({
 	linkFormat,
 	containerFormat,
 	containerPalette,
@@ -46,18 +46,25 @@ const enhanceSupportingContent = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
 ): DCRSupportingContent[] => {
-	return supportingContent.map((subLink) => ({
-		format: decideSubLinkFormat({
-			linkFormat: subLink.format
-				? decideFormat(subLink.format)
-				: undefined,
-			containerFormat: format,
-			containerPalette,
-		}),
-		headline: subLink.header?.headline || '',
-		url: subLink.properties.href || subLink.header?.url,
-		kickerText: subLink.header?.kicker?.item?.properties.kickerText,
-	}));
+	return supportingContent.map((subLink) => {
+		const linkFormat = subLink.format
+			? decideFormat(subLink.format)
+			: undefined;
+		return {
+			format: decidePresentationFormat({
+				linkFormat,
+				containerFormat: format,
+				containerPalette,
+			}),
+			headline: subLink.header?.headline || '',
+			url: subLink.properties.href || subLink.header?.url,
+			kickerText:
+				subLink.header?.kicker?.item?.properties.kickerText ||
+				(linkFormat && linkFormat.design === ArticleDesign.LiveBlog
+					? 'Live'
+					: undefined),
+		};
+	});
 };
 
 const enhanceCards = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This defaults the sublink kicker text for liveblogs to 'Live' in the event that there is no specific text provided.

Fixes #4952 

## Why?
Having no text doesn't look great and Live is the editorial default

| Before      | After      |
|-------------|------------|
| <img width="715" alt="Screenshot 2022-05-20 at 10 12 17" src="https://user-images.githubusercontent.com/1336821/169495899-b18c5329-255f-432e-8cee-eb70285465b0.png"> | <img width="715" alt="Screenshot 2022-05-20 at 10 11 29" src="https://user-images.githubusercontent.com/1336821/169495835-4b3bd19e-e53a-4c5c-b637-25f8b68c85c0.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
