### PR TITLE
ESLint reoganise and fix rules

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -66,34 +66,25 @@ module.exports = {
 
 		'@typescript-eslint/explicit-function-return-type': [0],
 		'@typescript-eslint/no-inferrable-types': [0],
-		// TODO, review these
-		'@typescript-eslint/no-explicit-any': [0],
-		'react/jsx-one-expression-per-line': [0],
-		'react/no-array-index-key': [0],
-		'@typescript-eslint/require-await': [0],
-		'array-callback-return': [0],
-		'consistent-return': [0],
-		'default-case': [0],
-		'global-require': [0],
-		'import/no-extraneous-dependencies': [0],
-		'no-case-declarations': [0],
-		'no-empty-pattern': [0],
-		'no-param-reassign': [0],
-		'no-restricted-syntax': [0],
-		'no-underscore-dangle': [0],
-		'no-useless-escape': [0],
-		'react/button-has-type': [0],
-		'react/jsx-no-target-blank': [0],
-		'react/sort-comp': [0],
-		'react/state-in-constructor': [0],
-		'react/no-danger': [0],
-		'react/jsx-curly-newline': [0],
-		'react-hooks/rules-of-hooks': 'error',
-		'react-hooks/exhaustive-deps': 'warn',
-		'arrow-body-style': [0],
-		'react/require-default-props': [0],
-		'react/jsx-uses-react': 'off',
-		'react/react-in-jsx-scope': 'off',
+
+		// TODO, review these (1314 problems)
+		'import/no-extraneous-dependencies': 'warn', // 683 problems
+		'react/jsx-one-expression-per-line': 'warn', // 325 problems
+		'consistent-return': 'warn', // 51 problems
+		'default-case': 'warn', // 50 problems
+		'react/no-danger': 'warn', // 48 problems
+		'no-underscore-dangle': 'warn', // 45 problems
+		'react/no-array-index-key': 'warn', // 34 problems
+		'react/button-has-type': 'warn', // 23 problems
+		'@typescript-eslint/require-await': 'warn', // 22 problems
+		'react/jsx-curly-newline': 'warn', // 8 problems
+		'no-case-declarations': 'warn', // 7 problems
+		'no-useless-escape': 'warn', // 6 problems
+		'no-empty-pattern': 'warn', // 4 problems
+		'react/jsx-no-target-blank': 'warn', // 3 problems
+		'array-callback-return': 'warn', // 2 problems
+		'global-require': 'warn', // 2 problems
+		'no-param-reassign': 'warn', // 1 problems
 		/** These rules will be disabled one-by-one */
 		...transitionRules,
 	},

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -67,6 +67,8 @@ module.exports = {
 		'@typescript-eslint/explicit-function-return-type': [0],
 		'@typescript-eslint/no-inferrable-types': [0],
 
+		'no-param-reassign': 'error',
+
 		// TODO, review these (1314 problems)
 		'import/no-extraneous-dependencies': 'warn', // 683 problems
 		'react/jsx-one-expression-per-line': 'warn', // 325 problems
@@ -84,7 +86,6 @@ module.exports = {
 		'react/jsx-no-target-blank': 'warn', // 3 problems
 		'array-callback-return': 'warn', // 2 problems
 		'global-require': 'warn', // 2 problems
-		'no-param-reassign': 'warn', // 1 problems
 		/** These rules will be disabled one-by-one */
 		...transitionRules,
 	},

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
 		// Fixed as part of @guardian-eslint move May 2022
 		'array-callback-return': 'error',
 		'global-require': 'error',
+		'no-empty-pattern': 'error',
 		'no-param-reassign': 'error',
 
 		// TODO, review these (1314 problems)

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -14,7 +14,6 @@ const rulesToReview = {
 	'react/jsx-curly-newline': 'warn', // 8 problems
 	'no-case-declarations': 'warn', // 7 problems
 	'no-useless-escape': 'warn', // 6 problems
-	'react/jsx-no-target-blank': 'warn', // 3 problems
 };
 
 const rulesToRemove = {
@@ -90,6 +89,7 @@ module.exports = {
 		'global-require': 'error',
 		'no-empty-pattern': 'error',
 		'no-param-reassign': 'error',
+		'react/jsx-no-target-blank': 'error',
 
 		...rulesToReview,
 		...rulesToRemove,

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -1,5 +1,36 @@
 const transitionRules = require('./eslint-guardian');
 
+/** TODO: Review these */
+const rulesToReview = {
+	'import/no-extraneous-dependencies': 'warn', // 683 problems
+	'react/jsx-one-expression-per-line': 'warn', // 325 problems
+	'consistent-return': 'warn', // 51 problems
+	'default-case': 'warn', // 50 problems
+	'react/no-danger': 'warn', // 48 problems
+	'no-underscore-dangle': 'warn', // 45 problems
+	'react/no-array-index-key': 'warn', // 34 problems
+	'react/button-has-type': 'warn', // 23 problems
+	'@typescript-eslint/require-await': 'warn', // 22 problems
+	'react/jsx-curly-newline': 'warn', // 8 problems
+	'no-case-declarations': 'warn', // 7 problems
+	'no-useless-escape': 'warn', // 6 problems
+	'react/jsx-no-target-blank': 'warn', // 3 problems
+};
+
+const rulesToRemove = {
+	'@typescript-eslint/explicit-module-boundary-types': 'off',
+	'@typescript-eslint/no-unsafe-call': 'off',
+	'@typescript-eslint/no-unsafe-assignment': 'off',
+	'@typescript-eslint/no-unsafe-return': 'off',
+	'@typescript-eslint/ban-ts-comment': 'off',
+	'@typescript-eslint/restrict-template-expressions': 'off',
+	'no-console': 'off',
+	'no-shadow': 'off',
+
+	'@typescript-eslint/explicit-function-return-type': 'off',
+	'@typescript-eslint/no-inferrable-types': 'off',
+};
+
 module.exports = {
 	env: {
 		browser: true,
@@ -53,19 +84,6 @@ module.exports = {
 		'react/jsx-indent-props': [2, 'tab'],
 		'react/prop-types': [0],
 		'react/jsx-boolean-value': [2, 'always'],
-		'import/prefer-default-export': 'off',
-		// TODO: remove
-		'@typescript-eslint/explicit-module-boundary-types': 'off',
-		'@typescript-eslint/no-unsafe-call': 'off',
-		'@typescript-eslint/no-unsafe-assignment': 'off',
-		'@typescript-eslint/no-unsafe-return': 'off',
-		'@typescript-eslint/ban-ts-comment': 'off',
-		'@typescript-eslint/restrict-template-expressions': 'off',
-		'no-console': 'off',
-		'no-shadow': 'off',
-
-		'@typescript-eslint/explicit-function-return-type': [0],
-		'@typescript-eslint/no-inferrable-types': [0],
 
 		// Fixed as part of @guardian-eslint move May 2022
 		'array-callback-return': 'error',
@@ -73,24 +91,8 @@ module.exports = {
 		'no-empty-pattern': 'error',
 		'no-param-reassign': 'error',
 
-		// TODO, review these (1314 problems)
-		'import/no-extraneous-dependencies': 'warn', // 683 problems
-		'react/jsx-one-expression-per-line': 'warn', // 325 problems
-		'consistent-return': 'warn', // 51 problems
-		'default-case': 'warn', // 50 problems
-		'react/no-danger': 'warn', // 48 problems
-		'no-underscore-dangle': 'warn', // 45 problems
-		'react/no-array-index-key': 'warn', // 34 problems
-		'react/button-has-type': 'warn', // 23 problems
-		'@typescript-eslint/require-await': 'warn', // 22 problems
-		'react/jsx-curly-newline': 'warn', // 8 problems
-		'no-case-declarations': 'warn', // 7 problems
-		'no-useless-escape': 'warn', // 6 problems
-		'no-empty-pattern': 'warn', // 4 problems
-		'react/jsx-no-target-blank': 'warn', // 3 problems
-		'array-callback-return': 'warn', // 2 problems
-		'global-require': 'warn', // 2 problems
-		/** These rules will be disabled one-by-one */
+		...rulesToReview,
+		...rulesToRemove,
 		...transitionRules,
 	},
 	settings: {

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -3,7 +3,6 @@ const transitionRules = require('./eslint-guardian');
 /** TODO: Review these */
 const rulesToReview = {
 	'import/no-extraneous-dependencies': 'warn', // 683 problems
-	'react/jsx-one-expression-per-line': 'warn', // 325 problems
 	'consistent-return': 'warn', // 51 problems
 	'default-case': 'warn', // 50 problems
 	'react/no-danger': 'warn', // 48 problems
@@ -90,6 +89,7 @@ module.exports = {
 		'no-empty-pattern': 'error',
 		'no-param-reassign': 'error',
 		'react/jsx-no-target-blank': 'error',
+		'react/jsx-one-expression-per-line': 'off',
 
 		...rulesToReview,
 		...rulesToRemove,

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -67,6 +67,9 @@ module.exports = {
 		'@typescript-eslint/explicit-function-return-type': [0],
 		'@typescript-eslint/no-inferrable-types': [0],
 
+		// Fixed as part of @guardian-eslint move May 2022
+		'array-callback-return': 'error',
+		'global-require': 'error',
 		'no-param-reassign': 'error',
 
 		// TODO, review these (1314 problems)

--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -28,7 +28,7 @@ const windowGuardian = {
 	ophan: {
 		setEventEmitter: () => null,
 		trackComponentAttention: () => null,
-		record: ({}: { [key: string]: any }) => null,
+		record: () => null,
 		viewId: '',
 		pageViewId: '',
 	},

--- a/dotcom-rendering/src/amp/components/AdConsent.tsx
+++ b/dotcom-rendering/src/amp/components/AdConsent.tsx
@@ -56,7 +56,7 @@ const clientConfigAus = {
 	},
 };
 
-export const AdConsent: React.FC = ({}) => {
+export const AdConsent: React.FC = () => {
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code

--- a/dotcom-rendering/src/amp/components/Epic.tsx
+++ b/dotcom-rendering/src/amp/components/Epic.tsx
@@ -647,6 +647,7 @@ export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
 									<span data-amp-bind-text="epicState.reminder.reminderLabel" />
 									. To find out what personal data we collect
 									and how we use it, view our{' '}
+									{/* eslint-disable-next-line react/jsx-no-target-blank -- we’re linking to Guardian */}
 									<a
 										target="_blank"
 										href="https://www.theguardian.com/help/privacy-policy"
@@ -667,6 +668,7 @@ export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
 								please{' '}
 								<a
 									target="_blank"
+									rel="noreferrer"
 									href="mailto:contribution.support@theguardian.com"
 								>
 									contact us

--- a/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
@@ -2,6 +2,6 @@ import type React from 'react';
 
 export const ContentAtomBlockComponent: React.FC<{
 	element: ContentAtomBlockElement;
-}> = ({}) => {
+}> = () => {
 	return null;
 };

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -8,7 +8,9 @@ let legacyManifest: AssetHash = {};
 try {
 	// path is relative to the server bundle
 
+	// eslint-disable-next-line global-require -- this may fail
 	manifest = require('./manifest.json');
+	// eslint-disable-next-line global-require -- this may fail
 	legacyManifest = require('./manifest.legacy.json');
 } catch (e) {
 	// do nothing

--- a/dotcom-rendering/src/model/enhance-dots.ts
+++ b/dotcom-rendering/src/model/enhance-dots.ts
@@ -3,7 +3,7 @@ import { transformDots } from './transformDots';
 const checkForDots = (elements: CAPIElement[]): CAPIElement[] => {
 	// Loop over elements and check if a dot is in the TextBlockElement
 	const enhanced: CAPIElement[] = [];
-	elements.map((element, i) => {
+	elements.forEach((element, i) => {
 		if (
 			element._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -619,7 +619,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 						} = trail;
 						// Don't try to render cards that have no publication date. This property is technically optional
 						// but we rarely if ever expect it not to exist
-						if (!webPublicationDate) return;
+						if (!webPublicationDate) return null;
 						return (
 							<CarouselCard
 								key={`${trail.url}${i}`}

--- a/dotcom-rendering/src/web/components/HeadlinesContainer.tsx
+++ b/dotcom-rendering/src/web/components/HeadlinesContainer.tsx
@@ -1,6 +1,0 @@
-type Props = { [key: string]: any };
-
-export const HeadlinesContainer: React.FC<Props> = ({}: Props) => {
-	// need funky layout
-	return null;
-};

--- a/dotcom-rendering/src/web/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/web/components/ShareIcons.tsx
@@ -245,6 +245,7 @@ export const ShareIcons = ({
 						role="button"
 						aria-label="Share via Email"
 						target="_blank"
+						rel="noreferrer"
 						data-ignore="global-link-styling"
 					>
 						<span

--- a/dotcom-rendering/src/web/lib/isLight.ts
+++ b/dotcom-rendering/src/web/lib/isLight.ts
@@ -6,11 +6,11 @@ function hexToRgb(hex: string): {
 } | null {
 	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 	const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-	hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+	const fullHex = hex.replace(shorthandRegex, (m, r, g, b) => {
 		return `${r}${r}${g}${g}${b}${b}`;
 	});
 
-	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(fullHex);
 	return result
 		? {
 				r: parseInt(result[1], 16),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- chore(eslint): remove unreported rules
- chore(eslint): fix no-param-reassign
- chore(eslint): correctly map over type
- chore(eslint): enfore no global require
- chore(eslint): enfore no-empty-pattern
- refactor(eslint): reorganise rules in eslint config
- fix(eslint): enforce react/jsx-no-target-blank
- chore(eslint): fix odd error
- chore(eslint): turn one-expression-per-line off

## Why?

End-of-spring cleanup. Part of #4935 