### PR TITLE
Remove `SlotBodyEnd` from blogs

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -18,20 +18,11 @@ import {
 	Lines,
 	StraightLines,
 } from '@guardian/source-react-components-development-kitchen';
-import { KeyEventsContainer } from '../components/KeyEventsContainer';
 import { buildAdTargeting } from '../../lib/ad-targeting';
-import { parse } from '../../lib/slot-machine-flags';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
-import { Liveness } from '../components/Liveness.importable';
-import { GetMatchStats } from '../components/GetMatchStats.importable';
-import { GetCricketScoreboard } from '../components/GetCricketScoreboard.importable';
-import { OnwardsLower } from '../components/OnwardsLower.importable';
-import { OnwardsUpper } from '../components/OnwardsUpper.importable';
-import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { ArticleLastUpdated } from '../components/ArticleLastUpdated';
 import { ArticleMeta } from '../components/ArticleMeta';
 import { ArticleTitle } from '../components/ArticleTitle';
@@ -40,15 +31,22 @@ import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { FilterKeyEventsToggle } from '../components/FilterKeyEventsToggle.importable';
 import { Footer } from '../components/Footer';
+import { GetCricketScoreboard } from '../components/GetCricketScoreboard.importable';
+import { GetMatchNav } from '../components/GetMatchNav.importable';
+import { GetMatchStats } from '../components/GetMatchStats.importable';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
 import { GridItem } from '../components/GridItem';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
+import { KeyEventsContainer } from '../components/KeyEventsContainer';
+import { Liveness } from '../components/Liveness.importable';
 import { MainMedia } from '../components/MainMedia';
+import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { Nav } from '../components/Nav/Nav';
+import { OnwardsLower } from '../components/OnwardsLower.importable';
+import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { RightColumn } from '../components/RightColumn';
-import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { Standfirst } from '../components/Standfirst';
 import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
@@ -267,10 +265,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		sharedAdTargeting: CAPIArticle.config.sharedAdTargeting,
 		adUnit: CAPIArticle.config.adUnit,
 	});
-
-	const showBodyEndSlot =
-		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
-		CAPIArticle.config.switches.slotBodyEnd;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -901,52 +895,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													older={pagination.older}
 													format={format}
 												/>
-											)}
-											{showBodyEndSlot && (
-												<Island clientOnly={true}>
-													<SlotBodyEnd
-														contentType={
-															CAPIArticle.contentType
-														}
-														contributionsServiceUrl={
-															contributionsServiceUrl
-														}
-														idApiUrl={
-															CAPIArticle.config
-																.idApiUrl
-														}
-														isMinuteArticle={
-															CAPIArticle.pageType
-																.isMinuteArticle
-														}
-														isPaidContent={
-															CAPIArticle.pageType
-																.isPaidContent
-														}
-														keywordsId={
-															CAPIArticle.config
-																.keywordIds
-														}
-														pageId={
-															CAPIArticle.pageId
-														}
-														sectionId={
-															CAPIArticle.config
-																.section
-														}
-														sectionName={
-															CAPIArticle.sectionName
-														}
-														shouldHideReaderRevenue={
-															CAPIArticle.shouldHideReaderRevenue
-														}
-														stage={
-															CAPIArticle.config
-																.stage
-														}
-														tags={CAPIArticle.tags}
-													/>
-												</Island>
 											)}
 											<StraightLines
 												data-print-layout="hide"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the `SlotBodyEnd` component from live blogs

## Why?
As per a message from @tjmw , we don't want to show it there