### PR TITLE
Implement `inline1ContainerSizing` variant - `inline1` takes full width

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -48,7 +48,7 @@ const articleWrapper = css`
 	z-index: 1;
 `;
 
-const adSharedCSS = css`
+const adStyles = css`
 	.ad-slot {
 		@media print {
 			/* stylelint-disable-next-line declaration-no-important */
@@ -118,48 +118,6 @@ const adSharedCSS = css`
 			margin-right: -398px;
 		}
 	}
-`;
-
-const adControlCSS = css`
-	.ad-slot--inline,
-	.ad-slot-liveblog--inline {
-		width: 300px;
-		margin: 12px auto;
-		min-width: 160px;
-		min-height: 274px;
-		text-align: center;
-
-		${from.tablet} {
-			margin-right: -100px;
-			width: auto;
-			float: right;
-			margin-top: 4px;
-			margin-left: 20px;
-		}
-		${from.desktop} {
-			width: auto;
-			float: right;
-			margin: 0;
-			margin-top: 4px;
-			margin-left: 20px;
-		}
-		&.ad-slot--fluid {
-			width: 100%;
-		}
-	}
-	.ad-slot--outstream {
-		${from.tablet} {
-			margin-left: 0;
-			width: 100%;
-			.ad-slot__label {
-				margin-left: 35px;
-				margin-right: 35px;
-			}
-		}
-	}
-`;
-
-const adVariantCSS = css`
 	.ad-slot--inline1 {
 		margin: 12px auto;
 		text-align: center;
@@ -204,16 +162,13 @@ const adVariantCSS = css`
 	}
 `;
 
-export const ArticleContainer = ({ children, format, abTests }: Props) => {
-	const isInline1ContainerSizingVariant =
-		abTests?.inline1ContainerSizingVariant === 'variant';
+export const ArticleContainer = ({ children, format }: Props) => {
 	return (
 		<div
 			css={[
 				articleWrapper,
 				articleWidth(format),
-				adSharedCSS,
-				isInline1ContainerSizingVariant ? adVariantCSS : adControlCSS,
+				adStyles,
 				carrotAdStyles,
 				labelStyles,
 			]}

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -39,8 +39,6 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 
 		const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 			/* keep array multi-line */
-			'inline1ContainerSizingVariant',
-			'inline1ContainerSizingControl',
 		];
 
 		const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -30,8 +30,6 @@ export const CoreVitals = () => {
 
 	const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 		/* linter, please keep this array multi-line */
-		'inline1ContainerSizingVariant',
-		'inline1ContainerSizingControl',
 	];
 
 	const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -555,10 +555,7 @@ export const CommentLayout = ({
 							</div>
 						</GridItem>
 						<GridItem area="body">
-							<ArticleContainer
-								format={format}
-								abTests={CAPIArticle.config.abTests}
-							>
+							<ArticleContainer format={format}>
 								<div css={maxWidth}>
 									<ArticleBody
 										format={format}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -393,10 +393,7 @@ export const ImmersiveLayout = ({
 							</div>
 						</GridItem>
 						<GridItem area="body">
-							<ArticleContainer
-								format={format}
-								abTests={CAPIArticle.config.abTests}
-							>
+							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
 									blocks={CAPIArticle.blocks}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -518,10 +518,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								</div>
 							</GridItem>
 							<GridItem area="body" element="article">
-								<ArticleContainer
-									format={format}
-									abTests={CAPIArticle.config.abTests}
-								>
+								<ArticleContainer format={format}>
 									<ArticleBody
 										format={format}
 										blocks={CAPIArticle.blocks}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -812,10 +812,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										) : (
 											<></>
 										)}
-										<ArticleContainer
-											format={format}
-											abTests={CAPIArticle.config.abTests}
-										>
+										<ArticleContainer format={format}>
 											{pagination.currentPage !== 1 && (
 												<Pagination
 													currentPage={

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -526,10 +526,7 @@ export const ShowcaseLayout = ({
 							</div>
 						</GridItem>
 						<GridItem area="body">
-							<ArticleContainer
-								format={format}
-								abTests={CAPIArticle.config.abTests}
-							>
+							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
 									blocks={CAPIArticle.blocks}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -641,10 +641,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</div>
 						</GridItem>
 						<GridItem area="body">
-							<ArticleContainer
-								format={format}
-								abTests={CAPIArticle.config.abTests}
-							>
+							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}
 									blocks={CAPIArticle.blocks}


### PR DESCRIPTION
## What does this change?

Following the completion of the `inline1ContainerSizing` test introduced in https://github.com/guardian/dotcom-rendering/pull/4506, the variant indicates it:

- improves CLS on desktop,  with a range of ~2% - 3% across regions
- increases revenue on desktop, with a range of ~1% - 7% across regions 
- worsens CLS on mobile,  with a range of ~ -2% - -5% across regions

The result for mobile is surprising as in theory it should be the same. We are investigating and will follow up.

`inline1` shifting around on desktop causing the text to reflow is a long standing source of complaints from users and editorial, so on balance we decided to go ahead with the variant.

## Why?

To improve the reading experience for our users and reduce CLS.

## Before

Passback flow - x3 layout shifts:

https://user-images.githubusercontent.com/7014230/162030374-9dcc1f32-bbb5-4918-a280-4590b1d95571.mp4

Teads flow - x2 layout shifts:

https://user-images.githubusercontent.com/7014230/162030531-0b1c7210-2fae-403b-8687-9c10dde489b5.mp4

## After

Passback flow - x2 layout shifts:

https://user-images.githubusercontent.com/7014230/162030708-e7f99e19-77de-4673-b0dd-3834c57e5e0d.mp4

Teads flow - x1 layout shift:

https://user-images.githubusercontent.com/7014230/162030855-2b5750e3-7d3f-449f-a1e0-b3dd47cd6af4.mp4


