### PR TITLE
Fix the decision logic for which format we use for presenting sublinks

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -29,12 +29,12 @@ const decidePresentationFormat = ({
 	// These types of article styles have background styles that sublinks
 	// need to respect so we use the container format here
 	if (
-		linkFormat.design === ArticleDesign.LiveBlog ||
-		linkFormat.design === ArticleDesign.Gallery ||
-		linkFormat.design === ArticleDesign.Audio ||
-		linkFormat.design === ArticleDesign.Video ||
-		linkFormat.theme === ArticleSpecial.SpecialReport ||
-		linkFormat.design === ArticleDesign.Analysis
+		containerFormat.design === ArticleDesign.LiveBlog ||
+		containerFormat.design === ArticleDesign.Gallery ||
+		containerFormat.design === ArticleDesign.Audio ||
+		containerFormat.design === ArticleDesign.Video ||
+		containerFormat.theme === ArticleSpecial.SpecialReport ||
+		containerFormat.design === ArticleDesign.Analysis
 	)
 		return containerFormat;
 	// Otherwise, we can allow the sublink to express its own styling


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes #4944 by correcting a bug where when checking the format of the container to decide how to display the sub link, we were actually reading the sublink format instead.

## Why?
So that when a card has a strong background colour we display sublinks better


| Before      | After      |
|-------------|------------|
| <img width="711" alt="Screenshot 2022-05-20 at 15 43 57" src="https://user-images.githubusercontent.com/1336821/169553005-94c78ad1-bbd6-4087-8b78-2c0394993e9c.png"> | <img width="711" alt="Screenshot 2022-05-20 at 15 43 24" src="https://user-images.githubusercontent.com/1336821/169552940-68546a39-40de-4c38-873c-7e13b69ddb23.png"> |
