### PR TITLE
ESLint warn on rules to review

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -16,17 +16,15 @@ const rulesToReview = {
 };
 
 const rulesToRemove = {
-	'@typescript-eslint/explicit-module-boundary-types': 'off',
-	'@typescript-eslint/no-unsafe-call': 'off',
-	'@typescript-eslint/no-unsafe-assignment': 'off',
-	'@typescript-eslint/no-unsafe-return': 'off',
-	'@typescript-eslint/ban-ts-comment': 'off',
-	'@typescript-eslint/restrict-template-expressions': 'off',
-	'no-console': 'off',
-	'no-shadow': 'off',
+	'@typescript-eslint/explicit-module-boundary-types': 'warn',
+	'@typescript-eslint/no-unsafe-call': 'warn',
+	'@typescript-eslint/no-unsafe-assignment': 'warn',
+	'@typescript-eslint/no-unsafe-return': 'warn',
+	'@typescript-eslint/ban-ts-comment': 'warn',
+	'@typescript-eslint/restrict-template-expressions': 'warn',
 
-	'@typescript-eslint/explicit-function-return-type': 'off',
-	'@typescript-eslint/no-inferrable-types': 'off',
+	'no-console': 'warn',
+	'no-shadow': 'warn',
 };
 
 module.exports = {

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -37,9 +37,7 @@ function buildSectionUrl(ajaxUrl: string, sectionName?: string) {
 	const sectionsWithoutPopular = ['info', 'global'];
 	const hasSection =
 		sectionName && !sectionsWithoutPopular.includes(sectionName);
-	const endpoint: string = `/most-read${
-		hasSection ? `/${sectionName}` : ''
-	}.json`;
+	const endpoint = `/most-read${hasSection ? `/${sectionName}` : ''}.json`;
 	return joinUrl([ajaxUrl, `${endpoint}?dcr=true`]);
 }
 

--- a/dotcom-rendering/src/web/components/MostViewedRight.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.tsx
@@ -33,7 +33,7 @@ export const MostViewedRight = ({
 	isAdFreeUser,
 	adBlockerDetected,
 }: Props) => {
-	const endpointUrl: string =
+	const endpointUrl =
 		'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true';
 	const { data, error } = useApi<CAPITrailTabType>(endpointUrl);
 

--- a/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
@@ -48,9 +48,7 @@ export const submitClickEventTracking = (
 		action: 'CLICK',
 	});
 
-export const withComponentId: (id: string) => OphanComponent = (
-	id: string = '',
-) => ({
+export const withComponentId: (id: string) => OphanComponent = (id = '') => ({
 	componentType: 'SIGN_IN_GATE',
 	id,
 });

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -8,7 +8,7 @@ import { hasUserDismissedGateMoreThanCount } from './dismissGate';
 import type { CanShowGateProps } from './types';
 
 // in our case if this is the n-numbered article or higher the user has viewed then set the gate
-export const isNPageOrHigherPageView = (n: number = 2): boolean => {
+export const isNPageOrHigherPageView = (n = 2): boolean => {
 	// get daily read article count array from local storage
 	const [dailyCount = {} as DailyArticle] = getDailyArticleCount() || [];
 

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -137,9 +137,7 @@ export const isRecentOneOffContributor = () => {
 	return false;
 };
 
-export const shouldHideSupportMessaging = (
-	isSignedIn: boolean = false,
-): boolean =>
+export const shouldHideSupportMessaging = (isSignedIn = false): boolean =>
 	!shouldShowSupportMessaging() ||
 	isRecurringContributor(isSignedIn) ||
 	isRecentOneOffContributor();

--- a/dotcom-rendering/src/web/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/web/lib/readerRevenueDevUtils.ts
@@ -89,7 +89,7 @@ const clearCommonReaderRevenueStateAndReload = (
 };
 
 const showMeTheEpic = (
-	asExistingSupporter: boolean = false,
+	asExistingSupporter = false,
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	clearCommonReaderRevenueStateAndReload(
@@ -99,7 +99,7 @@ const showMeTheEpic = (
 };
 
 const showMeTheBanner = (
-	asExistingSupporter: boolean = false,
+	asExistingSupporter = false,
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	clearBannerLastClosedAt();
@@ -111,7 +111,7 @@ const showMeTheBanner = (
 };
 
 const showNextVariant = (
-	asExistingSupporter: boolean = false,
+	asExistingSupporter = false,
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	incrementMvtCookie();
@@ -122,7 +122,7 @@ const showNextVariant = (
 };
 
 const showPreviousVariant = (
-	asExistingSupporter: boolean = false,
+	asExistingSupporter = false,
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	decrementMvtCookie();
@@ -133,7 +133,7 @@ const showPreviousVariant = (
 };
 
 const changeGeolocation = (
-	asExistingSupporter: boolean = false,
+	asExistingSupporter = false,
 	shouldHideReaderRevenue: boolean,
 ): void => {
 	getLocaleCode()


### PR DESCRIPTION
## What does this change?

Add warnings for the following rules, which we plan to remove or enforce:
- no-console
- no-shadow
- typescript-eslint/explicit-module-boundary-types
- typescript-eslint/no-unsafe-call
- typescript-eslint/no-unsafe-assignment
- typescript-eslint/no-unsafe-return
- typescript-eslint/ban-ts-comment
- typescript-eslint/restrict-template-expressions

## Why?

We need to start getting visibility.

## ESLint status

- 2548 problems (0 errors, 2548 warnings)
- 0 errors and 56 warnings potentially fixable with the `--fix` option.