### PR TITLE
ESLint: remove DCR import package rules

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -58,26 +58,6 @@ module.exports = {
 		'jsx-a11y',
 	],
 	rules: {
-		'dcr/only-import-below': [
-			'warn',
-			{
-				allowedImports: [
-					'react',
-					'@emotion/react',
-					'jsdom',
-					'curlyquotes',
-					'react-dom',
-					'./src/lib',
-					'./src/amp/lib',
-					'./src/amp/types',
-					'./src/static/icons',
-					'./src/model',
-					'./src/web',
-					'@testing-library',
-					'@guardian/frontend/static/',
-				],
-			},
-		],
 		'react/jsx-indent': [2, 'tab'],
 		'react/jsx-indent-props': [2, 'tab'],
 		'react/prop-types': [0],


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove `dcr/only-import-below`.

## Why?

This package is not maintained and there’s no clear value gained from having it.

Part of #4935