### PR TITLE
RiffRaff `allowedStages`

### DIFF
--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [mobile, mobile-preview]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 templates:
   cloudformation:
     type: cloud-formation

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -1,5 +1,8 @@
 stacks: [frontend]
 regions: [eu-west-1]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   frontend-cfn:
     type: cloud-formation


### PR DESCRIPTION
## Why?

Simplifies the RiffRaff UI when deploying, no invalid stages appear in the dropdown list.

I've limited both AR and DCR to `CODE` and `PROD`. I don't think either project has any other stages that RiffRaff can deploy to?

## Changes

- Added RiffRaff `allowedStages` for AR
- Added RiffRaff `allowedStages` for DCR
