### PR TITLE
AMP cookie sync for Relevant Yield

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -1,4 +1,5 @@
 import { adJson, stringify } from '../lib/ad-json';
+import { isInVariant } from '../lib/prebid-server-test';
 import type { RTCParameters } from '../lib/real-time-config';
 import { realTimeConfig } from '../lib/real-time-config';
 import { useContentABTestGroup } from './ContentABTest';
@@ -44,19 +45,6 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 
 	return adTargetingMapped;
 };
-
-// Variants for the Prebid server test
-// Assign each variant 4 groups e.g. 33.3% of content types each
-const variants = {
-	'relevant-yield': new Set([0, 1, 4, 5, 6, 7]),
-	pubmatic: new Set([2, 3, 8, 9, 10, 11]),
-};
-
-// Determine participation in a variant from group
-const isInVariant = (
-	variantName: 'relevant-yield' | 'pubmatic',
-	group: number | undefined,
-) => group !== undefined && variants[variantName].has(group);
 
 const useRealTimeConfig = (
 	usePrebid: boolean,

--- a/dotcom-rendering/src/amp/components/CookieSync.tsx
+++ b/dotcom-rendering/src/amp/components/CookieSync.tsx
@@ -1,0 +1,46 @@
+import { ClassNames } from '@emotion/react';
+import { isInVariant } from '../lib/prebid-server-test';
+import { useContentABTestGroup } from './ContentABTest';
+
+/**
+ * TODO ...
+ */
+export const CookieSync = () => {
+	const { group } = useContentABTestGroup();
+
+	// Currently we only perform cookie-sync for Relevant Yield
+	if (isInVariant('relevant-yield', group)) {
+		return (
+			<ClassNames>
+				{({ css }) => {
+					// Hide the iframe above the viewport
+					const cookieSyncIframeStyle = css`
+						position: fixed;
+						top: -1px;
+					`;
+
+					return (
+						<amp-iframe
+							class={cookieSyncIframeStyle}
+							data-block-on-consent=""
+							width="1"
+							title="User Sync"
+							height="1"
+							sandbox="allow-scripts allow-same-origin"
+							frameborder="0"
+							src="https://guardian-cdn.relevant-digital.com/static/tags/6214c1072d89bdff800f25f2_cookiesync.html?endpoint=relevant&max_sync_count=5"
+						>
+							<amp-img
+								layout="fill"
+								src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+								placeholder="true"
+							></amp-img>
+						</amp-iframe>
+					);
+				}}
+			</ClassNames>
+		);
+	}
+
+	return null;
+};

--- a/dotcom-rendering/src/amp/lib/prebid-server-test.ts
+++ b/dotcom-rendering/src/amp/lib/prebid-server-test.ts
@@ -1,0 +1,12 @@
+// Variants for the Prebid server test
+// Assign each variant 6 groups e.g. 50% of content types each
+const variants = {
+	'relevant-yield': new Set([0, 1, 4, 5, 6, 7]),
+	pubmatic: new Set([2, 3, 8, 9, 10, 11]),
+};
+
+// Determine participation in a variant from group
+export const isInVariant = (
+	variantName: 'relevant-yield' | 'pubmatic',
+	group: number | undefined,
+) => group !== undefined && variants[variantName].has(group);

--- a/dotcom-rendering/src/amp/pages/Article.tsx
+++ b/dotcom-rendering/src/amp/pages/Article.tsx
@@ -13,6 +13,7 @@ import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Onward } from '../components/Onward';
 import { Sidebar } from '../components/Sidebar';
+import { CookieSync } from '../components/CookieSync';
 import { filterForTagsOfType } from '../lib/tag-utils';
 import type { AmpExperiments } from '../server/ampExperimentCache';
 import type { ArticleModel } from '../types/ArticleModel';
@@ -56,6 +57,7 @@ export const Article: React.FC<{
 			<Analytics key="analytics" analytics={analytics} />
 			<AnalyticsIframe url={config.ampIframeUrl} />
 			<AdConsent />
+			<CookieSync />
 			{experimentsData && (
 				<AmpExperimentComponent experimentsData={experimentsData} />
 			)}


### PR DESCRIPTION
## What does this change?

> TODO

## Why?

> TODO

<!--

We use the international cookie sync URL regardless of region as this syncs with all bidders.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
