### PR TITLE
Change opinion byline color to opinion[300]

### DIFF
--- a/apps-rendering/src/components/Byline/CommentByline.tsx
+++ b/apps-rendering/src/components/Byline/CommentByline.tsx
@@ -5,24 +5,21 @@ import type { ArticleFormat } from '@guardian/libs';
 import { headline } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { darkModeCss } from 'styles';
-import { getThemeStyles } from 'themeStyles';
+
 import { DefaultByline } from './Byline.defaults';
 
-const commentStyles = (kicker: string): SerializedStyles => css`
-	color: ${kicker};
+const commentStyles = (format: ArticleFormat): SerializedStyles => css`
+	color: ${text.bylineLeftColumn(format)};
 	width: 75%;
 	${headline.medium({ fontWeight: 'light', fontStyle: 'italic' })}
 `;
 
-const commentAnchorStyles = (
-	kicker: string,
-	inverted: string,
-): SerializedStyles => css`
-	color: ${kicker};
+const commentAnchorStyles = (format: ArticleFormat): SerializedStyles => css`
+	color: ${text.bylineLeftColumn(format)};
 	text-decoration: none;
 
 	${darkModeCss`
-        color: ${inverted};
+        color: ${text.bylineDark(format)};
     `}
 `;
 
@@ -31,17 +28,13 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const CommentByline: React.FC<Props> = ({ format, bylineHtml }) => {
-	const { kicker, inverted } = getThemeStyles(format.theme);
-
-	return (
-		<DefaultByline
-			format={format}
-			bylineHtml={bylineHtml}
-			styles={commentStyles(text.bylineLeftColumn(format))}
-			anchorStyles={commentAnchorStyles(kicker, inverted)}
-		/>
-	);
-};
+const CommentByline: React.FC<Props> = ({ format, bylineHtml }) => (
+	<DefaultByline
+		format={format}
+		bylineHtml={bylineHtml}
+		styles={commentStyles(format)}
+		anchorStyles={commentAnchorStyles(format)}
+	/>
+);
 
 export default CommentByline;

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -179,7 +179,7 @@ const bylineLeftColumn = (format: ArticleFormat): Colour => {
 				case ArticlePillar.Culture:
 					return culture[400];
 				case ArticlePillar.Opinion:
-					return opinion[400];
+					return opinion[300];
 				case ArticleSpecial.Labs:
 					return labs[400];
 				case ArticleSpecial.SpecialReport:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the byline colour to opinion[400] to opinion[300] on comment articles

## Why?
To match DCR




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
