### PR TITLE
Hide dateline arrow

### DIFF
--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -20,7 +20,7 @@ const primaryStyles = css`
 		text-decoration: underline;
 	}
 	&::-webkit-details-marker {
-		display:none;
+		display: none;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -19,6 +19,9 @@ const primaryStyles = css`
 	:hover {
 		text-decoration: underline;
 	}
+	&::-webkit-details-marker {
+		display:none;
+	}
 `;
 
 // for liveblog smaller breakpoints article meta is located in the same


### PR DESCRIPTION
<details>
Hides the marker on Safari

## Why?
We don't need it

## Screenshots

Before
![Screenshot 2022-05-25 at 11 24 32](https://user-images.githubusercontent.com/20658471/170241829-563bd9f0-45d4-4c2f-89ef-3658e7ad34da.png)

After
![Screenshot 2022-05-25 at 11 24 42](https://user-images.githubusercontent.com/20658471/170241835-bc81b112-8403-4e8e-8404-d3c02f0c2bbd.png)

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
