### PR TITLE
fix: Disable broken Cypress test for Sport liveblogs

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-5/liveblog.interactivity.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-5/liveblog.interactivity.spec.js
@@ -209,45 +209,47 @@ describe('Liveblogs', function () {
 		});
 	});
 
-	it('should render live score updates to a cricketblog', function () {
-		// Get article with ?live to force the article to be 'live'
-		cy.visit(
-			'/Article?url=https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live',
-		);
+	// For some reason Sport deadblogs lose their scores after a certain duration. Not quite sure what causes this just yet
+	// but disabling this test until the issue with Sports blogs is fixed.
+	// it('should render live score updates to a cricketblog', function () {
+	// 	// Get article with ?live to force the article to be 'live'
+	// 	cy.visit(
+	// 		'/Article?url=https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live',
+	// 	);
 
-		// Initial request for the cricket data
-		cy.intercept(
-			{
-				url: /england-cricket-team\.json/,
-			},
-			{
-				statusCode: 200,
-				body: {
-					scorecardUrl: '/test',
-					match: match1,
-				},
-			},
-		);
+	// 	// Initial request for the cricket data
+	// 	cy.intercept(
+	// 		{
+	// 			url: /england-cricket-team\.json/,
+	// 		},
+	// 		{
+	// 			statusCode: 200,
+	// 			body: {
+	// 				scorecardUrl: '/test',
+	// 				match: match1,
+	// 			},
+	// 		},
+	// 	);
 
-		cy.contains('297 & 28 - 0 (4.5 overs)');
-		cy.contains('204 & 120 all out (64.2 overs)');
+	// 	cy.contains('297 & 28 - 0 (4.5 overs)');
+	// 	cy.contains('204 & 120 all out (64.2 overs)');
 
-		// We should always see a second request if it's 'live updating'
-		cy.intercept(
-			{
-				url: /england-cricket-team\.json/,
-			},
-			{
-				statusCode: 200,
-				body: {
-					scorecardUrl: '/test',
-					match: match2,
-				},
-			},
-		);
+	// 	// We should always see a second request if it's 'live updating'
+	// 	cy.intercept(
+	// 		{
+	// 			url: /england-cricket-team\.json/,
+	// 		},
+	// 		{
+	// 			statusCode: 200,
+	// 			body: {
+	// 				scorecardUrl: '/test',
+	// 				match: match2,
+	// 			},
+	// 		},
+	// 	);
 
-		// The cricket data is updated every 14 seconds, so we need a longer timeout here
-		// Wait for the 'updated' cricket score to appear on the page correctly!
-		cy.contains('297 & 104 - 3 (25 overs)', { timeout: 20000 });
-	});
+	// 	// The cricket data is updated every 14 seconds, so we need a longer timeout here
+	// 	// Wait for the 'updated' cricket score to appear on the page correctly!
+	// 	cy.contains('297 & 104 - 3 (25 overs)', { timeout: 20000 });
+	// });
 });


### PR DESCRIPTION
## What does this change?

Disable the Cypress test that checks if a score is updating in a liveblog.

## Why?

We've had this issue for a while now where deadblogs sometimes lose their score component after a certain period of time. I could replace the Deadblog that this test uses with a more recent one but thats just going to break again at some point.

Propose we re-enable this test once the bug with Deadblogs is fixed.