### PR TITLE
Fix PinnedPost content height check

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -91,6 +91,8 @@ export const EnhancePinnedPost = () => {
 	useEffect(() => {
 		if (!pinnedPost) return;
 
+		checkContentHeight();
+
 		const observer = new MutationObserver(checkContentHeight);
 		const config = { childList: true };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a `checkContentHeight` call before the `MutationObserver` is created to ensure the Show More button is rendered correctly. 

## Why?

Currently `checkContentHeight` is only called by the `MutationObserver` - this means that if no DOM mutation occurs, `checkContentHeight` isn't called.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/77005274/170302409-08cc7055-2b8e-47a4-bfaa-4bae7b5d7c8d.png
[after]: https://user-images.githubusercontent.com/77005274/170302512-774e3252-d171-4c11-9b54-38000868dd4f.png

