### PR TITLE
Increase Comment headline padding

### DIFF
--- a/apps-rendering/src/components/Headline/CommentHeadline.tsx
+++ b/apps-rendering/src/components/Headline/CommentHeadline.tsx
@@ -5,6 +5,7 @@ import { DefaultHeadline, defaultStyles } from './Headline.defaults';
 
 const commentStyles = css`
 	${headline.small({ fontWeight: 'light' })}
+	padding-top: ${remSpace[1]};
 	padding-bottom: ${remSpace[1]};
 
 	${from.tablet} {


### PR DESCRIPTION
## What does this change?
Adds `top-padding` to the comment headline.

## Why?
So that it doesn't look too close to the edge of the screen.
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/170517683-44c0f598-c9cc-4eb1-b295-d999e8a3afb6.png
[after]: https://user-images.githubusercontent.com/57295823/170517746-ee793268-54cf-4df8-b413-543a950290aa.png
