### PR TITLE
set colour for tabs so it doesn't use browser default

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
@@ -58,6 +58,7 @@ const unselectedStyles = css`
 
 const tabButton = css`
 	${headline.xxxsmall()};
+	color: ${neutral[7]};
 	margin: 0;
 	border: 0;
 	background: transparent;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Sets the colour for most popular tabs
## Why?
On iOS Safari they currently appear blue: https://github.com/guardian/dotcom-rendering/issues/3818