### PR TITLE
Handle multiple container palettes

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -112,35 +112,19 @@ const enhanceCards = (
 		});
 
 const decideContainerPalette = (
-	metadata?: { type: FEContainerPalette }[],
+	palettes?: FEContainerPalette[],
 ): DCRContainerPalette | undefined => {
-	switch (metadata?.[0]?.type) {
-		case 'EventPalette':
-			return 'EventPalette';
-		case 'SombreAltPalette':
-			return 'SombreAltPalette';
-		case 'EventAltPalette':
-			return 'EventAltPalette';
-		case 'InvestigationPalette':
-			return 'InvestigationPalette';
-		case 'LongRunningAltPalette':
-			return 'LongRunningAltPalette';
-		case 'LongRunningPalette':
-			return 'LongRunningPalette';
-		case 'SombrePalette':
-			return 'SombrePalette';
-		case 'BreakingPalette':
-			return 'BreakingPalette';
-		case 'Canonical':
-		case 'Dynamo':
-		case 'Special':
-		case 'DynamoLike':
-		case 'Breaking':
-		case 'Podcast':
-		case 'Branded':
-		default:
-			return undefined;
-	}
+	if (palettes?.includes('EventPalette')) return 'EventPalette';
+	if (palettes?.includes('SombreAltPalette')) return 'SombreAltPalette';
+	if (palettes?.includes('EventAltPalette')) return 'EventAltPalette';
+	if (palettes?.includes('InvestigationPalette'))
+		return 'InvestigationPalette';
+	if (palettes?.includes('LongRunningAltPalette'))
+		return 'LongRunningAltPalette';
+	if (palettes?.includes('LongRunningPalette')) return 'LongRunningPalette';
+	if (palettes?.includes('SombrePalette')) return 'SombrePalette';
+	if (palettes?.includes('BreakingPalette')) return 'BreakingPalette';
+	return undefined;
 };
 
 export const enhanceCollections = (
@@ -149,7 +133,7 @@ export const enhanceCollections = (
 	return collections.map((collection) => {
 		const { id, displayName, collectionType } = collection;
 		const containerPalette = decideContainerPalette(
-			collection.config.metadata,
+			collection.config.metadata?.map((meta) => meta.type),
 		);
 		return {
 			id,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This refactors how we decide which container palette to use to use `includes` rather than picking the first.

## Why?
Sometimes a container will have more than one palette and the order of this array cannot be guaranteed. So rather than picking the first item we now look to see if a particular palette exists anywhere and if it does we use it.


| Before      | After      |
|-------------|------------|
| <img width="1340" alt="Screenshot 2022-05-27 at 08 52 48" src="https://user-images.githubusercontent.com/1336821/170655829-53de474d-703c-49b3-a2e7-3ab4772d2a48.png"> | <img width="1340" alt="Screenshot 2022-05-27 at 08 50 17" src="https://user-images.githubusercontent.com/1336821/170655869-c811307e-9770-424c-94c9-920f6423308d.png"> |
