### PR TITLE
Bold headline with container palettes

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -203,6 +203,10 @@ export const CardHeadline = ({
 							palette.background.analysisUnderline,
 						),
 					showLine && lineStyles(palette),
+					containerPalette &&
+						css`
+							font-weight: bold;
+						`,
 				]}
 			>
 				<WithLink linkTo={linkTo}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This makes the headline bold when a `containerPalette` tag is applied

## Why?
Parity

| Before      | After      |
|-------------|------------|
| <img width="1346" alt="Screenshot 2022-05-27 at 09 10 18" src="https://user-images.githubusercontent.com/1336821/170659107-5e300d81-b006-4324-b347-2e9d2090a1a9.png"> | <img width="1346" alt="Screenshot 2022-05-27 at 09 07 33" src="https://user-images.githubusercontent.com/1336821/170659081-51a25191-1094-4cad-8076-9e31325cb7b5.png"> |
