### PR TITLE
Less trail text

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -114,7 +114,11 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 										showAge={showAge}
 										linkTo={card.url}
 										format={card.format}
-										trailText={card.trailText}
+										trailText={
+											card.supportingContent
+												? undefined
+												: card.trailText
+										}
 										headlineText={card.headline}
 										headlineSize="medium"
 										byline={card.byline}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -31,7 +31,6 @@ export const FixedSmallSlowIV = ({
 							linkTo={trail.url}
 							format={trail.format}
 							headlineText={trail.headline}
-							trailText={trail.trailText}
 							headlineSize="medium"
 							byline={trail.byline}
 							showByline={trail.showByline}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the trail text from Cards in certain situations. fixes #4945 

## Why?
We don't want to show it on `FixedSmallSlowIV` at all and only on the two larger cards on the bottom row of `DynamicSlow` when there are no sublinks

### `FixedSmallSlowIV`

| Before      | After      |
|-------------|------------|
| <img width="1346" alt="4-b" src="https://user-images.githubusercontent.com/1336821/170664228-6aca24e2-bdd9-4bd4-a7d2-6e1f99203067.png">| <img width="1346" alt="4-a" src="https://user-images.githubusercontent.com/1336821/170664243-40c92ef3-4430-441b-82d2-2d5e6a2d48dc.png"> |

### `DynamicSlow`

| Before      | After      |
|-------------|------------|
| <img width="1346" alt="sp-b" src="https://user-images.githubusercontent.com/1336821/170664261-dcea48b0-bc60-42e1-8bcd-6f64f1f40cb2.png">| <img width="1346" alt="sp-a" src="https://user-images.githubusercontent.com/1336821/170664274-202ac9bb-7e16-48a1-98b3-325319e0d331.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
