### PR TITLE
put dependabot on a weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,10 @@ updates:
     - package-ecosystem: "npm"
       directory: "/dotcom-rendering"
       schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "wednesday"
+        time: "10:00"
+        timezone: "Europe/London"
       labels:
         - "DCR Dependency"
       open-pull-requests-limit: 10


### PR DESCRIPTION
Based on [our discussion](https://github.com/guardian/dotcom-rendering/discussions/3910), we're going to try and get dependabot to auto merge green PRs. 

## What does this change?
Puts `dependabot` on weekly schedule, specifically a day that people will generally be around to support (Wednesday). I can't see anything we lose through not running it daily as we definitely do not merge daily.

## Before merging
- [ ] Ensure Snyk is running on PRs to not merge malicious updates  
- [ ] Add automerge on green builds

## Why?
So we can get updates for free-ish (a lot of dependabot PRs are on red builds, hopefully though this will help once we get updated).
