### PR TITLE
feat(enum): add enumEntries method

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -8,6 +9,7 @@ import {
 import { breakpoints, from } from '@guardian/source-foundations';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+import { enumEntries } from '../../layouts/lib/enumEntries';
 import type { Props as CardProps } from './Card';
 import { Card } from './Card';
 
@@ -84,32 +86,26 @@ const CardsWithDifferentThemes = ({
 	design: ArticleDesign;
 	title: string;
 }) => {
-	const cards = [];
-	for (const [pillarName, pillarValue] of Object.entries(ArticlePillar)) {
-		// We need to check if numeric here because the values are also exported as keynames
-		// See: https://www.typescriptlang.org/play?#code/KYOwrgtgBAggTgFwJYGMA2wAKS1oIZxQDeAsAFBSVQBywA7gM5QC8UADADTlVQDyADkhBIA9iBZQAjFwpUAyvxGIJAJhk8AwmDQIwcYBIDM6qgBkkAM2AMEATwwSALDIC+5cijEMRGAHRoRAHMACl4AIwArYBQEX1AEOCRrYPhkdCwcfDgASmyAbnIAegAqcgBtbioygCI2ao4oatpGaoBdE0oayXrGgSFREDaOqBqVHuqFJQQhys7qw3GtHT1gGdk5x3HzKxt7VfbZkab6Bh62A-WjvuExHskLnhrJxB6VB6rqpd19HsN3ue21jsGHqjla5FaUHIxUKQA
-		if (Number.isNaN(Number(pillarName))) {
-			cards.push({
-				title: pillarName,
-				format: {
-					display,
-					design,
-					theme: pillarValue as ArticlePillar,
-				},
-			});
-		}
+	const cards: Array<{ title: string; format: ArticleFormat }> = [];
+	for (const [pillarName, pillarValue] of enumEntries(ArticlePillar)) {
+		cards.push({
+			title: pillarName,
+			format: {
+				display,
+				design,
+				theme: pillarValue,
+			},
+		});
 	}
-	for (const [specialName, specialValue] of Object.entries(ArticleSpecial)) {
-		if (Number.isNaN(Number(specialName))) {
-			cards.push({
-				title: specialName,
-				format: {
-					display,
-					design,
-					theme: specialValue as ArticleSpecial,
-				},
-			});
-		}
+	for (const [specialName, specialValue] of enumEntries(ArticleSpecial)) {
+		cards.push({
+			title: specialName,
+			format: {
+				display,
+				design,
+				theme: specialValue,
+			},
+		});
 	}
 
 	return (
@@ -158,23 +154,19 @@ const CardsWithDifferentThemes = ({
 	);
 };
 
-for (const [displayName, displayValue] of Object.entries(ArticleDisplay)) {
-	if (Number.isNaN(Number(displayName))) {
-		const stories = storiesOf(
-			`Components/Card/Format variations/${displayName}`,
-			module,
-		);
-		for (const [designName, designValue] of Object.entries(ArticleDesign)) {
-			if (Number.isNaN(Number(designName))) {
-				stories.add(designName, () => {
-					return CardsWithDifferentThemes({
-						display: displayValue as ArticleDisplay,
-						design: designValue as ArticleDesign,
-						title: designName,
-					});
-				});
-			}
-		}
+for (const [displayName, displayValue] of enumEntries(ArticleDisplay)) {
+	const stories = storiesOf(
+		`Components/Card/Format variations/${displayName}`,
+		module,
+	);
+	for (const [designName, designValue] of enumEntries(ArticleDesign)) {
+		stories.add(designName, () => {
+			return CardsWithDifferentThemes({
+				display: displayValue,
+				design: designValue,
+				title: designName,
+			});
+		});
 	}
 }
 

--- a/dotcom-rendering/src/web/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Layout.stories.tsx
@@ -30,6 +30,7 @@ import { decideFormat } from '../lib/decideFormat';
 import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
 import { mockRESTCalls } from '../lib/mockRESTCalls';
 import { DecideLayout } from './DecideLayout';
+import { enumEntries } from './lib/enumEntries';
 
 const Fixtures: { [key: string]: CAPIArticleType } = {
 	Article,
@@ -81,79 +82,69 @@ const HydratedLayout = ({
 	return <DecideLayout CAPIArticle={ServerCAPI} NAV={NAV} format={format} />;
 };
 
-for (const [displayName] of Object.entries(ArticleDisplay)) {
-	if (Number.isNaN(Number(displayName))) {
-		for (const [designName] of Object.entries(ArticleDesign)) {
-			if (Number.isNaN(Number(designName))) {
-				for (const [pillarName] of Object.entries(ArticlePillar)) {
-					if (Number.isNaN(Number(pillarName))) {
-						const stories = storiesOf(
-							`Layouts/Format variations/${displayName}/${designName}`,
-							module,
-						).addParameters({
-							chromatic: {
-								diffThreshold: 0.2,
-								pauseAnimationAtEnd: true,
+for (const [displayName] of enumEntries(ArticleDisplay)) {
+	for (const [designName] of enumEntries(ArticleDesign)) {
+		for (const [pillarName] of enumEntries(ArticlePillar)) {
+			const stories = storiesOf(
+				`Layouts/Format variations/${displayName}/${designName}`,
+				module,
+			).addParameters({
+				chromatic: {
+					diffThreshold: 0.2,
+					pauseAnimationAtEnd: true,
+				},
+			});
+
+			const fixture = Fixtures[designName] || Fixtures.Article;
+
+			stories.add(pillarName, () => {
+				return (
+					<HydratedLayout
+						ServerCAPI={{
+							...fixture,
+							format: {
+								display: `${displayName}Display`,
+								//@ts-expect-error -- StandardDesign uses ArticleDesign fallback
+								design: `${designName}Design`,
+								theme: `${pillarName}Pillar`,
 							},
-						});
+						}}
+					/>
+				);
+			});
+		}
 
-						const fixture =
-							Fixtures[designName] || Fixtures.Article;
+		for (const [specialName] of enumEntries(ArticleSpecial)) {
+			const stories = storiesOf(
+				`Layouts/Format variations/${displayName}/${designName}`,
+				module,
+			).addParameters({
+				chromatic: {
+					diffThreshold: 0.2,
+					pauseAnimationAtEnd: true,
+				},
+			});
 
-						stories.add(pillarName, () => {
-							return (
-								<HydratedLayout
-									ServerCAPI={{
-										...fixture,
-										format: {
-											display:
-												`${displayName}Display` as CAPIDisplay,
-											design: `${designName}Design` as CAPIDesign,
-											theme: `${pillarName}Pillar` as CAPITheme,
-										},
-									}}
-								/>
-							);
-						});
-					}
-				}
+			const fixture = Fixtures[designName] || Fixtures.Article;
 
-				for (const [specialName] of Object.entries(ArticleSpecial)) {
-					if (Number.isNaN(Number(specialName))) {
-						const stories = storiesOf(
-							`Layouts/Format variations/${displayName}/${designName}`,
-							module,
-						).addParameters({
-							chromatic: {
-								diffThreshold: 0.2,
-								pauseAnimationAtEnd: true,
+			stories.add(specialName, () => {
+				return (
+					<HydratedLayout
+						ServerCAPI={{
+							...fixture,
+							format: {
+								display: `${displayName}Display`,
+								//@ts-expect-error -- StandardDesign uses ArticleDesign fallback
+								design: `${designName}Design`,
+								theme:
+									specialName === 'Labs'
+										? specialName
+										: `${specialName}Theme`,
 							},
-						});
-
-						const fixture =
-							Fixtures[designName] || Fixtures.Article;
-
-						stories.add(specialName, () => {
-							return (
-								<HydratedLayout
-									ServerCAPI={{
-										...fixture,
-										format: {
-											display:
-												`${displayName}Display` as CAPIDisplay,
-											design: `${designName}Design` as CAPIDesign,
-											theme:
-												specialName === 'Labs'
-													? specialName
-													: (`${specialName}Theme` as CAPITheme),
-										},
-									}}
-								/>
-							);
-						});
-					}
-				}
-			}
+						}}
+					/>
+				);
+			});
 		}
 	}
 }

--- a/dotcom-rendering/src/web/layouts/lib/enumEntries.test.ts
+++ b/dotcom-rendering/src/web/layouts/lib/enumEntries.test.ts
@@ -1,0 +1,24 @@
+import { ArticlePillar } from '@guardian/libs';
+import { enumEntries } from './enumEntries';
+
+describe('enumEntries', () => {
+	it('should have the string keys of an numeric enum', () => {
+		expect(Object.entries(ArticlePillar)).toEqual(
+			expect.arrayContaining(enumEntries(ArticlePillar)),
+		);
+	});
+
+	it('should have half as many keys as an numeric enum', () => {
+		expect(Object.entries(ArticlePillar).length / 2).toEqual(
+			enumEntries(ArticlePillar).length,
+		);
+	});
+
+	it('should have no keys that are valid numeric strings', () => {
+		expect(
+			enumEntries(ArticlePillar).find(([key]) =>
+				Number.isInteger(Number(key)),
+			),
+		).toBeUndefined();
+	});
+});

--- a/dotcom-rendering/src/web/layouts/lib/enumEntries.ts
+++ b/dotcom-rendering/src/web/layouts/lib/enumEntries.ts
@@ -1,0 +1,39 @@
+const isEntry = (
+	tuple: [string | number, string | number],
+): tuple is [string, number] =>
+	typeof tuple[0] === 'string' && typeof tuple[1] === 'number';
+
+/**
+ * TypeScript enums have values both as keys and values, so this
+ * method filters out keys that are created from values.
+ *
+ * @example
+ * enumEntries(ArticlePillar);
+ * [
+ * 	["News", 0],
+ * 	["Opinion", 1],
+ * 	["Sport", 2],
+ * 	["Culture", 3],
+ * 	["Lifestyle",4]
+ * ]
+ *
+ * // Compare with :
+ * Object.entries(ArticlePillar);
+ * [
+ * 	["0", "News"],
+ * 	["1", "Opinion"],
+ * 	["2", "Sport"],
+ * 	["3", "Culture"],
+ * 	["4", "Lifestyle"],
+ * 	["News", 0],
+ * 	["Opinion", 1],
+ * 	["Sport", 2],
+ * 	["Culture", 3],
+ * 	["Lifestyle",4]
+ * ];
+ *
+ * @see https://www.typescriptlang.org/play?#code/KYOwrgtgBAggTgFwJYGMA2wAKS1oIZxQDeAsAFBSVQBywA7gM5QC8UADADTlVQDyADkhBIA9iBZQAjFwpUAyvxGIJAJhk8AwmDQIwcYBIDM6qgBkkAM2AMEATwwSALDIC+5cijEMRGAHRoRAHMACl4AIwArYBQEX1AEOCRrYPhkdCwcfDgASmyAbnIAegAqcgBtbioygCI2ao4oatpGaoBdE0oayXrGgSFREDaOqBqVHuqFJQQhys7qw3GtHT1gGdk5x3HzKxt7VfbZkab6Bh62A-WjvuExHskLnhrJxB6VB6rqpd19HsN3ue21jsGHqjla5FaUHIxUKQA
+ */
+export const enumEntries = <T extends Record<string | number, string | number>>(
+	record: T,
+): Array<[keyof T, number]> => Object.entries(record).filter(isEntry);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add a new helper method `enumEntries`, that returns the entries from an enum anyone unfamiliar with the odd workings of TypeScript would expect.

```ts
enumEntries(ArticlePillar);
[
	["News", 0],
	["Opinion", 1],
	["Sport", 2],
	["Culture", 3],
	["Lifestyle",4]
]

// Compare with :
Object.entries(ArticlePillar);
[
	["0", "News"],
	["1", "Opinion"],
	["2", "Sport"],
	["3", "Culture"],
	["4", "Lifestyle"],
	["News", 0],
	["Opinion", 1],
	["Sport", 2],
	["Culture", 3],
	["Lifestyle",4]
];
```


## Why?

This simplifies our loops a lot and removes many type assertions.