### PR TITLE
Small accessibility fix

### DIFF
--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -143,7 +143,7 @@ const listItemStyles = (palette: Palette) => css`
 `;
 
 const trimLeadingSlash = (url: string): string =>
-	url.substr(0, 1) === '/' ? url.slice(1) : url;
+	url.startsWith('/') ? url.slice(1) : url;
 
 export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 	const [showMore, setShowMore] = useState(false);

--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -27,13 +27,6 @@ const wrapperCollapsedStyles = css`
 const rootSubnavStyles = css`
 	list-style: none;
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
-	/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
-	li::before {
-		content: '\\200B'; /* Zero width space */
-		display: block;
-		height: 0;
-		width: 0;
-	}
 	padding: 0 5px;
 
 	${from.mobileLandscape} {
@@ -186,6 +179,7 @@ export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 			<ul
 				ref={ulRef}
 				css={[expandSubNav ? expandedStyles : collapsedStyles]}
+				role="list"
 			>
 				{subNavSections.parent && (
 					<li


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Use `role="list"` for `list-style:none` instead of a CSS hack, as recommended by MDN. 
   > **[Accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns)**
   > In a notable exception, Safari will not recognize an unordered list as a list in the accessibility tree if has a `list-style` value of `none`.
  >
  > The most straightforward way to address this is to add an explicit `role="list"` to the `<ul>` element in the markup. This will restore the list semantics without affecting the design.
- Use `startsWith` instead of `substr`, as the latter is deprecated.

## Why?

We should keep things as semantic and explicit as possible.

Relying on our current CSS workaround is not the most accessible, and is not the recommended approach in the article quoted.