### PR TITLE
chore(chromatic): ignore Obituaries

### DIFF
--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -202,7 +202,18 @@ export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 					</li>
 				)}
 				{subNavSections.links.map((link) => (
-					<li key={link.url}>
+					<li
+						key={link.url}
+						/**
+						 * We’ve getting many false positive on changes to Obituaries.
+						 * Let’s try ignoring it for now.
+						 *
+						 * @see https://www.chromatic.com/docs/ignoring-elements#ignore-dom-elements
+						 */
+						data-chromatic={
+							link.title === 'Obituaries' ? 'ignore' : undefined
+						}
+					>
 						<a
 							css={linkStyle(palette)}
 							data-src-focus-disabled={true}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Ignore chromatic diffs for the Obituaries element in the `SubNav`.

## Why?

We are getting too many false positive on changes. Sometimes the element is on the same line, sometimes it’s not, and we can’t get it to be consistent accross runs.