### PR TITLE
Add Google to `frame-src` policy directive

### DIFF
--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -106,7 +106,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://www.scribd.com ${
+    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com ${
 		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
 	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''


### PR DESCRIPTION
## What does this change?
Adds `https://www.google.com` to the list of allowed frame sources in Apps Rendering's Content Security Policy.

## Why?
Because Google is not currently in the list of allowed origins in `frame-src`, and this results in embeds not being displayed.

> **Note**
> This CSP directive is not being applied to Editions - we recently disabled all generic embeds there so it would be have no effect.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:  https://user-images.githubusercontent.com/57295823/170689971-7032b5c3-75c9-4922-b6d8-ff71feb535c4.gif
[after]: https://user-images.githubusercontent.com/57295823/170689987-16237895-5e38-4c54-8634-cd23a4f65e4b.gif
