### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,6 @@
 
 ## Why?
 
-## Screenshots
-
 | Before      | After      |
 |-------------|------------|
 | ![before][] | ![after][] |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,9 @@
 <!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
+
 ## What does this change?
 
 ## Why?
 
 | Before      | After      |
-|-------------|------------|
-| ![before][] | ![after][] |
-
-[before]: https://example.com/before.png
-[after]: https://example.com/after.png
-
-<!--
-You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.
-
-| ![before2][] | ![after2][] |
-
-You can then reference the labels and map them to corresponding links.
-
-[before2]: https://example.com/before2.png
-[after2]: https://example.com/after2.png
--->
+| ----------- | ---------- |
+| BEFORE_HERE | AFTER_HERE |


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This makes it easier to upload before and after images to PRs

## Why?
I struggled with the other template when I first started using it and I have seen other people make the same mistakes when trying to upload images. I think this new version is simpler and easier to use


| Before      | After      |
|-------------|------------|
| <img width="344" alt="Screenshot 2022-05-27 at 11 28 56" src="https://user-images.githubusercontent.com/1336821/170702848-02a8d885-a527-4f7d-8a9f-89e5b167b79e.png">   | 😸  |
