### PR TITLE
Refactor `MainMedia`

### DIFF
--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -16,6 +16,7 @@ import Cutout from 'components/Cutout';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import Logo from 'components/Logo';
+import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
@@ -23,7 +24,6 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type { Comment as CommentItem, Editorial, Letter } from 'item';
-import MainMedia from 'mainMedia';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,

--- a/apps-rendering/src/components/Layout/InteractiveImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/InteractiveImmersiveLayout.tsx
@@ -14,6 +14,7 @@ import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import ImmersiveCaption from 'components/ImmersiveCaption';
 import Logo from 'components/Logo';
+import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
@@ -25,7 +26,6 @@ import type {
 	Review as ReviewItem,
 	Standard as StandardItem,
 } from 'item';
-import MainMedia from 'mainMedia';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -13,6 +13,7 @@ import Body from 'components/ArticleBody';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import Logo from 'components/LabsLogo';
+import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
@@ -20,7 +21,6 @@ import Standfirst from 'components/Standfirst';
 import { getFormat } from 'item';
 import type { Item } from 'item';
 import { pipe } from 'lib';
-import MainMedia from 'mainMedia';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,

--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -19,6 +19,7 @@ import Footer from 'components/Footer';
 import GridItem from 'components/GridItem';
 import LiveBlocks from 'components/LiveBlocks';
 import LiveblogHeader from 'components/LiveblogHeader';
+import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Tags from 'components/Tags';
@@ -26,7 +27,6 @@ import { getFormat } from 'item';
 import type { DeadBlog, LiveBlog } from 'item';
 import { toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
-import MainMedia from 'mainMedia';
 import type { FC } from 'react';
 import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
 

--- a/apps-rendering/src/components/Layout/MediaLayout.tsx
+++ b/apps-rendering/src/components/Layout/MediaLayout.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import { background, breakpoints, from } from '@guardian/source-foundations';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import MainMedia from 'components/MainMedia';
 import Body from 'components/media/articleBody';
 import Series from 'components/media/articleSeries';
 import Byline from 'components/media/byline';
@@ -12,7 +13,6 @@ import RelatedContent from 'components/RelatedContent';
 import Standfirst from 'components/Standfirst';
 import { getFormat } from 'item';
 import type { Item } from 'item';
-import MainMedia from 'mainMedia';
 import type { FC, ReactNode } from 'react';
 import { articleWidthStyles, onwardStyles } from 'styles';
 

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -21,6 +21,7 @@ import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import ImmersiveCaption from 'components/ImmersiveCaption';
 import Logo from 'components/Logo';
+import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
@@ -34,7 +35,6 @@ import type {
 	Standard as StandardItem,
 } from 'item';
 import { maybeRender, pipe } from 'lib';
-import MainMedia from 'mainMedia';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
@@ -1,0 +1,52 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { between, remSpace } from '@guardian/source-foundations';
+import { some } from '@guardian/types';
+import type { Image } from 'image';
+import type { FC } from 'react';
+import { Caption } from './MainMediaImage.defaults';
+
+const captionId = 'header-image-caption';
+
+const blogStyles = css`
+	margin-bottom: ${remSpace[4]};
+	position: relative;
+
+	${between.tablet.and.desktop} {
+		margin-top: ${remSpace[3]};
+	}
+`;
+
+const sizes: Sizes = {
+	mediaQueries: [{ breakpoint: 'tablet', size: '700px' }],
+	default: '100vw',
+};
+
+interface Props {
+	image: Image;
+	className?: SerializedStyles;
+	format: ArticleFormat;
+}
+
+const BlogMainMediaImage: FC<Props> = ({ className, image, format }) => (
+	<figure css={[blogStyles, className]} aria-labelledby={captionId}>
+		<Img
+			image={image}
+			sizes={sizes}
+			className={some(css())}
+			format={format}
+			supportsDarkMode
+			lightbox={some({
+				className: 'js-launch-slideshow',
+				caption: image.nativeCaption,
+				credit: image.credit,
+			})}
+		/>
+		<Caption format={format} image={image} />
+	</figure>
+);
+
+export default BlogMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/react';
 import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, remSpace } from '@guardian/source-foundations';
-import { some } from '@guardian/types';
+import { none } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import DefaultMainMediaImage from './MainMediaImage.defaults';
 
-const blogStyles = css`
+const styles = css`
 	margin-bottom: ${remSpace[4]};
 	position: relative;
 
@@ -16,7 +16,7 @@ const blogStyles = css`
 	}
 `;
 
-const blogSizes: Sizes = {
+const sizes: Sizes = {
 	mediaQueries: [{ breakpoint: 'tablet', size: '700px' }],
 	default: '100vw',
 };
@@ -29,10 +29,10 @@ interface Props {
 const BlogMainMediaImage: FC<Props> = ({ image, format }) => (
 	<DefaultMainMediaImage
 		image={image}
-		sizes={blogSizes}
+		sizes={sizes}
 		format={format}
-		css={css(blogStyles)}
-		imgCss={some(css())}
+		css={styles}
+		imgCss={none}
 	/>
 );
 

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
@@ -1,15 +1,11 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import Img from '@guardian/common-rendering/src/components/img';
 import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, remSpace } from '@guardian/source-foundations';
 import { some } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
-import { Caption } from './MainMediaImage.defaults';
-
-const captionId = 'header-image-caption';
+import DefaultMainMediaImage from './MainMediaImage.defaults';
 
 const blogStyles = css`
 	margin-bottom: ${remSpace[4]};
@@ -20,33 +16,25 @@ const blogStyles = css`
 	}
 `;
 
-const sizes: Sizes = {
+const blogSizes: Sizes = {
 	mediaQueries: [{ breakpoint: 'tablet', size: '700px' }],
 	default: '100vw',
 };
 
 interface Props {
 	image: Image;
-	className?: SerializedStyles;
 	format: ArticleFormat;
 }
 
-const BlogMainMediaImage: FC<Props> = ({ className, image, format }) => (
-	<figure css={[blogStyles, className]} aria-labelledby={captionId}>
-		<Img
-			image={image}
-			sizes={sizes}
-			className={some(css())}
-			format={format}
-			supportsDarkMode
-			lightbox={some({
-				className: 'js-launch-slideshow',
-				caption: image.nativeCaption,
-				credit: image.credit,
-			})}
-		/>
-		<Caption format={format} image={image} />
-	</figure>
+const BlogMainMediaImage: FC<Props> = ({ image, format }) => (
+	<DefaultMainMediaImage
+		image={image}
+		sizes={blogSizes}
+		format={format}
+		css={css(blogStyles)}
+		imgCss={some(css())}
+	/>
 );
+// <img className={some(css())}
 
 export default BlogMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/BlogMainMediaImage.tsx
@@ -35,6 +35,5 @@ const BlogMainMediaImage: FC<Props> = ({ image, format }) => (
 		imgCss={some(css())}
 	/>
 );
-// <img className={some(css())}
 
 export default BlogMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
@@ -1,0 +1,54 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { from, remSpace } from '@guardian/source-foundations';
+import { some } from '@guardian/types';
+import type { Image } from 'image';
+import type { FC } from 'react';
+import { wideContentWidth } from 'styles';
+import { Caption, imgStyles } from './MainMediaImage.defaults';
+
+const captionId = 'header-image-caption';
+
+const commentStyles = css`
+	margin: 0 0 ${remSpace[5]} 0;
+	position: relative;
+	${from.wide} {
+		width: ${wideContentWidth}px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
+
+const sizes: Sizes = {
+	mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
+	default: '100vw',
+};
+
+interface Props {
+	image: Image;
+	className?: SerializedStyles;
+	format: ArticleFormat;
+}
+
+const CommentMainMediaImage: FC<Props> = ({ className, image, format }) => (
+	<figure css={[commentStyles, className]} aria-labelledby={captionId}>
+		<Img
+			image={image}
+			sizes={sizes}
+			className={some(imgStyles(image.width, image.height))}
+			format={format}
+			supportsDarkMode
+			lightbox={some({
+				className: 'js-launch-slideshow',
+				caption: image.nativeCaption,
+				credit: image.credit,
+			})}
+		/>
+		<Caption format={format} image={image} />
+	</figure>
+);
+
+export default CommentMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
@@ -1,20 +1,15 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import Img from '@guardian/common-rendering/src/components/img';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
-import { some } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import { wideContentWidth } from 'styles';
-import { Caption, imgStyles } from './MainMediaImage.defaults';
-
-const captionId = 'header-image-caption';
+import DefaultMainMediaImage, { defaultSizes } from './MainMediaImage.defaults';
 
 const commentStyles = css`
 	margin: 0 0 ${remSpace[5]} 0;
 	position: relative;
+
 	${from.wide} {
 		width: ${wideContentWidth}px;
 		margin-left: auto;
@@ -22,33 +17,18 @@ const commentStyles = css`
 	}
 `;
 
-const sizes: Sizes = {
-	mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
-	default: '100vw',
-};
-
 interface Props {
 	image: Image;
-	className?: SerializedStyles;
 	format: ArticleFormat;
 }
 
-const CommentMainMediaImage: FC<Props> = ({ className, image, format }) => (
-	<figure css={[commentStyles, className]} aria-labelledby={captionId}>
-		<Img
-			image={image}
-			sizes={sizes}
-			className={some(imgStyles(image.width, image.height))}
-			format={format}
-			supportsDarkMode
-			lightbox={some({
-				className: 'js-launch-slideshow',
-				caption: image.nativeCaption,
-				credit: image.credit,
-			})}
-		/>
-		<Caption format={format} image={image} />
-	</figure>
+const CommentMainMediaImage: FC<Props> = ({ image, format }) => (
+	<DefaultMainMediaImage
+		image={image}
+		sizes={defaultSizes}
+		format={format}
+		css={css(commentStyles)}
+	/>
 );
 
 export default CommentMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
@@ -9,7 +9,7 @@ import DefaultMainMediaImage, {
 	defaultSizes,
 } from './MainMediaImage.defaults';
 
-const commentStyles = css`
+const styles = css`
 	margin: 0 0 ${remSpace[5]} 0;
 	position: relative;
 
@@ -30,7 +30,7 @@ const CommentMainMediaImage: FC<Props> = ({ image, format }) => (
 		image={image}
 		sizes={defaultSizes}
 		format={format}
-		css={css(commentStyles)}
+		css={styles}
 		imgCss={defaultImgCss(image)}
 	/>
 );

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/CommentMainMediaImage.tsx
@@ -4,7 +4,10 @@ import { from, remSpace } from '@guardian/source-foundations';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import { wideContentWidth } from 'styles';
-import DefaultMainMediaImage, { defaultSizes } from './MainMediaImage.defaults';
+import DefaultMainMediaImage, {
+	defaultImgCss,
+	defaultSizes,
+} from './MainMediaImage.defaults';
 
 const commentStyles = css`
 	margin: 0 0 ${remSpace[5]} 0;
@@ -28,6 +31,7 @@ const CommentMainMediaImage: FC<Props> = ({ image, format }) => (
 		sizes={defaultSizes}
 		format={format}
 		css={css(commentStyles)}
+		imgCss={defaultImgCss(image)}
 	/>
 );
 

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -10,14 +10,14 @@ import { Caption } from './MainMediaImage.defaults';
 
 const captionId = 'header-image-caption';
 
-const immersiveImgStyles = css`
+const imgStyles = css`
 	display: block;
 	height: 80vh;
 	object-fit: cover;
 	width: 100vw;
 `;
 
-const immersiveStyles = css`
+const styles = css`
 	margin: 0;
 	position: absolute;
 	left: 0;
@@ -37,11 +37,11 @@ interface Props {
 // NOTE: This component isn't currently used - this file exists to preserve
 // immersive styling and sizes so we don't lose them in the big MainMedia refactor.
 const ImmersiveMainMediaImage: FC<Props> = ({ className, image, format }) => (
-	<figure css={[immersiveStyles, className]} aria-labelledby={captionId}>
+	<figure css={[styles, className]} aria-labelledby={captionId}>
 		<Img
 			image={image}
 			sizes={getSizes(image)}
-			className={some(immersiveImgStyles)}
+			className={some(imgStyles)}
 			format={format}
 			supportsDarkMode
 			lightbox={some({

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -1,0 +1,55 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { some } from '@guardian/types';
+import type { Image } from 'image';
+import type { FC } from 'react';
+import { Caption } from './MainMediaImage.defaults';
+
+const captionId = 'header-image-caption';
+
+const immersiveImgStyles = css`
+	display: block;
+	height: 80vh;
+	object-fit: cover;
+	width: 100vw;
+`;
+
+const immersiveStyles = css`
+	margin: 0;
+	position: absolute;
+	left: 0;
+`;
+
+const getSizes = (image: Image): Sizes => ({
+	mediaQueries: [],
+	default: `${(100 * image.width) / image.height}vh `,
+});
+
+interface Props {
+	image: Image;
+	className?: SerializedStyles;
+	format: ArticleFormat;
+}
+
+const ImmersiveMainMediaImage: FC<Props> = ({ className, image, format }) => (
+	<figure css={[immersiveStyles, className]} aria-labelledby={captionId}>
+		<Img
+			image={image}
+			sizes={getSizes(image)}
+			className={some(immersiveImgStyles)}
+			format={format}
+			supportsDarkMode
+			lightbox={some({
+				className: 'js-launch-slideshow',
+				caption: image.nativeCaption,
+				credit: image.credit,
+			})}
+		/>
+		<Caption format={format} image={image} />
+	</figure>
+);
+
+export default ImmersiveMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -34,6 +34,8 @@ interface Props {
 	format: ArticleFormat;
 }
 
+// NOTE: This component isn't currently used - this file exists to preserve
+// immersive styling and sizes so we don't lose them in the big MainMedia refactor.
 const ImmersiveMainMediaImage: FC<Props> = ({ className, image, format }) => (
 	<figure css={[immersiveStyles, className]} aria-labelledby={captionId}>
 		<Img

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
@@ -1,0 +1,54 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { from } from '@guardian/source-foundations';
+import { some } from '@guardian/types';
+import type { Image } from 'image';
+import type { FC } from 'react';
+import { wideContentWidth } from 'styles';
+import { Caption, imgStyles } from './MainMediaImage.defaults';
+
+const captionId = 'header-image-caption';
+
+const interviewStyles = css`
+	position: relative;
+	margin: 0;
+	${from.wide} {
+		width: ${wideContentWidth}px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
+
+const sizes: Sizes = {
+	mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
+	default: '100vw',
+};
+
+interface Props {
+	image: Image;
+	className?: SerializedStyles;
+	format: ArticleFormat;
+}
+
+const InterviewMainMediaImage: FC<Props> = ({ className, image, format }) => (
+	<figure css={[interviewStyles, className]} aria-labelledby={captionId}>
+		<Img
+			image={image}
+			sizes={sizes}
+			className={some(imgStyles(image.width, image.height))}
+			format={format}
+			supportsDarkMode
+			lightbox={some({
+				className: 'js-launch-slideshow',
+				caption: image.nativeCaption,
+				credit: image.credit,
+			})}
+		/>
+		<Caption format={format} image={image} />
+	</figure>
+);
+
+export default InterviewMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
@@ -1,16 +1,10 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import Img from '@guardian/common-rendering/src/components/img';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
-import { some } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import { wideContentWidth } from 'styles';
-import { Caption, imgStyles } from './MainMediaImage.defaults';
-
-const captionId = 'header-image-caption';
+import DefaultMainMediaImage, { defaultSizes } from './MainMediaImage.defaults';
 
 const interviewStyles = css`
 	position: relative;
@@ -22,33 +16,18 @@ const interviewStyles = css`
 	}
 `;
 
-const sizes: Sizes = {
-	mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
-	default: '100vw',
-};
-
 interface Props {
 	image: Image;
-	className?: SerializedStyles;
 	format: ArticleFormat;
 }
 
-const InterviewMainMediaImage: FC<Props> = ({ className, image, format }) => (
-	<figure css={[interviewStyles, className]} aria-labelledby={captionId}>
-		<Img
-			image={image}
-			sizes={sizes}
-			className={some(imgStyles(image.width, image.height))}
-			format={format}
-			supportsDarkMode
-			lightbox={some({
-				className: 'js-launch-slideshow',
-				caption: image.nativeCaption,
-				credit: image.credit,
-			})}
-		/>
-		<Caption format={format} image={image} />
-	</figure>
+const InterviewMainMediaImage: FC<Props> = ({ image, format }) => (
+	<DefaultMainMediaImage
+		image={image}
+		sizes={defaultSizes}
+		format={format}
+		css={css(interviewStyles)}
+	/>
 );
 
 export default InterviewMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
@@ -9,7 +9,7 @@ import DefaultMainMediaImage, {
 	defaultSizes,
 } from './MainMediaImage.defaults';
 
-const interviewStyles = css`
+const styles = css`
 	position: relative;
 	margin: 0;
 	${from.wide} {
@@ -29,7 +29,7 @@ const InterviewMainMediaImage: FC<Props> = ({ image, format }) => (
 		image={image}
 		sizes={defaultSizes}
 		format={format}
-		css={css(interviewStyles)}
+		css={styles}
 		imgCss={defaultImgCss(image)}
 	/>
 );

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/InterviewMainMediaImage.tsx
@@ -4,7 +4,10 @@ import { from } from '@guardian/source-foundations';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import { wideContentWidth } from 'styles';
-import DefaultMainMediaImage, { defaultSizes } from './MainMediaImage.defaults';
+import DefaultMainMediaImage, {
+	defaultImgCss,
+	defaultSizes,
+} from './MainMediaImage.defaults';
 
 const interviewStyles = css`
 	position: relative;
@@ -27,6 +30,7 @@ const InterviewMainMediaImage: FC<Props> = ({ image, format }) => (
 		sizes={defaultSizes}
 		format={format}
 		css={css(interviewStyles)}
+		imgCss={defaultImgCss(image)}
 	/>
 );
 

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
@@ -56,10 +56,7 @@ const defaultSizes: Sizes = {
 	default: '100vw',
 };
 
-export const imgStyles = (
-	width: number,
-	height: number,
-): SerializedStyles => css`
+const imgStyles = (width: number, height: number): SerializedStyles => css`
 	display: block;
 	width: 100%;
 	height: calc(100vw * ${height / width});
@@ -72,7 +69,9 @@ export const imgStyles = (
 
 interface DefaultProps {
 	image: Image;
-	className?: SerializedStyles;
+	className?: string;
+	css?: SerializedStyles;
+	sizes: Sizes;
 	format: ArticleFormat;
 }
 
@@ -80,11 +79,12 @@ const DefaultMainMediaImage: FC<DefaultProps> = ({
 	className,
 	image,
 	format,
+	sizes,
 }) => (
-	<figure css={[defaultStyles, className]} aria-labelledby={captionId}>
+	<figure css={className} aria-labelledby={captionId}>
 		<Img
 			image={image}
-			sizes={defaultSizes}
+			sizes={sizes}
 			className={some(imgStyles(image.width, image.height))}
 			format={format}
 			supportsDarkMode
@@ -98,4 +98,7 @@ const DefaultMainMediaImage: FC<DefaultProps> = ({
 	</figure>
 );
 
+// ----- Exports ----- //
+
 export default DefaultMainMediaImage;
+export { defaultSizes, defaultStyles, imgStyles };

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
@@ -6,6 +6,7 @@ import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
+import type { Option } from '@guardian/types';
 import { some } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
@@ -56,6 +57,9 @@ const defaultSizes: Sizes = {
 	default: '100vw',
 };
 
+const defaultImgCss = (image: Image): Option<SerializedStyles> =>
+	some(imgStyles(image.width, image.height));
+
 const imgStyles = (width: number, height: number): SerializedStyles => css`
 	display: block;
 	width: 100%;
@@ -71,6 +75,7 @@ interface DefaultProps {
 	image: Image;
 	className?: string;
 	css?: SerializedStyles;
+	imgCss: Option<SerializedStyles>;
 	sizes: Sizes;
 	format: ArticleFormat;
 }
@@ -78,6 +83,7 @@ interface DefaultProps {
 const DefaultMainMediaImage: FC<DefaultProps> = ({
 	className,
 	image,
+	imgCss,
 	format,
 	sizes,
 }) => (
@@ -85,7 +91,7 @@ const DefaultMainMediaImage: FC<DefaultProps> = ({
 		<Img
 			image={image}
 			sizes={sizes}
-			className={some(imgStyles(image.width, image.height))}
+			className={imgCss}
 			format={format}
 			supportsDarkMode
 			lightbox={some({
@@ -101,4 +107,4 @@ const DefaultMainMediaImage: FC<DefaultProps> = ({
 // ----- Exports ----- //
 
 export default DefaultMainMediaImage;
-export { defaultSizes, defaultStyles, imgStyles };
+export { defaultSizes, defaultStyles, imgStyles, defaultImgCss };

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
@@ -1,0 +1,101 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import ImageDetails from '@guardian/common-rendering/src/components/imageDetails';
+import Img from '@guardian/common-rendering/src/components/img';
+import type { Sizes } from '@guardian/common-rendering/src/sizes';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDisplay } from '@guardian/libs';
+import { from, remSpace } from '@guardian/source-foundations';
+import { some } from '@guardian/types';
+import type { Image } from 'image';
+import type { FC } from 'react';
+import { wideContentWidth } from 'styles';
+
+// ----- Setup ----- //
+
+const captionId = 'header-image-caption';
+
+// ----- Subcomponents ----- //
+
+interface CaptionProps {
+	format: ArticleFormat;
+	image: Image;
+}
+
+export const Caption: FC<CaptionProps> = ({ format, image }: CaptionProps) => {
+	switch (format.display) {
+		case ArticleDisplay.Immersive:
+			return null;
+		default:
+			return (
+				<ImageDetails
+					caption={image.nativeCaption}
+					credit={image.credit}
+					supportsDarkMode
+					id={captionId}
+				/>
+			);
+	}
+};
+
+// ----- Component ----- //
+
+const defaultStyles = css`
+	margin: 0 0 ${remSpace[1]} 0;
+	position: relative;
+
+	${from.wide} {
+		width: ${wideContentWidth}px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
+
+const defaultSizes: Sizes = {
+	mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
+	default: '100vw',
+};
+
+export const imgStyles = (
+	width: number,
+	height: number,
+): SerializedStyles => css`
+	display: block;
+	width: 100%;
+	height: calc(100vw * ${height / width});
+
+	${from.wide} {
+		width: ${wideContentWidth}px;
+		height: ${(wideContentWidth * height) / width}px;
+	}
+`;
+
+interface DefaultProps {
+	image: Image;
+	className?: SerializedStyles;
+	format: ArticleFormat;
+}
+
+const DefaultMainMediaImage: FC<DefaultProps> = ({
+	className,
+	image,
+	format,
+}) => (
+	<figure css={[defaultStyles, className]} aria-labelledby={captionId}>
+		<Img
+			image={image}
+			sizes={defaultSizes}
+			className={some(imgStyles(image.width, image.height))}
+			format={format}
+			supportsDarkMode
+			lightbox={some({
+				className: 'js-launch-slideshow',
+				caption: image.nativeCaption,
+				credit: image.credit,
+			})}
+		/>
+		<Caption format={format} image={image} />
+	</figure>
+);
+
+export default DefaultMainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
@@ -2,12 +2,11 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import type { Image } from 'image';
 import type { FC } from 'react';
 import BlogMainMediaImage from './BlogMainMediaImage';
 import CommentMainMediaImage from './CommentMainMediaImage';
-import ImmersiveMainMediaImage from './ImmersiveMainMediaImage';
 import InterviewMainMediaImage from './InterviewMainMediaImage';
 import DefaultMainMediaImage from './MainMediaImage.defaults';
 
@@ -20,15 +19,16 @@ interface Props {
 }
 
 const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => {
-	if (format.display === ArticleDisplay.Immersive) {
-		return (
-			<ImmersiveMainMediaImage
-				image={image}
-				format={format}
-				className={className}
-			/>
-		);
-	}
+	// --- Temporarily commenting this out until the Immersive layout is implemented ---
+	// if (format.display === ArticleDisplay.Immersive) {
+	// 	return (
+	// 		<ImmersiveMainMediaImage
+	// 			image={image}
+	// 			format={format}
+	// 			className={className}
+	// 		/>
+	// 	);
+	//}
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
@@ -173,7 +173,7 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const HeaderImage: FC<Props> = ({ className, image, format }: Props) => (
+const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => (
 	<figure css={[getStyles(format), className]} aria-labelledby={captionId}>
 		<Img
 			image={image}
@@ -193,4 +193,4 @@ const HeaderImage: FC<Props> = ({ className, image, format }: Props) => (
 
 // ----- Exports ----- //
 
-export default HeaderImage;
+export default MainMediaImage;

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
@@ -9,6 +9,7 @@ import BlogMainMediaImage from './BlogMainMediaImage';
 import CommentMainMediaImage from './CommentMainMediaImage';
 import InterviewMainMediaImage from './InterviewMainMediaImage';
 import DefaultMainMediaImage, {
+	defaultImgCss,
 	defaultSizes,
 	defaultStyles,
 } from './MainMediaImage.defaults';
@@ -22,26 +23,10 @@ interface Props {
 }
 
 const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => {
-	// --- Temporarily commenting this out until the Immersive layout is implemented ---
-	// if (format.display === ArticleDisplay.Immersive) {
-	// 	return (
-	// 		<ImmersiveMainMediaImage
-	// 			image={image}
-	// 			format={format}
-	// 			className={className}
-	// 		/>
-	// 	);
-	//}
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
-			return (
-				<BlogMainMediaImage
-					image={image}
-					format={format}
-					className={className}
-				/>
-			);
+			return <BlogMainMediaImage image={image} format={format} />;
 		case ArticleDesign.Interview:
 			return <InterviewMainMediaImage image={image} format={format} />;
 		case ArticleDesign.Comment:
@@ -54,6 +39,7 @@ const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => {
 					image={image}
 					format={format}
 					css={defaultStyles}
+					imgCss={defaultImgCss(image)}
 					sizes={defaultSizes}
 				/>
 			);

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
@@ -1,171 +1,17 @@
 // ----- Imports ----- //
 
 import type { SerializedStyles } from '@emotion/react';
-import { css } from '@emotion/react';
-import ImageDetails from '@guardian/common-rendering/src/components/imageDetails';
-import Img from '@guardian/common-rendering/src/components/img';
-import type { Sizes } from '@guardian/common-rendering/src/sizes';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
-import { between, from, remSpace } from '@guardian/source-foundations';
-import { some } from '@guardian/types';
 import type { Image } from 'image';
 import type { FC } from 'react';
-import { wideContentWidth } from 'styles';
-
-// ----- Setup ----- //
-
-const captionId = 'header-image-caption';
-
-// ----- Subcomponents ----- //
-
-interface CaptionProps {
-	format: ArticleFormat;
-	image: Image;
-}
-
-const Caption: FC<CaptionProps> = ({ format, image }: CaptionProps) => {
-	switch (format.display) {
-		case ArticleDisplay.Immersive:
-			return null;
-		default:
-			return (
-				<ImageDetails
-					caption={image.nativeCaption}
-					credit={image.credit}
-					supportsDarkMode
-					id={captionId}
-				/>
-			);
-	}
-};
+import BlogMainMediaImage from './BlogMainMediaImage';
+import CommentMainMediaImage from './CommentMainMediaImage';
+import ImmersiveMainMediaImage from './ImmersiveMainMediaImage';
+import InterviewMainMediaImage from './InterviewMainMediaImage';
+import DefaultMainMediaImage from './MainMediaImage.defaults';
 
 // ----- Component ----- //
-
-const styles = css`
-	margin: 0 0 ${remSpace[1]} 0;
-	position: relative;
-
-	${from.wide} {
-		width: ${wideContentWidth}px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-`;
-
-const liveStyles = css`
-	margin-bottom: ${remSpace[4]};
-	position: relative;
-
-	${between.tablet.and.desktop} {
-		margin-top: ${remSpace[3]};
-	}
-`;
-
-const immersiveStyles = css`
-	margin: 0;
-	position: absolute;
-	left: 0;
-`;
-
-const commentStyles = css`
-	margin: 0 0 ${remSpace[5]} 0;
-	position: relative;
-	${from.wide} {
-		width: ${wideContentWidth}px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-`;
-
-const interviewStyles = css`
-	position: relative;
-	margin: 0;
-	${from.wide} {
-		width: ${wideContentWidth}px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-`;
-
-const imgStyles = (width: number, height: number): SerializedStyles => css`
-	display: block;
-	width: 100%;
-	height: calc(100vw * ${height / width});
-
-	${from.wide} {
-		width: ${wideContentWidth}px;
-		height: ${(wideContentWidth * height) / width}px;
-	}
-`;
-
-const immersiveImgStyles = css`
-	display: block;
-	height: 80vh;
-	object-fit: cover;
-	width: 100vw;
-`;
-
-const getStyles = ({ design, display }: ArticleFormat): SerializedStyles => {
-	switch (design) {
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-			return liveStyles;
-		case ArticleDesign.Interview:
-			return interviewStyles;
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return commentStyles;
-		default:
-			if (display === ArticleDisplay.Immersive) {
-				return immersiveStyles;
-			}
-
-			return styles;
-	}
-};
-
-const getImgStyles = (
-	format: ArticleFormat,
-	image: Image,
-): SerializedStyles => {
-	switch (format.design) {
-		case ArticleDesign.LiveBlog:
-		case ArticleDesign.DeadBlog:
-			return css();
-		default:
-			switch (format.display) {
-				case ArticleDisplay.Immersive:
-					return immersiveImgStyles;
-				default:
-					return imgStyles(image.width, image.height);
-			}
-	}
-};
-
-const getSizes = ({ display, design }: ArticleFormat, image: Image): Sizes => {
-	switch (design) {
-		case ArticleDesign.DeadBlog:
-		case ArticleDesign.LiveBlog:
-			return {
-				mediaQueries: [{ breakpoint: 'tablet', size: '700px' }],
-				default: '100vw',
-			};
-	}
-	switch (display) {
-		case ArticleDisplay.Immersive:
-			return {
-				mediaQueries: [],
-				default: `${(100 * image.width) / image.height}vh `,
-			};
-		default:
-			return {
-				mediaQueries: [{ breakpoint: 'wide', size: '620px' }],
-				default: '100vw',
-			};
-	}
-};
 
 interface Props {
 	image: Image;
@@ -173,23 +19,54 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => (
-	<figure css={[getStyles(format), className]} aria-labelledby={captionId}>
-		<Img
-			image={image}
-			sizes={getSizes(format, image)}
-			className={some(getImgStyles(format, image))}
-			format={format}
-			supportsDarkMode
-			lightbox={some({
-				className: 'js-launch-slideshow',
-				caption: image.nativeCaption,
-				credit: image.credit,
-			})}
-		/>
-		<Caption format={format} image={image} />
-	</figure>
-);
+const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return (
+			<ImmersiveMainMediaImage
+				image={image}
+				format={format}
+				className={className}
+			/>
+		);
+	}
+	switch (format.design) {
+		case ArticleDesign.LiveBlog:
+		case ArticleDesign.DeadBlog:
+			return (
+				<BlogMainMediaImage
+					image={image}
+					format={format}
+					className={className}
+				/>
+			);
+		case ArticleDesign.Interview:
+			return (
+				<InterviewMainMediaImage
+					image={image}
+					format={format}
+					className={className}
+				/>
+			);
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+			return (
+				<CommentMainMediaImage
+					image={image}
+					format={format}
+					className={className}
+				/>
+			);
+		default:
+			return (
+				<DefaultMainMediaImage
+					image={image}
+					format={format}
+					className={className}
+				/>
+			);
+	}
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/index.tsx
@@ -8,7 +8,10 @@ import type { FC } from 'react';
 import BlogMainMediaImage from './BlogMainMediaImage';
 import CommentMainMediaImage from './CommentMainMediaImage';
 import InterviewMainMediaImage from './InterviewMainMediaImage';
-import DefaultMainMediaImage from './MainMediaImage.defaults';
+import DefaultMainMediaImage, {
+	defaultSizes,
+	defaultStyles,
+} from './MainMediaImage.defaults';
 
 // ----- Component ----- //
 
@@ -40,29 +43,18 @@ const MainMediaImage: FC<Props> = ({ className, image, format }: Props) => {
 				/>
 			);
 		case ArticleDesign.Interview:
-			return (
-				<InterviewMainMediaImage
-					image={image}
-					format={format}
-					className={className}
-				/>
-			);
+			return <InterviewMainMediaImage image={image} format={format} />;
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
-			return (
-				<CommentMainMediaImage
-					image={image}
-					format={format}
-					className={className}
-				/>
-			);
+			return <CommentMainMediaImage image={image} format={format} />;
 		default:
 			return (
 				<DefaultMainMediaImage
 					image={image}
 					format={format}
-					className={className}
+					css={defaultStyles}
+					sizes={defaultSizes}
 				/>
 			);
 	}

--- a/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
@@ -59,7 +59,7 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const HeaderVideo: FC<Props> = ({ video, format }) => (
+const MainMediaVideo: FC<Props> = ({ video, format }) => (
 	<div
 		css={styles(format)}
 		data-posterUrl={video.posterUrl}
@@ -70,4 +70,4 @@ const HeaderVideo: FC<Props> = ({ video, format }) => (
 
 // ----- Exports ----- //
 
-export default HeaderVideo;
+export default MainMediaVideo;

--- a/apps-rendering/src/components/MainMedia/index.tsx
+++ b/apps-rendering/src/components/MainMedia/index.tsx
@@ -2,23 +2,11 @@
 
 import type { ArticleFormat } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import HeaderImage from 'components/HeaderImage';
-import HeaderVideo from 'components/HeaderVideo';
-import type { Image as ImageData } from 'image';
+import MainMediaImage from 'components/MainMedia/MainMediaImage';
+import MainMediaVideo from 'components/MainMedia/MainMediaVideo';
 import { maybeRender } from 'lib';
+import { MainMedia, MainMediaKind } from 'mainMedia';
 import type { FC } from 'react';
-import type { Video as VideoData } from 'video';
-
-// ----- Types ----- //
-
-export const enum MainMediaKind {
-	Image,
-	Video,
-}
-
-export type MainMedia =
-	| { kind: MainMediaKind.Image; image: ImageData }
-	| { kind: MainMediaKind.Video; video: VideoData };
 
 // ----- Component ----- //
 
@@ -31,9 +19,9 @@ const MainMedia: FC<Props> = ({ format, mainMedia }) =>
 	maybeRender(mainMedia, (media) => {
 		switch (media.kind) {
 			case MainMediaKind.Image:
-				return <HeaderImage image={media.image} format={format} />;
+				return <MainMediaImage image={media.image} format={format} />;
 			case MainMediaKind.Video:
-				return <HeaderVideo video={media.video} format={format} />;
+				return <MainMediaVideo video={media.video} format={format} />;
 		}
 	});
 

--- a/apps-rendering/src/mainMedia.ts
+++ b/apps-rendering/src/mainMedia.ts
@@ -1,0 +1,15 @@
+// ----- Imports ----- //
+
+import type { Image as ImageData } from 'image';
+import type { Video as VideoData } from 'video';
+
+// ----- Types ----- //
+
+export const enum MainMediaKind {
+	Image,
+	Video,
+}
+
+export type MainMedia =
+	| { kind: MainMediaKind.Image; image: ImageData }
+	| { kind: MainMediaKind.Video; video: VideoData };


### PR DESCRIPTION
## What does this change?
Refactors `mainMedia` to follow the new AR component structure. This was achieved by:

- Renaming `mainMedia.tsx` into `mainMedia.ts`: it now only contains types and no JSX.
- Creating a folder called `MainMedia` with an `index.tsx` file that decides whether to render an image or a video as the main media.
- Renaming `HeaderImage` and `HeaderVideo` into `MainMediaImage` and `MainMediaVideo` and moving them into the `MainMedia` folder as subcomponents.
- Splitting `MainMediaImage` into subcomponents based on display and design.

## Why?
So that it's easier to make changes that apply to specific formats only.

## Screenshots
N/A - there are no visual changes, this is just a structural refactor.