### PR TITLE
Replace article link in Cypress test

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
@@ -14,7 +14,7 @@ import { storage } from '@guardian/libs';
 // cookie or by selecting the edition in the UI. Unfortunately, the first solution did
 // not work and the second one is not possible at this point of the migration.
 const paidContentPage =
-	'https://www.theguardian.com/welcome-to-ontario/2022/jan/20/bracing-boat-trips-dinosaurs-and-cherry-pie-the-best-things-to-do-with-kids-in-ontario';
+	'https://www.theguardian.com/you-could-be-here/2022/may/13/kos-crete-corfu-and-mykonos-a-guide-to-greeces-favourite-islands';
 
 describe('Paid content tests', function () {
 	beforeEach(function () {
@@ -59,7 +59,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=destination%20ontario');
+			expect(requestURL).to.include('el=british%20airways%20holidays');
 		});
 	});
 
@@ -100,7 +100,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=destination%20ontario');
+			expect(requestURL).to.include('el=british%20airways%20holidays');
 		});
 	});
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces an article link in a Cypress test

## Why?
The previous article was taken down, so we're temporarily using a new article to unblock the build. 2nd PR we will follow to add a more permanent solution as this article might also be taken down in the future.

## Screenshots

Before
![image](https://user-images.githubusercontent.com/19683595/170960418-45722bf5-6ec4-4f52-92f8-76dd1a087e4a.png)

After

![image](https://user-images.githubusercontent.com/19683595/170964583-dd7769ed-0846-491e-9a0f-ac8bf70271a2.png)



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
