### PR TITLE
Chromatic: Ignore Obituaries (again)

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1429,6 +1429,15 @@ declare namespace JSX {
 
 	interface IntrinsicAttributes {
 		/**
+		 * ## Chromatic
+		 * Set this attribute to ignore elements Chromatic should ignore.
+		 * Helps lower the amount of false positive for dynamic content.
+		 *
+		 * @see https://www.chromatic.com/docs/ignoring-elements#ignore-dom-elements
+		 */
+		'data-chromatic'?: 'ignore';
+
+		/**
 		 * **Rendered Components – Ophan**
 		 *
 		 * The Ophan client automatically tracks components on the page

--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -186,6 +186,8 @@ export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 			<ul
 				ref={ulRef}
 				css={[expandSubNav ? expandedStyles : collapsedStyles]}
+				// We’ve getting many false positive on changes to “Obituaries”
+				data-chromatic="ignore"
 			>
 				{subNavSections.parent && (
 					<li

--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -202,18 +202,7 @@ export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 					</li>
 				)}
 				{subNavSections.links.map((link) => (
-					<li
-						key={link.url}
-						/**
-						 * We’ve getting many false positive on changes to Obituaries.
-						 * Let’s try ignoring it for now.
-						 *
-						 * @see https://www.chromatic.com/docs/ignoring-elements#ignore-dom-elements
-						 */
-						data-chromatic={
-							link.title === 'Obituaries' ? 'ignore' : undefined
-						}
-					>
+					<li key={link.url}>
 						<a
 							css={linkStyle(palette)}
 							data-src-focus-disabled={true}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Ignore the whole `ul` instead of only Obituaries.

## Why?

We get too many false positive. #5042 did not succeed.

<!--
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
