### PR TITLE
Render email signup embed caption with dangerouslySetInnerHTML

### DIFF
--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -50,7 +50,12 @@ export const EmbedBlockComponent = ({
 		>
 			<div data-cy="embed-block" css={embedContainerStyles(isEmailEmbed)}>
 				{isEmailEmbed && caption && (
-					<div css={emailCaptionStyle}>{caption}</div>
+					<div
+						css={emailCaptionStyle}
+						dangerouslySetInnerHTML={{
+							__html: caption,
+						}}
+					/>
 				)}
 				<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
 			</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Renders captions for email embeds using `dangerouslySetInnerHtml` to match [other caption-rendering implementations](https://github.com/guardian/dotcom-rendering/blob/a401bd0fbb839916af4fade22e8d1a3b2974b373/dotcom-rendering/src/web/components/Caption.tsx#L269)

## Why?

* Captions can contain HTML

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="643" alt="Screenshot 2022-05-30 at 10 48 36" src="https://user-images.githubusercontent.com/705427/170966460-7ce60793-9118-4a58-b8d5-2889ed26d8a9.png"> | <img width="637" alt="Screenshot 2022-05-30 at 10 46 32" src="https://user-images.githubusercontent.com/705427/170966038-6ca0a319-6252-4624-bf24-5ae27bd3ba29.png"> |
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.


| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
