### PR TITLE
Set geolocation header in cypress test 

### DIFF
--- a/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
@@ -4,18 +4,6 @@ import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
-// It is important to use this article for this test because its commercialProperties
-// coming from the CAPI object are the same for all editions. This way we are making sure
-// the Branding island the test expects will be in the DOM. If an article with different
-// commercialProperties across editions were to be used, the test would have different
-// outcome when running locally (UK edition) and when running in CI. For example,
-// it could be US edition if the CI server runs in US. The best way to deal with
-// this would be to control the edition in the test whether by setting the GU_EDITION
-// cookie or by selecting the edition in the UI. Unfortunately, the first solution did
-// not work and the second one is not possible at this point of the migration.
-const paidContentPage =
-	'https://www.theguardian.com/you-could-be-here/2022/may/13/kos-crete-corfu-and-mykonos-a-guide-to-greeces-favourite-islands';
-
 describe('Paid content tests', function () {
 	beforeEach(function () {
 		setLocalBaseUrl();
@@ -23,7 +11,12 @@ describe('Paid content tests', function () {
 	});
 
 	it('should send Google Analytics message on click of sponsor logo in metadata', function () {
-		cy.visit(`Article?url=${paidContentPage}`);
+		const paidContentPage =
+			'https://www.theguardian.com/food/2022/feb/23/how-to-make-chicken-cacciatore-recipe-felicity-cloake-masterclass';
+
+		cy.visit(`Article?url=${paidContentPage}`, {
+			headers: { 'x-gu-geolocation': 'ip.dummytext,country:UK' },
+		});
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
@@ -59,12 +52,16 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=british%20airways%20holidays');
+			expect(requestURL).to.include('el=ocado');
 		});
 	});
 
 	it('should send Google Analytics message on click of sponsor logo in onwards section', function () {
-		cy.visit(`Article?url=${paidContentPage}`);
+		const paidContentPage =
+			'https://www.theguardian.com/feasting-with-ocado/2022/apr/08/rukmini-iyers-recipe-for-slow-cooked-lamb-leg-al-pastor-with-pineapple-salsa';
+		cy.visit(`Article?url=${paidContentPage}`, {
+			headers: { 'x-gu-geolocation': 'ip.dummytext,country:UK' },
+		});
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");
@@ -100,7 +97,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=british%20airways%20holidays');
+			expect(requestURL).to.include('el=ocado');
 		});
 	});
 });

--- a/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
+++ b/dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js
@@ -59,9 +59,6 @@ describe('Paid content tests', function () {
 	it('should send Google Analytics message on click of sponsor logo in onwards section', function () {
 		const paidContentPage =
 			'https://www.theguardian.com/feasting-with-ocado/2022/apr/08/rukmini-iyers-recipe-for-slow-cooked-lamb-leg-al-pastor-with-pineapple-salsa';
-		cy.visit(`Article?url=${paidContentPage}`, {
-			headers: { 'x-gu-geolocation': 'ip.dummytext,country:UK' },
-		});
 
 		// Open the Privacy setting dialogue
 		cmpIframe().contains("It's your choice");


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## 1st change
* Removes unnecessary comment

## Why?
* After this PR https://github.com/guardian/dotcom-rendering/pull/4187 we can use any article we want and specify the edition to be rendered in the test.

## Screenshots

| Before      | After      |
|-------------|------------|
| US edition (no Ocado logo) | UK edition |
| ![image](https://user-images.githubusercontent.com/19683595/171035360-d23923de-7822-4c51-9a46-498952316f4c.png) | ![image](https://user-images.githubusercontent.com/19683595/171035214-d51c997d-c758-475e-8994-348e0621cda4.png) |


## 2nd change
* Uses two different articles in tests in `dotcom-rendering/cypress/integration/parallel-6/paid.content.spec.js` to make sure we're sending the expected information to Google Analytics: https://github.com/guardian/dotcom-rendering/pull/4098

## Why?
To test two types of articles where we could have this type of content

| Article type |      |
|-------------|-------------|
| Standard with metadata only | ![image](https://user-images.githubusercontent.com/19683595/171035214-d51c997d-c758-475e-8994-348e0621cda4.png) |
| Immersive with Onwards | ![image](https://user-images.githubusercontent.com/19683595/171037181-412e13c2-cfa9-4ee1-8802-597af8037262.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
