### PR TITLE
Send card position on key event click

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -118,7 +118,7 @@ export const KeyEventCard = ({
 				priority="secondary"
 				css={[linkStyles(palette), isSummary && summaryStyles(palette)]}
 				href={url}
-				data-link-name={`key event card ${cardPosition}`}
+				data-link-name={`key event card | ${cardPosition}`}
 			>
 				<time
 					dateTime={date.toISOString()}

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -11,6 +11,7 @@ interface Props {
 	isSummary: boolean;
 	filterKeyEvents: boolean;
 	format: ArticleFormat;
+	cardPosition?: string;
 }
 
 const linkStyles = (palette: Palette) => css`
@@ -106,6 +107,7 @@ export const KeyEventCard = ({
 	title,
 	filterKeyEvents,
 	format,
+	cardPosition,
 }: Props) => {
 	const palette = decidePalette(format);
 	const url = `?filterKeyEvents=${filterKeyEvents}&page=with:block-${id}#block-${id}`;
@@ -116,7 +118,7 @@ export const KeyEventCard = ({
 				priority="secondary"
 				css={[linkStyles(palette), isSummary && summaryStyles(palette)]}
 				href={url}
-				data-link-name="key event card"
+				data-link-name={`key event card ${cardPosition}`}
 			>
 				<time
 					dateTime={date.toISOString()}

--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -108,7 +108,8 @@ export const KeyEventsCarousel = ({
 		if (carousel.current) carousel.current.scrollLeft += cardWidth;
 	};
 	const filteredKeyEvents = keyEvents.filter(isValidKeyEvent);
-	const shortCarousel = filteredKeyEvents.length <= 4;
+	const carouselLength = filteredKeyEvents.length;
+	const shortCarousel = carouselLength <= 4;
 	return (
 		<>
 			<Hide from="desktop">
@@ -128,7 +129,7 @@ export const KeyEventsCarousel = ({
 						!shortCarousel && marginBottomStyles,
 					]}
 				>
-					{filteredKeyEvents.map((keyEvent) => {
+					{filteredKeyEvents.map((keyEvent, i) => {
 						return (
 							<KeyEventCard
 								format={format}
@@ -139,6 +140,7 @@ export const KeyEventsCarousel = ({
 								}
 								isSummary={keyEvent.attributes.summary}
 								title={keyEvent.title}
+								cardPosition={`${i} / ${carouselLength}`}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -129,7 +129,7 @@ export const KeyEventsCarousel = ({
 						!shortCarousel && marginBottomStyles,
 					]}
 				>
-					{filteredKeyEvents.map((keyEvent, i) => {
+					{filteredKeyEvents.map((keyEvent, index) => {
 						return (
 							<KeyEventCard
 								format={format}
@@ -140,7 +140,7 @@ export const KeyEventsCarousel = ({
 								}
 								isSummary={keyEvent.attributes.summary}
 								title={keyEvent.title}
-								cardPosition={`${i} / ${carouselLength}`}
+								cardPosition={`${index} of ${carouselLength}`}
 							/>
 						);
 					})}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Sends the key event card position (`key event index / key events total length`) in the data link name to be tracked in Ophan.

## Why?
There was a desire to understand if users were scrolling the carousel but this tracking can be expensive and adds additional javascript which we are trying to use only where essential, as this component renders above the fold on desktop. 

Instead, we are passing the key event card index and the total number of key events in the carousel. From this, we can infer if users are scrolling and clicking on older key events past the initial 7 on screen. 
