### PR TITLE
Use only Pubmatic for Prebid Server test

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -48,8 +48,8 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 // Variants for the Prebid server test
 // Assign each variant 4 groups e.g. 33.3% of content types each
 const variants = {
-	'relevant-yield': new Set([0, 1, 4, 5, 6, 7]),
-	pubmatic: new Set([2, 3, 8, 9, 10, 11]),
+	'relevant-yield': new Set<number>([]),
+	pubmatic: new Set<number>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
 };
 
 // Determine participation in a variant from group

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -338,7 +338,7 @@ describe('RegionalAd', () => {
 		expect(intRtcAttribute.vendors).toEqual({});
 	});
 
-	it('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
+	it.skip('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider
 				pageId="food/2022/feb/15/air-fryers-miraculous-kitchen-must-have-or-just-a-load-of-hot-air"


### PR DESCRIPTION
## What does this change?

Allocate all of our 12 AMP test groups (see #4110 for test framework) to Pubmatic for the Prebid Server test (see #4207).

Skip one of the unit tests that no longer applies since we're allocating no content to Relevant Yield.

## Why?

### Background

We've been running a test where we allocate AMP pages to one of two variants, each of which uses a different Prebid Server for header bidding. Each AMP page has its URL hashed and allocated to one of 12 buckets, and 6 of each of these buckets are allocated to a variant (`pubmatic` or `relevant-yield`).

However, there have been issues with running two Prebid Servers in parallel. For example, some SSPs are unable to integrate with two servers simultaneously.

### This change

Due to the issue above, we want to assess the outcome of using just a single Prebid Server for a period of time (around ten days). To do this, we allocate each of the 12 test groups to the Pubmatic variant, so that it runs each on each AMP page. In ten days time, we'll switch the servers so Relevant Yield is allocated 12 groups.

Since no pages will be allocated to RY, we have to skip a test that checks a given page maps to the Relevant Yield variant. I opted to skip this test rather than remove it because after ten days we'll switch vendors and this test can used again (skipping the equivalent Pubmatic one).
