### PR TITLE
tighter lineheight

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
@@ -21,7 +21,7 @@ export const TrailTextWrapper = ({
 				flex-direction: column;
 				color: ${palette.text.cardStandfirst};
 
-				${body.small()};
+				${body.small({ lineHeight: 'regular' })};
 				font-size: 14px;
 
 				padding-left: 5px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Tightens line height on fronts cards. it's loose by default but should be regular
## Why?
Was wrong before
## Screenshots
Before
![Screenshot 2022-06-01 at 12 31 18](https://user-images.githubusercontent.com/20658471/171395082-5c847629-c9cb-4f23-a00e-11ad85529421.png)
After
![Screenshot 2022-06-01 at 12 31 44](https://user-images.githubusercontent.com/20658471/171395104-bef463cf-3638-4377-b3e6-514f1517edc2.png)

