### PR TITLE
Fix email embeds when rendering alongside a rich link

### DIFF
--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -21,6 +21,8 @@ const emailCaptionStyle = css`
 `;
 
 const embedContainerStyles = (isEmailEmbed: boolean) => css`
+	/* By using inline-block we keep the content together if a rich link is placed inline nearby */
+	display: inline-block;
 	iframe {
 		/* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
 		/* stylelint-disable-next-line declaration-no-important */

--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, text, textSans } from '@guardian/source-foundations';
+import { from, space, text, textSans } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import { ClickToView } from './ClickToView';
 
@@ -21,8 +21,15 @@ const emailCaptionStyle = css`
 `;
 
 const embedContainerStyles = (isEmailEmbed: boolean) => css`
-	/* By using inline-block we keep the content together if a rich link is placed inline nearby */
-	display: inline-block;
+	/* By using inline-block we keep email embed content together if a rich link is placed inline nearby */
+	${isEmailEmbed &&
+	`
+		display: inline-block;
+		${from.tablet}{
+			display: flex;
+			flex-direction: column;
+		}
+	`}
 	iframe {
 		/* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
 		/* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This ensures the email embed elements stay together around any rich link that is placed inline in the article content.

Example: https://www.theguardian.com/politics/2022/may/30/tory-chris-philp-rules-out-new-inquiry-illicit-gathering-boris-johnson-flat

| Before      | After      |
|-------------|------------|
| ![2022-06-01 16 44 23](https://user-images.githubusercontent.com/1336821/171445402-212d9a9a-ea6a-48ab-98fb-d6a3187c7500.gif) | ![2022-06-01 16 43 02](https://user-images.githubusercontent.com/1336821/171445439-29726efd-eda8-406c-a08a-e1a8d16b9f8c.gif) |
