### PR TITLE
Filter image caption location for strings without any characters

### DIFF
--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -128,7 +128,7 @@ const CaptionLocation: FC<{ location: string[]; triangleColor: string }> = ({
 	return (
 		<h2 css={styles}>
 			<Triangle color={triangleColor} />
-			{location.join(', ')}
+			{location.filter((s) => /[a-zA-Z]/.test(s)).join(', ')}
 		</h2>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Filters image caption locations for strings with no characters

## Why?
Some image captions contain strings with just a space or punctuation mark which aren't filtered out by just checking that the content is truthy.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="757" alt="image" src="https://user-images.githubusercontent.com/99400613/171861232-ec6aab64-388d-40f0-ba18-4298403b2d9c.png"> | <img width="760" alt="image" src="https://user-images.githubusercontent.com/99400613/171861306-fd1b14b7-db25-4af5-b8e7-301145bcee52.png"> |
| <img width="763" alt="image" src="https://user-images.githubusercontent.com/99400613/171861508-f2981b13-4cbc-4861-9d00-950819582fb9.png"> | <img width="768" alt="image" src="https://user-images.githubusercontent.com/99400613/171861579-3d287376-212e-4b07-aa10-f17441287fa7.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
