### PR TITLE
Change byline avatar positioning

### DIFF
--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -16,10 +16,9 @@ import {
 	neutral,
 	remSpace,
 } from '@guardian/source-foundations';
-import { OptionKind } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { index, maybeRender } from 'lib';
+import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { getThemeStyles } from 'themeStyles';
 import EditionsAvatar from '../avatar';

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -71,12 +71,14 @@ const showcaseStyles = css`
 	padding-bottom: ${remSpace[6]};
 `;
 
-const commentStyles = (hasImage: boolean): SerializedStyles => css`
-	padding-right: ${hasImage ? '6.5625rem' : 0};
-`;
-
 const avatarWrapperStyles = css`
 	margin-top: -16px;
+`;
+
+const addressStyles = css`
+	flex-grow: 1;
+	flex-shrink: 0;
+	flex-basis: 50%;
 `;
 
 // ----- Byline Component Styles ----- //
@@ -178,7 +180,6 @@ const bylineSecondaryStyles = (format: ArticleFormat): SerializedStyles => {
 const getBylineStyles = (
 	format: ArticleFormat,
 	iconColor: string,
-	hasImage: boolean,
 	hasAvatar: boolean,
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
@@ -189,7 +190,7 @@ const getBylineStyles = (
 		return css(styles(iconColor, hasAvatar), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
-		return css(styles(iconColor, hasAvatar), commentStyles(hasImage));
+		return css(styles(iconColor, hasAvatar));
 	}
 	if (format.display === ArticleDisplay.Showcase) {
 		return css(styles(iconColor, hasAvatar), showcaseStyles);
@@ -268,10 +269,8 @@ const Byline: FC<Props> = ({ item }) => {
 		contributor.value.image.kind === OptionKind.Some;
 
 	return maybeRender(item.bylineHtml, (byline) => (
-		<div
-			css={getBylineStyles(format, iconColor, hasImage, hasAvatar(item))}
-		>
-			<address>{renderText(byline, format)}</address>
+		<div css={getBylineStyles(format, iconColor, hasAvatar(item))}>
+			<address css={addressStyles}>{renderText(byline, format)}</address>
 			{showShareIcon && <ShareIcon />}
 			{hasAvatar(item) && (
 				<div css={avatarWrapperStyles}>

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -262,11 +262,6 @@ const Byline: FC<Props> = ({ item }) => {
 
 	const iconColor = ignoreIconColour(format) ? neutral[100] : kickerColor;
 	const showShareIcon = hasShareIcon(format);
-	const contributor = index(0)(item.contributors);
-
-	const hasImage =
-		contributor.kind === OptionKind.Some &&
-		contributor.value.image.kind === OptionKind.Some;
 
 	return maybeRender(item.bylineHtml, (byline) => (
 		<div css={getBylineStyles(format, iconColor, hasAvatar(item))}>

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -76,14 +76,12 @@ const commentStyles = (hasImage: boolean): SerializedStyles => css`
 `;
 
 const avatarWrapperStyles = css`
-	position: absolute;
-	bottom: 0;
-	right: 0;
+	margin-top: -16px;
 `;
 
 // ----- Byline Component Styles ----- //
 
-const styles = (iconColor: string): SerializedStyles => {
+const styles = (iconColor: string, hasAvatar: boolean): SerializedStyles => {
 	return css`
 		position: relative;
 		display: flex;
@@ -105,12 +103,12 @@ const styles = (iconColor: string): SerializedStyles => {
 		}
 		min-height: ${remSpace[12]};
 
-		padding-bottom: ${remSpace[4]};
+		${!hasAvatar && `padding-bottom: ${remSpace[4]};`}
 		margin: 0;
 
 		${from.tablet} {
 			min-height: ${remSpace[9]};
-			padding-bottom: ${remSpace[9]};
+			${!hasAvatar && `padding-bottom: ${remSpace[9]};`}
 		}
 	`;
 };
@@ -184,25 +182,25 @@ const getBylineStyles = (
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {
-		return css(styles(iconColor), immersiveStyles);
+		return css(styles(iconColor, hasImage), immersiveStyles);
 	}
 	if (format.design === ArticleDesign.Interview) {
-		return css(styles(iconColor), interviewStyles);
+		return css(styles(iconColor, hasImage), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
-		return css(styles(iconColor), commentStyles(hasImage));
+		return css(styles(iconColor, hasImage), commentStyles(hasImage));
 	}
 	if (format.display === ArticleDisplay.Showcase) {
-		return css(styles(iconColor), showcaseStyles);
+		return css(styles(iconColor, hasImage), showcaseStyles);
 	}
 	if (
 		format.design === ArticleDesign.Gallery ||
 		format.design === ArticleDesign.Audio ||
 		format.design === ArticleDesign.Video
 	) {
-		return css(styles(iconColor), galleryStyles);
+		return css(styles(iconColor, hasImage), galleryStyles);
 	}
-	return styles(iconColor);
+	return styles(iconColor, hasImage);
 };
 
 // ----- Component ----- //

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -182,25 +182,28 @@ const getBylineStyles = (
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {
-		return css(styles(iconColor, hasImage), immersiveStyles);
+		return css(styles(iconColor, hasAvatar(format)), immersiveStyles);
 	}
 	if (format.design === ArticleDesign.Interview) {
-		return css(styles(iconColor, hasImage), interviewStyles);
+		return css(styles(iconColor, hasAvatar(format)), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
-		return css(styles(iconColor, hasImage), commentStyles(hasImage));
+		return css(
+			styles(iconColor, hasAvatar(format)),
+			commentStyles(hasImage),
+		);
 	}
 	if (format.display === ArticleDisplay.Showcase) {
-		return css(styles(iconColor, hasImage), showcaseStyles);
+		return css(styles(iconColor, hasAvatar(format)), showcaseStyles);
 	}
 	if (
 		format.design === ArticleDesign.Gallery ||
 		format.design === ArticleDesign.Audio ||
 		format.design === ArticleDesign.Video
 	) {
-		return css(styles(iconColor, hasImage), galleryStyles);
+		return css(styles(iconColor, hasAvatar(format)), galleryStyles);
 	}
-	return styles(iconColor, hasImage);
+	return styles(iconColor, hasAvatar(format));
 };
 
 // ----- Component ----- //

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -240,9 +240,10 @@ const hasShareIcon = (format: ArticleFormat): boolean =>
 		format.design === ArticleDesign.Comment
 	);
 
-const hasAvatar = (item: Item): boolean => {
+const hasAvatar = (format: ArticleFormat): boolean => {
 	return (
-		item.design === ArticleDesign.Comment && item.contributors.length > 0
+		format.design === ArticleDesign.Comment &&
+		format.contributors.length > 0
 	);
 };
 const ignoreIconColour = (format: ArticleFormat): boolean =>
@@ -272,7 +273,7 @@ const Byline: FC<Props> = ({ item }) => {
 		<div css={getBylineStyles(format, iconColor, hasImage)}>
 			<address>{renderText(byline, format)}</address>
 			{showShareIcon && <ShareIcon />}
-			{hasAvatar(item) && (
+			{hasAvatar(format) && (
 				<div css={avatarWrapperStyles}>
 					<EditionsAvatar item={item} />
 				</div>

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -179,31 +179,29 @@ const getBylineStyles = (
 	format: ArticleFormat,
 	iconColor: string,
 	hasImage: boolean,
+	hasAvatar: boolean,
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {
-		return css(styles(iconColor, false), immersiveStyles);
+		return css(styles(iconColor, hasAvatar), immersiveStyles);
 	}
 	if (format.design === ArticleDesign.Interview) {
-		return css(styles(iconColor, false), interviewStyles);
+		return css(styles(iconColor, hasAvatar), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
-		return css(
-			styles(iconColor, hasAvatar(format)),
-			commentStyles(hasImage),
-		);
+		return css(styles(iconColor, hasAvatar), commentStyles(hasImage));
 	}
 	if (format.display === ArticleDisplay.Showcase) {
-		return css(styles(iconColor, false), showcaseStyles);
+		return css(styles(iconColor, hasAvatar), showcaseStyles);
 	}
 	if (
 		format.design === ArticleDesign.Gallery ||
 		format.design === ArticleDesign.Audio ||
 		format.design === ArticleDesign.Video
 	) {
-		return css(styles(iconColor, false), galleryStyles);
+		return css(styles(iconColor, hasAvatar), galleryStyles);
 	}
-	return styles(iconColor, false);
+	return styles(iconColor, hasAvatar);
 };
 
 // ----- Component ----- //
@@ -240,7 +238,7 @@ const hasShareIcon = (format: ArticleFormat): boolean =>
 		format.design === ArticleDesign.Comment
 	);
 
-const hasAvatar = (format: ArticleFormat): boolean => {
+const hasAvatar = (format: Item): boolean => {
 	return (
 		format.design === ArticleDesign.Comment &&
 		format.contributors.length > 0
@@ -270,10 +268,12 @@ const Byline: FC<Props> = ({ item }) => {
 		contributor.value.image.kind === OptionKind.Some;
 
 	return maybeRender(item.bylineHtml, (byline) => (
-		<div css={getBylineStyles(format, iconColor, hasImage)}>
+		<div
+			css={getBylineStyles(format, iconColor, hasImage, hasAvatar(item))}
+		>
 			<address>{renderText(byline, format)}</address>
 			{showShareIcon && <ShareIcon />}
-			{hasAvatar(format) && (
+			{hasAvatar(item) && (
 				<div css={avatarWrapperStyles}>
 					<EditionsAvatar item={item} />
 				</div>

--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -182,10 +182,10 @@ const getBylineStyles = (
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {
-		return css(styles(iconColor, hasAvatar(format)), immersiveStyles);
+		return css(styles(iconColor, false), immersiveStyles);
 	}
 	if (format.design === ArticleDesign.Interview) {
-		return css(styles(iconColor, hasAvatar(format)), interviewStyles);
+		return css(styles(iconColor, false), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
 		return css(
@@ -194,16 +194,16 @@ const getBylineStyles = (
 		);
 	}
 	if (format.display === ArticleDisplay.Showcase) {
-		return css(styles(iconColor, hasAvatar(format)), showcaseStyles);
+		return css(styles(iconColor, false), showcaseStyles);
 	}
 	if (
 		format.design === ArticleDesign.Gallery ||
 		format.design === ArticleDesign.Audio ||
 		format.design === ArticleDesign.Video
 	) {
-		return css(styles(iconColor, hasAvatar(format)), galleryStyles);
+		return css(styles(iconColor, false), galleryStyles);
 	}
-	return styles(iconColor, hasAvatar(format));
+	return styles(iconColor, false);
 };
 
 // ----- Component ----- //


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the avatar in the byline to just have a negative margin instead of `position: absolute`
## Why?
On some screens the avatar image overlaps the standfirst because it's aligned with the bottom of the byline
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="367" alt="image" src="https://user-images.githubusercontent.com/99400613/171862343-fb2873de-1da0-43b5-8fe2-a10649d96ae5.png"> | <img width="367" alt="image" src="https://user-images.githubusercontent.com/99400613/171862291-96d5e486-29e5-4c40-b96f-5b4693698e78.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
