### PR TITLE
Add byline to DCFrontCard

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -865,6 +865,8 @@ type DCRFrontCard = {
 	/** @see JSX.IntrinsicAttributes["data-link-name"] */
 	dataLinkName: string;
 	discussionId?: string;
+	byline?: string;
+	showByline?: boolean;
 };
 
 type FECollectionType = {

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -109,5 +109,11 @@ export const enhanceCards = (
 					  )
 					: undefined,
 				discussionId: faciaCard.discussion.discussionId,
+				// there are two 'byline' properties on FEFrontCard; are they
+				// always the same? If not, which should be preferred?
+				byline:
+					faciaCard.properties.maybeContent?.trail.byline ??
+					undefined,
+				showByline: faciaCard.properties.showByline,
 			};
 		});

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -109,8 +109,8 @@ export const enhanceCards = (
 					  )
 					: undefined,
 				discussionId: faciaCard.discussion.discussionId,
-				// there are two 'byline' properties on FEFrontCard; are they
-				// always the same? If not, which should be preferred?
+				// nb. there is a distinct 'byline' property on FEFrontCard, at
+				// card.properties.byline
 				byline:
 					faciaCard.properties.maybeContent?.trail.byline ??
 					undefined,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Add `byline` and `showByline` fields to DCRFrontCard model.
- Pass values for these fields through from FE cards to DCR cards (when present) in `enhanceCards` function.

## Why?
The initial aim was to add bylines to comment cards to match with how they're rendered by Frontend (as per #5094). 

The final implementation has a slightly more general scope, however. The simplest way to recreate the byline behaviour of Frontend on DCR Fronts was to pass the `showByline` field through from the json for a Front card through to the container renderer. 

The reason for doing this is that it seems sensible to delegate showing bylines on Fronts cards to the logic that's already built out in Frontend by default, unless we want to add any significant deviations. Overrides could be added for special cases, until a time where it makes sense to implement a separate logic in DCR.

## Screenshots

### Frontend, unchanged
![frontend](https://user-images.githubusercontent.com/37048459/171884985-672c7ef9-389b-4de0-8ebe-e53f87c8ff4c.png)

### Before (DCR)
![DCR before](https://user-images.githubusercontent.com/37048459/171886060-243ee8e8-afb9-4569-889b-cc48e99f224e.png)

### After (DCR)
![DCR after](https://user-images.githubusercontent.com/37048459/171886691-7c87088d-f43e-4f7f-96a4-5bdcc3c192f2.png)

