### PR TITLE
Don't display campaign and tracking tags at the bottom of articles

### DIFF
--- a/apps-rendering/src/components/Tags/index.tsx
+++ b/apps-rendering/src/components/Tags/index.tsx
@@ -3,6 +3,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
@@ -69,6 +70,7 @@ interface Props {
 	tags: Array<{
 		webUrl: string;
 		webTitle: string;
+		type: TagType;
 	}>;
 	background?: string;
 	format: ArticleFormat;
@@ -76,15 +78,21 @@ interface Props {
 
 const Tags: FC<Props> = ({ tags, format }) => (
 	<ul css={styles(format)}>
-		{tags.map((tag, index) => {
-			return (
-				<li key={index} css={tagStyles}>
-					<a href={tag.webUrl} css={anchorStyles(format)}>
-						{tag.webTitle}
-					</a>
-				</li>
-			);
-		})}
+		{tags
+			.filter(
+				(tag) =>
+					tag.type !== TagType.CAMPAIGN &&
+					tag.type !== TagType.TRACKING,
+			)
+			.map((tag, index) => {
+				return (
+					<li key={index} css={tagStyles}>
+						<a href={tag.webUrl} css={anchorStyles(format)}>
+							{tag.webTitle}
+						</a>
+					</li>
+				);
+			})}
 	</ul>
 );
 


### PR DESCRIPTION
## Why?
Some tags aren't meaningful to users and add visual noise - particularly tags of type `CAMPAIGN` (created by the targeting tool) and `TRACKING` should be for internal use only and not be visible to readers.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/57295823/172355070-59ec87cc-0024-4802-8319-ab1e935020cf.png
[after]: https://user-images.githubusercontent.com/57295823/172355419-1d542ce8-8f02-440e-b104-470a662fce95.png

