### PR TITLE
Add role attribute to unordered lists

### DIFF
--- a/apps-rendering/config/.eslintrc.js
+++ b/apps-rendering/config/.eslintrc.js
@@ -96,8 +96,14 @@ module.exports = {
 		'import/no-default-export': 'off',
 		// The CSS `list-style: none` causes accessibility issues in Safari when applied to unordered lists (<ul>).
 		// Adding the `role="list"` attribute to the <ul> tag fixes the issue in Safari, but triggers
-		// the `no-redundant-roles` linting error.
-		'jsx-a11y/no-redundant-roles': 'off',
+		// the `no-redundant-roles` linting error. The configuration below prevents the error by telling
+		// the linter that `list` is allowed ARIA role for the <ul> tag.
+		'jsx-a11y/no-redundant-roles': [
+			'error',
+			{
+				ul: ['list'],
+			},
+		],
 	},
 	settings: {
 		react: {

--- a/apps-rendering/config/.eslintrc.js
+++ b/apps-rendering/config/.eslintrc.js
@@ -97,7 +97,7 @@ module.exports = {
 		// The CSS `list-style: none` causes accessibility issues in Safari when applied to unordered lists (<ul>).
 		// Adding the `role="list"` attribute to the <ul> tag fixes the issue in Safari, but triggers
 		// the `no-redundant-roles` linting error. The configuration below prevents the error by telling
-		// the linter that `list` is allowed ARIA role for the <ul> tag.
+		// the linter that `list` is an allowed ARIA role for the <ul> tag.
 		'jsx-a11y/no-redundant-roles': [
 			'error',
 			{

--- a/apps-rendering/config/.eslintrc.js
+++ b/apps-rendering/config/.eslintrc.js
@@ -94,6 +94,10 @@ module.exports = {
 		'react/react-in-jsx-scope': 'off',
 		indent: 'off',
 		'import/no-default-export': 'off',
+		// The CSS `list-style: none` causes accessibility issues in Safari when applied to unordered lists (<ul>).
+		// Adding the `role="list"` attribute to the <ul> tag fixes the issue in Safari, but triggers
+		// the `no-redundant-roles` linting error.
+		'jsx-a11y/no-redundant-roles': 'off',
 	},
 	settings: {
 		react: {

--- a/apps-rendering/src/components/List/index.tsx
+++ b/apps-rendering/src/components/List/index.tsx
@@ -43,7 +43,9 @@ interface Props {
 }
 
 const List: FC<Props> = ({ children, usePillarColour, format }) => (
-	<ul css={styles(usePillarColour, format)}>{children}</ul>
+	<ul css={styles(usePillarColour, format)} role="list">
+		{children}
+	</ul>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/RelatedContent/index.tsx
+++ b/apps-rendering/src/components/RelatedContent/index.tsx
@@ -112,7 +112,7 @@ const RelatedContent: FC<Props> = ({ content }) => {
 			return (
 				<section css={styles}>
 					<h2 css={headingStyles}>{title}</h2>
-					<ul css={listStyles}>
+					<ul css={listStyles} role="list">
 						{relatedItems.map((relatedItem, key) => {
 							return relatedItem.type === COMMENT &&
 								relatedItem.bylineImage ? (

--- a/apps-rendering/src/components/Tags/index.tsx
+++ b/apps-rendering/src/components/Tags/index.tsx
@@ -75,7 +75,7 @@ interface Props {
 }
 
 const Tags: FC<Props> = ({ tags, format }) => (
-	<ul css={styles(format)}>
+	<ul css={styles(format)} role="list">
 		{tags.map((tag, index) => {
 			return (
 				<li key={index} css={tagStyles}>

--- a/apps-rendering/src/components/TeamScore/index.tsx
+++ b/apps-rendering/src/components/TeamScore/index.tsx
@@ -96,7 +96,7 @@ const TeamScore: FC<Props> = ({ team, location }) => (
 			</div>
 		</div>
 		{team.scorers.length > 0 && (
-			<ul css={scorerStyles(location)}>
+			<ul css={scorerStyles(location)} role="list">
 				{team.scorers.map((scorer) => (
 					<li key={`${scorer.player}`}>
 						{scorer.player} {scorer.timeInMinutes}&apos;{' '}

--- a/apps-rendering/src/components/editions/teamScore/index.tsx
+++ b/apps-rendering/src/components/editions/teamScore/index.tsx
@@ -109,7 +109,7 @@ const TeamScore: FC<Props> = ({ team, location }) => {
 			<div css={infoStyles(location)}>
 				<h3 css={teamNameStyles}>{team.name}</h3>
 				{maybeRender(scorers, (s: Scorer[]) => (
-					<ul css={scorerStyles(location)}>
+					<ul css={scorerStyles(location)} role="list">
 						{s.map((scorer: Scorer) => (
 							<li key={`${scorer.player}`}>
 								{scorer.player} {scorer.timeInMinutes}&apos;{' '}

--- a/apps-rendering/src/components/media/tags.tsx
+++ b/apps-rendering/src/components/media/tags.tsx
@@ -39,7 +39,7 @@ interface TagsProps {
 }
 
 const Tags: FC<TagsProps> = ({ tags, background }) => (
-	<ul css={tagsStyles(background)}>
+	<ul css={tagsStyles(background)} role="list">
 		{tags.map((tag, index) => {
 			return (
 				<li key={index}>


### PR DESCRIPTION
## What does this change?
Adds a `role="list"` to `<ul>` tags in AR components.

## Why?
Because Safari won't recognise them as lists if they are styled with `list-style: none`. 
See https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns and #5041 for more details.

As described in the MDN docs, adding the role of list is necessary to avoid the issue in Safari.

## Screenshots

N/A
