### PR TITLE
Move email embed caption above iframe

### DIFF
--- a/apps-rendering/src/components/EmailSignup/index.tsx
+++ b/apps-rendering/src/components/EmailSignup/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { remSpace, text, textSans } from '@guardian/source-foundations';
+import { remSpace, space, text, textSans } from '@guardian/source-foundations';
 import { withDefault } from '@guardian/types';
 import type { EmailSignup } from 'embed';
 import { maybeRender } from 'lib';
@@ -26,19 +26,20 @@ const styles = css`
 const captionStyles = css`
 	${textSans.xsmall()}
 	color: ${text.supporting};
+	padding-bottom: ${space[1]}px;
 `;
 
 const EmailSignupEmbed: FC<Props> = ({ embed }) => (
 	<figure css={styles}>
+		{maybeRender(embed.caption, (caption) => (
+			<figcaption css={captionStyles}>{caption}</figcaption>
+		))}
 		<iframe
 			src={embed.src}
 			className="js-email-signup"
 			height="60"
 			title={withDefault('Email newsletter signup embed')(embed.alt)}
 		></iframe>
-		{maybeRender(embed.caption, (caption) => (
-			<figcaption css={captionStyles}>{caption}</figcaption>
-		))}
 	</figure>
 );
 

--- a/apps-rendering/src/components/EmailSignup/index.tsx
+++ b/apps-rendering/src/components/EmailSignup/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { remSpace, space, text, textSans } from '@guardian/source-foundations';
+import { remSpace, text, textSans } from '@guardian/source-foundations';
 import { withDefault } from '@guardian/types';
 import type { EmailSignup } from 'embed';
 import { maybeRender } from 'lib';
@@ -26,7 +26,7 @@ const styles = css`
 const captionStyles = css`
 	${textSans.xsmall()}
 	color: ${text.supporting};
-	padding-bottom: ${space[1]}px;
+	padding-bottom: ${remSpace[1]};
 `;
 
 const EmailSignupEmbed: FC<Props> = ({ embed }) => (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Moves the caption for an email signup embed above the iframe

## Why?

* Consistency with DCR (#4708)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="738" alt="Screenshot 2022-06-08 at 10 33 58" src="https://user-images.githubusercontent.com/705427/172584272-643c640a-7358-4fba-90fb-4c62bbd86963.png">  | <img width="677" alt="Screenshot 2022-06-08 at 10 33 36" src="https://user-images.githubusercontent.com/705427/172584202-56af62e5-636b-454b-a704-c4842a99ce46.png"> |
