### PR TITLE
Explicitly exit deno once Lighthouse script has finished

### DIFF
--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -182,7 +182,7 @@ try {
 		} Lighthouse report comment`,
 	);
 	console.log('See:', data.html_url);
-	Deno.exit(0);
+	Deno.exit();
 } catch (error: unknown) {
 	if (!(error instanceof Error)) {
 		console.error('Unknown error:', String(error));

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -182,6 +182,7 @@ try {
 		} Lighthouse report comment`,
 	);
 	console.log('See:', data.html_url);
+	Deno.exit(0);
 } catch (error: unknown) {
 	if (!(error instanceof Error)) {
 		console.error('Unknown error:', String(error));


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a `Deno.exit(0)` after action has completed.

## Why?

I'm not a deno expert, but I'm assuming that deno isn't exiting because its waiting for a promise to be fullfilled somewhere? This issue in octokit sounds potentially related and might be the root issue https://github.com/octokit/octokit.js/issues/2079 , although I'm not quite sure why it started now.

This PR makes deno explicitly exit with a success code once all tasks have been completed.