### PR TITLE
`.env` - Extra production protections & move injection from buildtime > runtime

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -5922,7 +5922,7 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -5988,7 +5988,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -14374,7 +14374,7 @@
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -15849,7 +15849,7 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -15857,7 +15857,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -16196,7 +16196,7 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -16204,7 +16204,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"

--- a/dotcom-rendering/docs/architecture/028-dotenv.md
+++ b/dotcom-rendering/docs/architecture/028-dotenv.md
@@ -38,3 +38,27 @@ const secrets = [
     // ...
 ];
 ```
+
+## Security
+
+`.env` variables are only available on the server, you should ensure that you **never** pass an environment variable into the clientside code
+e.g
+
+```jsx
+<Island>
+	<!-- Bad :((( -->
+	<MyComponent myProp={process.env.MY_VAR} />
+</Island>
+```
+
+This has considerable security implementations as this variable would then be available to any consumer of the site.
+
+## Limitations
+
+### Server Only
+
+DCR currently only supports `.env` variables being used on the _server_, but not the client.
+
+This limitation exists as the to maintain common & best practice within the organisation, we want to ensure that a re-deploy of the application would involve fetching a fresh environment variable. This means we cannot [inject environment variables through webpack](https://www.npmjs.com/package/dotenv-webpack) (which is done at build time) - and instead we load the dotenv directly when running the server bundle.
+
+This could be revisited in the future, but when doing so the [security implications](#security) of having `.env` variables available on the client should be considered and documented.

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -31,23 +31,25 @@ deploy:
 # prod #########################################
 
 build: export NODE_ENV=production
-build: clean-dist install gen-dotenv
+build: clean-dist install
 	$(call log, "building production bundles")
 	@webpack --config ./scripts/webpack/webpack.config.js --progress
 
 build-ci: export NODE_ENV=production
-build-ci: clean-dist install gen-dotenv
+build-ci: clean-dist install
 	$(call log, "building production bundles")
 	@SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
 
-start-ci: install
+start-ci: export NODE_ENV=production
+start-ci: install gen-dotenv
 	$(call log, "starting PROD server...")
 	@NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js
 
-start: install
+start: export NODE_ENV=production
+start: install gen-dotenv
 	$(call log, "starting PROD server...")
 	@echo '' # just a spacer
-	@NODE_ENV=production pm2 start dist/frontend.server.js
+	pm2 start dist/frontend.server.js
 	@echo '' # just a spacer
 	$(call log, "PROD server is running")
 	@pm2 logs

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -128,7 +128,7 @@
     "cypress-webpack-preprocessor-v5": "^5.0.0-alpha.1",
     "doctoc": "^2.1.0",
     "dompurify": "^2.3.6",
-    "dotenv-webpack": "^7.1.0",
+    "dotenv": "^16.0.1",
     "dynamic-import-polyfill": "^0.1.1",
     "eslint": "^8.15.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/dotcom-rendering/scripts/dotenv/gen-dotenv.js
+++ b/dotcom-rendering/scripts/dotenv/gen-dotenv.js
@@ -35,14 +35,21 @@ const genEnv = async (parameters) => {
 };
 
 const prod = async () => {
-	const params = await getAwsSsmParameters('prod');
-	await genEnv(params);
-	const isValid = await checkEnv();
-	if (!isValid) {
-		warn(
-			'[scripts/dotenv] Could not validate that the .env file was generated correctly',
-		);
-		throw new Error('Could not validate .env file was generated correctly');
+	try {
+		const params = await getAwsSsmParameters('prod');
+		await genEnv(params);
+		const isValid = await checkEnv();
+		if (!isValid) {
+			warn(
+				'[scripts/dotenv] Could not validate that the .env file was generated correctly',
+			);
+			throw new Error(
+				'Could not validate .env file was generated correctly',
+			);
+		}
+	} catch (err) {
+		console.error(err);
+		process.exit(1);
 	}
 };
 

--- a/dotcom-rendering/scripts/dotenv/gen-dotenv.js
+++ b/dotcom-rendering/scripts/dotenv/gen-dotenv.js
@@ -1,5 +1,7 @@
-const { CredentialsProviderError } = require('@aws-sdk/property-provider');
 const path = require('path');
+const { CredentialsProviderError } = require('@aws-sdk/property-provider');
+
+console.log(typeof ExpiredTokenException);
 const fs = require('fs').promises;
 const { prompt, log, warn } = require('../env/log');
 const secrets = require('../secrets');
@@ -41,7 +43,7 @@ const genEnv = async () => {
 		const validEnv = await checkEnv();
 		if (!validEnv) {
 			log(
-				'[scripts/dotenv] .env file is missing, attemting to generate it from AWS parameters...',
+				'[scripts/dotenv] .env file is missing or out of date, attemting to generate it from AWS parameters...',
 			);
 
 			await genEnv();
@@ -51,7 +53,13 @@ const genEnv = async () => {
 			log('[scripts/dotenv] valid .env file exists, moving on...');
 		}
 	} catch (err) {
-		if (err instanceof CredentialsProviderError) {
+		console.log(err);
+		console.log(typeof err);
+		if (
+			err instanceof CredentialsProviderError ||
+			// eslint-disable-next-line no-underscore-dangle -- '__type' is the only way to identify this exception type
+			err.__type === 'ExpiredTokenException'
+		) {
 			const PROD = process.env.NODE_ENV === 'production';
 			if (PROD) {
 				warn(

--- a/dotcom-rendering/scripts/webpack/webpack.config.server.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.server.js
@@ -1,5 +1,5 @@
 // @ts-check
-const Dotenv = require('dotenv-webpack');
+const nodeExternals = require('webpack-node-externals');
 const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
 const DEV = process.env.NODE_ENV === 'development';
@@ -22,7 +22,7 @@ module.exports = ({ sessionId }) => ({
 		runtimeChunk: false,
 	},
 	externals: [
-		require('webpack-node-externals')({
+		nodeExternals({
 			allowlist: [/^@guardian/],
 			additionalModuleDirs: [
 				// Since we use yarn-workspaces for the monorepo, node_modules will be co-located
@@ -61,7 +61,6 @@ module.exports = ({ sessionId }) => ({
 					team: 'dotcom',
 					sessionId,
 				}),
-				new Dotenv(),
 		  ]
 		: undefined,
 	module: {

--- a/dotcom-rendering/src/server/index.ts
+++ b/dotcom-rendering/src/server/index.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config';
+
 import { devServer } from './dev-server';
 import { prodServer } from './prod-server';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5109,9 +5109,9 @@
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
 "@types/prettier@^2.0.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
-  integrity sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
+  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
 
 "@types/pretty-hrtime@^1.0.0":
   version "1.0.1"
@@ -9272,26 +9272,17 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv-defaults@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
-  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
-  dependencies:
-    dotenv "^8.2.0"
-
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
-dotenv-webpack@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.1.0.tgz#211fefac6bf500bf3bb66b286e1b12a23a2a70c0"
-  integrity sha512-+aUOe+nqgLerA/n611oyC15fY79BIkGm2fOxJAcHDonMZ7AtDpnzv/Oe591eHAenIE0t6w03UyxDnLs/YUxx5Q==
-  dependencies:
-    dotenv-defaults "^2.0.2"
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
 
-dotenv@^8.0.0, dotenv@^8.2.0:
+dotenv@^8.0.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==


### PR DESCRIPTION
Co-author: @jamesgorrie 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR addresses the issues raised in https://github.com/guardian/dotcom-rendering/issues/5155:
1. Prior to this PR, dotenv variables were injected at builld time during webpack, however standard practice within the company is to have this happen at run or deploytime
2. There were not enough safeguards or clear flow to ensure we always have a valid .env file

**To address this we:**

Moved from using `dotenv-webpack` in the webpack config to directly using the`dotenv` package in the server entrypoint. This means that whenever the server is started; it loads in the .env file. 

As part of this I updated the documentation to clarify the limitations of this way of adding dotenv variables, as well as highlighting the existing security risk of leaking our dotenv variables into clientside code.

Broke `gen-dotenv` script into two separate flows, one for dev and one for prod, the new flows being: 

PROD (Failure on any of these steps will result in the server not starting):
```mermaid
flowchart LR
    id1("Prod start") --> id2("generate dotenv") --> id3("validate generated dotenv has all keys set") --> id4("start server")
```  

DEV:
```mermaid
flowchart LR
id1("Dev start") --> id2("Attempt to generate .env")
id2 -- success --> id4("start dev server")
id2 -- fail --> id5("does user have valid existing env?")
id5 -- yes --> id4
id5 -- no -->  id8("warn user they do not have valid env") --> id4
```

This should provide a secure prod experience where the server is unable to start unless it has a newly generated, valid `.env` file, and ensure that the dev experience both with and without credentials is as clear and easy to use as possible.



