### PR TITLE
Update Relevant Yield AMP script

### DIFF
--- a/dotcom-rendering/docs/commercial/overview.md
+++ b/dotcom-rendering/docs/commercial/overview.md
@@ -20,7 +20,7 @@ Among other tasks performed by the commercial modules we have
 
 As a result of architectural decision, dotcom-rendering currently makes use of frontend existing commercial modules. This means that when modifying any of those libraries it is important to check that your changes have not broken anything in Dotcom Rendering (see section "Development change checklist" for some pointers).
 
-That having been said, and when needed, once can make slight adjustement to an existing library to customise the code depending on whether it is working on Frontend or Dotcom Rendering by testing the value of `window.guardian.isDotcomRendering`. For this call
+That having been said, and when needed, one can make slight adjustments to an existing library to customise the code depending on whether it is working on Frontend or Dotcom Rendering by testing the value of `window.guardian.isDotcomRendering`. For this call
 
 ```
 import config from 'lib/config';

--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -25,7 +25,8 @@ const ampData = (section: string, contentType: string): string => {
 	return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
-const relevantYieldURLPrefix = 'https://pbs.relevant-digital.com/openrtb2/amp';
+const relevantYieldURLPrefix =
+	'https://guardian-pbs.relevant-digital.com/openrtb2/amp';
 
 const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	const adTargetingMapped: AdTargetParam[] = [];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

The Relevant Yield AMP script domain has been changed from `pbs.relevant-digital.com` to `guardian-pbs.relevant-digital.com`.

Note that the Relevant Yield cookie sync script that lives in the frontend repo has not been changed.

## Why?

Relevant Yield have asked us to make this change to their domain before our test with them next week (where we switch them on and switch off Pubmatic).

## Screenshots

Shows the ads loading locally with the new script:

![screenshot](https://user-images.githubusercontent.com/9574885/172820206-7a9afeec-ebe8-49fe-8e41-123f03ad142e.jpg)