### PR TITLE
Add Fronts container: fixed/small/slow-III

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
@@ -28,7 +28,7 @@ export const TrailTextWrapper = ({
 				padding-right: 5px;
 				padding-bottom: 6px;
 
-				${until.desktop} {
+				${until.tablet} {
 					display: none;
 				}
 			`}

--- a/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
@@ -28,7 +28,7 @@ export const TrailTextWrapper = ({
 				padding-right: 5px;
 				padding-bottom: 6px;
 
-				${until.tablet} {
+				${until.desktop} {
 					display: none;
 				}
 			`}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -34,24 +34,3 @@ export const Default = () => (
 	</ContainerLayout>
 );
 Default.story = { name: 'FixedSmallSlowIII' };
-
-export const Mobile = () => (
-	<ContainerLayout
-		title="FixedSmallSlowIII"
-		showTopBorder={true}
-		sideBorders={true}
-		padContent={false}
-		centralBorder="partial"
-	>
-		<FixedSmallSlowIII trails={trails} showAge={true} />
-	</ContainerLayout>
-);
-Mobile.story = {
-	name: 'with mobile viewport',
-	parameters: {
-		viewport: { defaultViewport: 'mobileMedium' },
-		chromatic: {
-			viewports: [breakpoints.mobile],
-		},
-	},
-};

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -30,12 +30,7 @@ export const Default = () => (
 		padContent={false}
 		centralBorder="partial"
 	>
-		<FixedSmallSlowIII
-			collectionId="abc"
-			trails={trails}
-			showAge={true}
-			hasMore={false}
-		/>
+		<FixedSmallSlowIII trails={trails} showAge={true} />
 	</ContainerLayout>
 );
 Default.story = { name: 'FixedSmallSlowIII' };
@@ -48,12 +43,7 @@ export const Mobile = () => (
 		padContent={false}
 		centralBorder="partial"
 	>
-		<FixedSmallSlowIII
-			collectionId="abc"
-			trails={trails}
-			showAge={true}
-			hasMore={false}
-		/>
+		<FixedSmallSlowIII trails={trails} showAge={true} />
 	</ContainerLayout>
 );
 Mobile.story = {

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -1,0 +1,67 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { ContainerLayout } from './ContainerLayout';
+import { FixedSmallSlowIII } from './FixedSmallSlowIII';
+
+export default {
+	component: FixedSmallSlowIII,
+	title: 'Components/FixedSmallSlowIII',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<ContainerLayout
+		title="FixedSmallSlowIII"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowIII
+			collectionId="abc"
+			trails={trails}
+			showAge={true}
+			hasMore={false}
+		/>
+	</ContainerLayout>
+);
+Default.story = { name: 'FixedSmallSlowIII' };
+
+export const Mobile = () => (
+	<ContainerLayout
+		title="FixedSmallSlowIII"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowIII
+			collectionId="abc"
+			trails={trails}
+			showAge={true}
+			hasMore={false}
+		/>
+	</ContainerLayout>
+);
+Mobile.story = {
+	name: 'with mobile viewport',
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+	},
+};

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -4,76 +4,65 @@ import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 
 type Props = {
-	collectionId: string;
 	trails: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	hasMore: boolean;
 };
 
 export const FixedSmallSlowIII = ({
-	collectionId,
 	trails,
 	containerPalette,
 	showAge,
-	hasMore,
 }: Props) => {
 	const smallTrails = trails.slice(0, 3);
 
 	return (
-		<>
-			<UL direction="row">
-				{smallTrails.map((trail, index) => {
-					return (
-						<LI
-							padSides={true}
-							showDivider={index > 0}
-							padBottomOnMobile={true}
-							percentage={index === 0 ? '50%' : '25%'}
-						>
-							<Card
-								containerPalette={containerPalette}
-								showAge={showAge}
-								linkTo={trail.url}
-								format={trail.format}
-								headlineText={trail.headline}
-								headlineSize={index === 0 ? 'large' : 'medium'}
-								byline={trail.byline}
-								showByline={trail.showByline}
-								showQuotes={
-									trail.format.design ===
-										ArticleDesign.Comment ||
-									trail.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={trail.webPublicationDate}
-								kickerText={trail.kickerText}
-								showPulsingDot={
-									trail.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								imageUrl={trail.image}
-								imagePosition="top"
-								imagePositionOnMobile={
-									index === 0 ? 'top' : 'left'
-								}
-								imageSize="medium"
-								mediaType={trail.mediaType}
-								mediaDuration={trail.mediaDuration}
-								starRating={trail.starRating}
-								branding={trail.branding}
-								dataLinkName={trail.dataLinkName}
-								discussionId={trail.discussionId}
-								trailText={
-									index === 0 ? undefined : trail.trailText
-								}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-			{hasMore && <span data-show-more-placeholder={collectionId} />}
-		</>
+		<UL direction="row">
+			{smallTrails.map((trail, index) => {
+				return (
+					<LI
+						padSides={true}
+						showDivider={index > 0}
+						padBottomOnMobile={true}
+						percentage={index === 0 ? '50%' : '25%'}
+					>
+						<Card
+							containerPalette={containerPalette}
+							showAge={showAge}
+							linkTo={trail.url}
+							format={trail.format}
+							headlineText={trail.headline}
+							headlineSize={index === 0 ? 'large' : 'medium'}
+							byline={trail.byline}
+							showByline={trail.showByline}
+							showQuotes={
+								trail.format.design === ArticleDesign.Comment ||
+								trail.format.design === ArticleDesign.Letter
+							}
+							webPublicationDate={trail.webPublicationDate}
+							kickerText={trail.kickerText}
+							showPulsingDot={
+								trail.format.design === ArticleDesign.LiveBlog
+							}
+							showSlash={true}
+							showClock={false}
+							imageUrl={trail.image}
+							imagePosition="top"
+							imagePositionOnMobile={index === 0 ? 'top' : 'left'}
+							imageSize="medium"
+							mediaType={trail.mediaType}
+							mediaDuration={trail.mediaDuration}
+							starRating={trail.starRating}
+							branding={trail.branding}
+							dataLinkName={trail.dataLinkName}
+							discussionId={trail.discussionId}
+							trailText={
+								index === 0 ? undefined : trail.trailText
+							}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
 	);
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -25,6 +25,7 @@ export const FixedSmallSlowIII = ({
 						showDivider={index > 0}
 						padBottomOnMobile={true}
 						percentage={index === 0 ? '50%' : '25%'}
+						key={trail.url}
 					>
 						<Card
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -1,0 +1,79 @@
+import { ArticleDesign } from '@guardian/libs';
+import { Card } from './Card/Card';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+
+type Props = {
+	collectionId: string;
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	hasMore: boolean;
+};
+
+export const FixedSmallSlowIII = ({
+	collectionId,
+	trails,
+	containerPalette,
+	showAge,
+	hasMore,
+}: Props) => {
+	const smallTrails = trails.slice(0, 3);
+
+	return (
+		<>
+			<UL direction="row">
+				{smallTrails.map((trail, index) => {
+					return (
+						<LI
+							padSides={true}
+							showDivider={index > 0}
+							padBottomOnMobile={true}
+							percentage={index === 0 ? '50%' : '25%'}
+						>
+							<Card
+								containerPalette={containerPalette}
+								showAge={showAge}
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								headlineSize={index === 0 ? 'large' : 'medium'}
+								byline={trail.byline}
+								showByline={trail.showByline}
+								showQuotes={
+									trail.format.design ===
+										ArticleDesign.Comment ||
+									trail.format.design === ArticleDesign.Letter
+								}
+								webPublicationDate={trail.webPublicationDate}
+								kickerText={trail.kickerText}
+								showPulsingDot={
+									trail.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								showSlash={true}
+								showClock={false}
+								imageUrl={trail.image}
+								imagePosition="top"
+								imagePositionOnMobile={
+									index === 0 ? 'top' : 'left'
+								}
+								imageSize="medium"
+								mediaType={trail.mediaType}
+								mediaDuration={trail.mediaDuration}
+								starRating={trail.starRating}
+								branding={trail.branding}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+								trailText={
+									index === 0 ? undefined : trail.trailText
+								}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			{hasMore && <span data-show-more-placeholder={collectionId} />}
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -53,11 +53,9 @@ export const DecideContainer = ({
 		case 'fixed/small/slow-III':
 			return (
 				<FixedSmallSlowIII
-					collectionId={collectionId}
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					hasMore={hasMore}
 				/>
 			);
 		default:

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -1,6 +1,7 @@
 import { DynamicFast } from '../components/DynamicFast';
 import { DynamicSlow } from '../components/DynamicSlow';
 import { FixedLargeSlowXIV } from '../components/FixedLargeSlowXIV';
+import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
 
 type Props = {
@@ -47,6 +48,16 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+				/>
+			);
+		case 'fixed/small/slow-III':
+			return (
+				<FixedSmallSlowIII
+					collectionId={collectionId}
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					hasMore={hasMore}
 				/>
 			);
 		default:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a container for the `fixed/small/slow-III` Fronts layout.


## Why?

Part of the Fronts migration (see: #4720, closes #5132)  

## Screenshots

| Before (Frontend prod)    | After (DCR local)     |
|-------------|------------|
| ![Before on Frontend](https://user-images.githubusercontent.com/37048459/172872990-f214fcba-b5a7-4d46-8c1b-573750a37f76.png) | ![After on DCR](https://user-images.githubusercontent.com/37048459/172873230-a6693089-c1a0-4a14-9c18-6aacc300978a.png) |
| ![Before, Frontend, tablet](https://user-images.githubusercontent.com/37048459/172875339-e8a2d3aa-5062-4794-96b3-ffad12afeecb.png) | ![After, DCR, tablet](https://user-images.githubusercontent.com/37048459/172875703-66910c11-bf03-4670-afe9-cd8e47313851.png) |
| ![Before, Frontend, mobile](https://user-images.githubusercontent.com/37048459/172876339-3c03107e-f30d-4e70-84d0-f01e0597eabb.png) | ![After, DCR, mobile](https://user-images.githubusercontent.com/37048459/172876778-d04c05f7-3f5b-4b67-bd4d-494717fd4142.png) |

Two of the visible differences ('Show More' button and 'Hide' link) are distinct features which will be added separately for all containers, so not part of this PR.

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
