### PR TITLE
Begone, react 'key' warnings 👋

### DIFF
--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -143,7 +143,7 @@ export const Body: React.FC<{
 			{elementsWithoutAds.map((item, i) => {
 				if (slotIndexes.includes(i)) {
 					return (
-						<React.Fragment key={i}>
+						<React.Fragment key={item.key}>
 							{item}
 							<div
 								id={`ad-${i + 1}`}

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -143,7 +143,7 @@ export const Body: React.FC<{
 			{elementsWithoutAds.map((item, i) => {
 				if (slotIndexes.includes(i)) {
 					return (
-						<>
+						<React.Fragment key={i}>
 							{item}
 							<div
 								id={`ad-${i + 1}`}
@@ -161,7 +161,7 @@ export const Body: React.FC<{
 									adTargeting={adTargeting}
 								/>
 							</div>
-						</>
+						</React.Fragment>
 					);
 				}
 				return item;

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -28,39 +28,70 @@ export const Elements = (
 	adTargeting?: AdTargeting,
 ): JSX.Element[] => {
 	const cleanedElements = enhance(elements);
-	const output = cleanedElements.map((element, i) => {
+	const output = cleanedElements.map((element) => {
 		switch (element._type) {
 			case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
-				return <AudioAtomBlockComponent element={element} />;
+				return (
+					<AudioAtomBlockComponent
+						key={element.elementId}
+						element={element}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
 				return (
 					<TextBlockComponent
-						key={i}
+						key={element.elementId}
 						html={element.html}
 						pillar={pillar}
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveAtomBlockComponent
+						key={element.elementId}
+						url={element.url}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.CommentBlockElement':
-				return <CommentBlockComponent key={i} element={element} />;
+				return (
+					<CommentBlockComponent
+						key={element.elementId}
+						element={element}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
-				return <ContentAtomBlockComponent element={element} />;
+				return (
+					<ContentAtomBlockComponent
+						key={element.elementId}
+						element={element}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
 				return (
 					<DisclaimerBlockComponent
-						key={i}
+						key={element.elementId}
 						html={element.html}
 						pillar={pillar}
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.EmbedBlockElement':
-				return <EmbedBlockComponentAMP key={i} element={element} />;
+				return (
+					<EmbedBlockComponentAMP
+						key={element.elementId}
+						element={element}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveAtomBlockComponent
+						key={element.elementId}
+						url={element.url}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
 				return (
 					<Expandable
+						key={element.elementId}
 						id={element.id}
 						type={element.label}
 						title={element.title}
@@ -78,7 +109,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
 				return (
 					<GuVideoBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
@@ -86,7 +117,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.ImageBlockElement':
 				return (
 					<ImageBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
@@ -94,6 +125,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
 				return (
 					<InteractiveAtomBlockComponent
+						key={element.elementId}
 						url={element.url}
 						html={element.html}
 						placeholderUrl={element.placeholderUrl}
@@ -102,6 +134,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.InteractiveBlockElement': // Plain Interactive Embeds
 				return (
 					<InteractiveBlockComponentAMP
+						key={element.elementId}
 						url={element.url}
 						isMandatory={element.isMandatory}
 					/>
@@ -109,6 +142,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.ProfileAtomBlockElement':
 				return (
 					<Expandable
+						key={element.elementId}
 						id={element.id}
 						type={element.label}
 						title={element.title}
@@ -126,7 +160,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
 				return (
 					<PullquoteBlockComponent
-						key={i}
+						key={element.elementId}
 						html={element.html}
 						pillar={pillar}
 					/>
@@ -134,6 +168,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.QABlockElement':
 				return (
 					<Expandable
+						key={element.elementId}
 						id={element.id}
 						type="Q&A"
 						title={element.title}
@@ -151,17 +186,22 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
 				return (
 					<RichLinkBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
-				return <SoundcloudBlockComponent key={i} element={element} />;
+				return (
+					<SoundcloudBlockComponent
+						key={element.elementId}
+						element={element}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
 				return (
 					<SubheadingBlockComponent
-						key={i}
+						key={element.elementId}
 						html={element.html}
 						pillar={pillar}
 						isImmersive={isImmersive}
@@ -170,7 +210,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.TextBlockElement':
 				return (
 					<TextBlockComponent
-						key={i}
+						key={element.elementId}
 						html={element.html}
 						pillar={pillar}
 					/>
@@ -178,6 +218,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.TimelineBlockElement':
 				return (
 					<TimelineBlockComponent
+						key={element.elementId}
 						id={element.id}
 						title={element.title}
 						description={element.description}
@@ -188,7 +229,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.TweetBlockElement':
 				return (
 					<TwitterBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
@@ -196,7 +237,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
 				return (
 					<VideoVimeoBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
@@ -204,7 +245,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
 				return (
 					<VideoYoutubeBlockComponent
-						key={i}
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 					/>
@@ -212,6 +253,7 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
 				return (
 					<YoutubeBlockComponentAMP
+						key={element.elementId}
 						element={element}
 						pillar={pillar}
 						adTargeting={adTargeting}

--- a/dotcom-rendering/src/amp/components/topMeta/Branding.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/Branding.tsx
@@ -73,7 +73,7 @@ export const BrandingRegionContainer: React.FC<{
 			.map((editionId) => {
 				const { branding } = commercialProperties[editionId];
 				return branding !== undefined ? (
-					<div css={regionClasses[editionId]}>
+					<div key={editionId} css={regionClasses[editionId]}>
 						{children(branding)}
 					</div>
 				) : null;

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -44,7 +44,7 @@
 			</li>
 			<li>
 				<a
-					href="/Interactive?url=https://www.theguardian.com/world/ng-interactive/2021/dec/03/french-election-polls-who-is-leading-the-race-to-be-the-next-president-of-france"
+					href="/Interactive?url=theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
 					>Interactive</a
 				>
 			</li>
@@ -55,7 +55,9 @@
 				>
 			</li>
 			<li>
-				<a href="/Front?url=https://www.theguardian.com/international">International Front</a>
+				<a href="/Front?url=https://www.theguardian.com/international"
+					>International Front</a
+				>
 			</li>
 		</ul>
 

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -94,6 +94,7 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 				{bigCards.map((card, cardIndex) => {
 					return (
 						<LI
+							key={card.url}
 							percentage="25%"
 							padSides={true}
 							padBottom={false}
@@ -139,6 +140,7 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 						{smallCards.map((card, cardIndex) => {
 							return (
 								<LI
+									key={card.url}
 									percentage="50%"
 									showDivider={true}
 									padSides={true}

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -101,6 +101,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						{bigCards.map((card, cardIndex) => {
 							return (
 								<LI
+									key={card.url}
 									percentage="50%"
 									showDivider={cardIndex !== 0}
 									padSides={true}
@@ -161,6 +162,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						{smallCards.map((card, cardIndex) => {
 							return (
 								<LI
+									key={card.url}
 									padSides={true}
 									showTopMarginWhenStacked={false}
 									padBottom={

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -21,6 +21,7 @@ export const FixedSmallSlowIV = ({
 			{slicedTrails.map((trail, index) => {
 				return (
 					<LI
+						key={trail.url}
 						padSides={true}
 						showDivider={index > 0}
 						padBottomOnMobile={true}

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
-import { renderArticleElement } from '../lib/renderElement';
+import { RenderArticleElement } from '../lib/renderElement';
 import { LastUpdated } from './LastUpdated';
 import { ShareIcons } from './ShareIcons';
 
@@ -63,22 +63,23 @@ export const LiveBlock = ({
 			host={host}
 			pageId={pageId}
 		>
-			{block.elements.map((element, index) =>
-				renderArticleElement({
-					format,
-					element,
-					isMainMedia: false,
-					host,
-					adTargeting,
-					ajaxUrl,
-					index,
-					pageId,
-					webTitle,
-					isAdFreeUser,
-					isSensitive,
-					switches,
-				}),
-			)}
+			{block.elements.map((element, index) => (
+				<RenderArticleElement
+					key={'elementId' in element ? element.elementId : index}
+					format={format}
+					element={element}
+					adTargeting={adTargeting}
+					ajaxUrl={ajaxUrl}
+					host={host}
+					index={index}
+					isMainMedia={false}
+					pageId={pageId}
+					webTitle={webTitle}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					switches={switches}
+				/>
+			))}
 			<footer
 				css={css`
 					display: flex;

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -65,7 +65,8 @@ export const LiveBlock = ({
 		>
 			{block.elements.map((element, index) => (
 				<RenderArticleElement
-					key={'elementId' in element ? element.elementId : index}
+					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+					key={index}
 					format={format}
 					element={element}
 					adTargeting={adTargeting}

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
-import { renderArticleElement } from '../lib/renderElement';
+import { RenderArticleElement } from '../lib/renderElement';
 
 const mainMedia = css`
 	height: 100%;
@@ -95,24 +95,25 @@ export const MainMedia: React.FC<{
 }) => {
 	return (
 		<div css={[mainMedia, chooseWrapper(format)]}>
-			{elements.map((element, index) =>
-				renderArticleElement({
-					format,
-					element,
-					adTargeting,
-					ajaxUrl,
-					host,
-					index,
-					isMainMedia: true,
-					starRating,
-					hideCaption,
-					pageId,
-					webTitle,
-					isAdFreeUser,
-					isSensitive,
-					switches,
-				}),
-			)}
+			{elements.map((element, index) => (
+				<RenderArticleElement
+					key={'elementId' in element ? element.elementId : index}
+					format={format}
+					element={element}
+					adTargeting={adTargeting}
+					ajaxUrl={ajaxUrl}
+					host={host}
+					index={index}
+					isMainMedia={true}
+					pageId={pageId}
+					webTitle={webTitle}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					switches={switches}
+					hideCaption={hideCaption}
+					starRating={starRating}
+				/>
+			))}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -97,7 +97,8 @@ export const MainMedia: React.FC<{
 		<div css={[mainMedia, chooseWrapper(format)]}>
 			{elements.map((element, index) => (
 				<RenderArticleElement
-					key={'elementId' in element ? element.elementId : index}
+					// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+					key={index}
 					format={format}
 					element={element}
 					adTargeting={adTargeting}

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import React from 'react';
 
 /*
  * Working on this file? Checkout out 027-pictures.md for background information & context!
@@ -280,7 +281,7 @@ export const Picture = ({
 			)}
 
 			{desiredWidths.map(({ breakpoint, width: desiredWidth }) => (
-				<>
+				<React.Fragment key={breakpoint}>
 					{/* HDPI Source (DPR2) - images in this srcset have `dpr=2&quality=45` in the url */}
 					{hdpiSourceSets.length > 0 && (
 						<source
@@ -301,7 +302,7 @@ export const Picture = ({
 						)}
 						media={`(min-width: ${breakpoint}px)`}
 					/>
-				</>
+				</React.Fragment>
 			))}
 
 			<img

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
-import { Fragment } from 'react';
+import React from 'react';
 import { CardHeadline } from './CardHeadline';
 
 type Alignment = 'vertical' | 'horizontal';
@@ -66,7 +66,7 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 				// The model has this property as optional but it is very likely
 				// to exist
 				if (!subLink.headline)
-					return <Fragment key={subLink.url}></Fragment>;
+					return <React.Fragment key={subLink.url}></React.Fragment>;
 				// The kicker defaults to 'Live' when the article is a liveblog
 				const kickerText =
 					subLink.format.design === ArticleDesign.LiveBlog

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
+import { Fragment } from 'react';
 import { CardHeadline } from './CardHeadline';
 
 type Alignment = 'vertical' | 'horizontal';
@@ -64,7 +65,8 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 			{supportingContent.map((subLink: DCRSupportingContent, index) => {
 				// The model has this property as optional but it is very likely
 				// to exist
-				if (!subLink.headline) return <></>;
+				if (!subLink.headline)
+					return <Fragment key={subLink.url}></Fragment>;
 				// The kicker defaults to 'Live' when the article is a liveblog
 				const kickerText =
 					subLink.format.design === ArticleDesign.LiveBlog
@@ -73,6 +75,7 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 				const shouldPadLeft = index > 0 && alignment === 'horizontal';
 				return (
 					<li
+						key={subLink.url}
 						css={[
 							liStyles,
 							shouldPadLeft && leftMargin,

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
-import React from 'react';
 import { CardHeadline } from './CardHeadline';
 
 type Alignment = 'vertical' | 'horizontal';

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -65,8 +65,7 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 			{supportingContent.map((subLink: DCRSupportingContent, index) => {
 				// The model has this property as optional but it is very likely
 				// to exist
-				if (!subLink.headline)
-					return <React.Fragment key={subLink.url}></React.Fragment>;
+				if (!subLink.headline) return null;
 				// The kicker defaults to 'Live' when the article is a liveblog
 				const kickerText =
 					subLink.format.design === ArticleDesign.LiveBlog

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -88,7 +88,8 @@ export const ArticleRenderer: React.FC<{
 	const renderedElements = elements.map((element, index) => {
 		return (
 			<RenderArticleElement
-				key={'elementId' in element ? element.elementId : index}
+				// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+				key={index}
 				format={format}
 				element={element}
 				adTargeting={adTargeting}

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -7,7 +7,7 @@ import {
 	labelStyles as adLabelStyles,
 } from '../components/AdSlot';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
-import { renderArticleElement } from './renderElement';
+import { RenderArticleElement } from './renderElement';
 import { withSignInGateSlot } from './withSignInGateSlot';
 
 // This is required for spacefinder to work!
@@ -86,21 +86,24 @@ export const ArticleRenderer: React.FC<{
 	abTests,
 }) => {
 	const renderedElements = elements.map((element, index) => {
-		return renderArticleElement({
-			format,
-			element,
-			adTargeting,
-			ajaxUrl,
-			host,
-			index,
-			isMainMedia: false,
-			pageId,
-			webTitle,
-			isAdFreeUser,
-			isSensitive,
-			switches,
-			abTests,
-		});
+		return (
+			<RenderArticleElement
+				key={'elementId' in element ? element.elementId : index}
+				format={format}
+				element={element}
+				adTargeting={adTargeting}
+				ajaxUrl={ajaxUrl}
+				host={host}
+				index={index}
+				isMainMedia={false}
+				pageId={pageId}
+				webTitle={webTitle}
+				isAdFreeUser={isAdFreeUser}
+				isSensitive={isSensitive}
+				switches={switches}
+				abTests={abTests}
+			/>
+		);
 	});
 
 	// const cleanedElements = elements.map(element =>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -779,7 +779,7 @@ const bareElements = new Set([
 	'model.dotcomrendering.pageElements.InteractiveBlockElement',
 ]);
 
-// renderArticleElement is a wrapper for renderElement that wraps elements in a
+// RenderArticleElement is a wrapper for renderElement that wraps elements in a
 // Figure and adds metadata and (role-) styling appropriate for most article
 // types.
 export const RenderArticleElement = ({

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -782,7 +782,7 @@ const bareElements = new Set([
 // renderArticleElement is a wrapper for renderElement that wraps elements in a
 // Figure and adds metadata and (role-) styling appropriate for most article
 // types.
-export const renderArticleElement = ({
+export const RenderArticleElement = ({
 	format,
 	element,
 	adTargeting,

--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -1,6 +1,7 @@
 // This placeholder div is used by the SignInGate component to insert the sign in gate into the appropriate location within body of an article,
 // if the SignInGateSelector determines a gate should be rendered.
 
+import React from 'react';
 import { Island } from '../components/Island';
 import { SignInGateSelector } from '../components/SignInGateSelector.importable';
 
@@ -34,7 +35,7 @@ export const withSignInGateSlot = ({
 }: Props): React.ReactNode => {
 	return renderedElements.map((element, i) => {
 		return (
-			<>
+			<React.Fragment key={element?.key}>
 				{element}
 				{/* Add the placeholder div after the second article element */}
 				{i === 1 && (
@@ -54,7 +55,7 @@ export const withSignInGateSlot = ({
 						</Island>
 					</div>
 				)}
-			</>
+			</React.Fragment>
 		);
 	});
 };


### PR DESCRIPTION
Keys, keys, **_KEYS_**! React is always telling us to use keys ... 

Well no more! I've gone through and added keys everywhere I could find that react was complaining about in my terminal.

And the grand reveal.... drum role please 🥁🥁🥁

<img width="851" alt="image" src="https://user-images.githubusercontent.com/9575458/173063774-a2f8b235-4428-4364-a3fd-f58f76be2b14.png">
😍😍😍😍😍 I am at peace once again 

--- 

Actual technical notes because PRs can't be all fun and games 😢

In most if not all these places I don't believe adding keys actually impacts our site - since these are all server rendered, they're only rendered once and never re-rendered, therefor keys aren't strictly necessary ... but react will still warn you in console anyway.

I switched the `renderArticleElement` function to being a `RenderArticleElement` component so that I could add a key to it, but in all honesty there was no real reason for it not to be a component anyway so I think this is better, or at least more 'reacty'!

