### PR TITLE
docs(lighthouse): explain "pull_request" event

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,9 +5,14 @@ on:
       - main
     paths-ignore:
       - "apps-rendering/**"
+
+  # We need to run on "pull_request" to get the PR number in the event.
+  # When running on "push", we cannot add a comment to a specific PR.
   pull_request:
     #  If/when we compare results to `main`, we should also run on 'reopened'
     types: [opened, synchronize]
+    paths:
+      - 'dotcom-rendering/**'
 
 jobs:
   lhci:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds some description behind choosing the `pull_request` event. Prevent running on the `apps-rendering` directory.

## Why?

@jamesgorrie was confused, and I realised we did not capture this decision anywhere.

