### PR TITLE
Adds `fixed/thrasher` support to DCR Fronts

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -1,6 +1,7 @@
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { decideFormat } from '../web/lib/decideFormat';
 import { getDataLinkNameCard } from '../web/lib/getDataLinkName';
+import { enhanceSnaps } from './enhanceSnaps';
 
 /**
  *
@@ -115,6 +116,6 @@ export const enhanceCards = (
 			byline:
 				faciaCard.properties.maybeContent?.trail.byline ?? undefined,
 			showByline: faciaCard.properties.showByline,
-			snapData: faciaCard.enriched,
+			snapData: enhanceSnaps(faciaCard.enriched),
 		};
 	});

--- a/dotcom-rendering/src/model/enhanceSnaps.ts
+++ b/dotcom-rendering/src/model/enhanceSnaps.ts
@@ -1,0 +1,24 @@
+/**
+ *
+ * This function takes a FESnapType and turns it into a DCRSnapType mutating
+ * certain properties such as embedCss to work with Emotion.
+ *
+ * @returns the DCR snap with its properties mutated
+ */
+export const enhanceSnaps = (
+	snap: FESnapType | undefined,
+): DCRSnapType | undefined => {
+	const dcrSnap = snap;
+
+	// Emotion doesn't parse this conditional CSS correctly which is used by some thrashers to check
+	// if theres a pageskin. This regex fixes the vast majority of these cases should allow future snaps
+	// to be built with DCR in mind.
+	if (dcrSnap?.embedCss) {
+		dcrSnap.embedCss = dcrSnap.embedCss.replace(
+			/body:not\(\.has-active-pageskin\)(?! &)/g,
+			'body:not(.has-active-pageskin) &',
+		);
+	}
+
+	return dcrSnap;
+};

--- a/dotcom-rendering/src/model/enhanceSnaps.ts
+++ b/dotcom-rendering/src/model/enhanceSnaps.ts
@@ -1,6 +1,6 @@
 /**
  *
- * This function takes a FESnapType and turns it into a DCRSnapType mutating
+ * This function takes a FESnapType and turns it into a DCRSnapType. It mutates
  * certain properties such as embedCss to work with Emotion.
  *
  * @returns the DCR snap with its properties mutated

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -34,6 +34,7 @@ type Props = {
 	innerBackgroundColour?: string;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
+	showLeftColumn?: boolean;
 };
 
 const containerStyles = css`

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -34,7 +34,6 @@ type Props = {
 	innerBackgroundColour?: string;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
-	showLeftColumn?: boolean;
 };
 
 const containerStyles = css`

--- a/dotcom-rendering/src/web/components/Snap.tsx
+++ b/dotcom-rendering/src/web/components/Snap.tsx
@@ -3,14 +3,15 @@ import { css } from '@emotion/react';
 const snapStyles = css`
 	overflow-y: hidden;
 	position: relative;
+	display: flex;
 `;
 
 type Props = {
-	snapData: DCRSnapType;
+	snapData?: DCRSnapType;
 };
 
 export const Snap = ({ snapData }: Props) => {
-	if (snapData.embedHtml === undefined) {
+	if (snapData?.embedHtml === undefined) {
 		return <></>;
 	}
 
@@ -19,10 +20,10 @@ export const Snap = ({ snapData }: Props) => {
 			css={[
 				snapStyles,
 				css`
-					${snapData?.embedCss}
+					${snapData.embedCss}
 				`,
 			]}
-			dangerouslySetInnerHTML={{ __html: snapData?.embedHtml }}
+			dangerouslySetInnerHTML={{ __html: snapData.embedHtml }}
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -13,6 +13,7 @@ import { Header } from '../components/Header';
 import { Island } from '../components/Island';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { Nav } from '../components/Nav/Nav';
+import { Snap } from '../components/Snap';
 import { SubNav } from '../components/SubNav.importable';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
@@ -126,6 +127,24 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					if (trails.length === 0) return null;
 
 					const ophanName = ophanComponentId(collection.displayName);
+					const ophanComponentLink = `container-${
+						index + 1
+					} | ${ophanName}`;
+
+					if (collection.collectionType === 'fixed/thrasher') {
+						return (
+							<ElementContainer
+								padded={false}
+								showTopBorder={false}
+								showSideBorders={false}
+								ophanComponentLink={ophanComponentLink}
+								ophanComponentName={ophanName}
+								element="section"
+							>
+								<Snap snapData={trails[0].snapData} />
+							</ElementContainer>
+						);
+					}
 
 					return (
 						<ContainerLayout
@@ -139,10 +158,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							centralBorder="partial"
 							url={collection.href}
 							// same as above re 'palette styles' for index increment
-							ophanComponentLink={`container-${
-								index + 1
-							} | ${ophanName}`}
-							ophanComponentName={`${ophanName}`}
+							ophanComponentLink={ophanComponentLink}
+							ophanComponentName={ophanName}
 							containerPalette={collection.containerPalette}
 							showDateHeader={collection.config.showDateHeader}
 							editionId={front.editionId}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Depends on https://github.com/guardian/dotcom-rendering/pull/4847
Closes https://github.com/guardian/dotcom-rendering/issues/5134

Adds the `fixed/thrasher` container layout for rendering custom cards on DCR front pages.

### Why?

This makes it easy to see which thrashers are working on DCR and which ones aren't.

### Screenshots

<details>
<summary>Thrashers working really well on some pages like Sports</summary>

| Frontend | DCR |
| - | - |
| ![image](https://user-images.githubusercontent.com/21217225/173384895-12a75c14-b41a-44c5-8c84-a12483b7f138.png) | ![image](https://user-images.githubusercontent.com/21217225/173393698-7744b0c8-782e-4c55-9b1a-36d401f214b1.png) |
</details>

<details>
<summary>Thrashers that aren't working as well</summary>

| ![Secure Drop: tries to modify the page styles which is no longer allowed by DCR](https://user-images.githubusercontent.com/21217225/174754304-ce6dd39c-0c35-4b5d-8c47-46b30bee08f3.png) | 
|:--:| 
| *Secure Drop: tries to modify the page styles which is no longer allowed by DCR* |

| ![ Nuggets: we don't let thrashers use JS anymore and are planning on making Nuggets their own component in DCR](https://user-images.githubusercontent.com/21217225/174754489-8d3fe610-6fd7-415b-9afd-6b80a02271e6.png) | 
|:--:| 
| *Nuggets: we don't let thrashers use JS anymore and are planning on making Nuggets their own component in DCR* |


| ![ Nuggets: we don't let thrashers use JS anymore and are planning on making Nuggets their own component in DCR](https://user-images.githubusercontent.com/21217225/174756417-471484fd-8e02-4a29-b2ce-655a084aa3ab.png) | 
|:--:| 
| *Lots of issues with buttons in thrashers relying on Frontend CSS styles* |


</details>