### PR TITLE
Move Key Events Carousel behind A/B Test and Switch

### DIFF
--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -31,6 +31,9 @@ type Props = {
  * @param {ArticleFormat} props.format - The format model for the article
  * */
 export const Article = ({ CAPIArticle, NAV, format }: Props) => {
+	const showKeyEventsCarousel =
+		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
+
 	return (
 		<StrictMode>
 			<Global
@@ -52,9 +55,7 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 				format.design === ArticleDesign.DeadBlog) && (
 				<SkipTo
 					id={
-						// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-						CAPIArticle.config.abTests.keyEventsCarouselVariant ===
-						'variant'
+						showKeyEventsCarousel
 							? 'key-events-carousel'
 							: 'keyevents'
 					}

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -52,7 +52,9 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 				format.design === ArticleDesign.DeadBlog) && (
 				<SkipTo
 					id={
-						CAPIArticle.config.switches.keyEventsCarousel
+						// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+						CAPIArticle.config.abTests.keyEventsCarouselVariant ===
+						'variant'
 							? 'key-events-carousel'
 							: 'keyevents'
 					}

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -33,6 +33,7 @@ type Props = {
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
 	abTests?: ServerSideTests;
+	showKeyEventsCarousel?: boolean;
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -116,6 +117,7 @@ export const ArticleBody = ({
 	keyEvents,
 	filterKeyEvents,
 	abTests,
+	showKeyEventsCarousel,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const palette = decidePalette(format);
@@ -163,9 +165,7 @@ export const ArticleBody = ({
 						onFirstPage={onFirstPage}
 						keyEvents={keyEvents}
 						filterKeyEvents={filterKeyEvents}
-						isKeyEventsCarouselVariant={
-							abTests?.keyEventsCarouselVariant === 'variant'
-						}
+						isKeyEventsCarouselVariant={showKeyEventsCarousel}
 					/>
 				</div>
 			</>

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -163,6 +163,9 @@ export const ArticleBody = ({
 						onFirstPage={onFirstPage}
 						keyEvents={keyEvents}
 						filterKeyEvents={filterKeyEvents}
+						isKeyEventsCarouselVariant={
+							abTests?.keyEventsCarouselVariant === 'variant'
+						}
 					/>
 				</div>
 			</>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -296,9 +296,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const cricketMatchUrl =
 		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
 
-	const isKeyEventsCarouselVariant =
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		CAPIArticle.config.abTests.keyEventsCarouselVariant === 'variant';
+	const showKeyEventsCarousel =
+		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	return (
 		<>
@@ -589,7 +588,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 					</StandFirstGrid>
 				</ElementContainer>
-				{isKeyEventsCarouselVariant && CAPIArticle.keyEvents.length ? (
+				{showKeyEventsCarousel && CAPIArticle.keyEvents.length && (
 					<ElementContainer
 						showTopBorder={false}
 						backgroundColour={
@@ -609,8 +608,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</Island>
 						</Hide>
 					</ElementContainer>
-				) : (
-					<></>
 				)}
 				<ElementContainer
 					showTopBorder={false}
@@ -767,7 +764,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									</div>
 								</Hide>
 								{/* Key events */}
-								{!isKeyEventsCarouselVariant ? (
+								{!showKeyEventsCarousel && (
 									<div
 										css={[
 											!footballMatchUrl && sticky,
@@ -783,7 +780,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											}
 										/>
 									</div>
-								) : null}
+								)}
 								{/* Match stats */}
 								{footballMatchUrl && (
 									<Island
@@ -819,7 +816,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										accordionTitle="Live feed"
 										context="liveFeed"
 									>
-										{!isKeyEventsCarouselVariant &&
+										{!showKeyEventsCarousel &&
 										CAPIArticle.keyEvents.length ? (
 											<Hide above="desktop">
 												<Island deferUntil="visible">
@@ -915,6 +912,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												}
 												abTests={
 													CAPIArticle.config.abTests
+												}
+												showKeyEventsCarousel={
+													showKeyEventsCarousel
 												}
 											/>
 											{pagination.totalPages > 1 && (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -296,6 +296,10 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const cricketMatchUrl =
 		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
 
+	const isKeyEventsCarouselVariant =
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		CAPIArticle.config.abTests.keyEventsCarouselVariant === 'variant';
+
 	return (
 		<>
 			<div data-print-layout="hide">
@@ -585,8 +589,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 					</StandFirstGrid>
 				</ElementContainer>
-				{CAPIArticle.config.switches.keyEventsCarousel &&
-				CAPIArticle.keyEvents.length ? (
+				{isKeyEventsCarouselVariant && CAPIArticle.keyEvents.length ? (
 					<ElementContainer
 						showTopBorder={false}
 						backgroundColour={
@@ -764,8 +767,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									</div>
 								</Hide>
 								{/* Key events */}
-								{!CAPIArticle.config.switches
-									.keyEventsCarousel && (
+								{!isKeyEventsCarouselVariant ? (
 									<div
 										css={[
 											!footballMatchUrl && sticky,
@@ -781,7 +783,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											}
 										/>
 									</div>
-								)}
+								) : null}
 								{/* Match stats */}
 								{footballMatchUrl && (
 									<Island
@@ -817,8 +819,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										accordionTitle="Live feed"
 										context="liveFeed"
 									>
-										{!CAPIArticle.config.switches
-											.keyEventsCarousel &&
+										{!isKeyEventsCarouselVariant &&
 										CAPIArticle.keyEvents.length ? (
 											<Hide above="desktop">
 												<Island deferUntil="visible">

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -28,7 +28,7 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
-	isKeyEventsCarouselVariant: boolean;
+	isKeyEventsCarouselVariant?: boolean;
 };
 
 export const LiveBlogRenderer = ({

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -28,6 +28,7 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
+	isKeyEventsCarouselVariant: boolean;
 };
 
 export const LiveBlogRenderer = ({
@@ -51,6 +52,7 @@ export const LiveBlogRenderer = ({
 	onFirstPage,
 	keyEvents,
 	filterKeyEvents = false,
+	isKeyEventsCarouselVariant = false,
 }: Props) => {
 	return (
 		<>
@@ -77,7 +79,7 @@ export const LiveBlogRenderer = ({
 					</PinnedPost>
 				</>
 			)}
-			{switches.keyEventsCarousel && keyEvents?.length ? (
+			{isKeyEventsCarouselVariant && keyEvents?.length ? (
 				<Hide above="desktop">
 					<Island deferUntil="visible">
 						<KeyEventsCarousel


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Previously the key events carousel was behind an on off switch. This PR amends the show/hide logic so that the old key events container is hidden and the new carousel is shown if the user is  opted in to the A/B test.

## Why?
Having an opt in A/B test allows Editiorial the opportunity to preview the feature before it is rolled out to the public. 

