### PR TITLE
Introduce `CommercialLazyLoadMarginReloaded` test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -6,6 +6,7 @@ import {
 import { getCookie } from '@guardian/libs';
 import { tests } from '../experiments/ab-tests';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -29,6 +30,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 		const clientSideTestsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
 			commercialEndOfQuarter2Test,
+			commercialLazyLoadMarginReloaded,
 		];
 
 		const userInClientSideTestToForceMetrics = ABTestAPI?.allRunnableTests(

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -5,6 +5,7 @@ import {
 	initCoreWebVitals,
 } from '@guardian/libs';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 import { useAB } from '../lib/useAB';
 
 export const CoreVitals = () => {
@@ -23,6 +24,7 @@ export const CoreVitals = () => {
 	const clientSideTestsToForceMetrics: ABTest[] = [
 		/* keep array multi-line */
 		commercialEndOfQuarter2Test,
+		commercialLazyLoadMarginReloaded,
 	];
 
 	const userInClientSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { commercialEndOfQuarter2Test } from './tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from './tests/commercial-lazy-load-margin-reloaded';
 import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	commercialEndOfQuarter2Test,
+	commercialLazyLoadMarginReloaded,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -7,13 +7,17 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 		'Once again test various margins at which ads are lazily-loaded in order to find the optimal one, this time using values between 0% and 70% of the viewport height',
 	start: '2022-06-20',
 	expiry: '2022-07-04',
-	audience: 10 / 100,
+	audience: 20 / 100,
 	audienceOffset: 10 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
 	idealOutcome:
 		'One of the variants shows a marked improvement in all of the metrics that we are considering',
 	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
 		{
 			id: 'variant-1',
 			test: (): void => {},
@@ -40,10 +44,6 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 		},
 		{
 			id: 'variant-7',
-			test: (): void => {},
-		},
-		{
-			id: 'variant-8',
 			test: (): void => {},
 		},
 	],

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -1,0 +1,55 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const commercialLazyLoadMarginReloaded: ABTest = {
+	id: 'CommercialLazyLoadMarginReloaded',
+	author: 'Simon Byford',
+	description:
+		'Once again test various margins at which ads are lazily-loaded in order to find the optimal one, this time using values between 0% and 70% of the viewport height',
+	start: '2022-06-20',
+	expiry: '2022-07-04',
+	audience: 10 / 100,
+	audienceOffset: 10 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
+	idealOutcome:
+		'One of the variants shows a marked improvement in all of the metrics that we are considering',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-1',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-2',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-3',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-4',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-5',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-6',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-7',
+			test: (): void => {},
+		},
+		{
+			id: 'variant-8',
+			test: (): void => {},
+		},
+	],
+	canRun: () => true,
+};

--- a/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -15,10 +15,6 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 		'One of the variants shows a marked improvement in all of the metrics that we are considering',
 	variants: [
 		{
-			id: 'control',
-			test: (): void => {},
-		},
-		{
 			id: 'variant-1',
 			test: (): void => {},
 		},


### PR DESCRIPTION
## What does this change?

Introduces an A/B test in DCR which can be used to measure the impact of this change: https://github.com/guardian/frontend/pull/25107

## Why?

The test definition must exist in both frontend and DCR

![Screenshot 2022-06-14 at 09 52 50](https://user-images.githubusercontent.com/7423751/173536495-3bb0058e-501d-4ed3-b9be-7493c89cea19.png)

