### PR TITLE
Don't focus on `ShadyPie`

### DIFF
--- a/dotcom-rendering/src/web/components/ShadyPie.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.tsx
@@ -14,6 +14,7 @@ export const ShadyPie = () => {
 	return (
 		<a
 			href={`https://support.theguardian.com/uk/subscribe/digital?${params.toString()}`}
+			tabIndex={-1}
 		>
 			<img
 				src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #4495, where the tab order for the page wasn't logical. You ended up being transported to the top of the page when tabbing through from the bottom.

We now disallow focus on `ShadyPie` (a component that shows when an ad blocker is in use) as this is not editorial content
