### PR TITLE
Decrease padding-top on figCaption component

### DIFF
--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -62,7 +62,7 @@ type Props = {
 
 const styles = (supportsDarkMode: boolean) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
-	padding-top: ${remSpace[2]};
+	padding-top: ${remSpace[1]};
 	color: ${text.supporting};
 
 	${darkModeCss(supportsDarkMode)`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Reduces the top padding on the FigCaption component in common rendering
## Why?
Request from design after a review
## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="627" alt="image" src="https://user-images.githubusercontent.com/99400613/173564124-5f77a3c1-b982-4867-abe3-7d0f40883526.png"> | <img width="630" alt="image" src="https://user-images.githubusercontent.com/99400613/173564214-3518cfb6-354c-41d8-9a0e-2cb3aca96723.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
