### PR TITLE
fix: Add a title to InteractiveBlockElement iframes

### DIFF
--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
@@ -252,6 +252,7 @@ export const InteractiveBlockComponent = ({
 			iframe.style.width = '100%';
 			iframe.style.border = 'none';
 			iframe.height = decideHeight(role).toString();
+			iframe.title = caption ?? alt ?? 'Interactive Content';
 			if (url.startsWith('http:')) {
 				iframe.src = url.replace('http:', 'https:');
 			} else {


### PR DESCRIPTION
## What does this change?

Sets a title on the iframes used by interactive block elements which is used by screen readers to announce the contents of an iframe.

Previously when focusing an iframe it would get announced as "frame", now it'll be announced as hopefully something a bit more relevant or fall back to "Interactive Content".

Not a perfect solution as the alt-text on some Interactives is ocasionally used as a "parameter" for data https://github.com/guardian/interactive-atom-picture-loop/blob/e2eeb5034ca9405a363b5b37537cf5a81112b23c/src/js/app.js#L30

## Why?

Fixes #4492 