### PR TITLE
Apply default card styles to analysis pieces

### DIFF
--- a/apps-rendering/src/components/Card/index.tsx
+++ b/apps-rendering/src/components/Card/index.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import type { RelatedItem } from '@guardian/apps-rendering-api-models/relatedItem';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import Img from '@guardian/common-rendering/src/components/img';
-import { border } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
@@ -249,23 +248,6 @@ const cardStyles = (
 				h2 {
 					${headline.xxxsmall({ fontWeight: 'bold' })}
 					color: ${kicker};
-				}
-			`;
-		}
-
-		case RelatedItemType.ANALYSIS: {
-			return css`
-				${headline.xxxsmall({
-					lineHeight: 'regular',
-					fontWeight: 'light',
-				})};
-				h3 {
-					box-shadow: inset 0 -0.025rem ${border.articleLink(format)};
-					display: inline;
-
-					${darkModeCss`
-                        box-shadow: inset 0 -0.025rem ${neutral[46]};
-                    `}
 				}
 			`;
 		}


### PR DESCRIPTION
## What does this change?
Specific styling for analysis pieces has been removed from cards in the "Related content" section at the bottom of articles, and default styling is applied.

## Why?
It has been decided that the specific styling of analysis pieces should be removed.

## Screenshots

**Before**
<img width="1007" alt="Screenshot 2022-06-14 at 15 18 11" src="https://user-images.githubusercontent.com/55602675/173601428-4b04644c-7ce2-40cc-b64e-641caedc776e.png">

**After**
<img width="1007" alt="Screenshot 2022-06-14 at 15 18 38" src="https://user-images.githubusercontent.com/55602675/173601448-b7947ce3-9030-44cf-bb16-bde007a7ba46.png">


