### PR TITLE
`0%` AB test for sticky right-hand ads

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -7,6 +7,7 @@ import { getCookie } from '@guardian/libs';
 import { tests } from '../experiments/ab-tests';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
+import { multiStickyRightAds } from '../experiments/tests/multi-sticky-right-ads';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -31,6 +32,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 			/* keep array multi-line */
 			commercialEndOfQuarter2Test,
 			commercialLazyLoadMarginReloaded,
+			multiStickyRightAds,
 		];
 
 		const userInClientSideTestToForceMetrics = ABTestAPI?.allRunnableTests(

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -6,6 +6,7 @@ import {
 } from '@guardian/libs';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
+import { multiStickyRightAds } from '../experiments/tests/multi-sticky-right-ads';
 import { useAB } from '../lib/useAB';
 
 export const CoreVitals = () => {
@@ -25,6 +26,7 @@ export const CoreVitals = () => {
 		/* keep array multi-line */
 		commercialEndOfQuarter2Test,
 		commercialLazyLoadMarginReloaded,
+		multiStickyRightAds,
 	];
 
 	const userInClientSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { commercialEndOfQuarter2Test } from './tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from './tests/commercial-lazy-load-margin-reloaded';
+import { multiStickyRightAds } from './tests/multi-sticky-right-ads';
 import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseVariants,
 	commercialEndOfQuarter2Test,
 	commercialLazyLoadMarginReloaded,
+	multiStickyRightAds,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/multi-sticky-right-ads.ts
+++ b/dotcom-rendering/src/web/experiments/tests/multi-sticky-right-ads.ts
@@ -1,0 +1,20 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const multiStickyRightAds: ABTest = {
+	id: 'MultiStickyRightAds',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2022-06-9',
+	expiry: '2022-07-04',
+	audience: 0 / 100,
+	audienceOffset: 50 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Sticky ads in the right column leads to an increase in revenue per 1000 pageviews with no significant impact on page health / performance',
+	description:
+		'Test the commercial and performance impact of sticky ads in the right column',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add the DCR  equivalent to the `0%` AB test for the sticky ads in the right column ([Frontend PR](https://github.com/guardian/frontend/pull/25097)).

<img width="1438" alt="Screenshot 2022-06-14 at 16 38 27" src="https://user-images.githubusercontent.com/8000415/173618631-087c59be-0e71-45b7-9b3b-72f59ab4b659.png">


## Why?

So this test is exposed on DCR as well as Frontend rendered content.