### PR TITLE
RFC: Fronts container incorporating another container

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
@@ -1,0 +1,36 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { ContainerLayout } from './ContainerLayout';
+import { FixedMediumSlowVI } from './FixedMediumSlowVI';
+
+export default {
+	component: FixedMediumSlowVI,
+	title: 'Components/FixedMediumSlowVI',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<ContainerLayout
+		title="FixedSmallSlowVI"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowVI trails={trails} showAge={true} />
+	</ContainerLayout>
+);
+Default.story = { name: 'FixedSmallSlowVI' };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -62,6 +62,7 @@ export const FixedMediumSlowVI = ({
 								branding={trail.branding}
 								dataLinkName={trail.dataLinkName}
 								discussionId={trail.discussionId}
+								snapData={trail.snapData}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -1,0 +1,77 @@
+import { ArticleDesign } from '@guardian/libs';
+import { Card } from './Card/Card';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FixedSmallSlowIV } from './FixedSmallSlowIV';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedMediumSlowVI = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	const topTrails = trails.slice(0, 2);
+	const bottomTrails = trails.slice(2, 6);
+
+	return (
+		<>
+			<UL direction="row" padBottom={true}>
+				{topTrails.map((trail, index) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={index > 0}
+							padBottomOnMobile={index === 0 ? true : false}
+							percentage={index === 0 ? '75%' : '25%'}
+						>
+							<Card
+								containerPalette={containerPalette}
+								showAge={showAge}
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								headlineSize="medium"
+								byline={trail.byline}
+								showByline={trail.showByline}
+								showQuotes={
+									trail.format.design ===
+										ArticleDesign.Comment ||
+									trail.format.design === ArticleDesign.Letter
+								}
+								webPublicationDate={trail.webPublicationDate}
+								kickerText={trail.kickerText}
+								showPulsingDot={
+									trail.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								showSlash={true}
+								showClock={false}
+								imageUrl={trail.image}
+								imagePosition="top"
+								imagePositionOnMobile="left"
+								imageSize="medium"
+								mediaType={trail.mediaType}
+								mediaDuration={trail.mediaDuration}
+								starRating={trail.starRating}
+								branding={trail.branding}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			<FixedSmallSlowIV
+				trails={bottomTrails}
+				containerPalette={containerPalette}
+				showAge={showAge}
+			/>
+		</>
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a container for `fixed/medium/slow-vi`. This will close #5133.


## The question
In this version I have used another container component (`fixed/small/slow-iv`) to render the second row of cards. Is this a pattern that we are happy with as a team?


## Pros
1. As far as I can tell, when these containers were originally designed they were thought of as being made up of rows of reusable 'slices'. So it's possible to re-use `fixed/small/slow-iv` here without editing it at all, and this seems to be in keeping with the original rationale.
2. If adopted as a more general pattern, it will hopefully make the relationships between the different container/slice types more explicit (it can be hard to tell at a glance what the list of hard-coded props in different rows are doing). And potentially be easier to maintain as there will be less duplicated code where changes will need to be made.


## Cons
1. Introduces coupling between the two components. Regardless of the original intentions behind the container system, this might not be desirable in the future. Hopefully Chromatic would show up any unintended changes in the medium component which were caused by a change in the small component, but nevertheless this coupling potentially violates the principle of least surprise.
2. I know there are some other ongoing discussions about a) whether it's actually desirable to reduce code repetition in these containers, all things considered, and b) how best to do it if we are going to try. Adding the component reuse pattern in this PR might make it harder to adopt a different abstraction later on.


## tl;dr
Overall, I'm very happy to just duplicate the code if people have reservations, but thought it might be worth discussing.