### PR TITLE
Add fronts container: fixed/medium/slow-vi

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
@@ -1,0 +1,36 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { ContainerLayout } from './ContainerLayout';
+import { FixedMediumSlowVI } from './FixedMediumSlowVI';
+
+export default {
+	component: FixedMediumSlowVI,
+	title: 'Components/FixedMediumSlowVI',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<ContainerLayout
+		title="FixedSmallSlowVI"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowVI trails={trails} showAge={true} />
+	</ContainerLayout>
+);
+Default.story = { name: 'FixedSmallSlowVI' };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -36,7 +36,7 @@ export const FixedMediumSlowVI = ({
 								linkTo={trail.url}
 								format={trail.format}
 								headlineText={trail.headline}
-								headlineSize="medium"
+								headlineSize={index === 0 ? 'large' : 'medium'}
 								byline={trail.byline}
 								showByline={trail.showByline}
 								showQuotes={
@@ -46,6 +46,9 @@ export const FixedMediumSlowVI = ({
 								}
 								webPublicationDate={trail.webPublicationDate}
 								kickerText={trail.kickerText}
+								trailText={
+									index === 0 ? trail.trailText : undefined
+								}
 								showPulsingDot={
 									trail.format.design ===
 									ArticleDesign.LiveBlog
@@ -53,9 +56,9 @@ export const FixedMediumSlowVI = ({
 								showSlash={true}
 								showClock={false}
 								imageUrl={trail.image}
-								imagePosition="top"
+								imagePosition={index === 0 ? 'right' : 'top'}
 								imagePositionOnMobile="left"
-								imageSize="medium"
+								imageSize={index === 0 ? 'large' : 'medium'}
 								mediaType={trail.mediaType}
 								mediaDuration={trail.mediaDuration}
 								starRating={trail.starRating}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -57,7 +57,9 @@ export const FixedMediumSlowVI = ({
 								showClock={false}
 								imageUrl={trail.image}
 								imagePosition={index === 0 ? 'right' : 'top'}
-								imagePositionOnMobile="left"
+								imagePositionOnMobile={
+									index === 0 ? 'top' : 'left'
+								}
 								imageSize={index === 0 ? 'large' : 'medium'}
 								mediaType={trail.mediaType}
 								mediaDuration={trail.mediaDuration}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -62,6 +62,7 @@ export const FixedMediumSlowVI = ({
 								branding={trail.branding}
 								dataLinkName={trail.dataLinkName}
 								discussionId={trail.discussionId}
+								snapData={trail.snapData}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -1,0 +1,77 @@
+import { ArticleDesign } from '@guardian/libs';
+import { Card } from './Card/Card';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FixedSmallSlowIV } from './FixedSmallSlowIV';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedMediumSlowVI = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	const topTrails = trails.slice(0, 2);
+	const bottomTrails = trails.slice(2, 6);
+
+	return (
+		<>
+			<UL direction="row" padBottom={true}>
+				{topTrails.map((trail, index) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={index > 0}
+							padBottomOnMobile={index === 0 ? true : false}
+							percentage={index === 0 ? '75%' : '25%'}
+						>
+							<Card
+								containerPalette={containerPalette}
+								showAge={showAge}
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								headlineSize="medium"
+								byline={trail.byline}
+								showByline={trail.showByline}
+								showQuotes={
+									trail.format.design ===
+										ArticleDesign.Comment ||
+									trail.format.design === ArticleDesign.Letter
+								}
+								webPublicationDate={trail.webPublicationDate}
+								kickerText={trail.kickerText}
+								showPulsingDot={
+									trail.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								showSlash={true}
+								showClock={false}
+								imageUrl={trail.image}
+								imagePosition="top"
+								imagePositionOnMobile="left"
+								imageSize="medium"
+								mediaType={trail.mediaType}
+								mediaDuration={trail.mediaDuration}
+								starRating={trail.starRating}
+								branding={trail.branding}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			<FixedSmallSlowIV
+				trails={bottomTrails}
+				containerPalette={containerPalette}
+				showAge={showAge}
+			/>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -2,7 +2,6 @@ import { ArticleDesign } from '@guardian/libs';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FixedSmallSlowIV } from './FixedSmallSlowIV';
 
 type Props = {
 	trails: TrailType[];
@@ -73,11 +72,53 @@ export const FixedMediumSlowVI = ({
 					);
 				})}
 			</UL>
-			<FixedSmallSlowIV
-				trails={bottomTrails}
-				containerPalette={containerPalette}
-				showAge={showAge}
-			/>
+			<UL direction="row">
+				{bottomTrails.map((trail, index) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={index > 0}
+							padBottomOnMobile={true}
+						>
+							<Card
+								containerPalette={containerPalette}
+								showAge={showAge}
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								headlineSize="small"
+								byline={trail.byline}
+								showByline={trail.showByline}
+								showQuotes={
+									trail.format.design ===
+										ArticleDesign.Comment ||
+									trail.format.design === ArticleDesign.Letter
+								}
+								webPublicationDate={trail.webPublicationDate}
+								kickerText={trail.kickerText}
+								showPulsingDot={
+									trail.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								showSlash={true}
+								showClock={false}
+								imageUrl={trail.image}
+								imagePosition="top"
+								imagePositionOnMobile="left"
+								imageSize="medium"
+								mediaType={trail.mediaType}
+								mediaDuration={trail.mediaDuration}
+								starRating={trail.starRating}
+								branding={trail.branding}
+								dataLinkName={trail.dataLinkName}
+								snapData={trail.snapData}
+								discussionId={trail.discussionId}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -1,6 +1,7 @@
 import { DynamicFast } from '../components/DynamicFast';
 import { DynamicSlow } from '../components/DynamicSlow';
 import { FixedLargeSlowXIV } from '../components/FixedLargeSlowXIV';
+import { FixedMediumSlowVI } from '../components/FixedMediumSlowVI';
 import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
 
@@ -53,6 +54,14 @@ export const DecideContainer = ({
 		case 'fixed/small/slow-III':
 			return (
 				<FixedSmallSlowIII
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		case 'fixed/medium/slow-VI':
+			return (
+				<FixedMediumSlowVI
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for `fixed/medium/slow-vi` Fronts container. Closes #5133.

## Why?

As part of the Fronts migration to DCR (see #4720)

## Screenshots

General differences: 'hide' button, 'More You may have missed' button, and the way the comment count is displayed are outside the scope of this PR.

The screenshots in the middle row (tablet view) differ in a couple of ways which I _think_ are out of scope, but I'm not 100% sure:
1. The trail text for the primary card still shows on tablet views in DCR, but not on Frontend. This is a broader issue which is still under discussion ([see this thread for context](https://github.com/guardian/dotcom-rendering/pull/5165#discussion_r893611289)).
2. The 'headshot'-style layout for the Rhiannon Lucy Cosslett article is not present in the DCR version. Am I right in thinking that this is a separate feature which we haven't added to DCR yet? Or is it something that I need to enable for this container?


| Before (Frontend)     | After (DCR)     |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/37048459/173834855-5b2de601-9318-499e-9167-9d6eecbcf50c.png) | ![image](https://user-images.githubusercontent.com/37048459/173834756-845445f1-a0bf-4778-8e2d-f9de813fadc8.png) |
| ![before, tablet](https://user-images.githubusercontent.com/37048459/173835062-453ea10d-fc2f-4b45-8c0d-49527485187a.png) | ![after, tablet](https://user-images.githubusercontent.com/37048459/173835004-db659667-9da4-4758-8982-cc447617865a.png) |
| ![image](https://user-images.githubusercontent.com/37048459/173835362-7df4b414-93d3-4121-905a-7af5d259dda9.png) | ![image](https://user-images.githubusercontent.com/37048459/173835412-f99dc0ea-ff07-4840-8b36-98ac77249ef4.png) |


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
