### PR TITLE
Footer spacing

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -582,6 +582,191 @@ cardStories.add('when horizontal, opinion, with a small image', () => {
 					imageSize="small"
 				/>
 			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="small"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a medium image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="medium"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="medium"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a large image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="large"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="large"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a jumbo image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="jumbo"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="jumbo"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
 		</>
 	);
 });

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -14,6 +14,7 @@ type Props = {
 const ageStyles = (format: ArticleFormat, palette: Palette) => {
 	return css`
 		${textSans.xxsmall({ lineHeight: 'tight' })};
+		margin-top: -4px;
 		color: ${palette.text.cardFooter};
 
 		/* Provide side padding for positioning and also to keep spacing

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const ageStyles = (format: ArticleFormat, palette: Palette) => {
 	return css`
-		${textSans.xxsmall()};
+		${textSans.xxsmall({ lineHeight: 'tight' })};
 		color: ${palette.text.cardFooter};
 
 		/* Provide side padding for positioning and also to keep spacing

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -20,6 +20,10 @@ const spaceBetween = css`
 	align-items: center;
 `;
 
+const marginBottom = css`
+	margin-bottom: 3px;
+`;
+
 const flexEnd = css`
 	display: flex;
 	justify-content: flex-end;
@@ -39,7 +43,7 @@ export const CardFooter = ({
 	const palette = decidePalette(format, containerPalette);
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
-		return <footer>{cardBranding}</footer>;
+		return <footer css={marginBottom}>{cardBranding}</footer>;
 	}
 
 	if (
@@ -48,7 +52,7 @@ export const CardFooter = ({
 		format.design === ArticleDesign.Letter
 	) {
 		return (
-			<footer>
+			<footer css={marginBottom}>
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
@@ -75,7 +79,7 @@ export const CardFooter = ({
 		format.design === ArticleDesign.Video
 	) {
 		return (
-			<footer>
+			<footer css={marginBottom}>
 				{supportingContent}
 				<div css={spaceBetween}>
 					{mediaMeta}
@@ -88,7 +92,7 @@ export const CardFooter = ({
 
 	if (age) {
 		return (
-			<footer>
+			<footer css={marginBottom}>
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
@@ -99,7 +103,7 @@ export const CardFooter = ({
 	}
 
 	return (
-		<footer>
+		<footer css={marginBottom}>
 			{supportingContent}
 			<div css={flexEnd}>
 				<>{commentCount}</>

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { decidePalette } from '../../../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
+	containerPalette?: DCRContainerPalette;
+	renderLines?: boolean;
 	age?: JSX.Element;
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
@@ -21,16 +25,48 @@ const flexEnd = css`
 	justify-content: flex-end;
 `;
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types -- because react
 export const CardFooter = ({
 	format,
+	containerPalette,
+	renderLines,
 	age,
 	mediaMeta,
 	commentCount,
 	cardBranding,
 	supportingContent,
 }: Props) => {
+	const palette = decidePalette(format, containerPalette);
+
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer>{cardBranding}</footer>;
+	}
+
+	if (
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Editorial ||
+		format.design === ArticleDesign.Letter
+	) {
+		return (
+			<footer>
+				{supportingContent}
+				<div css={spaceBetween}>
+					{age}
+					{renderLines && (
+						<StraightLines
+							cssOverrides={css`
+								/* Fill the space */
+								flex: 1;
+								align-self: flex-end;
+							`}
+							color={palette.border.lines}
+							count={4}
+						/>
+					)}
+					{commentCount}
+				</div>
+			</footer>
+		);
 	}
 
 	if (

--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -7,7 +7,7 @@ type Props = {
 export const HeadlineWrapper = ({ children }: Props) => (
 	<div
 		css={css`
-			padding-bottom: 8px;
+			padding-bottom: 6px;
 			padding-left: 5px;
 			padding-right: 5px;
 			padding-top: 1px;

--- a/dotcom-rendering/src/web/components/CardCommentCount.tsx
+++ b/dotcom-rendering/src/web/components/CardCommentCount.tsx
@@ -13,7 +13,8 @@ type Props = {
 const containerStyles = (palette: Palette) => css`
 	display: flex;
 	flex-direction: row;
-	${textSans.xxsmall()};
+	${textSans.xxsmall({ lineHeight: 'tight' })};
+	margin-top: -4px;
 	padding-left: 5px;
 	padding-right: 5px;
 	color: ${palette.text.cardFooter};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Following a [design review](https://www.figma.com/file/5CfbWOeZPRi15lXBD5u1rW/Card-layout-system?node-id=220%3A5279) this PR adjusts the spacing in the card footer

## Why?
We wanted

1) a space below the `Lines` and
2) better alignment for content


| Before      | After      |
|-------------|------------|
| <img width="469" alt="b1" src="https://user-images.githubusercontent.com/1336821/173845766-e57c4c21-38c6-438f-a750-68ea84791755.png"> | <img width="470" alt="a1" src="https://user-images.githubusercontent.com/1336821/173845791-7e5f2000-6ce5-47df-bab3-ea7c4c43cc7b.png"> |
| <img width="231" alt="b2" src="https://user-images.githubusercontent.com/1336821/173845819-5c8ed93c-c6df-4d7d-bdfe-de3b78fec8c1.png"> | <img width="231" alt="a2" src="https://user-images.githubusercontent.com/1336821/173845844-15dcc118-3395-4f5a-a3e1-973718f7dd27.png"> |
| <img width="469" alt="b3" src="https://user-images.githubusercontent.com/1336821/173845949-fe09ef48-e3de-4904-834c-a15e16dcf72e.png"> | <img width="470" alt="Screenshot 2022-06-15 at 15 00 35" src="https://user-images.githubusercontent.com/1336821/173846252-ffb45e85-fd4a-40cd-a344-d041ff431429.png"> |
