### PR TITLE
fix(deno): explicit exit

### DIFF
--- a/scripts/deno/ophan-components.ts
+++ b/scripts/deno/ophan-components.ts
@@ -156,3 +156,5 @@ ${
 
 await updateIssue('data-component');
 await updateIssue('data-link-name');
+
+Deno.exit();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Be explicit about exiting from this script.

## Why?

It seems that [sometimes the action times out after 6h](https://github.com/guardian/dotcom-rendering/runs/6895667299?check_suite_focus=true) and this might be because we’re not exiting.