### PR TITLE
Add topics to types

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -260,13 +260,13 @@ type CustomParams = {
 
 type AdTargeting =
 	| {
-			adUnit: string;
-			customParams: CustomParams;
-			disableAds?: false;
-	  }
+		adUnit: string;
+		customParams: CustomParams;
+		disableAds?: false;
+	}
 	| {
-			disableAds: true;
-	  };
+		disableAds: true;
+	};
 
 interface SectionNielsenAPI {
 	name: string;
@@ -604,6 +604,7 @@ interface CAPIArticleType {
 
 	// Included on live and dead blogs. Used when polling
 	mostRecentBlockId?: string;
+	topics?: Topic[];
 }
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
@@ -1150,6 +1151,15 @@ type MatchReportType = {
 	minByMinUrl: string;
 	reportUrl: string;
 };
+
+interface Topic {
+	type: TopicType,
+	value: string,
+	count: number,
+}
+
+type TopicType = 'ORG' | 'PRODUCT' | 'PERSON' | 'GPE' | 'WORK_OF_ART' | 'LOC';
+
 
 /**
  * Onwards

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -399,6 +399,12 @@
         },
         "mostRecentBlockId": {
             "type": "string"
+        },
+        "topics": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Topic"
+            }
         }
     },
     "required": [
@@ -4249,6 +4255,36 @@
             "enum": [
                 "CricketMatchType",
                 "FootballMatchType"
+            ],
+            "type": "string"
+        },
+        "Topic": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/TopicType"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "count",
+                "type",
+                "value"
+            ]
+        },
+        "TopicType": {
+            "enum": [
+                "GPE",
+                "LOC",
+                "ORG",
+                "PERSON",
+                "PRODUCT",
+                "WORK_OF_ART"
             ],
             "type": "string"
         }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds topics data to the CAPI article model and regenerates schema. 
The corresponding frontend PR can be found [here](https://github.com/guardian/frontend/pull/25116) 

## Why?
Journalism Dev is adding automatic filters to liveblogs. This PR updates the CAPI article model to expect a new field containing an optional array of top mention filters

