### PR TITLE
Card footer ❤️

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -582,6 +582,191 @@ cardStories.add('when horizontal, opinion, with a small image', () => {
 					imageSize="small"
 				/>
 			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="small"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a medium image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="medium"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="medium"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a large image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="large"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="large"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</>
+	);
+});
+
+cardStories.add('when horizontal, opinion, with a jumbo image', () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="jumbo"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Comment,
+						theme: ArticlePillar.Opinion,
+					}}
+					imagePosition="left"
+					imageSize="jumbo"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline:
+								'A longer headline to see how wrapping works',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
 		</>
 	);
 });

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -111,12 +111,12 @@ const decideIfAgeShouldShow = ({
 const DecideFooter = ({
 	isOpinion,
 	hasSublinks,
-	renderAge,
+	displayAge,
 	renderFooter,
 }: {
 	isOpinion: boolean;
 	hasSublinks?: boolean;
-	renderAge: boolean;
+	displayAge: boolean;
 	renderFooter: Function;
 }) => {
 	if (isOpinion) {
@@ -124,8 +124,8 @@ const DecideFooter = ({
 			// Opinion cards with sublinks show their footers under the trailtext but
 			// without the lines, these sit by themselves at the bottom
 			return renderFooter({
-				renderAge,
-				renderLines: false,
+				displayAge,
+				displayLines: false,
 			});
 		} else {
 			// Opinion cards without sublinks render the whole footer including lines, outside, sitting along the very bottom of the card
@@ -134,8 +134,8 @@ const DecideFooter = ({
 	} else {
 		// Non opinion cards always show their footer underneath the headline/trail text
 		return renderFooter({
-			renderAge,
-			renderLines: false,
+			displayAge,
+			displayLines: false,
 		});
 	}
 };
@@ -143,12 +143,12 @@ const DecideFooter = ({
 const CommentFooter = ({
 	hasSublinks,
 	palette,
-	renderAge,
+	displayAge,
 	renderFooter,
 }: {
 	hasSublinks?: boolean;
 	palette: Palette;
-	renderAge: boolean;
+	displayAge: boolean;
 	renderFooter: Function;
 }) => {
 	return hasSublinks ? (
@@ -159,8 +159,8 @@ const CommentFooter = ({
 		// When an opinion card has no sublinks we show the entire footer, including lines
 		// outside, along the entire bottom of the card
 		renderFooter({
-			renderAge,
-			renderLines: true,
+			displayAge,
+			displayLines: true,
 		})
 	);
 };
@@ -207,19 +207,19 @@ export const Card = ({
 		format.design === ArticleDesign.Letter;
 
 	const renderFooter = ({
-		renderAge,
-		renderLines,
+		displayAge,
+		displayLines,
 	}: {
-		renderAge?: boolean;
-		renderLines?: boolean;
+		displayAge?: boolean;
+		displayLines?: boolean;
 	}) => {
 		return (
 			<CardFooter
 				format={format}
 				containerPalette={containerPalette}
-				renderLines={renderLines}
+				displayLines={displayLines}
 				age={
-					renderAge && webPublicationDate ? (
+					displayAge && webPublicationDate ? (
 						<CardAge
 							format={format}
 							containerPalette={containerPalette}
@@ -276,7 +276,7 @@ export const Card = ({
 		);
 	};
 
-	const renderAge = decideIfAgeShouldShow({
+	const displayAge = decideIfAgeShouldShow({
 		containerPalette,
 		format,
 		showAge,
@@ -382,7 +382,7 @@ export const Card = ({
 						<DecideFooter
 							isOpinion={isOpinion}
 							hasSublinks={hasSublinks}
-							renderAge={renderAge}
+							displayAge={displayAge}
 							renderFooter={renderFooter}
 						/>
 
@@ -411,7 +411,7 @@ export const Card = ({
 			)}
 			<CommentFooter
 				hasSublinks={hasSublinks}
-				renderAge={renderAge}
+				displayAge={displayAge}
 				palette={palette}
 				renderFooter={renderFooter}
 			/>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -409,12 +409,14 @@ export const Card = ({
 			) : (
 				<></>
 			)}
-			<CommentFooter
-				hasSublinks={hasSublinks}
-				displayAge={displayAge}
-				palette={palette}
-				renderFooter={renderFooter}
-			/>
+			{isOpinion && (
+				<CommentFooter
+					hasSublinks={hasSublinks}
+					displayAge={displayAge}
+					palette={palette}
+					renderFooter={renderFooter}
+				/>
+			)}
 		</CardWrapper>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -108,6 +108,63 @@ const decideIfAgeShouldShow = ({
 	return false;
 };
 
+const DecideFooter = ({
+	isOpinion,
+	hasSublinks,
+	renderAge,
+	renderFooter,
+}: {
+	isOpinion: boolean;
+	hasSublinks?: boolean;
+	renderAge: boolean;
+	renderFooter: Function;
+}) => {
+	if (isOpinion) {
+		if (hasSublinks) {
+			// Opinion cards with sublinks show their footers under the trailtext but
+			// without the lines, these sit by themselves at the bottom
+			return renderFooter({
+				renderAge,
+				renderLines: false,
+			});
+		} else {
+			// Opinion cards without sublinks render the whole footer including lines, outside, sitting along the very bottom of the card
+			return null;
+		}
+	} else {
+		// Non opinion cards always show their footer underneath the headline/trail text
+		return renderFooter({
+			renderAge,
+			renderLines: false,
+		});
+	}
+};
+
+const CommentFooter = ({
+	hasSublinks,
+	palette,
+	renderAge,
+	renderFooter,
+}: {
+	hasSublinks?: boolean;
+	palette: Palette;
+	renderAge: boolean;
+	renderFooter: Function;
+}) => {
+	return hasSublinks ? (
+		// For opinion cards with sublinks there is already a footer rendered inside that
+		// shows the metadata. We only want to render the lines here
+		<StraightLines color={palette.border.lines} count={4} />
+	) : (
+		// When an opinion card has no sublinks we show the entire footer, including lines
+		// outside, along the entire bottom of the card
+		renderFooter({
+			renderAge,
+			renderLines: true,
+		})
+	);
+};
+
 export const Card = ({
 	linkTo,
 	format,
@@ -322,30 +379,12 @@ export const Card = ({
 								</AvatarContainer>
 							</Hide>
 						)}
-						{/* INSIDE FOOTER */}
-						{isOpinion ? (
-							<>
-								{hasSublinks ? (
-									// Opinion cards with sublinks show their footers under the trailtext but
-									// without the lines, these sit by themselves at the bottom
-									renderFooter({
-										renderAge,
-										renderLines: false,
-									})
-								) : (
-									<>
-										{/* Opinion cards without sublinks render the whole footer including
-											lines, outside, sitting along the very bottom of the card */}
-									</>
-								)}
-							</>
-						) : (
-							// Non opinion cards always show their footer underneath the headline/trail text
-							renderFooter({
-								renderAge,
-								renderLines: false,
-							})
-						)}
+						<DecideFooter
+							isOpinion={isOpinion}
+							hasSublinks={hasSublinks}
+							renderAge={renderAge}
+							renderFooter={renderFooter}
+						/>
 
 						{hasSublinks && noOfSublinks <= 2 ? (
 							<SupportingContent
@@ -370,25 +409,12 @@ export const Card = ({
 			) : (
 				<></>
 			)}
-			{/* OUTSIDE FOOTER */}
-			{isOpinion ? (
-				<>
-					{hasSublinks ? (
-						// For opinion cards with sublinks there is already a footer rendered inside that
-						// shows the metadata. We only want to render the lines here
-						<StraightLines color={palette.border.lines} count={4} />
-					) : (
-						// When an opinion card has no sublinks we show the entire footer, including lines
-						// outside, along the entire bottom of the card
-						renderFooter({
-							renderAge,
-							renderLines: true,
-						})
-					)}
-				</>
-			) : (
-				<>{/* Non opinion cards never render a footer here */}</>
-			)}
+			<CommentFooter
+				hasSublinks={hasSublinks}
+				renderAge={renderAge}
+				palette={palette}
+				renderFooter={renderFooter}
+			/>
 		</CardWrapper>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -162,7 +162,7 @@ export const Card = ({
 				containerPalette={containerPalette}
 				renderLines={renderLines}
 				age={
-					webPublicationDate ? (
+					renderAge && webPublicationDate ? (
 						<CardAge
 							format={format}
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -10,6 +10,7 @@ import { CardHeadline } from '../CardHeadline';
 import { Flex } from '../Flex';
 import { Hide } from '../Hide';
 import { MediaMeta } from '../MediaMeta';
+import { Snap } from '../Snap';
 import { StarRating } from '../StarRating/StarRating';
 import { SupportingContent } from '../SupportingContent';
 import { AvatarContainer } from './components/AvatarContainer';
@@ -23,7 +24,6 @@ import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
-import { Snap } from '../Snap';
 
 export type Props = {
 	linkTo: string;
@@ -120,7 +120,7 @@ export const Card = ({
 	imageUrl,
 	imagePosition = 'top',
 	imagePositionOnMobile = 'left',
-	imageSize,
+	imageSize = 'small',
 	trailText,
 	avatar,
 	showClock,

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -119,25 +119,18 @@ const DecideFooter = ({
 	displayAge: boolean;
 	renderFooter: Function;
 }) => {
-	if (isOpinion) {
-		if (hasSublinks) {
-			// Opinion cards with sublinks show their footers under the trailtext but
-			// without the lines, these sit by themselves at the bottom
-			return renderFooter({
-				displayAge,
-				displayLines: false,
-			});
-		} else {
-			// Opinion cards without sublinks render the whole footer including lines, outside, sitting along the very bottom of the card
-			return null;
-		}
-	} else {
-		// Non opinion cards always show their footer underneath the headline/trail text
-		return renderFooter({
-			displayAge,
-			displayLines: false,
-		});
+	if (isOpinion && !hasSublinks) {
+		// Opinion cards without sublinks render the entire footer, including lines,
+		// outside, sitting along the very bottom of the card
+		return null;
 	}
+	// For all other cases (including opinion cards that *do* have sublinks) we
+	// render a version of the footer without lines here
+	return renderFooter({
+		displayAge,
+		displayLines: false,
+	});
+	// Note. Opinion cards always show the lines at the botom of the card (in CommentFooter)
 };
 
 const CommentFooter = ({

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -13,7 +13,8 @@ type Props = {
 
 const ageStyles = (format: ArticleFormat, palette: Palette) => {
 	return css`
-		${textSans.xxsmall()};
+		${textSans.xxsmall({ lineHeight: 'tight' })};
+		margin-top: -4px;
 		color: ${palette.text.cardFooter};
 
 		/* Provide side padding for positioning and also to keep spacing

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -6,7 +6,7 @@ import { decidePalette } from '../../../lib/decidePalette';
 type Props = {
 	format: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
-	renderLines?: boolean;
+	displayLines?: boolean;
 	age?: JSX.Element;
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
@@ -33,7 +33,7 @@ const flexEnd = css`
 export const CardFooter = ({
 	format,
 	containerPalette,
-	renderLines,
+	displayLines,
 	age,
 	mediaMeta,
 	commentCount,
@@ -56,7 +56,7 @@ export const CardFooter = ({
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
-					{renderLines && (
+					{displayLines && (
 						<StraightLines
 							cssOverrides={css`
 								/* Fill the space */

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import { decidePalette } from '../../../lib/decidePalette';
 
 type Props = {
 	format: ArticleFormat;
+	containerPalette?: DCRContainerPalette;
+	renderLines?: boolean;
 	age?: JSX.Element;
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
@@ -16,6 +20,11 @@ const spaceBetween = css`
 	align-items: center;
 `;
 
+const margins = css`
+	margin-top: 3px;
+	margin-bottom: 3px;
+`;
+
 const flexEnd = css`
 	display: flex;
 	justify-content: flex-end;
@@ -23,14 +32,45 @@ const flexEnd = css`
 
 export const CardFooter = ({
 	format,
+	containerPalette,
+	renderLines,
 	age,
 	mediaMeta,
 	commentCount,
 	cardBranding,
 	supportingContent,
 }: Props) => {
+	const palette = decidePalette(format, containerPalette);
+
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
-		return <footer>{cardBranding}</footer>;
+		return <footer css={margins}>{cardBranding}</footer>;
+	}
+
+	if (
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Editorial ||
+		format.design === ArticleDesign.Letter
+	) {
+		return (
+			<footer css={margins}>
+				{supportingContent}
+				<div css={spaceBetween}>
+					{age}
+					{renderLines && (
+						<StraightLines
+							cssOverrides={css`
+								/* Fill the space */
+								flex: 1;
+								align-self: flex-end;
+							`}
+							color={palette.border.lines}
+							count={4}
+						/>
+					)}
+					{commentCount}
+				</div>
+			</footer>
+		);
 	}
 
 	if (
@@ -39,7 +79,7 @@ export const CardFooter = ({
 		format.design === ArticleDesign.Video
 	) {
 		return (
-			<footer>
+			<footer css={margins}>
 				{supportingContent}
 				<div css={spaceBetween}>
 					{mediaMeta}
@@ -52,7 +92,7 @@ export const CardFooter = ({
 
 	if (age) {
 		return (
-			<footer>
+			<footer css={margins}>
 				{supportingContent}
 				<div css={spaceBetween}>
 					{age}
@@ -63,7 +103,7 @@ export const CardFooter = ({
 	}
 
 	return (
-		<footer>
+		<footer css={margins}>
 			{supportingContent}
 			<div css={flexEnd}>
 				<>{commentCount}</>

--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -46,13 +46,13 @@ const flexBasisStyles = ({
 
 type Props = {
 	children: React.ReactNode;
-	imageSize?: ImageSizeType;
+	imageSize: ImageSizeType;
 	imagePosition: ImagePositionType;
 };
 
 export const ContentWrapper = ({
 	children,
-	imageSize = 'small',
+	imageSize,
 	imagePosition,
 }: Props) => {
 	const isHorizontal = imagePosition === 'left' || imagePosition === 'right';

--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -7,7 +7,7 @@ type Props = {
 export const HeadlineWrapper = ({ children }: Props) => (
 	<div
 		css={css`
-			padding-bottom: 4px;
+			padding-bottom: 8px;
 			padding-left: 5px;
 			padding-right: 5px;
 			padding-top: 1px;

--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -7,7 +7,7 @@ type Props = {
 export const HeadlineWrapper = ({ children }: Props) => (
 	<div
 		css={css`
-			padding-bottom: 8px;
+			padding-bottom: 4px;
 			padding-left: 5px;
 			padding-right: 5px;
 			padding-top: 1px;

--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -4,7 +4,7 @@ import { between, from, until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
-	imageSize?: ImageSizeType;
+	imageSize: ImageSizeType;
 	imagePosition: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 };
@@ -47,7 +47,7 @@ const flexBasisStyles = ({
 
 export const ImageWrapper = ({
 	children,
-	imageSize = 'large',
+	imageSize,
 	imagePosition,
 	imagePositionOnMobile,
 }: Props) => {

--- a/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
@@ -26,7 +26,7 @@ export const TrailTextWrapper = ({
 
 				padding-left: 5px;
 				padding-right: 5px;
-				padding-bottom: 6px;
+				padding-bottom: 8px;
 
 				${until.tablet} {
 					display: none;

--- a/dotcom-rendering/src/web/components/CardCommentCount.tsx
+++ b/dotcom-rendering/src/web/components/CardCommentCount.tsx
@@ -13,7 +13,8 @@ type Props = {
 const containerStyles = (palette: Palette) => css`
 	display: flex;
 	flex-direction: row;
-	${textSans.xxsmall()};
+	${textSans.xxsmall({ lineHeight: 'tight' })};
+	margin-top: -4px;
 	padding-left: 5px;
 	padding-right: 5px;
 	color: ${palette.text.cardFooter};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR replaces #5200 and #5197 and fixes #5104 

Following a [design review](https://www.figma.com/file/5CfbWOeZPRi15lXBD5u1rW/Card-layout-system?node-id=220%3A5279) this PR adjusts position and spacing for the card footer

## Why?
There were some edge cases where alignment wasn't great and the meta data was appearing in a sub optimal location.

We now space and align the footer and its metadata better and have rationalised the decision logic for where the footer should be placed

### Opinion cards
Most of the changes were made for opinion cards

The lines that show at the bottom of Opinion cards now always show at the bottom. If the card has any sublinks then the footer metadata is shown _above_ the sublinks, immediately below the trail text.

| Before      | After      |
|-------------|------------|
| <img width="231" alt="abb" src="https://user-images.githubusercontent.com/1336821/174591106-d6f24042-5457-41af-9cf4-69442b4d4c36.png"> | <img width="225" alt="aaa" src="https://user-images.githubusercontent.com/1336821/174591150-da9fdd14-29bf-49ff-a5a4-e0f4790d6f06.png"> |
| <img width="710" alt="bbb" src="https://user-images.githubusercontent.com/1336821/174591177-0abb2550-7080-439f-8b9e-bad426549ed6.png"> | <img width="712" alt="baa" src="https://user-images.githubusercontent.com/1336821/174591197-aece0bd1-7f35-44ce-bc97-b5ed8e584d40.png"> |
| <img width="513" alt="cbb" src="https://user-images.githubusercontent.com/1336821/174591222-3ffa3742-9871-45d6-bff5-2037d78904ee.png"> | <img width="472" alt="caa" src="https://user-images.githubusercontent.com/1336821/174591251-c1b0a2d5-405b-4495-bec9-885e1cc7055f.png"> |

### Everything else
The footer (the card age if showing and any comment count) always appears below the trail text

| Before      | After      |
|-------------|------------|
| <img width="958" alt="Screenshot 2022-06-20 at 12 24 40" src="https://user-images.githubusercontent.com/1336821/174592015-8475d122-82db-4442-9787-6b2566902b67.png"> | <img width="958" alt="Screenshot 2022-06-20 at 12 27 17" src="https://user-images.githubusercontent.com/1336821/174592262-05d624c9-b415-4fa2-953c-ea8147d6e662.png"> |
|<img width="549" alt="Screenshot 2022-06-20 at 12 30 47" src="https://user-images.githubusercontent.com/1336821/174592669-9d7ed217-9fb7-47b2-85fd-1c8b420ca7fd.png">|<img width="549" alt="Screenshot 2022-06-20 at 12 30 04" src="https://user-images.githubusercontent.com/1336821/174592691-a8a36468-e561-4938-8b79-14a1e80e7304.png">|

