### PR TITLE
Display `img` as block

### DIFF
--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -288,6 +288,9 @@ export const ImageComponent = ({
 					img {
 						object-fit: cover;
 					}
+					picture {
+						height: 100%;
+					}
 				`}
 			>
 				<Picture

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -216,6 +216,16 @@ const descendingByBreakpoint = (a: ImageWidthType, b: ImageWidthType) => {
 	return b.breakpoint - a.breakpoint;
 };
 
+/**
+ * Used on `picture` and `img` to prevent having a line-height,
+ * as these elements are which are `inline` by default.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#styling_with_css
+ */
+const block = css`
+	display: block;
+`;
+
 export const Picture = ({
 	role,
 	format,
@@ -247,7 +257,7 @@ export const Picture = ({
 		});
 
 	return (
-		<picture>
+		<picture css={block}>
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 			{format.display === ArticleDisplay.Immersive && isMainMedia && (
 				<>
@@ -313,11 +323,7 @@ export const Picture = ({
 				loading={
 					isLazy && !Picture.disableLazyLoading ? 'lazy' : undefined
 				}
-				// https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
-				// explains why we added the css `vertical-align: middle;` to the img tag
-				css={css`
-					vertical-align: middle;
-				`}
+				css={block}
 			/>
 		</picture>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Display `img` and `picture` as `block`, instead of the default `inline`.

## Why?

We were previously using a `vertical-align` property, which yield the same effect, but it’s more explicit to set the display type. The best explanation I found of how this think about this is in [Understanding Layout Algorithms by Josh W. Comeau](https://www.joshwcomeau.com/css/understanding-layout-algorithms/#inline-magic-space):

> Hmm… Why is there a bit of extra space underneath the image?
> […]
> By default, inline elements are “baseline” aligned. This means that the bottom of the image will align with the invisible horizontal line that text sits on. That's why there's some space below the image — that space is for the descenders, like the letters `j` and `p`.
> […]
> There are a number of ways to solve this problem. Perhaps the simplest is to treat this image as a block, within Flow layout:

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/174595563-d54091b2-0ae9-4b5e-9b8a-957479a33e0c.png
[after]: https://user-images.githubusercontent.com/76776/174594929-056b6a8e-96ed-4b23-b2bd-bf90c5d3ddaa.png

