### PR TITLE
Bypass metric sampling in AB test definition

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -5,7 +5,6 @@ import {
 } from '@guardian/commercial-core';
 import { getCookie } from '@guardian/libs';
 import { tests } from '../experiments/ab-tests';
-import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
@@ -29,7 +28,6 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 		// For these tests switch off sampling and collect metrics for 100% of views
 		const clientSideTestsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
-			commercialEndOfQuarter2Test,
 			commercialLazyLoadMarginReloaded,
 		];
 

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -4,7 +4,6 @@ import {
 	getCookie,
 	initCoreWebVitals,
 } from '@guardian/libs';
-import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 import { useAB } from '../lib/useAB';
 
@@ -23,7 +22,6 @@ export const CoreVitals = () => {
 	// For these tests switch off sampling and collect metrics for 100% of views
 	const clientSideTestsToForceMetrics: ABTest[] = [
 		/* keep array multi-line */
-		commercialEndOfQuarter2Test,
 		commercialLazyLoadMarginReloaded,
 	];
 

--- a/dotcom-rendering/src/web/experiments/tests/commercial-end-of-quarter-2-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/commercial-end-of-quarter-2-test.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
 
 export const commercialEndOfQuarter2Test: ABTest = {
 	id: 'CommercialEndOfQuarter2Test',
@@ -13,8 +14,8 @@ export const commercialEndOfQuarter2Test: ABTest = {
 	description:
 		'Check whether all changes made this quarter when combined lead to an increase in revenue per 1000 pageviews',
 	variants: [
-		{ id: 'control', test: (): void => {} },
-		{ id: 'variant', test: (): void => {} },
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant', test: bypassMetricsSampling },
 	],
 	canRun: () => true,
 };

--- a/dotcom-rendering/src/web/experiments/utils.ts
+++ b/dotcom-rendering/src/web/experiments/utils.ts
@@ -3,5 +3,5 @@ import { bypassCoreWebVitalsSampling } from '@guardian/libs';
 
 export const bypassMetricsSampling = (): void => {
 	void bypassCommercialMetricsSampling();
-	bypassCoreWebVitalsSampling();
+	void bypassCoreWebVitalsSampling();
 };

--- a/dotcom-rendering/src/web/experiments/utils.ts
+++ b/dotcom-rendering/src/web/experiments/utils.ts
@@ -1,0 +1,7 @@
+import { bypassCommercialMetricsSampling } from '@guardian/commercial-core';
+import { bypassCoreWebVitalsSampling } from '@guardian/libs';
+
+export const bypassMetricsSampling = (): void => {
+	void bypassCommercialMetricsSampling();
+	bypassCoreWebVitalsSampling();
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
See [corresponding frontend change](https://github.com/guardian/frontend/pull/25121)