### PR TITLE
Add link to design.theguardian.com

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -6,21 +6,23 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
--   [Quick start](#quick-start)
-    -   [Install Node.js](#install-nodejs)
-    -   [Running instructions](#running-instructions)
-    -   [Detailed Setup](#detailed-setup)
-    -   [Technologies](#technologies)
-    -   [Architecture Diagram](#architecture-diagram)
-    -   [Concepts](#concepts)
-    -   [Feedback](#feedback)
--   [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
--   [Code Quality](#code-quality)
-    -   [Snyk Code Scanning](#snyk-code-scanning)
--   [IDE setup](#ide-setup)
-    -   [Extensions](#extensions)
-    -   [Auto fix on save](#auto-fix-on-save)
--   [Thanks](#thanks)
+- [Quick start](#quick-start)
+  - [Install Node.js](#install-nodejs)
+  - [Running instructions](#running-instructions)
+  - [Environment Variables](#environment-variables)
+  - [Detailed Setup](#detailed-setup)
+  - [Technologies](#technologies)
+  - [Architecture Diagram](#architecture-diagram)
+  - [UI Design System](#ui-design-system)
+  - [Concepts](#concepts)
+  - [Feedback](#feedback)
+- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+- [Code Quality](#code-quality)
+  - [Snyk Code Scanning](#snyk-code-scanning)
+- [IDE setup](#ide-setup)
+  - [Extensions](#extensions)
+  - [Auto fix on save](#auto-fix-on-save)
+- [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -97,8 +97,10 @@ You can see a _web only_ architecture diagram by running `make arch-diagram`. It
 ### UI Design System
 
 For a high-level overview of some of the key ideas behind the design of the Dotcom website, see [design.theguardian.com](https://design.theguardian.com/).
+This resource was made in 2018 and is not maintained so it should not be taken as authoritative on details, but most of it still applies and it gives a very quick and visual overview. It also provides an explanation of some journalism- or Guardian-specific terms that you might see in the codebase, like 'kicker' and 'standfirst'.
 
-This guide was made in 2018, but most of it still applies. It also provides an explanation of some journalism- or Guardian-specific terms which are used in the codebase, like 'kicker'.
+For more detailed and up-to-date information, you can look at the [Guardian Source](https://theguardian.design/2a1e5182b/p/300696-) site and [Source developer guide](https://guardian.github.io/source/?path=/story/source--page).
+
 
 ### Concepts
 

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -92,6 +92,12 @@ If you're new to JavaScript projects, if you're trying to integrate with other a
 
 You can see a _web only_ architecture diagram by running `make arch-diagram`. It will give you an overview of the current server and browser web architecture.
 
+### UI Design System
+
+For a high-level overview of some of the key ideas behind the design of the Dotcom website, see [design.theguardian.com](https://design.theguardian.com/).
+
+This guide was made in 2018, but most of it still applies. It also provides an explanation of some journalism- or Guardian-specific terms which are used in the codebase, like 'kicker'.
+
 ### Concepts
 
 There are some concepts to learn, that will make working with Dotcom Rendering clearer:

--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -96,11 +96,10 @@ You can see a _web only_ architecture diagram by running `make arch-diagram`. It
 
 ### UI Design System
 
+[Source](https://theguardian.design) is the Guardian's design system. For detailed and up-to-date information on how to use it, see the [Source developer guide](https://guardian.github.io/source).
+
 For a high-level overview of some of the key ideas behind the design of the Dotcom website, see [design.theguardian.com](https://design.theguardian.com/).
-This resource was made in 2018 and is not maintained so it should not be taken as authoritative on details, but most of it still applies and it gives a very quick and visual overview. It also provides an explanation of some journalism- or Guardian-specific terms that you might see in the codebase, like 'kicker' and 'standfirst'.
-
-For more detailed and up-to-date information, you can look at the [Guardian Source](https://theguardian.design/2a1e5182b/p/300696-) site and [Source developer guide](https://guardian.github.io/source/?path=/story/source--page).
-
+This resource was made in 2018 and is not maintained so it <strong>should not be taken as authoritative</strong> on details, but most of it still applies and it gives a very quick and visual overview. It also provides an explanation of some journalism- or Guardian-specific terms that you might see in the codebase, like 'kicker' and 'standfirst'.
 
 ### Concepts
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a link to design.theguardian.com to the documentation.

## Why?

I couldn't find a link to it in the existing docs for this repo.

There are a number of principles governing the UI which might not be obvious to new contributors to the codebase. In addition, there are a number of journalism- or Guardian-specific terms for describing aspects of the UI which are present in the codebase, and again these might not be obvious to new contributors.

Although it was made a few years ago, and I'm assuming that it isn't maintained, this resource still seems to be largely accurate, and I think it does a great job of introducing some of these concepts and terms.

My feeling is that even if it's not 100% accurate today, it will still be more helpful than misleading as a guide for new contributors. I'm definitely open to other opinions on this, though!
