### PR TITLE
Remove `is-ci` As Direct Dependency

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -84,7 +84,6 @@
     "express": "^4.17.1",
     "html-webpack-plugin": "^5.3.2",
     "husky": "^5.2.0",
-    "is-ci": "^2.0.0",
     "jest": "^26.6.1",
     "jsdom": "^16.7.0",
     "node-fetch": "^3.1.1",


### PR DESCRIPTION
## Why?

It's no longer used directly, but still exists as a transitive dependency for Jest.

Paired with @MarSavar and @iainjchambers-guardian on this

## Changes

- Removed `is-ci` from direct dep list
