### PR TITLE
Move accordion behind auto filter feature switch

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -301,6 +301,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const showKeyEventsCarousel =
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
+	const isInFilteringBeta =
+		CAPIArticle.config.abTests.automaticFiltersVariant == 'variant';
+
 	return (
 		<>
 			<div data-print-layout="hide">
@@ -813,6 +816,170 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									) : (
 										<></>
 									)}
+									{isInFilteringBeta ? (
+										<>
+											{!showKeyEventsCarousel &&
+											CAPIArticle.keyEvents.length ? (
+												<Hide above="desktop">
+													<Island deferUntil="visible">
+														<FilterKeyEventsToggle
+															filterKeyEvents={
+																CAPIArticle.filterKeyEvents
+															}
+															id="filter-toggle-mobile"
+														/>
+													</Island>
+												</Hide>
+											) : (
+												<></>
+											)}
+											<ArticleContainer format={format}>
+												{pagination.currentPage !==
+													1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
+													/>
+												)}
+												<ArticleBody
+													format={format}
+													blocks={CAPIArticle.blocks}
+													pinnedPost={
+														CAPIArticle.pinnedPost
+													}
+													adTargeting={adTargeting}
+													host={host}
+													pageId={CAPIArticle.pageId}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													ajaxUrl={
+														CAPIArticle.config
+															.ajaxUrl
+													}
+													section={
+														CAPIArticle.config
+															.section
+													}
+													switches={
+														CAPIArticle.config
+															.switches
+													}
+													isSensitive={
+														CAPIArticle.config
+															.isSensitive
+													}
+													isAdFreeUser={
+														CAPIArticle.isAdFreeUser
+													}
+													shouldHideReaderRevenue={
+														CAPIArticle.shouldHideReaderRevenue
+													}
+													tags={CAPIArticle.tags}
+													isPaidContent={
+														!!CAPIArticle.config
+															.isPaidContent
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													contentType={
+														CAPIArticle.contentType
+													}
+													sectionName={
+														CAPIArticle.sectionName ||
+														''
+													}
+													isPreview={
+														CAPIArticle.config
+															.isPreview
+													}
+													idUrl={
+														CAPIArticle.config
+															.idUrl || ''
+													}
+													isDev={
+														!!CAPIArticle.config
+															.isDev
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+													keyEvents={
+														CAPIArticle.keyEvents
+													}
+													filterKeyEvents={
+														CAPIArticle.filterKeyEvents
+													}
+													abTests={
+														CAPIArticle.config
+															.abTests
+													}
+													showKeyEventsCarousel={
+														showKeyEventsCarousel
+													}
+												/>
+												{pagination.totalPages > 1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
+													/>
+												)}
+												<StraightLines
+													data-print-layout="hide"
+													count={4}
+													cssOverrides={css`
+														display: block;
+													`}
+												/>
+												<SubMeta
+													format={format}
+													subMetaKeywordLinks={
+														CAPIArticle.subMetaKeywordLinks
+													}
+													subMetaSectionLinks={
+														CAPIArticle.subMetaSectionLinks
+													}
+													pageId={CAPIArticle.pageId}
+													webUrl={CAPIArticle.webURL}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													showBottomSocialButtons={
+														CAPIArticle.showBottomSocialButtons
+													}
+													badge={CAPIArticle.badge}
+												/>
+											</ArticleContainer>
+										</>
+									) : (
 									<Accordion
 										supportsDarkMode={false}
 										accordionTitle="Live feed"

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -302,7 +302,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	const isInFilteringBeta =
-		CAPIArticle.config.abTests.automaticFiltersVariant == 'variant';
+		CAPIArticle.config.abTests.automaticFiltersVariant == 'variant' &&
+		CAPIArticle.topics;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -980,152 +980,172 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											</ArticleContainer>
 										</>
 									) : (
-									<Accordion
-										supportsDarkMode={false}
-										accordionTitle="Live feed"
-										context="liveFeed"
-									>
-										{!showKeyEventsCarousel &&
-										CAPIArticle.keyEvents.length ? (
-											<Hide above="desktop">
-												<Island deferUntil="visible">
-													<FilterKeyEventsToggle
-														filterKeyEvents={
-															CAPIArticle.filterKeyEvents
+										<Accordion
+											supportsDarkMode={false}
+											accordionTitle="Live feed"
+											context="liveFeed"
+										>
+											{!showKeyEventsCarousel &&
+											CAPIArticle.keyEvents.length ? (
+												<Hide above="desktop">
+													<Island deferUntil="visible">
+														<FilterKeyEventsToggle
+															filterKeyEvents={
+																CAPIArticle.filterKeyEvents
+															}
+															id="filter-toggle-mobile"
+														/>
+													</Island>
+												</Hide>
+											) : (
+												<></>
+											)}
+											<ArticleContainer format={format}>
+												{pagination.currentPage !==
+													1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
 														}
-														id="filter-toggle-mobile"
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
 													/>
-												</Island>
-											</Hide>
-										) : (
-											<></>
-										)}
-										<ArticleContainer format={format}>
-											{pagination.currentPage !== 1 && (
-												<Pagination
-													currentPage={
-														pagination.currentPage
-													}
-													totalPages={
-														pagination.totalPages
-													}
-													newest={pagination.newest}
-													oldest={pagination.oldest}
-													newer={pagination.newer}
-													older={pagination.older}
+												)}
+												<ArticleBody
 													format={format}
+													blocks={CAPIArticle.blocks}
+													pinnedPost={
+														CAPIArticle.pinnedPost
+													}
+													adTargeting={adTargeting}
+													host={host}
+													pageId={CAPIArticle.pageId}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													ajaxUrl={
+														CAPIArticle.config
+															.ajaxUrl
+													}
+													section={
+														CAPIArticle.config
+															.section
+													}
+													switches={
+														CAPIArticle.config
+															.switches
+													}
+													isSensitive={
+														CAPIArticle.config
+															.isSensitive
+													}
+													isAdFreeUser={
+														CAPIArticle.isAdFreeUser
+													}
+													shouldHideReaderRevenue={
+														CAPIArticle.shouldHideReaderRevenue
+													}
+													tags={CAPIArticle.tags}
+													isPaidContent={
+														!!CAPIArticle.config
+															.isPaidContent
+													}
+													contributionsServiceUrl={
+														contributionsServiceUrl
+													}
+													contentType={
+														CAPIArticle.contentType
+													}
+													sectionName={
+														CAPIArticle.sectionName ||
+														''
+													}
+													isPreview={
+														CAPIArticle.config
+															.isPreview
+													}
+													idUrl={
+														CAPIArticle.config
+															.idUrl || ''
+													}
+													isDev={
+														!!CAPIArticle.config
+															.isDev
+													}
+													onFirstPage={
+														pagination.currentPage ===
+														1
+													}
+													keyEvents={
+														CAPIArticle.keyEvents
+													}
+													filterKeyEvents={
+														CAPIArticle.filterKeyEvents
+													}
+													abTests={
+														CAPIArticle.config
+															.abTests
+													}
+													showKeyEventsCarousel={
+														showKeyEventsCarousel
+													}
 												/>
-											)}
-											<ArticleBody
-												format={format}
-												blocks={CAPIArticle.blocks}
-												pinnedPost={
-													CAPIArticle.pinnedPost
-												}
-												adTargeting={adTargeting}
-												host={host}
-												pageId={CAPIArticle.pageId}
-												webTitle={CAPIArticle.webTitle}
-												ajaxUrl={
-													CAPIArticle.config.ajaxUrl
-												}
-												section={
-													CAPIArticle.config.section
-												}
-												switches={
-													CAPIArticle.config.switches
-												}
-												isSensitive={
-													CAPIArticle.config
-														.isSensitive
-												}
-												isAdFreeUser={
-													CAPIArticle.isAdFreeUser
-												}
-												shouldHideReaderRevenue={
-													CAPIArticle.shouldHideReaderRevenue
-												}
-												tags={CAPIArticle.tags}
-												isPaidContent={
-													!!CAPIArticle.config
-														.isPaidContent
-												}
-												contributionsServiceUrl={
-													contributionsServiceUrl
-												}
-												contentType={
-													CAPIArticle.contentType
-												}
-												sectionName={
-													CAPIArticle.sectionName ||
-													''
-												}
-												isPreview={
-													CAPIArticle.config.isPreview
-												}
-												idUrl={
-													CAPIArticle.config.idUrl ||
-													''
-												}
-												isDev={
-													!!CAPIArticle.config.isDev
-												}
-												onFirstPage={
-													pagination.currentPage === 1
-												}
-												keyEvents={
-													CAPIArticle.keyEvents
-												}
-												filterKeyEvents={
-													CAPIArticle.filterKeyEvents
-												}
-												abTests={
-													CAPIArticle.config.abTests
-												}
-												showKeyEventsCarousel={
-													showKeyEventsCarousel
-												}
-											/>
-											{pagination.totalPages > 1 && (
-												<Pagination
-													currentPage={
-														pagination.currentPage
-													}
-													totalPages={
-														pagination.totalPages
-													}
-													newest={pagination.newest}
-													oldest={pagination.oldest}
-													newer={pagination.newer}
-													older={pagination.older}
+												{pagination.totalPages > 1 && (
+													<Pagination
+														currentPage={
+															pagination.currentPage
+														}
+														totalPages={
+															pagination.totalPages
+														}
+														newest={
+															pagination.newest
+														}
+														oldest={
+															pagination.oldest
+														}
+														newer={pagination.newer}
+														older={pagination.older}
+														format={format}
+													/>
+												)}
+												<StraightLines
+													data-print-layout="hide"
+													count={4}
+													cssOverrides={css`
+														display: block;
+													`}
+												/>
+												<SubMeta
 													format={format}
+													subMetaKeywordLinks={
+														CAPIArticle.subMetaKeywordLinks
+													}
+													subMetaSectionLinks={
+														CAPIArticle.subMetaSectionLinks
+													}
+													pageId={CAPIArticle.pageId}
+													webUrl={CAPIArticle.webURL}
+													webTitle={
+														CAPIArticle.webTitle
+													}
+													showBottomSocialButtons={
+														CAPIArticle.showBottomSocialButtons
+													}
+													badge={CAPIArticle.badge}
 												/>
-											)}
-											<StraightLines
-												data-print-layout="hide"
-												count={4}
-												cssOverrides={css`
-													display: block;
-												`}
-											/>
-											<SubMeta
-												format={format}
-												subMetaKeywordLinks={
-													CAPIArticle.subMetaKeywordLinks
-												}
-												subMetaSectionLinks={
-													CAPIArticle.subMetaSectionLinks
-												}
-												pageId={CAPIArticle.pageId}
-												webUrl={CAPIArticle.webURL}
-												webTitle={CAPIArticle.webTitle}
-												showBottomSocialButtons={
-													CAPIArticle.showBottomSocialButtons
-												}
-												badge={CAPIArticle.badge}
-											/>
-										</ArticleContainer>
-									</Accordion>
+											</ArticleContainer>
+										</Accordion>
 									)}
 								</div>
 							</GridItem>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -302,8 +302,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	const isInFilteringBeta =
-		CAPIArticle.config.switches.automaticFilters &&
-		CAPIArticle.topics;
+		CAPIArticle.config.switches.automaticFilters && CAPIArticle.topics;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1126,6 +1126,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											/>
 										</ArticleContainer>
 									</Accordion>
+									)}
 								</div>
 							</GridItem>
 							<GridItem area="right-column">

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -302,7 +302,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	const isInFilteringBeta =
-		CAPIArticle.config.abTests.automaticFiltersVariant == 'variant' &&
+		CAPIArticle.config.switches.automaticFilters &&
 		CAPIArticle.topics;
 
 	return (


### PR DESCRIPTION
## What does this change?
Moves the Live Feed header accordion behind the auto filter AB test. 
**This test is currently switched off and set to 0%.**

## Why?
As part of the automatic filters redesign, the header accordion is being removed.
NB: When removing the accordion, we lose horizontal padding. In the interest of keeping the PR small, this has been ticketed here (https://trello.com/c/XL3ulWuM/414-auto-filters-fix-padding-in-live-feed) and will be addressed in an upcoming PR.

## Screenshots

**Before:** 
![Screenshot 2022-06-22 at 11 34 43](https://user-images.githubusercontent.com/55602675/175009701-c3599758-8b65-405a-9d0f-f9a95ed80664.png)

**After:** 
![Screenshot 2022-06-22 at 11 34 58](https://user-images.githubusercontent.com/55602675/175009727-a9bb8a21-8bd0-4876-8826-e1c0763c1528.png)

