### PR TITLE
Dropdown notification badge support

### DIFF
--- a/dotcom-rendering/src/web/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.stories.tsx
@@ -98,3 +98,32 @@ export const DropdownNoActive = () => (
 	</Header>
 );
 DropdownNoActive.story = { name: 'Dropdown with nothing active' };
+
+const linksWithNotifications = [
+	{
+		url: '/account-overview',
+		title: 'Account Overview',
+		dataLinkName: 'account-overview',
+	},
+	{
+		url: '/billing',
+		title: 'Billing',
+		dataLinkName: 'billing',
+		notifications: ['Billing attempt failed'],
+	},
+];
+
+export const DropdownWithNotifications = () => (
+	<Header>
+		<Nav>
+			<Dropdown
+				id="d3"
+				label="My Account"
+				links={linksWithNotifications}
+				dataLinkName="linkname3"
+			/>
+		</Nav>
+	</Header>
+);
+
+DropdownWithNotifications.story = { name: 'Dropdown with notifications' };

--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -6,6 +6,7 @@ import {
 	from,
 	neutral,
 	news,
+	palette,
 	text,
 	textSans,
 	until,
@@ -13,12 +14,14 @@ import {
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import { getZIndex } from '../lib/getZIndex';
+import { linkNotificationCount } from '../lib/linkNotificationCount';
 
 export interface DropdownLinkType {
 	url: string;
 	title: string;
 	isActive?: boolean;
 	dataLinkName: string;
+	notifications?: string[];
 }
 
 interface Props {
@@ -138,6 +141,7 @@ const buttonStyles = (overrideColor?: string) => css`
 	padding: 0px 10px 6px 5px;
 	margin: 1px 0 0;
 	text-decoration: none;
+	position: relative;
 
 	:hover {
 		color: ${brandAlt[400]};
@@ -170,6 +174,58 @@ const buttonExpanded = css`
 		transform: translateY(1px) rotate(-135deg);
 	}
 `;
+
+const badgeDiameter = 20;
+const notificationColor = palette.error[400];
+
+const notificationBadgeStyles = css`
+	background-color: ${notificationColor};
+	color: ${palette.neutral[100]};
+	position: absolute;
+	top: 0;
+	left: 0;
+	min-width: ${badgeDiameter}px;
+	height: ${badgeDiameter}px;
+	border-radius: ${badgeDiameter / 2}px;
+	text-align: center;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 0 5px;
+	margin-left: -10px;
+	margin-top: -3px;
+`;
+
+const notificationStyles = css`
+	${textSans.xxsmall()};
+	color: ${notificationColor};
+`;
+
+const redDotDiameter = 16;
+const redDotStyles = css`
+	background-color: ${notificationColor};
+	width: ${redDotDiameter}px;
+	height: ${redDotDiameter}px;
+	border-radius: ${redDotDiameter / 2}px;
+	position: absolute;
+	left: 5px;
+	top: 12px;
+`;
+
+const notificationCountStyles = css`
+	${textSans.xsmall()};
+	line-height: ${badgeDiameter}px;
+`;
+
+const NotificationBadge = ({ count }: { count: number }) => {
+	return (
+		<div css={notificationBadgeStyles}>
+			<span css={notificationCountStyles}>{count + 0}</span>
+		</div>
+	);
+};
+
+const RedDot = () => <div css={redDotStyles} />;
 
 export const Dropdown = ({
 	id,
@@ -219,6 +275,8 @@ export const Dropdown = ({
 	// needs to be unique to allow multiple dropdowns on same page
 	const dropdownID = `dropbox-id-${id}`;
 	const checkboxID = `checkbox-id-${id}`;
+
+	const notificationCount = linkNotificationCount(links);
 
 	return (
 		<>
@@ -281,8 +339,12 @@ export const Dropdown = ({
 						aria-expanded={isExpanded ? 'true' : 'false'}
 						data-link-name={dataLinkName}
 						data-cy="dropdown-button"
+						type="button"
 					>
 						{label}
+						{notificationCount > 0 && (
+							<NotificationBadge count={notificationCount} />
+						)}
 					</button>
 					<div css={isExpanded ? displayBlock : displayNone}>
 						{children ? (
@@ -290,7 +352,12 @@ export const Dropdown = ({
 						) : (
 							<ul css={ulStyles} data-cy="dropdown-options">
 								{links.map((l, index) => (
-									<li key={l.title}>
+									<li
+										css={css`
+											position: relative;
+										`}
+										key={l.title}
+									>
 										<a
 											href={l.url}
 											css={[
@@ -301,7 +368,21 @@ export const Dropdown = ({
 											data-link-name={l.dataLinkName}
 										>
 											{l.title}
+											{l.notifications?.map(
+												(notification) => (
+													<div
+														css={notificationStyles}
+													>
+														{notification}
+													</div>
+												),
+											)}
 										</a>
+
+										{l.notifications?.length &&
+											l.notifications.length > 0 && (
+												<RedDot />
+											)}
 									</li>
 								))}
 							</ul>

--- a/dotcom-rendering/src/web/lib/linkNotificationCount.test.ts
+++ b/dotcom-rendering/src/web/lib/linkNotificationCount.test.ts
@@ -1,0 +1,47 @@
+import type { DropdownLinkType } from '../components/Dropdown';
+import { linkNotificationCount } from './linkNotificationCount';
+
+describe('linksNotificationCount', () => {
+	it('returns the sum of notifications across all links', () => {
+		const links: DropdownLinkType[] = [
+			{
+				url: 'https://example.com/1',
+				title: 'One',
+				dataLinkName: 'One',
+				notifications: ['Notification here!'],
+			},
+			{
+				url: 'https://example.com/2',
+				title: 'Two',
+				dataLinkName: 'Two',
+				notifications: [
+					'Another notification here!',
+					'And another one.',
+				],
+			},
+		];
+
+		const notificationCount = linkNotificationCount(links);
+
+		expect(notificationCount).toEqual(3);
+	});
+
+	it('returns 0 when there are no notifications', () => {
+		const links = [
+			{
+				url: 'https://example.com/1',
+				title: 'One',
+				dataLinkName: 'One',
+			},
+			{
+				url: 'https://example.com/2',
+				title: 'Two',
+				dataLinkName: 'Two',
+			},
+		];
+
+		const notificationCount = linkNotificationCount(links);
+
+		expect(notificationCount).toEqual(0);
+	});
+});

--- a/dotcom-rendering/src/web/lib/linkNotificationCount.ts
+++ b/dotcom-rendering/src/web/lib/linkNotificationCount.ts
@@ -1,0 +1,8 @@
+import type { DropdownLinkType } from '../components/Dropdown';
+
+export const linkNotificationCount = (links: DropdownLinkType[]): number => {
+	return links.reduce((runningCount, link) => {
+		const thisLinkNotificationCount = link.notifications?.length ?? 0;
+		return runningCount + thisLinkNotificationCount;
+	}, 0);
+};


### PR DESCRIPTION
## What does this change?

Adds support for rendering user notifications with the `Dropdown` component.

## Why?

Currently this isn't wired up to any system to actually trigger notifications. In future we'd like to trigger these via Braze. The use case we have in mind is to let readers know when there's an issue with their payment method.

## Screenshots

![Screenshot 2022-06-21 at 17 07 54](https://user-images.githubusercontent.com/379839/174848360-c603caa5-6512-4375-8aa8-34c6012ab0c2.png)

![Screenshot 2022-06-21 at 17 08 11](https://user-images.githubusercontent.com/379839/174848389-080977ad-6794-4be0-93d8-3330e6a81a06.png)

Example with larger notification count:

![Screenshot 2022-06-21 at 17 17 54](https://user-images.githubusercontent.com/379839/174848634-ff948f34-7352-4206-83ad-80be54c12a3e.png)