### PR TITLE
Slightly less padding on the headline to align with image

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -10,7 +10,6 @@ export const HeadlineWrapper = ({ children }: Props) => (
 			padding-bottom: 8px;
 			padding-left: 5px;
 			padding-right: 5px;
-			padding-top: 1px;
 			flex-grow: 1;
 		`}
 	>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This aligns the headline with the image to close #4721.

There has [already been work done](https://github.com/guardian/dotcom-rendering/pull/4921) in this area which did create the correct alignment but it seems there could have been a regression since then because when I checked we were 1 pixel out.

| Before      | After      |
|-------------|------------|
| <img width="256" alt="Screenshot 2022-06-22 at 05 53 21" src="https://user-images.githubusercontent.com/1336821/174947215-6ee738e6-ef16-4322-b367-db25e9b1f52a.png">] | <img width="256" alt="Screenshot 2022-06-22 at 05 56 57" src="https://user-images.githubusercontent.com/1336821/174947226-fc2764c0-5cee-42b8-a5f4-7c129d49577a.png"> |
