### PR TITLE
Don't underline headline for `Analysis` if a palette exists

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -198,6 +198,7 @@ export const CardHeadline = ({
 						? labTextStyles(size)
 						: fontStyles(size),
 					format.design === ArticleDesign.Analysis &&
+						!containerPalette &&
 						underlinedStyles(
 							size,
 							palette.background.analysisUnderline,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes #4726 by not setting the underline styles for card headlines when the card appears inside a container using a palette

## Why?
To match designs

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1220" alt="Screenshot 2022-06-22 at 06 08 46" src="https://user-images.githubusercontent.com/1336821/174948762-2222f713-0442-4193-9c83-0c5221842638.png"> | <img width="1220" alt="Screenshot 2022-06-22 at 06 07 37" src="https://user-images.githubusercontent.com/1336821/174948793-58253f27-d711-401a-afd5-55677b8b76d4.png"> |
