### PR TITLE
Use black card headline for features

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -382,7 +382,6 @@ const textCardHeadline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport) return WHITE;
 	if (format.display === ArticleDisplay.Immersive) return BLACK;
 	switch (format.design) {
-		case ArticleDesign.Feature:
 		case ArticleDesign.Interview:
 			return pillarPalette[format.theme].dark;
 		case ArticleDesign.Gallery:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This closes #4727 by defaulting the card headline colour to black for `Design.Feature`


| Before      | After      |
|-------------|------------|
| <img width="1001" alt="Screenshot 2022-06-22 at 06 47 29" src="https://user-images.githubusercontent.com/1336821/174956604-4e71b162-23b4-445b-bd73-f6730d7091cf.png">| <img width="1001" alt="Screenshot 2022-06-22 at 06 47 05" src="https://user-images.githubusercontent.com/1336821/174956666-e4f73f86-3765-45db-b59c-333f3c32dec6.png"> |

