### PR TITLE
Fix dividers and spacing on FixedLargeSlowXIV

### DIFF
--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -139,7 +139,11 @@ export const FixedLargeSlowXIV = ({
 						<LI
 							padSides={true}
 							percentage="25%"
-							showDivider={cardIndex !== 4 && cardIndex !== 8}
+							showDivider={
+								cardIndex !== 0 &&
+								cardIndex !== 4 &&
+								cardIndex !== 8
+							}
 							padBottom={cardIndex < 4}
 							padBottomOnMobile={
 								cardIndex !== thirdSlice.length - 1


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

It does three main things:
1. Puts the bottom two rows of cards in this container into a single `UL`.
2. Fixes a small bug in the way that the spacing was implemented on mobile devices.
3. Fixes a small bug in the way the cards were being sliced, which led to skipping a couple of cards.

## Why?

Change (1) allows us to add bottom padding to the `<li>` elements in the 3rd row of cards, instead of to the `<ul>` which wrapped it before. Because the padding is on the `li`, the divider line now spans the gap created by that padding (because the divider line is set to be the same height as the `li`. This means that the dividers for these two rows are continuous, [as in the figma design](https://www.figma.com/file/sx2vMFHbL7SsUo0LcpsKNe/%E2%AC%A3--Front-container?node-id=0%3A1).

Change 2 also brings the component into line with the figma designs. On single-column layouts in the figma, there is uniform spacing between each card, regardless of which 'slice' they belong to.


## Screenshots

These are screenshots from Storybook, and they focus in on the main visual change. All of the changes are quite subtle, and none of them _should_ affect anything outside the component itself, so to see the other differences it's probably easiest to check out the [chromatic build](https://www.chromatic.com/build?appId=5dfcbf3012392c0020e7140b&number=13319) where the diffs are highlighted.

It's worth bearing in mind that (3) leads to larger diffs on wider views, but this is just because the cards being rendered are different. (I've put an explanatory note in Chromatic for the relevant pages.)

| Before      | After      |
|-------------|------------|
| ![before (gaps between dividers on different rows)](https://user-images.githubusercontent.com/37048459/175034700-393781e8-c30c-403b-9997-6c3a1908d7e5.png)| ![image](https://user-images.githubusercontent.com/37048459/175035407-07782c8f-bdff-4d1a-acbb-d68bd20e66d4.png) |


You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
