### PR TITLE
Bump atoms-rendering to get "was this useful" labels

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -59,7 +59,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.1.2",
+    "@guardian/atoms-rendering": "^23.2.0",
     "@guardian/braze-components": "^7.2.0",
     "@guardian/commercial-core": "^3.4.0",
     "@guardian/consent-management-platform": "10.7.0",


### PR DESCRIPTION
## What does this change?
Bumps atoms-rendering to get labels on "was this useful" for explainer atoms:
https://github.com/guardian/atoms-rendering/pull/416

Part of https://github.com/guardian/dotcom-rendering/issues/4446