### PR TITLE
Card meta placement

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { brandAltBackground } from '@guardian/source-foundations';
+import { brandAltBackground, space } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { decidePalette } from '../../lib/decidePalette';
@@ -64,9 +64,8 @@ const StarRatingComponent = ({ rating }: { rating: number }) => (
 	<div
 		css={css`
 			background-color: ${brandAltBackground.primary};
-			position: absolute;
-			bottom: 0;
-			margin-top: 2px;
+			margin-top: ${space[1]}px;
+			display: inline-block;
 		`}
 	>
 		<Hide when="above" breakpoint="desktop">
@@ -325,10 +324,10 @@ export const Card = ({
 								byline={byline}
 								showByline={showByline}
 							/>
+							{starRating !== undefined ? (
+								<StarRatingComponent rating={starRating} />
+							) : null}
 						</HeadlineWrapper>
-						{starRating !== undefined ? (
-							<StarRatingComponent rating={starRating} />
-						) : null}
 						{avatar && (
 							<Hide when="above" breakpoint="tablet">
 								<AvatarContainer>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -216,19 +216,6 @@ export const Card = ({
 						/>
 					) : undefined
 				}
-				mediaMeta={
-					(format.design === ArticleDesign.Gallery ||
-						format.design === ArticleDesign.Audio ||
-						format.design === ArticleDesign.Video) &&
-					mediaType ? (
-						<MediaMeta
-							containerPalette={containerPalette}
-							format={format}
-							mediaType={mediaType}
-							mediaDuration={mediaDuration}
-						/>
-					) : undefined
-				}
 				commentCount={
 					discussionId ? (
 						<Link
@@ -327,6 +314,17 @@ export const Card = ({
 							{starRating !== undefined ? (
 								<StarRatingComponent rating={starRating} />
 							) : null}
+							{(format.design === ArticleDesign.Gallery ||
+								format.design === ArticleDesign.Audio ||
+								format.design === ArticleDesign.Video) &&
+							mediaType ? (
+								<MediaMeta
+									containerPalette={containerPalette}
+									format={format}
+									mediaType={mediaType}
+									mediaDuration={mediaDuration}
+								/>
+							) : undefined}
 						</HeadlineWrapper>
 						{avatar && (
 							<Hide when="above" breakpoint="tablet">

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -67,7 +67,7 @@ const starWrapper = css`
 	margin-top: 2px;
 `;
 
-const StarRatingComponent: React.FC<{ rating: number }> = ({ rating }) => (
+const StarRatingComponent = ({ rating }: { rating: number }) => (
 	<>
 		<Hide when="above" breakpoint="desktop">
 			<div css={starWrapper}>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -60,26 +60,22 @@ export type Props = {
 	discussionId?: string;
 };
 
-const starWrapper = css`
-	background-color: ${brandAltBackground.primary};
-	position: absolute;
-	bottom: 0;
-	margin-top: 2px;
-`;
-
 const StarRatingComponent = ({ rating }: { rating: number }) => (
-	<>
+	<div
+		css={css`
+			background-color: ${brandAltBackground.primary};
+			position: absolute;
+			bottom: 0;
+			margin-top: 2px;
+		`}
+	>
 		<Hide when="above" breakpoint="desktop">
-			<div css={starWrapper}>
-				<StarRating rating={rating} size="small" />
-			</div>
+			<StarRating rating={rating} size="small" />
 		</Hide>
 		<Hide when="below" breakpoint="desktop">
-			<div css={starWrapper}>
-				<StarRating rating={rating} size="medium" />
-			</div>
+			<StarRating rating={rating} size="medium" />
 		</Hide>
-	</>
+	</div>
 );
 
 /**
@@ -299,9 +295,6 @@ export const Card = ({
 						imagePositionOnMobile={imagePositionOnMobile}
 					>
 						<img src={imageUrl} alt="" role="presentation" />
-						{starRating !== undefined ? (
-							<StarRatingComponent rating={starRating} />
-						) : null}
 					</ImageWrapper>
 				)}
 				<ContentWrapper
@@ -333,6 +326,9 @@ export const Card = ({
 								showByline={showByline}
 							/>
 						</HeadlineWrapper>
+						{starRating !== undefined ? (
+							<StarRatingComponent rating={starRating} />
+						) : null}
 						{avatar && (
 							<Hide when="above" breakpoint="tablet">
 								<AvatarContainer>

--- a/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardFooter.tsx
@@ -8,7 +8,6 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	displayLines?: boolean;
 	age?: JSX.Element;
-	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	supportingContent?: JSX.Element;
@@ -35,7 +34,6 @@ export const CardFooter = ({
 	containerPalette,
 	displayLines,
 	age,
-	mediaMeta,
 	commentCount,
 	cardBranding,
 	supportingContent,
@@ -68,23 +66,6 @@ export const CardFooter = ({
 						/>
 					)}
 					{commentCount}
-				</div>
-			</footer>
-		);
-	}
-
-	if (
-		format.design === ArticleDesign.Gallery ||
-		format.design === ArticleDesign.Audio ||
-		format.design === ArticleDesign.Video
-	) {
-		return (
-			<footer css={margins}>
-				{supportingContent}
-				<div css={spaceBetween}>
-					{mediaMeta}
-					{/* Show age if we have it otherwise try for commentCount */}
-					{age || commentCount}
 				</div>
 			</footer>
 		);

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -41,8 +41,7 @@ const durationStyles = (palette: Palette) => css`
 const wrapperStyles = css`
 	display: flex;
 	align-items: center;
-
-	padding: 0 5px 5px 5px;
+	margin-top: 4px;
 `;
 
 export function secondsToDuration(secs?: number): string {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR repositions the card meta items, `MediaMeta` and `StarRating` so that they sit underneath the headline. Closes #4736 

## Why?
This is part of the work to [rationalise Card designs](https://www.figma.com/file/5CfbWOeZPRi15lXBD5u1rW/Card-layout-system?node-id=220%3A5279)


| Before      | After      |
|-------------|------------|
| <img width="325" alt="Screenshot 2022-06-23 at 07 29 42" src="https://user-images.githubusercontent.com/1336821/175230603-11e6842e-ac83-44ee-bc00-9ce291c39fc5.png"> | <img width="327" alt="Screenshot 2022-06-23 at 07 26 40" src="https://user-images.githubusercontent.com/1336821/175230456-8b67e206-ad39-4d87-b03e-ad6ea4eed75b.png"> |
| <img width="248" alt="Screenshot 2022-06-23 at 07 29 26" src="https://user-images.githubusercontent.com/1336821/175230625-4d857361-9c2c-4a7d-b467-c62b9a270b91.png"> | <img width="248" alt="Screenshot 2022-06-23 at 07 27 01" src="https://user-images.githubusercontent.com/1336821/175230486-cdade46b-5704-46b2-bbae-de2d61a1687a.png">  |
