### PR TITLE
Add aria-label and data-link-name

### DIFF
--- a/dotcom-rendering/src/web/components/FilterButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.importable.tsx
@@ -4,12 +4,13 @@ import { Button, SvgCross } from '@guardian/source-react-components';
 import { decidePalette } from '../lib/decidePalette';
 
 interface LabelProps {
-	text: string;
+	value: string;
 	count?: number;
 }
 
 interface ButtonProps {
-	text: string;
+	value: string;
+	type?: TopicType;
 	count?: number;
 	format: ArticleFormat;
 	isActive: boolean;
@@ -58,15 +59,16 @@ const valueStyles = css`
 	max-width: 150px;
 `;
 
-const Label = ({ text, count }: LabelProps) => (
+const Label = ({ value, count }: LabelProps) => (
 	<>
-		<span css={valueStyles}>{text}</span>{' '}
+		<span css={valueStyles}>{value}</span>{' '}
 		{count && <span css={countStyles}>({count})</span>}
 	</>
 );
 
 export const FilterButton = ({
-	text,
+	type,
+	value,
 	count,
 	isActive,
 	format,
@@ -74,18 +76,27 @@ export const FilterButton = ({
 }: ButtonProps) => {
 	const palette = decidePalette(format);
 
+	const dataLinkName = type ? `${type}:${value}` : value;
+
 	return isActive ? (
 		<Button
 			cssOverrides={[buttonStyles(palette), activeStyles(palette)]}
 			onClick={onClick}
 			icon={<SvgCross />}
 			iconSide="right"
+			aria-label={`Deactivate ${value} filter`}
+			data-link-name={`${dataLinkName} | filter off`}
 		>
-			<Label text={text} count={count} />
+			<Label value={value} count={count} />
 		</Button>
 	) : (
-		<Button cssOverrides={buttonStyles(palette)} onClick={onClick}>
-			<Label text={text} count={count} />
+		<Button
+			cssOverrides={buttonStyles(palette)}
+			onClick={onClick}
+			aria-label={`Activate ${value} filter`}
+			data-link-name={`${dataLinkName} | filter on`}
+		>
+			<Label value={value} count={count} />
 		</Button>
 	);
 };

--- a/dotcom-rendering/src/web/components/FilterButton.stories.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.stories.tsx
@@ -42,7 +42,8 @@ export const DefaultStory = () => (
 	<Container>
 		<FilterButton
 			isActive={false}
-			text="nhs"
+			type="ORG"
+			value="nhs"
 			count={21}
 			format={format}
 			onClick={() => {}}
@@ -56,7 +57,8 @@ export const ActiveStory = () => (
 	<Container>
 		<FilterButton
 			isActive={true}
-			text="nhs"
+			type="ORG"
+			value="nhs"
 			count={21}
 			format={format}
 			onClick={() => {}}
@@ -70,7 +72,8 @@ export const TruncatedStory = () => (
 	<Container>
 		<FilterButton
 			isActive={false}
-			text="Something thats too long to fit"
+			type="ORG"
+			value="Something thats too long to fit"
 			count={21}
 			format={format}
 			onClick={() => {}}
@@ -84,7 +87,8 @@ export const TruncatedActiveStory = () => (
 	<Container>
 		<FilterButton
 			isActive={true}
-			text="Something thats too long to fit"
+			type="ORG"
+			value="Something thats too long to fit"
 			count={21}
 			format={format}
 			onClick={() => {}}
@@ -98,7 +102,7 @@ export const FilterKeyEventsStory = () => (
 	<Container>
 		<FilterButton
 			isActive={false}
-			text="Filter Key Events"
+			value="Filter Key Events"
 			format={format}
 			onClick={() => {}}
 		/>
@@ -111,7 +115,7 @@ export const FilterKeyEventsActiveStory = () => (
 	<Container>
 		<FilterButton
 			isActive={true}
-			text="Filter Key Events"
+			value="Filter Key Events"
 			format={format}
 			onClick={() => {}}
 		/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds `aria-label` and `data-link-name` values to the `FilterButton` component, adds a `type` prop and updates the relevant stories.

By adding a `type` prop to the button we're able to provide more accurate tracking data - these types are provided by as part of the filtering `topic`. 

```js
interface Topic {
	type: TopicType,
	value: string,
	count: number,
}

type TopicType = 'ORG' | 'PRODUCT' | 'PERSON' | 'GPE' | 'WORK_OF_ART' | 'LOC';

```

This is optional as we also need the button to also work as a replacement for the Key Event filter toggle.

## Why?

Accessibility and tracking.

## Screenshots

| Default      | Active      | Truncated      | Truncated Active      | FilterKeyEvents      | FilterKeyEvents  Active    |
|-------------|------------|------------|------------|------------|------------|
| ![default][] | ![active][] | ![truncated][] | ![truncatedActive][] | ![filterKeyEvents][] |  ![filterKeyEventsActive][] |

[default]: https://user-images.githubusercontent.com/77005274/175048296-104f384a-97c3-4eb8-aa8e-2189f5af9e18.png
[active]: https://user-images.githubusercontent.com/77005274/175048398-43adc2dd-23eb-415f-b961-95f052494342.png
[truncated]: https://user-images.githubusercontent.com/77005274/175048559-57628c6f-c5cd-43e7-bad5-d9b0dba92c40.png
[truncatedActive]: https://user-images.githubusercontent.com/77005274/175048631-a3dc97c5-8320-44ef-9790-282aab86bb52.png
[filterKeyEvents]: https://user-images.githubusercontent.com/77005274/175048731-fa14b853-2426-48ed-ba38-1c69574f60b4.png
[filterKeyEventsActive]: https://user-images.githubusercontent.com/77005274/175048479-40612a68-fc65-415b-8300-852d4e931844.png

