### PR TITLE
Add padding to live feed when header is removed

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1,4 +1,5 @@
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
 import Accordion from '@guardian/common-rendering/src/components/accordion';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
@@ -12,9 +13,9 @@ import {
 	brandLine,
 	from,
 	neutral,
+	remSpace,
 	space,
 	until,
-	remSpace,
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import {
@@ -313,8 +314,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	const isInFilteringBeta =
-		CAPIArticle.config.switches.automaticFilters &&
-		CAPIArticle.topics;
+		CAPIArticle.config.switches.automaticFilters && CAPIArticle.topics;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1,4 +1,3 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
 import Accordion from '@guardian/common-rendering/src/components/accordion';
@@ -255,7 +254,7 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const paddingBody: SerializedStyles = css`
+const paddingBody = css`
 	padding: ${space[3]}px;
 	${from.mobileLandscape} {
 		padding: ${space[3]}px ${space[5]}px;

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -13,7 +13,6 @@ import {
 	brandLine,
 	from,
 	neutral,
-	remSpace,
 	space,
 	until,
 } from '@guardian/source-foundations';
@@ -257,9 +256,9 @@ interface Props {
 }
 
 const paddingBody: SerializedStyles = css`
-	padding: ${remSpace[3]};
+	padding: ${space[3]}px;
 	${from.mobileLandscape} {
-		padding: ${remSpace[3]} ${remSpace[5]};
+		padding: ${space[3]}px ${space[5]}px;
 	}
 	${from.desktop} {
 		padding: 0;

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
 import Accordion from '@guardian/common-rendering/src/components/accordion';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
@@ -14,6 +14,7 @@ import {
 	neutral,
 	space,
 	until,
+	remSpace,
 } from '@guardian/source-foundations';
 import { Hide } from '@guardian/source-react-components';
 import {
@@ -253,6 +254,16 @@ interface Props {
 	NAV: NavType;
 	format: ArticleFormat;
 }
+
+const paddingBody: SerializedStyles = css`
+	padding: ${remSpace[3]};
+	${from.mobileLandscape} {
+		padding: ${remSpace[3]} ${remSpace[5]};
+	}
+	${from.desktop} {
+		padding: 0;
+	}
+`;
 
 export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const {
@@ -818,7 +829,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<></>
 									)}
 									{isInFilteringBeta ? (
-										<>
+										<div css={paddingBody}>
 											{!showKeyEventsCarousel &&
 											CAPIArticle.keyEvents.length ? (
 												<Hide above="desktop">
@@ -979,7 +990,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													badge={CAPIArticle.badge}
 												/>
 											</ArticleContainer>
-										</>
+										</div>
 									) : (
 										<Accordion
 											supportsDarkMode={false}


### PR DESCRIPTION
## What does this change?
Adds padding to live feed element when header is removed (building on #5240)

## Why?
As part of the automatic filters redesign, the header accordion is being removed. Removing the header also removes the padding, so this needs to be added back in.

## Screenshots
**Before**: 
![Screenshot 2022-06-22 at 11 34 58](https://user-images.githubusercontent.com/55602675/175270643-4f8f1b2e-f57d-470b-b1a4-f15f450e7c1b.png)
**After**: 
![Screenshot 2022-06-23 at 10 43 55](https://user-images.githubusercontent.com/55602675/175270353-42b84613-9165-4929-abe3-3bc6b2f07d84.png)
