### PR TITLE
Tweak vertical positioning of top nav items for consistency

### DIFF
--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -132,11 +132,10 @@ const buttonStyles = (overrideColor?: string) => css`
 	background: none;
 	border: none;
 	/* Design System: The buttons should be components that handle their own layout using primitives  */
-	line-height: 1.2;
 	color: ${overrideColor || brandText.primary};
 	transition: color 80ms ease-out;
-	padding: 0px 10px 6px 5px;
-	margin: 1px 0 0;
+	padding: 0px 10px 0px 5px;
+	margin: 0;
 	text-decoration: none;
 
 	:hover {

--- a/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
+++ b/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
@@ -70,7 +70,7 @@ export const EditionDropdown: React.FC<{
 		<div css={editionDropdown}>
 			<div
 				css={css`
-					padding-top: 7px;
+					padding-top: 5px;
 				`}
 			>
 				<Dropdown


### PR DESCRIPTION
## What does this change?

This contains a tweak to make the vertical alignment of the nav menu items more consistent, which was more noticeable when signed in. Extracted from #5241.

## Why?

I noticed while working on the notification badge support that when signed in the `My Account` menu item sits slightly higher than the others.

## Screenshots

### Before

![Screenshot 2022-06-21 at 17 20 37](https://user-images.githubusercontent.com/379839/174849772-5b31c47a-a743-404a-bfbd-a6f193072ee0.png)

### After

(Ignore the notification badge, that's not included here):

![Screenshot 2022-06-21 at 17 20 25](https://user-images.githubusercontent.com/379839/174849797-7935d46a-b58d-405b-a5de-ab0d18812df7.png)
