### PR TITLE
Migrate Data Types To AR

### DIFF
--- a/apps-rendering/src/option.ts
+++ b/apps-rendering/src/option.ts
@@ -1,0 +1,120 @@
+// ----- Types ----- //
+
+enum OptionKind {
+	Some,
+	None,
+}
+
+type Some<A> = {
+	kind: OptionKind.Some;
+	value: A;
+};
+
+type None = {
+	kind: OptionKind.None;
+};
+
+/**
+ * Represents a value that may or may not exist; it's either a Some or a None.
+ */
+type Option<A> = Some<A> | None;
+
+// ----- Constructors ----- //
+
+const some = <A>(a: A): Some<A> => ({ kind: OptionKind.Some, value: a });
+const none: None = { kind: OptionKind.None };
+
+/**
+ * Turns a value that may be `null` or `undefined` into an `Option`.
+ * If it's `null` or `undefined` the `Option` will be a `None`. If it's
+ * some other value the `Option` will be a `Some` "wrapping" that value.
+ * @param a The value that may be `null` or `undefined`
+ * @returns {Option<A>} An `Option`
+ */
+const fromNullable = <A>(a: A | null | undefined): Option<A> =>
+	a === null || a === undefined ? none : some(a);
+
+// ----- Functions ----- //
+
+/**
+ * Returns the value if `Some`, otherwise returns `a`. You can think of it
+ * as "unwrapping" the `Option`, getting you back a plain value
+ * @param a The value to fall back to if the `Option` is `None`
+ * @param optA The Option
+ * @returns {A} The value for a `Some`, `a` for a `None`
+ * @example
+ * const bylineOne = some('CP Scott');
+ * withDefault('Jane Smith')(bylineOne); // Returns 'CP Scott'
+ *
+ * const bylineTwo = none;
+ * withDefault('Jane Smith')(bylineTwo); // Returns 'Jane Smith'
+ */
+const withDefault = <A>(a: A) => (optA: Option<A>): A =>
+	optA.kind === OptionKind.Some ? optA.value : a;
+
+/**
+ * Applies a function to a `Some`, does nothing to a `None`.
+ * @param f The function to apply
+ * @param optA The Option
+ * @returns {Option<B>} A new `Option`
+ * @example
+ * const creditOne = some('Nicéphore Niépce');
+ * // Returns Some('Photograph: Nicéphore Niépce')
+ * map(name => `Photograph: ${name}`)(creditOne);
+ *
+ * const creditTwo = none;
+ * map(name => `Photograph: ${name}`)(creditTwo); // Returns None
+ *
+ * // All together
+ * compose(withDefault(''), map(name => `Photograph: ${name}`))(credit);
+ */
+const map = <A, B>(f: (a: A) => B) => (optA: Option<A>): Option<B> =>
+	optA.kind === OptionKind.Some ? some(f(optA.value)) : none;
+
+/**
+ * Takes two Options and applies a function if both are `Some`,
+ * does nothing if either are a `None`.
+ * @param f The function to apply
+ * @param optA The first Option
+ * @param optB The second Option
+ * @returns {Option<C>} A new `Option`
+ */
+const map2 = <A, B, C>(f: (a: A, b: B) => C) => (optA: Option<A>) => (
+	optB: Option<B>,
+): Option<C> =>
+	optA.kind === OptionKind.Some && optB.kind === OptionKind.Some
+		? some(f(optA.value, optB.value))
+		: none;
+
+/**
+ * Like `map` but applies a function that *also* returns an `Option`.
+ * Then "unwraps" the result for you so you don't end up with
+ * `Option<Option<A>>`
+ * @param f The function to apply
+ * @param optA The Option
+ * @returns {Option<B>} A new `Option`
+ * @example
+ * type GetUser = number => Option<User>;
+ * type GetUserName = User => Option<string>;
+ *
+ * const userId = 1;
+ * const username: Option<string> = compose(andThen(getUserName), getUser)(userId);
+ */
+const andThen = <A, B>(f: (a: A) => Option<B>) => (
+	optA: Option<A>,
+): Option<B> => (optA.kind === OptionKind.Some ? f(optA.value) : none);
+
+// ----- Exports ----- //
+
+export {
+	OptionKind,
+	some,
+	none,
+	fromNullable,
+	withDefault,
+	map,
+	map2,
+	andThen,
+};
+
+export type { Option };

--- a/apps-rendering/src/option.ts
+++ b/apps-rendering/src/option.ts
@@ -49,8 +49,10 @@ const fromNullable = <A>(a: A | null | undefined): Option<A> =>
  * const bylineTwo = none;
  * withDefault('Jane Smith')(bylineTwo); // Returns 'Jane Smith'
  */
-const withDefault = <A>(a: A) => (optA: Option<A>): A =>
-	optA.kind === OptionKind.Some ? optA.value : a;
+const withDefault =
+	<A>(a: A) =>
+	(optA: Option<A>): A =>
+		optA.kind === OptionKind.Some ? optA.value : a;
 
 /**
  * Applies a function to a `Some`, does nothing to a `None`.
@@ -68,8 +70,10 @@ const withDefault = <A>(a: A) => (optA: Option<A>): A =>
  * // All together
  * compose(withDefault(''), map(name => `Photograph: ${name}`))(credit);
  */
-const map = <A, B>(f: (a: A) => B) => (optA: Option<A>): Option<B> =>
-	optA.kind === OptionKind.Some ? some(f(optA.value)) : none;
+const map =
+	<A, B>(f: (a: A) => B) =>
+	(optA: Option<A>): Option<B> =>
+		optA.kind === OptionKind.Some ? some(f(optA.value)) : none;
 
 /**
  * Takes two Options and applies a function if both are `Some`,
@@ -79,12 +83,13 @@ const map = <A, B>(f: (a: A) => B) => (optA: Option<A>): Option<B> =>
  * @param optB The second Option
  * @returns {Option<C>} A new `Option`
  */
-const map2 = <A, B, C>(f: (a: A, b: B) => C) => (optA: Option<A>) => (
-	optB: Option<B>,
-): Option<C> =>
-	optA.kind === OptionKind.Some && optB.kind === OptionKind.Some
-		? some(f(optA.value, optB.value))
-		: none;
+const map2 =
+	<A, B, C>(f: (a: A, b: B) => C) =>
+	(optA: Option<A>) =>
+	(optB: Option<B>): Option<C> =>
+		optA.kind === OptionKind.Some && optB.kind === OptionKind.Some
+			? some(f(optA.value, optB.value))
+			: none;
 
 /**
  * Like `map` but applies a function that *also* returns an `Option`.
@@ -100,9 +105,10 @@ const map2 = <A, B, C>(f: (a: A, b: B) => C) => (optA: Option<A>) => (
  * const userId = 1;
  * const username: Option<string> = compose(andThen(getUserName), getUser)(userId);
  */
-const andThen = <A, B>(f: (a: A) => Option<B>) => (
-	optA: Option<A>,
-): Option<B> => (optA.kind === OptionKind.Some ? f(optA.value) : none);
+const andThen =
+	<A, B>(f: (a: A) => Option<B>) =>
+	(optA: Option<A>): Option<B> =>
+		optA.kind === OptionKind.Some ? f(optA.value) : none;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/result.test.ts
+++ b/apps-rendering/src/result.test.ts
@@ -1,0 +1,126 @@
+// ----- Imports ----- //
+
+import { withDefault } from './option';
+import { andThen, either, err, map, mapError, ok, toOption } from './result';
+import type { Result } from './result';
+
+// ----- Setup ----- //
+
+const identity = <A>(a: A): A => a;
+const pipe2 = <A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C => g(f(a));
+
+const mockOk: Result<string, number> = ok(4);
+const mockErr: Result<string, number> = err('message');
+
+const onOk = (a: number): number => a + 2;
+const onError = (e: string): string => `Output: ${e}`;
+
+// ----- Tests ----- //
+
+describe('either', () => {
+	it('runs the correct function when Result is Ok', () => {
+		expect(
+			either<string, number, number | string>(onError, onOk)(mockOk),
+		).toBe(6);
+	});
+
+	it('runs the correct function when Result is Err', () => {
+		expect(
+			either<string, number, number | string>(onError, onOk)(mockErr),
+		).toBe('Output: message');
+	});
+});
+
+describe('map', () => {
+	it('runs the function when Result is Ok', () => {
+		expect(pipe2(mockOk, map(onOk), either(identity, identity))).toBe(6);
+	});
+
+	it('passes the error through when Result is Err', () => {
+		expect(
+			pipe2(
+				mockErr,
+				map((a: number) => `Output: ${a}`),
+				either(identity, identity),
+			),
+		).toBe('message');
+	});
+});
+
+describe('andThen', () => {
+	it('runs the function and unwraps the result when both Results are Ok', () => {
+		const f = (a: number): Result<string, number> => ok(a + 2);
+
+		expect(
+			pipe2(
+				mockOk,
+				andThen(f),
+				either<string, number, string | number>(identity, identity),
+			),
+		).toBe(6);
+	});
+
+	it('passes through the Err when the first Result is Err', () => {
+		const f = (a: number): Result<string, number> => ok(a + 2);
+
+		expect(
+			pipe2(
+				mockErr,
+				andThen(f),
+				either<string, number, string | number>(identity, identity),
+			),
+		).toBe('message');
+	});
+
+	it('passes through the Err when the second Result is Err', () => {
+		const f = (): Result<string, number> => err('message');
+
+		expect(
+			pipe2(
+				mockOk,
+				andThen(f),
+				either<string, number, string | number>(identity, identity),
+			),
+		).toBe('message');
+	});
+
+	it('passes through the first Err when the first Result is Err', () => {
+		const f = (): Result<string, number> => err('secondMessage');
+
+		expect(
+			pipe2(
+				mockErr,
+				andThen(f),
+				either<string, number, string | number>(identity, identity),
+			),
+		).toBe('message');
+	});
+});
+
+describe('mapError', () => {
+	it('passes through the result when Result is Ok', () => {
+		expect(
+			pipe2(
+				mockOk,
+				mapError(onError),
+				either<string, number, string | number>(identity, identity),
+			),
+		).toBe(4);
+	});
+
+	it('runs the function when Result is Err', () => {
+		expect(
+			pipe2(mockErr, mapError(onError), either(identity, identity)),
+		).toBe('Output: message');
+	});
+});
+
+describe('toOption', () => {
+	it('produces Some when Result is Ok', () => {
+		expect(pipe2(mockOk, toOption, withDefault(6))).toBe(4);
+	});
+
+	it('produces None when Result is Err', () => {
+		expect(pipe2(mockErr, toOption, withDefault(6))).toBe(6);
+	});
+});

--- a/apps-rendering/src/result.ts
+++ b/apps-rendering/src/result.ts
@@ -61,9 +61,10 @@ function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
  *     error => `Uh oh, an error: ${error}`,
  * )(flakyTaskResult)
  */
-const either = <E, A, C>(f: (e: E) => C, g: (a: A) => C) => (
-	result: Result<E, A>,
-): C => (result.kind === ResultKind.Ok ? g(result.value) : f(result.err));
+const either =
+	<E, A, C>(f: (e: E) => C, g: (a: A) => C) =>
+	(result: Result<E, A>): C =>
+		result.kind === ResultKind.Ok ? g(result.value) : f(result.err);
 
 /**
  * The companion to `map`.
@@ -71,10 +72,10 @@ const either = <E, A, C>(f: (e: E) => C, g: (a: A) => C) => (
  * @param f The function to apply if this is an `Err`
  * @param result The Result
  */
-const mapError = <E, F>(f: (e: E) => F) => <A>(
-	result: Result<E, A>,
-): Result<F, A> =>
-	result.kind === ResultKind.Err ? err(f(result.err)) : result;
+const mapError =
+	<E, F>(f: (e: E) => F) =>
+	<A>(result: Result<E, A>): Result<F, A> =>
+		result.kind === ResultKind.Err ? err(f(result.err)) : result;
 
 /**
  * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
@@ -91,8 +92,10 @@ const toOption = <E, A>(result: Result<E, A>): Option<A> =>
  * @param f The function to apply if this is an `Ok`
  * @param result The Result
  */
-const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
-	result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
+const map =
+	<A, B>(f: (a: A) => B) =>
+	<E>(result: Result<E, A>): Result<E, B> =>
+		result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
 
 /**
  * Similar to `Option.andThen`. Applies to a `Result` a function that
@@ -107,9 +110,10 @@ const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
  * // Both succeed: Ok('email_address')
  * andThen(getEmail)(requestUser(id))
  */
-const andThen = <E, A, B>(f: (a: A) => Result<E, B>) => (
-	result: Result<E, A>,
-): Result<E, B> => (result.kind === ResultKind.Ok ? f(result.value) : result);
+const andThen =
+	<E, A, B>(f: (a: A) => Result<E, B>) =>
+	(result: Result<E, A>): Result<E, B> =>
+		result.kind === ResultKind.Ok ? f(result.value) : result;
 
 /**
  * The return type of the `partition` function

--- a/apps-rendering/src/result.ts
+++ b/apps-rendering/src/result.ts
@@ -1,0 +1,150 @@
+// ----- Imports ----- //
+
+import { none, some } from './option';
+import type { Option } from './option';
+
+// ----- Types ----- //
+
+enum ResultKind {
+	Ok,
+	Err,
+}
+
+type Ok<A> = {
+	kind: ResultKind.Ok;
+	value: A;
+};
+
+type Err<E> = {
+	kind: ResultKind.Err;
+	err: E;
+};
+
+/**
+ * Represents either a value or an error; it's either an `Ok` or an `Err`.
+ */
+type Result<E, A> = Err<E> | Ok<A>;
+
+// ----- Constructors ----- //
+
+const ok = <A>(a: A): Ok<A> => ({ kind: ResultKind.Ok, value: a });
+const err = <E>(e: E): Err<E> => ({ kind: ResultKind.Err, err: e });
+
+/**
+ * Converts an operation that might throw into a `Result`
+ * @param f The operation that might throw
+ * @param error The error to return if the operation throws
+ */
+function fromUnsafe<A, E>(f: () => A, error: E): Result<E, A> {
+	try {
+		return ok(f());
+	} catch (_) {
+		return err(error);
+	}
+}
+
+// ----- Functions ----- //
+
+/**
+ * The method for turning a `Result<E, A>` into a plain value.
+ * If this is an `Err`, apply the first function to the error value and
+ * return the result. If this is an `Ok`, apply the second function to
+ * the value and return the result.
+ * @param f The function to apply if this is an `Err`
+ * @param g The function to apply if this is an `Ok`
+ * @param result The Result
+ * @example
+ * const flakyTaskResult: Result<string, number> = flakyTask(options);
+ *
+ * either(
+ *     data => `We got the data! Here it is: ${data}`,
+ *     error => `Uh oh, an error: ${error}`,
+ * )(flakyTaskResult)
+ */
+const either = <E, A, C>(f: (e: E) => C, g: (a: A) => C) => (
+	result: Result<E, A>,
+): C => (result.kind === ResultKind.Ok ? g(result.value) : f(result.err));
+
+/**
+ * The companion to `map`.
+ * Applies a function to the error in `Err`, does nothing to an `Ok`.
+ * @param f The function to apply if this is an `Err`
+ * @param result The Result
+ */
+const mapError = <E, F>(f: (e: E) => F) => <A>(
+	result: Result<E, A>,
+): Result<F, A> =>
+	result.kind === ResultKind.Err ? err(f(result.err)) : result;
+
+/**
+ * Converts a `Result<E, A>` into an `Option<A>`. If the result is an
+ * `Ok` this will be a `Some`, if the result is an `Err` this will be
+ * a `None`.
+ * @param result The Result
+ */
+const toOption = <E, A>(result: Result<E, A>): Option<A> =>
+	result.kind === ResultKind.Ok ? some(result.value) : none;
+
+/**
+ * Similar to `Option.map`.
+ * Applies a function to the value in an `Ok`, does nothing to an `Err`.
+ * @param f The function to apply if this is an `Ok`
+ * @param result The Result
+ */
+const map = <A, B>(f: (a: A) => B) => <E>(result: Result<E, A>): Result<E, B> =>
+	result.kind === ResultKind.Ok ? ok(f(result.value)) : result;
+
+/**
+ * Similar to `Option.andThen`. Applies to a `Result` a function that
+ * *also* returns a `Result`, and unwraps them to avoid nested `Result`s.
+ * Can be useful for stringing together operations that might fail.
+ * @example
+ * type RequestUser = number => Result<string, User>;
+ * type GetEmail = User => Result<string, string>;
+ *
+ * // Request fails: Err('Network failure')
+ * // Request succeeds, problem accessing email: Err('Email field missing')
+ * // Both succeed: Ok('email_address')
+ * andThen(getEmail)(requestUser(id))
+ */
+const andThen = <E, A, B>(f: (a: A) => Result<E, B>) => (
+	result: Result<E, A>,
+): Result<E, B> => (result.kind === ResultKind.Ok ? f(result.value) : result);
+
+/**
+ * The return type of the `partition` function
+ */
+type Partitioned<E, A> = { errs: E[]; oks: A[] };
+
+/**
+ * Takes a list of `Result`s and separates out the `Ok`s from the `Err`s.
+ * @param results A list of `Result`s
+ * @return {Partitioned} An object with two fields, one for the list of `Err`s
+ * and one for the list of `Ok`s
+ */
+const partition = <E, A>(results: Array<Result<E, A>>): Partitioned<E, A> =>
+	results.reduce(
+		({ errs, oks }: Partitioned<E, A>, result) =>
+			either<E, A, Partitioned<E, A>>(
+				(err) => ({ errs: [...errs, err], oks }),
+				(ok) => ({ errs, oks: [...oks, ok] }),
+			)(result),
+		{ errs: [], oks: [] },
+	);
+
+// ----- Exports ----- //
+
+export {
+	ResultKind,
+	ok,
+	err,
+	fromUnsafe,
+	partition,
+	either,
+	mapError,
+	toOption,
+	map,
+	andThen,
+};
+
+export type { Result };


### PR DESCRIPTION
## Why?

This migrates the remaining code from `@guardian/types` into AR (the rest made its way into `@guardian/libs` a while back). Some bug fixes and feature requests have started accumulating for these data types, and they can't be implemented while the [original repo](https://github.com/guardian/types) is archived. AR is the most extensive consumer of this library and will therefore benefit most from these updates.

This doesn't add any new functionality, it copies the code across verbatim (except for a few whitespace changes made by the version of prettier in this repo 🙄).

**Note:** This PR just moves the code across; it doesn't remove the dependency on the original `@guardian/types` library or update any of the imports yet. I'm trying to break up the changes to avoid enormous PRs, so that work will come in a follow-up.

## Changes

- Migrated `Option`
- Migrated `Result`
- Migrated tests
