### PR TITLE
chore(deps): bump @guardian/consent-management-platform from 10.7.0 to 10.7.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@guardian/atoms-rendering": "^23.2.0",
     "@guardian/braze-components": "^7.2.0",
     "@guardian/commercial-core": "^3.4.0",
-    "@guardian/consent-management-platform": "10.7.0",
+    "@guardian/consent-management-platform": "10.7.1",
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/libs": "^5.0.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.4.0.tgz#30fa768df0ca77ae912a1d55c4de2427d8608654"
   integrity sha512-r/JPn0MpUUOZ/gy0E0NJOBwGDM0fga1nXxXiwY60Ya8S2fOdqrtGJfcnfDOd55wDbQQ0VbRWnO3SO/J6ZA9icw==
 
-"@guardian/consent-management-platform@10.7.0":
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.7.0.tgz#d95cc6b95bcf7cbcafce8f0400f6af72cdc4d245"
-  integrity sha512-SizoTGZAXo9Q3QdEFdpRblMVJeSf5ZdHoswjitMV7yZTnndDblcu50NvkOD5F5aQucUVuVVopdN29icxGibe3Q==
+"@guardian/consent-management-platform@10.7.1":
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.7.1.tgz#ed672e1a7cc0e177d820dc7b2ebbfd26531a2d86"
+  integrity sha512-9wN4Bu0VMfpDg0p1/PjO/hAuPN7pJrBm24YXLWmAnfvHci0Wr+WMSF5ZOwhbMA01jl5IP3Hr1TKpFbkg3NhGdg==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

Bumps the CMP to 10.7.1 to incorporate changes from:
- https://github.com/guardian/consent-management-platform/pull/629

## What does this change?

**Reproduced from [above PR](https://github.com/guardian/consent-management-platform/pull/629).**

Adds Quantum Metric as a vendor identifiable to the `getConsentFor` function as `qm`.

Example use: 

```ts
const qmConsent: boolean = getConsentFor('qm');
```

## Why?

Needed for https://trello.com/c/72Khgq68/709-add-quantum-metric-to-list-of-vendors-the-cmp-knows-about (requested by @GHaberis).

Frontend PR: [TBD](https://github.com/guardian/frontend/pull/25141)