### PR TITLE
Add active topic to CAPIArticle model and use in url construction

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -612,6 +612,7 @@ interface CAPIArticleType {
 	// Included on live and dead blogs. Used when polling
 	mostRecentBlockId?: string;
 	topics?: Topic[];
+	activeTopic?: string;
 }
 
 type StageType = 'DEV' | 'CODE' | 'PROD';

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -405,6 +405,9 @@
             "items": {
                 "$ref": "#/definitions/Topic"
             }
+        },
+        "activeTopic": {
+            "type": "string"
         }
     },
     "required": [

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -16,6 +16,7 @@ type Props = {
 	webURL: string;
 	mostRecentBlockId: string;
 	hasPinnedPost: boolean;
+	activeTopic?: string;
 };
 
 const isServer = typeof window === 'undefined';
@@ -106,6 +107,7 @@ function getKey(
 	ajaxUrl: string,
 	latestBlockId: string,
 	filterKeyEvents: boolean,
+	activeTopic?: string,
 ): string | undefined {
 	try {
 		// Construct the url to poll
@@ -117,6 +119,7 @@ function getKey(
 			'filterKeyEvents',
 			filterKeyEvents ? 'true' : 'false',
 		);
+		if (activeTopic) url.searchParams.set('activeTopic', activeTopic);
 		return url.href;
 	} catch {
 		window.guardian.modules.sentry.reportError(
@@ -142,6 +145,7 @@ export const Liveness = ({
 	webURL,
 	mostRecentBlockId,
 	hasPinnedPost,
+	activeTopic,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
 	const [topOfBlogVisible, setTopOfBlogVisible] = useState<boolean>();
@@ -203,11 +207,14 @@ export const Liveness = ({
 	window.mockLiveUpdate = onSuccess;
 
 	// useApi returns { data, loading, error } but we're not using them here
-	useApi(getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents), {
-		refreshInterval: 10_000,
-		refreshWhenHidden: true,
-		onSuccess,
-	});
+	useApi(
+		getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents, activeTopic),
+		{
+			refreshInterval: 10_000,
+			refreshWhenHidden: true,
+			onSuccess,
+		},
+	);
 
 	useEffect(() => {
 		document.title =

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -664,6 +664,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										CAPIArticle.mostRecentBlockId || ''
 									}
 									hasPinnedPost={!!CAPIArticle.pinnedPost}
+									activeTopic={CAPIArticle.activeTopic}
 								/>
 							</Island>
 						</>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds an optional `activeTopic` field to the CAPIArticle model and regenerates the schema based on this. It also threads this new field through the the `liveness` script so that we can use the active topic as a query in the url, if available.

## Why?
As part of the addition of automated topics in liveblogs, we want to pass the active topic to the server via a query param so that we have the correct query parameters when polling.

We also want to pass this data back to DCR via the CAPIArticle model so that we don't need to rely on extracting the topic from the url query param string. This follows the data flow pattern as filterKeyEvents.
