### PR TITLE
Update `topics` naming

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -618,8 +618,8 @@ interface CAPIArticleType {
 
 	// Included on live and dead blogs. Used when polling
 	mostRecentBlockId?: string;
-	topics?: Topic[];
-	activeTopic?: string;
+	availableTopics?: Topic[];
+	selectedTopics?: string;
 }
 
 type StageType = 'DEV' | 'CODE' | 'PROD';

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -400,13 +400,13 @@
         "mostRecentBlockId": {
             "type": "string"
         },
-        "topics": {
+        "availableTopics": {
             "type": "array",
             "items": {
                 "$ref": "#/definitions/Topic"
             }
         },
-        "activeTopic": {
+        "selectedTopics": {
             "type": "string"
         }
     },

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -16,7 +16,7 @@ type Props = {
 	webURL: string;
 	mostRecentBlockId: string;
 	hasPinnedPost: boolean;
-	activeTopic?: string;
+	selectedTopics?: string;
 };
 
 const isServer = typeof window === 'undefined';
@@ -107,7 +107,7 @@ function getKey(
 	ajaxUrl: string,
 	latestBlockId: string,
 	filterKeyEvents: boolean,
-	activeTopic?: string,
+	selectedTopics?: string,
 ): string | undefined {
 	try {
 		// Construct the url to poll
@@ -119,7 +119,7 @@ function getKey(
 			'filterKeyEvents',
 			filterKeyEvents ? 'true' : 'false',
 		);
-		if (activeTopic) url.searchParams.set('activeTopic', activeTopic);
+		if (selectedTopics) url.searchParams.set('topics', selectedTopics);
 		return url.href;
 	} catch {
 		window.guardian.modules.sentry.reportError(
@@ -145,7 +145,7 @@ export const Liveness = ({
 	webURL,
 	mostRecentBlockId,
 	hasPinnedPost,
-	activeTopic,
+	selectedTopics,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
 	const [topOfBlogVisible, setTopOfBlogVisible] = useState<boolean>();
@@ -208,7 +208,7 @@ export const Liveness = ({
 
 	// useApi returns { data, loading, error } but we're not using them here
 	useApi(
-		getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents, activeTopic),
+		getKey(pageId, ajaxUrl, latestBlockId, filterKeyEvents, selectedTopics),
 		{
 			refreshInterval: 10_000,
 			refreshWhenHidden: true,

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -312,7 +312,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
 
 	const isInFilteringBeta =
-		CAPIArticle.config.switches.automaticFilters && CAPIArticle.topics;
+		CAPIArticle.config.switches.automaticFilters &&
+		CAPIArticle.availableTopics;
 
 	return (
 		<>
@@ -674,7 +675,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										CAPIArticle.mostRecentBlockId || ''
 									}
 									hasPinnedPost={!!CAPIArticle.pinnedPost}
-									activeTopic={CAPIArticle.activeTopic}
+									selectedTopics={CAPIArticle.selectedTopics}
 								/>
 							</Island>
 						</>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Based on the discusion [here](https://github.com/guardian/dotcom-rendering/pull/5264) this PR renames `topics` and `activeTopic` on `CAPIArticle` to `availableTopics` and `selectedTopics`.

## Why?

This allows us to use `topics` as a param when polling for liveblog updates, and hopefully reduces confusion.

