### PR TITLE
Add recipe schema atom

### DIFF
--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -333,6 +333,12 @@ interface QABlockElement {
 	role?: RoleType;
 }
 
+interface RecipeSchemaAtomBlockElement {
+	_type: 'model.dotcomrendering.pageElements.RecipeSchemaAtomBlockElement';
+	id: string;
+	json: string;
+}
+
 interface RichLinkBlockElement {
 	_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement';
 	elementId: string;
@@ -590,6 +596,7 @@ type CAPIElement =
 	| PullquoteBlockElement
 	| QABlockElement
 	| QuizAtomBlockElement
+	| RecipeSchemaAtomBlockElement
 	| RichLinkBlockElement
 	| SoundcloudBlockElement
 	| SpotifyBlockElement

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -111,6 +111,9 @@
                         "$ref": "#/definitions/QABlockElement"
                     },
                     {
+                        "$ref": "#/definitions/RecipeSchemaAtomBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/RichLinkBlockElement"
                     },
                     {
@@ -2335,6 +2338,28 @@
                 "title"
             ]
         },
+        "RecipeSchemaAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.RecipeSchemaAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "json": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "id",
+                "json"
+            ]
+        },
         "RichLinkBlockElement": {
             "type": "object",
             "properties": {
@@ -3426,6 +3451,9 @@
                             },
                             {
                                 "$ref": "#/definitions/QABlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/RecipeSchemaAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/RichLinkBlockElement"

--- a/dotcom-rendering/src/web/components/RecipeAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/RecipeAtomWrapper.importable.tsx
@@ -1,0 +1,11 @@
+// RecipeAtomWrapper.importable.tsx
+import { RecipeAtom } from '@guardian/atoms-rendering';
+
+type RecipeSchemaProps = {
+	id: string;
+	json: string;
+};
+
+export const RecipeSchemaAtomWrapper = (props: RecipeSchemaProps) => (
+	<RecipeAtom {...props}></RecipeAtom>
+);

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -37,6 +37,7 @@ import { PersonalityQuizAtomWrapper } from '../components/PersonalityQuizAtomWra
 import { ProfileAtomWrapper } from '../components/ProfileAtomWrapper.importable';
 import { PullQuoteBlockComponent } from '../components/PullQuoteBlockComponent';
 import { QandaAtomWrapper } from '../components/QandaAtomWrapper.importable';
+import { RecipeSchemaAtomWrapper } from '../components/RecipeAtomWrapper.importable';
 import { RichLinkComponent } from '../components/RichLinkComponent.importable';
 import { SoundcloudBlockComponent } from '../components/SoundcloudBlockComponent';
 import { SpotifyBlockComponent } from '../components/SpotifyBlockComponent.importable';
@@ -505,6 +506,14 @@ export const renderElement = ({
 						pillar={format.theme}
 					/>
 				</Island>,
+			];
+		case 'model.dotcomrendering.pageElements.RecipeSchemaAtomBlockElement':
+			return [
+				true,
+				<RecipeSchemaAtomWrapper
+					id={element.id}
+					json={element.json}
+				></RecipeSchemaAtomWrapper>,
 			];
 		case 'model.dotcomrendering.pageElements.QuizAtomBlockElement':
 			return [


### PR DESCRIPTION
## What does this change?

This adds a barebones recipe atom to dotcom-rendering codebase. The desired result is being able to add custom blobs of [recipe schema](https://schema.org/Recipe) to specific articles. This will have no impact on what appears visually but will render under the hood as something web crawlers can understand. 

This ought to make pages with recipe schema atoms eligible for [rich results](https://search.google.com/test/rich-results) in search engines - and machine readable for all sorts other interesting possibilities. 

Used [chart atom](https://github.com/guardian/dotcom-rendering/blob/10f09832a0b2295b69da896bd2ada8d17efda32e/dotcom-rendering/src/web/lib/renderElement.tsx#L199-L205) and [partial hydration documentation](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/architecture/027-better-partial-hydration.md) for reference. I've erred on the side of not wrapping them in islands as the schema needs to be present for web crawlers and the like (though obviously happy to be corrected).

## Why?

This is for an experiment Ophan is hoping to run in which recipe schema can be rendered under the hood for a handful of pages, allowing us to track a before and after picture of SEO performance. Semantic markup for recipes has a storied Guardian history of not quite being implemented. If we can get some schema on the site and a clear SEO performance bump follows, maybe that will help make the case for it to be implemented more broadly.

