### PR TITLE
Extra cards container

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -1,9 +1,10 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source-foundations';
 import { verticalDivider } from '../../../lib/verticalDivider';
 
 const liStyles = css`
-	/* This position relative is needed to contain the veritcal divider */
+	/* This position relative is needed to contain the vertical divider */
 	position: relative;
 
 	display: flex;
@@ -72,6 +73,7 @@ type Props = {
 	padBottomOnMobile?: boolean; // Should be true if spacing below is desired on mobile devices
 	showTopMarginWhenStacked?: boolean;
 	snapAlignStart?: boolean; // True when snapping card when scrolling e.g. in carousel
+	customStyles?: SerializedStyles;
 };
 
 export const LI = ({
@@ -85,6 +87,7 @@ export const LI = ({
 	padBottomOnMobile,
 	showTopMarginWhenStacked,
 	snapAlignStart = false,
+	customStyles = undefined,
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
@@ -100,6 +103,7 @@ export const LI = ({
 				padBottomOnMobile && mobilePaddingBottomStyles,
 				showTopMarginWhenStacked && marginTopStyles,
 				snapAlignStart && snapAlignStartStyles,
+				customStyles && customStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -73,7 +73,6 @@ type Props = {
 	padBottomOnMobile?: boolean; // Should be true if spacing below is desired on mobile devices
 	showTopMarginWhenStacked?: boolean;
 	snapAlignStart?: boolean; // True when snapping card when scrolling e.g. in carousel
-	customStyles?: SerializedStyles;
 };
 
 export const LI = ({
@@ -87,7 +86,6 @@ export const LI = ({
 	padBottomOnMobile,
 	showTopMarginWhenStacked,
 	snapAlignStart = false,
-	customStyles = undefined,
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
@@ -103,7 +101,6 @@ export const LI = ({
 				padBottomOnMobile && mobilePaddingBottomStyles,
 				showTopMarginWhenStacked && marginTopStyles,
 				snapAlignStart && snapAlignStartStyles,
-				customStyles && customStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -105,6 +105,9 @@ export const LI = ({
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
+	// paddingSize is set here because the offset value used for the
+	// verticalDividerWithBottomOffset needs to match the value used for
+	// paddingBottom
 	const paddingSize = '10px';
 
 	return (

--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -1,7 +1,7 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source-foundations';
 import { verticalDivider } from '../../../lib/verticalDivider';
+import { verticalDividerWithBottomOffset } from '../../../lib/verticalDividerWithBottomOffset';
 
 const liStyles = css`
 	/* This position relative is needed to contain the vertical divider */
@@ -10,16 +10,19 @@ const liStyles = css`
 	display: flex;
 `;
 
-const sidePaddingStyles = (padSidesOnMobile: boolean) => css`
+const sidePaddingStyles = (
+	padSidesOnMobile: boolean,
+	paddingSize: string,
+) => css`
 	/* Set spacing on the li element */
 	${padSidesOnMobile && until.tablet} {
-		padding-left: 10px;
-		padding-right: 10px;
+		padding-left: ${paddingSize};
+		padding-right: ${paddingSize};
 	}
 
 	${from.tablet} {
-		padding-left: 10px;
-		padding-right: 10px;
+		padding-left: ${paddingSize};
+		padding-right: ${paddingSize};
 	}
 `;
 
@@ -28,13 +31,13 @@ const snapAlignStartStyles = css`
 	scroll-snap-align: start;
 `;
 
-const paddingBottomStyles = css`
-	padding-bottom: 10px;
+const paddingBottomStyles = (paddingSize: string) => css`
+	padding-bottom: ${paddingSize};
 `;
 
-const mobilePaddingBottomStyles = css`
+const mobilePaddingBottomStyles = (paddingSize: string) => css`
 	${until.tablet} {
-		padding-bottom: 10px;
+		padding-bottom: ${paddingSize};
 	}
 `;
 
@@ -62,6 +65,15 @@ const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
 	return sizeStyle;
 };
 
+function decideDivider(
+	offsetBottomPaddingOnDivider: boolean,
+	paddingSize: string,
+) {
+	return offsetBottomPaddingOnDivider
+		? verticalDividerWithBottomOffset(paddingSize)
+		: verticalDivider;
+}
+
 type Props = {
 	children: React.ReactNode;
 	percentage?: CardPercentageType; // Used to give a particular LI more or less weight / space
@@ -73,6 +85,9 @@ type Props = {
 	padBottomOnMobile?: boolean; // Should be true if spacing below is desired on mobile devices
 	showTopMarginWhenStacked?: boolean;
 	snapAlignStart?: boolean; // True when snapping card when scrolling e.g. in carousel
+	// Prevent the divider from spanning the LI's bottom padding. To be used when you know that the
+	// LI will have bottom padding, but won't have another card in the same container directly below it.
+	offsetBottomPaddingOnDivider?: boolean;
 };
 
 export const LI = ({
@@ -86,19 +101,22 @@ export const LI = ({
 	padBottomOnMobile,
 	showTopMarginWhenStacked,
 	snapAlignStart = false,
+	offsetBottomPaddingOnDivider = false,
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
+	const paddingSize = '10px';
 
 	return (
 		<li
 			css={[
 				liStyles,
 				sizeStyles,
-				showDivider && verticalDivider,
-				padSides && sidePaddingStyles(padSidesOnMobile),
-				padBottom && paddingBottomStyles,
-				padBottomOnMobile && mobilePaddingBottomStyles,
+				showDivider &&
+					decideDivider(offsetBottomPaddingOnDivider, paddingSize),
+				padSides && sidePaddingStyles(padSidesOnMobile, paddingSize),
+				padBottom && paddingBottomStyles(paddingSize),
+				padBottomOnMobile && mobilePaddingBottomStyles(paddingSize),
 				showTopMarginWhenStacked && marginTopStyles,
 				snapAlignStart && snapAlignStartStyles,
 			]}

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.stories.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.stories.tsx
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+import { trails } from '../../../fixtures/manual/trails';
+import { ExtraCardsContainer } from './ExtraCardsContainer';
+
+export default {
+	component: ExtraCardsContainer,
+	title: 'Components/ExtraCardsContainer',
+};
+
+const wrapperStyles = css`
+	max-width: 960px;
+	padding: 20px 10px;
+`;
+
+export const Five = () => (
+	<div css={wrapperStyles}>
+		<ExtraCardsContainer trails={trails.slice(0, 5)} />
+	</div>
+);
+Five.story = { name: 'Five cards' };
+
+export const Eight = () => (
+	<div css={wrapperStyles}>
+		<ExtraCardsContainer trails={trails.slice(0, 8)} />
+	</div>
+);
+Eight.story = { name: 'Eight cards' };
+
+export const Nine = () => (
+	<div css={wrapperStyles}>
+		<ExtraCardsContainer trails={trails.slice(0, 9)} />
+	</div>
+);
+Nine.story = { name: 'Nine cards' };
+
+export const Eleven = () => (
+	<div css={wrapperStyles}>
+		<ExtraCardsContainer trails={trails.slice(0, 11)} />
+	</div>
+);
+Eleven.story = { name: 'Eleven cards' };

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
@@ -18,23 +17,6 @@ function isFirstInRow(cardIndex: number) {
 	return cardIndex % 4 === 0;
 }
 
-const dividerOffsetStyle = css`
-	/**
-	 * - This 'nth-last-of-type' selector will select the last 4 <li> elements
-	 *   in the list.
-	 * - The reason for doing this is that we need to make sure that
-	 *   the vertical divider lines between cards don't reach past the bottom
-	 *   of the card itself unless there is another card directly below it.
-	 *   (Because we're padding the bottom of the cards, the vertical line will
-	 *   stretch to the bottom of this padding by default.)
-	 * - In a container of 4 columns, the last 4 elements will never have a
-	 *   card directly below them, even if the bottom row is not full.
-	*/
-	ul &:nth-last-of-type(-n + 4) {
-		--card-divider-offset-bottom: 10px;
-	}
-`;
-
 export const ExtraCardsContainer = ({
 	trails,
 	containerPalette,
@@ -50,7 +32,7 @@ export const ExtraCardsContainer = ({
 						percentage={percentage}
 						padBottom={true}
 						showDivider={!isFirstInRow(index)}
-						customStyles={dividerOffsetStyle}
+						key={trail.url}
 					>
 						<Card
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
@@ -17,6 +17,23 @@ function isFirstInRow(cardIndex: number) {
 	return cardIndex % 4 === 0;
 }
 
+function hasNoCardBelowIt(cardIndex: number, trailsLength: number) {
+	/**
+		When there are 4 columns of cards being wrapped row-wise, the last
+		4 cards will not have a card directly below them, e.g.
+
+		When the last row is full:		│	And also when it's not:
+			┌──┐┌──┐┌──┐┌──┐			│		┌──┐┌──┐┌──┐┌──┐
+			│  ││  ││  ││  │			│		│  ││  ││-4││-3│
+			└──┘└──┘└──┘└──┘			│		└──┘└──┘└──┘└──┘
+			┌──┐┌──┐┌──┐┌──┐			│		┌──┐┌──┐
+			│-4││-3││-2││-1│			│		│-2││-1│
+			└──┘└──┘└──┘└──┘			│		└──┘└──┘
+										│
+	*/
+	return cardIndex >= trailsLength - 4;
+}
+
 export const ExtraCardsContainer = ({
 	trails,
 	containerPalette,
@@ -33,6 +50,10 @@ export const ExtraCardsContainer = ({
 						padBottom={true}
 						showDivider={!isFirstInRow(index)}
 						key={trail.url}
+						offsetBottomPaddingOnDivider={hasNoCardBelowIt(
+							index,
+							trails.length,
+						)}
 					>
 						<Card
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
@@ -1,0 +1,87 @@
+import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
+import { Card } from './Card/Card';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showImages?: boolean;
+};
+
+function isFirstInRow(cardIndex: number) {
+	// We don't want to show dividers on the first card from the left on each
+	// row. Given that there are 4 columns, the leftmost cards will have
+	// indexes 0, 4, 8, etc.
+	// Modulo ( m % n ) gives the 'remainder' when m is divided by n.
+	return cardIndex % 4 === 0;
+}
+
+const dividerOffsetStyle = css`
+	/**
+	 * - This 'nth-last-of-type' selector will select the last 4 <li> elements
+	 *   in the list.
+	 * - The reason for doing this is that we need to make sure that
+	 *   the vertical divider lines between cards don't reach past the bottom
+	 *   of the card itself unless there is another card directly below it.
+	 *   (Because we're padding the bottom of the cards, the vertical line will
+	 *   stretch to the bottom of this padding by default.)
+	 * - In a container of 4 columns, the last 4 elements will never have a
+	 *   card directly below them, even if the bottom row is not full.
+	*/
+	ul &:nth-last-of-type(-n + 4) {
+		--card-divider-offset-bottom: 10px;
+	}
+`;
+
+export const ExtraCardsContainer = ({
+	trails,
+	containerPalette,
+	showImages = false,
+}: Props) => {
+	const percentage = '25%';
+	return (
+		<>
+			<UL direction="row" padBottom={true} wrapCards={true}>
+				{trails.map((trail, index) => (
+					<LI
+						padSides={true}
+						percentage={percentage}
+						padBottom={true}
+						showDivider={!isFirstInRow(index)}
+						customStyles={dividerOffsetStyle}
+					>
+						<Card
+							containerPalette={containerPalette}
+							showAge={true}
+							linkTo={trail.url}
+							format={trail.format}
+							headlineText={trail.headline}
+							headlineSize="medium"
+							byline={trail.byline}
+							showByline={trail.showByline}
+							showQuotes={
+								trail.format.design === ArticleDesign.Comment ||
+								trail.format.design === ArticleDesign.Letter
+							}
+							webPublicationDate={trail.webPublicationDate}
+							kickerText={trail.kickerText}
+							showPulsingDot={
+								trail.format.design === ArticleDesign.LiveBlog
+							}
+							showSlash={true}
+							showClock={false}
+							imageUrl={showImages ? trail.image : undefined}
+							mediaType={trail.mediaType}
+							mediaDuration={trail.mediaDuration}
+							starRating={trail.starRating}
+							branding={trail.branding}
+							discussionId={trail.discussionId}
+						/>
+					</LI>
+				))}
+			</UL>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/web/lib/verticalDivider.ts
@@ -12,6 +12,7 @@ export const verticalDivider = css`
 			left: 0;
 			width: 1px;
 			height: 100%;
+			height: calc(100% - var(--card-divider-offset-bottom));
 			border-left: 1px solid ${border.secondary};
 		}
 	}

--- a/dotcom-rendering/src/web/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/web/lib/verticalDivider.ts
@@ -12,7 +12,6 @@ export const verticalDivider = css`
 			left: 0;
 			width: 1px;
 			height: 100%;
-			height: calc(100% - var(--card-divider-offset-bottom));
 			border-left: 1px solid ${border.secondary};
 		}
 	}

--- a/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
+++ b/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
@@ -1,0 +1,24 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { border, from } from '@guardian/source-foundations';
+
+export function verticalDividerWithBottomOffset(
+	bottomPaddingSize: string,
+): SerializedStyles {
+	return css`
+		${from.tablet} {
+			:before {
+				content: '';
+				display: block;
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				width: 1px;
+				/* 100% is a reasonable fallback for browsers which don't support calc() */
+				height: 100%;
+				height: calc(100% - ${bottomPaddingSize});
+				border-left: 1px solid ${border.secondary};
+			}
+		}
+	`;
+}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a new container type, `ExtraCardsContainer`, which can display a set of cards of arbitrary length.
- Adds a new prop, `offsetBottomPaddingOnDivider`, to the `LI` component, to allow the length of the card dividers to be adjusted in the new container component.
- Also adds a new vertical divider style object, to implement this adjustment when needed.

## Why?

- The motivation for adding a flexible container is, primarily, in anticipation of adding `Show More` functionality to DCR Fronts.
- This container needs to be flexible on the server side because a 'show more' container can contain any number of cards.
- But the reason for rendering all of the rows of cards in a single `UL` component is that this allows the cards to re-arrange automatically if some of the cards are removed on the client side. (This should fix a bug in the existing Frontend implementation of client-side deduping, which is [documented in this issue](https://github.com/guardian/dotcom-rendering/issues/4604#issuecomment-1140818041).)
- However, there is some doubt about when we will introduce client-side deduping. If we decide not to pursue it then it might be worth revisiting this component, because some of the relatively complicated logic could be avoided if we can follow the established DCR pattern and place each row in a different `UL` 'slice' on the server side.

## Screenshots
Desktop:
![Desktop screenshot](https://user-images.githubusercontent.com/37048459/175943747-964f699c-fbac-4e5c-8192-7f208f5139c4.png)

Mobile:
<img src="https://user-images.githubusercontent.com/37048459/175944067-5ce6ea85-bd0c-4f06-ab15-6bbb2329c203.png" alt="Mobile screenshot" width="300px" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
