### PR TITLE
Configure all interactives to load on page idle

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -32,7 +32,6 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
-	abTests?: ServerSideTests;
 	showKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
 };
@@ -117,7 +116,6 @@ export const ArticleBody = ({
 	onFirstPage,
 	keyEvents,
 	filterKeyEvents,
-	abTests,
 	showKeyEventsCarousel,
 	availableTopics,
 }: Props) => {
@@ -205,7 +203,6 @@ export const ArticleBody = ({
 				isDev={isDev}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
-				abTests={abTests}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -41,8 +41,6 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 
 		const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 			/* keep array multi-line */
-			'interactivesIdleLoadingVariant',
-			'interactivesIdleLoadingControl',
 		];
 
 		const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -34,8 +34,6 @@ export const CoreVitals = () => {
 
 	const serverSideTestsToForceMetrics: Array<keyof ServerSideTests> = [
 		/* linter, please keep this array multi-line */
-		'interactivesIdleLoadingVariant',
-		'interactivesIdleLoadingControl',
 	];
 
 	const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -580,7 +580,6 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
-										abTests={CAPIArticle.config.abTests}
 									/>
 									{showBodyEndSlot && (
 										<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -413,7 +413,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -546,7 +546,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
-										abTests={CAPIArticle.config.abTests}
 									/>
 
 									{/* <StraightLines data-print-layout="hide" count={4} /> */}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -965,10 +965,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													abTests={
-														CAPIArticle.config
-															.abTests
-													}
 													showKeyEventsCarousel={
 														showKeyEventsCarousel
 													}
@@ -1131,10 +1127,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													}
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
-													}
-													abTests={
-														CAPIArticle.config
-															.abTests
 													}
 													showKeyEventsCarousel={
 														showKeyEventsCarousel

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -547,7 +547,6 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -667,7 +667,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -64,7 +64,6 @@ export const ArticleRenderer: React.FC<{
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	abTests?: ServerSideTests;
 }> = ({
 	format,
 	elements,
@@ -83,7 +82,6 @@ export const ArticleRenderer: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	isDev,
-	abTests,
 }) => {
 	const renderedElements = elements.map((element, index) => {
 		return (
@@ -102,7 +100,6 @@ export const ArticleRenderer: React.FC<{
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
 				switches={switches}
-				abTests={abTests}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -78,7 +78,6 @@ type Props = {
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: { [key: string]: boolean };
-	abTests?: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -132,19 +131,12 @@ export const renderElement = ({
 	isAdFreeUser,
 	switches,
 	isSensitive,
-	abTests,
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
 
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
-
-	const isInteractivesIdleLoadingVariant =
-		abTests?.interactivesIdleLoadingVariant === 'variant';
-
-	const shouldIdleLoadInteractives =
-		!isAdFreeUser && isInteractivesIdleLoadingVariant;
 
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
@@ -390,9 +382,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return [
 				true,
-				<Island
-					deferUntil={shouldIdleLoadInteractives ? 'idle' : 'visible'}
-				>
+				<Island deferUntil="idle">
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}
@@ -797,7 +787,6 @@ export const RenderArticleElement = ({
 	isAdFreeUser,
 	isSensitive,
 	switches,
-	abTests,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -816,7 +805,6 @@ export const RenderArticleElement = ({
 		isAdFreeUser,
 		isSensitive,
 		switches,
-		abTests,
 	});
 
 	if (!ok) {

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -382,6 +382,8 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return [
 				true,
+				// Deferring interactives until CPU idle achieves the lowest Cumulative Layout Shift (CLS)
+				// For more information on the experiment we ran see: https://github.com/guardian/dotcom-rendering/pull/4942
 				<Island deferUntil="idle">
 					<InteractiveBlockComponent
 						url={element.url}


### PR DESCRIPTION
## What does this change?

This commit configures all interactives to load on page idle and strips out the `InteractivesIdleLoading` test logic.

## Why?

The `InteractivesIdleLoading` experiment has concluded. Pages where interactives were loaded on page idle were shown to have a lower CLS than pages where interactives were loaded on visible (i.e. lazily)

![Screenshot 2022-06-27 at 16 28 51](https://user-images.githubusercontent.com/7423751/175977290-6a2d1276-cafc-4a6d-b217-424ad4bb52c9.png)

More info in the original PR: https://github.com/guardian/dotcom-rendering/pull/4942

