### PR TITLE
Add missing params to mobile

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -35,6 +35,7 @@ type Props = {
 	abTests?: ServerSideTests;
 	showKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
+	selectedTopics?: string;
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -120,6 +121,7 @@ export const ArticleBody = ({
 	abTests,
 	showKeyEventsCarousel,
 	availableTopics,
+	selectedTopics,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const palette = decidePalette(format);
@@ -169,6 +171,7 @@ export const ArticleBody = ({
 						filterKeyEvents={filterKeyEvents}
 						isKeyEventsCarouselVariant={showKeyEventsCarousel}
 						availableTopics={availableTopics}
+						selectedTopics={selectedTopics}
 					/>
 				</div>
 			</>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -958,6 +958,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													showKeyEventsCarousel={
 														showKeyEventsCarousel
 													}
+													availableTopics={
+														CAPIArticle.availableTopics
+													}
+													selectedTopics={
+														CAPIArticle.selectedTopics
+													}
 												/>
 												{pagination.totalPages > 1 && (
 													<Pagination
@@ -1127,6 +1133,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													}
 													availableTopics={
 														CAPIArticle.availableTopics
+													}
+													selectedTopics={
+														CAPIArticle.selectedTopics
 													}
 												/>
 												{pagination.totalPages > 1 && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Passes through two new params (`activeTopics` & `selectedTopics`) to the mobile variant of the `TopicFilterBank` component. 
  
## Why?
These params are needed to render the topics and allow clicked state to persist. They had been provided to the desktop variant but not the mobile variant.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/176130341-9033ef74-9311-47da-8122-dae53b870b9e.png
[after]: https://user-images.githubusercontent.com/20416599/176130161-4546e3fa-61a2-476e-bdaf-21df0934188c.png



