### PR TITLE
fix: Hydration of components when rendered through Frontend

### DIFF
--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,0 +1,39 @@
+import { decideAssetOrigin } from './assets';
+
+describe('decideAssetOrigin for stage', () => {
+	it('PROD', () => {
+		expect(decideAssetOrigin('PROD', false)).toEqual(
+			'https://assets.guim.co.uk/',
+		);
+		expect(decideAssetOrigin('PROD', true)).toEqual(
+			'https://assets.guim.co.uk/',
+		);
+		expect(decideAssetOrigin('prod', true)).toEqual(
+			'https://assets.guim.co.uk/',
+		);
+	});
+	it('CODE', () => {
+		expect(decideAssetOrigin('CODE', false)).toEqual(
+			'https://assets-code.guim.co.uk/',
+		);
+		expect(decideAssetOrigin('CODE', true)).toEqual(
+			'https://assets-code.guim.co.uk/',
+		);
+		expect(decideAssetOrigin('code', true)).toEqual(
+			'https://assets-code.guim.co.uk/',
+		);
+	});
+	it('DEV', () => {
+		expect(decideAssetOrigin('DEV', false)).toEqual('/');
+		expect(decideAssetOrigin(undefined, false)).toEqual('/');
+		expect(decideAssetOrigin('DEV', true)).toEqual(
+			'http://localhost:3030/',
+		);
+		expect(decideAssetOrigin('dev', true)).toEqual(
+			'http://localhost:3030/',
+		);
+		expect(decideAssetOrigin(undefined, true)).toEqual(
+			'http://localhost:3030/',
+		);
+	});
+});

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -22,7 +22,7 @@ try {
  * @param {'PROD' | 'CODE' | undefined} stage the environment code is executing in
  * @returns {string}
  */
-const decideAssetOrigin = (
+export const decideAssetOrigin = (
 	stage: string | undefined,
 	isDev: boolean,
 ): string => {

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -33,6 +33,8 @@ const decideAssetOrigin = (
 			return 'https://assets-code.guim.co.uk/';
 		default: {
 			if (isDev) {
+				// Use absolute asset paths in development mode
+				// This is so paths are correct when treated as relative to Frontend
 				return 'http://localhost:3030/';
 			} else {
 				return '/';

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -22,25 +22,34 @@ try {
  * @param {'PROD' | 'CODE' | undefined} stage the environment code is executing in
  * @returns {string}
  */
-const decideAssetOrigin = (stage: string | undefined): string => {
+const decideAssetOrigin = (
+	stage: string | undefined,
+	isDev: boolean,
+): string => {
 	switch (stage?.toUpperCase()) {
 		case 'PROD':
 			return 'https://assets.guim.co.uk/';
 		case 'CODE':
 			return 'https://assets-code.guim.co.uk/';
-		default:
-			return '/';
+		default: {
+			if (isDev) {
+				return 'http://localhost:3030/';
+			} else {
+				return '/';
+			}
+		}
 	}
 };
-export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE);
+
+const isDev = process.env.NODE_ENV === 'development';
+
+export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE, isDev);
 
 export const getScriptArrayFromFile = (
 	file: `${string}.js`,
 ): { src: string; legacy?: boolean }[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
-
-	const isDev = process.env.NODE_ENV === 'development';
 
 	const filename = isDev ? file : manifest[file];
 	const legacyFilename = isDev

--- a/dotcom-rendering/src/web/browser/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/web/browser/decidePublicPath.test.ts
@@ -1,0 +1,77 @@
+import { decidePublicPath } from './decidePublicPath';
+
+const mockHostname = (hostname: string | undefined) => {
+	Object.defineProperty(window, 'location', {
+		value: {
+			hostname,
+		},
+		writable: true,
+	});
+};
+
+const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
+	Object.defineProperty(window, 'guardian', {
+		value: {
+			config: {
+				frontendAssetsFullURL,
+			},
+		},
+		writable: true,
+	});
+};
+
+describe('decidePublicPath', () => {
+	beforeEach(() => {
+		jest.resetModules();
+
+		// Ensures we always set a hostname in the test
+		// and the default hostname isn't accidentally used
+		mockHostname(undefined);
+
+		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
+
+		process.env = { NODE_ENV: undefined, HOSTNAME: undefined };
+	});
+
+	it('localhost with development flag', () => {
+		process.env.NODE_ENV = 'development';
+		mockHostname('localhost');
+		expect(decidePublicPath()).toEqual('http://localhost:3030/assets/');
+	});
+
+	it('localhost with production flag', () => {
+		process.env.NODE_ENV = 'production';
+		mockHostname('localhost');
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('localhost with no flag', () => {
+		mockHostname('localhost');
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('hostname set with development flag', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.HOSTNAME = 'some-other-hostname.com';
+		mockHostname('some-other-hostname.com');
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('hostname set with production flag', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.HOSTNAME = 'some-other-hostname.com';
+		mockHostname('some-other-hostname.com');
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('hostname set with no flag', () => {
+		process.env.HOSTNAME = 'some-other-hostname.com';
+		mockHostname('some-other-hostname.com');
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('no hostname env or flag set', () => {
+		mockHostname('theguardian.com');
+		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
+	});
+});

--- a/dotcom-rendering/src/web/browser/decidePublicPath.ts
+++ b/dotcom-rendering/src/web/browser/decidePublicPath.ts
@@ -1,0 +1,21 @@
+/**
+ * Determine the path that webpack should use as base for dynamic imports
+ *
+ * @returns The webpack public path to use
+ */
+export const decidePublicPath = (): string => {
+	const isDev = process.env.NODE_ENV === 'development';
+	if (isDev && window.location.hostname === 'localhost') {
+		// Use the absolute path when in development mode and running locally
+		// Ensures asset paths are correct relative to Frontend
+		return 'http://localhost:3030/assets/';
+	} else if (
+		window.location.hostname === (process.env.HOSTNAME ?? 'localhost')
+	) {
+		// Use a relative path when hostname is set or using localhost in non-dev environments
+		// e.g. when using a reverse proxy, or running in CI
+		return '/assets/';
+	} else {
+		return `${window.guardian.config.frontendAssetsFullURL}assets/`;
+	}
+};

--- a/dotcom-rendering/src/web/browser/webpackPublicPath.ts
+++ b/dotcom-rendering/src/web/browser/webpackPublicPath.ts
@@ -1,10 +1,19 @@
+/**
+ * Determine the path that webpack should use as base for dynamic imports
+ *
+ * @returns The webpack public path to use
+ */
 const decidePublicPath = () => {
 	const isDev = process.env.NODE_ENV === 'development';
 	if (isDev && window.location.hostname === 'localhost') {
+		// Use the absolute path when in development mode and running locally
+		// Ensures asset paths are correct relative to Frontend
 		return 'http://localhost:3030/assets/';
 	} else if (
 		window.location.hostname === (process.env.HOSTNAME ?? 'localhost')
 	) {
+		// Use a relative path when hostname is set or using localhost in non-dev environments
+		// e.g. when using a reverse proxy, or running in CI
 		return '/assets/';
 	} else {
 		return `${window.guardian.config.frontendAssetsFullURL}assets/`;

--- a/dotcom-rendering/src/web/browser/webpackPublicPath.ts
+++ b/dotcom-rendering/src/web/browser/webpackPublicPath.ts
@@ -1,7 +1,17 @@
+const decidePublicPath = () => {
+	const isDev = process.env.NODE_ENV === 'development';
+	if (isDev && window.location.hostname === 'localhost') {
+		return 'http://localhost:3030/assets/';
+	} else if (
+		window.location.hostname === (process.env.HOSTNAME ?? 'localhost')
+	) {
+		return '/assets/';
+	} else {
+		return `${window.guardian.config.frontendAssetsFullURL}assets/`;
+	}
+};
+
 // allows us to define public path dynamically
 // dynamic imports will use this as the base to find their assets
 // https://webpack.js.org/guides/public-path/#on-the-fly
-__webpack_public_path__ =
-	window.location.hostname === (process.env.HOSTNAME || 'localhost')
-		? '/assets/'
-		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
+__webpack_public_path__ = decidePublicPath();

--- a/dotcom-rendering/src/web/browser/webpackPublicPath.ts
+++ b/dotcom-rendering/src/web/browser/webpackPublicPath.ts
@@ -1,26 +1,7 @@
-/**
- * Determine the path that webpack should use as base for dynamic imports
- *
- * @returns The webpack public path to use
- */
-const decidePublicPath = () => {
-	const isDev = process.env.NODE_ENV === 'development';
-	if (isDev && window.location.hostname === 'localhost') {
-		// Use the absolute path when in development mode and running locally
-		// Ensures asset paths are correct relative to Frontend
-		return 'http://localhost:3030/assets/';
-	} else if (
-		window.location.hostname === (process.env.HOSTNAME ?? 'localhost')
-	) {
-		// Use a relative path when hostname is set or using localhost in non-dev environments
-		// e.g. when using a reverse proxy, or running in CI
-		return '/assets/';
-	} else {
-		return `${window.guardian.config.frontendAssetsFullURL}assets/`;
-	}
-};
-
 // allows us to define public path dynamically
 // dynamic imports will use this as the base to find their assets
+
+import { decidePublicPath } from './decidePublicPath';
+
 // https://webpack.js.org/guides/public-path/#on-the-fly
 __webpack_public_path__ = decidePublicPath();


### PR DESCRIPTION
## What does this change?

Re-introduce a variant of a fix first used in https://github.com/guardian/dotcom-rendering/pull/3471.

When running DCR locally in development, ensure we use absolute paths for the assets that we serve. 

Do this in two places:
-  `decideAssetOrigin`: This is where we decide the path to give scripts included in the `<head>` e.g. Sentry, the CMP, islands, etc.
- `__webpack_public_path__`: The base of the URL that is used to fetch dynamic imports. We need to ensure this is absolute in development so that `.importable.js` bundles can be fetched when requesting via Frontend.

Without these two changes, DCR articles rendered via Frontend will not be able to fetch the `<head>` scripts, preventing critical services such as CMP and Island hydration from starting. _Incidentally, this is why the commercial bundle hangs, since we're not able to obtain consent._

This will not affect production asset serving, since all assets are served from a separate `assets.guim.co.uk` URL.

This should fix https://github.com/guardian/frontend/issues/24874.

## Why?

The issue arises when running DCR locally and proxying through Frontend. Illustrated in the diagram below, when DCR returns the HTML, it includes asset paths that are relative to DCR's dev server and not Frontend. Therefore, when the browser evaluates the page, it'll go off and fetch assets relative to Frontend, resulting in 404s.

```mermaid
sequenceDiagram
    participant Browser as Browser
    participant Frontend as Frontend :9000
    participant DCR as DCR :3030

    Browser ->> Frontend: GET http://localhost:9000/...

    Frontend ->> DCR: POST DCR data model

    activate DCR

    DCR ->> Frontend: Article HTML

    deactivate DCR
    activate Frontend

    Frontend ->> Browser: Article HTML

    deactivate Frontend

    par
        Browser -x Frontend: GET /assets/islands.js
    and
        Browser -x Frontend: GET /assets/bootCMP.js
    and
        Browser -x Frontend: GET /assets/loadSentry.js
    and
        Browser -x Frontend: GET ...
    end
```

We can fix this by supplying absolute paths:

```mermaid
sequenceDiagram
    participant Browser as Browser
    participant Frontend as Frontend :9000
    participant DCR as DCR :3030

    Browser ->> Frontend: GET http://localhost:9000/...

    Frontend ->> DCR: POST DCR data model

    activate DCR

    DCR ->> Frontend: Article HTML

    deactivate DCR
    activate Frontend

    Frontend ->> Browser: Article HTML

    deactivate Frontend

    par
        Browser ->> DCR: GET http:localhost:3030/assets/islands.js
        activate DCR
        DCR ->> Browser: islands.js
        deactivate DCR
    and
        Browser ->> DCR: GET http:localhost:3030/assets/bootCMP.js
        activate DCR
        DCR ->> Browser: bootCMP.js
        deactivate DCR
    and
        Browser ->> DCR: GET http:localhost:3030/assets/loadSentry.js
        activate DCR
        DCR ->> Browser: loadSentry.js
        deactivate DCR
    and
        Browser ->> DCR: GET ...
    end
```
