### PR TITLE
RFC: Use Percy/Cypress for integration-style visual regression testing

### DIFF
--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -55,7 +55,7 @@ use-cases, too.)
   seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
   at the time of writing.
 - Cost?
-
+- Time to execute. This is an unknown quantity at this stage but if the execution time for Percy is too long it could delay deployments
 ### Other considerations
 
 - Cypress lists [a number of other packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -18,10 +18,7 @@ testing in cases where Storybook is not so well-suited.
 ### Pros
 
 The following benefits or use cases have been raised by members of the
-Dotcom team. (Commercial have also 
-[expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256)
-in using Percy with Cypress, so we should find out more about their 
-use-cases, too.)
+department.
 
 - Cypress uses a headless browser to query our own server, which 
   avoids the difficulties of setting more complex configurations in

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -41,7 +41,7 @@ department.
   user interaction, without needing to write separate stories for each
   state.
 - Because Percy is part of Browserstack, it should enable us to make use of cross-browser testing
-- Commercial have also 
+- The commercial-dev team have also 
 [expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience
 ### Cons
 

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -4,69 +4,79 @@
 
 ## Context
 
-Percy is a service which takes snapshots and allows for visual
-regression testing. A recent [Spike PR](https://github.com/guardian/dotcom-rendering/pull/5256)
-shows that it can be integrated with Cypress (which we are already
-using in the codebase) and with CI via Github Actions.
+Percy is a service which takes snapshots and allows for visual regression
+testing. A recent [Spike
+PR](https://github.com/guardian/dotcom-rendering/pull/5256) shows that it can be
+integrated with Cypress (which we are already using in the codebase) and with CI
+via Github Actions.
 
-We are currently using Storybook and Chromatic to run visual
-regression testing on a component level. The proposal to use Percy
-with Cypress is not that we replace the testing already done with
-Chromatic, but rather that we supplement Chromatic testing with Percy
-testing in cases where Storybook is not so well-suited.
+We are currently using Storybook and Chromatic to run visual regression testing
+on a component level. The proposal to use Percy with Cypress is not that we
+replace the testing already done with Chromatic, but rather that we supplement
+Chromatic testing with Percy testing in cases where Storybook is not so
+well-suited.
 
 ### Pros
 
 The following benefits or use cases have been raised by members of the
 department.
 
--   Cypress uses a headless browser to query our own server, which
-    avoids the difficulties of setting more complex configurations in
-    Storybook.
-    -   Example use-case: [Testing image rendering](https://github.com/guardian/dotcom-rendering/issues/5131#issuecomment-1154034615),
+-   Cypress uses a headless browser to query our own server, which avoids the
+    difficulties of setting more complex configurations in Storybook.
+    -   Example use-case: [Testing image
+        rendering](https://github.com/guardian/dotcom-rendering/issues/5131#issuecomment-1154034615),
         which depends on a salt value set in `.env`.
 -   Cypress makes it easier to test a larger slice of the rendering flow.
     -   Example use-case: Changes to the `enhance` methods like
         [`enhanceCollections`](https://github.com/guardian/dotcom-rendering/blob/1b37daa385aa348d3ac666d81ba0f666f56bf577/dotcom-rendering/src/model/enhanceCollections.ts#L4)
-        can have a significant visual impact, because they control which
-        props are forwarded to the React components which render collections.
-        Because many of the props are optional, none of the existing tests
-        or type checks will catch these changes, and contributors may not
-        expect their edit to have visual impacts because `enhance` is one
-        step removed from the actual rendering functions. But currently our
-        Storybook tests [will not catch](https://github.com/guardian/dotcom-rendering/pull/5119#issuecomment-1147538238)
+        can have a significant visual impact, because they control which props
+        are forwarded to the React components which render collections. Because
+        many of the props are optional, none of the existing tests or type
+        checks will catch these changes, and contributors may not expect their
+        edit to have visual impacts because `enhance` is one step removed from
+        the actual rendering functions. But currently our Storybook tests [will
+        not
+        catch](https://github.com/guardian/dotcom-rendering/pull/5119#issuecomment-1147538238)
         this kind of change.
--   Because Cypress can easily do integration tests, this should in
-    theory make it easier to visually test states which result from
-    user interaction, without needing to write separate stories for each
-    state.
--   Because Percy is part of Browserstack, it should enable us to make use of cross-browser testing.
--   The commercial-dev team have also
-    [expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience.
+-   Because Cypress can easily do integration tests, this should in theory make
+    it easier to visually test states which result from user interaction,
+    without needing to write separate stories for each state.
+-   Because Percy is part of Browserstack, it should enable us to make use of
+    cross-browser testing.
+-   The commercial-dev team have also [expressed
+    interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want
+    to snapshot the page to verify ad placement but need the page loaded by a
+    real browser to be sure they are capturing a realistic experience.
 
 ### Cons
 
--   Even though the code footprint of Percy when it's being added to
-    Cypress is fairly light, this would nevertheless introduce
-    dependency on a new service and set of packages.
--   Percy seems to be a relatively new service, and the documentation
-    is not currently as detailed as one might hope (although it does
-    seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
+-   Even though the code footprint of Percy when it's being added to Cypress is
+    fairly light, this would nevertheless introduce dependency on a new service
+    and set of packages.
+-   Percy seems to be a relatively new service, and the documentation is not
+    currently as detailed as one might hope (although it does seem to have
+    [solid
+    backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
     at the time of writing.
 -   Cost impact is unknown.
--   Time to execute. This is an unknown quantity at this stage but if the execution time for Percy is too long it could delay deployments
+-   Time to execute. This is an unknown quantity at this stage but if the
+    execution time for Percy is too long it could delay deployments
 
 ### Other considerations
 
--   Cypress lists [a number of other packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)
-    which can complement Cypress to add visual regression testing. How
-    much do we know about the alternatives to Percy?
+-   Cypress lists [a number of other
+    packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)
+    which can complement Cypress to add visual regression testing. How much do
+    we know about the alternatives to Percy?
 -   Can we do more with Storybook to cover the use-cases outline above?
 
 ## Decision
 
--   We will use Percy, via the Cypress integration, to add visual regression tests for DCR. This will
-    generally complement the existing visual regression tests that we're already running with Storybook and
-    Chromatic, but some existing tests will be moved from Chromatic to Percy if the latter is a significantly better fit (e.g. layouts).
+-   We will use Percy, via the Cypress integration, to add visual regression
+    tests for DCR. This will generally complement the existing visual regression
+    tests that we're already running with Storybook and Chromatic, but some
+    existing tests will be moved from Chromatic to Percy if the latter is a
+    significantly better fit (e.g. layouts).
 
--   The unknowns (cost, execution time) should be revisited once we have a clearer sense of how we will use Percy in practice.
+-   The unknowns (cost, execution time) should be revisited once we have a
+    clearer sense of how we will use Percy in practice.

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -1,0 +1,64 @@
+# Use Percy/Cypress for e2e-style visual regression testing
+
+## Status: Proposed
+
+## Context
+
+Percy is a service which takes snapshots and allows for visual
+regression testing. A recent [Spike PR](https://github.com/guardian/dotcom-rendering/pull/5256)
+shows that it can be integrated with Cypress (which we are already
+using in the codebase) and with CI via Github Actions.
+
+We are currently using Storybook and Chromatic to run visual 
+regression testing on a component level. The proposal to use Percy 
+with Cypress is not that we replace the testing already done with 
+Chromatic, but rather that we supplement Chromatic testing with Percy 
+testing in cases where Storybook is not so well-suited.
+
+### Pros
+
+The following benefits or use cases have been raised by members of the
+Dotcom team. (Commercial have also 
+[expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256)
+in using Percy with Cypress, so we should find out more about their 
+use-cases, too.)
+
+- Cypress uses a headless browser to query our own server, which 
+  avoids the difficulties of setting more complex configurations in
+  Storybook.
+  - Example use-case: [Testing image rendering](https://github.com/guardian/dotcom-rendering/issues/5131#issuecomment-1154034615),
+  which depends on a salt value set in `.env`.
+- Cypress makes it easier to test a larger slice of the rendering flow.
+  - Example use-case: Changes to the `enhance` methods like
+  [`enhanceCollections`](https://github.com/guardian/dotcom-rendering/blob/1b37daa385aa348d3ac666d81ba0f666f56bf577/dotcom-rendering/src/model/enhanceCollections.ts#L4)
+  can have a significant visual impact, because they control which
+  props are forwarded to the React components which render collections.
+  Because many of the props are optional, none of the existing tests
+  or type checks will catch these changes, and contributors may not
+  expect their edit to have visual impacts because `enhance` is one
+  step removed from the actual rendering functions. But currently our
+  Storybook tests [will not catch](https://github.com/guardian/dotcom-rendering/pull/5119#issuecomment-1147538238)
+  this kind of change.
+- Because Cypress can easily do integration tests, this should in 
+  theory make it easier to visually test states which result from
+  user interaction, without needing to write separate stories for each
+  state.
+- Because Percy is part of Browserstack, it should make cross-browser   testing easy.
+
+### Cons
+
+- Even though the code footprint of Percy when it's being added to
+  Cypress is fairly light, this would nevertheless introduce
+  dependency on a new service and set of packages.
+- Percy seems to be a relatively new service, and the documentation
+  is not currently as detailed as one might hope (although it does
+  seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
+  at the time of writing.
+- Cost?
+
+### Other considerations
+
+- Cypress lists [a number of other packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)
+  which can complement Cypress to add visual regression testing. How
+  much do we know about the alternatives to Percy?
+- Can we do more with Storybook to cover the use-cases outline above?

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -52,7 +52,7 @@ department.
   is not currently as detailed as one might hope (although it does
   seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
   at the time of writing.
-- Cost?
+- Cost impact is unknown
 - Time to execute. This is an unknown quantity at this stage but if the execution time for Percy is too long it could delay deployments
 ### Other considerations
 

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -1,4 +1,4 @@
-# Use Percy/Cypress for e2e-style visual regression testing
+# Use Percy/Cypress for integration-style visual regression testing
 
 ## Status: Proposed
 

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -1,6 +1,6 @@
 # Use Percy/Cypress for integration-style visual regression testing
 
-## Status: Proposed
+## Status: Accepted
 
 ## Context
 
@@ -9,10 +9,10 @@ regression testing. A recent [Spike PR](https://github.com/guardian/dotcom-rende
 shows that it can be integrated with Cypress (which we are already
 using in the codebase) and with CI via Github Actions.
 
-We are currently using Storybook and Chromatic to run visual 
-regression testing on a component level. The proposal to use Percy 
-with Cypress is not that we replace the testing already done with 
-Chromatic, but rather that we supplement Chromatic testing with Percy 
+We are currently using Storybook and Chromatic to run visual
+regression testing on a component level. The proposal to use Percy
+with Cypress is not that we replace the testing already done with
+Chromatic, but rather that we supplement Chromatic testing with Percy
 testing in cases where Storybook is not so well-suited.
 
 ### Pros
@@ -20,43 +20,53 @@ testing in cases where Storybook is not so well-suited.
 The following benefits or use cases have been raised by members of the
 department.
 
-- Cypress uses a headless browser to query our own server, which 
-  avoids the difficulties of setting more complex configurations in
-  Storybook.
-  - Example use-case: [Testing image rendering](https://github.com/guardian/dotcom-rendering/issues/5131#issuecomment-1154034615),
-  which depends on a salt value set in `.env`.
-- Cypress makes it easier to test a larger slice of the rendering flow.
-  - Example use-case: Changes to the `enhance` methods like
-  [`enhanceCollections`](https://github.com/guardian/dotcom-rendering/blob/1b37daa385aa348d3ac666d81ba0f666f56bf577/dotcom-rendering/src/model/enhanceCollections.ts#L4)
-  can have a significant visual impact, because they control which
-  props are forwarded to the React components which render collections.
-  Because many of the props are optional, none of the existing tests
-  or type checks will catch these changes, and contributors may not
-  expect their edit to have visual impacts because `enhance` is one
-  step removed from the actual rendering functions. But currently our
-  Storybook tests [will not catch](https://github.com/guardian/dotcom-rendering/pull/5119#issuecomment-1147538238)
-  this kind of change.
-- Because Cypress can easily do integration tests, this should in 
-  theory make it easier to visually test states which result from
-  user interaction, without needing to write separate stories for each
-  state.
-- Because Percy is part of Browserstack, it should enable us to make use of cross-browser testing
-- The commercial-dev team have also 
-[expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience
+-   Cypress uses a headless browser to query our own server, which
+    avoids the difficulties of setting more complex configurations in
+    Storybook.
+    -   Example use-case: [Testing image rendering](https://github.com/guardian/dotcom-rendering/issues/5131#issuecomment-1154034615),
+        which depends on a salt value set in `.env`.
+-   Cypress makes it easier to test a larger slice of the rendering flow.
+    -   Example use-case: Changes to the `enhance` methods like
+        [`enhanceCollections`](https://github.com/guardian/dotcom-rendering/blob/1b37daa385aa348d3ac666d81ba0f666f56bf577/dotcom-rendering/src/model/enhanceCollections.ts#L4)
+        can have a significant visual impact, because they control which
+        props are forwarded to the React components which render collections.
+        Because many of the props are optional, none of the existing tests
+        or type checks will catch these changes, and contributors may not
+        expect their edit to have visual impacts because `enhance` is one
+        step removed from the actual rendering functions. But currently our
+        Storybook tests [will not catch](https://github.com/guardian/dotcom-rendering/pull/5119#issuecomment-1147538238)
+        this kind of change.
+-   Because Cypress can easily do integration tests, this should in
+    theory make it easier to visually test states which result from
+    user interaction, without needing to write separate stories for each
+    state.
+-   Because Percy is part of Browserstack, it should enable us to make use of cross-browser testing.
+-   The commercial-dev team have also
+    [expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience.
+
 ### Cons
 
-- Even though the code footprint of Percy when it's being added to
-  Cypress is fairly light, this would nevertheless introduce
-  dependency on a new service and set of packages.
-- Percy seems to be a relatively new service, and the documentation
-  is not currently as detailed as one might hope (although it does
-  seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
-  at the time of writing.
-- Cost impact is unknown
-- Time to execute. This is an unknown quantity at this stage but if the execution time for Percy is too long it could delay deployments
+-   Even though the code footprint of Percy when it's being added to
+    Cypress is fairly light, this would nevertheless introduce
+    dependency on a new service and set of packages.
+-   Percy seems to be a relatively new service, and the documentation
+    is not currently as detailed as one might hope (although it does
+    seem to have [solid backing](https://www.browserstack.com/blog/browserstack-has-acquired-percy/),
+    at the time of writing.
+-   Cost impact is unknown.
+-   Time to execute. This is an unknown quantity at this stage but if the execution time for Percy is too long it could delay deployments
+
 ### Other considerations
 
-- Cypress lists [a number of other packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)
-  which can complement Cypress to add visual regression testing. How
-  much do we know about the alternatives to Percy?
-- Can we do more with Storybook to cover the use-cases outline above?
+-   Cypress lists [a number of other packages](https://docs.cypress.io/guides/tooling/visual-testing#Tooling)
+    which can complement Cypress to add visual regression testing. How
+    much do we know about the alternatives to Percy?
+-   Can we do more with Storybook to cover the use-cases outline above?
+
+## Decision
+
+-   We will use Percy, via the Cypress integration, to add visual regression tests for DCR. This will
+    generally complement the existing visual regression tests that we're already running with Storybook and
+    Chromatic, but some existing tests will be moved from Chromatic to Percy if the latter is a significantly better fit (e.g. layouts).
+
+-   The unknowns (cost, execution time) should be revisited once we have a clearer sense of how we will use Percy in practice.

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -40,7 +40,7 @@ department.
   theory make it easier to visually test states which result from
   user interaction, without needing to write separate stories for each
   state.
-- Because Percy is part of Browserstack, it should make cross-browser   testing easy.
+- Because Percy is part of Browserstack, it should enable us to make use of cross-browser testing
 - Commercial have also 
 [expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience
 ### Cons

--- a/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
+++ b/dotcom-rendering/docs/architecture/030-use-percy-for-e2e-visual-regression-testing.md
@@ -41,7 +41,8 @@ department.
   user interaction, without needing to write separate stories for each
   state.
 - Because Percy is part of Browserstack, it should make cross-browser   testing easy.
-
+- Commercial have also 
+[expressed interest](https://github.com/guardian/dotcom-rendering/pull/5256). They want to snapshot the page to verify ad placement but need the page loaded by a real browser to be sure they are capturing a realistic experience
 ### Cons
 
 - Even though the code footprint of Percy when it's being added to


### PR DESCRIPTION
This is a draft Architectural Decision Record, outlining the case for (and against) using Percy with Cypress to add an extra layer of visual regression testing to DCR.

There have been a number of conversations recently, both within and outside the Dotcom team, about adopting Percy. And in the light of @arelra's recent [Spike PR](https://github.com/guardian/dotcom-rendering/pull/5256), this seems like a good time to have a more general discussion about whether using Percy fits with the Dotcom team's testing needs.

I've started the conversation here in the form of a draft ADR, because this feels like a proposal which should be documented in our ADRs. However, the content of the ADR itself is very much open to change, so please feel free to suggest changes in the comments below, or to open a PR on this branch with changes.

I've tried to link out from the ADR to some of the conversations which I was aware of, particularly some comments of @oliverlloyd's. If I remember rightly, other people on the team have been contributing to these discussions too, especially @OllysCoding? However, I haven't been able to find these discussions on Github. If I've missed anything, please feel free to add it in!