### PR TITLE
useApi: return 'loading=false' if url undefined

### DIFF
--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -40,6 +40,6 @@ export const useApi = <T,>(
 	return {
 		data,
 		error,
-		loading: url && !error && !data,
+		loading: !!url && !error && !data,
 	};
 };

--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -40,6 +40,6 @@ export const useApi = <T,>(
 	return {
 		data,
 		error,
-		loading: !error && !data,
+		loading: typeof url !== 'undefined' && !error && !data,
 	};
 };

--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -40,6 +40,6 @@ export const useApi = <T,>(
 	return {
 		data,
 		error,
-		loading: url !== undefined && !error && !data,
+		loading: url && !error && !data,
 	};
 };

--- a/dotcom-rendering/src/web/lib/useApi.tsx
+++ b/dotcom-rendering/src/web/lib/useApi.tsx
@@ -40,6 +40,6 @@ export const useApi = <T,>(
 	return {
 		data,
 		error,
-		loading: typeof url !== 'undefined' && !error && !data,
+		loading: url !== undefined && !error && !data,
 	};
 };


### PR DESCRIPTION
[SWR recommends](https://swr.vercel.app/docs/conditional-fetching#conditional) handling conditional fetching for their useSWR hook by passing a falsey value if you don't want to make a
request.

We have a `useApi` hook which wraps `useSWR`, and this wrapper returns `loading=!data & !error`. This means it was returning `loading=true` when a falsey value was passed as the `url`, even though nothing was actually loading.

It seems more intuitive to me that `loading` should be `false` if no request has actually been made, and this would also be useful for an upcoming feature where we want to wait until a user event before we make the API request. As far as I can tell, no components which use `useAPI` currently rely on the existing behaviour, because they all have `url` as a required parameter, so their behaviour shouldn't be affected by the extra condition being added here.

The components which currently use the `loading` value returned by the hook are:

- src/web/components/GetCricketScoreboard.importable.tsx
- src/web/components/GetMatchNav.importable.tsx
- src/web/components/GetMatchStats.importable.tsx
- src/web/components/GetMatchTabs.importable.tsx
- src/web/components/OnwardsData.tsx

I've tested these locally and they appear to be working as they do in prod. See e.g. [this cricket liveblog](https://www.theguardian.com/sport/live/2022/jun/24/england-v-new-zealand-third-test-day-two-live-score-updates-cricket) and [this football match report](https://www.theguardian.com/football/live/2022/may/29/huddersfield-town-v-nottingham-forest-championship-play-off-final-live).