### PR TITLE
Ensure selected topic is always available in ui

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -619,7 +619,7 @@ interface CAPIArticleType {
 	// Included on live and dead blogs. Used when polling
 	mostRecentBlockId?: string;
 	availableTopics?: Topic[];
-	selectedTopics?: string;
+	selectedTopics?: Topic[];
 }
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
@@ -1173,7 +1173,7 @@ type MatchReportType = {
 interface Topic {
 	type: TopicType;
 	value: string;
-	count: number;
+	count?: number;
 }
 
 type TopicType = 'ORG' | 'PRODUCT' | 'PERSON' | 'GPE' | 'WORK_OF_ART' | 'LOC';

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -407,7 +407,10 @@
             }
         },
         "selectedTopics": {
-            "type": "string"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Topic"
+            }
         }
     },
     "required": [
@@ -4275,7 +4278,6 @@
                 }
             },
             "required": [
-                "count",
                 "type",
                 "value"
             ]

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -35,7 +35,7 @@ type Props = {
 	abTests?: ServerSideTests;
 	showKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
-	selectedTopics?: string;
+	selectedTopics?: Topic[];
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -16,7 +16,7 @@ type Props = {
 	webURL: string;
 	mostRecentBlockId: string;
 	hasPinnedPost: boolean;
-	selectedTopics?: string;
+	selectedTopics?: Topic[];
 };
 
 const isServer = typeof window === 'undefined';
@@ -107,7 +107,7 @@ function getKey(
 	ajaxUrl: string,
 	latestBlockId: string,
 	filterKeyEvents: boolean,
-	selectedTopics?: string,
+	selectedTopics?: Topic[],
 ): string | undefined {
 	try {
 		// Construct the url to poll
@@ -119,7 +119,11 @@ function getKey(
 			'filterKeyEvents',
 			filterKeyEvents ? 'true' : 'false',
 		);
-		if (selectedTopics) url.searchParams.set('topics', selectedTopics);
+		if (selectedTopics && selectedTopics.length > 0)
+			url.searchParams.set(
+				'topics',
+				`${selectedTopics[0].type}:${selectedTopics[0].value}`,
+			);
 		return url.href;
 	} catch {
 		window.guardian.modules.sentry.reportError(

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -81,6 +81,7 @@ export const TopicFilterBank = ({
 	const palette = decidePalette(format);
 
 	const selectedTopic = selectedTopics?.[0];
+	const topFiveTopics = availableTopics.slice(0, 5);
 
 	if (selectedTopic) {
 		const selectedIndex = availableTopics.findIndex(
@@ -88,10 +89,7 @@ export const TopicFilterBank = ({
 		);
 
 		if (selectedIndex > 4) {
-			// this removes the topic at it's original index
-			const topicToMove = availableTopics.splice(selectedIndex, 1)[0];
-			// this adds the removed topic in index 4
-			availableTopics.splice(4, 0, topicToMove);
+			topFiveTopics.splice(4, 1, availableTopics[selectedIndex]);
 		}
 	}
 
@@ -115,7 +113,7 @@ export const TopicFilterBank = ({
 					/>
 				)}
 
-				{availableTopics.slice(0, 5).map((topic) => {
+				{topFiveTopics.map((topic) => {
 					const buttonParams = `${topic.type}:${topic.value}`;
 					const isActive =
 						selectedTopic !== undefined &&

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -113,8 +113,7 @@ export const TopicFilterBank = ({
 				{topFiveTopics.map((topic) => {
 					const buttonParams = `${topic.type}:${topic.value}`;
 					const isActive =
-						selectedTopic !== undefined &&
-						isEqual(selectedTopic)(topic);
+						!!selectedTopic && isEqual(selectedTopic)(topic);
 
 					return (
 						<FilterButton

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -5,7 +5,7 @@ import { FilterButton } from './FilterButton.importable';
 
 type Props = {
 	availableTopics: Topic[];
-	selectedTopics?: string;
+	selectedTopics?: Topic[];
 	format: ArticleFormat;
 	filterKeyEvents: boolean;
 	keyEvents?: Block[];
@@ -66,6 +66,11 @@ const handleKeyEventClick = (filterKeyEvents: boolean) => {
 	window.location.search = urlParams.toString();
 };
 
+const availableTopicIsSelected =
+	(selectedTopic: Topic) => (availableTopic: Topic) =>
+		availableTopic.type === selectedTopic.type &&
+		availableTopic.value === selectedTopic.value;
+
 export const TopicFilterBank = ({
 	availableTopics,
 	selectedTopics,
@@ -74,6 +79,22 @@ export const TopicFilterBank = ({
 	filterKeyEvents = false,
 }: Props) => {
 	const palette = decidePalette(format);
+
+	const selectedTopic = selectedTopics?.[0];
+
+	if (selectedTopic) {
+		const selectedIndex = availableTopics.findIndex(
+			availableTopicIsSelected(selectedTopic),
+		);
+
+		if (selectedIndex > 4) {
+			// this removes the topic at it's original index
+			const topicToMove = availableTopics.splice(selectedIndex, 1)[0];
+			// this adds the removed topic in index 4
+			availableTopics.splice(4, 0, topicToMove);
+		}
+	}
+
 	return (
 		<div css={containerStyles}>
 			<div css={headlineStyles}>
@@ -96,9 +117,9 @@ export const TopicFilterBank = ({
 
 				{availableTopics.slice(0, 5).map((topic) => {
 					const buttonParams = `${topic.type}:${topic.value}`;
-					const isActive = selectedTopics
-						? selectedTopics.includes(buttonParams)
-						: false;
+					const isActive =
+						selectedTopic !== undefined &&
+						availableTopicIsSelected(selectedTopic)(topic);
 
 					return (
 						<FilterButton

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -66,7 +66,7 @@ const handleKeyEventClick = (filterKeyEvents: boolean) => {
 	window.location.search = urlParams.toString();
 };
 
-const isEqual = (selectedTopic: Topic) => (availableTopic: Topic) =>
+const isEqual = (selectedTopic: Topic, availableTopic: Topic) =>
 	availableTopic.type === selectedTopic.type &&
 	availableTopic.value === selectedTopic.value;
 
@@ -83,7 +83,9 @@ export const TopicFilterBank = ({
 	const topFiveTopics = availableTopics.slice(0, 5);
 
 	if (selectedTopic) {
-		const selectedIndex = availableTopics.findIndex(isEqual(selectedTopic));
+		const selectedIndex = availableTopics.findIndex((availableTopic) =>
+			isEqual(selectedTopic, availableTopic),
+		);
 
 		if (selectedIndex > 4) {
 			topFiveTopics.splice(4, 1, availableTopics[selectedIndex]);
@@ -113,7 +115,7 @@ export const TopicFilterBank = ({
 				{topFiveTopics.map((topic) => {
 					const buttonParams = `${topic.type}:${topic.value}`;
 					const isActive =
-						!!selectedTopic && isEqual(selectedTopic)(topic);
+						!!selectedTopic && isEqual(selectedTopic, topic);
 
 					return (
 						<FilterButton

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -66,10 +66,9 @@ const handleKeyEventClick = (filterKeyEvents: boolean) => {
 	window.location.search = urlParams.toString();
 };
 
-const availableTopicIsSelected =
-	(selectedTopic: Topic) => (availableTopic: Topic) =>
-		availableTopic.type === selectedTopic.type &&
-		availableTopic.value === selectedTopic.value;
+const isEqual = (selectedTopic: Topic) => (availableTopic: Topic) =>
+	availableTopic.type === selectedTopic.type &&
+	availableTopic.value === selectedTopic.value;
 
 export const TopicFilterBank = ({
 	availableTopics,
@@ -84,9 +83,7 @@ export const TopicFilterBank = ({
 	const topFiveTopics = availableTopics.slice(0, 5);
 
 	if (selectedTopic) {
-		const selectedIndex = availableTopics.findIndex(
-			availableTopicIsSelected(selectedTopic),
-		);
+		const selectedIndex = availableTopics.findIndex(isEqual(selectedTopic));
 
 		if (selectedIndex > 4) {
 			topFiveTopics.splice(4, 1, availableTopics[selectedIndex]);
@@ -117,7 +114,7 @@ export const TopicFilterBank = ({
 					const buttonParams = `${topic.type}:${topic.value}`;
 					const isActive =
 						selectedTopic !== undefined &&
-						availableTopicIsSelected(selectedTopic)(topic);
+						isEqual(selectedTopic)(topic);
 
 					return (
 						<FilterButton

--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -15,6 +15,8 @@ const availableTopics: Topic[] = [
 	{ type: 'PERSON', value: 'Anas Sarwar', count: 4 },
 ];
 
+const selectedTopics: Topic[] = [{ type: 'GPE', value: 'United Kingdom' }];
+
 const format = {
 	theme: ArticlePillar.News,
 	design: ArticleDesign.LiveBlog,
@@ -64,4 +66,27 @@ export const topicBank = () => {
 };
 topicBank.story = {
 	name: 'topicBank',
+};
+
+export const topicBankSelectedIsNotInTop5 = () => {
+	return (
+		<Wrapper>
+			<TopicFilterBank
+				availableTopics={availableTopics}
+				selectedTopics={selectedTopics}
+				format={format}
+				keyEvents={[
+					{
+						...baseProperties,
+						blockFirstPublished: 1638279933000,
+						title: 'title',
+					},
+				]}
+				filterKeyEvents={false}
+			/>
+		</Wrapper>
+	);
+};
+topicBankSelectedIsNotInTop5.story = {
+	name: 'topicBankSelectedIsNotInTop5',
 };

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -31,7 +31,7 @@ type Props = {
 	filterKeyEvents?: boolean;
 	isKeyEventsCarouselVariant?: boolean;
 	availableTopics?: Topic[];
-	selectedTopics?: string;
+	selectedTopics?: Topic[];
 };
 
 export const LiveBlogRenderer = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR does the following:

- Updates the `selectedTopics` in `CAPIArticleType` interface to be `Topic[]`
- make `count` field optional in `Topic` model
- Ran `gen-schema` to create the new schema

- Adds logic in `TopicFilterBank` component to make sure the selected topic is always included within the 5 available topics 
## Why?
User loads the liveblog page, which has a list of 5 filter topics (we only allow 5 topics for now due to space limitation). After a few minutes, user chooses one of the topics and page refreshes again. 
But during the time between when user first loaded the page and when user chooses a topic, the available topics list could have updated in the server, so a new list is given to DCR. Due to this, there is a possibility that the selected topic is not within the top 5 of the  available topics. 

This change makes sure that, the selected topic would always show up within the UI topics. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/15894063/176686617-c4454635-0b19-4b8e-afa8-466b90b1d671.png) | ![after](https://user-images.githubusercontent.com/15894063/176686018-56fa9041-3f87-4f8e-bebc-83e9a9edbce5.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
