### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@guardian/dotcom-platform @JamieB-gu @MarSavar @iainjchambers-guardian
+*	@guardian/dotcom-platform @JamieB-gu @georgeblahblah @iainjchambers-guardian

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@guardian/dotcom-platform @JamieB-gu @georgeblahblah @iainjchambers-guardian
+*	@guardian/dotcom-platform @guardian/apps-rendering


### PR DESCRIPTION
## Why?
@georgeblahblah is joining the AR team and I'm leaving it. This change will add him as a reviewer for PRs in this repo.

For discussion: should we have an `@guardian/ar-platform` (or similar) GitHub team so we don't have to manually raise PRs  to change the codeowners file every time someone joins or leaves the team?

**Update** I've created a dedicated Github team (`@guardian/apps-rendering`).