### PR TITLE
fix(tsc): add id to TopicFilterBank

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -73,6 +73,7 @@ export const topicBankSelectedIsNotInTop5 = () => {
 	return (
 		<Wrapper>
 			<TopicFilterBank
+				id="key-events-carousel-desktop"
 				availableTopics={availableTopics}
 				selectedTopics={selectedTopics}
 				format={format}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the required `id` prop to `TopicFilterBank`. 

## Why?
To make things type right.