### PR TITLE
Fix Island performance logs

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -49,12 +49,10 @@ export const doHydration = (
 		})
 		.then(({ clientOnly, timeTaken }) => {
 			// Log performance info
-			const entry = window.performance
-				.getEntriesByType('resource')
-				.find((p) => p.name.includes(`${name}-importable.`));
-			const { requestStart = 0, responseEnd = 0 } =
-				entry instanceof PerformanceResourceTiming ? entry : {};
-			const download = Math.ceil(responseEnd - requestStart);
+			const { duration: download = -1 } =
+				window.performance
+					.getEntriesByType('resource')
+					.find((p) => p.name.includes(`/${name}-importable.`)) ?? {};
 
 			const action = clientOnly ? 'Rendering' : 'Hydrating';
 


### PR DESCRIPTION
## What does this change?

Remove useless and innaccurate measurements in favour of the [`duration` property](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/duration), which is supported in all modern browsers.

Fall back to a invalid duration (`-1`)if it was not found.

## Why?

The measurements in #5296 were wrong! The dowload time started from time origin.

## Screenshots

| When | logs |
|--|--|
| Before | ![before][] |  |
| After | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/177144978-9db7212b-77a0-45c0-b08c-2ccfc6bd4177.png
[after]: https://user-images.githubusercontent.com/76776/177145247-51ac2012-487a-4e5d-89ca-f5a75aa4619e.png
