### PR TITLE
Swap out ab test to switch

### DIFF
--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -31,8 +31,7 @@ type Props = {
  * @param {ArticleFormat} props.format - The format model for the article
  * */
 export const Article = ({ CAPIArticle, NAV, format }: Props) => {
-	const showKeyEventsCarousel =
-		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
+	const showKeyEventsCarousel = CAPIArticle.config.switches.keyEventsCarousel;
 
 	return (
 		<StrictMode>

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -167,7 +167,7 @@ export const ArticleBody = ({
 						onFirstPage={onFirstPage}
 						keyEvents={keyEvents}
 						filterKeyEvents={filterKeyEvents}
-						isKeyEventsCarouselVariant={showKeyEventsCarousel}
+						isKeyEventsCarousel={showKeyEventsCarousel}
 						availableTopics={availableTopics}
 						selectedTopics={selectedTopics}
 					/>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -303,8 +303,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const cricketMatchUrl =
 		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
 
-	const showKeyEventsCarousel =
-		CAPIArticle.config.abTests.keyEventsCarouselVariant == 'variant';
+	const showKeyEventsCarousel = CAPIArticle.config.switches.keyEventsCarousel;
 
 	const isInFilteringBeta =
 		CAPIArticle.config.switches.automaticFilters &&

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -29,7 +29,7 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
-	isKeyEventsCarouselVariant?: boolean;
+	isKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
 };
@@ -55,7 +55,7 @@ export const LiveBlogRenderer = ({
 	onFirstPage,
 	keyEvents,
 	filterKeyEvents = false,
-	isKeyEventsCarouselVariant = false,
+	isKeyEventsCarousel = false,
 	availableTopics,
 	selectedTopics,
 }: Props) => {
@@ -84,7 +84,7 @@ export const LiveBlogRenderer = ({
 					</PinnedPost>
 				</>
 			)}
-			{isKeyEventsCarouselVariant && keyEvents?.length ? (
+			{isKeyEventsCarousel && keyEvents?.length ? (
 				<Hide above="desktop">
 					<Island deferUntil="visible">
 						<KeyEventsCarousel


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The key events carousel should be rolled out to 100% of users but we would still like the safety of a switch. As such, a feature switch is more appropriate than an A/B test so the a/b test is being swapped out in favour of a feature switch. 

Frontend companion PR is available [here](https://github.com/guardian/frontend/pull/25181) 