### PR TITLE
Fix spacing for pinned post and key events carousel

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -58,7 +58,7 @@ const summaryStyles = (palette: Palette) => css`
 
 const listItemStyles = (palette: Palette) => css`
 	position: relative;
-	padding-bottom: ${space[4]}px;
+	padding-bottom: ${space[3]}px;
 	padding-top: ${space[3]}px;
 	padding-right: ${space[3]}px;
 	background-color: ${palette.background.keyEvent};

--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -55,6 +55,7 @@ const marginBottomStyles = css`
 `;
 const titleStyles = css`
 	${headline.xxxsmall({ fontWeight: 'bold', lineHeight: 'regular' })};
+	padding-top: ${space[3]}px;
 `;
 
 const containerStyles = css`

--- a/dotcom-rendering/src/web/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/web/components/PinnedPost.tsx
@@ -20,9 +20,14 @@ import { decidePalette } from '../lib/decidePalette';
 const pinnedPostContainer = (palette: Palette) => css`
 	border: 3px solid ${palette.border.pinnedPost};
 	padding-bottom: ${space[1]}px;
-	margin-bottom: ${space[9]}px;
 	position: relative;
 	background: ${neutral[100]};
+	${from.mobile} {
+		margin-bottom: ${space[6] + space[5] / 2}px;
+	}
+	${from.desktop} {
+		margin-bottom: ${space[9]}px;
+	}
 	#pinned-post-checkbox:checked ~ #collapsible-body {
 		max-height: fit-content;
 		margin-bottom: ${space[1]}px;

--- a/dotcom-rendering/src/web/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/web/components/PinnedPost.tsx
@@ -23,7 +23,7 @@ const pinnedPostContainer = (palette: Palette) => css`
 	position: relative;
 	background: ${neutral[100]};
 	${from.mobile} {
-		margin-bottom: ${space[6] + space[5] / 2}px;
+		margin-bottom: 34px;
 	}
 	${from.desktop} {
 		margin-bottom: ${space[9]}px;


### PR DESCRIPTION
## What does this change?
Amends spacing within Pinned Post and Key Events Carousel.

## Why?
As part of the automatic filters redesign, the spacing between the Pinned Post and the Key Events Carousel is changing to 24px.


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/55602675/177186106-c4d8037c-9995-45ee-9328-19dad59223e9.png

[after]: https://user-images.githubusercontent.com/55602675/177186189-2f4bf16e-40e9-4d59-b111-44cf03d014f6.png

