### PR TITLE
Don't default kicker to 'Live' on sublinks

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -63,11 +63,7 @@ const enhanceSupportingContent = (
 			format: presentationFormat,
 			headline: subLink.header?.headline || '',
 			url: subLink.properties.href || subLink.header?.url,
-			kickerText:
-				subLink.header?.kicker?.item?.properties.kickerText ||
-				(linkFormat && linkFormat.design === ArticleDesign.LiveBlog
-					? 'Live'
-					: undefined),
+			kickerText: subLink.header?.kicker?.item?.properties.kickerText,
 		};
 	});
 };

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
 import { CardHeadline } from './CardHeadline';
 
@@ -65,11 +64,6 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 				// The model has this property as optional but it is very likely
 				// to exist
 				if (!subLink.headline) return null;
-				// The kicker defaults to 'Live' when the article is a liveblog
-				const kickerText =
-					subLink.format.design === ArticleDesign.LiveBlog
-						? 'Live'
-						: subLink.kickerText;
 				const shouldPadLeft = index > 0 && alignment === 'horizontal';
 				return (
 					<li
@@ -83,7 +77,7 @@ export const SupportingContent = ({ supportingContent, alignment }: Props) => {
 					>
 						<CardHeadline
 							headlineText={subLink.headline}
-							kickerText={kickerText}
+							kickerText={subLink.kickerText}
 							format={subLink.format}
 							size="tiny"
 							showSlash={false}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
On articles, the kicker text is forced to 'Live' on headlines. But for sublinks we want to keep showing the actual kicker text. This PR removes the code which forces the text to 'Live' in relation to `SupportingContent` (sublinks).

| Before      | After      |
|-------------|------------|
| <img width="976" alt="Screenshot 2022-07-05 at 11 08 10" src="https://user-images.githubusercontent.com/1336821/177305249-2d80da67-8578-4136-822b-95ea336f8531.png"> | <img width="976" alt="Screenshot 2022-07-05 at 11 07 11" src="https://user-images.githubusercontent.com/1336821/177305267-c2d13900-658b-40d5-a82d-a7d6b8162c3b.png"> |
