### PR TITLE
Smaller Islands - Re-enable code splitting for webpack chunks

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 
@@ -37,10 +36,6 @@ module.exports = ({ isLegacyJS, sessionId }) => ({
 		filename: generateName(isLegacyJS),
 		chunkFilename: generateName(isLegacyJS),
 		publicPath: '',
-	},
-	// fix for known issue with webpack dynamic imports
-	optimization: {
-		splitChunks: { cacheGroups: { default: false } },
 	},
 	plugins: [
 		new WebpackManifestPlugin({


### PR DESCRIPTION
## What does this change?

The current Webpack browser script is generating chunks with duplicated dependencies.

Hence each (dynamically imported) island contains duplicated dependencies e.g. `preact`, `@guardalin/libs`, etc.

This means increased download, parse and compilation times for larger chunks and is likely contributing to a lower Lighthouse / web vitals score for network or CPU constrained devices.

After some investigation I found that we had previously disabled Webpack's code splitting aross entry points. The reason for the [initial change](https://github.com/guardian/dotcom-rendering/pull/1492/commits/e03b72c3dd1a952b035408079e986c031a5a0006) is unclear but in our post-loadable, post-islands world there doesn't seem to be any adverse effects of re-enabling - **please verify!**

This PR re-enables code splitting across entry points.

This results in an overall reduction of:

| Chunk | Type | Before | After | Reduction | ~% Reduction |
|--|--|--|--|--|--|
|all |parsed |2.05MB |1.44MB 💾 |**0.60MB**  | 30% |
|all |gzip |627kB |512kB |115kB| 19% |

Some islands have seen very large reductions e.g. `OnwardsUpper-importable`:

| Chunk | Type | Before | After | Reduction | ~% Reduction |
|--|--|--|--|--|--|
|`OnwardsUpper-importable` |parsed |88kB |21kB |67kB | 76% |
|`OnwardsUpper-importable` |gzip |23kB |8kB |15kB| 65% |

## Why?

Reduce the amount of JavaScript we ship to the client.

Browsers spend less time downloading, parsing and compiling duplicated code.

## Notes

### Further Improvements

Webpack will in some cases, not split chunks if it deems the chunk to be within configured bounds so **there is still dependency duplication**.

I think we could improve this further by configuring cache groups using [SplitChunksPlugin](https://webpack.js.org/plugins/split-chunks-plugin/)

However care needs to be taken when specifying custom cache groups. Splitting chunks too finely or in an unsuitable manner can risk degrading performance by introducing waterfall module loading or saturating network requests.

## Before and After

### Webpack Stats

| Before      | After      |
|-------------|------------|
| ![before-stats][] | ![after-stats][] |
| ![before-onwu][] | ![after-onwu][] |

[before-stats]: https://user-images.githubusercontent.com/7014230/177203108-6e5427b4-8493-4090-82a2-0cfd28f9957d.png
[after-stats]: https://user-images.githubusercontent.com/7014230/177203150-ed12f032-1265-4830-b271-821674d7cb96.png

[before-onwu]: https://user-images.githubusercontent.com/7014230/177204560-3c612384-a597-4e5e-910c-077da49535db.png

[after-onwu]: https://user-images.githubusercontent.com/7014230/177204582-0efdd311-7afe-4ac3-8046-e80e30a6baab.png

### Lighthouse

Comparing Lighthouse results for scripting is difficult due to run-to-run variability.

Running Lighthouse on a page with noads, mobile, x4 cpu slowdown, did show a positive trend in the reported duplicated modules and in the script parse and compilation times. We would need to verify this against RUM to determine if there is a measurable positive or negative impact.

It is also likely that any small improvements will be obsfucated by heavier scripts we have on the page e.g. commercial.

_So please take these results with a (cautiously optimistic) pinch of salt!_

| Before      | After      |
|-------------|------------|
| ![before-lh-mainthread][] | ![after-lh-mainthread][] |
| ![before-lh-dupes][] | ![after-lh-dupes][] |

[before-lh-mainthread]: https://user-images.githubusercontent.com/7014230/177219353-078ecd79-4601-4218-a3b3-fe570d1da73b.png
[after-lh-mainthread]: https://user-images.githubusercontent.com/7014230/177219397-7548cb2f-d555-4443-8403-11b27a4fc572.png

[before-lh-dupes]: https://user-images.githubusercontent.com/7014230/177221864-5757b790-09fc-42e7-abcf-e7cd7fceff07.png
[after-lh-dupes]: https://user-images.githubusercontent.com/7014230/177221449-235c15e5-cd70-4334-ad46-d94bb23e2892.png

