### PR TITLE
AR `getBranding`

### DIFF
--- a/apps-rendering/src/capi.test.ts
+++ b/apps-rendering/src/capi.test.ts
@@ -8,7 +8,7 @@ describe('server logic runs as expected', () => {
 		const capiUrl = capiEndpoint(articleId, key);
 
 		expect(capiUrl).toEqual(
-			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CinternalShortId%2CliveBloggingNow%2ClastModified&show-tags=all&show-blocks=all&show-elements=all&show-related=true&show-references=all',
+			'https://content.guardianapis.com/cities/2019/sep/13/reclaimed-lakes-and-giant-airports-how-mexico-city-might-have-looked?format=thrift&api-key=TEST_KEY&show-atoms=all&show-fields=headline%2Cstandfirst%2CbylineHtml%2CfirstPublicationDate%2CshouldHideAdverts%2CshouldHideReaderRevenue%2CdisplayHint%2CstarRating%2Ccommentable%2CinternalShortId%2CliveBloggingNow%2ClastModified%2CisInappropriateForSponsorship&show-tags=all&show-blocks=all&show-elements=all&show-related=true&show-references=all',
 		);
 	});
 });

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -190,6 +190,7 @@ const capiEndpoint = (articleId: string, key: string): string => {
 		'internalShortId',
 		'liveBloggingNow',
 		'lastModified',
+		'isInappropriateForSponsorship',
 	];
 
 	const params = new URLSearchParams({

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -16,7 +16,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { fromNullable, map } from '@guardian/types';
+import { fromNullable, map, none } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
@@ -231,11 +231,28 @@ function getDisplay(content: Content): ArticleDisplay {
 	return ArticleDisplay.Standard;
 }
 
+/**
+ * Some pieces are supported and contain a branding logo. The branding
+ * information is separate from the CAPI model, and is passed to AR by MAPI.
+ * 
+ * Sometimes we don't want to show the branding information, even if it's
+ * present. This is controlled by the `isInappropriateForSponsorship` field
+ * from CAPI, set via a Composer checkbox.
+ * 
+ * This function derives the branding information based on these conditions.
+ * @param renderingRequest The request from MAPI
+ * @returns An optional object containing branding information
+ */
+const getBranding = ({ content, branding }: RenderingRequest): Option<Branding> =>
+	content.fields?.isInappropriateForSponsorship === true
+		? none
+		: fromNullable(branding)
+
 const itemFields = (
 	context: Context,
 	request: RenderingRequest,
 ): ItemFields => {
-	const { content, branding, commentCount, relatedContent } = request;
+	const { content, commentCount, relatedContent } = request;
 	return {
 		theme: themeFromString(content.pillarId),
 		display: getDisplay(content),
@@ -259,7 +276,7 @@ const itemFields = (
 		tags: content.tags,
 		shouldHideReaderRevenue:
 			content.fields?.shouldHideReaderRevenue ?? false,
-		branding: fromNullable(branding),
+		branding: getBranding(request),
 		internalShortId: fromNullable(content.fields?.internalShortId),
 		commentCount: fromNullable(commentCount),
 		relatedContent: pipe(

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -234,19 +234,22 @@ function getDisplay(content: Content): ArticleDisplay {
 /**
  * Some pieces are supported and contain a branding logo. The branding
  * information is separate from the CAPI model, and is passed to AR by MAPI.
- * 
+ *
  * Sometimes we don't want to show the branding information, even if it's
  * present. This is controlled by the `isInappropriateForSponsorship` field
  * from CAPI, set via a Composer checkbox.
- * 
+ *
  * This function derives the branding information based on these conditions.
  * @param renderingRequest The request from MAPI
  * @returns An optional object containing branding information
  */
-const getBranding = ({ content, branding }: RenderingRequest): Option<Branding> =>
+const getBranding = ({
+	content,
+	branding,
+}: RenderingRequest): Option<Branding> =>
 	content.fields?.isInappropriateForSponsorship === true
 		? none
-		: fromNullable(branding)
+		: fromNullable(branding);
 
 const itemFields = (
 	context: Context,


### PR DESCRIPTION
## Why?

Some pieces are supported and contain a branding logo. The branding information is separate from the CAPI model, and is passed to AR by MAPI.

Sometimes we don't want to show the branding information, even if it's present. This is controlled by the `isInappropriateForSponsorship` field from CAPI, set via a Composer checkbox.

This PR adds a function that derives the branding information based on these conditions.

## Changes

- Add `getBranding` function
- Respect the `isInappropriateForSponsorship` field
