### PR TITLE
Dblatcher/footer promotes daily newsletter

### DIFF
--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -60,10 +60,10 @@ const emailSignup = css`
 		width: 247px;
 	}
 	${between.leftCol.and.wide} {
-		width: 300px;
+		width: 325px;
 	}
 	${from.wide} {
-		width: 460px;
+		width: 498px;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -239,13 +239,13 @@ const year = new Date().getFullYear();
 const decideSignupLink = (edition: EditionId): string => {
 	switch (edition) {
 		case 'US':
-			return 'https://www.theguardian.com/info/2015/dec/08/daily-email-us';
+			return 'https://www.theguardian.com/info/2018/sep/17/guardian-us-morning-briefing-sign-up-to-stay-informed';
 		case 'AU':
-			return 'https://www.theguardian.com/info/2015/dec/08/daily-email-au';
+			return 'https://www.theguardian.com/world/guardian-australia-morning-mail/2014/jun/24/-sp-guardian-australias-morning-mail-subscribe-by-email';
 		case 'UK':
 		case 'INT': // There's no international version so we default to UK
 		default:
-			return 'https://www.theguardian.com/info/2015/dec/08/daily-email-uk';
+			return 'https://www.theguardian.com/global/ng-interactive/2022/apr/13/first-edition-sign-up-guardian';
 	}
 };
 
@@ -282,8 +282,8 @@ export const Footer = ({
 		<div css={footerItemContainers}>
 			<div css={emailSignup}>
 				<div>
-					All the day's headlines and highlights from the Guardian,
-					direct to you every morning
+					Original reporting and incisive analysis, direct from the
+					Guardian every morning
 				</div>
 				<LinkButton
 					size="small"

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -60,10 +60,10 @@ const emailSignup = css`
 		width: 247px;
 	}
 	${between.leftCol.and.wide} {
-		width: 325px;
+		width: 300px;
 	}
 	${from.wide} {
-		width: 498px;
+		width: 460px;
 	}
 `;
 
@@ -166,6 +166,7 @@ const footerItemContainers = css`
 		display: flex;
 	}
 
+	clear: both;
 	width: 100%;
 	padding: 0 10px;
 	position: relative;

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -236,6 +236,8 @@ const FooterLinks = ({
 
 const year = new Date().getFullYear();
 
+// Hard coding the values here is not ideal - ideally, they would sourced from the
+// newsletters API by frontend and included in the request.
 const decideSignupLink = (edition: EditionId): string => {
 	switch (edition) {
 		case 'US':
@@ -246,6 +248,19 @@ const decideSignupLink = (edition: EditionId): string => {
 		case 'INT': // There's no international version so we default to UK
 		default:
 			return 'https://www.theguardian.com/global/ng-interactive/2022/apr/13/first-edition-sign-up-guardian';
+	}
+};
+
+const decideSignupNewsletterName = (edition: EditionId): string => {
+	switch (edition) {
+		case 'US':
+			return 'us-morning-newsletter';
+		case 'AU':
+			return 'morning-mail';
+		case 'UK':
+		case 'INT': // There's no international version so we default to UK
+		default:
+			return 'morning-briefing';
 	}
 };
 
@@ -288,6 +303,9 @@ export const Footer = ({
 				<LinkButton
 					size="small"
 					href={decideSignupLink(editionId)}
+					data-link-name={`footer : ${decideSignupNewsletterName(
+						editionId,
+					)}`}
 					cssOverrides={emailSignupButton}
 					icon={<SvgArrowRightStraight />}
 					iconSide="right"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The link in the footer points to the sign-up pages for the curated daily newsletters (First Edition(UK), Morning Mail(AUS) and First Thing(US)) instead of the guardian headlines newsletters.

Small css change so when the pillar links wrap on (very) narrow screen, the second row will not float to the left of the containers below it.

## Why?

duplicates the change to frontend: https://github.com/guardian/frontend/pull/25182

## Screenshots

| Before      | After      |
|-------------|------------|
| ![www theguardian com_australia-news_2022_jul_04_cargo-ship-stranded-off-sydney-nsw-coast-portland-bay-bulk-carrier](https://user-images.githubusercontent.com/30567854/177334735-57889f24-cbf3-487b-a932-afdce79dd32e.png) | ![localhost_3030_Article_url=https___www theguardian com_australia-news_2022_jul_04_cargo-ship-stranded-off-sydney-nsw-coast-portland-bay-bulk-carrier](https://user-images.githubusercontent.com/30567854/177334639-4650b009-8c42-4a71-9858-2ba4f5a56cf7.png)|
| <img width="323" alt="Screenshot 2022-07-05 at 14 17 01" src="https://user-images.githubusercontent.com/30567854/177337599-3dd37674-242f-4f2f-ad8f-28a0faee0cb3.png"> | <img width="323" alt="Screenshot 2022-07-05 at 14 18 39" src="https://user-images.githubusercontent.com/30567854/177337145-1d812850-dcfe-4c02-b3cf-f9166b0be161.png">  |


