### PR TITLE
Fix: Only show padding bottom if carousel length is greater than 6 on desktop

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -113,6 +113,7 @@ export const KeyEventsCarousel = ({
 	const filteredKeyEvents = keyEvents.filter(isValidKeyEvent);
 	const carouselLength = filteredKeyEvents.length;
 	const shortCarousel = carouselLength <= 4;
+	const longCarousel = carouselLength > 6;
 	return (
 		<>
 			<span id={id} />
@@ -127,12 +128,7 @@ export const KeyEventsCarousel = ({
 					shortCarousel && leftMarginStyles,
 				]}
 			>
-				<ul
-					css={[
-						containerStyles,
-						!shortCarousel && marginBottomStyles,
-					]}
-				>
+				<ul css={[containerStyles, longCarousel && marginBottomStyles]}>
 					{filteredKeyEvents.map((keyEvent, index) => {
 						return (
 							<KeyEventCard
@@ -150,7 +146,7 @@ export const KeyEventsCarousel = ({
 					})}
 				</ul>
 				<Hide until="desktop">
-					{keyEvents.length > 6 && (
+					{longCarousel && (
 						<>
 							<Button
 								hideLabel={true}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Only adds padding bottom to desktop if there are greater than 6 events in the carousel which is when we show buttons below the carousel.  

Also changes the button render logic to use `filtered key events` rather than `key events`. If left unchanged, this could create a bug if there are more `key events` than in `filtered key events`

## Why?
Fixes a bug where carousels with 5 or 6 events had unnecessary padding below it. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/177352633-dcbbd5a8-abca-4a06-8acd-7c89da67f156.png
[after]: https://user-images.githubusercontent.com/20416599/177352652-dcbeadb4-3503-4f20-a7c9-edbd6259b943.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
