### PR TITLE
Fix sponsor logo sizes

### DIFF
--- a/dotcom-rendering/src/model/enhanceCommercialProperties.test.ts
+++ b/dotcom-rendering/src/model/enhanceCommercialProperties.test.ts
@@ -1,0 +1,55 @@
+import { Labs } from '../../fixtures/generated/articles/Labs';
+import { Standard } from '../../fixtures/generated/articles/Standard';
+import { enhanceCommercialProperties } from './enhanceCommercialProperties';
+
+const isNumber = (width: unknown): width is number => typeof width === 'number';
+
+describe('Enhance Branding', () => {
+	it('does not change properties if they have no branding', () => {
+		const { commercialProperties } = Standard;
+		expect(enhanceCommercialProperties(commercialProperties)).toEqual(
+			commercialProperties,
+		);
+	});
+
+	it('should have no widths above 140', () => {
+		const { commercialProperties: partial } = Labs;
+		const commercialProperties: CommercialProperties = {
+			...partial,
+			US: {
+				...partial.US,
+				branding: {
+					brandingType: {
+						name: 'paid-content',
+					},
+					sponsorName: 'Amazon',
+					logo: {
+						src: 'https://static.theguardian.com/commercial/sponsor/04/Oct/2018/6b15ba78-da66-415d-8540-a34cc4d3156b-romanoffs_TT_PO-center.png',
+						dimensions: {
+							width: 280,
+							height: 180,
+						},
+						link: 'https://www.amazon.com/dp/B07FV6K8HF',
+						label: 'Paid for by',
+					},
+					aboutThisLink:
+						'https://www.theguardian.com/info/2016/jan/25/content-funding',
+				},
+			},
+		};
+
+		const dimensionsFail = Object.values(commercialProperties)
+			.map((p) => p.branding?.logo.dimensions.width)
+			.filter(isNumber);
+
+		expect(Math.max(...dimensionsFail)).toBeGreaterThan(140);
+
+		const dimensionsPass = Object.values(
+			enhanceCommercialProperties(commercialProperties),
+		)
+			.map((p) => p.branding?.logo.dimensions.width)
+			.filter(isNumber);
+
+		expect(Math.max(...dimensionsPass)).toBeLessThanOrEqual(140);
+	});
+});

--- a/dotcom-rendering/src/model/enhanceCommercialProperties.ts
+++ b/dotcom-rendering/src/model/enhanceCommercialProperties.ts
@@ -1,0 +1,46 @@
+/**
+ * Sponsorship logo should never be wider than 140px.
+ * This method returns dimensions in the correct aspect ratio,
+ * capped at 140px wide.
+ */
+const cappedDimensions = ({
+	logo: { dimensions },
+}: Branding): { width: number; height: number } => {
+	if (dimensions.width <= 140) return dimensions;
+	const scaling = 140 / dimensions.width;
+	return {
+		width: 140,
+		height: Math.round(dimensions.height * scaling),
+	};
+};
+
+const enhanceEditionCommercialProperties = (
+	properties: EditionCommercialProperties,
+): EditionCommercialProperties => {
+	const { branding } = properties;
+	if (!branding) return properties;
+
+	const dimensions = cappedDimensions(branding);
+	return {
+		...properties,
+		branding: {
+			...branding,
+			logo: {
+				...branding.logo,
+				dimensions,
+			},
+		},
+	};
+};
+
+export const enhanceCommercialProperties = ({
+	UK,
+	US,
+	AU,
+	INT,
+}: CommercialProperties): CommercialProperties => ({
+	UK: enhanceEditionCommercialProperties(UK),
+	US: enhanceEditionCommercialProperties(US),
+	AU: enhanceEditionCommercialProperties(AU),
+	INT: enhanceEditionCommercialProperties(INT),
+});

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral, textSans, until } from '@guardian/source-foundations';
+import { neutral, textSans } from '@guardian/source-foundations';
 import { trackSponsorLogoLinkClick } from '../browser/ga/ga';
 
 const brandingStyle = css`
@@ -12,14 +12,11 @@ const brandingLabelStyle = css`
 `;
 
 const brandingLogoStyle = css`
-	${until.phablet} {
-		max-width: 140px;
-	}
-	max-width: 280px;
-	width: 100%;
 	padding: 10px 0;
+
+	display: block;
 	img {
-		max-width: 100%;
+		display: block;
 	}
 `;
 
@@ -33,11 +30,14 @@ const brandingAboutLink = (palette: Palette) => css`
 	}
 `;
 
-export const Branding: React.FC<{
+type Props = {
 	branding: Branding;
 	palette: Palette;
-}> = ({ branding, palette }) => {
-	if (!branding) return null;
+};
+
+export const Branding = ({ branding, palette }: Props) => {
+	const sponsorId = branding.sponsorName.toLowerCase();
+
 	return (
 		<div css={brandingStyle}>
 			<div css={brandingLabelStyle}>{branding.logo.label}</div>
@@ -47,14 +47,15 @@ export const Branding: React.FC<{
 					data-sponsor={branding.sponsorName.toLowerCase()}
 					rel="nofollow"
 					aria-label={`Visit the ${branding.sponsorName} website`}
-					onClick={() =>
-						trackSponsorLogoLinkClick(
-							branding.sponsorName.toLowerCase(),
-						)
-					}
+					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-cy="branding-logo"
 				>
-					<img src={branding.logo.src} alt={branding.sponsorName} />
+					<img
+						width={branding.logo.dimensions.width}
+						height={branding.logo.dimensions.height}
+						src={branding.logo.src}
+						alt={branding.sponsorName}
+					/>
 				</a>
 			</div>
 

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -2,6 +2,7 @@ import type express from 'express';
 import { Standard as ExampleArticle } from '../../../fixtures/generated/articles/Standard';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceCollections } from '../../model/enhanceCollections';
+import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { extract as extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
@@ -22,6 +23,9 @@ const enhanceCAPIType = (body: Record<string, unknown>): CAPIArticleType => {
 		blocks: enhanceBlocks(data.blocks, data.format),
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),
 		standfirst: enhanceStandfirst(data.standfirst),
+		commercialProperties: enhanceCommercialProperties(
+			data.commercialProperties,
+		),
 	};
 	return CAPIArticle;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the sponsor logo size to a maximum of 140.

Reduce CLS by setting a explicit height. If the logo is oversized, do the math to scale it down.

## Why?

Fixes #5309 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/177353477-457d95c8-f1d0-4312-8333-a1e4d2b80d4d.png
[after]: https://user-images.githubusercontent.com/76776/177353509-a0ee6bce-79db-4c85-acd0-4caae5432a49.png