### PR TITLE
Updated top right ad size reference

### DIFF
--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { adSizes } from '@guardian/commercial-core';
+import { slotSizeMappings as sizeMappings } from '@guardian/commercial-core';
 import { getCookie } from '@guardian/libs';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { ShadyPie } from './ShadyPie';
@@ -75,14 +75,7 @@ export const TopRightAdSlot = ({
 				data-link-name="ad slot right"
 				data-name="right"
 				// mark: 01303e88-ef1f-462d-9b6e-242419435cec
-				data-mobile={[
-					adSizes.outOfPage,
-					adSizes.empty,
-					adSizes.mpu,
-					adSizes.googleCard,
-					adSizes.halfPage,
-					adSizes.fluid,
-				]
+				data-mobile={(sizeMappings.right.mobile || [])
 					.map((size) => size.toString())
 					.join('|')}
 				aria-hidden="true"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changed the way that the top right ads get their sizes to use a standardised pre-defined array instead of cherry picking sizes.
## Why?
Keeping this in line with the way that other ads fetch their sizing info.

