### PR TITLE
Fix: Line height in key event cards

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -16,7 +16,6 @@ interface Props {
 
 const linkStyles = (palette: Palette) => css`
 	text-decoration: none;
-	line-height: 1.35;
 
 	&::before {
 		content: '';
@@ -136,7 +135,7 @@ export const KeyEventCard = ({
 				>
 					{timeAgo(date.getTime())}
 				</time>
-				<span css={textStyles(palette)}>{title}</span>
+				<div css={textStyles(palette)}>{title}</div>
 			</Link>
 		</li>
 	);


### PR DESCRIPTION
## What does this change?
Uses a div instead of a span and removes the custom line height.
## Why?
When using a span the text is given a line height of 150%. By using a div instead, the text styles from source are respected and we get the expected 135% line height. This also means we don't need the custom line height property added earlier in the CSS. 
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:https://user-images.githubusercontent.com/20416599/177368175-1d1884f0-ae6f-4bed-99d3-af67d67a76c6.png
[after]: https://user-images.githubusercontent.com/20416599/177368121-efb5ac4d-6f0f-4f1f-93ea-3aa1df344fd9.png
