### PR TITLE
Fix:  hidden scrollbar on narrow desktop breakpoint for key events carousel

### DIFF
--- a/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterKeyEventsToggle.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, neutral, remSpace } from '@guardian/source-foundations';
+import { from, neutral, remSpace, until } from '@guardian/source-foundations';
 import { ToggleSwitch } from '@guardian/source-react-components-development-kitchen';
 import { useState } from 'react';
 
@@ -14,7 +14,9 @@ const cssOverrides = css`
 
 const toggleWrapperStyles = css`
 	display: flex;
-
+	${until.desktop} {
+		padding-top: ${remSpace[3]};
+	}
 	${from.desktop} {
 		border-top: 1px solid ${neutral[86]};
 	}

--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -29,10 +29,6 @@ const carouselStyles = (palette: Palette) => css`
 	scroll-behavior: smooth;
 	overflow-x: auto;
 	overflow-y: hidden;
-	scrollbar-width: none;
-	&::-webkit-scrollbar {
-		display: none;
-	}
 	margin-right: -10px;
 	${from.tablet} {
 		margin-right: -20px;
@@ -41,6 +37,10 @@ const carouselStyles = (palette: Palette) => css`
 	${from.desktop} {
 		margin-right: 0px;
 		background-color: ${palette.background.keyEventFromDesktop};
+		scrollbar-width: none;
+		&::-webkit-scrollbar {
+			display: none;
+		}
 	}
 `;
 const leftMarginStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Show the horizontal scroll bar on the key events carousel until desktop breakpoint and add `padding-top` to the key events toggle. 

## Why?
Previously we hid the scroll bar as a design choice. However, this means that users without a trackpad who are viewing the key events carousel on desktop on a narrow breakpoint are unable to move left or right. To fix this, we are adding back in the visible scroll bar until desktop breakpoint so users can navigate via this. This PR also adds padding top to the key events toggle until desktop to account for the space now taken up by the scroll bar. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://user-images.githubusercontent.com/20416599/177518218-bce37990-7773-4181-b24b-4b869a2b02c6.png
[before]: https://user-images.githubusercontent.com/20416599/177518237-b355bbc6-6a3f-40ee-8b2a-333dd2485976.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
