### PR TITLE
chore: Add snyk monitoring for main branch

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,57 +1,18 @@
-# This action runs every day at 6 AM, on every push not from dependabot, and every pull_request from dependabot
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
-name: DCR Snyk
+# This action runs snyk monitor on every push to main
+name: Snyk
 
 on:
-    schedule:
-        - cron: '0 6 * * *'
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-        # @dependabot push events have readon-only access and CodeQL needs write access
-        # see: https://github.com/guardian/dotcom-rendering/pull/3883
-        branches-ignore:
-            - "dependabot/**"
-    pull_request:
-        # @dependabot pull_request actions have write access for CodeQL to run
-        branches:
-            - "dependabot/**"
-    workflow_dispatch:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
-    security:
-        name: DCR Snyk
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout branch
-              uses: actions/checkout@v3
-
-            - name: Set command to monitor
-              if: github.ref == 'refs/heads/main'
-              run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
-
-            - name: Run Snyk to check for vulnerabilities
-              uses: snyk/actions/node@0.3.0
-              continue-on-error: true # To make sure that SARIF upload gets called
-              env:
-                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-              with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --file=yarn.lock --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
-                  command: test
-
-            - name: Upload result to GitHub Code Scanning
-              uses: github/codeql-action/upload-sarif@v1
-              with:
-                  sarif_file: snyk-node.sarif
-                  checkout_path: ${{ github.workspace }}/dotcom-rendering
-
-            - name: Run Snyk monitor to update snyk.io
-              if: github.ref == 'refs/heads/main'
-              uses: snyk/actions/node@0.3.0
-              continue-on-error: true # To make sure that SARIF upload gets called
-              env:
-                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-              with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --file=dotcom-rendering/yarn.lock --dev=true --prune-repeated-subdependencies
-                  command: monitor
+  security:
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    with:
+      DEBUG: true
+      ORG: guardian-dotcom-n2y
+      SKIP_NODE: false
+    secrets:
+       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
This PR reliably integrates the repository with the snyk GitHub action which will scan your code’s dependencies and alert you if vulnerabilities are found. This PR has only been raised on repos that have already been tested to make sure scanning will work out of the box. ‘reliably integrated’ means that this action compares the hash of the last commit on main to the one that snyk has, and makes sure that they match.If you think that this repository doesn’t belong to your team, please mark your team as something other than an Admin for this repo before closing the PR, or its highly likely further PRs will be raised.