### PR TITLE
Use DCR's layout components more in #5184

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -24,30 +24,6 @@ import type {
 	CanShowData as RRCanShowData,
 	EpicConfig as RREpicConfig,
 } from './SlotBodyEnd/ReaderRevenueEpic';
-import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
-
-const wrapperStyle = (contentType: string) => css`
-	${contentType.toLowerCase() === 'interactive'
-		? `
-		position: relative;
-		${from.tablet} {
-			max-width: 620px;
-		}
-		${from.desktop} {
-			margin-left: 0px;
-			margin-right: 310px;
-		}
-		${from.leftCol} {
-			margin-left: 150px;
-			padding-left: 10px;
-		}
-		${from.wide} {
-			margin-left: 229px;
-		}
-	`
-		: ''}
-`;
 
 type Props = {
 	contentType: string;
@@ -193,11 +169,7 @@ export const SlotBodyEnd = ({
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount]);
 
 	if (SelectedEpic) {
-		return (
-			<div css={wrapperStyle(contentType)}>
-				<SelectedEpic />
-			</div>
-		);
+		return <SelectedEpic />;
 	}
 
 	return null;

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -22,6 +22,7 @@ import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMeta } from '../components/ArticleMeta';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
+import { ContainerLayout } from '../components/ContainerLayout';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
@@ -36,11 +37,13 @@ import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { Nav } from '../components/Nav/Nav';
 import { OnwardsLower } from '../components/OnwardsLower.importable';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { Standfirst } from '../components/Standfirst';
 import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
+import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { getCurrentPillar } from '../lib/layoutHelpers';
 import {
@@ -48,8 +51,6 @@ import {
 	interactiveLegacyClasses,
 } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
-import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
-import { getContributionsServiceUrl } from '../lib/contributions';
 
 const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -174,19 +175,6 @@ const stretchLines = css`
 	${until.mobileLandscape} {
 		margin-left: -10px;
 		margin-right: -10px;
-	}
-`;
-
-const stretchMetaLines = css`
-	margin: 0 -10px;
-	${from.mobileLandscape} {
-		margin: 0 -20px;
-	}
-	${from.tablet} {
-		margin-right: -40px;
-	}
-	${from.leftCol} {
-		margin-right: -20px;
 	}
 `;
 
@@ -534,73 +522,63 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
 									/>
-
-									<Island clientOnly={true}>
-										<SlotBodyEnd
-											contentType={
-												CAPIArticle.contentType
-											}
-											contributionsServiceUrl={
-												contributionsServiceUrl
-											}
-											idApiUrl={
-												CAPIArticle.config.idApiUrl
-											}
-											isMinuteArticle={
-												CAPIArticle.pageType
-													.isMinuteArticle
-											}
-											isPaidContent={
-												CAPIArticle.pageType
-													.isPaidContent
-											}
-											keywordsId={
-												CAPIArticle.config.keywordIds
-											}
-											pageId={CAPIArticle.pageId}
-											sectionId={
-												CAPIArticle.config.section
-											}
-											sectionName={
-												CAPIArticle.sectionName
-											}
-											shouldHideReaderRevenue={
-												CAPIArticle.shouldHideReaderRevenue
-											}
-											stage={CAPIArticle.config.stage}
-											tags={CAPIArticle.tags}
-										/>
-									</Island>
-									{/* <StraightLines data-print-layout="hide" count={4} /> */}
-									<div css={stretchMetaLines}>
-										<StraightLines
-											count={4}
-											data-print-layout="hide"
-											cssOverrides={css`
-												display: block;
-											`}
-										/>
-									</div>
-									<SubMeta
-										format={format}
-										subMetaKeywordLinks={
-											CAPIArticle.subMetaKeywordLinks
-										}
-										subMetaSectionLinks={
-											CAPIArticle.subMetaSectionLinks
-										}
-										pageId={CAPIArticle.pageId}
-										webUrl={CAPIArticle.webURL}
-										webTitle={CAPIArticle.webTitle}
-										showBottomSocialButtons={
-											CAPIArticle.showBottomSocialButtons
-										}
-										badge={CAPIArticle.badge}
-									/>
 								</ArticleContainer>
 							</GridItem>
 						</InteractiveGrid>
 					</div>
+				</ElementContainer>
+
+				<ContainerLayout
+					sideBorders={true}
+					stretchRight={false}
+					centralBorder="full"
+				>
+					<div
+						css={css`
+							width: 620px;
+						`}
+					>
+						<Island clientOnly={true}>
+							<SlotBodyEnd
+								contentType={CAPIArticle.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={CAPIArticle.config.idApiUrl}
+								isMinuteArticle={
+									CAPIArticle.pageType.isMinuteArticle
+								}
+								isPaidContent={
+									CAPIArticle.pageType.isPaidContent
+								}
+								keywordsId={CAPIArticle.config.keywordIds}
+								pageId={CAPIArticle.pageId}
+								sectionId={CAPIArticle.config.section}
+								sectionName={CAPIArticle.sectionName}
+								shouldHideReaderRevenue={
+									CAPIArticle.shouldHideReaderRevenue
+								}
+								stage={CAPIArticle.config.stage}
+								tags={CAPIArticle.tags}
+							/>
+						</Island>
+						<StraightLines count={4} data-print-layout="hide" />
+					</div>
+				</ContainerLayout>
+
+				<ElementContainer showTopBorder={false}>
+					<SubMeta
+						format={format}
+						subMetaKeywordLinks={CAPIArticle.subMetaKeywordLinks}
+						subMetaSectionLinks={CAPIArticle.subMetaSectionLinks}
+						pageId={CAPIArticle.pageId}
+						webUrl={CAPIArticle.webURL}
+						webTitle={CAPIArticle.webTitle}
+						showBottomSocialButtons={
+							CAPIArticle.showBottomSocialButtons
+						}
+						badge={CAPIArticle.badge}
+					/>
 				</ElementContainer>
 
 				<ElementContainer


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR is proposing change to another PR (https://github.com/guardian/dotcom-rendering/pull/5184), specifically it is proposing the use of DCR's own components, `ContainerLayout` & `ElementContainer` to decide the position of content

## Why?
The specific problem of how much space to have to the left of content at different breakpoints is well known and the solution to this problem has been abstracted and wrappers for this created by the DCR platform. This PR allows these centralised solutions to be used

### Why are we moving content around inside `InteractiveLayout`?
Initially I made comments on @tomrf1 's PR thinking this would be a simple change. But it turned out my simple proposals did not work. The reason was because the grid being used by the interactive layout is different, content is stretched further left and right, so the only way to make this solution work was to break the bottom parts of the article out of the grid and into their own containers.

<img width="698" alt="Screenshot 2022-07-06 at 11 33 41" src="https://user-images.githubusercontent.com/1336821/177534721-83cc246a-dc2d-40c9-8176-f3398be3f01c.png">
