### PR TITLE
Docs: Add instructions for running CI server locally

### DIFF
--- a/dotcom-rendering/docs/testing.md
+++ b/dotcom-rendering/docs/testing.md
@@ -76,6 +76,7 @@ By using mocked data and endpoints, we increase the speed that tests execute at 
 ### How to run locally
 
 Running Cypress locally requires having a DCR server running. To run the CI server locally, you can run `make run-ci`. This command runs `make stop`, followed by `make build-ci` and `make start-ci`. You can run these separate commands yourself instead if you want more control over when the site gets re-built.
+The Cypress server should automatically re-load in response to changes in `.spec.` files, but the CI server will need to be re-built every time you want to update the DCR code itself, as opposed to the spec code. You can re-build by running `make ci-build`, or re-running `make ci-run`.
 
 To run Cypress in interactive mode (visually):
 

--- a/dotcom-rendering/docs/testing.md
+++ b/dotcom-rendering/docs/testing.md
@@ -75,8 +75,7 @@ By using mocked data and endpoints, we increase the speed that tests execute at 
 
 ### How to run locally
 
-Running Cypress locally requires having a DCR server running. To run the CI server locally, you can run `make run-ci`. This command runs `make stop`, followed by `make build-ci` and `make start-ci`. You can run these separate commands yourself instead if you want more control over when the site gets re-built.
-The Cypress server should automatically re-load in response to changes in `.spec.` files, but the CI server will need to be re-built every time you want to update the DCR code itself, as opposed to the spec code. You can re-build by running `make ci-build`, or re-running `make ci-run`.
+Running Cypress locally requires having a DCR server running. To run the CI server locally, you can run `make run-ci`. The Cypress server should automatically re-load in response to changes in `.spec.` files, but the CI server will need to be re-built every time you want to update the DCR code itself, as opposed to the spec code. You can re-build DCR by re-running `make run-ci`.
 
 To run Cypress in interactive mode (visually):
 

--- a/dotcom-rendering/docs/testing.md
+++ b/dotcom-rendering/docs/testing.md
@@ -74,6 +74,9 @@ The down side to these types of tests is that they are slower and have a depende
 By using mocked data and endpoints, we increase the speed that tests execute at and have complete certainty in what to expect from our mocked endpoints. The risk though is that an api might have changed or break and we won't be aware of this.
 
 ### How to run locally
+
+Running Cypress locally requires having a DCR server running. To run the CI server locally, you can run `make run-ci`. This command runs `make stop`, followed by `make build-ci` and `make start-ci`. You can run these separate commands yourself instead if you want more control over when the site gets re-built.
+
 To run Cypress in interactive mode (visually):
 
 ```


### PR DESCRIPTION
## What does this change?

It adds instructions for how to run the CI server locally.

## Why?

The server needs to be running in order to run Cypress tests locally, and currently this process doesn't seem to be documented.
