### PR TITLE
fix: align to the centre of the dot

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -80,7 +80,7 @@ const listItemStyles = (palette: Palette) => css`
 		border-top: 1px dotted ${palette.border.keyEvent};
 		left: 0;
 		right: 0;
-		top: 18px;
+		top: 19px;
 	}
 
 	&:last-child::before {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Nudge the dotted line 1px down.

## Why?

So it’s perfectly centred with the dots.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/177583450-7cb67763-78e2-42c3-ade9-15857f0e6864.png
[after]: https://user-images.githubusercontent.com/76776/177583364-0e12936b-b35f-4adf-95c1-96dedf57bb0d.png
