### PR TITLE
fix(ci): generate .env on TeamCity

### DIFF
--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -42,7 +42,10 @@ else
 		#Code Validation
 		make validate-ci
 
-		#Cypress Tests
+		# Generate .env file
+		make gen-dotenv-ci
+
+		# Cypress Tests
 		# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
 		# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
 		make cypress


### PR DESCRIPTION
## What does this change?

Generate a `.env` as part of our CI script on TeamCity.

## Why?

`main` is failing.