### PR TITLE
update case for the key events title in filter bank

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -112,7 +112,7 @@ export const TopicFilterBank = ({
 			<div css={topicStyles}>
 				{keyEvents?.length && (
 					<FilterButton
-						value={'Key Events'}
+						value={'Key events'}
 						count={keyEvents.length}
 						format={format}
 						isActive={filterKeyEvents}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
small update on the title of `Key events` when it's used within the filters section
## Why?
The change was requested by @BenSullivan-iOS 
## Screenshots


| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/177779848-0433fa15-f38a-4520-8fd1-51e9f8c130d9.png) | ![image](https://user-images.githubusercontent.com/15894063/177779907-23801eaa-64c4-4c48-97b6-92151aceb05a.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
