### PR TITLE
fix: explicit grid column width

### DIFF
--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -215,7 +215,7 @@ const StandardGrid = ({
 				${until.tablet} {
 					grid-column-gap: 0px;
 
-					grid-template-columns: 1fr; /* Main content */
+					grid-template-columns: 100%; /* Main content */
 					${isMatchReport
 						? css`
 								grid-template-areas:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Be explicit that the one column should be exactly 100% of its parent’s width. No wider.

## Why?


We don’t want the size of the main column to be decided by it’s largest children size.

This caused issues with embeds on a page that gets subsequently resized.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/178004355-9ccd849f-acdf-4e96-be32-be74a32f4ad8.png
[after]: https://user-images.githubusercontent.com/76776/178004343-d4b1488b-38bc-4ee2-9649-311712065165.png