### PR TITLE
Dynamo styles

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -8931,7 +8931,7 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "big.js": {
       "version": "5.2.2",
@@ -10088,7 +10088,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.2.0",
@@ -10131,7 +10131,7 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
       "version": "5.4.0",
@@ -12320,7 +12320,7 @@
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
         "inherits": "^2.0.1",
         "obuf": "^1.0.0",
@@ -12429,7 +12429,7 @@
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw=="
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -16336,7 +16336,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.18.1",
@@ -16597,7 +16597,7 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
       "version": "2.0.1",
@@ -16675,7 +16675,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -16697,7 +16697,7 @@
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -16708,12 +16708,12 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "setprototypeof": {
           "version": "1.1.0",
@@ -17174,7 +17174,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "strict-uri-encode": {
       "version": "2.0.0",

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -100,6 +100,9 @@ type Palette = {
 		cardHeadline: Colour;
 		cardByline: Colour;
 		cardKicker: Colour;
+		dynamoHeadline: Colour;
+		dynamoKicker: Colour;
+		dynamoMeta: Colour;
 		linkKicker: Colour;
 		cardStandfirst: Colour;
 		cardFooter: Colour;

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -217,6 +217,7 @@ export const Card = ({
 							containerPalette={containerPalette}
 							webPublicationDate={webPublicationDate}
 							showClock={showClock}
+							isDynamo={isDynamo}
 						/>
 					) : undefined
 				}
@@ -229,6 +230,8 @@ export const Card = ({
 							data-name="comment-count-marker"
 							data-discussion-id={discussionId}
 							data-format={JSON.stringify(format)}
+							data-is-dynamo={isDynamo ? 'true' : undefined}
+							data-container-palette={containerPalette}
 							data-ignore="global-link-styling"
 							data-link-name="Comment count"
 							href={`${linkTo}#comments`}
@@ -319,6 +322,7 @@ export const Card = ({
 								}
 								byline={byline}
 								showByline={showByline}
+								isDynamo={isDynamo}
 							/>
 							{starRating !== undefined ? (
 								<StarRatingComponent rating={starRating} />

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -59,7 +59,7 @@ export type Props = {
 	containerType?: DCRContainerType;
 	showAge?: boolean;
 	discussionId?: string;
-	transparent?: boolean;
+	isDynamo?: boolean;
 };
 
 const StarRatingComponent = ({ rating }: { rating: number }) => (
@@ -186,7 +186,7 @@ export const Card = ({
 	containerType,
 	showAge = false,
 	discussionId,
-	transparent,
+	isDynamo,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -270,7 +270,7 @@ export const Card = ({
 			format={format}
 			containerPalette={containerPalette}
 			containerType={containerType}
-			transparent={transparent}
+			isDynamo={isDynamo}
 		>
 			<CardLink
 				linkTo={linkTo}

--- a/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardAge.tsx
@@ -9,13 +9,20 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	webPublicationDate: string;
 	showClock?: boolean;
+	isDynamo?: boolean;
 };
 
-const ageStyles = (format: ArticleFormat, palette: Palette) => {
+const ageStyles = (
+	format: ArticleFormat,
+	palette: Palette,
+	isDynamo?: boolean,
+) => {
 	return css`
 		${textSans.xxsmall({ lineHeight: 'tight' })};
 		margin-top: -4px;
-		color: ${palette.text.cardFooter};
+		color: ${isDynamo
+			? palette.text.dynamoHeadline
+			: palette.text.cardFooter};
 
 		/* Provide side padding for positioning and also to keep spacing
     between any sibings (like Lines) */
@@ -51,6 +58,7 @@ export const CardAge = ({
 	containerPalette,
 	webPublicationDate,
 	showClock,
+	isDynamo,
 }: Props) => {
 	const displayString = timeAgo(new Date(webPublicationDate).getTime());
 	const palette = decidePalette(format, containerPalette);
@@ -60,7 +68,7 @@ export const CardAge = ({
 	}
 
 	return (
-		<span css={ageStyles(format, palette)}>
+		<span css={ageStyles(format, palette, isDynamo)}>
 			<span>
 				{showClock && <ClockIcon />}
 				<time dateTime={webPublicationDate} data-relativeformat="med">

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -9,7 +9,7 @@ type Props = {
 	format: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
 	containerType?: DCRContainerType;
-	transparent?: boolean;
+	isDynamo?: boolean;
 };
 
 const cardStyles = (
@@ -99,14 +99,14 @@ export const CardWrapper = ({
 	format,
 	containerPalette,
 	containerType,
-	transparent,
+	isDynamo,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
 		<div
 			css={[
 				cardStyles(format, palette, containerType),
-				transparent &&
+				isDynamo &&
 					css`
 						background: transparent;
 					`,

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -16,6 +16,7 @@ const cardStyles = (
 	format: ArticleFormat,
 	palette?: Palette,
 	containerType?: DCRContainerType,
+	isDynamo?: boolean,
 ) => {
 	const cardPalette = palette ?? decidePalette(format);
 	const baseCardStyles = css`
@@ -29,10 +30,13 @@ const cardStyles = (
 
 		/* Styling for top bar */
 		:before {
-			background-color: ${cardPalette.topBar.card};
+			background-color: ${isDynamo
+				? cardPalette.text.dynamoKicker
+				: cardPalette.topBar.card};
 			content: '';
 			height: ${containerType === 'dynamic/package' ? '4px' : '1px'};
 			z-index: 2;
+			width: ${isDynamo ? '25%' : '100%'};
 		}
 
 		:hover .image-overlay {
@@ -105,7 +109,7 @@ export const CardWrapper = ({
 	return (
 		<div
 			css={[
-				cardStyles(format, palette, containerType),
+				cardStyles(format, palette, containerType, isDynamo),
 				isDynamo &&
 					css`
 						background: transparent;

--- a/dotcom-rendering/src/web/components/CardCommentCount.tsx
+++ b/dotcom-rendering/src/web/components/CardCommentCount.tsx
@@ -8,25 +8,28 @@ type Props = {
 	format: ArticleFormat;
 	short: string;
 	long: string;
+	isDynamo?: boolean;
 };
 
-const containerStyles = (palette: Palette) => css`
+const containerStyles = (palette: Palette, isDynamo?: boolean) => css`
 	display: flex;
 	flex-direction: row;
 	${textSans.xxsmall({ lineHeight: 'tight' })};
 	margin-top: -4px;
 	padding-left: 5px;
 	padding-right: 5px;
-	color: ${palette.text.cardFooter};
+	color: ${isDynamo ? palette.text.dynamoHeadline : palette.text.cardFooter};
 `;
 
-const svgStyles = (palette: Palette) => css`
+const svgStyles = (palette: Palette, isDynamo?: boolean) => css`
 	svg {
 		margin-bottom: -5px;
 		height: 14px;
 		width: 14px;
 		margin-right: 2px;
-		fill: ${palette.text.cardFooter};
+		fill: ${isDynamo
+			? palette.text.dynamoHeadline
+			: palette.text.cardFooter};
 	}
 `;
 
@@ -51,11 +54,12 @@ export const CardCommentCount = ({
 	format,
 	short,
 	long,
+	isDynamo,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
-		<div css={containerStyles(palette)}>
-			<div css={svgStyles(palette)}>
+		<div css={containerStyles(palette, isDynamo)}>
+			<div css={svgStyles(palette, isDynamo)}>
 				<CommentIcon />
 			</div>
 			<div css={longStyles} aria-hidden="true">

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -211,6 +211,9 @@ export const CardHeadline = ({
 	isDynamo,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
+	const kickerColour = isDynamo
+		? palette.text.dynamoKicker
+		: palette.text.cardKicker;
 	return (
 		<>
 			<h4
@@ -236,16 +239,12 @@ export const CardHeadline = ({
 					{kickerText && (
 						<Kicker
 							text={kickerText}
-							palette={palette}
+							color={kickerColour}
 							showPulsingDot={showPulsingDot}
 							showSlash={showSlash}
-							inCard={true}
-							isDynamo={isDynamo}
 						/>
 					)}
-					{showQuotes && (
-						<QuoteIcon colour={palette.text.cardKicker} />
-					)}
+					{showQuotes && <QuoteIcon colour={kickerColour} />}
 
 					<span
 						css={css`

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -23,6 +23,7 @@ type Props = {
 	showByline?: boolean;
 	showLine?: boolean; // If true a short line is displayed above, used for sublinks
 	linkTo?: string; // If provided, the headline is wrapped in a link
+	isDynamo?: boolean;
 };
 
 const fontStyles = ({
@@ -207,6 +208,7 @@ export const CardHeadline = ({
 	showByline,
 	showLine,
 	linkTo,
+	isDynamo,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
@@ -238,6 +240,7 @@ export const CardHeadline = ({
 							showPulsingDot={showPulsingDot}
 							showSlash={showSlash}
 							inCard={true}
+							isDynamo={isDynamo}
 						/>
 					)}
 					{showQuotes && (
@@ -246,7 +249,9 @@ export const CardHeadline = ({
 
 					<span
 						css={css`
-							color: ${palette.text.cardHeadline};
+							color: ${isDynamo
+								? palette.text.dynamoHeadline
+								: palette.text.cardHeadline};
 						`}
 						className="show-underline"
 					>

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -175,6 +175,7 @@ export const ContainerLayout = ({
 							fontColour={fontColour || overrides?.text.container}
 							description={description}
 							url={url}
+							containerPalette={containerPalette}
 							showDateHeader={showDateHeader}
 							editionId={editionId}
 						/>

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -3,10 +3,10 @@ import {
 	between,
 	from,
 	headline,
+	news,
 	space,
 	text,
 	until,
-	news,
 } from '@guardian/source-foundations';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { getEditionFromId } from '../lib/edition';
@@ -92,7 +92,7 @@ export const ContainerTitle = ({
 		containerPalette && decideContainerOverrides(containerPalette);
 
 	const now = new Date();
-	const locale = editionId && getEditionFromId(editionId)?.locale;
+	const locale = editionId && getEditionFromId(editionId).locale;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -30,7 +30,11 @@ export const Default = () => (
 		padContent={false}
 		centralBorder="partial"
 	>
-		<DynamicPackage trails={trails} showAge={true} />
+		<DynamicPackage
+			trails={trails}
+			showAge={true}
+			containerPalette="LongRunningPalette"
+		/>
 	</ContainerLayout>
 );
 Default.story = {

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -54,7 +54,7 @@ export const DynamicPackage = ({
 						dataLinkName={primary.dataLinkName}
 						snapData={primary.snapData}
 						discussionId={primary.discussionId}
-						transparent={true}
+						isDynamo={true}
 					/>
 				</LI>
 				<LI

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -8,6 +8,7 @@ type Props = {
 	showPulsingDot?: boolean;
 	showSlash?: boolean;
 	inCard?: boolean; // True when headline is showing inside a card (used to handle coloured backgrounds)
+	isDynamo?: boolean;
 };
 
 const kickerStyles = (colour: string) => css`
@@ -24,16 +25,29 @@ const slashStyles = css`
 	}
 `;
 
+const decideColour = ({
+	palette,
+	inCard,
+	isDynamo,
+}: {
+	palette: Palette;
+	inCard?: boolean;
+	isDynamo?: boolean;
+}) => {
+	if (isDynamo) return palette.text.dynamoKicker;
+	if (inCard) return palette.text.cardKicker;
+	return palette.text.linkKicker;
+};
+
 export const Kicker = ({
 	text,
 	palette,
 	showPulsingDot,
 	showSlash = true,
 	inCard,
+	isDynamo,
 }: Props) => {
-	const kickerColour = inCard
-		? palette.text.cardKicker
-		: palette.text.linkKicker;
+	const kickerColour = decideColour({ palette, inCard, isDynamo });
 	return (
 		<span css={kickerStyles(kickerColour)}>
 			{showPulsingDot && <PulsingDot colour={kickerColour} />}

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -4,11 +4,9 @@ import { PulsingDot } from './PulsingDot.importable';
 // Defines a prefix to be used with a headline (e.g. 'Live /')
 type Props = {
 	text: string;
-	palette: Palette;
+	color: string;
 	showPulsingDot?: boolean;
 	showSlash?: boolean;
-	inCard?: boolean; // True when headline is showing inside a card (used to handle coloured backgrounds)
-	isDynamo?: boolean;
 };
 
 const kickerStyles = (colour: string) => css`
@@ -25,32 +23,15 @@ const slashStyles = css`
 	}
 `;
 
-const decideColour = ({
-	palette,
-	inCard,
-	isDynamo,
-}: {
-	palette: Palette;
-	inCard?: boolean;
-	isDynamo?: boolean;
-}) => {
-	if (isDynamo) return palette.text.dynamoKicker;
-	if (inCard) return palette.text.cardKicker;
-	return palette.text.linkKicker;
-};
-
 export const Kicker = ({
 	text,
-	palette,
+	color,
 	showPulsingDot,
 	showSlash = true,
-	inCard,
-	isDynamo,
 }: Props) => {
-	const kickerColour = decideColour({ palette, inCard, isDynamo });
 	return (
-		<span css={kickerStyles(kickerColour)}>
-			{showPulsingDot && <PulsingDot colour={kickerColour} />}
+		<span css={kickerStyles(color)}>
+			{showPulsingDot && <PulsingDot colour={color} />}
 			<span css={showSlash && slashStyles}>{text}</span>
 		</span>
 	);

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -82,7 +82,7 @@ export const LinkHeadline = ({
 			{kickerText && (
 				<Kicker
 					text={kickerText}
-					palette={palette}
+					color={palette.text.linkKicker}
 					showPulsingDot={showPulsingDot}
 					showSlash={showSlash}
 				/>

--- a/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
+++ b/dotcom-rendering/src/web/lib/decideContainerOverrides.ts
@@ -44,7 +44,27 @@ const textCardKicker = (containerPalette: DCRContainerPalette): string => {
 };
 
 const textCardByline = textCardKicker;
-const textContainerDate = textCardKicker;
+
+const textContainerDate = (containerPalette: DCRContainerPalette): string => {
+	switch (containerPalette) {
+		case 'LongRunningPalette':
+			return '#c70000';
+		case 'LongRunningAltPalette':
+			return '#8b0000';
+		case 'SombrePalette':
+			return '#c1d8fc';
+		case 'SombreAltPalette':
+			return '#ff5943';
+		case 'InvestigationPalette':
+			return '#ffe500';
+		case 'BreakingPalette':
+			return '#8b0000';
+		case 'EventPalette':
+			return '#c70000';
+		case 'EventAltPalette':
+			return '#c70000';
+	}
+};
 
 const textCardCommentCount = (
 	containerPalette: DCRContainerPalette,

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1326,13 +1326,13 @@ export const decidePalette = (
 			articleLink: textArticleLink(format),
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline:
-				overrides?.text.cardHeadline || textCardHeadline(format),
-			cardByline: overrides?.text.cardByline || textCardByline(format),
-			cardKicker: overrides?.text.cardKicker || textCardKicker(format),
+				overrides?.text.cardHeadline ?? textCardHeadline(format),
+			cardByline: overrides?.text.cardByline ?? textCardByline(format),
+			cardKicker: overrides?.text.cardKicker ?? textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardStandfirst:
-				overrides?.text.cardStandfirst || textCardStandfirst(format),
-			cardFooter: overrides?.text.cardFooter || textCardFooter(format),
+				overrides?.text.cardStandfirst ?? textCardStandfirst(format),
+			cardFooter: overrides?.text.cardFooter ?? textCardFooter(format),
 			headlineByline: textHeadlineByline(format),
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
@@ -1367,7 +1367,7 @@ export const decidePalette = (
 			seriesTitle: backgroundSeriesTitle(format),
 			sectionTitle: backgroundSectionTitle(format),
 			avatar: backgroundAvatar(format),
-			card: overrides?.background.card || backgroundCard(format),
+			card: overrides?.background.card ?? backgroundCard(format),
 			headline: backgroundHeadline(format),
 			headlineByline: backgroundHeadlineByline(format),
 			bullet: backgroundBullet(format),
@@ -1429,7 +1429,7 @@ export const decidePalette = (
 			filterButton: borderFilterButton(),
 		},
 		topBar: {
-			card: overrides?.topBar.card || topBarCard(format),
+			card: overrides?.topBar.card ?? topBarCard(format),
 		},
 		hover: {
 			headlineByline: hoverHeadlineByline(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1327,12 +1327,17 @@ export const decidePalette = (
 			articleLinkHover: textArticleLinkHover(format),
 			cardHeadline:
 				overrides?.text.cardHeadline ?? textCardHeadline(format),
+			dynamoHeadline:
+				overrides?.text.dynamoHeadline ?? textCardHeadline(format),
 			cardByline: overrides?.text.cardByline ?? textCardByline(format),
 			cardKicker: overrides?.text.cardKicker ?? textCardKicker(format),
+			dynamoKicker:
+				overrides?.text.dynamoKicker ?? textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardStandfirst:
 				overrides?.text.cardStandfirst ?? textCardStandfirst(format),
 			cardFooter: overrides?.text.cardFooter ?? textCardFooter(format),
+			dynamoMeta: overrides?.text.dynamoMeta ?? textCardFooter(format),
 			headlineByline: textHeadlineByline(format),
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces the `isDynamo` prop and then varies styles based upon it

## Why?
The first card of the `dynamic/package` container is special. It is considered to be a 'dynamo' and a number of things change based on this status.

It gets a transparent background, a different width for its topbar and there is a special palette for the colours used. These colours were already present in the code after we did the overrides work for container palettes, this PR ensures these properties are now used.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1207" alt="Screenshot 2022-07-11 at 07 10 11" src="https://user-images.githubusercontent.com/1336821/178200491-54cdf393-d3e4-4f64-a239-acc718789589.png"> | <img width="1207" alt="Screenshot 2022-07-11 at 07 07 29" src="https://user-images.githubusercontent.com/1336821/178200523-1c5e6bd8-66c5-4a22-aebd-344b8f170ef6.png"> |