### PR TITLE
Fix beta text colour for automatic filters

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, headline, space, textSans } from '@guardian/source-foundations';
-import { decidePalette } from '../lib/decidePalette';
 import { FilterButton } from './FilterButton.importable';
 
 type Props = {
@@ -81,8 +80,6 @@ export const TopicFilterBank = ({
 	filterKeyEvents = false,
 	id,
 }: Props) => {
-	const palette = decidePalette(format);
-
 	const selectedTopic = selectedTopics?.[0];
 	const topFiveTopics = availableTopics.slice(0, 5);
 

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -25,10 +25,6 @@ const headlineAccentStyles = css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'tight' })};
 `;
 
-const betaTextStyles = (palette: Palette) => css`
-	color: ${palette.text.keyEvent};
-`;
-
 const topicStyles = css`
 	display: flex;
 	align-items: flex-start;
@@ -105,7 +101,7 @@ export const TopicFilterBank = ({
 			<div css={headlineStyles}>
 				Filters{' '}
 				<span css={headlineAccentStyles}>
-					(<span css={betaTextStyles(palette)}>BETA</span>):
+					(<span>BETA</span>):
 				</span>
 			</div>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR removes the `BETA` text colour style so that it would stay the same colour as it's sibling text `FILTERS`

## Why?
It was initially styled to be red as it was supposed to be a link that would go to a page to get user feedback. But at this stage we haven't yet worked on the user feedback link so the colour needs to stay black for now. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
