### PR TITLE
chore: use allowlist over whitelist

### DIFF
--- a/dotcom-rendering/src/amp/components/Onward.tsx
+++ b/dotcom-rendering/src/amp/components/Onward.tsx
@@ -13,7 +13,7 @@ const innerContainerStyles = css`
 `;
 
 const sectionHasMostViewed = (sectionID: string): boolean => {
-	const whitelist = new Set([
+	const allowlist = new Set([
 		'commentisfree',
 		'sport',
 		'football',
@@ -40,7 +40,7 @@ const sectionHasMostViewed = (sectionID: string): boolean => {
 		'global-development',
 	]);
 
-	return whitelist.has(sectionID);
+	return allowlist.has(sectionID);
 };
 
 export const Onward: React.FC<{

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -16,7 +16,7 @@ type PillarForContainer =
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
 // If you change this list then you should also update ^
 // order matters here (first match wins)
-export const WHITELISTED_TAGS = [
+export const ALLOWLIST_TAGS = [
 	// sport tags
 	'sport/cricket',
 	'sport/rugby-union',
@@ -51,7 +51,7 @@ const firstPopularTag = (
 	pageTags: string | string[],
 	isPaidContent: boolean,
 ) => {
-	// This function looks for the first tag in pageTags, that also exists in our whitelist
+	// This function looks for the first tag in pageTags, that also exists in our allowlist
 	if (!pageTags) {
 		// If there are no page tags we will never find a match so
 		return false;
@@ -65,12 +65,12 @@ const firstPopularTag = (
 		tags = pageTags;
 	}
 
-	const firstTagInWhitelist =
-		tags.find((tag: string) => WHITELISTED_TAGS.includes(tag)) || false;
+	const firstTagInAllowlist =
+		tags.find((tag: string) => ALLOWLIST_TAGS.includes(tag)) || false;
 
 	// For paid content we just return the first tag, otherwise we
-	// filter for the first tag in the whitelist
-	return isPaidContent ? tags[0] : firstTagInWhitelist;
+	// filter for the first tag in the allowlist
+	return isPaidContent ? tags[0] : firstTagInAllowlist;
 };
 
 const onwardsWrapper = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes whitelist => allowlist as per our [inclusive language recommendations](https://github.com/guardian/our-engineering-culture/blob/main/inclusive-communication.md#some-examples).

I have left the [Sentry value](https://github.com/guardian/dotcom-rendering/blob/52befb48891e12880e8baf55bc83e44034cce2e7/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts#L38) as it corresponds with the property they expect from us.

This came about as I was trying to understand how the OnwardsUpper data logic works.

No-op refactor.