### PR TITLE
add missing colon for the automatic filters title

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -96,7 +96,7 @@ export const TopicFilterBank = ({
 	return (
 		<div css={containerStyles}>
 			<div css={headlineStyles}>
-				Filters <span css={headlineAccentStyles}>(BETA)</span>
+				Filters <span css={headlineAccentStyles}>(BETA):</span>
 			</div>
 			<div css={topicStyles}>
 				{keyEvents?.length && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the missing colon `:` to the automatic filters title in the page
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/178465188-cfc54182-3765-448b-8825-0cf5fd8d98a9.png) | ![image](https://user-images.githubusercontent.com/15894063/178465223-8b9e6722-347a-4da4-a1b4-b3fd6cc3467f.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
