### PR TITLE
move colon to after the BETA styling is applied

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -96,7 +96,7 @@ export const TopicFilterBank = ({
 	return (
 		<div css={containerStyles}>
 			<div css={headlineStyles}>
-				Filters <span css={headlineAccentStyles}>(BETA):</span>
+				Filters <span css={headlineAccentStyles}>(BETA)</span>:
 			</div>
 			<div css={topicStyles}>
 				{keyEvents?.length && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Move the colon out of the span where `BETA` styling exists
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/178467691-a015c3ce-29f1-4d7f-9bcb-7ee10175ad70.png) | ![image](https://user-images.githubusercontent.com/15894063/178467651-4750d35e-270d-4fa5-9c6d-26a004483724.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
