### PR TITLE
refactor: Add a `FrontCard` component that provides sensible defaults for Cards being used on Fronts

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -19,39 +18,15 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI padSides={true} percentage="75%">
-					<Card
+					<FrontCard
+						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={primary.url}
-						format={primary.format}
-						headlineText={primary.headline}
-						trailText={primary.trailText}
+						//Overrides
 						headlineSize="large"
-						byline={primary.byline}
-						showByline={primary.showByline}
-						showQuotes={
-							primary.format.design === ArticleDesign.Comment ||
-							primary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={primary.webPublicationDate}
-						kickerText={primary.kickerText}
-						showPulsingDot={
-							primary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={primary.image}
 						imagePosition="right"
 						imagePositionOnMobile="top"
 						imageSize="large"
-						mediaType={primary.mediaType}
-						mediaDuration={primary.mediaDuration}
-						starRating={primary.starRating}
-						branding={primary.branding}
-						supportingContent={primary.supportingContent}
-						dataLinkName={primary.dataLinkName}
-						snapData={primary.snapData}
-						discussionId={primary.discussionId}
 					/>
 				</LI>
 				<LI
@@ -60,35 +35,10 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 					showTopMarginWhenStacked={true}
 					percentage="25%"
 				>
-					<Card
+					<FrontCard
+						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={secondary.url}
-						format={secondary.format}
-						headlineText={secondary.headline}
-						headlineSize="medium"
-						byline={secondary.byline}
-						showByline={secondary.showByline}
-						showQuotes={
-							secondary.format.design === ArticleDesign.Comment ||
-							secondary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={secondary.webPublicationDate}
-						kickerText={secondary.kickerText}
-						showPulsingDot={
-							secondary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={secondary.image}
-						mediaType={secondary.mediaType}
-						mediaDuration={secondary.mediaDuration}
-						starRating={secondary.starRating}
-						branding={secondary.branding}
-						supportingContent={secondary.supportingContent}
-						dataLinkName={secondary.dataLinkName}
-						snapData={secondary.snapData}
-						discussionId={secondary.discussionId}
 					/>
 				</LI>
 			</UL>
@@ -103,37 +53,10 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 							showTopMarginWhenStacked={cardIndex > 0}
 							showDivider={cardIndex > 0}
 						>
-							<Card
+							<FrontCard
+								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								linkTo={card.url}
-								format={card.format}
-								headlineText={card.headline}
-								headlineSize="medium"
-								byline={card.byline}
-								showByline={card.showByline}
-								showQuotes={
-									card.format.design ===
-										ArticleDesign.Comment ||
-									card.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={card.webPublicationDate}
-								kickerText={card.kickerText}
-								showPulsingDot={
-									card.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								imageUrl={card.image}
-								mediaType={card.mediaType}
-								mediaDuration={card.mediaDuration}
-								starRating={card.starRating}
-								branding={card.branding}
-								supportingContent={card.supportingContent}
-								dataLinkName={card.dataLinkName}
-								snapData={card.snapData}
-								discussionId={card.discussionId}
 							/>
 						</LI>
 					);
@@ -155,41 +78,13 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 										cardIndex < smallCards.length - 1
 									}
 								>
-									<Card
+									<FrontCard
+										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										linkTo={card.url}
-										format={card.format}
-										headlineText={card.headline}
+										//Overrides
 										headlineSize="small"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										starRating={card.starRating}
-										branding={card.branding}
-										supportingContent={
-											card.supportingContent
-										}
-										dataLinkName={card.dataLinkName}
-										snapData={card.snapData}
-										discussionId={card.discussionId}
+										imageUrl={undefined}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -27,6 +27,7 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 						imagePosition="right"
 						imagePositionOnMobile="top"
 						imageSize="large"
+						supportingContent={primary.supportingContent}
 					/>
 				</LI>
 				<LI
@@ -39,6 +40,8 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						// Overrides
+						supportingContent={secondary.supportingContent}
 					/>
 				</LI>
 			</UL>
@@ -57,6 +60,8 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								// Overrides
+								supportingContent={card.supportingContent}
 							/>
 						</LI>
 					);
@@ -85,6 +90,9 @@ export const DynamicFast = ({ trails, containerPalette, showAge }: Props) => {
 										//Overrides
 										headlineSize="small"
 										imageUrl={undefined}
+										supportingContent={
+											card.supportingContent
+										}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -24,7 +24,6 @@ export const DynamicPackage = ({
 						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						//Overrides
 						containerType="dynamic/package"
 						headlineSize="huge"
 						imagePosition="bottom"
@@ -56,7 +55,6 @@ export const DynamicPackage = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										//Overrides
 										containerType="dynamic/package"
 										imageUrl={
 											// Always show the image on the first card and only

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -25,6 +25,7 @@ export const DynamicPackage = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 						//Overrides
+						containerType="dynamic/package"
 						headlineSize="huge"
 						imagePosition="bottom"
 						imagePositionOnMobile="bottom"

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -21,39 +20,15 @@ export const DynamicPackage = ({
 		<>
 			<UL direction="row">
 				<LI padSides={true} percentage="75%">
-					<Card
+					<FrontCard
+						trail={primary}
 						containerPalette={containerPalette}
-						containerType="dynamic/package"
 						showAge={showAge}
-						linkTo={primary.url}
-						format={primary.format}
-						headlineText={primary.headline}
+						//Overrides
 						headlineSize="huge"
-						byline={primary.byline}
-						showByline={primary.showByline}
-						showQuotes={
-							primary.format.design === ArticleDesign.Comment ||
-							primary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={primary.webPublicationDate}
-						kickerText={primary.kickerText}
-						showPulsingDot={
-							primary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={primary.image}
 						imagePosition="bottom"
 						imagePositionOnMobile="bottom"
 						imageSize="large"
-						mediaType={primary.mediaType}
-						mediaDuration={primary.mediaDuration}
-						starRating={primary.starRating}
-						branding={primary.branding}
-						supportingContent={primary.supportingContent}
-						dataLinkName={primary.dataLinkName}
-						snapData={primary.snapData}
-						discussionId={primary.discussionId}
 						isDynamo={true}
 					/>
 				</LI>
@@ -75,32 +50,12 @@ export const DynamicPackage = ({
 									}
 									padBottomOnMobile={false}
 								>
-									<Card
+									<FrontCard
+										trail={card}
 										containerPalette={containerPalette}
-										containerType="dynamic/package"
 										showAge={showAge}
-										linkTo={card.url}
-										format={card.format}
-										headlineText={card.headline}
-										headlineSize="medium"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
+										//Overrides
+										containerType="dynamic/package"
 										imageUrl={
 											// Always show the image on the first card and only
 											// on the second if there are two items in two
@@ -109,16 +64,6 @@ export const DynamicPackage = ({
 												? card.image
 												: undefined
 										}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										starRating={card.starRating}
-										branding={card.branding}
-										supportingContent={
-											card.supportingContent
-										}
-										dataLinkName={card.dataLinkName}
-										snapData={card.snapData}
-										discussionId={card.discussionId}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -29,6 +29,7 @@ export const DynamicPackage = ({
 						imagePosition="bottom"
 						imagePositionOnMobile="bottom"
 						imageSize="large"
+						supportingContent={primary.supportingContent}
 						isDynamo={true}
 					/>
 				</LI>
@@ -63,6 +64,9 @@ export const DynamicPackage = ({
 											remaining.length === 2
 												? card.image
 												: undefined
+										}
+										supportingContent={
+											card.supportingContent
 										}
 									/>
 								</LI>

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -24,39 +23,15 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI padSides={true} percentage="75%">
-					<Card
+					<FrontCard
+						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={primary.url}
-						format={primary.format}
-						headlineText={primary.headline}
-						trailText={primary.trailText}
+						//Overrides
 						headlineSize="large"
-						byline={primary.byline}
-						showByline={primary.showByline}
-						showQuotes={
-							primary.format.design === ArticleDesign.Comment ||
-							primary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={primary.webPublicationDate}
-						kickerText={primary.kickerText}
-						showPulsingDot={
-							primary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={primary.image}
 						imagePosition="right"
 						imagePositionOnMobile="top"
 						imageSize="large"
-						mediaType={primary.mediaType}
-						mediaDuration={primary.mediaDuration}
-						starRating={primary.starRating}
-						branding={primary.branding}
-						supportingContent={primary.supportingContent}
-						dataLinkName={primary.dataLinkName}
-						snapData={primary.snapData}
-						discussionId={primary.discussionId}
 					/>
 				</LI>
 				<LI
@@ -65,35 +40,10 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 					showTopMarginWhenStacked={true}
 					percentage="25%"
 				>
-					<Card
+					<FrontCard
+						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={secondary.url}
-						format={secondary.format}
-						headlineText={secondary.headline}
-						headlineSize="medium"
-						byline={secondary.byline}
-						showByline={secondary.showByline}
-						showQuotes={
-							secondary.format.design === ArticleDesign.Comment ||
-							secondary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={secondary.webPublicationDate}
-						kickerText={secondary.kickerText}
-						showPulsingDot={
-							secondary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={secondary.image}
-						mediaType={secondary.mediaType}
-						mediaDuration={secondary.mediaDuration}
-						starRating={secondary.starRating}
-						branding={secondary.branding}
-						supportingContent={secondary.supportingContent}
-						dataLinkName={secondary.dataLinkName}
-						snapData={secondary.snapData}
-						discussionId={secondary.discussionId}
 					/>
 				</LI>
 			</UL>
@@ -112,48 +62,11 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 										cardIndex < bigCards.length
 									}
 								>
-									<Card
+									<FrontCard
+										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										linkTo={card.url}
-										format={card.format}
-										trailText={
-											card.supportingContent
-												? undefined
-												: card.trailText
-										}
-										headlineText={card.headline}
-										headlineSize="medium"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										imageUrl={card.image}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										starRating={card.starRating}
-										branding={card.branding}
-										supportingContent={
-											card.supportingContent
-										}
 										imagePositionOnMobile="none"
-										dataLinkName={card.dataLinkName}
-										snapData={card.snapData}
-										discussionId={card.discussionId}
 									/>
 								</LI>
 							);
@@ -174,41 +87,13 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 									}
 									padBottomOnMobile={false}
 								>
-									<Card
+									<FrontCard
+										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										linkTo={card.url}
-										format={card.format}
-										headlineText={card.headline}
-										imageUrl={card.image}
-										imagePosition="left"
-										imageSize="small"
+										//Overrides
 										headlineSize="small"
-										byline={card.byline}
-										showByline={card.showByline}
-										showQuotes={
-											card.format.design ===
-												ArticleDesign.Comment ||
-											card.format.design ===
-												ArticleDesign.Letter
-										}
-										webPublicationDate={
-											card.webPublicationDate
-										}
-										kickerText={card.kickerText}
-										showPulsingDot={
-											card.format.design ===
-											ArticleDesign.LiveBlog
-										}
-										showSlash={true}
-										showClock={false}
-										mediaType={card.mediaType}
-										mediaDuration={card.mediaDuration}
-										starRating={card.starRating}
-										branding={card.branding}
-										dataLinkName={card.dataLinkName}
-										snapData={card.snapData}
-										discussionId={card.discussionId}
+										imagePosition="left"
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -27,7 +27,6 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						//Overrides
 						headlineSize="large"
 						imagePosition="right"
 						imagePositionOnMobile="top"
@@ -45,7 +44,6 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						// Overrides
 						supportingContent={secondary.supportingContent}
 					/>
 				</LI>
@@ -98,7 +96,6 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										//Overrides
 										headlineSize="small"
 										imagePosition="left"
 										supportingContent={

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -32,6 +32,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						imagePosition="right"
 						imagePositionOnMobile="top"
 						imageSize="large"
+						supportingContent={primary.supportingContent}
 					/>
 				</LI>
 				<LI
@@ -44,6 +45,8 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						// Overrides
+						supportingContent={secondary.supportingContent}
 					/>
 				</LI>
 			</UL>
@@ -66,6 +69,10 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
+										// Overrides
+										supportingContent={
+											card.supportingContent
+										}
 										imagePositionOnMobile="none"
 									/>
 								</LI>
@@ -94,6 +101,9 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 										//Overrides
 										headlineSize="small"
 										imagePosition="left"
+										supportingContent={
+											card.supportingContent
+										}
 									/>
 								</LI>
 							);

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -26,7 +26,6 @@ export const FixedLargeSlowXIV = ({
 						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						//Overrides
 						headlineSize="large"
 						imagePosition="right"
 						imagePositionOnMobile="top"
@@ -55,7 +54,6 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								//Overrides
 								headlineSize="small"
 							/>
 						</LI>
@@ -83,7 +81,6 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								//Overrides
 								headlineSize="small"
 								imageUrl={undefined}
 							/>

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -23,67 +22,22 @@ export const FixedLargeSlowXIV = ({
 		<>
 			<UL direction="row" padBottom={true}>
 				<LI padSides={true} percentage="75%" padBottomOnMobile={true}>
-					<Card
+					<FrontCard
+						trail={primary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={primary.url}
-						format={primary.format}
-						headlineText={primary.headline}
-						trailText={primary.trailText}
+						//Overrides
 						headlineSize="large"
-						byline={primary.byline}
-						showByline={primary.showByline}
-						showQuotes={
-							primary.format.design === ArticleDesign.Comment ||
-							primary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={primary.webPublicationDate}
-						kickerText={primary.kickerText}
-						showPulsingDot={
-							primary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={primary.image}
 						imagePosition="right"
 						imagePositionOnMobile="top"
 						imageSize="large"
-						mediaType={primary.mediaType}
-						mediaDuration={primary.mediaDuration}
-						starRating={primary.starRating}
-						branding={primary.branding}
-						snapData={primary.snapData}
-						discussionId={primary.discussionId}
 					/>
 				</LI>
 				<LI padSides={true} showDivider={true} percentage="25%">
-					<Card
+					<FrontCard
+						trail={secondary}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						linkTo={secondary.url}
-						format={secondary.format}
-						headlineText={secondary.headline}
-						headlineSize="medium"
-						byline={secondary.byline}
-						showByline={secondary.showByline}
-						showQuotes={
-							secondary.format.design === ArticleDesign.Comment ||
-							secondary.format.design === ArticleDesign.Letter
-						}
-						webPublicationDate={secondary.webPublicationDate}
-						kickerText={secondary.kickerText}
-						showPulsingDot={
-							secondary.format.design === ArticleDesign.LiveBlog
-						}
-						showSlash={true}
-						showClock={false}
-						imageUrl={secondary.image}
-						mediaType={secondary.mediaType}
-						mediaDuration={secondary.mediaDuration}
-						starRating={secondary.starRating}
-						branding={secondary.branding}
-						snapData={secondary.snapData}
-						discussionId={secondary.discussionId}
 					/>
 				</LI>
 			</UL>
@@ -97,37 +51,12 @@ export const FixedLargeSlowXIV = ({
 							key={card.url}
 							padBottomOnMobile={cardIndex != 3}
 						>
-							<Card
+							<FrontCard
+								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								linkTo={card.url}
-								format={card.format}
-								headlineText={card.headline}
+								//Overrides
 								headlineSize="small"
-								imageUrl={card.image}
-								imagePosition="top"
-								byline={card.byline}
-								showByline={card.showByline}
-								showQuotes={
-									card.format.design ===
-										ArticleDesign.Comment ||
-									card.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={card.webPublicationDate}
-								kickerText={card.kickerText}
-								showPulsingDot={
-									card.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								mediaType={card.mediaType}
-								mediaDuration={card.mediaDuration}
-								starRating={card.starRating}
-								branding={card.branding}
-								discussionId={card.discussionId}
-								dataLinkName={card.dataLinkName}
-								snapData={card.snapData}
 							/>
 						</LI>
 					);
@@ -150,37 +79,13 @@ export const FixedLargeSlowXIV = ({
 							}
 							key={card.url}
 						>
-							<Card
+							<FrontCard
+								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								linkTo={card.url}
-								format={card.format}
-								headlineText={card.headline}
+								//Overrides
 								headlineSize="small"
 								imageUrl={undefined}
-								imagePosition="top"
-								byline={card.byline}
-								showByline={card.showByline}
-								showQuotes={
-									card.format.design ===
-										ArticleDesign.Comment ||
-									card.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={card.webPublicationDate}
-								kickerText={card.kickerText}
-								showPulsingDot={
-									card.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								mediaType={card.mediaType}
-								mediaDuration={card.mediaDuration}
-								starRating={card.starRating}
-								branding={card.branding}
-								discussionId={card.discussionId}
-								dataLinkName={card.dataLinkName}
-								snapData={card.snapData}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -32,7 +32,6 @@ export const FixedMediumSlowVI = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								//Overrides
 								headlineSize={index === 0 ? 'large' : 'medium'}
 								imagePosition={index === 0 ? 'right' : 'top'}
 								imagePositionOnMobile={
@@ -57,7 +56,6 @@ export const FixedMediumSlowVI = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								//Overrides
 								headlineSize="small"
 							/>
 						</LI>

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -29,44 +28,17 @@ export const FixedMediumSlowVI = ({
 							padBottomOnMobile={index === 0 ? true : false}
 							percentage={index === 0 ? '75%' : '25%'}
 						>
-							<Card
+							<FrontCard
+								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								linkTo={trail.url}
-								format={trail.format}
-								headlineText={trail.headline}
+								//Overrides
 								headlineSize={index === 0 ? 'large' : 'medium'}
-								byline={trail.byline}
-								showByline={trail.showByline}
-								showQuotes={
-									trail.format.design ===
-										ArticleDesign.Comment ||
-									trail.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={trail.webPublicationDate}
-								kickerText={trail.kickerText}
-								trailText={
-									index === 0 ? trail.trailText : undefined
-								}
-								showPulsingDot={
-									trail.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								imageUrl={trail.image}
 								imagePosition={index === 0 ? 'right' : 'top'}
 								imagePositionOnMobile={
 									index === 0 ? 'top' : 'left'
 								}
 								imageSize={index === 0 ? 'large' : 'medium'}
-								mediaType={trail.mediaType}
-								mediaDuration={trail.mediaDuration}
-								starRating={trail.starRating}
-								branding={trail.branding}
-								dataLinkName={trail.dataLinkName}
-								discussionId={trail.discussionId}
-								snapData={trail.snapData}
 							/>
 						</LI>
 					);
@@ -81,39 +53,10 @@ export const FixedMediumSlowVI = ({
 							showDivider={index > 0}
 							padBottomOnMobile={true}
 						>
-							<Card
+							<FrontCard
+								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								linkTo={trail.url}
-								format={trail.format}
-								headlineText={trail.headline}
-								headlineSize="small"
-								byline={trail.byline}
-								showByline={trail.showByline}
-								showQuotes={
-									trail.format.design ===
-										ArticleDesign.Comment ||
-									trail.format.design === ArticleDesign.Letter
-								}
-								webPublicationDate={trail.webPublicationDate}
-								kickerText={trail.kickerText}
-								showPulsingDot={
-									trail.format.design ===
-									ArticleDesign.LiveBlog
-								}
-								showSlash={true}
-								showClock={false}
-								imageUrl={trail.image}
-								imagePosition="top"
-								imagePositionOnMobile="left"
-								imageSize="medium"
-								mediaType={trail.mediaType}
-								mediaDuration={trail.mediaDuration}
-								starRating={trail.starRating}
-								branding={trail.branding}
-								dataLinkName={trail.dataLinkName}
-								snapData={trail.snapData}
-								discussionId={trail.discussionId}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -57,6 +57,8 @@ export const FixedMediumSlowVI = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
+								//Overrides
+								headlineSize="small"
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -30,7 +30,6 @@ export const FixedSmallSlowIII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							//Overrides
 							headlineSize={index === 0 ? 'large' : 'medium'}
 							imagePositionOnMobile={index === 0 ? 'top' : 'left'}
 							trailText={

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -27,36 +26,13 @@ export const FixedSmallSlowIII = ({
 						percentage={index === 0 ? '50%' : '25%'}
 						key={trail.url}
 					>
-						<Card
+						<FrontCard
+							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							linkTo={trail.url}
-							format={trail.format}
-							headlineText={trail.headline}
+							//Overrides
 							headlineSize={index === 0 ? 'large' : 'medium'}
-							byline={trail.byline}
-							showByline={trail.showByline}
-							showQuotes={
-								trail.format.design === ArticleDesign.Comment ||
-								trail.format.design === ArticleDesign.Letter
-							}
-							webPublicationDate={trail.webPublicationDate}
-							kickerText={trail.kickerText}
-							showPulsingDot={
-								trail.format.design === ArticleDesign.LiveBlog
-							}
-							showSlash={true}
-							showClock={false}
-							imageUrl={trail.image}
-							imagePosition="top"
 							imagePositionOnMobile={index === 0 ? 'top' : 'left'}
-							imageSize="medium"
-							mediaType={trail.mediaType}
-							mediaDuration={trail.mediaDuration}
-							starRating={trail.starRating}
-							branding={trail.branding}
-							dataLinkName={trail.dataLinkName}
-							discussionId={trail.discussionId}
 							trailText={
 								index === 0 ? undefined : trail.trailText
 							}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -29,7 +29,6 @@ export const FixedSmallSlowIV = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							// Overrides
 							imageSize="medium"
 						/>
 					</LI>

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -1,7 +1,6 @@
-import { ArticleDesign } from '@guardian/libs';
-import { Card } from './Card/Card';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -26,37 +25,12 @@ export const FixedSmallSlowIV = ({
 						showDivider={index > 0}
 						padBottomOnMobile={true}
 					>
-						<Card
+						<FrontCard
+							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							linkTo={trail.url}
-							format={trail.format}
-							headlineText={trail.headline}
-							headlineSize="medium"
-							byline={trail.byline}
-							showByline={trail.showByline}
-							showQuotes={
-								trail.format.design === ArticleDesign.Comment ||
-								trail.format.design === ArticleDesign.Letter
-							}
-							webPublicationDate={trail.webPublicationDate}
-							kickerText={trail.kickerText}
-							showPulsingDot={
-								trail.format.design === ArticleDesign.LiveBlog
-							}
-							showSlash={true}
-							showClock={false}
-							imageUrl={trail.image}
-							imagePosition="top"
-							imagePositionOnMobile="left"
+							// Overrides
 							imageSize="medium"
-							mediaType={trail.mediaType}
-							mediaDuration={trail.mediaDuration}
-							starRating={trail.starRating}
-							branding={trail.branding}
-							dataLinkName={trail.dataLinkName}
-							snapData={trail.snapData}
-							discussionId={trail.discussionId}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -18,7 +18,7 @@ type Props = {
  * @param {ImagePositionType} [imagePosition="top"] - Defaults to "top"
  * @param {ImagePositionType} [imagePositionOnMobile="left"] - Defaults to "left"
  * @param {ImageSizeType} [imageSize="medium"] - Defaults to "medium"
- * @param {DCRSupportingContent[]} [imageSize=undefined] - Defaults to undefined, set to trail.supportingContent if you want this card to show sublinks.
+ * @param {DCRSupportingContent[]} [supportingContent=undefined] - Defaults to undefined, set to trail.supportingContent if you want this card to show sublinks.
  */
 export const FrontCard = (props: Props) => {
 	const { trail } = props;

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -8,10 +8,17 @@ type Props = {
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
- * @param {string} [headlineSize="medium"] - Defaults to "medium"
- * @param {string} [imagePosition="top"] - Defaults to "top"
- * @param {string} [imagePositionOnMobile="left"] - Defaults to "left"
- * @param {string} [imageSize="medium"] - Defaults to "medium"
+ *
+ * Any prop used by the original Card can be used in FrontCard to override the defaults.
+ *
+ * Note: Below parameters are not an exhaustive list of params used by FrontCard, rather they are a list of
+ * commonly overridden params to make it easier for a developer to know if they actually need to override these values.
+ *
+ * @param {SmallHeadlineSize} [headlineSize="medium"] - Defaults to "medium"
+ * @param {ImagePositionType} [imagePosition="top"] - Defaults to "top"
+ * @param {ImagePositionType} [imagePositionOnMobile="left"] - Defaults to "left"
+ * @param {ImageSizeType} [imageSize="medium"] - Defaults to "medium"
+ * @param {DCRSupportingContent[]} [imageSize=undefined] - Defaults to undefined, set to trail.supportingContent if you want this card to show sublinks.
  */
 export const FrontCard = (props: Props) => {
 	const { trail } = props;

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -37,7 +37,6 @@ export const FrontCard = (props: Props) => {
 		dataLinkName: trail.dataLinkName,
 		snapData: trail.snapData,
 		discussionId: trail.discussionId,
-		supportingContent: trail.supportingContent,
 	};
 
 	return Card({ ...defaultProps, ...props });

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -1,0 +1,44 @@
+import { ArticleDesign } from '@guardian/libs';
+import type { Props as CardProps } from './Card/Card';
+import { Card } from './Card/Card';
+
+type Props = {
+	trail: TrailType;
+} & Partial<CardProps>;
+
+/**
+ * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
+ * @param {string} [headlineSize=medium]
+ * @property {string} [imagePosition=top]
+ * @property {string} [imagePositionOnMobile=left]
+ * @property {string} [imageSize=medium]
+ */
+export const FrontCard = (props: Props) => {
+	const { trail } = props;
+	const defaultProps: CardProps = {
+		linkTo: trail.url,
+		format: trail.format,
+		headlineText: trail.headline,
+		byline: trail.byline,
+		showByline: trail.showByline,
+		showQuotes:
+			trail.format.design === ArticleDesign.Comment ||
+			trail.format.design === ArticleDesign.Letter,
+		webPublicationDate: trail.webPublicationDate,
+		kickerText: trail.kickerText,
+		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,
+		showSlash: true,
+		showClock: false,
+		imageUrl: trail.image,
+		mediaType: trail.mediaType,
+		mediaDuration: trail.mediaDuration,
+		starRating: trail.starRating,
+		branding: trail.branding,
+		dataLinkName: trail.dataLinkName,
+		snapData: trail.snapData,
+		discussionId: trail.discussionId,
+		supportingContent: trail.supportingContent,
+	};
+
+	return Card({ ...defaultProps, ...props });
+};

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -9,9 +9,9 @@ type Props = {
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
  * @param {string} [headlineSize=medium]
- * @property {string} [imagePosition=top]
- * @property {string} [imagePositionOnMobile=left]
- * @property {string} [imageSize=medium]
+ * @param {string} [imagePosition=top]
+ * @param {string} [imagePositionOnMobile=left]
+ * @param {string} [imageSize=medium]
  */
 export const FrontCard = (props: Props) => {
 	const { trail } = props;

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -21,7 +21,7 @@ type Props = {
  * @param {DCRSupportingContent[]} [supportingContent=undefined] - Defaults to undefined, set to trail.supportingContent if you want this card to show sublinks.
  */
 export const FrontCard = (props: Props) => {
-	const { trail } = props;
+	const { trail, ...cardProps } = props;
 	const defaultProps: CardProps = {
 		linkTo: trail.url,
 		format: trail.format,
@@ -46,5 +46,5 @@ export const FrontCard = (props: Props) => {
 		discussionId: trail.discussionId,
 	};
 
-	return Card({ ...defaultProps, ...props });
+	return Card({ ...defaultProps, ...cardProps });
 };

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -8,10 +8,10 @@ type Props = {
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
- * @param {string} [headlineSize=medium]
- * @param {string} [imagePosition=top]
- * @param {string} [imagePositionOnMobile=left]
- * @param {string} [imageSize=medium]
+ * @param {string} [headlineSize="medium"] - Defaults to "medium"
+ * @param {string} [imagePosition="top"] - Defaults to "top"
+ * @param {string} [imagePositionOnMobile="left"] - Defaults to "left"
+ * @param {string} [imageSize="medium"] - Defaults to "medium"
  */
 export const FrontCard = (props: Props) => {
 	const { trail } = props;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a `FrontCard` wrapper class around the regular `Card` class that provides reasonable defaults used by most Front cards (These defaults can be overriden easily)

## Why?

1. We have a lot of copy-pasted behaviour that will always be the same regardless of Container such as deciding if we should show the Live icon or if we should show the Opinion squiggly lines.
2. Card has a **lot** of props, to the point that just defining a single card in a Container takes up almost an entire viewport which I think has 3 problems:
   1. Hard to understand what the differences are between Cards just by looking at the code.
   2. Easy to make copy paste errors.
   3. Hard to add new features/props to Card without needing to do a lot of prop-fu in all of the Containers (we only have 7 containers at the moment so its not so bad but once we support all of the containers we'll have to edit dozens and dozens of files if we want to add new props)
