### PR TITLE
Increase caption and credit font size to 14px

### DIFF
--- a/apps-rendering/src/components/Credit/index.tsx
+++ b/apps-rendering/src/components/Credit/index.tsx
@@ -22,7 +22,9 @@ const mediaStyles = css`
 `;
 
 const defaultStyles = css`
-	${textSans.xsmall()}
+	${textSans.xsmall({
+		lineHeight: 'regular',
+	})}
 `;
 
 const Credit: FC<Props> = ({ format, credit }) =>

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -38,7 +38,9 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles | undefined =>
 		: undefined;
 
 const textStyles = css`
-	${textSans.xsmall()}
+	${textSans.xsmall({
+		lineHeight: 'regular',
+	})}
 	color: ${neutral[46]};
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Increases the font size of captions (and credits) to `14px`

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="623" alt="Screenshot 2022-07-12 at 17 06 02" src="https://user-images.githubusercontent.com/705427/178540271-eb6e9641-0dfe-4105-a110-017c0d2efc1e.png"> | <img width="622" alt="Screenshot 2022-07-12 at 17 05 31" src="https://user-images.githubusercontent.com/705427/178540143-d24cb1df-7b8c-49af-83d7-c03e21f00d10.png"> |
