### PR TITLE
Add check to recipeMarkup to avoid undefined json-ld

### DIFF
--- a/dotcom-rendering/src/web/server/articleTemplate.ts
+++ b/dotcom-rendering/src/web/server/articleTemplate.ts
@@ -292,7 +292,11 @@ https://workforus.theguardian.com/careers/product-engineering/
 			<body>
                 ${html}
                 ${[...lowPriorityScriptTags].join('\n')}
-				<script type="application/ld+json">${recipeMarkup}</script>
+				${
+					recipeMarkup !== undefined
+						? `<script type="application/ld+json">${recipeMarkup}</script>`
+						: ''
+				}
             </body>
         </html>`;
 };


### PR DESCRIPTION
We are accidentally adding an 'undefined' json-ld script to the page:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/9575458/178547455-ffff3c9e-64b4-4618-9483-5149e63a3a1a.png">

This is upsetting google:
<img width="654" alt="image" src="https://user-images.githubusercontent.com/9575458/178547607-e56b3d98-f7be-4100-be2f-9906e5e85950.png">
<img width="945" alt="image" src="https://user-images.githubusercontent.com/9575458/178547539-64f9a7d0-ff2e-4071-a1c2-de8afc0f8646.png">

This affects all pages that aren't receiving the recipe markup, so we should look to resolve this quickly to avoid any impact on our search rankings!

Before:
2 json LD tags, the second of which is 'undefined'
<img width="943" alt="image" src="https://user-images.githubusercontent.com/9575458/178547969-9e67934d-f533-4445-9d70-55f285561b12.png">

After:
Only 1 json LD tag, which is always populated
<img width="944" alt="image" src="https://user-images.githubusercontent.com/9575458/178547826-f7256ef9-4508-45f2-aef3-94f5d06c673d.png">

