### PR TITLE
add logic for adding the pinned post in the live layout in AR

### DIFF
--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -23,12 +23,13 @@ import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Tags from 'components/Tags';
-import { getFormat } from 'item';
+import { getFormat, Item } from 'item';
 import type { DeadBlog, LiveBlog } from 'item';
 import { toNullable } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import type { FC } from 'react';
 import { articleWidthStyles, darkModeCss, onwardStyles } from 'styles';
+import { OptionKind } from '@guardian/types';
 
 // ----- Component ----- //
 
@@ -111,6 +112,10 @@ const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
 		[],
 	);
 
+const showPinnedPost = (item: LiveBlog | DeadBlog) =>
+	item.pagedBlocks.currentPage.pageNumber === 1 &&
+	item.pinnedBlock.kind === OptionKind.Some;
+
 interface Props {
 	item: LiveBlog | DeadBlog;
 }
@@ -181,6 +186,8 @@ const LiveLayout: FC<Props> = ({ item }) => {
 						`}
 						id="liveblock-container"
 					>
+						{/* This is a placeholder for the pinned post */}
+						{showPinnedPost(item) && <></>}
 						{item.pagedBlocks.currentPage.pageNumber > 1 &&
 							pagination}
 						<LiveBlocks

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -82,6 +82,7 @@ interface LiveBlog extends Fields {
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 	pagedBlocks: LiveBlogPagedBlocks;
+	pinnedBlock: Option<LiveBlock>;
 }
 
 interface DeadBlog extends Fields {
@@ -89,6 +90,7 @@ interface DeadBlog extends Fields {
 	blocks: LiveBlock[];
 	totalBodyBlocks: number;
 	pagedBlocks: LiveBlogPagedBlocks;
+	pinnedBlock: Option<LiveBlock>;
 }
 
 interface Review extends Fields {
@@ -387,6 +389,7 @@ const fromCapiLiveBlog =
 			blocks: parsedBlocks,
 			pagedBlocks,
 			totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
+			pinnedBlock: fromNullable(parsedBlocks.find((b) => b.isPinned)),
 			...itemFields(context, request),
 		};
 	};

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -21,6 +21,7 @@ type LiveBlock = {
 	lastModified: Date;
 	body: Body;
 	contributors: Contributor[];
+	isPinned: Boolean;
 };
 
 // ----- Functions ----- //
@@ -66,6 +67,7 @@ const parse =
 				contributorTags(block.contributors, tags),
 				context,
 			),
+			isPinned: block.attributes.pinned ?? false,
 		});
 	};
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
