### PR TITLE
Replace triangle icon on captions with camera

### DIFF
--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -5,35 +5,38 @@ import { css } from '@emotion/react';
 import { remSpace } from '@guardian/source-foundations';
 import { brandAltText, neutral, text } from '@guardian/source-foundations';
 import { textSans } from '@guardian/source-foundations';
+import { SvgCamera } from '@guardian/source-react-components';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
-import { fill } from '../editorialPalette';
 import { darkModeCss } from '../lib';
 
 // ----- Sub-Components ----- //
 
-interface TriangleProps {
+interface CameraProps {
 	format: ArticleFormat;
 	supportsDarkMode: boolean;
 }
 
-const triangleStyles = (
-	format: ArticleFormat,
-	supportsDarkMode: boolean,
-): SerializedStyles => css`
-	fill: ${fill.icon(format)};
-	height: 0.8em;
+const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	display: inline-block;
+	height: 1.2rem;
+	vertical-align: middle;
 	padding-right: ${remSpace[1]};
 
+	svg {
+		height: 100%;
+		fill: ${text.supporting};
+	}
+
 	${darkModeCss(supportsDarkMode)`
-        fill: ${fill.iconDark(format)};
+        fill: ${brandAltText.supporting};
     `}
 `;
 
-const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
+const Camera: FC<CameraProps> = ({ format, supportsDarkMode }) => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
@@ -41,13 +44,9 @@ const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
 			return null;
 		default:
 			return (
-				<svg
-					css={triangleStyles(format, supportsDarkMode)}
-					viewBox="0 0 10 9"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<polygon points="0,9 5,0 10,9" />
-				</svg>
+				<span css={cameraStyles(supportsDarkMode)}>
+					<SvgCamera />
+				</span>
 			);
 	}
 };
@@ -97,7 +96,7 @@ const FigCaption: FC<Props> = ({ format, supportsDarkMode, children }) => {
 		case OptionKind.Some:
 			return (
 				<figcaption css={getStyles(format, supportsDarkMode)}>
-					<Triangle
+					<Camera
 						format={format}
 						supportsDarkMode={supportsDarkMode}
 					/>

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -12,7 +12,7 @@ import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from '../lib';
-import { fill } from '@guardian/common-rendering/src/editorialPalette';
+import { fill, text } from '@guardian/common-rendering/src/editorialPalette';
 
 // ----- Sub-Components ----- //
 
@@ -72,11 +72,11 @@ type Props = {
 const styles = (supportsDarkMode: boolean) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
-	color: ${neutral[46]};
+	color: ${text.figCaption()};
 
 	${darkModeCss(supportsDarkMode)`
-    color: ${neutral[60]};
-  `}
+    	color: ${text.figCaptionDark()};
+  	`}
 `;
 
 const mediaStyles = (supportsDarkMode: boolean) => css`

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -3,7 +3,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { remSpace } from '@guardian/source-foundations';
-import { brandAltText, neutral, text } from '@guardian/source-foundations';
+import { neutral } from '@guardian/source-foundations';
 import { textSans } from '@guardian/source-foundations';
 import { SvgCamera } from '@guardian/source-react-components';
 import type { ArticleFormat } from '@guardian/libs';
@@ -12,6 +12,7 @@ import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from '../lib';
+import { fill } from '@guardian/common-rendering/src/editorialPalette';
 
 // ----- Sub-Components ----- //
 
@@ -24,7 +25,7 @@ const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	display: inline-block;
 	width: 1.2rem;
 	margin-right: ${remSpace[1]};
-	fill: ${text.supporting};
+	fill: ${fill.cameraCaptionIcon()};
 	position: relative;
 
 	::before {
@@ -41,7 +42,7 @@ const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	}
 
 	${darkModeCss(supportsDarkMode)`
-        fill: ${brandAltText.supporting};
+        fill: ${fill.cameraCaptionIconDark()};
     `}
 `;
 
@@ -71,10 +72,10 @@ type Props = {
 const styles = (supportsDarkMode: boolean) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
-	color: ${text.supporting};
+	color: ${neutral[46]};
 
 	${darkModeCss(supportsDarkMode)`
-    color: ${brandAltText.supporting};
+    color: ${neutral[60]};
   `}
 `;
 

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -22,13 +22,22 @@ interface CameraProps {
 
 const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	display: inline-block;
-	height: 1.2rem;
-	vertical-align: middle;
-	padding-right: ${remSpace[1]};
+	width: 1.2rem;
+	margin-right: ${remSpace[1]};
+	fill: ${text.supporting};
+	position: relative;
+
+	::before {
+		content: ' ';
+		display: block;
+		padding-top: 0.85rem;
+	}
 
 	svg {
-		height: 100%;
-		fill: ${text.supporting};
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
 	}
 
 	${darkModeCss(supportsDarkMode)`

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -20,6 +20,9 @@ import { Colour } from '.';
 
 // ----- Functions ----- //
 
+const cameraCaptionIcon = (): Colour => neutral[46];
+const cameraCaptionIconDark = (): Colour => neutral[60];
+
 const commentCount = (format: ArticleFormat): Colour => {
 	switch (format.theme) {
 		case ArticlePillar.News:
@@ -130,25 +133,27 @@ const richLink = (_format: ArticleFormat): Colour => {
 
 const richLinkDark = (_format: ArticleFormat): Colour => {
 	return neutral[7];
-}
+};
 
 /**
  *  This is applied server-side. When the page loads, client-side JS applies a class name that overrides this style.
  */
- const richLinkSvgPreload = (_format: ArticleFormat): Colour => {
+const richLinkSvgPreload = (_format: ArticleFormat): Colour => {
 	return neutral[7];
-}
+};
 
 /**
  *  This is applied server-side. When the page loads, client-side JS applies a class name that overrides this style.
  */
 const richLinkSvgPreloadDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
-}
+};
 
 // ----- API ----- //
 
 const fill = {
+	cameraCaptionIcon,
+	cameraCaptionIconDark,
 	commentCount,
 	icon,
 	iconDark,

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -632,15 +632,15 @@ const richLink = (format: ArticleFormat): Colour => {
 
 const richLinkDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
-}
+};
 
 const richLinkAnchor = (_format: ArticleFormat): Colour => {
 	return neutral[7];
-}
+};
 
 const richLinkAnchorDark = (_format: ArticleFormat): Colour => {
 	return neutral[60];
-}
+};
 
 const seriesTitleDark = (format: ArticleFormat): Colour => {
 	if (format.display === ArticleDisplay.Immersive) {
@@ -684,6 +684,10 @@ const pagination = (format: ArticleFormat): Colour => {
 	}
 };
 
+const figCaption = (): Colour => neutral[46];
+
+const figCaptionDark = (): Colour => neutral[60];
+
 // ----- API ----- //
 
 const text = {
@@ -698,6 +702,8 @@ const text = {
 	bylineDark,
 	dropCap,
 	dropCapDark,
+	figCaption,
+	figCaptionDark,
 	follow,
 	followDark,
 	headline,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Replaces the triangle icon on captions with the camera icon for AR & Editions

## Screenshots

### AR

| Before      | After      |
|-------------|------------|
| <img width="707" alt="Screenshot 2022-07-13 at 09 03 31" src="https://user-images.githubusercontent.com/705427/178682882-528b3f1c-0b6f-46ac-9147-3c1c07e50568.png"> | <img width="663" alt="Screenshot 2022-07-13 at 09 03 08" src="https://user-images.githubusercontent.com/705427/178682823-b3b72e95-5957-4603-9560-a31cce9d05d9.png"> |

### Editions

| Before      | After      |
|-------------|------------|
| <img width="673" alt="Screenshot 2022-07-13 at 09 04 35" src="https://user-images.githubusercontent.com/705427/178683067-6863838a-e3cb-4d63-8b15-1085cc2e191b.png"> | <img width="675" alt="Screenshot 2022-07-13 at 09 04 06" src="https://user-images.githubusercontent.com/705427/178682985-0a11de14-1a5a-407d-9d6a-4145c28ab03b.png"> |

