### PR TITLE
Feat: hide pinned post when filtering

### DIFF
--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -59,7 +59,8 @@ export const LiveBlogRenderer = ({
 	availableTopics,
 	selectedTopics,
 }: Props) => {
-	const filtered = !!selectedTopics || filterKeyEvents;
+	const filtered =
+		(selectedTopics && selectedTopics.length > 0) || filterKeyEvents;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -59,7 +59,7 @@ export const LiveBlogRenderer = ({
 	availableTopics,
 	selectedTopics,
 }: Props) => {
-	const filtered = selectedTopics?.length || filterKeyEvents;
+	const filtered = !!selectedTopics || filterKeyEvents;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -59,9 +59,11 @@ export const LiveBlogRenderer = ({
 	availableTopics,
 	selectedTopics,
 }: Props) => {
+	const filtered = selectedTopics?.length || filterKeyEvents;
+
 	return (
 		<>
-			{pinnedPost && onFirstPage && (
+			{pinnedPost && onFirstPage && !filtered && (
 				<>
 					<Island clientOnly={true} deferUntil="idle">
 						<EnhancePinnedPost />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides the pinned post when the user is filtering a liveblog.

## Why?
Editorial have requested we hide the pinned post when the user is filtering as it doesn't necessarily relate to the filter in use. 
In order to be consistent, filtering here refers to filtering using the key events toggle or an auto filter button. 


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before-button][] | ![after-button][] |

[before-button]: https://user-images.githubusercontent.com/20416599/178691997-1c7a8d3d-5c75-4c5d-9e56-87e393dd8755.png
[after-button]: https://user-images.githubusercontent.com/20416599/178691791-2b6f195a-3284-4709-aa1c-abff55250565.png


| Before      | After      |
|-------------|------------|
| ![before-toggle][] | ![after-toggle][] |

[before-toggle]: https://user-images.githubusercontent.com/20416599/178692115-782e1dfe-e1e5-44fc-9c0d-71884704fca8.png
[after-toggle]: https://user-images.githubusercontent.com/20416599/178692153-cf863273-c142-4caf-8f19-981f7238a76f.png

<!--
<img width="1473" alt="Screenshot 2022-07-13 at 09 11 42" src="https://user-images.githubusercontent.com/20416599/178688553-d69a32ff-1767-407c-b343-5360c0e160ee.png">

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
