### PR TITLE
GHA: Ignore changes which only affect dotcom docs

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -3,6 +3,7 @@ on:
     push:
         paths-ignore:
             - "apps-rendering/**"
+            - "dotcom-rendering/docs/**"
 
 jobs:
     amp_validation:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -3,6 +3,7 @@ on:
     push:
         paths-ignore:
             - "apps-rendering/**"
+            - "dotcom-rendering/docs/**"
 
 jobs:
     build_check:

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -3,7 +3,7 @@ on:
     push:
         paths-ignore:
             - "apps-rendering/**"
-
+            - "dotcom-rendering/docs/**"
 jobs:
     build_check:
         name: DCR Bundle Analyser

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 name: Chromatic 👓
 on:
   push:
+    paths-ignore:
+      - "dotcom-rendering/docs/**"
 jobs:
   chromatic:
     name: Chromatic

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths-ignore:
       - "apps-rendering/**"
+      - "dotcom-rendering/docs/**"
 
 jobs:
   compressed_size:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - "apps-rendering/**"
+      - "dotcom-rendering/docs/**"
 jobs:
   cypress:
     name: DCR Cypress

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -3,6 +3,7 @@ on:
     push:
         paths-ignore:
             - "apps-rendering/**"
+            - "dotcom-rendering/docs/**"
 
 jobs:
     jest:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths-ignore:
       - "apps-rendering/**"
+      - "dotcom-rendering/docs/**"
 
   # We need to run on "pull_request" to get the PR number in the event.
   # When running on "push", we cannot add a comment to a specific PR.

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - "apps-rendering/**"
+      - "dotcom-rendering/docs/**"
 
 jobs:
   build_check:

--- a/.github/workflows/stories-check.yml
+++ b/.github/workflows/stories-check.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - 'apps-rendering/**'
+      - "dotcom-rendering/docs/**"
 
 jobs:
   build_check:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -3,6 +3,7 @@ on:
     push:
         paths-ignore:
             - "apps-rendering/**"
+            - "dotcom-rendering/docs/**"
 
 jobs:
     typescript:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add `dotcom-rendering/docs/**` to the 'ignore' list in workflow 'on' conditions for workflows which don't affect docs.

## Why?

To reduce unnecessary workflow runs (closes #5362 )

