### PR TITLE
Add `/FrontJSON` to view enhanced json for fronts

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -58,6 +58,10 @@
 				<a href="/Front?url=https://www.theguardian.com/international"
 					>International Front</a
 				>
+				(<a
+					href="/FrontJSON?url=https://www.theguardian.com/international"
+					>Enhanced JSON</a
+				>)
 			</li>
 		</ul>
 
@@ -368,15 +372,23 @@
 						const a = document.createElement('a');
 						const slug = text.slice(guurl.length, 64);
 
-						a.setAttribute(
-							'href',
-							`/${getPageType(text)}?url=${text}`,
-						);
-						a.innerText = `📋 ${getPageType(
-							text,
-						)} from clipboard: /${slug}…`;
+						const pageType = getPageType(text);
+
+						a.setAttribute('href', `/${pageType}?url=${text}`);
+						a.innerText = `📋 ${pageType} from clipboard: /${slug}…`;
 
 						li.appendChild(a);
+
+						if (pageType === 'Front') {
+							const aJSON = document.createElement('a');
+							aJSON.setAttribute(
+								'href',
+								`/${pageType}JSON?url=${text}`,
+							);
+							aJSON.innerHTML = 'Enhanced JSON';
+							li.append(' (', aJSON, ')');
+						}
+
 						fragment.appendChild(li);
 
 						document
@@ -391,14 +403,14 @@
 			checkClipboard();
 
 			const makeTestArticle = (a) => `
-                <div class="test-article">
-                    <span>${a.name}</span>
-                    <span><a href="/Article?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/Article?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
-                    <span><a href="/AMPArticle?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
-                    <span><a href="https://www.theguardian.com${a.article}">example</a></span>
-                    <span><a href="https://amp.theguardian.com${a.article}">example</a></span>
-                </div>
-            `;
+			             <div class="test-article">
+			                 <span>${a.name}</span>
+			                 <span><a href="/Article?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/Article?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
+			                 <span><a href="/AMPArticle?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
+			                 <span><a href="https://www.theguardian.com${a.article}">example</a></span>
+			                 <span><a href="https://amp.theguardian.com${a.article}">example</a></span>
+			             </div>
+			         `;
 
 			testContentTypes.forEach((a) => {
 				document.getElementById('test-articles-by-content').innerHTML +=

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -5,6 +5,7 @@ import {
 	renderArticleJson,
 	renderBlocks,
 	renderFront,
+	renderFrontJson,
 	renderInteractive,
 	renderKeyEvents,
 } from '../web/server';
@@ -30,6 +31,8 @@ export const devServer = () => {
 				return renderKeyEvents(req, res);
 			case '/Front':
 				return renderFront(req, res);
+			case '/FrontJSON':
+				return renderFrontJson(req, res);
 			default:
 				next();
 		}

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -12,6 +12,7 @@ import {
 	renderPerfTest as renderArticlePerfTest,
 	renderBlocks,
 	renderFront,
+	renderFrontJson,
 	renderInteractive,
 	renderKeyEvents,
 } from '../web/server';
@@ -57,6 +58,7 @@ export const prodServer = (): void => {
 	app.post('/Blocks', logRenderTime, renderBlocks);
 	app.post('/KeyEvents', logRenderTime, renderKeyEvents);
 	app.post('/Front', logRenderTime, renderFront);
+	app.post('/FrontJSON', logRenderTime, renderFrontJson);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -96,6 +98,21 @@ export const prodServer = (): void => {
 			// Eg. http://localhost:9000/Front?url=https://www.theguardian.com/uk/sport
 			try {
 				return renderFront(req, res);
+			} catch (error) {
+				console.error(error);
+			}
+		},
+	);
+
+	app.get(
+		'/FrontJSON',
+		logRenderTime,
+		// TODO: ensure getContentFromURLMiddleware supports fronts
+		getContentFromURLMiddleware,
+		async (req: Request, res: Response) => {
+			// Eg. http://localhost:9000/FrontJSON?url=https://www.theguardian.com/uk/sport
+			try {
+				return renderFrontJson(req, res);
 			} catch (error) {
 				console.error(error);
 			}

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -193,6 +193,7 @@ export const renderFront = (
 	res: express.Response,
 ): void => {
 	try {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We validate the data in this func
 		const front = enhanceFront(body);
 		const html = frontToHtml({
 			front,
@@ -203,4 +204,12 @@ export const renderFront = (
 		const message = e instanceof Error ? e.stack : 'Unknown Error';
 		res.status(500).send(`<pre>${message}</pre>`);
 	}
+};
+
+export const renderFrontJson = (
+	{ body }: express.Request,
+	res: express.Response,
+): void => {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We validate the data in this func
+	res.json(enhanceFront(body));
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Historically in DCR, the `.json?dcr` data for an article was almost exactly the same format as what made its way through our rendering code - this made it especially easy to diagnose issues, and figure out exactly where to look in the code. 

With fronts, we're now doing significantly more transformation in DCR, which means looking at a `.json?dcr` variant of a front does not show you the same data that might be consumed during rendering!

By adding this `/FrontJSON` endpoint, anyone with a DCR local server up and running can quickly view the 'enhanced' (transformed) data that we're passing directly to the rendering layer, making local debugging & testing much easier!
 
## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
|           | <img width="807" alt="image" src="https://user-images.githubusercontent.com/9575458/178722117-31964726-66ac-4d89-a70c-84995b4eb2d5.png"> |

[before]: https://user-images.githubusercontent.com/9575458/178722276-d9cbe30b-11bf-4434-bf99-88e27146d797.png
[after]: https://user-images.githubusercontent.com/9575458/178721966-e4752338-189d-4cd6-8e5b-067751f96ed2.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
