### PR TITLE
Add containers to all inline ad slots and refactor slot css

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -41,8 +41,8 @@ const articleWrapper = css`
 	flex-grow: 1;
 
 	/* Due to MainMedia using position: relative, this seems to effect the rendering order
-    To mitigate we use z-index
-    TODO: find a cleaner solution */
+		To mitigate we use z-index
+		TODO: find a cleaner solution */
 	z-index: 1;
 `;
 
@@ -88,57 +88,63 @@ const adStyles = css`
 			width: 100%;
 		}
 	}
-	/** ad-slot-offset-right is only added to inline2+ slots */
-	.ad-slot--offset-right {
-		${from.desktop} {
-			float: right;
-			width: auto;
-			margin-right: -318px;
-		}
 
-		${from.wide} {
-			margin-right: -398px;
-		}
-	}
 	/* Unlike other inlines do not float right inline1 */
-	.ad-slot-container .ad-slot--inline1 {
-		margin: 12px auto;
-		text-align: center;
-		${until.tablet} {
-			/* Prevent merger with any nearby float left elements e.g. rich-links */
-			clear: left;
-			width: 300px;
-		}
+	.ad-slot-container--article {
+		margin-top: 12px;
+		margin-bottom: 12px;
+
 		${from.tablet} {
 			background-color: ${neutral[97]};
 		}
-		&.ad-slot--fluid {
-			width: 100%;
+
+		.ad-slot {
+			margin-left: auto;
+			margin-right: auto;
 		}
-	}
-	.ad-slot--inline:not(.ad-slot--inline1) {
-		width: 300px;
-		margin: 12px auto;
-		min-width: 300px;
-		min-height: 274px;
-		text-align: center;
-		${from.tablet} {
-			margin-right: -100px;
-			width: auto;
-			float: right;
-			margin-top: 4px;
-			margin-left: 20px;
+
+		.ad-slot--inline1, .ad-slot--top-above-nav {
+			text-align: center;
+
+			${from.mobile} {
+				/* Prevent merger with any nearby float left elements e.g. rich-links */
+				clear: left;
+				width: 300px;
+			}
+			${from.tablet} {
+				background-color: ${neutral[97]};
+				width: auto;
+			}
+			&.ad-slot--fluid {
+				width: 100%;
+			}
 		}
-		${from.desktop} {
-			width: auto;
-			float: right;
-			margin: 0;
-			margin-top: 4px;
-			margin-left: 20px;
+
+		// AKA inline2+
+		.ad-slot--inline:not(.ad-slot--inline1) {
+			${from.mobile} {
+				/* Prevent merger with any nearby float left elements e.g. rich-links */
+				clear: left;
+			}
+
+			&.ad-slot--fluid {
+				width: 100%;
+			}
 		}
-		&.ad-slot--fluid {
-			width: 100%;
+
+
+		&.ad-slot--offset-right {
+			${from.desktop} {
+				float: right;
+				width: 300px;
+				margin-right: -318px;
+			}
+	
+			${from.wide} {
+				margin-right: -398px;
+			}
 		}
+
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -68,7 +68,6 @@ const adStyles = css`
 	.ad-slot-container--liveblog {
 		background-color: ${neutral[93]};
 		margin: 0 auto ${space[3]}px;
-		width: 100%;
 		text-align: center;
 
 		.ad-slot {
@@ -79,6 +78,14 @@ const adStyles = css`
 		.ad-slot__label {
 			color: ${neutral[46]};
 			border-top-color: ${neutral[86]};
+		}
+
+		${from.mobile} {
+			width: 300px;
+		}
+
+		${from.tablet} {
+			width: 100%;
 		}
 	}
 	/** ad-slot-offset-right is only added to inline2+ slots */

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -11,7 +11,7 @@ type Props = {
 const articleWidth = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Interactive: {
-			// These articles use a special template which manages it's own width
+			/* These articles use a special template which manages it's own width */
 			return null;
 		}
 		case ArticleDesign.LiveBlog:
@@ -65,75 +65,54 @@ const adStyles = css`
 	.ad-slot--fluid {
 		width: 100%;
 	}
-	.ad-slot-container--liveblog {
-		background-color: ${neutral[93]};
-		margin: 0 auto ${space[3]}px;
-		// this is centering the ad iframe as they are display: inline; elements by default
+
+	.ad-slot-container {
+		margin: ${space[3]}px auto;
+		/* this is centring the ad iframe as they are display: inline; elements by default */
 		text-align: center;
-
-		.ad-slot {
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-		.ad-slot__label {
-			color: ${neutral[46]};
-			border-top-color: ${neutral[86]};
-		}
 
 		${from.mobile} {
 			width: 300px;
 		}
 
 		${from.tablet} {
-			width: 100%;
+			width: auto;
+			background-color: ${neutral[97]};
 		}
-	}
-
-	/* Unlike other inlines do not float right inline1 */
-	.ad-slot-container--article {
-		margin-top: 12px;
-		margin-bottom: 12px;
-		// this is centering the ad iframe as they are display: inline; elements by default
-		text-align: center;
 
 		/* Prevent merger with any nearby float left elements e.g. rich-links */
 		${until.desktop} {
 			clear: left;
 		}
 
-		${from.tablet} {
-			background-color: ${neutral[97]};
-		}
-
 		.ad-slot {
 			margin-left: auto;
 			margin-right: auto;
-		}
 
-		.ad-slot--inline,
-		.ad-slot--top-above-nav {
-			${from.mobile} {
-				width: 300px;
-			}
-			${from.tablet} {
-				width: auto;
-			}
 			&.ad-slot--fluid {
 				width: 100%;
 			}
 		}
 
-		&.ad-slot--offset-right {
-			${from.desktop} {
-				float: right;
-				width: 300px;
-				margin-right: -318px;
+		/* liveblogs ads have different background colours due the darker page background */
+		.ad-slot--liveblog-inline {
+			background-color: ${neutral[93]};
+			.ad-slot__label {
+				color: ${neutral[46]};
+				border-top-color: ${neutral[86]};
 			}
+		}
+	}
 
-			${from.wide} {
-				margin-right: -398px;
-			}
+	.ad-slot-container--offset-right {
+		${from.desktop} {
+			float: right;
+			width: 300px;
+			margin-right: -318px;
+		}
+
+		${from.wide} {
+			margin-right: -398px;
 		}
 	}
 `;

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -111,7 +111,7 @@ const adStyles = css`
 			margin-right: auto;
 		}
 
-		.ad-slot--inline1,
+		.ad-slot--inline,
 		.ad-slot--top-above-nav {
 			${from.mobile} {
 				width: 300px;
@@ -119,22 +119,6 @@ const adStyles = css`
 			${from.tablet} {
 				width: auto;
 			}
-			&.ad-slot--fluid {
-				width: 100%;
-			}
-		}
-
-		// AKA inline2+
-		.ad-slot--inline:not(.ad-slot--inline1) {
-			${from.mobile} {
-				/* Prevent merger with any nearby float left elements e.g. rich-links */
-				width: 300px;
-			}
-
-			${from.tablet} {
-				width: auto;
-			}
-
 			&.ad-slot--fluid {
 				width: 100%;
 			}

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -89,7 +89,6 @@ const adStyles = css`
 
 			${from.tablet} {
 				width: 100%;
-				padding-bottom: ${space[6]}px;
 
 				& > div:not(.ad-slot__label) {
 					width: 300px;

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -131,8 +131,7 @@ const adStyles = css`
 			width: 100%;
 		}
 	}
-	.ad-slot--inline:not(.ad-slot--inline1),
-	.ad-slot-liveblog--inline:not(.ad-slot--inline1) {
+	.ad-slot--inline:not(.ad-slot--inline1) {
 		width: 300px;
 		margin: 12px auto;
 		min-width: 300px;

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -68,6 +68,7 @@ const adStyles = css`
 	.ad-slot-container--liveblog {
 		background-color: ${neutral[93]};
 		margin: 0 auto ${space[3]}px;
+		// this is centering the ad iframe as they are display: inline; elements by default
 		text-align: center;
 
 		.ad-slot {
@@ -93,6 +94,10 @@ const adStyles = css`
 	.ad-slot-container--article {
 		margin-top: 12px;
 		margin-bottom: 12px;
+		// this is centering the ad iframe as they are display: inline; elements by default
+		text-align: center;
+		/* Prevent merger with any nearby float left elements e.g. rich-links */
+		clear: left;
 
 		${from.tablet} {
 			background-color: ${neutral[97]};
@@ -103,16 +108,12 @@ const adStyles = css`
 			margin-right: auto;
 		}
 
-		.ad-slot--inline1, .ad-slot--top-above-nav {
-			text-align: center;
-
+		.ad-slot--inline1,
+		.ad-slot--top-above-nav {
 			${from.mobile} {
-				/* Prevent merger with any nearby float left elements e.g. rich-links */
-				clear: left;
 				width: 300px;
 			}
 			${from.tablet} {
-				background-color: ${neutral[97]};
 				width: auto;
 			}
 			&.ad-slot--fluid {
@@ -124,7 +125,11 @@ const adStyles = css`
 		.ad-slot--inline:not(.ad-slot--inline1) {
 			${from.mobile} {
 				/* Prevent merger with any nearby float left elements e.g. rich-links */
-				clear: left;
+				width: 300px;
+			}
+
+			${from.tablet} {
+				width: auto;
 			}
 
 			&.ad-slot--fluid {
@@ -132,19 +137,17 @@ const adStyles = css`
 			}
 		}
 
-
 		&.ad-slot--offset-right {
 			${from.desktop} {
 				float: right;
 				width: 300px;
 				margin-right: -318px;
 			}
-	
+
 			${from.wide} {
 				margin-right: -398px;
 			}
 		}
-
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -62,45 +62,23 @@ const adStyles = css`
 			width: auto;
 		}
 	}
-	.ad-slot-container {
-		max-width: 300px;
-	}
 	.ad-slot--fluid {
 		width: 100%;
 	}
-	.ad-slot--liveblog-inline {
+	.ad-slot-container--liveblog {
+		background-color: ${neutral[93]};
 		margin: 0 auto ${space[3]}px;
+		width: 100%;
+		text-align: center;
+
+		.ad-slot {
+			margin-left: auto;
+			margin-right: auto;
+		}
 
 		.ad-slot__label {
 			color: ${neutral[46]};
 			border-top-color: ${neutral[86]};
-		}
-
-		&.ad-slot--outstream {
-			${from.tablet} {
-				width: 620px;
-			}
-		}
-
-		&:not(.ad-slot--outstream) {
-			width: 300px;
-			background-color: ${neutral[93]};
-			text-align: center;
-
-			${from.tablet} {
-				width: 100%;
-
-				& > div:not(.ad-slot__label) {
-					width: 300px;
-					margin-left: auto;
-					margin-right: auto;
-				}
-			}
-		}
-
-		&.ad-slot--fluid {
-			background-color: green;
-			width: 100%;
 		}
 	}
 	/** ad-slot-offset-right is only added to inline2+ slots */
@@ -116,7 +94,7 @@ const adStyles = css`
 		}
 	}
 	/* Unlike other inlines do not float right inline1 */
-	.ad-slot--inline1 {
+	.ad-slot-container .ad-slot--inline1 {
 		margin: 12px auto;
 		text-align: center;
 		${until.tablet} {

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -96,8 +96,11 @@ const adStyles = css`
 		margin-bottom: 12px;
 		// this is centering the ad iframe as they are display: inline; elements by default
 		text-align: center;
+
 		/* Prevent merger with any nearby float left elements e.g. rich-links */
-		clear: left;
+		${until.desktop} {
+			clear: left;
+		}
 
 		${from.tablet} {
 			background-color: ${neutral[97]};

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -109,6 +109,7 @@ const adStyles = css`
 			float: right;
 			width: 300px;
 			margin-right: -318px;
+			background-color: transparent;
 		}
 
 		${from.wide} {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
CSS on article and liveblog inline advert containers and slots.

## Why?
We have been having issues with 'expanding' adverts escaping their slots (see below before image(s). We have added containers to all inline slots to align and constrain their widths.

This PR apply's the relevant CSS as well as refactoring the slot CSS to be more concise and readable.

Changes on frontend https://github.com/guardian/frontend/pull/25236

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="910" alt="image" src="https://user-images.githubusercontent.com/1731150/178730529-d2f1d0e8-efb9-4cda-9eaf-22db89d71264.png"> | |
![Screenshot 2022-07-13 at 13 14 03](https://user-images.githubusercontent.com/1731150/178730902-bd437109-6e15-45ed-8def-c7ac1c8f8739.png) | ![Screenshot 2022-07-13 at 13 15 05](https://user-images.githubusercontent.com/1731150/178731136-a3cb3b4b-6a7a-464e-8886-be9923873502.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
