### PR TITLE
Use Braze to power `My Account` notifications

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.2.1",
-    "@guardian/braze-components": "^7.2.0",
+    "@guardian/braze-components": "^7.3.0",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.7.1",
     "@guardian/discussion-rendering": "^10.1.1",

--- a/dotcom-rendering/src/web/components/BrazeMessaging.importable.tsx
+++ b/dotcom-rendering/src/web/components/BrazeMessaging.importable.tsx
@@ -10,10 +10,13 @@ type Props = {
  * on every page
  */
 export const BrazeMessaging = ({ idApiUrl }: Props) => {
-	const { brazeMessages } = useBraze(idApiUrl);
+	const { brazeMessages, brazeCards } = useBraze(idApiUrl);
 
 	if (brazeMessages) {
 		log('tx', 'Braze Messages Interface loaded', brazeMessages);
+	}
+	if (brazeCards) {
+		log('tx', 'Braze Cards Interface loaded', brazeCards);
 	}
 
 	// we don’t render anything

--- a/dotcom-rendering/src/web/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.stories.tsx
@@ -34,22 +34,26 @@ const Nav = ({ children }: { children: React.ReactNode }) => (
 
 const links = [
 	{
+		id: 'uk',
 		url: '/preference/edition/uk',
 		title: 'UK edition',
 		isActive: true,
 		dataLinkName: 'linkname-UK',
 	},
 	{
+		id: 'us',
 		url: '/preference/edition/us',
 		title: 'US edition',
 		dataLinkName: 'linkname-US',
 	},
 	{
+		id: 'au',
 		url: '/preference/edition/au',
 		title: 'Australian edition',
 		dataLinkName: 'linkname-AU',
 	},
 	{
+		id: 'int',
 		url: '/preference/edition/int',
 		title: 'International edition',
 		dataLinkName: 'linkname-INT',
@@ -101,11 +105,13 @@ DropdownNoActive.story = { name: 'Dropdown with nothing active' };
 
 const linksWithNotifications = [
 	{
+		id: 'account-overview',
 		url: '/account-overview',
 		title: 'Account Overview',
 		dataLinkName: 'account-overview',
 	},
 	{
+		id: 'billing',
 		url: '/billing',
 		title: 'Billing',
 		dataLinkName: 'billing',

--- a/dotcom-rendering/src/web/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.test.tsx
@@ -3,22 +3,26 @@ import { Dropdown } from './Dropdown';
 
 const links = [
 	{
+		id: 'uk',
 		url: '/preference/edition/uk',
 		title: 'UK edition',
 		isActive: true,
 		dataLinkName: 'linkname-UK',
 	},
 	{
+		id: 'us',
 		url: '/preference/edition/us',
 		title: 'US edition',
 		dataLinkName: 'linkname-US',
 	},
 	{
+		id: 'au',
 		url: '/preference/edition/au',
 		title: 'Australian edition',
 		dataLinkName: 'linkname-AU',
 	},
 	{
+		id: 'int',
 		url: '/preference/edition/int',
 		title: 'International edition',
 		dataLinkName: 'linkname-INT',

--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -17,6 +17,7 @@ import { getZIndex } from '../lib/getZIndex';
 import { linkNotificationCount } from '../lib/linkNotificationCount';
 
 export interface DropdownLinkType {
+	id: string;
 	url: string;
 	title: string;
 	isActive?: boolean;

--- a/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
+++ b/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
@@ -34,24 +34,28 @@ export const EditionDropdown: React.FC<{
 }> = ({ editionId, dataLinkName }) => {
 	const links = [
 		{
+			id: 'uk',
 			url: '/preference/edition/uk',
 			isActive: editionId === 'UK',
 			title: 'UK edition',
 			dataLinkName: 'nav2 : topbar : edition-picker: UK',
 		},
 		{
+			id: 'us',
 			url: '/preference/edition/us',
 			isActive: editionId === 'US',
 			title: 'US edition',
 			dataLinkName: 'nav2 : topbar : edition-picker: US',
 		},
 		{
+			id: 'au',
 			url: '/preference/edition/au',
 			isActive: editionId === 'AU',
 			title: 'Australian edition',
 			dataLinkName: 'nav2 : topbar : edition-picker: AU',
 		},
 		{
+			id: 'int',
 			url: '/preference/edition/int',
 			isActive: editionId === 'INT',
 			title: 'International edition',

--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -24,6 +24,7 @@ type Props = {
 	urls: ReaderRevenueCategories;
 	remoteHeader: boolean;
 	contributionsServiceUrl: string;
+	idApiUrl: string;
 };
 
 export const Header = ({
@@ -35,6 +36,7 @@ export const Header = ({
 	urls,
 	remoteHeader,
 	contributionsServiceUrl,
+	idApiUrl,
 }: Props) => (
 	<div css={headerStyles}>
 		<Hide when="below" breakpoint="desktop">
@@ -63,6 +65,7 @@ export const Header = ({
 					idUrl={idUrl}
 					mmaUrl={mmaUrl}
 					discussionApiUrl={discussionApiUrl}
+					idApiUrl={idApiUrl}
 				/>
 			</Island>
 		</div>

--- a/dotcom-rendering/src/web/components/Links.importable.test.tsx
+++ b/dotcom-rendering/src/web/components/Links.importable.test.tsx
@@ -1,0 +1,15 @@
+import { buildIdentityLinks } from './Links.importable';
+
+describe('buildIdentityLinks', () => {
+	it('contains a unique ID for every item', () => {
+		const mmaUrl = 'https://manage.theguardian.com';
+		const idUrl = 'https://profile.theguardian.com';
+		const userId = '12345';
+
+		const links = buildIdentityLinks(mmaUrl, idUrl, userId);
+
+		const linksCount = links.length;
+		const uniqueIdCount = new Set(links.map((link) => link.id)).size;
+		expect(uniqueIdCount).toEqual(linksCount);
+	});
+});

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -342,6 +342,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
+								idApiUrl={CAPIArticle.config.idApiUrl}
 							/>
 						</ElementContainer>
 					)}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -66,6 +66,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							urls={front.nav.readerRevenueLinks.header}
 							remoteHeader={front.config.switches.remoteHeader}
 							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
+							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
 						/>
 					</ElementContainer>
 					<ElementContainer

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -219,6 +219,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 							contributionsServiceUrl={
 								CAPIArticle.contributionsServiceUrl
 							}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</ElementContainer>
 				</div>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -277,6 +277,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
+								idApiUrl={CAPIArticle.config.idApiUrl}
 							/>
 						</ElementContainer>
 					</div>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -357,6 +357,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.switches.remoteHeader
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</ElementContainer>
 

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -160,6 +160,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						urls={CAPIArticle.nav.readerRevenueLinks.header}
 						remoteHeader={CAPIArticle.config.switches.remoteHeader}
 						contributionsServiceUrl={contributionsServiceUrl}
+						idApiUrl={CAPIArticle.config.idApiUrl}
 					/>
 				</ElementContainer>
 				<ElementContainer

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -282,6 +282,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									contributionsServiceUrl={
 										contributionsServiceUrl
 									}
+									idApiUrl={CAPIArticle.config.idApiUrl}
 								/>
 							</ElementContainer>
 							<ElementContainer

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -378,6 +378,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
+								idApiUrl={CAPIArticle.config.idApiUrl}
 							/>
 						</ElementContainer>
 					)}

--- a/dotcom-rendering/src/web/lib/braze/types.ts
+++ b/dotcom-rendering/src/web/lib/braze/types.ts
@@ -1,8 +1,0 @@
-enum SlotNames {
-	Banner = 'Banner',
-	EndOfArticle = 'EndOfArticle',
-}
-
-type SlotName = keyof typeof SlotNames;
-
-export { SlotNames, SlotName };

--- a/dotcom-rendering/src/web/lib/linkNotificationCount.test.ts
+++ b/dotcom-rendering/src/web/lib/linkNotificationCount.test.ts
@@ -5,12 +5,14 @@ describe('linksNotificationCount', () => {
 	it('returns the sum of notifications across all links', () => {
 		const links: DropdownLinkType[] = [
 			{
+				id: 'one',
 				url: 'https://example.com/1',
 				title: 'One',
 				dataLinkName: 'One',
 				notifications: ['Notification here!'],
 			},
 			{
+				id: 'two',
 				url: 'https://example.com/2',
 				title: 'Two',
 				dataLinkName: 'Two',
@@ -29,11 +31,13 @@ describe('linksNotificationCount', () => {
 	it('returns 0 when there are no notifications', () => {
 		const links = [
 			{
+				id: 'one',
 				url: 'https://example.com/1',
 				title: 'One',
 				dataLinkName: 'One',
 			},
 			{
+				id: 'two',
 				url: 'https://example.com/2',
 				title: 'Two',
 				dataLinkName: 'Two',

--- a/dotcom-rendering/src/web/lib/notification.test.ts
+++ b/dotcom-rendering/src/web/lib/notification.test.ts
@@ -1,0 +1,122 @@
+import { addNotificationsToDropdownLinks } from './notification';
+
+describe('addNotificationsToDropdownLinks', () => {
+	it('augments dropdown links with notifications', () => {
+		const links = [
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+			},
+			{
+				id: 'edit_profile',
+				url: `https://example.com/edit_profile`,
+				title: 'Profile',
+				dataLinkName: 'nav2 : topbar : edit profile',
+			},
+		];
+		const notifications = [
+			{
+				message: 'Some notification message',
+				target: 'account_overview',
+			},
+		];
+
+		const linksWithNotifications = addNotificationsToDropdownLinks(
+			links,
+			notifications,
+		);
+
+		expect(linksWithNotifications).toEqual([
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+				notifications: ['Some notification message'],
+			},
+			{
+				id: 'edit_profile',
+				url: `https://example.com/edit_profile`,
+				title: 'Profile',
+				dataLinkName: 'nav2 : topbar : edit profile',
+			},
+		]);
+	});
+
+	it('adds multiple notification messages to a link', () => {
+		const links = [
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+			},
+		];
+		const notifications = [
+			{
+				message: 'Some notification message',
+				target: 'account_overview',
+			},
+			{
+				message: 'Another notification message',
+				target: 'account_overview',
+			},
+		];
+
+		const linksWithNotifications = addNotificationsToDropdownLinks(
+			links,
+			notifications,
+		);
+
+		expect(linksWithNotifications).toEqual([
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+				notifications: [
+					'Some notification message',
+					'Another notification message',
+				],
+			},
+		]);
+	});
+
+	it('adds new notifications if target already has notifications', () => {
+		const links = [
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+				notifications: ['Existing notification message'],
+			},
+		];
+		const notifications = [
+			{
+				message: 'New notification message',
+				target: 'account_overview',
+			},
+		];
+
+		const linksWithNotifications = addNotificationsToDropdownLinks(
+			links,
+			notifications,
+		);
+
+		expect(linksWithNotifications).toEqual([
+			{
+				id: 'account_overview',
+				url: `https://example.com/account_overview`,
+				title: 'Account overview',
+				dataLinkName: 'nav2 : topbar : account overview',
+				notifications: [
+					'Existing notification message',
+					'New notification message',
+				],
+			},
+		]);
+	});
+});

--- a/dotcom-rendering/src/web/lib/notification.ts
+++ b/dotcom-rendering/src/web/lib/notification.ts
@@ -1,0 +1,83 @@
+import type { BrazeCard } from '@guardian/braze-components';
+import type { DropdownLinkType } from '../components/Dropdown';
+
+export interface Notification {
+	target: string;
+	message: string;
+}
+
+export const mapBrazeCardsToNotifications = (
+	cards: BrazeCard[],
+): Notification[] => {
+	return cards
+		.filter(
+			(card: BrazeCard) =>
+				Boolean(card.extras.message) && Boolean(card.extras.target),
+		)
+		.map((card) => {
+			return {
+				target: card.extras.target,
+				message: card.extras.message,
+			};
+		});
+};
+
+const groupNotificationsByTarget = (
+	notifications: Notification[],
+): { [k: string]: Notification[] } => {
+	return notifications.reduce<{ [k: string]: Notification[] }>(
+		(groupings, notification) => {
+			const alreadyGotNotificationsForTarget =
+				Object.prototype.hasOwnProperty.call(
+					groupings,
+					notification.target,
+				);
+
+			if (!alreadyGotNotificationsForTarget) {
+				groupings[notification.target] = [];
+			}
+
+			groupings[notification.target].push(notification);
+
+			return groupings;
+		},
+		{},
+	);
+};
+
+export const addNotificationsToDropdownLinks = (
+	links: DropdownLinkType[],
+	notifications: Notification[],
+): DropdownLinkType[] => {
+	const notificationsByTarget = groupNotificationsByTarget(notifications);
+
+	const linksWithNotifications = links.map((link) => {
+		const targetHasNewNotifications = Object.prototype.hasOwnProperty.call(
+			notificationsByTarget,
+			link.id,
+		);
+
+		if (targetHasNewNotifications) {
+			const newMessages = notificationsByTarget[link.id].map(
+				(n) => n.message,
+			);
+
+			const existingNotifications = link.notifications;
+			if (existingNotifications) {
+				return {
+					...link,
+					notifications: [...existingNotifications, ...newMessages],
+				};
+			} else {
+				return {
+					...link,
+					notifications: newMessages,
+				};
+			}
+		} else {
+			return link;
+		}
+	});
+
+	return linksWithNotifications;
+};

--- a/dotcom-rendering/src/web/lib/useBraze.ts
+++ b/dotcom-rendering/src/web/lib/useBraze.ts
@@ -1,25 +1,42 @@
-import type { BrazeMessagesInterface } from '@guardian/braze-components';
-import { NullBrazeMessages } from '@guardian/braze-components/logic';
+import type {
+	BrazeCardsInterface,
+	BrazeMessagesInterface,
+} from '@guardian/braze-components/logic';
+import {
+	NullBrazeCards,
+	NullBrazeMessages,
+} from '@guardian/braze-components/logic';
 import useSWRImmutable from 'swr/immutable';
-import { buildBrazeMessages } from './braze/buildBrazeMessages';
+import { buildBrazeMessaging } from './braze/buildBrazeMessaging';
 
 /**
- * Returns brazeMessages as BrazeMessagesInterface
+ * Returns brazeMessaging as BrazeMessagesInterface and BrazeCardsInterface
+ *
+ * BrazeMessages is used to show single-impression messages (like ad impressions).
+ * In contrast, BrazeCards can provide persistent user notifications.
  *
  * We're using useSWRImmutable to ensure this call is only made once
  * [doc]: https://swr.vercel.app/docs/revalidation#disable-automatic-revalidations
  */
 export const useBraze = (
 	idApiUrl: string,
-): { brazeMessages: BrazeMessagesInterface | undefined } => {
-	const { data: brazeMessages, error } = useSWRImmutable(
-		'braze-message',
-		() => buildBrazeMessages(idApiUrl),
+): {
+	brazeMessages: BrazeMessagesInterface | undefined;
+	brazeCards: BrazeCardsInterface | undefined;
+} => {
+	const { data, error } = useSWRImmutable('braze-message', () =>
+		buildBrazeMessaging(idApiUrl),
 	);
 
 	if (error) {
-		return { brazeMessages: new NullBrazeMessages() };
+		return {
+			brazeMessages: new NullBrazeMessages(),
+			brazeCards: new NullBrazeCards(),
+		};
 	}
 
-	return { brazeMessages };
+	return {
+		brazeMessages: data?.brazeMessages,
+		brazeCards: data?.brazeCards,
+	};
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,10 +2799,10 @@
     is-mobile "^3.1.1"
     youtube-player "^5.5.2"
 
-"@guardian/braze-components@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
-  integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
+"@guardian/braze-components@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
+  integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
 "@guardian/commercial-core@^4.3.0":
   version "4.3.0"


### PR DESCRIPTION
## What does this change?

This wires up Braze to power the notifications UI added in #5241 using Braze [content cards](https://www.braze.com/docs/user_guide/message_building_by_channel/content_cards).

## Why?

There's a strategy to try using more persistent notifications on the web, as opposed to in-app messages (like in the banner and epic slots, which are more single-shot).

## Screenshots

![Screenshot 2022-07-12 at 15 12 25](https://user-images.githubusercontent.com/379839/178744489-c4cea1b0-c391-4de5-b8ef-52bc6c4b522d.png)

## Things to highlight

* This is behind a switch which is currently set to `false` in prod

* I've added an `id` field to the `DropdownLinkType` which is what we're using to target the relevant link in Braze. Interested in thoughts on this approach!

* The `useBraze` custom hook now returns an object which has this type:

```ts
{
	brazeMessages: BrazeMessagesInterface | undefined;
	brazeCards: BrazeCardsInterface | undefined;
}
```

We decided to keep the existing messages class separate from the new content cards class as their use cases are quite different. Most call sites will use one or the other, though the work to initialise them both is identical).

* `useBraze` is now used in `Links.importable.tx` to get the `brazeCards` instance.