### PR TITLE
Immersive Layout - Tags

### DIFF
--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -112,7 +112,7 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 				{children}
 			</ArticleBody>
 			<section css={articleWidthStyles}>
-				<Tags tags={item.tags} format={item} />
+				<Tags item={item} />
 			</section>
 		</article>
 		<section css={onwardStyles}>

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -8,6 +8,7 @@ import MainMedia, { ImmersiveCaption } from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
+import Tags from 'components/Tags';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
 import type { Item } from 'item';
@@ -50,14 +51,6 @@ const linesStyles = css`
 	}
 `;
 
-const tagsStyles = css`
-	${grid.column.centre}
-
-	${from.leftCol} {
-		grid-row: 4;
-	}
-`;
-
 type Props = {
 	item: Item;
 };
@@ -85,7 +78,7 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => (
 					<StraightLines cssOverrides={linesStyles} />
 					<Metadata item={item} />
 					<div css={bodyStyles}>{children}</div>
-					<section css={tagsStyles}>Tags</section>
+					<Tags item={item} />
 				</div>
 			</article>
 		</main>

--- a/apps-rendering/src/components/Layout/InteractiveImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/InteractiveImmersiveLayout.tsx
@@ -90,7 +90,7 @@ const InteractiveImmersiveLayout: FC<Props> = ({ item, children }) => {
 				<Body format={item}>{children}</Body>
 				{epicContainer}
 				<section className="js-tags" css={articleWidthStyles}>
-					<Tags tags={item.tags} format={item} />
+					<Tags item={item} />
 				</section>
 			</article>
 			<section css={onwardStyles}>

--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -192,7 +192,7 @@ const LiveLayout: FC<Props> = ({ item }) => {
 				</GridItem>
 			</main>
 			<section css={articleWidthStyles}>
-				<Tags tags={item.tags} format={item} />
+				<Tags item={item} />
 			</section>
 			<section css={onwardStyles}>
 				<RelatedContent content={item.relatedContent} />

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -142,7 +142,7 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 				</Body>
 				{epicContainer}
 				<section className="js-tags" css={articleWidthStyles}>
-					<Tags tags={item.tags} format={item} />
+					<Tags item={item} />
 				</section>
 			</article>
 			<section css={onwardStyles}>

--- a/apps-rendering/src/components/Tags/ImmersiveTags.tsx
+++ b/apps-rendering/src/components/Tags/ImmersiveTags.tsx
@@ -1,0 +1,35 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { from } from '@guardian/source-foundations';
+import { grid } from 'grid/grid';
+import { getFormat, Item } from 'item';
+import { FC } from 'react';
+import { defaultStyles, DefaultTags } from './Tags.defaults';
+
+// ----- Component ----- //
+
+const styles = css`
+    ${grid.column.centre}
+
+    ${from.leftCol} {
+        grid-row: 4;
+    }
+`;
+
+type Props = {
+    item: Item;
+}
+
+const ImmersiveTags: FC<Props> = ({ item }) => (
+    <section css={styles}>
+        <DefaultTags
+            item={item}
+            css={defaultStyles(getFormat(item))}
+        />
+    </section>
+)
+
+// ----- Exports ----- //
+
+export default ImmersiveTags;

--- a/apps-rendering/src/components/Tags/ImmersiveTags.tsx
+++ b/apps-rendering/src/components/Tags/ImmersiveTags.tsx
@@ -3,32 +3,30 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
-import { getFormat, Item } from 'item';
-import { FC } from 'react';
+import type { Item } from 'item';
+import { getFormat } from 'item';
+import type { FC } from 'react';
 import { defaultStyles, DefaultTags } from './Tags.defaults';
 
 // ----- Component ----- //
 
 const styles = css`
-    ${grid.column.centre}
+	${grid.column.centre}
 
-    ${from.leftCol} {
-        grid-row: 4;
-    }
+	${from.leftCol} {
+		grid-row: 4;
+	}
 `;
 
 type Props = {
-    item: Item;
-}
+	item: Item;
+};
 
 const ImmersiveTags: FC<Props> = ({ item }) => (
-    <section css={styles}>
-        <DefaultTags
-            item={item}
-            css={defaultStyles(getFormat(item))}
-        />
-    </section>
-)
+	<section css={styles}>
+		<DefaultTags item={item} css={defaultStyles(getFormat(item))} />
+	</section>
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Tags/Tags.defaults.tsx
+++ b/apps-rendering/src/components/Tags/Tags.defaults.tsx
@@ -7,7 +7,8 @@ import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
-import { getFormat, Item } from 'item';
+import type { Item } from 'item';
+import { getFormat } from 'item';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
@@ -69,7 +70,7 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 
 interface Props {
 	item: Item;
-    css: SerializedStyles;
+	css: SerializedStyles;
 	className?: string;
 }
 
@@ -93,7 +94,4 @@ const DefaultTags: FC<Props> = ({ item, className }) => (
 
 // ----- Exports ----- //
 
-export {
-    DefaultTags,
-    defaultStyles,
-}
+export { DefaultTags, defaultStyles };

--- a/apps-rendering/src/components/Tags/Tags.defaults.tsx
+++ b/apps-rendering/src/components/Tags/Tags.defaults.tsx
@@ -1,0 +1,99 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
+import { neutral, remSpace, textSans } from '@guardian/source-foundations';
+import { getFormat, Item } from 'item';
+import type { FC } from 'react';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+const backgroundColour = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return neutral[86];
+		case ArticleDesign.LiveBlog:
+			return neutral[93];
+		default:
+			return neutral[97];
+	}
+};
+
+const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
+	margin-top: 0;
+	margin-bottom: 0;
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	padding: ${remSpace[3]} 0 ${remSpace[2]} 0;
+	${textSans.medium()}
+
+	${darkModeCss`
+		background-color: ${background.articleContentDark(format)};
+		color: ${neutral[86]};
+	`}
+`;
+
+const tagStyles = css`
+	margin-right: 1rem;
+	margin-bottom: 1rem;
+	line-height: 0;
+`;
+
+const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
+	text-decoration: none;
+	white-space: nowrap;
+	padding: 6px 16px;
+	border-radius: 30px;
+	text-overflow: ellipsis;
+	max-width: 18.75rem;
+	color: ${neutral[7]};
+	background-color: ${backgroundColour(format)};
+	display: inline-block;
+	white-space: nowrap;
+	overflow: hidden;
+	line-height: 1;
+
+	${darkModeCss`
+		color: ${neutral[86]};
+		background-color: ${neutral[20]};
+	`};
+`;
+
+interface Props {
+	item: Item;
+    css: SerializedStyles;
+	className?: string;
+}
+
+const DefaultTags: FC<Props> = ({ item, className }) => (
+	<ul css={className} role="list">
+		{item.tags
+			.filter(
+				(tag) =>
+					tag.type !== TagType.CAMPAIGN &&
+					tag.type !== TagType.TRACKING,
+			)
+			.map((tag, index) => (
+				<li key={index} css={tagStyles}>
+					<a href={tag.webUrl} css={anchorStyles(getFormat(item))}>
+						{tag.webTitle}
+					</a>
+				</li>
+			))}
+	</ul>
+);
+
+// ----- Exports ----- //
+
+export {
+    DefaultTags,
+    defaultStyles,
+}

--- a/apps-rendering/src/components/Tags/Tags.stories.tsx
+++ b/apps-rendering/src/components/Tags/Tags.stories.tsx
@@ -1,22 +1,14 @@
 // ----- Imports ----- //
 
-import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ArticleFormat } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
+import { article } from 'fixtures/item';
 import Tags from './';
-
-// ----- Setup ----- //
-
-const tag = {
-	webTitle: 'Tag title',
-	webUrl: 'https://mapi.co.uk/tag',
-	type: TagType.KEYWORD,
-};
 
 // ----- Stories ----- //
 
 const Default = (format: ArticleFormat): JSX.Element => (
-	<Tags tags={[tag, tag, tag]} format={format} />
+	<Tags item={article} />
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/Tags/Tags.stories.tsx
+++ b/apps-rendering/src/components/Tags/Tags.stories.tsx
@@ -7,9 +7,7 @@ import Tags from './';
 
 // ----- Stories ----- //
 
-const Default = (format: ArticleFormat): JSX.Element => (
-	<Tags item={article} />
-);
+const Default = (format: ArticleFormat): JSX.Element => <Tags item={article} />;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Tags/Tags.test.tsx
+++ b/apps-rendering/src/components/Tags/Tags.test.tsx
@@ -16,15 +16,16 @@ describe('Tags component renders as expected', () => {
 		const tags = renderer.create(
 			<Tags item={article} />,
 		);
-		const link = tags.root.findByType('a');
-		expect(link.props.href).toBe(article.tags[0].webUrl);
+		const links = tags.root.findAllByType('a');
+		expect(links[0].props.href).toBe(article.tags[0].webUrl);
 	});
 
 	it('Renders tag title', () => {
 		const tags = renderer.create(
 			<Tags item={article} />,
 		);
-		expect(tags.root.findByType('a').children.includes(article.tags[0].webTitle)).toBe(
+		const links = tags.root.findAllByType('a')
+		expect(links[0].children.includes(article.tags[0].webTitle)).toBe(
 			true,
 		);
 	});
@@ -33,6 +34,6 @@ describe('Tags component renders as expected', () => {
 		const tags = renderer.create(
 			<Tags item={article} />,
 		);
-		expect(tags.root.findAllByType('li').length).toBe(7);
+		expect(tags.root.findAllByType('li').length).toBe(6);
 	});
 });

--- a/apps-rendering/src/components/Tags/Tags.test.tsx
+++ b/apps-rendering/src/components/Tags/Tags.test.tsx
@@ -13,27 +13,19 @@ expect.extend(matchers);
 
 describe('Tags component renders as expected', () => {
 	it('Renders link to tag', () => {
-		const tags = renderer.create(
-			<Tags item={article} />,
-		);
+		const tags = renderer.create(<Tags item={article} />);
 		const links = tags.root.findAllByType('a');
 		expect(links[0].props.href).toBe(article.tags[0].webUrl);
 	});
 
 	it('Renders tag title', () => {
-		const tags = renderer.create(
-			<Tags item={article} />,
-		);
-		const links = tags.root.findAllByType('a')
-		expect(links[0].children.includes(article.tags[0].webTitle)).toBe(
-			true,
-		);
+		const tags = renderer.create(<Tags item={article} />);
+		const links = tags.root.findAllByType('a');
+		expect(links[0].children.includes(article.tags[0].webTitle)).toBe(true);
 	});
 
 	it('Renders correct number of tags', () => {
-		const tags = renderer.create(
-			<Tags item={article} />,
-		);
+		const tags = renderer.create(<Tags item={article} />);
 		expect(tags.root.findAllByType('li').length).toBe(6);
 	});
 });

--- a/apps-rendering/src/components/Tags/Tags.test.tsx
+++ b/apps-rendering/src/components/Tags/Tags.test.tsx
@@ -1,9 +1,7 @@
 // ----- Imports ----- //
 
 import { matchers } from '@emotion/jest';
-import { TagType } from '@guardian/content-api-models/v1/tagType';
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { article } from 'fixtures/item';
 import renderer from 'react-test-renderer';
 import Tags from './';
 
@@ -11,42 +9,30 @@ import Tags from './';
 
 expect.extend(matchers);
 
-const mockTag = {
-	webTitle: 'Tag title',
-	webUrl: 'https://mapi.co.uk/tag',
-	type: TagType.KEYWORD,
-};
-
-const mockFormat: ArticleFormat = {
-	theme: ArticlePillar.News,
-	design: ArticleDesign.Comment,
-	display: ArticleDisplay.Standard,
-};
-
 // ----- Tests ----- //
 
 describe('Tags component renders as expected', () => {
 	it('Renders link to tag', () => {
 		const tags = renderer.create(
-			<Tags tags={[mockTag]} format={mockFormat} />,
+			<Tags item={article} />,
 		);
 		const link = tags.root.findByType('a');
-		expect(link.props.href).toBe('https://mapi.co.uk/tag');
+		expect(link.props.href).toBe(article.tags[0].webUrl);
 	});
 
 	it('Renders tag title', () => {
 		const tags = renderer.create(
-			<Tags tags={[mockTag]} format={mockFormat} />,
+			<Tags item={article} />,
 		);
-		expect(tags.root.findByType('a').children.includes('Tag title')).toBe(
+		expect(tags.root.findByType('a').children.includes(article.tags[0].webTitle)).toBe(
 			true,
 		);
 	});
 
 	it('Renders correct number of tags', () => {
 		const tags = renderer.create(
-			<Tags tags={[mockTag, mockTag]} format={mockFormat} />,
+			<Tags item={article} />,
 		);
-		expect(tags.root.findAllByType('li').length).toBe(2);
+		expect(tags.root.findAllByType('li').length).toBe(7);
 	});
 });

--- a/apps-rendering/src/components/Tags/index.tsx
+++ b/apps-rendering/src/components/Tags/index.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
 import { ArticleDisplay } from '@guardian/libs';
-import { getFormat, Item } from 'item';
+import type { Item } from 'item';
+import { getFormat } from 'item';
 import type { FC } from 'react';
 import ImmersiveTags from './ImmersiveTags';
 import { defaultStyles, DefaultTags } from './Tags.defaults';
@@ -10,7 +11,7 @@ import { defaultStyles, DefaultTags } from './Tags.defaults';
 
 type Props = {
 	item: Item;
-}
+};
 
 const Tags: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
@@ -19,8 +20,8 @@ const Tags: FC<Props> = ({ item }) => {
 		return <ImmersiveTags item={item} />;
 	}
 
-	return <DefaultTags item={item} css={defaultStyles(getFormat(item))} />
-}
+	return <DefaultTags item={item} css={defaultStyles(getFormat(item))} />;
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Tags/index.tsx
+++ b/apps-rendering/src/components/Tags/index.tsx
@@ -1,98 +1,26 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from '@emotion/react';
-import { css } from '@emotion/react';
-import { background } from '@guardian/common-rendering/src/editorialPalette';
-import { TagType } from '@guardian/content-api-models/v1/tagType';
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign } from '@guardian/libs';
-import { neutral, remSpace, textSans } from '@guardian/source-foundations';
+import { ArticleDisplay } from '@guardian/libs';
+import { getFormat, Item } from 'item';
 import type { FC } from 'react';
-import { darkModeCss } from 'styles';
+import ImmersiveTags from './ImmersiveTags';
+import { defaultStyles, DefaultTags } from './Tags.defaults';
 
 // ----- Component ----- //
 
-const backgroundColour = (format: ArticleFormat): string => {
-	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return neutral[86];
-		case ArticleDesign.LiveBlog:
-			return neutral[93];
-		default:
-			return neutral[97];
-	}
-};
-
-const styles = (format: ArticleFormat): SerializedStyles => css`
-	margin-top: 0;
-	margin-bottom: 0;
-	display: flex;
-	flex-wrap: wrap;
-	list-style: none;
-	padding: ${remSpace[3]} 0 ${remSpace[2]} 0;
-	${textSans.medium()}
-
-	${darkModeCss`
-		background-color: ${background.articleContentDark(format)};
-		color: ${neutral[86]};
-	`}
-`;
-
-const tagStyles = css`
-	margin-right: 1rem;
-	margin-bottom: 1rem;
-	line-height: 0;
-`;
-
-const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
-	text-decoration: none;
-	white-space: nowrap;
-	padding: 6px 16px;
-	border-radius: 30px;
-	text-overflow: ellipsis;
-	max-width: 18.75rem;
-	color: ${neutral[7]};
-	background-color: ${backgroundColour(format)};
-	display: inline-block;
-	white-space: nowrap;
-	overflow: hidden;
-	line-height: 1;
-
-	${darkModeCss`
-		color: ${neutral[86]};
-		background-color: ${neutral[20]};
-	`};
-`;
-
-interface Props {
-	tags: Array<{
-		webUrl: string;
-		webTitle: string;
-		type: TagType;
-	}>;
-	background?: string;
-	format: ArticleFormat;
+type Props = {
+	item: Item;
 }
 
-const Tags: FC<Props> = ({ tags, format }) => (
-	<ul css={styles(format)} role="list">
-		{tags
-			.filter(
-				(tag) =>
-					tag.type !== TagType.CAMPAIGN &&
-					tag.type !== TagType.TRACKING,
-			)
-			.map((tag, index) => (
-				<li key={index} css={tagStyles}>
-					<a href={tag.webUrl} css={anchorStyles(format)}>
-						{tag.webTitle}
-					</a>
-				</li>
-			))}
-	</ul>
-);
+const Tags: FC<Props> = ({ item }) => {
+	const format = getFormat(item);
+
+	if (format.display === ArticleDisplay.Immersive) {
+		return <ImmersiveTags item={item} />;
+	}
+
+	return <DefaultTags item={item} css={defaultStyles(getFormat(item))} />
+}
 
 // ----- Exports ----- //
 


### PR DESCRIPTION
## Why?

Following on from #5248 this continues the work to build the immersive layout in AR. This PR adds tags to the bottom of the article.

I've refactored the `Tags` component to use the `index`/`defaults` pattern introduced by @iainjchambers-guardian for some of our other components. Other existing examples can be found in the `Headline` and `Standfirst` components. This pattern was introduced because we found that our components varied widely depending on `format`. It was becoming difficult to reason about them as a single entity, and we were often required to pass props that were unnecessary for a given variant. Therefore we decided to split the variations out into sub-components, and use `index` files to handle the routing based on `format`. To minimise duplicating everything across all sub-components we also introduced a "defaults" file, which provides common layout and styles.

## Changes

- Refactored tags component to use index/defaults pattern
- Updated usages of tags component
- Added `ImmersiveTags` component
- Updated tests and stories to use main item fixture

## Screenshots

| Mobile | Tablet | Desktop |
| - | - | - |
| ![tags-mobile] | ![tags-tablet] | ![tags-desktop] |

[tags-mobile]: https://user-images.githubusercontent.com/53781962/179046487-f4a72e37-1980-40f8-81bf-35533560aaac.jpg
[tags-desktop]: https://user-images.githubusercontent.com/53781962/179046493-b86827bb-1a2c-4d5e-94a0-abe93b533818.jpg
[tags-tablet]: https://user-images.githubusercontent.com/53781962/179046497-f371fd96-916c-47c5-a8c1-c0928a4b659b.jpg
