### PR TITLE
fix: Use npm ci when installing apps-rendering in CI environment

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -18,9 +18,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Validate AMP
               run: make ampValidation
               working-directory: dotcom-rendering

--- a/.github/workflows/ar-nodejs.yml
+++ b/.github/workflows/ar-nodejs.yml
@@ -31,10 +31,6 @@ jobs:
                   key: node-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: node-
 
-            - name: install
-              run: npm ci
-              working-directory: apps-rendering
-
             - name: lint
               run: npm run lint
               working-directory: apps-rendering

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -18,9 +18,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Generate production build
               run: make build
               working-directory: dotcom-rendering

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -18,9 +18,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Generate production build
               run: make build
               working-directory: dotcom-rendering

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,11 +15,6 @@ jobs:
       # Root yarn installs all workspaces (root, common, dotcom)
       - uses: bahmutov/npm-install@v1
 
-      # Install packages for apps-rendering project
-      - uses: bahmutov/npm-install@v1
-        with:
-          working-directory: apps-rendering
-
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -15,9 +15,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Run Jest
               run: CI=true yarn test
               working-directory: dotcom-rendering

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,9 +15,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Prettier check
               run: yarn prettier:check
               working-directory: dotcom-rendering

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -18,9 +18,6 @@ jobs:
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - uses: bahmutov/npm-install@v1
 
-      - name: Install
-        run: yarn
-
       - name: Run check-schema script
         run: make check-schema
         working-directory: dotcom-rendering

--- a/.github/workflows/stories-check.yml
+++ b/.github/workflows/stories-check.yml
@@ -18,9 +18,6 @@ jobs:
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - uses: bahmutov/npm-install@v1
 
-      - name: Install
-        run: yarn
-
       - name: Run check-stories script
         run: make check-stories
         working-directory: dotcom-rendering

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,9 +15,6 @@ jobs:
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1
 
-            - name: Install
-              run: yarn
-
             - name: Check typescript
               run: yarn tsc
               working-directory: dotcom-rendering

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"common-rendering"
 	],
 	"scripts": {
-		"postinstall": "npm install --prefix ./apps-rendering",
+		"postinstall": "if [ \"$CI\" = true ]; then npm ci --prefix ./apps-rendering ; else npm install --prefix ./apps-rendering ; fi",
 		"storybook": "node --max-old-space-size=4096 $(yarn bin)/start-storybook --static-dir ./dotcom-rendering/src/static -p 6006",
 		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook --static-dir ./dotcom-rendering/src/static",
 		"build:dcr": "cd ./dotcom-rendering && yarn makeBuild",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

 - Adds a condition to the `postinstall` script to use `npm ci` instead of `npm install` when being ran in Github Actions
 - Removes a lot of superfluous yarn & npm install steps(Probably should have been done in a seperate PR, got a bit ahead of myself!)

## Why?

Currently Turbosnap is being skipped on every PR because `npm install` keeps updating the `package-lock.json` file for apps-rendering. Turbosnap is very cautious about when to run tests and if it detects that the package-lock.json has changed it will revert to the standard Chromatic behaviour of running all tests.

## Alternatives

### Yarn --ignore-scripts

Yarn has an --ignore-scripts option which can be used to disable the postinstall script, but it seems like it applies this restriction to all dependencies too.

### Turbosnap CLI

Turbosnap has a CLI option to specifically ignore certain files from the "Should I run all stories?" failsafe, but I couldn't see how/if this can be enabled using the Github action options.