### PR TITLE
Remove unwanted characters from Filters title

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -134,6 +134,7 @@ type Palette = {
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
+		betaLabel: Colour;
 	};
 	background: {
 		article: Colour;
@@ -277,13 +278,13 @@ type CustomParams = {
 
 type AdTargeting =
 	| {
-			adUnit: string;
-			customParams: CustomParams;
-			disableAds?: false;
-	  }
+		adUnit: string;
+		customParams: CustomParams;
+		disableAds?: false;
+	}
 	| {
-			disableAds: true;
-	  };
+		disableAds: true;
+	};
 
 interface SectionNielsenAPI {
 	name: string;

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, headline, space, textSans } from '@guardian/source-foundations';
+import { decidePalette } from '../lib/decidePalette';
 import { FilterButton } from './FilterButton.importable';
 
 type Props = {
@@ -20,8 +21,9 @@ const headlineStyles = css`
 	padding-bottom: ${space[3]}px;
 `;
 
-const headlineAccentStyles = css`
-	${textSans.small({ fontWeight: 'regular', lineHeight: 'tight' })};
+const headlineAccentStyles = (palette: Palette) => css`
+	color: ${palette.text.betaLabel};
+	${textSans.xxsmall({ fontWeight: 'regular', lineHeight: 'tight' })};
 `;
 
 const topicStyles = css`
@@ -80,6 +82,7 @@ export const TopicFilterBank = ({
 	filterKeyEvents = false,
 	id,
 }: Props) => {
+	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
 	const topFiveTopics = availableTopics.slice(0, 5);
 
@@ -96,7 +99,7 @@ export const TopicFilterBank = ({
 	return (
 		<div css={containerStyles}>
 			<div css={headlineStyles}>
-				Filters <span css={headlineAccentStyles}>BETA</span>
+				Filters <span css={headlineAccentStyles(palette)}>BETA</span>
 			</div>
 			<div css={topicStyles}>
 				{keyEvents?.length && (

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1170,6 +1170,8 @@ const textDropCap = (format: ArticleFormat): string => {
 	}
 };
 
+const textBetaLabel = (): string => neutral[46];
+
 const textBlockquote = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -1366,6 +1368,7 @@ export const decidePalette = (
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
+			betaLabel: textBetaLabel(),
 		},
 		background: {
 			article: backgroundArticle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the parenthesis and colon from the `Filters BETA` title and updates`BETA` font styles

## Why?
This is a design request. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/178956325-49fc5b24-0b9b-4d01-bbe0-98b8f22da56a.png
[after]: https://user-images.githubusercontent.com/20416599/178959244-283379de-5228-47a4-9029-31237624d587.png

