### PR TITLE
Increase timeout for visibility assertion on liveblog new block test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-5/liveblog.interactivity.cy.js
@@ -209,9 +209,9 @@ describe('Liveblogs', function () {
 			// the page. Using data-gu-name="media" for now to get
 			// around this scroll depth issue
 			cy.get('div[data-gu-name="media"]').scrollIntoView();
-			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e').should(
-				'be.visible',
-			);
+			cy.get('#46d194c9-ea50-4cd5-af8b-a51e8b15c65e', {
+				timeout: 10000,
+			}).should('be.visible');
 		});
 	});
 


### PR DESCRIPTION
## What does this change?

Increase timeout for visibility assertion on liveblog new block test.

The block has a Twitter embed which maybe impacting the test as Twitter is currently experiencing issues.

## Why?

Flakey test
