### PR TITLE
Use HTTP3 for downloading Assets if part of HTTP3 experiment

### DIFF
--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -49,7 +49,6 @@ export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE, isDev);
 
 export const getScriptArrayFromFile = (
 	file: `${string}.js`,
-	offerHttp3: boolean,
 ): { src: string; legacy?: boolean }[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
@@ -60,17 +59,16 @@ export const getScriptArrayFromFile = (
 		: legacyManifest[file];
 
 	const scripts = [];
-	const http3Suffix = offerHttp3 ? '?http3' : '';
 
 	if (filename) {
 		scripts.push({
-			src: `${ASSET_ORIGIN}assets/${filename}${http3Suffix}`,
+			src: `${ASSET_ORIGIN}assets/${filename}`,
 			legacy: false,
 		});
 	}
 	if (legacyFilename) {
 		scripts.push({
-			src: `${ASSET_ORIGIN}assets/${legacyFilename}${http3Suffix}`,
+			src: `${ASSET_ORIGIN}assets/${legacyFilename}`,
 			legacy: true,
 		});
 	}

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -49,6 +49,7 @@ export const ASSET_ORIGIN = decideAssetOrigin(process.env.GU_STAGE, isDev);
 
 export const getScriptArrayFromFile = (
 	file: `${string}.js`,
+	offerHttp3: boolean,
 ): { src: string; legacy?: boolean }[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
@@ -59,16 +60,17 @@ export const getScriptArrayFromFile = (
 		: legacyManifest[file];
 
 	const scripts = [];
+	const http3Suffix = offerHttp3 ? '?http3' : '';
 
 	if (filename) {
 		scripts.push({
-			src: `${ASSET_ORIGIN}assets/${filename}`,
+			src: `${ASSET_ORIGIN}assets/${filename}${http3Suffix}`,
 			legacy: false,
 		});
 	}
 	if (legacyFilename) {
 		scripts.push({
-			src: `${ASSET_ORIGIN}assets/${legacyFilename}`,
+			src: `${ASSET_ORIGIN}assets/${legacyFilename}${http3Suffix}`,
 			legacy: true,
 		});
 	}

--- a/dotcom-rendering/src/web/lib/getHttp3Url.ts
+++ b/dotcom-rendering/src/web/lib/getHttp3Url.ts
@@ -1,0 +1,7 @@
+// Evaluating the performance of HTTP3 over HTTP2, this file can be removed once the experiment is concluded.
+// See: https://github.com/guardian/dotcom-rendering/pull/5394
+export const getHttp3Url = (url: string): string => {
+	const urlObject = new URL(url);
+	urlObject.searchParams.append('http', 'true');
+	return urlObject.toString();
+};

--- a/dotcom-rendering/src/web/lib/getHttp3Url.ts
+++ b/dotcom-rendering/src/web/lib/getHttp3Url.ts
@@ -2,6 +2,6 @@
 // See: https://github.com/guardian/dotcom-rendering/pull/5394
 export const getHttp3Url = (url: string): string => {
 	const urlObject = new URL(url);
-	urlObject.searchParams.append('http', 'true');
+	urlObject.searchParams.append('http3', 'true');
 	return urlObject.toString();
 };

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -117,6 +117,10 @@ export const articleToHtml = ({ data }: Props): string => {
 			'model.dotcomrendering.pageElements.TweetBlockElement',
 	);
 
+	// Evaluating the performance of HTTP3 over HTTP2
+	// See: https://github.com/guardian/dotcom-rendering/pull/5394
+	const offerHttp3 = CAPIArticle.config.switches.offerHttp3;
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -126,17 +130,19 @@ export const articleToHtml = ({ data }: Props): string => {
 	 */
 	const priorityScriptTags = generateScriptTags([
 		{ src: polyfillIO },
-		...getScriptArrayFromFile('bootCmp.js'),
-		...getScriptArrayFromFile('ophan.js'),
+		...getScriptArrayFromFile('bootCmp.js', offerHttp3),
+		...getScriptArrayFromFile('ophan.js', offerHttp3),
 		CAPIArticle.config && { src: CAPIArticle.config.commercialBundleUrl },
-		...getScriptArrayFromFile('sentryLoader.js'),
-		...getScriptArrayFromFile('dynamicImport.js'),
+		...getScriptArrayFromFile('sentryLoader.js', offerHttp3),
+		...getScriptArrayFromFile('dynamicImport.js', offerHttp3),
 		pageHasNonBootInteractiveElements && {
-			src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
+			src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js${
+				offerHttp3 ? '?http3' : ''
+			}`,
 		},
-		...getScriptArrayFromFile('islands.js'),
+		...getScriptArrayFromFile('islands.js', offerHttp3),
 		...expeditedIslands.flatMap((name) =>
-			getScriptArrayFromFile(`${name}.js`),
+			getScriptArrayFromFile(`${name}.js`, offerHttp3),
 		),
 	]);
 
@@ -148,14 +154,14 @@ export const articleToHtml = ({ data }: Props): string => {
 	 * unlikely.
 	 */
 	const lowPriorityScriptTags = generateScriptTags([
-		...getScriptArrayFromFile('atomIframe.js'),
-		...getScriptArrayFromFile('embedIframe.js'),
-		...getScriptArrayFromFile('newsletterEmbedIframe.js'),
-		...getScriptArrayFromFile('relativeTime.js'),
-		...getScriptArrayFromFile('initDiscussion.js'),
+		...getScriptArrayFromFile('atomIframe.js', offerHttp3),
+		...getScriptArrayFromFile('embedIframe.js', offerHttp3),
+		...getScriptArrayFromFile('newsletterEmbedIframe.js', offerHttp3),
+		...getScriptArrayFromFile('relativeTime.js', offerHttp3),
+		...getScriptArrayFromFile('initDiscussion.js', offerHttp3),
 	]);
 
-	const gaChunk = getScriptArrayFromFile('ga.js');
+	const gaChunk = getScriptArrayFromFile('ga.js', offerHttp3);
 	const modernScript = gaChunk.find((script) => script.legacy === false);
 	const legacyScript = gaChunk.find((script) => script.legacy === true);
 	const gaPath = {

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -119,7 +119,7 @@ export const articleToHtml = ({ data }: Props): string => {
 
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
-	const offerHttp3 = CAPIArticle.config.switches.offerHttp3;
+	const { offerHttp3 } = CAPIArticle.config.switches;
 
 	/**
 	 * The highest priority scripts.

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -77,6 +77,10 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
+	//
+	// See :https://github.com/guardian/dotcom-rendering/pull/5394
+	const offerHttp3 = front.config.switches.offerHttp3;
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -84,14 +88,15 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
+
 	const priorityScriptTags = generateScriptTags([
 		{ src: polyfillIO },
-		...getScriptArrayFromFile('bootCmp.js'),
-		...getScriptArrayFromFile('ophan.js'),
+		...getScriptArrayFromFile('bootCmp.js', offerHttp3),
+		...getScriptArrayFromFile('ophan.js', offerHttp3),
 		front.config && { src: front.config.commercialBundleUrl },
-		...getScriptArrayFromFile('sentryLoader.js'),
-		...getScriptArrayFromFile('dynamicImport.js'),
-		...getScriptArrayFromFile('islands.js'),
+		...getScriptArrayFromFile('sentryLoader.js', offerHttp3),
+		...getScriptArrayFromFile('dynamicImport.js', offerHttp3),
+		...getScriptArrayFromFile('islands.js', offerHttp3),
 	]);
 
 	/**
@@ -102,13 +107,13 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	 * unlikely.
 	 */
 	const lowPriorityScriptTags = generateScriptTags([
-		...getScriptArrayFromFile('atomIframe.js'),
-		...getScriptArrayFromFile('embedIframe.js'),
-		...getScriptArrayFromFile('newsletterEmbedIframe.js'),
-		...getScriptArrayFromFile('relativeTime.js'),
+		...getScriptArrayFromFile('atomIframe.js', offerHttp3),
+		...getScriptArrayFromFile('embedIframe.js', offerHttp3),
+		...getScriptArrayFromFile('newsletterEmbedIframe.js', offerHttp3),
+		...getScriptArrayFromFile('relativeTime.js', offerHttp3),
 	]);
 
-	const gaChunk = getScriptArrayFromFile('ga.js');
+	const gaChunk = getScriptArrayFromFile('ga.js', offerHttp3);
 	const modernScript = gaChunk.find((script) => script.legacy === false);
 	const legacyScript = gaChunk.find((script) => script.legacy === true);
 	const gaPath = {

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -77,9 +77,9 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
-	//
-	// See :https://github.com/guardian/dotcom-rendering/pull/5394
-	const offerHttp3 = front.config.switches.offerHttp3;
+	// Evaluating the performance of HTTP3 over HTTP2
+	// See: https://github.com/guardian/dotcom-rendering/pull/5394
+	const { offerHttp3 } = CAPIArticle.config.switches;
 
 	/**
 	 * The highest priority scripts.


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Paired on with @paulmr 

As part of an experiment that @paulmr is working on we'd like to try and load some of our JS and other assets over a HTTP3 connection. This is done by appending ?http3 to our asset urls.

There will be a corresponding change made over on the Assets VCL to support this query parameter.

## Why?

Fastly has recently added support for HTTP3 connections on their CDN and we've been asked to trial it out. In theory we should be able to improve stats such as TTI as HTTP3 uses the QUIC protocol for transferring assets. QUIC offers, among other things, improved multiplexing (Parallel downloads over a single connection) and a much faster handshake for establishing connections.

We recently added a new experiment which users can opt into and receive HTTP3 on the main www.theguardian.com domain, unfortunately this doesn't work for our other domains such as Assets and Images as we can't access a users experiment cookies in the VCL for those domains. As a workaround we'd like to append ?http3 to our asset URL's if we detect a user is part of the experiment, this will then allow us to check for that query parameter in the Asset VCL and offer HTTP3 if its detected.

HTTP3 is backwards compatible with older browsers, so in theory we can just enable it for everyone, we'd like to try and get some measure of its impact before we do that though.

This article describes HTTP3 far better than I ever could and includes some nice benchmarks https://requestmetrics.com/web-performance/http3-is-fast

## This isn't an ideal solution

Ideally we'd like to be able to test our entire site using HTTP3, (especially images!) but besides just turning on HTTP3 by default we couldn't really think of a great way of doing this.

One alternative might be to modify the DOM at the edge and rewrite any URL's to point to their HTTP3 alternatives but that doesn't really deal with URL's in JS and might skew our experiment by adding extra page load time to mutate the page.