### PR TITLE
Fail pre-push if `main` branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,13 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+currentBranch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [[ $currentBranch == "main" ]]
+then
+	echo "⚠️ You should not push to the \`main\` branch"
+	exit 1
+fi
+
 yarn workspace @guardian/dotcom-rendering prettier:check
 yarn workspace @guardian/dotcom-rendering tsc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,11 @@
 	},
 	"jest.jestCommandLine": "yarn workspaces run test",
     "typescript.tsdk": "node_modules/typescript/lib",
-    "gitlens.advanced.blame.customArguments": ["--ignore-revs-file", ".git-blame-ignore-revs"]
+    "gitlens.advanced.blame.customArguments": [
+        "--ignore-revs-file",
+        ".git-blame-ignore-revs"
+    ],
+    "git.branchProtection": [
+        "main"
+    ]
 }

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2,6 +2,384 @@
     "type": "object",
     "properties": {
         "pressedPage": {
+            "$ref": "#/definitions/FEPressedPageType"
+        },
+        "nav": {
+            "$ref": "#/definitions/CAPINavType"
+        },
+        "editionId": {
+            "$ref": "#/definitions/EditionId"
+        },
+        "editionLongForm": {
+            "type": "string"
+        },
+        "guardianBaseURL": {
+            "type": "string"
+        },
+        "pageId": {
+            "type": "string"
+        },
+        "webTitle": {
+            "type": "string"
+        },
+        "webURL": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "keywordIds": {
+                    "type": "string"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "type": "object"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "userAttributesApiUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "isFront": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "discussionFrontendUrl": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "weatherapiurl": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "brazeApiKey",
+                "buildNumber",
+                "calloutsUrl",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "discussionFrontendUrl",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isFront",
+                "isPaidContent",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "keywordIds",
+                "keywords",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "userAttributesApiUrl",
+                "weatherapiurl",
+                "webTitle"
+            ]
+        },
+        "commercialProperties": {
+            "$ref": "#/definitions/Record<string,unknown>"
+        },
+        "pageFooter": {
+            "$ref": "#/definitions/FooterType"
+        }
+    },
+    "required": [
+        "commercialProperties",
+        "config",
+        "editionId",
+        "editionLongForm",
+        "guardianBaseURL",
+        "nav",
+        "pageFooter",
+        "pageId",
+        "pressedPage",
+        "webTitle",
+        "webURL"
+    ],
+    "definitions": {
+        "FEPressedPageType": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1940,381 +2318,6 @@
                 "seoData"
             ]
         },
-        "nav": {
-            "$ref": "#/definitions/CAPINavType"
-        },
-        "editionId": {
-            "$ref": "#/definitions/EditionId"
-        },
-        "editionLongForm": {
-            "type": "string"
-        },
-        "guardianBaseURL": {
-            "type": "string"
-        },
-        "pageId": {
-            "type": "string"
-        },
-        "webTitle": {
-            "type": "string"
-        },
-        "webURL": {
-            "type": "string"
-        },
-        "config": {
-            "type": "object",
-            "properties": {
-                "avatarApiUrl": {
-                    "type": "string"
-                },
-                "externalEmbedHost": {
-                    "type": "string"
-                },
-                "ajaxUrl": {
-                    "type": "string"
-                },
-                "keywords": {
-                    "type": "string"
-                },
-                "revisionNumber": {
-                    "type": "string"
-                },
-                "isProd": {
-                    "type": "boolean"
-                },
-                "switches": {
-                    "$ref": "#/definitions/Switches"
-                },
-                "section": {
-                    "type": "string"
-                },
-                "keywordIds": {
-                    "type": "string"
-                },
-                "locationapiurl": {
-                    "type": "string"
-                },
-                "sharedAdTargeting": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "buildNumber": {
-                    "type": "string"
-                },
-                "abTests": {
-                    "type": "object"
-                },
-                "pbIndexSites": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    }
-                },
-                "ampIframeUrl": {
-                    "type": "string"
-                },
-                "beaconUrl": {
-                    "type": "string"
-                },
-                "userAttributesApiUrl": {
-                    "type": "string"
-                },
-                "host": {
-                    "type": "string"
-                },
-                "brazeApiKey": {
-                    "type": "string"
-                },
-                "calloutsUrl": {
-                    "type": "string"
-                },
-                "requiresMembershipAccess": {
-                    "type": "boolean"
-                },
-                "onwardWebSocket": {
-                    "type": "string"
-                },
-                "a9PublisherId": {
-                    "type": "string"
-                },
-                "contentType": {
-                    "type": "string"
-                },
-                "facebookIaAdUnitRoot": {
-                    "type": "string"
-                },
-                "ophanEmbedJsUrl": {
-                    "type": "string"
-                },
-                "idUrl": {
-                    "type": "string"
-                },
-                "dcrSentryDsn": {
-                    "type": "string"
-                },
-                "isFront": {
-                    "type": "boolean",
-                    "enum": [
-                        true
-                    ]
-                },
-                "idWebAppUrl": {
-                    "type": "string"
-                },
-                "discussionApiUrl": {
-                    "type": "string"
-                },
-                "sentryPublicApiKey": {
-                    "type": "string"
-                },
-                "omnitureAccount": {
-                    "type": "string"
-                },
-                "dfpAccountId": {
-                    "type": "string"
-                },
-                "pageId": {
-                    "type": "string"
-                },
-                "forecastsapiurl": {
-                    "type": "string"
-                },
-                "assetsPath": {
-                    "type": "string"
-                },
-                "pillar": {
-                    "type": "string"
-                },
-                "commercialBundleUrl": {
-                    "type": "string"
-                },
-                "discussionApiClientHeader": {
-                    "type": "string"
-                },
-                "membershipUrl": {
-                    "type": "string"
-                },
-                "dfpHost": {
-                    "type": "string"
-                },
-                "cardStyle": {
-                    "type": "string"
-                },
-                "googletagUrl": {
-                    "type": "string"
-                },
-                "sentryHost": {
-                    "type": "string"
-                },
-                "shouldHideAdverts": {
-                    "type": "boolean"
-                },
-                "mmaUrl": {
-                    "type": "string"
-                },
-                "membershipAccess": {
-                    "type": "string"
-                },
-                "isPreview": {
-                    "type": "boolean"
-                },
-                "googletagJsUrl": {
-                    "type": "string"
-                },
-                "supportUrl": {
-                    "type": "string"
-                },
-                "edition": {
-                    "type": "string"
-                },
-                "discussionFrontendUrl": {
-                    "type": "string"
-                },
-                "ipsosTag": {
-                    "type": "string"
-                },
-                "ophanJsUrl": {
-                    "type": "string"
-                },
-                "isPaidContent": {
-                    "type": "boolean"
-                },
-                "mobileAppsAdUnitRoot": {
-                    "type": "string"
-                },
-                "plistaPublicApiKey": {
-                    "type": "string"
-                },
-                "frontendAssetsFullURL": {
-                    "type": "string"
-                },
-                "googleSearchId": {
-                    "type": "string"
-                },
-                "allowUserGeneratedContent": {
-                    "type": "boolean"
-                },
-                "dfpAdUnitRoot": {
-                    "type": "string"
-                },
-                "idApiUrl": {
-                    "type": "string"
-                },
-                "omnitureAmpAccount": {
-                    "type": "string"
-                },
-                "adUnit": {
-                    "type": "string"
-                },
-                "hasPageSkin": {
-                    "type": "boolean"
-                },
-                "webTitle": {
-                    "type": "string"
-                },
-                "stripePublicToken": {
-                    "type": "string"
-                },
-                "googleRecaptchaSiteKey": {
-                    "type": "string"
-                },
-                "discussionD2Uid": {
-                    "type": "string"
-                },
-                "weatherapiurl": {
-                    "type": "string"
-                },
-                "googleSearchUrl": {
-                    "type": "string"
-                },
-                "optimizeEpicUrl": {
-                    "type": "string"
-                },
-                "stage": {
-                    "$ref": "#/definitions/StageType"
-                },
-                "idOAuthUrl": {
-                    "type": "string"
-                },
-                "isSensitive": {
-                    "type": "boolean"
-                },
-                "isDev": {
-                    "type": "boolean"
-                },
-                "thirdPartyAppsAccount": {
-                    "type": "string"
-                },
-                "avatarImagesUrl": {
-                    "type": "string"
-                },
-                "fbAppId": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "a9PublisherId",
-                "abTests",
-                "adUnit",
-                "ajaxUrl",
-                "allowUserGeneratedContent",
-                "ampIframeUrl",
-                "assetsPath",
-                "avatarApiUrl",
-                "avatarImagesUrl",
-                "beaconUrl",
-                "brazeApiKey",
-                "buildNumber",
-                "calloutsUrl",
-                "commercialBundleUrl",
-                "contentType",
-                "dcrSentryDsn",
-                "dfpAccountId",
-                "dfpAdUnitRoot",
-                "dfpHost",
-                "discussionApiClientHeader",
-                "discussionApiUrl",
-                "discussionD2Uid",
-                "discussionFrontendUrl",
-                "edition",
-                "externalEmbedHost",
-                "facebookIaAdUnitRoot",
-                "fbAppId",
-                "forecastsapiurl",
-                "frontendAssetsFullURL",
-                "googleRecaptchaSiteKey",
-                "googleSearchId",
-                "googleSearchUrl",
-                "googletagJsUrl",
-                "googletagUrl",
-                "hasPageSkin",
-                "host",
-                "idApiUrl",
-                "idOAuthUrl",
-                "idUrl",
-                "idWebAppUrl",
-                "ipsosTag",
-                "isDev",
-                "isFront",
-                "isPaidContent",
-                "isPreview",
-                "isProd",
-                "isSensitive",
-                "keywordIds",
-                "keywords",
-                "locationapiurl",
-                "membershipAccess",
-                "membershipUrl",
-                "mmaUrl",
-                "mobileAppsAdUnitRoot",
-                "omnitureAccount",
-                "omnitureAmpAccount",
-                "onwardWebSocket",
-                "ophanEmbedJsUrl",
-                "ophanJsUrl",
-                "optimizeEpicUrl",
-                "pageId",
-                "pbIndexSites",
-                "pillar",
-                "plistaPublicApiKey",
-                "requiresMembershipAccess",
-                "revisionNumber",
-                "section",
-                "sentryHost",
-                "sentryPublicApiKey",
-                "sharedAdTargeting",
-                "shouldHideAdverts",
-                "stage",
-                "stripePublicToken",
-                "supportUrl",
-                "switches",
-                "userAttributesApiUrl",
-                "weatherapiurl",
-                "webTitle"
-            ]
-        },
-        "commercialProperties": {
-            "$ref": "#/definitions/Record<string,unknown>"
-        },
-        "pageFooter": {
-            "$ref": "#/definitions/FooterType"
-        }
-    },
-    "required": [
-        "commercialProperties",
-        "config",
-        "editionId",
-        "editionLongForm",
-        "guardianBaseURL",
-        "nav",
-        "pageFooter",
-        "pageId",
-        "pressedPage",
-        "webTitle",
-        "webURL"
-    ],
-    "definitions": {
         "Record<string,unknown>": {
             "type": "object"
         },


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Don’t allow pre-push to exectute if on `main` branch.

If an administrator uses `--no-verify`, it will still fail as we’ve enforced branch protection rules for administrators.

## Why?

I recently pushed to `main` by mistake.

- #5393 

## Screenshots

![image](https://user-images.githubusercontent.com/76776/179013677-9fa63740-c0e1-4b61-842b-37c445703915.png)

![image](https://user-images.githubusercontent.com/76776/179013629-e65fae42-d3de-4246-87ac-16276cb0d10d.png)
