### PR TITLE
Reduce Comment byline width between mobile and phablet breakpoints

### DIFF
--- a/apps-rendering/src/components/Byline/CommentByline.tsx
+++ b/apps-rendering/src/components/Byline/CommentByline.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import { headline } from '@guardian/source-foundations';
+import { between, headline } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { darkModeCss } from 'styles';
 import { DefaultByline } from './Byline.defaults';
@@ -11,6 +11,10 @@ const commentStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.bylineLeftColumn(format)};
 	width: 75%;
 	${headline.medium({ fontWeight: 'light', fontStyle: 'italic' })}
+
+	${between.mobile.and.phablet} {
+		width: 65%;
+	}
 `;
 
 const commentAnchorStyles = (format: ArticleFormat): SerializedStyles => css`

--- a/apps-rendering/src/components/Byline/CommentByline.tsx
+++ b/apps-rendering/src/components/Byline/CommentByline.tsx
@@ -13,7 +13,7 @@ const commentStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'light', fontStyle: 'italic' })}
 
 	${between.mobile.and.phablet} {
-		width: 65%;
+		width: 68%;
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
 
## What does this change?

* Reduces byline width on Comment pieces to 68% between `mobile` and `phablet` breakpoints

## Why?

To fix #5398 

## Screenshots

### iPhone SE 2

| Before      | After      |
|-------------|------------|
| ![iPhoneSE2Before][] | ![iPhoneSE2After][] |

[iPhoneSE2Before]: https://user-images.githubusercontent.com/53781962/179043999-55f39d2e-321b-4cde-a907-6c4d7b7d0d6a.jpg
[iPhoneSE2After]: https://user-images.githubusercontent.com/705427/179215005-7d31a83c-b8be-4924-a9d7-d6266ef33a93.png

### iPhone 13 Pro

| Before      | After      |
|-------------|------------|
| ![iPhone13ProBefore][] | ![iPhone13ProAfter][] |

[iPhone13ProBefore]: https://user-images.githubusercontent.com/53781962/179043993-808b44c3-cf9c-4225-a53c-e8d34287c499.jpg
[iPhone13ProAfter]: https://user-images.githubusercontent.com/705427/179214322-cc1e08bd-80ba-47aa-9a1a-eede534e0791.png

### iPhone 13 Pro Max

| Before      | After      |
|-------------|------------|
| ![iPhone13ProMaxBefore][] | ![iPhone13ProMaxAfter][] |

[iPhone13ProMaxBefore]: https://user-images.githubusercontent.com/53781962/179043983-060cd0c7-fee9-4e8e-a117-88cbbe21c457.jpg
[iPhone13ProMaxAfter]: https://user-images.githubusercontent.com/705427/179214769-268a186f-f0da-4aa0-985d-4ae8004abad3.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
