### PR TITLE
Add styling to <span> wrapper on byline date

### DIFF
--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -16,11 +16,14 @@ const datelineStyles = css`
 const primaryStyles = css`
 	list-style: none;
 	cursor: pointer;
-	:hover {
-		text-decoration: underline;
-	}
 	&::-webkit-details-marker {
 		display: none;
+	}
+`;
+
+const hoverUnderline = css`
+	:hover {
+		text-decoration: underline;
 	}
 `;
 
@@ -52,7 +55,9 @@ export const Dateline: React.FC<{
 						standfirstColouring(palette),
 				]}
 			>
-				<summary css={primaryStyles}>{primaryDateline}</summary>
+				<summary css={primaryStyles}>
+					<span css={hoverUnderline}>{primaryDateline}</span>
+				</summary>
 				{secondaryDateline}
 			</details>
 		);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a `<span>` to wrap the contents of the `<summary>` element
- Add the hover styling directly to the span, instead of the summary

## Why?

The intention here is to fix a bug whereby the underline wasn't being displayed on Safari. 

It's possible that the original has something to do with the way that Safari renders `<summary>` elements in general, where it uses a webkit pseudo-element for the summary marker.

Closes #5025 

## Potential limitations

Unfortunately I haven't been able to properly work out why the original bug occurred, so this is a bit of a workaround, but I don't think that the fix is likely to have unintended side-effects, so it seems reasonable to use the workaround, rather than sinking time into working out where the bug came from.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="858" alt="image" src="https://user-images.githubusercontent.com/37048459/179219383-7c612ef3-4b2c-4470-8bbe-d32272a10f87.png">| <img width="848" alt="image" src="https://user-images.githubusercontent.com/37048459/179219259-77423ef6-8654-4a3d-a63b-eaa37d798af9.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
