### PR TITLE
Move Tag Colours To Editorial Palette

### DIFF
--- a/apps-rendering/src/components/Tags/Tags.defaults.tsx
+++ b/apps-rendering/src/components/Tags/Tags.defaults.tsx
@@ -2,7 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { background, text } from '@guardian/common-rendering/src/editorialPalette';
+import {
+	background,
+	text,
+} from '@guardian/common-rendering/src/editorialPalette';
 import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/Tags/Tags.defaults.tsx
+++ b/apps-rendering/src/components/Tags/Tags.defaults.tsx
@@ -2,10 +2,9 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { background, text } from '@guardian/common-rendering/src/editorialPalette';
 import { TagType } from '@guardian/content-api-models/v1/tagType';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import type { Item } from 'item';
 import { getFormat } from 'item';
@@ -13,19 +12,6 @@ import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
-
-const backgroundColour = (format: ArticleFormat): string => {
-	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return neutral[86];
-		case ArticleDesign.LiveBlog:
-			return neutral[93];
-		default:
-			return neutral[97];
-	}
-};
 
 const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	margin-top: 0;
@@ -55,16 +41,16 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	border-radius: 30px;
 	text-overflow: ellipsis;
 	max-width: 18.75rem;
-	color: ${neutral[7]};
-	background-color: ${backgroundColour(format)};
+	color: ${text.tag(format)};
+	background-color: ${background.tag(format)};
 	display: inline-block;
 	white-space: nowrap;
 	overflow: hidden;
 	line-height: 1;
 
 	${darkModeCss`
-		color: ${neutral[86]};
-		background-color: ${neutral[20]};
+		color: ${text.tagDark(format)};
+		background-color: ${background.tagDark(format)};
 	`};
 `;
 

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -69,13 +69,13 @@ type Props = {
 	children: Option<ReactNode>;
 };
 
-const styles = (supportsDarkMode: boolean) => css`
+const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
-	color: ${text.figCaption()};
+	color: ${text.figCaption(format)};
 
 	${darkModeCss(supportsDarkMode)`
-    	color: ${text.figCaptionDark()};
+    	color: ${text.figCaptionDark(format)};
   	`}
 `;
 
@@ -95,9 +95,9 @@ const getStyles = (
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-			return css(styles(supportsDarkMode), mediaStyles(supportsDarkMode));
+			return css(styles(format, supportsDarkMode), mediaStyles(supportsDarkMode));
 		default:
-			return styles(supportsDarkMode);
+			return styles(format, supportsDarkMode);
 	}
 };
 

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -532,6 +532,21 @@ const seriesDark = (format: ArticleFormat): Colour => {
 	return neutral[10];
 }
 
+const tag = (format: ArticleFormat): Colour => {
+	switch (format.design) {
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return neutral[86];
+		case ArticleDesign.LiveBlog:
+			return neutral[93];
+		default:
+			return neutral[97];
+	}
+}
+
+const tagDark = (_format: ArticleFormat): Colour => neutral[20];
+
 // ----- API ----- //
 
 const background = {
@@ -568,6 +583,8 @@ const background = {
 	standfirstDark,
 	supportBanner,
 	supportBannerDark,
+	tag,
+	tagDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -947,9 +947,9 @@ const pullquoteDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const figCaption = (): Colour => neutral[46];
+const figCaption = (_format: ArticleFormat): Colour => neutral[46];
 
-const figCaptionDark = (): Colour => neutral[60];
+const figCaptionDark = (_format: ArticleFormat): Colour => neutral[60];
 
 const tag = (_format: ArticleFormat): Colour => neutral[7];
 

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -951,6 +951,10 @@ const figCaption = (): Colour => neutral[46];
 
 const figCaptionDark = (): Colour => neutral[60];
 
+const tag = (_format: ArticleFormat): Colour => neutral[7];
+
+const tagDark = (_format: ArticleFormat): Colour => neutral[86];
+
 // ----- API ----- //
 
 const text = {
@@ -1005,6 +1009,8 @@ const text = {
 	standfirstLinkDark,
 	seriesTitle,
 	seriesTitleDark,
+	tag,
+	tagDark,
 	pagination,
 };
 


### PR DESCRIPTION
## Why?

Migrates several tag colours to `editorialPalette`. The background colours as suggested by @iainjchambers-guardian in https://github.com/guardian/dotcom-rendering/pull/5385#discussion_r922054607 and also some text colours.

Also added a `format` argument to some existing palette functions for consistency.

## Changes

- Added tag colours to `text`
- Added tag colours to `background`
- Added format argument to palette functions
