### PR TITLE
chore: Restrics use of props on FrontCard

### DIFF
--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -4,7 +4,26 @@ import { Card } from './Card/Card';
 
 type Props = {
 	trail: TrailType;
-} & Partial<CardProps>;
+	headlineSize?: SmallHeadlineSize;
+	showQuotes?: boolean;
+	showByline?: boolean;
+	imageUrl?: string;
+	imagePosition?: ImagePositionType;
+	imagePositionOnMobile?: ImagePositionType;
+	imageSize?: ImageSizeType;
+	trailText?: string;
+	avatar?: AvatarType;
+	kickerText?: string;
+	showPulsingDot?: boolean;
+	showSlash?: boolean;
+	supportingContent?: DCRSupportingContent[];
+	snapData?: DCRSnapType;
+	containerPalette?: DCRContainerPalette;
+	containerType?: DCRContainerType;
+	showAge?: boolean;
+	discussionId?: string;
+	isDynamo?: true;
+};
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

I merged down #5364 so that people could start using the new FrontCard component to make layouts but there was an outstanding point on weather we should restrict what props can be used in the component.

Follow up on https://github.com/guardian/dotcom-rendering/pull/5364#discussion_r920428971

I have mixed feelings about this, I feel like the FrontCard should work identically to a normal Card but accept an additional `trails` property to auto-fill all the props, at the same time I think the intellisense in VSCode works better if we're explicit about what props a Component accepts instead of using a `Partial<CardProps>`