### PR TITLE
Fix offset-right ad position/label with 160x600

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -107,7 +107,7 @@ const adStyles = css`
 	.ad-slot-container--offset-right {
 		${from.desktop} {
 			float: right;
-			width: 300px;
+			max-width: 300px;
 			margin-right: -318px;
 			background-color: transparent;
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Follow up to #5382, fix the container size and ad postion on smaller width ads when floated right.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-07-15 at 11 59 15](https://user-images.githubusercontent.com/1731150/179230255-2beba77c-1424-45fa-b66f-25a3d96897a1.png) | ![Screenshot 2022-07-15 at 14 22 30](https://user-images.githubusercontent.com/1731150/179231714-850155af-37c4-4f45-b1e2-b010ac295e28.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
