### PR TITLE
Fix fluid ad width on mobile

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -70,28 +70,21 @@ const adStyles = css`
 		margin: ${space[3]}px auto;
 		/* this is centring the ad iframe as they are display: inline; elements by default */
 		text-align: center;
-
-		${from.mobile} {
-			width: 300px;
-		}
+		display: flex;
+		justify-content: center;
 
 		${from.tablet} {
-			width: auto;
 			background-color: ${neutral[97]};
+
+			.ad-slot {
+				/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
+				flex: 1;
+			}
 		}
 
 		/* Prevent merger with any nearby float left elements e.g. rich-links */
 		${until.desktop} {
 			clear: left;
-		}
-
-		.ad-slot {
-			margin-left: auto;
-			margin-right: auto;
-
-			&.ad-slot--fluid {
-				width: 100%;
-			}
 		}
 
 		/* liveblogs ads have different background colours due the darker page background */


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Another follow up to #5382 to fix fluid ad widths.

Uses flex box so that ads of any size can be centred on mobile.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-07-15 at 16 12 31](https://user-images.githubusercontent.com/1731150/179255178-520866a1-85d4-48c6-82c9-0ce2ca49cc02.png) | ![Screenshot 2022-07-15 at 16 12 11](https://user-images.githubusercontent.com/1731150/179255222-594c2964-9dc7-4c75-9f4b-ce582860e3ca.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
