### PR TITLE
Reposition headline for Interview articles

### DIFF
--- a/apps-rendering/src/components/Headline/InterviewHeadline.tsx
+++ b/apps-rendering/src/components/Headline/InterviewHeadline.tsx
@@ -30,9 +30,7 @@ const InterviewHeadline: React.FC<Props> = ({ item }) => {
 	return (
 		<div
 			css={css`
-				padding-left: 0;
-				padding-right: ${remSpace[12]};
-				position: relative;
+				padding: ${remSpace[4]} ${remSpace[12]} 0 0;
 				${from.wide} {
 					margin: 0 auto;
 				}

--- a/apps-rendering/src/components/HeadlineTag/index.tsx
+++ b/apps-rendering/src/components/HeadlineTag/index.tsx
@@ -16,8 +16,6 @@ const headlineTagStyles = (format: ArticleFormat): SerializedStyles => css`
 	${from.wide} {
 		padding: 0 ${remSpace[2]};
 	}
-	position: absolute;
-	transform: translateY(-100%);
 `;
 
 type Props = {

--- a/apps-rendering/src/components/Standfirst/InterviewStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/InterviewStandfirst.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import type { Item } from 'item';
+import { getFormat } from 'item';
+import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
+import type { FC } from 'react';
+import { remSpace } from '@guardian/source-foundations';
+
+const styles = css`
+	padding: ${remSpace[4]} 0 0;
+`;
+
+interface Props {
+	item: Item;
+}
+
+const InterviewStandfirst: FC<Props> = ({ item }) => (
+	<DefaultStandfirst
+		item={item}
+		css={css(defaultStyles(getFormat(item)), styles)}
+	/>
+);
+
+export default InterviewStandfirst;

--- a/apps-rendering/src/components/Standfirst/InterviewStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/InterviewStandfirst.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
+import { remSpace } from '@guardian/source-foundations';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
 import type { FC } from 'react';
-import { remSpace } from '@guardian/source-foundations';
+import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
 
 const styles = css`
 	padding: ${remSpace[4]} 0 0;

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -33,7 +33,7 @@ const darkStyles = (format: ArticleFormat): SerializedStyles => darkModeCss`
 
 export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: 'bold' })}
-	padding: 0;
+	padding: ${remSpace[3]} 0 0;
 	margin-bottom: ${remSpace[3]};
 	color: ${text.standfirst(format)};
 
@@ -41,7 +41,6 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 
 	p,
 	ul {
-		padding: ${remSpace[3]} 0 0;
 		margin: 0;
 	}
 

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -33,7 +33,7 @@ const darkStyles = (format: ArticleFormat): SerializedStyles => darkModeCss`
 
 export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.xxxsmall({ fontWeight: 'bold' })}
-	padding: ${remSpace[3]} 0 0;
+	padding: 0;
 	margin-bottom: ${remSpace[3]};
 	color: ${text.standfirst(format)};
 
@@ -41,6 +41,7 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 
 	p,
 	ul {
+		padding: ${remSpace[3]} 0 0;
 		margin: 0;
 	}
 

--- a/apps-rendering/src/components/Standfirst/index.tsx
+++ b/apps-rendering/src/components/Standfirst/index.tsx
@@ -6,6 +6,7 @@ import { getFormat } from 'item';
 import DeadBlogStandfirst from './DeadBlogStandfirst';
 import ImmersiveLabsStandfirst from './ImmersiveLabsStandfirst';
 import ImmersiveStandfirst from './ImmersiveStandfirst';
+import InterviewStandfirst from './InterviewStandfirst';
 import LabsStandfirst from './LabsStandfirst';
 import LiveBlogStandfirst from './LiveBlogStandfirst';
 import MediaStandfirst from './MediaStandfirst';
@@ -50,6 +51,8 @@ const Standfirst: React.FC<Props> = ({ item }) => {
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
 			return <ReviewStandfirst item={item} />;
+		case ArticleDesign.Interview:
+			return <InterviewStandfirst item={item} />;
 		default:
 			return (
 				<DefaultStandfirst


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Moves the headline below main media for Interview articles
- Adds an `InterviewStandfirst` component to match spacing between the headline and standfirst with Dotcom (16px)
- Updates default Standfirst spacing to match Dotcom (36px between headline and standfirst)

## Why?

Fix #5315 

## Screenshots

### Interview article

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/179267957-0fd2bbec-aaf4-4233-bd5c-0da0a760f072.png
[after]: https://user-images.githubusercontent.com/705427/179267849-4de33cc1-c643-47fd-8302-172e73950c88.png

### Default article

| Before      | After      |
|-------------|------------|
| ![beforeDefault][] | ![afterDefault][] |

[beforeDefault]: https://user-images.githubusercontent.com/705427/179268187-54dd8122-41f2-4aec-8afb-6debda3cf82b.png
[afterDefault]: https://user-images.githubusercontent.com/705427/179268081-6a7f55e7-9b6e-43d7-9abd-6bb424d194a3.png

