### PR TITLE
Split Code Ownership By Project Directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*	@guardian/dotcom-platform @guardian/apps-rendering
+*			@guardian/dotcom-platform @guardian/apps-rendering
+/apps-rendering/	@guardian/apps-rendering
+/dotcom-rendering/	@guardian/dotcom-platform


### PR DESCRIPTION
## Why?

At the moment everyone on both the dotcom and apps-rendering teams gets a review request for every PR opened. This makes sense for anything affecting the codebase as a whole (README, root dependencies, gitignore etc.). However, I think it's probable that:

- For the large majority of PRs that affect apps-rendering only you don't need a review from the dotcom team.
- For the large majority of PRs that affect dotcom-rendering only you don't need a review from the apps-rendering team.

I would also argue that, while both teams own and maintain the codebase as a whole, the dotcom team specifically owns and maintains the `dotcom-rendering` project directory, and the apps-rendering team owns and maintains the `apps-rendering` directory.

Therefore I'd suggest that we change the CODEOWNERS file to reflect this. I think the consequence of this change should be that apps-rendering gets review requests for any change to `/apps-rendering`, dotcom gets review requests for any change to `/dotcom-rendering`, and both teams get review requests for changes to anything else. Please let me know if you think this is incorrect or if you believe there will be other unintended effects as a result of this change!

## Changes

- Makes the apps-rendering team owners of the `apps-rendering` directory
- Makes the dotcom-rendering team owners of the `dotcom-rendering` directory
- Makes both teams owners of everything else
