### PR TITLE
Use dot separator for live/dead blog first published times

### DIFF
--- a/common-rendering/src/components/FirstPublished.tsx
+++ b/common-rendering/src/components/FirstPublished.tsx
@@ -9,7 +9,7 @@ import { darkModeCss } from '../lib';
 const padString = (time: number) => (time < 10 ? `0${time}` : time);
 
 const fallbackDate = (date: Date) =>
-	`${padString(date.getHours())}:${padString(date.getMinutes())}`;
+	`${padString(date.getHours())}.${padString(date.getMinutes())}`;
 
 const FirstPublished = ({
 	firstPublished,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses a `.` to separate hours and minutes on live / dead blogs
- Uses local time, to match DCR

## Why?

To fix #4770 

## Screenshots

> **Note**: all screenshots below taken at 12:00 BST

| Before      | After      | Dotcom |
|-------------|------------| -- |
| ![before][] | ![after][] | ![dotcom][] |

[before]: https://user-images.githubusercontent.com/705427/179497959-b80325e6-e50f-4abe-ae6b-7a17c3e0a407.png
[after]: https://user-images.githubusercontent.com/705427/179497882-80a182fc-b736-4d33-aceb-c07d746880a0.png
[dotcom]: https://user-images.githubusercontent.com/705427/179498088-196c613f-c337-47ec-89cb-73c263496929.png