### PR TITLE
Set blog byline line-height to 115% (tight)

### DIFF
--- a/apps-rendering/src/components/Byline/DeadBlogByline.tsx
+++ b/apps-rendering/src/components/Byline/DeadBlogByline.tsx
@@ -6,7 +6,7 @@ import { DefaultByline } from './Byline.defaults';
 import { blogColor } from './LiveBlogByline';
 
 const blogStyles = css`
-	${headline.xxxsmall({ lineHeight: 'regular', fontStyle: 'italic' })}
+	${headline.xxxsmall({ lineHeight: 'tight', fontStyle: 'italic' })}
 `;
 
 const blogAnchorStyles = css`

--- a/apps-rendering/src/components/Byline/LiveBlogByline.tsx
+++ b/apps-rendering/src/components/Byline/LiveBlogByline.tsx
@@ -22,7 +22,7 @@ export const blogColor = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const blogStyles = css`
-	${headline.xxxsmall({ lineHeight: 'regular', fontStyle: 'italic' })}
+	${headline.xxxsmall({ lineHeight: 'tight', fontStyle: 'italic' })}
 `;
 
 const blogAnchorStyles = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Sets the blog byline `line-height` to `tight` (115%)

## Why?

To fix #4336 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/179489930-d2d234c2-676d-4e1c-aae6-72dc275d9786.png
[after]: https://user-images.githubusercontent.com/705427/179489885-7472496e-232a-4b32-b025-7f2e5efa6673.png
