### PR TITLE
fix: Height of flexbox ad slot

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -79,6 +79,8 @@ const adStyles = css`
 			.ad-slot {
 				/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
 				flex: 1;
+				/* Ensures slots do not take on 100% of the container height, allowing them to be sticky in containers */
+				align-self: flex-start;
 			}
 		}
 


### PR DESCRIPTION
Co-authored-by: Jake Lee Kennedy <jake.kennedy@guardian.co.uk>

## What does this change?

Apply `align-self: flex-start` to ad slots.

## Why?

Applying flex to the container causes the height of the child element (the slot) to fill the full height of the container. Applying this changes causes the slot to take on `auto` height, which allows it to be sticky.