### PR TITLE
Fix sport liveblog header text colour

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -83,6 +83,7 @@ type Colour = string;
 type Palette = {
 	text: {
 		headline: Colour;
+		headlineWhenMatch: Colour;
 		seriesTitle: Colour;
 		sectionTitle: Colour;
 		seriesTitleWhenMatch: Colour;

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -24,6 +24,7 @@ type Props = {
 	webPublicationDateDeprecated: string;
 	hasStarRating?: boolean;
 	hasAvatar?: boolean;
+	isMatch?: boolean;
 };
 
 const curly = (x: any) => x;
@@ -363,6 +364,7 @@ export const ArticleHeadline = ({
 	webPublicationDateDeprecated,
 	hasStarRating,
 	hasAvatar,
+	isMatch,
 }: Props) => {
 	const palette = decidePalette(format);
 
@@ -725,7 +727,9 @@ export const ArticleHeadline = ({
 									css={[
 										standardFont,
 										css`
-											color: ${palette.text.headline};
+											color: ${isMatch
+												? palette.text.headlineWhenMatch
+												: palette.text.headline};
 											padding-bottom: ${space[9]}px;
 										`,
 									]}

--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -64,6 +64,7 @@ export const GetMatchNav = ({
 						webPublicationDateDeprecated={
 							webPublicationDateDeprecated
 						}
+						isMatch={true}
 					/>
 				</div>
 			);

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -122,6 +122,16 @@ const textSeriesTitleWhenMatch = (format: ArticleFormat): string => {
 	}
 };
 
+const textHeadlineWhenMatch = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.MatchReport:
+		case ArticleDesign.LiveBlog:
+			return BLACK;
+		default:
+			return textSeriesTitle(format);
+	}
+};
+
 const textSectionTitle = textSeriesTitle;
 
 const textByline = (format: ArticleFormat): string => {
@@ -1313,6 +1323,7 @@ export const decidePalette = (
 	return {
 		text: {
 			headline: textHeadline(format),
+			headlineWhenMatch: textHeadlineWhenMatch(format),
 			seriesTitle: textSeriesTitle(format),
 			seriesTitleWhenMatch: textSeriesTitleWhenMatch(format),
 			sectionTitle: textSectionTitle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a new prop, `isMatch`, to ArticleHeadline.tsx, which allows it to use a different text colour for match liveblogs.

## Why?

Before, the headline was rendered as white text on a yellow background.

The solution of adding `isMatch` and `palette.text.headlineWhenMatch` was chosen because it follows the pattern established by the `seriesTitleWhenMatch` property (h/t @OllysCoding).


## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="918" alt="image" src="https://user-images.githubusercontent.com/37048459/179498544-b1558ca7-773c-4742-b3d1-63b5a8ba6e8c.png">| <img width="910" alt="image" src="https://user-images.githubusercontent.com/37048459/179497951-f4f9a04a-b33b-43f9-a89e-e449d569b440.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
