### PR TITLE
Add min-height to liveblog inline ads to reduce CLS

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
-import { carrotAdStyles, labelStyles } from './AdSlot';
+import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
 
 type Props = {
 	format: ArticleFormat;
@@ -96,7 +96,7 @@ const adStyles = css`
 
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
-			min-height: 274px;
+			min-height: ${250 + labelHeight}px;
 			background-color: ${neutral[93]};
 			.ad-slot__label {
 				color: ${neutral[46]};

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -96,6 +96,7 @@ const adStyles = css`
 
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
+			min-height: 274px;
 			background-color: ${neutral[93]};
 			.ad-slot__label {
 				color: ${neutral[46]};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This add a minimum height to inline ad slots on liveblogs pages

## Why?

When the user scrolls down the page, the ads are lazy-loaded to appear "just in time" for the user to see them, to maximise ad viewability amongst other things. However, as ads take a few seconds to load and render, the ad will sometimes load whilst in the viewport. This causes CLS as the elements in the DOM below this ad will be moved down to make space.

Since we always load inline slots in liveblog pages, we should create the space for them to appear in as early as possible (hopefully before they're in the viewport), then lazy load the ads in to this space. This way, when the ad renders in the viewport, the space in which the ads loads is already there, so elements in the DOM below this point will not be moved down and will not cause CLS.

https://user-images.githubusercontent.com/9574885/179529018-72746b18-ad41-49ce-baeb-f9b91390790b.mov

https://user-images.githubusercontent.com/9574885/179529026-a148da9e-51db-4603-98e7-4c89c586999e.mov

https://user-images.githubusercontent.com/9574885/179786902-d84cebf0-9d59-4510-a952-18a681a479dd.mov

https://user-images.githubusercontent.com/9574885/179786925-1a0849c8-ba80-4a0b-a022-c61b6aabeeab.mov