### PR TITLE
Replace hardcoded colour with Source colour in sports match headers

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -998,7 +998,7 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 };
 
 const backgroundMatchNav = (): string => {
-	return '#FFE500';
+	return brandAlt[400];
 };
 
 const backgroundUnderline = (format: ArticleFormat): string =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Replaces a hard-coded hex value with a reference to the corresponding value in Source's palette.

## Why?

I believe that this is the recommended practice in DCR. (Helps to improve consistency and maintainability.)

## Screenshots

There is no visible difference in the output (verified locally).