### PR TITLE
`/Onwards`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -281,13 +281,13 @@ type CustomParams = {
 
 type AdTargeting =
 	| {
-		adUnit: string;
-		customParams: CustomParams;
-		disableAds?: false;
-	}
+			adUnit: string;
+			customParams: CustomParams;
+			disableAds?: false;
+	  }
 	| {
-		disableAds: true;
-	};
+			disableAds: true;
+	  };
 
 interface SectionNielsenAPI {
 	name: string;
@@ -789,6 +789,16 @@ type TopicType = 'ORG' | 'PRODUCT' | 'PERSON' | 'GPE' | 'WORK_OF_ART' | 'LOC';
 /**
  * Onwards
  */
+type CAPIOnwardsType = {
+	heading: string;
+	trails: CAPITrailType[];
+	description?: string;
+	url?: string;
+	ophanComponentName: OphanComponentName;
+	format: CAPIFormat;
+	isCuratedContent?: boolean;
+};
+
 type OnwardsType = {
 	heading: string;
 	trails: TrailType[];

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -799,16 +799,6 @@ type CAPIOnwardsType = {
 	isCuratedContent?: boolean;
 };
 
-type OnwardsType = {
-	heading: string;
-	trails: TrailType[];
-	description?: string;
-	url?: string;
-	ophanComponentName: OphanComponentName;
-	format: ArticleFormat;
-	isCuratedContent?: boolean;
-};
-
 type OphanComponentName =
 	| 'series'
 	| 'more-on-this-story'

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -8,6 +8,7 @@ import {
 	renderFrontJson,
 	renderInteractive,
 	renderKeyEvents,
+	renderOnwards,
 } from '../web/server';
 
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
@@ -29,6 +30,8 @@ export const devServer = () => {
 				return renderBlocks(req, res);
 			case '/KeyEvents':
 				return renderKeyEvents(req, res);
+			case '/Onwards':
+				return renderOnwards(req, res);
 			case '/Front':
 				return renderFront(req, res);
 			case '/FrontJSON':

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -15,6 +15,7 @@ import {
 	renderFrontJson,
 	renderInteractive,
 	renderKeyEvents,
+	renderOnwards,
 } from '../web/server';
 import { recordBaselineCloudWatchMetrics } from './lib/aws/metrics-baseline';
 import { getContentFromURLMiddleware } from './lib/get-content-from-url';
@@ -57,6 +58,7 @@ export const prodServer = (): void => {
 	app.post('/AMPInteractive', logRenderTime, renderAMPArticle);
 	app.post('/Blocks', logRenderTime, renderBlocks);
 	app.post('/KeyEvents', logRenderTime, renderKeyEvents);
+	app.post('/Onwards', logRenderTime, renderOnwards);
 	app.post('/Front', logRenderTime, renderFront);
 	app.post('/FrontJSON', logRenderTime, renderFrontJson);
 

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -426,7 +426,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 	</div>
 );
 
-export const Carousel: React.FC<Props> = ({
+export const Carousel = ({
 	heading,
 	trails,
 	ophanComponentName,

--- a/dotcom-rendering/src/web/components/Carousel.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.tsx
@@ -20,6 +20,16 @@ import { FetchCommentCounts } from './FetchCommentCounts.importable';
 import { Hide } from './Hide';
 import { LeftColumn } from './LeftColumn';
 
+type Props = {
+	heading: string;
+	trails: TrailType[];
+	description?: string;
+	url?: string;
+	ophanComponentName: OphanComponentName;
+	format: ArticleFormat;
+	isCuratedContent?: boolean;
+};
+
 // Carousel icons - need replicating from source for centring
 
 const SvgChevronLeftSingle = () => {
@@ -416,13 +426,13 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 	</div>
 );
 
-export const Carousel: React.FC<OnwardsType> = ({
+export const Carousel: React.FC<Props> = ({
 	heading,
 	trails,
 	ophanComponentName,
 	format,
 	isCuratedContent,
-}: OnwardsType) => {
+}: Props) => {
 	const palette = decidePalette(format);
 	const carouselRef = useRef<HTMLUListElement>(null);
 

--- a/dotcom-rendering/src/web/components/OnwardsData.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsData.tsx
@@ -3,13 +3,13 @@ import { useEffect } from 'react';
 import { decideTrail } from '../lib/decideTrail';
 import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
+import { Carousel } from './Carousel';
 import { Placeholder } from './Placeholder';
 
 type Props = {
 	url: string;
 	limit: number; // Limit the number of items shown (the api often returns more)
 	ophanComponentName: OphanComponentName;
-	Container: React.FC<OnwardsType>;
 	format: ArticleFormat;
 	isCuratedContent?: boolean;
 };
@@ -29,7 +29,6 @@ export const OnwardsData = ({
 	url,
 	limit,
 	ophanComponentName,
-	Container,
 	format,
 	isCuratedContent,
 }: Props) => {
@@ -75,7 +74,7 @@ export const OnwardsData = ({
 		return (
 			<div css={[minHeight, revealStyles]} className="onwards">
 				<div className="pending">
-					<Container
+					<Carousel
 						heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
 						trails={buildTrails(data.trails, limit)}
 						description={data.description}

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
 import { joinUrl } from '../../lib/joinUrl';
-import { Carousel } from './Carousel';
 import { ElementContainer } from './ElementContainer';
 import { OnwardsData } from './OnwardsData';
 
@@ -277,7 +276,6 @@ export const OnwardsUpper = ({
 						url={url}
 						limit={8}
 						ophanComponentName={ophanComponentName}
-						Container={Carousel}
 						format={format}
 					/>
 				</ElementContainer>
@@ -288,7 +286,6 @@ export const OnwardsUpper = ({
 						url={curatedDataUrl}
 						limit={20}
 						ophanComponentName="curated-content"
-						Container={Carousel}
 						isCuratedContent={true}
 						format={format}
 					/>

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -12,6 +12,7 @@ import { articleToHtml } from './articleToHtml';
 import { blocksToHtml } from './blocksToHtml';
 import { frontToHtml } from './frontToHtml';
 import { keyEventsToHtml } from './keyEventsToHtml';
+import { onwardsToHtml } from './onwardsToHtml';
 
 function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
@@ -189,12 +190,43 @@ export const renderKeyEvents = (
 	}
 };
 
+export const renderOnwards = (
+	{ body }: { body: CAPIOnwardsType },
+	res: express.Response,
+): void => {
+	try {
+		const {
+			heading,
+			description,
+			url,
+			ophanComponentName,
+			trails,
+			format,
+			isCuratedContent,
+		} = body;
+
+		const html = onwardsToHtml({
+			heading,
+			description,
+			url,
+			ophanComponentName,
+			trails,
+			format,
+			isCuratedContent,
+		});
+
+		res.status(200).send(html);
+	} catch (e) {
+		const message = e instanceof Error ? e.stack : 'Unknown Error';
+		res.status(500).send(`<pre>${message}</pre>`);
+	}
+};
+
 export const renderFront = (
 	{ body }: express.Request,
 	res: express.Response,
 ): void => {
 	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We validate the data in this func
 		const front = enhanceFront(body);
 		const html = frontToHtml({
 			front,
@@ -211,6 +243,5 @@ export const renderFrontJson = (
 	{ body }: express.Request,
 	res: express.Response,
 ): void => {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- We validate the data in this func
 	res.json(enhanceFront(body));
 };

--- a/dotcom-rendering/src/web/server/onwardsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/onwardsToHtml.tsx
@@ -1,0 +1,41 @@
+import { renderToString } from 'react-dom/server';
+import { Carousel } from '../components/Carousel';
+import { decideFormat } from '../lib/decideFormat';
+import { decideTrail } from '../lib/decideTrail';
+
+const buildTrails = (
+	trails: CAPITrailType[],
+	trailLimit: number,
+): TrailType[] => {
+	return trails.slice(0, trailLimit).map(decideTrail);
+};
+
+/**
+ * onwardsToHtml is used by the /Onwards endpoint to render the Carousel at the bottom of articles
+ * It takes an array of json key-event blocks and returns the resulting html string
+ *
+ * @returns string (the html)
+ */
+export const onwardsToHtml = ({
+	heading,
+	// description,
+	// url,
+	ophanComponentName,
+	trails,
+	format: CAPIFormat,
+	isCuratedContent,
+}: CAPIOnwardsType): string => {
+	const format = decideFormat(CAPIFormat);
+
+	const html = renderToString(
+		<Carousel
+			heading={heading}
+			ophanComponentName={ophanComponentName}
+			isCuratedContent={isCuratedContent}
+			trails={buildTrails(trails, 8)}
+			format={format}
+		/>,
+	);
+
+	return html;
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces the `/Onwards` endpoint. When passed `CAPIOnwardsType` this endpoint will return the html needed to render the trails given in the request.

```ts
type CAPIOnwardsType = {
	heading: string;
	trails: CAPITrailType[];
	description?: string;
	url?: string;
	ophanComponentName: OphanComponentName;
	format: CAPIFormat;
	isCuratedContent?: boolean;
};
```

The request contains properties of the CAPI type. These are transformed to their DCR version before being rendered

DCR Onwards type:
```ts
type OnwardsType = {
	heading: string;
	trails: TrailType[];
	description?: string;
	url?: string;
	ophanComponentName: OphanComponentName;
	format: ArticleFormat;
	isCuratedContent?: boolean;
};
```

This DCR data is then given to the `Carousel` component and the resulting html returned.

## Why?
This PR is part of a wider effort to move the rendering logic for onwards content onto the server. We want to ensure that the `Card` component is not being rendered in the browser (because it is using `IMAGE_SALT` and `crypto` neither of which are available on the client.

Subsequent PRs to follow:

1) Add a query param (say, `html=true`) to the onwards api endpoints such that when given, the Frontend code will pass the trail json data to DCR to be rendered to html (using this PR's code). If not given or `html=false`, then the response will be the same json we get now

2) Once the `html=true` param is available, we can have a version of DCR that expects html in the response and inserts that into the DOM rather than asking React to generate the html for us.
