### PR TITLE
Dependabot should ignore aws-cdk & related dependencies for AR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
       labels:
         - "AR Dependency"
       rebase-strategy: "disabled"
+      ignore:
+        # aws-cdk is a peer dependency of @guardian/cdk
+        # The version of the aws-cdk dependencies should match exactly the version specified by @guardian/cdk
+        - dependency-name: 'aws-cdk'
+        - dependency-name: '@aws-cdk/core'
+        - dependency-name: '@aws-cdk/assert'
+        - dependency-name: '@aws-cdk/cloudformation-include'
     - package-ecosystem: "npm"
       directory: "/dotcom-rendering"
       schedule:


### PR DESCRIPTION
## What does this change?

- Ignores `aws-cdk`, `@aws-cdk/core`, `@aws-cdk/assert` and `@aws-cdk/cloudformation-include` from dependabot's configuration for Apps Rendering

## Why?

These dependencies are peer deps of `@guardian/cdk` and so the version here should match exactly the version specified by @guardian/cdk. It is not helpful to have Dependabot open PRs to upgrade these dependencies alone

Fixes #5436 

