### PR TITLE
Immersive Layout - Onward Content

### DIFF
--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -116,7 +116,7 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 			</section>
 		</article>
 		<section css={onwardStyles}>
-			<RelatedContent content={item.relatedContent} />
+			<RelatedContent item={item} />
 		</section>
 		<Footer isCcpa={false} format={item} />
 	</main>

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -6,6 +6,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import Headline from 'components/Headline';
 import MainMedia, { ImmersiveCaption } from 'components/MainMedia';
 import Metadata from 'components/Metadata';
+import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
@@ -82,7 +83,7 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => (
 				</div>
 			</article>
 		</main>
-		<aside>Related content</aside>
+		<RelatedContent item={item} />
 		<aside>Comments</aside>
 		<footer>Footer</footer>
 	</>

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -87,7 +87,7 @@ const LabsLayout: FC<Props> = ({ item, children }) => {
 				</Body>
 			</article>
 			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
+				<RelatedContent item={item} />
 			</section>
 			<Footer isCcpa={false} format={item} />
 		</main>

--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -196,7 +196,7 @@ const LiveLayout: FC<Props> = ({ item }) => {
 				<Tags item={item} />
 			</section>
 			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
+				<RelatedContent item={item} />
 			</section>
 			<section css={articleWidthStyles}>
 				<Footer format={item} isCcpa={false} />

--- a/apps-rendering/src/components/Layout/MediaLayout.tsx
+++ b/apps-rendering/src/components/Layout/MediaLayout.tsx
@@ -70,7 +70,7 @@ const MediaLayout: FC<Props> = ({ item, children }) => {
 				</section>
 			</article>
 			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
+				<RelatedContent item={item} />
 			</section>
 			<Footer isCcpa={false} format={item} />
 		</main>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -146,7 +146,7 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 				</section>
 			</article>
 			<section css={onwardStyles}>
-				<RelatedContent content={item.relatedContent} />
+				<RelatedContent item={item} />
 			</section>
 			{commentContainer}
 			<Footer isCcpa={false} format={item} />

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -1,57 +1,59 @@
 // ----- Imports ----- //
 
-import { ResizedRelatedContent } from 'item';
-import type { FC } from 'react';
-import DefaultRelatedContent, { defaultStyles } from './RelatedContent.defaults';
-import type { Option } from '@guardian/types';
 import { css } from '@emotion/react';
-import { grid } from 'grid/grid';
 import { from, neutral, until } from '@guardian/source-foundations';
+import type { Option } from '@guardian/types';
+import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
+import type { ResizedRelatedContent } from 'item';
+import type { FC } from 'react';
+import DefaultRelatedContent, {
+	defaultStyles,
+} from './RelatedContent.defaults';
 
 // ----- Component ----- //
 
 const styles = css`
-    ${grid.container}
+	${grid.container}
 `;
 
 const hrStyles = css`
-    ${grid.column.all}
-    grid-row: 1;
-    width: 100%;
-    border: 0;
-    border-top: 1px solid ${neutral[46]};
-    margin: 0;
+	${grid.column.all}
+	grid-row: 1;
+	width: 100%;
+	border: 0;
+	border-top: 1px solid ${neutral[46]};
+	margin: 0;
 `;
 
 const relatedContentStyles = css`
-    ${grid.column.centre}
-    grid-row: 2;
-    border: 0;
+	${grid.column.centre}
+	grid-row: 2;
+	border: 0;
 
-    ${until.wide} {
-        padding-left: 0;
-        padding-right: 0;
-    }
+	${until.wide} {
+		padding-left: 0;
+		padding-right: 0;
+	}
 
-    ${from.desktop} {
-        ${grid.between('centre-column-start', 'right-column-end')}
-    }
+	${from.desktop} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
 `;
 
 type Props = {
-    content: Option<ResizedRelatedContent>;
+	content: Option<ResizedRelatedContent>;
 };
 
 const ImmersiveRelatedContent: FC<Props> = ({ content }) => (
-    <aside css={styles}>
-        <hr css={hrStyles} />
-        <DefaultRelatedContent
-            content={content}
-            css={css(defaultStyles, relatedContentStyles)}
-        />
-        <LeftCentreBorder rows={[1, 3]} />
-    </aside>
+	<aside css={styles}>
+		<hr css={hrStyles} />
+		<DefaultRelatedContent
+			content={content}
+			css={css(defaultStyles, relatedContentStyles)}
+		/>
+		<LeftCentreBorder rows={[1, 3]} />
+	</aside>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -1,0 +1,59 @@
+// ----- Imports ----- //
+
+import { ResizedRelatedContent } from 'item';
+import type { FC } from 'react';
+import DefaultRelatedContent, { defaultStyles } from './RelatedContent.defaults';
+import type { Option } from '@guardian/types';
+import { css } from '@emotion/react';
+import { grid } from 'grid/grid';
+import { from, neutral, until } from '@guardian/source-foundations';
+import LeftCentreBorder from 'grid/LeftCentreBorder';
+
+// ----- Component ----- //
+
+const styles = css`
+    ${grid.container}
+`;
+
+const hrStyles = css`
+    ${grid.column.all}
+    grid-row: 1;
+    width: 100%;
+    border: 0;
+    border-top: 1px solid ${neutral[46]};
+    margin: 0;
+`;
+
+const relatedContentStyles = css`
+    ${grid.column.centre}
+    grid-row: 2;
+    border: 0;
+
+    ${until.wide} {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    ${from.desktop} {
+        ${grid.between('centre-column-start', 'right-column-end')}
+    }
+`;
+
+type Props = {
+    content: Option<ResizedRelatedContent>;
+};
+
+const ImmersiveRelatedContent: FC<Props> = ({ content }) => (
+    <aside css={styles}>
+        <hr css={hrStyles} />
+        <DefaultRelatedContent
+            content={content}
+            css={css(defaultStyles, relatedContentStyles)}
+        />
+        <LeftCentreBorder rows={[1, 3]} />
+    </aside>
+);
+
+// ----- Exports ----- //
+
+export default ImmersiveRelatedContent;

--- a/apps-rendering/src/components/RelatedContent/RelatedContent.defaults.tsx
+++ b/apps-rendering/src/components/RelatedContent/RelatedContent.defaults.tsx
@@ -1,0 +1,152 @@
+// ----- Imports ----- //
+
+import { css, SerializedStyles } from '@emotion/react';
+import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
+import {
+	from,
+	headline,
+	neutral,
+	remSpace,
+	until,
+} from '@guardian/source-foundations';
+import type { Option } from '@guardian/types';
+import { map, none, withDefault } from '@guardian/types';
+import BylineCard from 'components/BylineCard';
+import Card from 'components/Card';
+import type { ResizedRelatedContent } from 'item';
+import { pipe } from 'lib';
+import type { FC } from 'react';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+interface Props {
+	content: Option<ResizedRelatedContent>;
+    css: SerializedStyles;
+	className?: string;
+}
+
+const headingStyles = css`
+	${headline.xsmall({ fontWeight: 'bold' })}
+	margin: 0 0 ${remSpace[4]} 0;
+
+	${darkModeCss`
+        color: ${neutral[86]};
+    `}
+`;
+
+const listStyles = css`
+	list-style: none;
+	display: flex;
+	flex-direction: row;
+	margin: 0;
+	padding: 0;
+	overflow-x: scroll;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+
+	.js-android & {
+		li {
+			flex: 1 1 50%;
+			max-width: initial;
+		}
+		li:nth-child(n + 3) {
+			display: none;
+		}
+		li {
+			margin-right: 0;
+			margin-left: ${remSpace[2]};
+		}
+
+		li:first-of-type {
+			margin-left: 0;
+		}
+
+		${from.mobileLandscape} {
+			li {
+				flex: 1 1 33.33%;
+			}
+			li:nth-child(3) {
+				display: flex;
+			}
+		}
+		${from.tablet} {
+			li {
+				flex: 0 0 10rem;
+			}
+			li:nth-child(n + 3) {
+				display: flex;
+			}
+			li:nth-child(n + 2) {
+				margin-left: ${remSpace[5]};
+			}
+		}
+		${from.desktop} {
+			li {
+				flex: 0 0 13.75rem;
+			}
+		}
+	}
+`;
+
+const defaultStyles = css`
+	border-top: 1px solid ${neutral[46]};
+	padding-top: ${remSpace[3]};
+
+	${until.wide} {
+		padding-left: ${remSpace[4]};
+		padding-right: ${remSpace[4]};
+	}
+
+	${darkModeCss`
+		background: ${neutral[0]};
+	`}
+`;
+
+const COMMENT = RelatedItemType.COMMENT;
+
+const DefaultRelatedContent: FC<Props> = ({ content, className }) => {
+	return pipe(
+		content,
+		map(({ title, relatedItems, resizedImages }) => {
+			if (relatedItems.length === 0) {
+				return null;
+			}
+
+			return (
+				<section css={className}>
+					<h2 css={headingStyles}>{title}</h2>
+					<ul css={listStyles} role="list">
+						{relatedItems.map((relatedItem, key) => {
+							return relatedItem.type === COMMENT &&
+								relatedItem.bylineImage ? (
+								<BylineCard
+									key={key}
+									relatedItem={relatedItem}
+								/>
+							) : (
+								<Card
+									key={key}
+									relatedItem={relatedItem}
+									image={resizedImages[key]}
+									kickerText={none}
+								/>
+							);
+						})}
+					</ul>
+				</section>
+			);
+		}),
+		withDefault<JSX.Element | null>(null),
+	);
+};
+
+// ----- Exports ----- //
+
+export {
+	defaultStyles,
+}
+
+export default DefaultRelatedContent;

--- a/apps-rendering/src/components/RelatedContent/RelatedContent.defaults.tsx
+++ b/apps-rendering/src/components/RelatedContent/RelatedContent.defaults.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import {
 	from,
@@ -22,7 +23,7 @@ import { darkModeCss } from 'styles';
 
 interface Props {
 	content: Option<ResizedRelatedContent>;
-    css: SerializedStyles;
+	css: SerializedStyles;
 	className?: string;
 }
 
@@ -145,8 +146,6 @@ const DefaultRelatedContent: FC<Props> = ({ content, className }) => {
 
 // ----- Exports ----- //
 
-export {
-	defaultStyles,
-}
+export { defaultStyles };
 
 export default DefaultRelatedContent;

--- a/apps-rendering/src/components/RelatedContent/index.tsx
+++ b/apps-rendering/src/components/RelatedContent/index.tsx
@@ -1,10 +1,13 @@
 // ----- Imports ----- //
 
-import type { FC } from 'react';
-import DefaultRelatedContent, { defaultStyles } from './RelatedContent.defaults';
 import { ArticleDisplay } from '@guardian/libs';
+import type { Item } from 'item';
+import { getFormat } from 'item';
+import type { FC } from 'react';
 import ImmersiveRelatedContent from './ImmersiveRelatedContent';
-import { getFormat, Item } from 'item';
+import DefaultRelatedContent, {
+	defaultStyles,
+} from './RelatedContent.defaults';
 
 // ----- Component ----- //
 
@@ -16,7 +19,7 @@ const RelatedContent: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	if (format.display === ArticleDisplay.Immersive) {
-		return <ImmersiveRelatedContent content={item.relatedContent} />
+		return <ImmersiveRelatedContent content={item.relatedContent} />;
 	}
 
 	return (
@@ -25,7 +28,7 @@ const RelatedContent: FC<Props> = ({ item }) => {
 			css={defaultStyles}
 		/>
 	);
-}
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/RelatedContent/index.tsx
+++ b/apps-rendering/src/components/RelatedContent/index.tsx
@@ -1,140 +1,32 @@
-import { css } from '@emotion/react';
-import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
-import {
-	from,
-	headline,
-	neutral,
-	remSpace,
-	until,
-} from '@guardian/source-foundations';
-import type { Option } from '@guardian/types';
-import { map, none, withDefault } from '@guardian/types';
-import BylineCard from 'components/BylineCard';
-import Card from 'components/Card';
-import type { ResizedRelatedContent } from 'item';
-import { pipe } from 'lib';
+// ----- Imports ----- //
+
 import type { FC } from 'react';
-import { darkModeCss } from 'styles';
+import DefaultRelatedContent, { defaultStyles } from './RelatedContent.defaults';
+import { ArticleDisplay } from '@guardian/libs';
+import ImmersiveRelatedContent from './ImmersiveRelatedContent';
+import { getFormat, Item } from 'item';
+
+// ----- Component ----- //
 
 interface Props {
-	content: Option<ResizedRelatedContent>;
+	item: Item;
 }
 
-const headingStyles = css`
-	${headline.xsmall({ fontWeight: 'bold' })}
-	margin: 0 0 ${remSpace[4]} 0;
+const RelatedContent: FC<Props> = ({ item }) => {
+	const format = getFormat(item);
 
-	${darkModeCss`
-        color: ${neutral[86]};
-    `}
-`;
-
-const listStyles = css`
-	list-style: none;
-	display: flex;
-	flex-direction: row;
-	margin: 0;
-	padding: 0;
-	overflow-x: scroll;
-
-	&::-webkit-scrollbar {
-		display: none;
+	if (format.display === ArticleDisplay.Immersive) {
+		return <ImmersiveRelatedContent content={item.relatedContent} />
 	}
 
-	.js-android & {
-		li {
-			flex: 1 1 50%;
-			max-width: initial;
-		}
-		li:nth-child(n + 3) {
-			display: none;
-		}
-		li {
-			margin-right: 0;
-			margin-left: ${remSpace[2]};
-		}
-
-		li:first-of-type {
-			margin-left: 0;
-		}
-
-		${from.mobileLandscape} {
-			li {
-				flex: 1 1 33.33%;
-			}
-			li:nth-child(3) {
-				display: flex;
-			}
-		}
-		${from.tablet} {
-			li {
-				flex: 0 0 10rem;
-			}
-			li:nth-child(n + 3) {
-				display: flex;
-			}
-			li:nth-child(n + 2) {
-				margin-left: ${remSpace[5]};
-			}
-		}
-		${from.desktop} {
-			li {
-				flex: 0 0 13.75rem;
-			}
-		}
-	}
-`;
-
-const styles = css`
-	border-top: 1px solid ${neutral[46]};
-	padding-top: ${remSpace[3]};
-
-	${until.wide} {
-		padding-left: ${remSpace[4]};
-		padding-right: ${remSpace[4]};
-	}
-
-	${darkModeCss`
-		background: ${neutral[0]};
-	`}
-`;
-
-const COMMENT = RelatedItemType.COMMENT;
-
-const RelatedContent: FC<Props> = ({ content }) => {
-	return pipe(
-		content,
-		map(({ title, relatedItems, resizedImages }) => {
-			if (relatedItems.length === 0) {
-				return null;
-			}
-
-			return (
-				<section css={styles}>
-					<h2 css={headingStyles}>{title}</h2>
-					<ul css={listStyles} role="list">
-						{relatedItems.map((relatedItem, key) => {
-							return relatedItem.type === COMMENT &&
-								relatedItem.bylineImage ? (
-								<BylineCard
-									key={key}
-									relatedItem={relatedItem}
-								/>
-							) : (
-								<Card
-									key={key}
-									relatedItem={relatedItem}
-									image={resizedImages[key]}
-									kickerText={none}
-								/>
-							);
-						})}
-					</ul>
-				</section>
-			);
-		}),
-		withDefault<JSX.Element | null>(null),
+	return (
+		<DefaultRelatedContent
+			content={item.relatedContent}
+			css={defaultStyles}
+		/>
 	);
-};
+}
+
+// ----- Exports ----- //
 
 export default RelatedContent;


### PR DESCRIPTION
## Why?

This continues the work on the new immersive layout, following on from #5385. This adds related content to the bottom of the article. As with the `Tags` PR I've refactored the related content component to use the new `index`/`defaults` pattern.

**Note:** Unfortunately I had difficulty matching the existing related content design with the new immersive layout in particular, and the Guardian grid layout in general. I have adapted it to make it fit (as best I can, I'm no designer 😅), but I think the related content designs and models may be due a broader overhaul at some point.

## Changes

- Added related content to immersive layout
- Refactored related content to use new index/defaults pattern
- Added `ImmersiveRelatedContent`
- Updated layouts to use new related content component

## Screenshots

| Mobile | Tablet | Desktop | Wide |
| - | - | - | - |
| ![related-content-mobile] | ![related-content-tablet] | ![related-content-desktop] | ![related-content-wide] |

[related-content-wide]: https://user-images.githubusercontent.com/53781962/179752069-244264a4-1514-423c-9b49-8018302a2013.jpg
[related-content-desktop]: https://user-images.githubusercontent.com/53781962/179752076-f4100a12-a90b-479d-a61e-a9a46cbfc2c3.jpg
[related-content-tablet]: https://user-images.githubusercontent.com/53781962/179752081-36dcdabd-7a40-4466-a7fa-2b9c70988ab7.jpg
[related-content-mobile]: https://user-images.githubusercontent.com/53781962/179752083-c06e6edd-ad87-498d-8604-1d5e54640739.jpg
