### PR TITLE
Older richllinks don't always have `imageAsset`

### DIFF
--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -22,7 +22,7 @@ interface CAPIRichLinkType {
 	format: CAPIFormat;
 	starRating?: number;
 	contributorImage?: string;
-	imageAsset: ImageAsset;
+	imageAsset?: ImageAsset;
 }
 interface ImageAsset {
 	index: number;
@@ -64,7 +64,7 @@ export const RichLinkComponent = ({
 		window.guardian.modules.sentry.reportError(error, 'rich-link');
 	}
 
-	if (data) {
+	if (data?.imageAsset) {
 		const richLinkImageData: RichLinkImageData = {
 			thumbnailUrl: data.thumbnailUrl,
 			altText: data.imageAsset.fields.altText,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the absolute requirement for a rich link to have the `imageAsset` property

## Why?
Some [older articles](https://www.theguardian.com/media/2007/mar/28/pressandpublishing.royalsandthemedia) don't provide this when inserted as richlinks and this was causing javascript errors when the `imageAsset.fields` property was accessed.


