### PR TITLE
RFC: CSS Variables

### DIFF
--- a/dotcom-rendering/src/static/css/light.css
+++ b/dotcom-rendering/src/static/css/light.css
@@ -1,0 +1,4 @@
+:root {
+	--white: #ffffff;
+	--black: #121212;
+}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -27,8 +27,8 @@ import type { DCRContainerPalette } from '../../types/front';
 import { decideContainerOverrides } from './decideContainerOverrides';
 import { transparentColour } from './transparentColour';
 
-const WHITE = neutral[100];
-const BLACK = neutral[7];
+const WHITE = 'var(--white)';
+const BLACK = 'var(--black)';
 
 const blogsGrayBackgroundPalette = (format: ArticleFormat): string => {
 	switch (format.theme) {

--- a/dotcom-rendering/src/web/server/articleTemplate.ts
+++ b/dotcom-rendering/src/web/server/articleTemplate.ts
@@ -286,6 +286,10 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <style class="webfont">${getFontsCss()}</style>
                 <style>${resets.resetCSS}</style>
 				${css}
+				<link
+					rel="stylesheet"
+					href="${ASSET_ORIGIN}static/frontend/css/light.css"
+				/>
 				<link rel="stylesheet" media="print" href="${ASSET_ORIGIN}static/frontend/css/print.css">
 			</head>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the usage of [css variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) to DCR. What do you think?

## Why?
CSS variables have long been wanted on DCR but we did not adopt them because they are not supported on IE11. Now that we no longer offer official support for this browser we have the opportunity to adopt them.

This particular PR is providing the building blocks for future work. In particular, it offers us the ability to have page level colours - such a pillar colour - which removes the need for local props on components. This simplifies the rendering of some content and makes it easier to do certain refactors, such as moving content from the client to the server

## Future enhancements
This PR is very basic but is built with future enhancements in mind

### Script generation
Rather than create this file manually we should look to build a script that generates it based on imports from `Source`. This script can then be rerun to add new properties or reflect changes to the `source` libs.

### Dark mode
How we implement dark mode on the site is [discussed in this document](https://github.com/guardian/source/discussions/1060). One of the key elements of that solution is the use of css variables.

This PR does not go all the way down the dark path but if we wanted to do that later then we'd need to add a second css file, `dark.css`. We would then need to consider how we mark the reader's preference in the document, such as via a class on the `body` tag. @mxdvl made a [very good suggestion](https://github.com/guardian/source/discussions/1060#discussioncomment-1913032) for how this setting might be made, which is likely to be the best method.

The `link` tag could have a media property

```html
<link
	rel="stylesheet"
	href="${CDN}static/frontend/css/dark.css"
	media="(prefers-color-scheme: dark)"
/>
```
We should consider if we want to allow readers the option to switch between modes on the site (a toggle somewhere) or if we are okay using the system setting (e.g.: system prefs).

Consider if we would need a listener against changes to the system preferences which updated the setting (the `.light` class) on the site