### PR TITLE
Add `atoms-rendering@23.2.2` to fix zero durations on video overlays

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -59,7 +59,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.2.1",
+    "@guardian/atoms-rendering": "^23.2.2",
     "@guardian/braze-components": "^7.3.0",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,10 +2791,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.2.1":
-  version "23.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.2.1.tgz#6f18d76425d753e5dbac7309a52d539fcb782966"
-  integrity sha512-zLAHEwn1qMufV7hSl3tI6/E0lH8uxgkW7KkUJRQOrdqvjSSrkk1i21hGhPyg6f6ajW4vaAGyh+ZiU8I0lmFk7A==
+"@guardian/atoms-rendering@^23.2.2":
+  version "23.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.2.2.tgz#89a2cc6610b3a3d405918d0b9029ab6ab7154b62"
+  integrity sha512-ieDEj0eBxTgN/W2m+lV/ngPjNgoUWxYMxdKRHN7PjvnDKsOQ9l6ZBve4L1LqMVhODK24aINP+Wj1yjDsl9ETAA==
   dependencies:
     is-mobile "^3.1.1"
     youtube-player "^5.5.2"
@@ -14332,7 +14332,7 @@ load-json-file@^6.2.0:
 load-script@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
 
 loader-runner@^2.4.0:
   version "2.4.0"
@@ -19975,9 +19975,9 @@ type-detect@4.0.8:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.4.0, type-fest@^2.8.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.1.tgz#621c84220df0e01a8469002594fc005714f0cfba"
-  integrity sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
+  integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps `@guardian/atoms-rendering` to `v23.2.2`

## Why?
This [brings a fix](https://github.com/guardian/atoms-rendering/commit/317ecad37d8faae0429215033dc156f6a5054ead) to how zero duration video overlays are displayed
