### PR TITLE
Remove colon from the Key events header in `KeyEventsCarousel`

### DIFF
--- a/dotcom-rendering/package-lock.json
+++ b/dotcom-rendering/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@guardian/dotcom-rendering",
+  "version": "0.1.0-alpha",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
+    }
+  }
+}

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -203,7 +203,8 @@
     "webpack-merge": "^5.7.3",
     "webpack-messages": "^2.0.4",
     "webpack-node-externals": "^3.0.0",
-    "webpack-sources": "^3.2.3"
+    "webpack-sources": "^3.2.3",
+    "yarn": "^1.22.19"
   },
   "resolutions": {
     "@types/serve-static": "^1.13.9"

--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -118,7 +118,7 @@ export const KeyEventsCarousel = ({
 		<>
 			<span id={id} />
 			<Hide from="desktop">
-				<div css={titleStyles}>Key events:</div>
+				<div css={titleStyles}>Key events</div>
 			</Hide>
 			<div
 				ref={carousel}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21404,6 +21404,11 @@ yargs@^16.1.1, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yarn@^1.22.19:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
+
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
## What does this change?
Removes the colon from the Key events header in `KeyEventsCarousel`

## Why?
In order to align the design with the Filters header

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
https://user-images.githubusercontent.com/55602675/180026798-fc9504fc-7bfa-4195-a38d-af27b8b271e3.png

[after]: 
https://user-images.githubusercontent.com/55602675/180026901-26656ae7-0d3c-44fd-b934-c6673a7fa47c.png
