### PR TITLE
Reduce live/deadblog dateline line height

### DIFF
--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -38,7 +38,8 @@ const commentDatelineStyles = css`
 `;
 
 const blogDatelineStyles = (color: string): SerializedStyles => css`
-	${textSans.xxsmall()}
+	${textSans.xxsmall({ lineHeight: 'tight' })}
+	display: block;
 	color: ${color};
 
 	${from.desktop} {

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -153,7 +153,7 @@ const isLive = (design: ArticleDesign): boolean =>
 	design === ArticleDesign.LiveBlog;
 
 // This styling function is only temprarily used and will be removed
-// after the liveblog header is completed and ackground colours
+// after the liveblog header is completed and background colours
 // are added
 const tempraryBackgroundStyle = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Sets the `line-height` of the dateline for live/deadblogs to `tight` (115%)

## Why?

To fix #4335

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/180174524-15f0980d-fd8a-4626-a306-c18e75252101.png
[after]: https://user-images.githubusercontent.com/705427/180174364-5e988d6c-c742-41aa-a9e1-db76e2100b78.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
