### PR TITLE
Remove colon from key events header in KeyEventsCarousel

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -118,7 +118,7 @@ export const KeyEventsCarousel = ({
 		<>
 			<span id={id} />
 			<Hide from="desktop">
-				<div css={titleStyles}>Key events:</div>
+				<div css={titleStyles}>Key events</div>
 			</Hide>
 			<div
 				ref={carousel}


### PR DESCRIPTION
## What does this change?
Removes the colon from the Key events header in `KeyEventsCarousel`

## Why?
In order to align the design with the Filters header

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
https://user-images.githubusercontent.com/55602675/180026798-fc9504fc-7bfa-4195-a38d-af27b8b271e3.png

[after]: 
https://user-images.githubusercontent.com/55602675/180026901-26656ae7-0d3c-44fd-b934-c6673a7fa47c.png
