### PR TITLE
Set min-height to smallest inline ad height

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -97,8 +97,13 @@ const adStyles = css`
 
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
-			/* outstreamMobile is the smallest ad height we serve for liveblog-inline slots */
+			/* outstreamMobile is the ad with the smallest height that we serve for mobile
+			   liveblog-inline slots. For desktop, this is an mpu */
 			min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
+			${from.tablet} {
+				min-height: ${adSizes.mpu.height + labelHeight}px;
+			}
+
 			background-color: ${neutral[93]};
 			.ad-slot__label {
 				color: ${neutral[46]};

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -97,6 +97,7 @@ const adStyles = css`
 
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
+			/* outstreamMobile is the smallest ad height we serve for liveblog-inline slots */
 			min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
 			background-color: ${neutral[93]};
 			.ad-slot__label {

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { adSizes } from '@guardian/commercial-core';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
@@ -96,7 +97,7 @@ const adStyles = css`
 
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
-			min-height: ${250 + labelHeight}px;
+			min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
 			background-color: ${neutral[93]};
 			.ad-slot__label {
 				color: ${neutral[46]};

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -100,7 +100,7 @@ const adStyles = css`
 			/* outstreamMobile is the ad with the smallest height that we serve for mobile
 			   liveblog-inline slots. For desktop, this is an mpu */
 			min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
-			${from.tablet} {
+			${from.desktop} {
 				min-height: ${adSizes.mpu.height + labelHeight}px;
 			}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Sets the min-height of inline ads on liveblogs to be 221px.

-> Outstream height + ad label height
-> 197px + 24px
-> 221px

## Why?

We currently set the min-height of inline ads on liveblogs to be 274px (MPU height + ad label height). However, we don't just serve MPU ads in these slots, we also serve Outstream ads in which have a smaller height of 197px. This means that we get extra space underneath the ad when an Outstream ad loads in these slots.

## Why not?

For inline liveblog MPU sizes, there will be ~53px of CLS if the advert loads whilst in the viewport.

## Reasoning 

Given that Outstream ads are fairly common and 53px blank space for each Outstream ad on the page is probably worse than 53px of CLS for each MPU which only occurs when the ad loads in the viewport, it is worth making this change. If we stop serving Outstream ads or serve significantly less Outstream ads, we will want to review this change.

Before this [change](https://github.com/guardian/dotcom-rendering/pull/5429) we had 221px or 274px of CLS for each ad that loaded in the viewport.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9574885/180240561-d6a70e81-6f18-4a31-a245-93ce5cf20215.png
[after]: https://user-images.githubusercontent.com/9574885/180242270-5c2fa7f3-93e9-4650-920e-a115566704cf.png
