### PR TITLE
Refactor FECollectionConfigType as separate type

### DIFF
--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -233,6 +233,24 @@ export type DCRSnapType = {
 	embedCss?: string;
 };
 
+type FECollectionConfigType = {
+	displayName: string;
+	metadata?: { type: FEContainerPalette }[];
+	collectionType: FEContainerType;
+	href?: string;
+	groups?: string[];
+	uneditable: boolean;
+	showTags: boolean;
+	showSections: boolean;
+	hideKickers: boolean;
+	showDateHeader: boolean;
+	showLatestUpdate: boolean;
+	excludeFromRss: boolean;
+	showTimestamps: boolean;
+	hideShowMore: boolean;
+	platform: string;
+};
+
 export type FECollectionType = {
 	id: string;
 	displayName: string;
@@ -249,23 +267,7 @@ export type FECollectionType = {
 	hideKickers: boolean;
 	showDateHeader: boolean;
 	showLatestUpdate: boolean;
-	config: {
-		displayName: string;
-		metadata?: { type: FEContainerPalette }[];
-		collectionType: FEContainerType;
-		href?: string;
-		groups?: string[];
-		uneditable: boolean;
-		showTags: boolean;
-		showSections: boolean;
-		hideKickers: boolean;
-		showDateHeader: boolean;
-		showLatestUpdate: boolean;
-		excludeFromRss: boolean;
-		showTimestamps: boolean;
-		hideShowMore: boolean;
-		platform: string;
-	};
+	config: FECollectionConfigType;
 	hasMore: boolean;
 };
 


### PR DESCRIPTION
This is to allow easier reference to the config type (e.g. in an upcoming PR where config will be passed from Frontend to a DCR endpoint, but not as part of an FECollectionType.

(It was originally part of #5116, but has been picked out to try to slim the PR down.)

This should be a self-contained edit which doesn't change any behaviour or affect any existing interfaces.

Co-authored-by: Ioanna Kokkini <ioannakok@users.noreply.github.com>
