### PR TITLE
fix: Only wrap layout content if toggleable

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -198,7 +198,7 @@ export const ContainerLayout = ({
 								editionId={editionId}
 							/>
 						</Hide>
-						{toggleable && sectionId !== undefined && (
+						{toggleable && sectionId && (
 							<ShowHideButton
 								sectionId={sectionId}
 								overrideContainerToggleColour={
@@ -207,9 +207,13 @@ export const ContainerLayout = ({
 							/>
 						)}
 					</div>
-					<div css={hiddenStyles} id={`container-${sectionId}`}>
-						{children}
-					</div>
+					{toggleable && sectionId ? (
+						<div css={hiddenStyles} id={`container-${sectionId}`}>
+							{children}
+						</div>
+					) : (
+						children
+					)}
 				</Container>
 			</Flex>
 		</ElementContainer>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Only wrap Container children in a toggleable div if the Container is actually toggleable.

## Why?

Closes #5470 
Fixes https://github.com/guardian/dotcom-rendering/issues/5469