### PR TITLE
Add `ShowMore/` endpoint

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -2,7 +2,8 @@
 // CAPIArticleType and its subtypes //
 // ------------------------- //
 
-import type { FECollectionConfigType, FEFrontCard } from './src/types/front';
+type FEFrontCard = import('./src/types/front').FEFrontCard;
+type FECollectionConfigType = import('./src/types/front').FECollectionConfigType;
 
 type DCRSnapType = import('./src/types/front').DCRSnapType;
 type DCRSupportingContent = import('./src/types/front').DCRSupportingContent;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -676,7 +676,6 @@ interface KeyEventsRequest {
  */
  interface ShowMoreRequest {
 	cards: FEFrontCard[];
-	startIndex: number;
 	config: FECollectionConfigType;
 }
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -2,6 +2,8 @@
 // CAPIArticleType and its subtypes //
 // ------------------------- //
 
+import type { FECollectionConfigType, FEFrontCard } from './src/types/front';
+
 type DCRSnapType = import('./src/types/front').DCRSnapType;
 type DCRSupportingContent = import('./src/types/front').DCRSupportingContent;
 
@@ -667,6 +669,16 @@ interface KeyEventsRequest {
 	format: CAPIFormat;
 	filterKeyEvents: boolean;
 }
+
+/**
+ * ShowMoreRequest is the expected body format for POST requests made to /Cards
+ */
+ interface CardsRequest {
+	cards: FEFrontCard[];
+	startIndex: number;
+	config: FECollectionConfigType;
+}
+
 
 interface BadgeType {
 	seriesTag: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -673,7 +673,7 @@ interface KeyEventsRequest {
 /**
  * ShowMoreRequest is the expected body format for POST requests made to /Cards
  */
- interface CardsRequest {
+ interface ShowMoreRequest {
 	cards: FEFrontCard[];
 	startIndex: number;
 	config: FECollectionConfigType;

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -38,7 +38,6 @@ export const devServer = () => {
 			case '/FrontJSON':
 				return renderFrontJson(req, res);
 			case '/ShowMore':
-				// @ts-expect-error - only a skeleton render fn is implemented in this commit
 				return renderShowMore(req, res);
 			default:
 				next();

--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -9,6 +9,7 @@ import {
 	renderInteractive,
 	renderKeyEvents,
 	renderOnwards,
+	renderShowMore,
 } from '../web/server';
 
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
@@ -36,6 +37,9 @@ export const devServer = () => {
 				return renderFront(req, res);
 			case '/FrontJSON':
 				return renderFrontJson(req, res);
+			case '/ShowMore':
+				// @ts-expect-error - only a skeleton render fn is implemented in this commit
+				return renderShowMore(req, res);
 			default:
 				next();
 		}

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -16,6 +16,7 @@ import {
 	renderInteractive,
 	renderKeyEvents,
 	renderOnwards,
+	renderShowMore,
 } from '../web/server';
 import { recordBaselineCloudWatchMetrics } from './lib/aws/metrics-baseline';
 import { getContentFromURLMiddleware } from './lib/get-content-from-url';
@@ -61,6 +62,7 @@ export const prodServer = (): void => {
 	app.post('/Onwards', logRenderTime, renderOnwards);
 	app.post('/Front', logRenderTime, renderFront);
 	app.post('/FrontJSON', logRenderTime, renderFrontJson);
+	app.post('/ShowMore', logRenderTime, renderShowMore);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -233,7 +233,7 @@ export type DCRSnapType = {
 	embedCss?: string;
 };
 
-type FECollectionConfigType = {
+export type FECollectionConfigType = {
 	displayName: string;
 	metadata?: { type: FEContainerPalette }[];
 	collectionType: FEContainerType;

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import type { DCRContainerPalette } from '../../types/front';
 import { Card } from './Card/Card';
@@ -8,6 +9,7 @@ type Props = {
 	trails: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showImages?: boolean;
+	isShowMoreContainer?: boolean;
 };
 
 function isFirstInRow(cardIndex: number) {
@@ -35,14 +37,25 @@ function hasNoCardBelowIt(cardIndex: number, trailsLength: number) {
 	return cardIndex >= trailsLength - 4;
 }
 
+function getDataLinkName(originalName: string, isShowMoreContainer: boolean) {
+	const prefix = isShowMoreContainer ? 'showmore | ' : '';
+	return `${prefix}${originalName}`;
+}
+
+const topPaddingStyle = css`
+	padding-top: 10px;
+`;
+
 export const ExtraCardsContainer = ({
 	trails,
 	containerPalette,
 	showImages = false,
+	isShowMoreContainer = false,
 }: Props) => {
 	const percentage = '25%';
 	return (
 		<>
+			{isShowMoreContainer && <div css={topPaddingStyle} />}
 			<UL direction="row" padBottom={true} wrapCards={true}>
 				{trails.map((trail, index) => (
 					<LI
@@ -82,6 +95,10 @@ export const ExtraCardsContainer = ({
 							starRating={trail.starRating}
 							branding={trail.branding}
 							discussionId={trail.discussionId}
+							dataLinkName={getDataLinkName(
+								trail.dataLinkName,
+								isShowMoreContainer,
+							)}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -1,6 +1,6 @@
 import type express from 'express';
-import { decideContainerPalette } from 'src/model/decideContainerPalette';
-import { enhanceCards } from 'src/model/enhanceCards';
+import { decideContainerPalette } from '../../model/decideContainerPalette';
+import { enhanceCards } from '../../model/enhanceCards';
 import { Standard as ExampleArticle } from '../../../fixtures/generated/articles/Standard';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceCollections } from '../../model/enhanceCollections';

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -245,3 +245,10 @@ export const renderFrontJson = (
 ): void => {
 	res.json(enhanceFront(body));
 };
+/**
+ * Skeleton rendering function for the `ShowMore/` endpoint.
+ * Function will be filled out in the next commits.
+ */
+export const renderShowMore = (): void => {
+	return;
+};

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -1,8 +1,8 @@
 import type express from 'express';
-import { decideContainerPalette } from '../../model/decideContainerPalette';
-import { enhanceCards } from '../../model/enhanceCards';
 import { Standard as ExampleArticle } from '../../../fixtures/generated/articles/Standard';
+import { decideContainerPalette } from '../../model/decideContainerPalette';
 import { enhanceBlocks } from '../../model/enhanceBlocks';
+import { enhanceCards } from '../../model/enhanceCards';
 import { enhanceCollections } from '../../model/enhanceCollections';
 import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';

--- a/dotcom-rendering/src/web/server/showMoreToHtml.tsx
+++ b/dotcom-rendering/src/web/server/showMoreToHtml.tsx
@@ -1,0 +1,28 @@
+import { renderToString } from 'react-dom/server';
+import type { DCRContainerPalette, DCRFrontCard } from 'src/types/front';
+import { ExtraCardsContainer } from '../components/ExtraCardsContainer';
+
+interface DCRShowMoreContainerType {
+	cards: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+}
+/**
+ * showMoreToHtml is used by the /Cards endpoint to render extra fronts cards
+ *
+ * @returns string (the html)
+ */
+
+export const showMoreToHtml = ({
+	cards,
+	containerPalette,
+}: DCRShowMoreContainerType): string => {
+	const html = renderToString(
+		<ExtraCardsContainer
+			trails={cards}
+			containerPalette={containerPalette}
+			isShowMoreContainer={true}
+		/>,
+	);
+
+	return html;
+};


### PR DESCRIPTION
>**Note**
>This PR contains cherry-picked commits from #5116 in order to break down the size of that PR. For more discussion and history of this issue, please see that PR.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a new route to the dev and prod servers, `ShowMore/`. It also adds a handler for this route, which calls a new method called `ShowMoreToHtml`. The endpoint expects to receive a list of cards info and a collection config from Frontend. The rendering function uses this data to generate an `ExtraCardsContainer` and serialises the markup to be returned to Frontend.

To support this use-case, a new prop is added to `ExtraCardsContainer` to allow it to style itself, and to modify cards' `data-link-names` in a way that is suitable for being inserted below an existing container, as in the 'show more' functionality.


## Why?

Replicating functionality from Frontend, as part of the Fronts migration.

### Dependencies
- [x] #5467 (merged) 
- [ ]  #5463 
- [ ] Frontend PR [#25086](https://github.com/guardian/frontend/pull/25086)
