### PR TITLE
Use larger font for key event times

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -163,6 +163,7 @@ const textStyles = (
 	color: ${text.keyEventsInline(format)};
 	display: block;
 	text-decoration: none;
+	transform: translateY(-2px);
 
 	&:hover {
 		color: ${text.keyEventsInline(format)};

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -190,7 +190,7 @@ const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
 	display: block;
-	transform: translateY(-2.5px);
+	transform: translateY(-4px);
 
 	${darkModeCss(supportsDarkMode)`
 		color: ${neutral[60]};

--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -187,7 +187,7 @@ const textStyles = (
 `;
 
 const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	${textSans.xxsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
+	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
 	display: block;
 	transform: translateY(-2.5px);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses `textSans.xsmall` instead of `textSans.xxsmall` for key event times

## Why?

- To fix #4331 and align with dotcom

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://user-images.githubusercontent.com/705427/180784058-169d5995-63e4-4b26-abb6-fd98bd351dfc.png
[before]: https://user-images.githubusercontent.com/705427/180784062-61ba47f6-e6d4-46bd-8410-29923524743b.png