### PR TITLE
feat(eslint): catch falsy JSX fragments

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
 		'react-hooks',
 		'import',
 		'jsx-a11y',
+		'jsx-expressions',
 	],
 	rules: {
 		// React & Hooks
@@ -73,6 +74,9 @@ module.exports = {
 			// https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md#options
 			{ packageDir: ['..', '.'] },
 		],
+
+		/** @see https://github.com/hpersson/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md */
+		'jsx-expressions/strict-logical-expressions': 'error',
 
 		...rulesToReview,
 		...rulesToRemove,

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -139,6 +139,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-jsx-expressions": "^1.3.1",
     "eslint-plugin-mocha": "^10.0.4",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -91,7 +91,7 @@ export const Blocks: React.FunctionComponent<{
 				key={block.id}
 				css={blockStyle(pillar)}
 			>
-				{block.blockFirstPublishedDisplay && (
+				{!!block.blockFirstPublishedDisplay && (
 					<a
 						css={firstPublishedStyle}
 						href={blockLink(url, block.id)}
@@ -99,11 +99,11 @@ export const Blocks: React.FunctionComponent<{
 						{block.blockFirstPublishedDisplay}
 					</a>
 				)}
-				{block.title && <h2>{block.title}</h2>}
+				{!!block.title && <h2>{block.title}</h2>}
 				{Elements(block.elements, pillar, false)}
 				{/* Some elements float (e.g. rich links) */}
 				<div css={clearBoth} />{' '}
-				{block.blockLastUpdatedDisplay && (
+				{!!block.blockLastUpdatedDisplay && (
 					<div css={lastUpdatedStyle}>
 						Updated at {block.blockLastUpdatedDisplay}
 					</div>

--- a/dotcom-rendering/src/amp/components/Caption.tsx
+++ b/dotcom-rendering/src/amp/components/Caption.tsx
@@ -67,7 +67,7 @@ export const Caption = ({
 	return (
 		<figure css={figureStyle}>
 			{children}
-			{captionText && (
+			{!!captionText && (
 				<>
 					<figcaption
 						css={[captionStyle, padCaption && captionPadding]}

--- a/dotcom-rendering/src/amp/components/Expandable.tsx
+++ b/dotcom-rendering/src/amp/components/Expandable.tsx
@@ -184,7 +184,7 @@ export const Expandable: React.FC<{
 		</div>
 
 		<div css={innerStyle} hidden={true} id={id}>
-			{img && (
+			{!!img && (
 				<amp-img
 					class={imageStyle}
 					src={img}
@@ -195,7 +195,7 @@ export const Expandable: React.FC<{
 				/>
 			)}
 			{children}
-			{credit && (
+			{!!credit && (
 				<span css={creditStyle}>
 					<span css={iconStyle}>
 						<InfoIcon />

--- a/dotcom-rendering/src/amp/components/MainMedia.tsx
+++ b/dotcom-rendering/src/amp/components/MainMedia.tsx
@@ -91,8 +91,10 @@ const mainImage = (element: ImageBlockElement) => {
 				layout="responsive"
 				srcset={scrsetStringFromImagesSources(element.imageSources)}
 			/>
-			{(element.data.caption ||
-				(element.data.credit && element.displayCredit)) && (
+			{!!(
+				element.data.caption ||
+				(element.data.credit && element.displayCredit)
+			) && (
 				<>
 					<input
 						aria-checked={false}

--- a/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
@@ -61,7 +61,7 @@ export const ImageBlockComponent: React.FC<{
 				width={image.width.toString()}
 				layout="responsive"
 			/>
-			{(element.data.caption ||
+			{(!!element.data.caption ||
 				(element.data.credit && element.displayCredit)) && (
 				<figcaption css={captionStyle}>
 					<span css={iconStyle}>

--- a/dotcom-rendering/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
@@ -89,7 +89,7 @@ export const InteractiveAtomBlockComponent: React.FunctionComponent<{
 						resizable=""
 						data-cy="atom-embed-url"
 					>
-						{placeholderUrl && (
+						{!!placeholderUrl && (
 							<amp-img
 								placeholder={true}
 								layout="fill"

--- a/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -49,7 +49,7 @@ export const TimelineBlockComponent: React.FC<{
 			{events.map((e) => (
 				<li css={eventStyle} key={e.title}>
 					<time css={[eventIconStyle, highlight]}>{e.date}</time>
-					{e.toDate && (
+					{!!e.toDate && (
 						<>
 							{' '}
 							- <time css={highlight}>{e.toDate}</time>

--- a/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
@@ -85,7 +85,7 @@ export const TwitterBlockComponent: React.FC<{
 			data-tweetid={element.id}
 			data-dnt="true"
 		>
-			{fallbackHTML && (
+			{!!fallbackHTML && (
 				<div placeholder="" css={TextStyle(pillar)}>
 					<blockquote
 						dangerouslySetInnerHTML={{ __html: fallbackHTML }}

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -93,7 +93,7 @@ const BylineMeta: React.FunctionComponent<{
 				/>
 			</div>
 
-			{shouldShowBylineImage && (
+			{!!shouldShowBylineImage && (
 				<amp-img
 					class={bylineImageStyle}
 					src={bylineImageUrl}

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -432,7 +432,7 @@ export const ArticleHeadline = ({
 									{curly(headlineString)}
 								</h1>
 							</WithAgeWarning>
-							{byline && (
+							{!!byline && (
 								<HeadlineByline
 									format={format}
 									byline={byline}
@@ -575,7 +575,7 @@ export const ArticleHeadline = ({
 									{curly(headlineString)}
 								</h1>
 							</WithAgeWarning>
-							{byline && (
+							{!!byline && (
 								<HeadlineByline
 									format={format}
 									byline={byline}
@@ -697,7 +697,7 @@ export const ArticleHeadline = ({
 									</span>
 								</h1>
 							</WithAgeWarning>
-							{byline && (
+							{!!byline && (
 								<HeadlineByline
 									format={format}
 									byline={byline}

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -348,7 +348,7 @@ export const ArticleMeta = ({
 				)}
 				<RowBelowLeftCol>
 					<>
-						{avatarUrl && (
+						{!!avatarUrl && (
 							<AvatarContainer>
 								<Avatar
 									imageSrc={avatarUrl}
@@ -359,7 +359,7 @@ export const ArticleMeta = ({
 						)}
 
 						<div>
-							{shouldShowContributor(format) && byline && (
+							{shouldShowContributor(format) && !!byline && (
 								<Contributor
 									byline={byline}
 									tags={tags}

--- a/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
@@ -19,7 +19,7 @@ export const FieldLabel = ({ formField }: { formField: CampaignField }) => (
 	<label css={fieldLabelStyles} htmlFor={formField.name}>
 		{formField.label}
 		{!formField.required && <span css={optionalTextStyles}>Optional</span>}
-		{formField.description && (
+		{!!formField.description && (
 			<div>
 				<span css={fieldDescription}>
 					{`(${formField.description})`}

--- a/dotcom-rendering/src/web/components/Callout/FileUpload.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FileUpload.tsx
@@ -54,7 +54,7 @@ export const FileUpload = ({ formField, formData, setFormData }: Props) => {
 				onChange={onSelectFile}
 			/>
 			<p>We accept images and pdfs. Maximum total file size: 6MB</p>
-			{error && <div css={errorMessagesStyles}>{error}</div>}
+			{!!error && <div css={errorMessagesStyles}>{error}</div>}
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -160,7 +160,7 @@ export const Form = ({ onSubmit, formFields, error }: FormProps) => {
 					onChange={(e) => setTwitterHandle(e.target.value)}
 				/>
 			</div>
-			{error && <div css={errorMessagesStyles}>{error}</div>}
+			{!!error && <div css={errorMessagesStyles}>{error}</div>}
 			<div css={footerPaddingStyles}>
 				<Button priority="secondary" size="xsmall" type="submit">
 					Share with the Guardian

--- a/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutBlockComponent.importable.tsx
@@ -326,7 +326,7 @@ export const CalloutBlockComponent = ({
 						</div>
 						<div css={headingTextStyles(palette)}>
 							<h4 css={headingTextHeaderStyles}>{title}</h4>
-							{description && (
+							{!!description && (
 								<div
 									css={descriptionStyles}
 									dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -262,7 +262,7 @@ export const Caption = ({
 			) : (
 				<CameraIcon palette={palette} format={format} />
 			)}
-			{captionText && (
+			{!!captionText && (
 				<span
 					css={captionLink(palette)}
 					dangerouslySetInnerHTML={{
@@ -271,7 +271,7 @@ export const Caption = ({
 					key="caption"
 				/>
 			)}
-			{credit && displayCredit && ` ${credit}`}
+			{!!credit && displayCredit && ` ${credit}`}
 		</figcaption>
 	);
 
@@ -302,7 +302,7 @@ export const Caption = ({
 						shouldLimitWidth && bigLeftMargin,
 					]}
 				>
-					{captionText && (
+					{!!captionText && (
 						<span
 							css={captionLink(palette)}
 							dangerouslySetInnerHTML={{
@@ -311,7 +311,7 @@ export const Caption = ({
 							key="caption"
 						/>
 					)}
-					{credit && displayCredit && ` ${credit}`}
+					{!!credit && displayCredit && ` ${credit}`}
 				</figcaption>
 			);
 		default:

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -295,7 +295,7 @@ export const Card = ({
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}
 			>
-				{imageUrl && (
+				{!!imageUrl && (
 					<ImageWrapper
 						imageSize={imageSize}
 						imagePosition={imagePosition}
@@ -363,7 +363,7 @@ export const Card = ({
 					</Flex>
 					{/* This div is needed to push this content to the bottom of the card */}
 					<div>
-						{trailText && (
+						{!!trailText && (
 							<TrailTextWrapper
 								containerPalette={containerPalette}
 								format={format}

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -262,7 +262,7 @@ export const CardHeadline = ({
 				]}
 			>
 				<WithLink linkTo={linkTo}>
-					{kickerText && (
+					{!!kickerText && (
 						<Kicker
 							text={kickerText}
 							color={kickerColour}
@@ -284,7 +284,7 @@ export const CardHeadline = ({
 					</span>
 				</WithLink>
 			</h4>
-			{byline && showByline && (
+			{!!byline && showByline && (
 				<Byline
 					text={byline}
 					format={format}

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -198,7 +198,7 @@ export const ContainerLayout = ({
 								editionId={editionId}
 							/>
 						</Hide>
-						{toggleable && sectionId && (
+						{toggleable && !!sectionId && (
 							<ShowHideButton
 								sectionId={sectionId}
 								overrideContainerToggleColour={

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -104,7 +104,7 @@ export const ContainerTitle = ({
 			) : (
 				<h2 css={headerStyles(fontColour)}>{title}</h2>
 			)}
-			{description && (
+			{!!description && (
 				<p
 					css={descriptionStyles(fontColour)}
 					dangerouslySetInnerHTML={{ __html: description }}

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -135,7 +135,7 @@ export const Contributor = ({ byline, tags, format }: Props) => {
 					<BylineLink byline={byline} tags={tags} />
 				</div>
 			)}
-			{twitterHandle && (
+			{!!twitterHandle && (
 				<div css={[twitterHandleStyles, twitterHandleColour(palette)]}>
 					<TwitterIcon />
 					<a

--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -380,10 +380,9 @@ export const Dropdown = ({
 											)}
 										</a>
 
-										{l.notifications?.length &&
-											l.notifications.length > 0 && (
-												<RedDot />
-											)}
+										{!!l.notifications?.length && (
+											<RedDot />
+										)}
 									</li>
 								))}
 							</ul>

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -80,7 +80,7 @@ export const ElementContainer = ({
 						padded && padding,
 					]}
 				>
-					{children && children}
+					{children}
 				</div>
 			);
 			const style = css`

--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -58,7 +58,7 @@ export const EmbedBlockComponent = ({
 			sourceDomain={sourceDomain}
 		>
 			<div data-cy="embed-block" css={embedContainerStyles(isEmailEmbed)}>
-				{isEmailEmbed && caption && (
+				{!!(isEmailEmbed && caption) && (
 					<div
 						css={emailCaptionStyle}
 						dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/web/components/FilterButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.importable.tsx
@@ -62,7 +62,7 @@ const valueStyles = css`
 const Label = ({ value, count }: LabelProps) => (
 	<>
 		<span css={valueStyles}>{value}</span>{' '}
-		{count && <span css={countStyles}>({count})</span>}
+		{!!count && <span css={countStyles}>({count})</span>}
 	</>
 );
 

--- a/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/GuVideoBlockComponent.tsx
@@ -29,7 +29,7 @@ export const GuVideoBlockComponent = ({
 		<div css={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
 
-			{caption && (
+			{!!caption && (
 				<Caption
 					captionText={caption}
 					format={format}

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -306,7 +306,7 @@ export const ImageComponent = ({
 					isLazy={!isMainMedia}
 					isMainMedia={isMainMedia}
 				/>
-				{title && (
+				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 			</div>
@@ -337,8 +337,10 @@ export const ImageComponent = ({
 					isLazy={!isMainMedia}
 					isMainMedia={isMainMedia}
 				/>
-				{starRating && <PositionStarRating rating={starRating} />}
-				{title && (
+				{typeof starRating === 'number' && (
+					<PositionStarRating rating={starRating} />
+				)}
+				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 			</div>
@@ -407,8 +409,10 @@ export const ImageComponent = ({
 						</Row>
 					</Hide>
 				)}
-				{starRating && <PositionStarRating rating={starRating} />}
-				{title && (
+				{typeof starRating === 'number' && (
+					<PositionStarRating rating={starRating} />
+				)}
+				{!!title && (
 					<ImageTitle title={title} role={role} palette={palette} />
 				)}
 			</div>

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
@@ -324,7 +324,7 @@ export const InteractiveBlockComponent = ({
 					</>
 				)}
 			</figure>
-			{caption && (
+			{!!caption && (
 				<Caption
 					captionText={caption}
 					format={format}

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -81,7 +81,7 @@ export const LinkHeadline = ({
 
 	return (
 		<h4 css={fontStyles(size)}>
-			{kickerText && (
+			{!!kickerText && (
 				<Kicker
 					text={kickerText}
 					color={palette.text.linkKicker}
@@ -109,7 +109,7 @@ export const LinkHeadline = ({
 					>
 						{headlineText}
 					</a>
-					{byline && (
+					{!!byline && (
 						<Byline text={byline} format={format} size={size} />
 					)}
 				</>
@@ -117,7 +117,7 @@ export const LinkHeadline = ({
 				// We don't have a link so simply use a span here
 				<>
 					<span>{headlineText}</span>
-					{byline && (
+					{!!byline && (
 						<Byline text={byline} size={size} format={format} />
 					)}
 				</>

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -98,8 +98,8 @@ export const LiveBlock = ({
 					context="LiveBlock"
 				/>
 				{showLastUpdated &&
-					block.blockLastUpdated &&
-					block.blockLastUpdatedDisplay && (
+					!!block.blockLastUpdated &&
+					!!block.blockLastUpdatedDisplay && (
 						<LastUpdated
 							lastUpdated={block.blockLastUpdated}
 							lastUpdatedDisplay={block.blockLastUpdatedDisplay}

--- a/dotcom-rendering/src/web/components/MatchNav.tsx
+++ b/dotcom-rendering/src/web/components/MatchNav.tsx
@@ -225,7 +225,7 @@ export const MatchNav = ({ homeTeam, awayTeam, comments }: Props) => (
 					scorers={awayTeam.scorers}
 				/>
 			</Row>
-			{comments && <Comments comments={comments} />}
+			{!!comments && <Comments comments={comments} />}
 		</StretchBackground>
 	</div>
 );

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -110,7 +110,7 @@ export const MediaMeta = ({
 		<div css={wrapperStyles}>
 			<MediaIcon mediaType={mediaType} palette={palette} />
 			&nbsp;
-			{mediaDuration && (
+			{!!mediaDuration && (
 				<MediaDuration
 					mediaDuration={mediaDuration}
 					palette={palette}

--- a/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
@@ -100,7 +100,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 					/>
 				)}
 			</div>
-			{trail.ageWarning && (
+			{!!trail.ageWarning && (
 				<div css={ageWarningStyles}>
 					<AgeWarning age={trail.ageWarning} size="small" />
 				</div>

--- a/dotcom-rendering/src/web/components/MostViewedFooterSecondTierItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterSecondTierItem.tsx
@@ -114,14 +114,14 @@ export const MostViewedFooterSecondTierItem = ({
 							byline={showByline ? byline : undefined}
 						/>
 
-						{ageWarning && (
+						{!!ageWarning && (
 							<div css={ageWarningStyles}>
 								<AgeWarning age={ageWarning} size="small" />
 							</div>
 						)}
 					</div>
 					<>
-						{avatarToShow && (
+						{!!avatarToShow && (
 							<div css={avatarContainerStyles}>
 								<div css={avatarSizeStyles}>
 									<Avatar

--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -79,7 +79,7 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 		>
 			<a css={linkTagStyles} href={trail.url} ref={hoverRef}>
 				<div css={lineWrapperStyles}>
-					{trail.image && (
+					{!!trail.image && (
 						<div css={imageWrapperStyles}>
 							<Avatar
 								imageSrc={trail.image}
@@ -115,7 +115,7 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 							/>
 						)}
 						<div css={marginTopStyles}>
-							{trail.ageWarning && (
+							{!!trail.ageWarning && (
 								<AgeWarning
 									age={trail.ageWarning}
 									size="small"

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
@@ -114,7 +114,7 @@ export const MultiImageBlockComponent = ({
 						hideCaption={true}
 						role={images[0].role}
 					/>
-					{caption && (
+					{!!caption && (
 						<Caption
 							format={format}
 							captionText={caption}
@@ -154,7 +154,7 @@ export const MultiImageBlockComponent = ({
 							/>
 						</GridItem>
 					</SideBySideGrid>
-					{caption && (
+					{!!caption && (
 						<Caption
 							captionText={caption}
 							format={format}
@@ -202,7 +202,7 @@ export const MultiImageBlockComponent = ({
 							/>
 						</GridItem>
 					</OneAboveTwoGrid>
-					{caption && (
+					{!!caption && (
 						<Caption
 							captionText={caption}
 							format={format}
@@ -257,7 +257,7 @@ export const MultiImageBlockComponent = ({
 							/>
 						</GridItem>
 					</GridOfFour>
-					{caption && (
+					{!!caption && (
 						<Caption
 							captionText={caption}
 							format={format}

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -266,11 +266,11 @@ export const OnwardsUpper = ({
 
 	const curatedDataUrl = showRelatedContent
 		? getContainerDataUrl(pillar, editionId, ajaxUrl)
-		: null;
+		: undefined;
 
 	return (
 		<div css={onwardsWrapper}>
-			{url && (
+			{!!url && (
 				<ElementContainer>
 					<OnwardsData
 						url={url}
@@ -280,7 +280,7 @@ export const OnwardsUpper = ({
 					/>
 				</ElementContainer>
 			)}
-			{!isPaidContent && curatedDataUrl && (
+			{!!(!isPaidContent && curatedDataUrl) && (
 				<ElementContainer showTopBorder={true}>
 					<OnwardsData
 						url={curatedDataUrl}

--- a/dotcom-rendering/src/web/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/web/components/PinnedPost.tsx
@@ -162,7 +162,7 @@ export const PinnedPost = ({ pinnedPost, children, format }: Props) => {
 			/>
 			<div css={rowStyles(palette)}>
 				<SvgPinned />
-				{pinnedPost.blockFirstPublished && (
+				{!!pinnedPost.blockFirstPublished && (
 					<time data-relativeformat="med" css={timeAgoStyles}>
 						From {timeAgo(pinnedPost.blockFirstPublished)}
 					</time>

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -245,7 +245,7 @@ export const RichLink = ({
 			<div css={neutralBackground}>
 				<a css={richLinkLink} href={url}>
 					<div css={richLinkTopBorder(palette)} />
-					{showImage && (
+					{!!showImage && (
 						<div>
 							<img
 								css={imageStyles}
@@ -282,7 +282,7 @@ export const RichLink = ({
 									{mainContributor}
 								</div>
 							)}
-							{starRating && starRating > 0 && (
+							{!!starRating && (
 								<div css={starWrapper}>
 									<StarRating
 										rating={starRating}
@@ -290,13 +290,13 @@ export const RichLink = ({
 									/>
 								</div>
 							)}
-							{isPaidContent && sponsorName && (
+							{!!(isPaidContent && sponsorName) && (
 								<div css={paidForBranding}>
 									Paid for by {sponsorName}
 								</div>
 							)}
 						</div>
-						{isOpinion && contributorImage && (
+						{!!(isOpinion && contributorImage) && (
 							<div css={contributorImageWrapper}>
 								<Avatar
 									imageSrc={contributorImage}

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -317,7 +317,7 @@ export const SecureSignupIframe = ({
 				</div>
 			)}
 
-			{errorMessage && <ErrorMessageWithAdvice text={errorMessage} />}
+			{!!errorMessage && <ErrorMessageWithAdvice text={errorMessage} />}
 
 			{hasResponse &&
 				(responseOk ? (
@@ -353,7 +353,7 @@ export const SecureSignupIframe = ({
 					</div>
 				))}
 
-			{captchaSiteKey && (
+			{!!captchaSiteKey && (
 				<div
 					css={css`
 						.grecaptcha-badge {

--- a/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
@@ -61,7 +61,7 @@ export const SpotifyBlockComponent = ({
 					width={width}
 					allowFullScreen={true}
 				/>
-				{caption && (
+				{!!caption && (
 					<Caption
 						captionText={caption}
 						format={format}

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
@@ -65,7 +65,7 @@ export const VideoFacebookBlockComponent = ({
 						allowFullScreen={true}
 					/>
 				</MaintainAspectRatio>
-				{caption && (
+				{!!caption && (
 					<Caption
 						captionText={caption}
 						format={format}

--- a/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/VimeoBlockComponent.tsx
@@ -61,7 +61,7 @@ export const VimeoBlockComponent = ({
 					allowFullScreen={true}
 				/>
 			</div>
-			{caption && (
+			{!!caption && (
 				<Caption
 					captionText={caption}
 					format={format}

--- a/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
@@ -32,7 +32,7 @@ export const VineBlockComponent = ({
 			source={source}
 			sourceDomain={sourceDomain}
 		>
-			{element.url && element.width && element.height && (
+			{!!(element.url && element.width && element.height) && (
 				<div>
 					<div css={titleStyle}>
 						<p>{element.title}</p>

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -32,17 +32,20 @@ type Props = {
 	stickyVideos: boolean;
 };
 
-const expiredOverlayStyles = (overrideImage: string) => css`
-	height: 0px;
-	position: relative;
-	background-image: url(${overrideImage});
-	background-size: cover;
-	background-position: 49% 49%;
-	background-repeat: no-repeat;
-	padding-bottom: 56%;
-	color: ${neutral[100]};
-	background-color: ${neutral[20]};
-`;
+const expiredOverlayStyles = (overrideImage?: string) =>
+	overrideImage
+		? css`
+				height: 0px;
+				position: relative;
+				background-image: url(${overrideImage});
+				background-size: cover;
+				background-position: 49% 49%;
+				background-repeat: no-repeat;
+				padding-bottom: 56%;
+				color: ${neutral[100]};
+				background-color: ${neutral[20]};
+		  `
+		: undefined;
 
 const expiredTextWrapperStyles = css`
 	display: flex;
@@ -120,7 +123,7 @@ export const YoutubeBlockComponent = ({
 					margin-bottom: 16px;
 				`}
 			>
-				<div css={overrideImage && expiredOverlayStyles(overrideImage)}>
+				<div css={expiredOverlayStyles(overrideImage)}>
 					<div css={expiredTextWrapperStyles}>
 						<div css={expiredSVGWrapperStyles}>
 							<SvgAlertRound />

--- a/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeEmbedBlockComponent.tsx
@@ -49,7 +49,7 @@ export const YoutubeEmbedBlockComponent = ({
 					allowFullScreen={true}
 				/>
 			</MaintainAspectRatio>
-			{caption && (
+			{!!caption && (
 				<Caption
 					captionText={caption}
 					format={format}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -441,7 +441,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									/>
 									{/* BOTTOM */}
 									<div>
-										{avatarUrl && (
+										{!!avatarUrl && (
 											<div css={avatarPositionStyles}>
 												<ContributorAvatar
 													imageSrc={avatarUrl}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -309,7 +309,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							/>
 						</GridItem>
 						<GridItem area="byline">
-							{CAPIArticle.byline && (
+							{!!CAPIArticle.byline && (
 								<HeadlineByline
 									format={format}
 									tags={CAPIArticle.tags}

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -384,7 +384,7 @@ export const InteractiveImmersiveLayout = ({
 							/>
 						</GridItem>
 						<GridItem area="byline">
-							{CAPIArticle.byline && (
+							{!!CAPIArticle.byline && (
 								<HeadlineByline
 									format={format}
 									tags={CAPIArticle.tags}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -535,16 +535,15 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 						<GridItem area="lastupdated">
 							<Hide until="desktop">
-								{CAPIArticle.blocks.length &&
-									CAPIArticle.blocks[0].blockLastUpdated && (
-										<ArticleLastUpdated
-											format={format}
-											lastUpdated={
-												CAPIArticle.blocks[0]
-													.blockLastUpdated
-											}
-										/>
-									)}
+								{!!CAPIArticle.blocks[0]?.blockLastUpdated && (
+									<ArticleLastUpdated
+										format={format}
+										lastUpdated={
+											CAPIArticle.blocks[0]
+												.blockLastUpdated
+										}
+									/>
+								)}
 							</Hide>
 						</GridItem>
 						<GridItem area="lines">
@@ -685,7 +684,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<LiveGrid>
 							<GridItem area="media">
 								<div css={maxWidth}>
-									{footballMatchUrl && (
+									{!!footballMatchUrl && (
 										<Island
 											clientOnly={true}
 											placeholderHeight={40}
@@ -696,7 +695,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											/>
 										</Island>
 									)}
-									{cricketMatchUrl && (
+									{!!cricketMatchUrl && (
 										<Island
 											clientOnly={true}
 											placeholderHeight={172}
@@ -811,7 +810,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										</Hide>
 									)}
 								{/* Match stats */}
-								{footballMatchUrl && (
+								{!!footballMatchUrl && (
 									<Island
 										deferUntil="visible"
 										clientOnly={true}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -487,42 +487,40 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 						<GridItem area="matchNav" element="aside">
 							<div css={maxWidth}>
-								{format.design === ArticleDesign.MatchReport &&
-									footballMatchUrl && (
-										<Island
-											deferUntil="visible"
-											clientOnly={true}
-											placeholderHeight={230}
-										>
-											<GetMatchNav
-												matchUrl={footballMatchUrl}
-												format={format}
-												headlineString={
-													CAPIArticle.headline
-												}
-												tags={CAPIArticle.tags}
-												webPublicationDateDeprecated={
-													CAPIArticle.webPublicationDateDeprecated
-												}
-											/>
-										</Island>
-									)}
+								{isMatchReport && (
+									<Island
+										deferUntil="visible"
+										clientOnly={true}
+										placeholderHeight={230}
+									>
+										<GetMatchNav
+											matchUrl={footballMatchUrl}
+											format={format}
+											headlineString={
+												CAPIArticle.headline
+											}
+											tags={CAPIArticle.tags}
+											webPublicationDateDeprecated={
+												CAPIArticle.webPublicationDateDeprecated
+											}
+										/>
+									</Island>
+								)}
 							</div>
 						</GridItem>
 						<GridItem area="matchtabs" element="aside">
 							<div css={maxWidth}>
-								{format.design === ArticleDesign.MatchReport &&
-									footballMatchUrl && (
-										<Island
-											clientOnly={true}
-											placeholderHeight={40}
-										>
-											<GetMatchTabs
-												matchUrl={footballMatchUrl}
-												format={format}
-											/>
-										</Island>
-									)}
+								{isMatchReport && (
+									<Island
+										clientOnly={true}
+										placeholderHeight={40}
+									>
+										<GetMatchTabs
+											matchUrl={footballMatchUrl}
+											format={format}
+										/>
+									</Island>
+								)}
 							</div>
 						</GridItem>
 						<GridItem area="headline">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5630,6 +5630,13 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/experimental-utils@^5.5.0":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.30.7.tgz#a815318385b7c81e57ddb5f640895cc08879035f"
+  integrity sha512-r218ZVL0zFBYzEq8/9K2ZhRgsmKUhm8xd3sWChgvTbmP98kHGuY83IUl64SS9fx9OSBM9vMLdzBfox4eDdm/ZQ==
+  dependencies:
+    "@typescript-eslint/utils" "5.30.7"
+
 "@typescript-eslint/parser@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.6.0.tgz#11677324659641400d653253c03dcfbed468d199"
@@ -5695,6 +5702,14 @@
     "@typescript-eslint/types" "5.26.0"
     "@typescript-eslint/visitor-keys" "5.26.0"
 
+"@typescript-eslint/scope-manager@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz#8269a931ef1e5ae68b5eb80743cc515c4ffe3dd7"
+  integrity sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/visitor-keys" "5.30.7"
+
 "@typescript-eslint/scope-manager@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz#9dd7f007dc8f3a34cdff6f79f5eaab27ae05157e"
@@ -5748,6 +5763,11 @@
   version "5.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.26.0.tgz#cb204bb154d3c103d9cc4d225f311b08219469f3"
   integrity sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==
+
+"@typescript-eslint/types@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
+  integrity sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==
 
 "@typescript-eslint/types@5.6.0":
   version "5.6.0"
@@ -5812,6 +5832,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz#05da9f1b281985bfedcf62349847f8d168eecc07"
+  integrity sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/visitor-keys" "5.30.7"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/typescript-estree@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz#dfbb19c9307fdd81bd9c650c67e8397821d7faf0"
@@ -5862,6 +5895,18 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.7.tgz#7135be070349e9f7caa262b0ca59dc96123351bb"
+  integrity sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.30.7"
+    "@typescript-eslint/types" "5.30.7"
+    "@typescript-eslint/typescript-estree" "5.30.7"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
@@ -5891,6 +5936,14 @@
   integrity sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==
   dependencies:
     "@typescript-eslint/types" "5.26.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.30.7":
+  version "5.30.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz#c093abae75b4fd822bfbad9fc337f38a7a14909a"
+  integrity sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==
+  dependencies:
+    "@typescript-eslint/types" "5.30.7"
     eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.6.0":
@@ -10088,6 +10141,14 @@ eslint-plugin-jsx-a11y@^6.5.1:
     jsx-ast-utils "^3.2.1"
     language-tags "^1.0.5"
     minimatch "^3.0.4"
+
+eslint-plugin-jsx-expressions@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-expressions/-/eslint-plugin-jsx-expressions-1.3.1.tgz#af3e48e6147e12a4a190c7a3aad0d6e3546d9933"
+  integrity sha512-7PTIx62Oy4l3Igtat361C/SCrJ4yXNNJRh/pzXMbzvPzFkvOpHBkTXITkH8PMLDu1RAdilDpjaOUv1m14DbY7w==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.5.0"
+    tsutils "^3.21.0"
 
 eslint-plugin-mocha@^10.0.4:
   version "10.0.4"


### PR DESCRIPTION
## What does this change?

Add and enforce the following [strict-logical-expressions](https://github.com/hpersson/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md) ESLint /JSX rule.

## Why?

We have had a number of times where this has bitten us:
- #5344
- #4712
- #3149
- #1441

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/180758412-27c079ad-ab02-44b5-bbd6-cdf4879eb699.png
[after]: https://user-images.githubusercontent.com/76776/180758261-dc7974b1-2327-46eb-b066-bb669e3fe930.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
