### PR TITLE
Bug/fix 0 when no caresoul

### DIFF
--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -598,7 +598,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 					</StandFirstGrid>
 				</ElementContainer>
-				{showKeyEventsCarousel && CAPIArticle.keyEvents.length && (
+				{showKeyEventsCarousel && CAPIArticle.keyEvents.length > 0 ? (
 					<ElementContainer
 						showTopBorder={false}
 						backgroundColour={
@@ -619,6 +619,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</Island>
 						</Hide>
 					</ElementContainer>
+				) : (
+					<></>
 				)}
 				<ElementContainer
 					showTopBorder={false}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes a bug where the number `0` was showing up when there was no key events.
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
