### PR TITLE
fix 0 for filterbank when no caresoul

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -112,9 +112,7 @@ export const TopicFilterBank = ({
 							handleKeyEventClick(filterKeyEvents, id);
 						}}
 					/>
-				) : (
-					<></>
-				)}
+				) : null}
 
 				{topFiveTopics.map((topic) => {
 					const buttonParams = `${topic.type}:${topic.value}`;

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -102,7 +102,7 @@ export const TopicFilterBank = ({
 				Filters <span css={headlineAccentStyles(palette)}>BETA</span>
 			</div>
 			<div css={topicStyles}>
-				{keyEvents?.length && (
+				{keyEvents?.length ? (
 					<FilterButton
 						value={'Key events'}
 						count={keyEvents.length}
@@ -112,6 +112,8 @@ export const TopicFilterBank = ({
 							handleKeyEventClick(filterKeyEvents, id);
 						}}
 					/>
+				) : (
+					<></>
 				)}
 
 				{topFiveTopics.map((topic) => {

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -619,9 +619,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</Island>
 						</Hide>
 					</ElementContainer>
-				) : (
-					<></>
-				)}
+				) : null}
 				<ElementContainer
 					showTopBorder={false}
 					borderColour={palette.border.article}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes the bug where 0 appears in the filter sections when no key events exist
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
