### PR TITLE
Card avatars

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -685,11 +685,6 @@ type SmallHeadlineSize =
 	| 'huge'
 	| 'ginormous';
 
-type AvatarType = {
-	src: string;
-	alt: string;
-};
-
 type MediaType = 'Video' | 'Audio' | 'Gallery';
 
 type LineEffectType = 'labs' | 'dotted' | 'straight';

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -78,10 +78,9 @@ const enhanceSupportingContent = (
 };
 
 const decideAvatarUrl = (
-	tags?: TagType[],
+	tags: TagType[] = [],
 	byline?: string,
 ): string | undefined => {
-	if (!tags || tags.length === 0) return undefined;
 	const soleContributor = getSoleContributor(tags, byline);
 	return soleContributor?.bylineLargeImageUrl ?? undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -81,9 +81,8 @@ const decideAvatarUrl = (
 	tags?: TagType[],
 	byline?: string,
 ): string | undefined => {
-	if (!tags || tags.length === 0) return;
+	if (!tags || tags.length === 0) return undefined;
 	const soleContributor = getSoleContributor(tags, byline);
-	// eslint-disable-next-line consistent-return -- because I want to return undefined and you can't stop me
 	return soleContributor?.bylineLargeImageUrl ?? undefined;
 };
 

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -622,7 +622,70 @@
                                                             "$ref": "#/definitions/Record<string,unknown>"
                                                         },
                                                         "tags": {
-                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "sectionId",
+                                                                                    "sectionName",
+                                                                                    "tagType",
+                                                                                    "url",
+                                                                                    "webTitle",
+                                                                                    "webUrl"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
                                                         }
                                                     },
                                                     "required": [
@@ -644,6 +707,29 @@
                                                 },
                                                 "byline": {
                                                     "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imgSource": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "imgSource"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
                                                 },
                                                 "webTitle": {
                                                     "type": "string"
@@ -1203,7 +1289,70 @@
                                                             "$ref": "#/definitions/Record<string,unknown>"
                                                         },
                                                         "tags": {
-                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "sectionId",
+                                                                                    "sectionName",
+                                                                                    "tagType",
+                                                                                    "url",
+                                                                                    "webTitle",
+                                                                                    "webUrl"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
                                                         }
                                                     },
                                                     "required": [
@@ -1225,6 +1374,29 @@
                                                 },
                                                 "byline": {
                                                     "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imgSource": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "imgSource"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
                                                 },
                                                 "webTitle": {
                                                     "type": "string"
@@ -1784,7 +1956,70 @@
                                                             "$ref": "#/definitions/Record<string,unknown>"
                                                         },
                                                         "tags": {
-                                                            "$ref": "#/definitions/Record<string,unknown>"
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "tags": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "tagType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webTitle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bio": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "bylineImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "sectionId",
+                                                                                    "sectionName",
+                                                                                    "tagType",
+                                                                                    "url",
+                                                                                    "webTitle",
+                                                                                    "webUrl"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "properties"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "tags"
+                                                            ]
                                                         }
                                                     },
                                                     "required": [
@@ -1806,6 +2041,29 @@
                                                 },
                                                 "byline": {
                                                     "type": "string"
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "item": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "imgSource": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "imgSource"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "item",
+                                                        "type"
+                                                    ]
                                                 },
                                                 "webTitle": {
                                                     "type": "string"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -720,10 +720,7 @@
                                                                 "imgSource": {
                                                                     "type": "string"
                                                                 }
-                                                            },
-                                                            "required": [
-                                                                "imgSource"
-                                                            ]
+                                                            }
                                                         }
                                                     },
                                                     "required": [
@@ -1387,10 +1384,7 @@
                                                                 "imgSource": {
                                                                     "type": "string"
                                                                 }
-                                                            },
-                                                            "required": [
-                                                                "imgSource"
-                                                            ]
+                                                            }
                                                         }
                                                     },
                                                     "required": [
@@ -2054,10 +2048,7 @@
                                                                 "imgSource": {
                                                                     "type": "string"
                                                                 }
-                                                            },
-                                                            "required": [
-                                                                "imgSource"
-                                                            ]
+                                                            }
                                                         }
                                                     },
                                                     "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -159,7 +159,7 @@ export type FEFrontCard = {
 		image?: {
 			type: string;
 			item: {
-				imgSource: string;
+				imgSource?: string;
 			};
 		};
 		webTitle: string;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -90,6 +90,21 @@ export type DCRContainerPalette =
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;
 
+export type FETagType = {
+	id: string;
+	url: string;
+	tagType: string;
+	sectionId: string;
+	sectionName: string;
+	webTitle: string;
+	webUrl: string;
+	twitterHandle?: string;
+	// bio is html
+	bio?: string;
+	bylineImageUrl?: string;
+	contributorLargeImagePath?: string;
+};
+
 export type FEFrontCard = {
 	properties: {
 		isBreaking: boolean;
@@ -135,12 +150,18 @@ export type FEFrontCard = {
 				standfirst?: string;
 			};
 			elements: Record<string, unknown>;
-			tags: Record<string, unknown>;
+			tags: { tags: { properties: FETagType }[] };
 		};
 		maybeContentId?: string;
 		isLiveBlog: boolean;
 		isCrossword: boolean;
 		byline?: string;
+		image?: {
+			type: string;
+			item: {
+				imgSource: string;
+			};
+		};
 		webTitle: string;
 		linkText?: string;
 		webUrl?: string;
@@ -220,6 +241,7 @@ export type DCRFrontCard = {
 	discussionId?: string;
 	byline?: string;
 	showByline?: boolean;
+	avatarUrl?: string;
 };
 
 export type FESnapType = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -99,7 +99,7 @@ export type FETagType = {
 	webTitle: string;
 	webUrl: string;
 	twitterHandle?: string;
-	// bio is html
+	/* bio is html */
 	bio?: string;
 	bylineImageUrl?: string;
 	contributorLargeImagePath?: string;

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -358,7 +358,6 @@ export const WithAnAvatarWhenVertical = () => {
 				>
 					<Card
 						{...basicCardProps}
-						imageUrl=""
 						avatarUrl="https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3"
 						format={{
 							display: ArticleDisplay.Standard,
@@ -378,7 +377,6 @@ export const WithAnAvatarWhenHorizontal = () => {
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
-					imageUrl=""
 					avatarUrl="https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3"
 					format={{
 						display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -359,10 +359,7 @@ export const WithAnAvatarWhenVertical = () => {
 					<Card
 						{...basicCardProps}
 						imageUrl=""
-						avatar={{
-							src: 'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
-							alt: '',
-						}}
+						avatarUrl="https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3"
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Comment,
@@ -382,10 +379,7 @@ export const WithAnAvatarWhenHorizontal = () => {
 				<Card
 					{...basicCardProps}
 					imageUrl=""
-					avatar={{
-						src: 'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
-						alt: '',
-					}}
+					avatarUrl="https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3"
 					format={{
 						display: ArticleDisplay.Standard,
 						design: ArticleDesign.Comment,

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -356,7 +356,7 @@ export const Card = ({
 								/>
 							) : undefined}
 						</HeadlineWrapper>
-						{imageType === 'avatar' && avatarUrl && (
+						{imageType === 'avatar' && !!avatarUrl && (
 							<Hide when="above" breakpoint="tablet">
 								<AvatarContainer>
 									<Avatar

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -47,7 +47,7 @@ export type Props = {
 	/** Size is ignored when position = 'top' because in that case the image flows based on width */
 	imageSize?: ImageSizeType;
 	trailText?: string;
-	avatar?: AvatarType;
+	avatarUrl?: string;
 	showClock?: boolean;
 	mediaType?: MediaType;
 	mediaDuration?: number;
@@ -178,7 +178,7 @@ export const Card = ({
 	imagePositionOnMobile = 'left',
 	imageSize = 'small',
 	trailText,
-	avatar,
+	avatarUrl,
 	showClock,
 	mediaType,
 	mediaDuration,
@@ -277,6 +277,11 @@ export const Card = ({
 		return <Snap snapData={snapData} />;
 	}
 
+	// Decide what type of image to show, main media, avatar or none
+	let imageType: 'mainmedia' | 'avatar' | undefined;
+	if (imageUrl && avatarUrl) imageType = 'avatar';
+	else if (imageUrl) imageType = 'mainmedia';
+
 	return (
 		<CardWrapper
 			format={format}
@@ -295,7 +300,7 @@ export const Card = ({
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}
 			>
-				{imageUrl && (
+				{imageType === 'mainmedia' && (
 					<ImageWrapper
 						imageSize={imageSize}
 						imagePosition={imagePosition}
@@ -348,12 +353,12 @@ export const Card = ({
 								/>
 							) : undefined}
 						</HeadlineWrapper>
-						{avatar && (
+						{imageType === 'avatar' && avatarUrl && (
 							<Hide when="above" breakpoint="tablet">
 								<AvatarContainer>
 									<Avatar
-										imageSrc={avatar.src}
-										imageAlt={avatar.alt}
+										imageSrc={avatarUrl}
+										imageAlt={byline ?? ''}
 										containerPalette={containerPalette}
 										format={format}
 									/>
@@ -375,12 +380,12 @@ export const Card = ({
 								/>
 							</TrailTextWrapper>
 						)}
-						{avatar && (
+						{imageType === 'avatar' && avatarUrl && (
 							<Hide when="below" breakpoint="tablet">
 								<AvatarContainer>
 									<Avatar
-										imageSrc={avatar.src}
-										imageAlt={avatar.alt}
+										imageSrc={avatarUrl}
+										imageAlt={byline ?? ''}
 										containerPalette={containerPalette}
 										format={format}
 									/>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -383,7 +383,7 @@ export const Card = ({
 								/>
 							</TrailTextWrapper>
 						)}
-						{imageType === 'avatar' && avatarUrl && (
+						{imageType === 'avatar' && !!avatarUrl && (
 							<Hide when="below" breakpoint="tablet">
 								<AvatarContainer>
 									<Avatar

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -279,8 +279,11 @@ export const Card = ({
 
 	// Decide what type of image to show, main media, avatar or none
 	let imageType: 'mainmedia' | 'avatar' | undefined;
-	if (imageUrl && avatarUrl) imageType = 'avatar';
-	else if (imageUrl) imageType = 'mainmedia';
+	if (imageUrl && avatarUrl) {
+		imageType = 'avatar';
+	} else if (imageUrl) {
+		imageType = 'mainmedia';
+	}
 
 	return (
 		<CardWrapper

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -44,6 +44,7 @@ export const FrontCard = (props: Props) => {
 		dataLinkName: trail.dataLinkName,
 		snapData: trail.snapData,
 		discussionId: trail.discussionId,
+		avatarUrl: trail.avatarUrl,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds the logic to display avatars on `Card`s

### When should an avatar be displayed?
This PR is stating that an avatar should only display if:

1) The container layout supports the use of an image
Cards that do not have the `imageUrl` property set in their layout will also not show an avatar

2) There is a single contributor tag and its title matches the byline

3) There is an `image` property and its `type` is equal to 'Cutout'.


| Before      | After      |
|-------------|------------|
| <img width="1210" alt="Screenshot 2022-07-25 at 12 34 23" src="https://user-images.githubusercontent.com/1336821/180768553-b53d380b-8697-4916-bc40-fba68836d271.png"> | <img width="1210" alt="Screenshot 2022-07-25 at 12 33 53" src="https://user-images.githubusercontent.com/1336821/180768607-5864d6e7-09a0-4365-9cd4-abcd2e70e4cc.png"> |

Fixes https://github.com/guardian/dotcom-rendering/issues/5093