### PR TITLE
Refactor captions

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -129,7 +129,7 @@ type Palette = {
 		blockquote: Colour;
 		numberedTitle: Colour;
 		numberedPosition: Colour;
-		overlayedCaption: Colour;
+		overlaidCaption: Colour;
 		shareCount: Colour;
 		shareCountUntilDesktop: Colour;
 		cricketScoreboardLink: Colour;

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -64,44 +64,28 @@ const bottomPadding = css`
 const BylineMeta: React.FunctionComponent<{
 	articleData: ArticleModel;
 	pillar: ArticleTheme;
-}> = ({ articleData, pillar }) => {
-	const contributorTag = articleData.tags.find(
-		(t) => t.type === 'Contributor',
-	);
-	const contributorCount = articleData.tags.filter(
-		(t) => t.type === 'Contributor',
-	).length;
-	const bylineImageUrl = contributorTag
-		? contributorTag.bylineLargeImageUrl
-		: null;
-
-	const shouldShowBylineImage =
-		contributorTag && bylineImageUrl && contributorCount === 1;
+}> = ({ articleData: { byline, tags, guardianBaseURL }, pillar }) => {
+	const soleContributor = getSoleContributor(tags, byline);
 
 	return (
 		<div css={bylineWrapper}>
-			<div
-				css={[
-					bylineStyle(pillar),
-					!shouldShowBylineImage && bottomPadding,
-				]}
-			>
+			<div css={[bylineStyle(pillar), !soleContributor && bottomPadding]}>
 				<Byline
-					byline={articleData.byline}
-					tags={articleData.tags}
-					guardianBaseURL={articleData.guardianBaseURL}
+					byline={byline}
+					tags={tags}
+					guardianBaseURL={guardianBaseURL}
 				/>
 			</div>
 
-			{!!shouldShowBylineImage && (
+			{soleContributor?.bylineLargeImageUrl ? (
 				<amp-img
 					class={bylineImageStyle}
-					src={bylineImageUrl}
-					alt={`Contributor image for: ${contributorTag.title}`}
+					src={soleContributor.bylineLargeImageUrl}
+					alt={`Contributor image for: ${soleContributor.title}`}
 					width="180"
 					height="150"
 				/>
-			)}
+			) : null}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -38,7 +38,7 @@ interface CaptionBlockElement {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 }
 
 interface CalloutBlockElement {

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -593,7 +593,7 @@
                 "shouldLimitWidth": {
                     "type": "boolean"
                 },
-                "isOverlayed": {
+                "isOverlaid": {
                     "type": "boolean"
                 }
             },

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -1,6 +1,12 @@
 import { JSDOM } from 'jsdom';
 
-const ishalfWidthImage = (element: CAPIElement): boolean => {
+interface HalfWidthImageBlockElement extends ImageBlockElement {
+	role: 'halfWidth';
+}
+
+const isHalfWidthImage = (
+	element?: CAPIElement,
+): element is HalfWidthImageBlockElement => {
 	if (!element) return false;
 	return (
 		element._type ===
@@ -9,7 +15,9 @@ const ishalfWidthImage = (element: CAPIElement): boolean => {
 	);
 };
 
-const isMultiImage = (element: CAPIElement): boolean => {
+const isMultiImage = (
+	element?: CAPIElement,
+): element is MultiImageBlockElement => {
 	if (!element) return false;
 	return (
 		element._type ===
@@ -17,14 +25,14 @@ const isMultiImage = (element: CAPIElement): boolean => {
 	);
 };
 
-const isImage = (element: CAPIElement): boolean => {
+const isImage = (element?: CAPIElement): element is ImageBlockElement => {
 	if (!element) return false;
 	return (
 		element._type === 'model.dotcomrendering.pageElements.ImageBlockElement'
 	);
 };
 
-const isTitle = (element: CAPIElement): boolean => {
+const isTitle = (element?: CAPIElement): element is SubheadingBlockElement => {
 	if (!element) return false;
 	// Checks if this element is a 'title' based on the convention: <h2>Title text</h2>
 	if (
@@ -41,16 +49,16 @@ const extractTitle = (element: CAPIElement): string => {
 	const subHeading = element as SubheadingBlockElement;
 	// Extract 'title' based on the convention: <h2>Title text</h2>
 	const frag = JSDOM.fragment(subHeading.html);
-	if (!frag || !frag.firstElementChild) return '';
+	if (!frag.firstElementChild) return '';
 	const isH2tag = frag.firstElementChild.nodeName === 'H2';
 	if (isH2tag) {
 		// element is an essay title
-		return (frag.textContent && frag.textContent.trim()) || '';
+		return frag.textContent?.trim() ?? '';
 	}
 	return '';
 };
 
-const isCaption = (element: CAPIElement): boolean => {
+const isCaption = (element?: CAPIElement): element is TextBlockElement => {
 	if (!element) return false;
 	// Checks if this element is a 'caption' based on the convention: <ul><li><Caption text</li></ul>
 	if (
@@ -80,13 +88,9 @@ const extractCaption = (element: CAPIElement): string => {
 };
 
 const constructMultiImageElement = (
-	thisElement: CAPIElement,
-	nextElement: CAPIElement,
+	first: ImageBlockElement,
+	second: ImageBlockElement,
 ): MultiImageBlockElement => {
-	// We cast here because we're certain each element is an image (because of the guards we set earlier) but
-	// TS isn't inferring that and needs a little help
-	const first = thisElement as ImageBlockElement;
-	const second = nextElement as ImageBlockElement;
 	return {
 		_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
 		elementId: first.elementId,
@@ -113,7 +117,7 @@ const addMultiImageElements = (elements: CAPIElement[]): CAPIElement[] => {
 	const withMultiImageElements: CAPIElement[] = [];
 	elements.forEach((thisElement, i) => {
 		const nextElement = elements[i + 1];
-		if (ishalfWidthImage(thisElement) && ishalfWidthImage(nextElement)) {
+		if (isHalfWidthImage(thisElement) && isHalfWidthImage(nextElement)) {
 			// Pair found. Add a multi element and remove the next entry
 			withMultiImageElements.push(
 				constructMultiImageElement(thisElement, nextElement),
@@ -138,7 +142,7 @@ const addTitles = (elements: CAPIElement[]): CAPIElement[] => {
 			withTitles.push({
 				...thisElement,
 				title: extractTitle(nextElement),
-			} as ImageBlockElement);
+			});
 			// Remove the element
 			elements.splice(i + 1, 1);
 		} else if (
@@ -150,7 +154,7 @@ const addTitles = (elements: CAPIElement[]): CAPIElement[] => {
 			withTitles.push({
 				...thisElement,
 				title: extractTitle(subsequentElement),
-			} as ImageBlockElement);
+			});
 			// Remove the element
 			elements.splice(i + 2, 1);
 		} else {
@@ -167,14 +171,14 @@ const addCaptionsToImages = (elements: CAPIElement[]): CAPIElement[] => {
 		const nextElement = elements[i + 1];
 		const subsequentElement = elements[i + 2];
 		if (isImage(thisElement) && isCaption(nextElement)) {
-			const thisImage = thisElement as ImageBlockElement;
+			const thisImage = thisElement;
 			withSpecialCaptions.push({
 				...thisImage,
 				data: {
 					...thisImage.data,
 					caption: extractCaption(nextElement),
 				},
-			} as ImageBlockElement);
+			});
 			// Remove the next element
 			elements.splice(i + 1, 1);
 		} else if (
@@ -182,14 +186,14 @@ const addCaptionsToImages = (elements: CAPIElement[]): CAPIElement[] => {
 			isTitle(nextElement) &&
 			isCaption(subsequentElement)
 		) {
-			const thisImage = thisElement as ImageBlockElement;
+			const thisImage = thisElement;
 			withSpecialCaptions.push({
 				...thisImage,
 				data: {
 					...thisImage.data,
 					caption: extractCaption(subsequentElement),
 				},
-			} as ImageBlockElement);
+			});
 			// Remove the subsequent element
 			elements.splice(i + 2, 1);
 		} else {
@@ -209,7 +213,7 @@ const addCaptionsToMultis = (elements: CAPIElement[]): CAPIElement[] => {
 			withSpecialCaptions.push({
 				...thisElement,
 				caption: extractCaption(nextElement),
-			} as MultiImageBlockElement);
+			});
 			// Remove the next element
 			elements.splice(i + 1, 1);
 		} else if (
@@ -220,7 +224,7 @@ const addCaptionsToMultis = (elements: CAPIElement[]): CAPIElement[] => {
 			withSpecialCaptions.push({
 				...thisElement,
 				caption: extractCaption(subsequentElement),
-			} as MultiImageBlockElement);
+			});
 			// Remove the subsequent element
 			elements.splice(i + 2, 1);
 		} else {
@@ -270,7 +274,7 @@ const removeCredit = (elements: CAPIElement[]): CAPIElement[] => {
 					...thisElement.data,
 					credit: '',
 				},
-			} as ImageBlockElement);
+			});
 		} else {
 			// Pass through
 			withoutCredit.push(thisElement);
@@ -286,31 +290,51 @@ class Enhancer {
 		this.elements = elements;
 	}
 
+	/**
+	 * Photo essays by convention have all image captions removed and rely completely on
+	 * special captions set using the `ul`/`li` trick
+	 */
 	stripCaptions() {
 		this.elements = stripCaptions(this.elements);
 		return this;
 	}
 
+	/**
+	 * Replace pairs of halfWidth images with MultiImageBlockElements
+	 */
 	addMultiImageElements() {
 		this.elements = addMultiImageElements(this.elements);
 		return this;
 	}
 
+	/**
+	 * Photo essay have a convention of adding titles to images if the subsequent block is a h2
+	 */
 	addTitles() {
 		this.elements = addTitles(this.elements);
 		return this;
 	}
 
+	/**
+	 * If any MultiImageBlockElement is followed by a ul/l caption, delete the special caption
+	 * element and use the value for the multi image `caption` prop
+	 */
 	addCaptionsToMultis() {
 		this.elements = addCaptionsToMultis(this.elements);
 		return this;
 	}
 
+	/**
+	 * In photo essays, we also use ul captions for normal images as well
+	 */
 	addCaptionsToImages() {
 		this.elements = addCaptionsToImages(this.elements);
 		return this;
 	}
 
+	/**
+	 * By convention, photo essays don't include credit for images in the caption
+	 */
 	removeCredit() {
 		this.elements = removeCredit(this.elements);
 		return this;
@@ -322,23 +346,13 @@ const enhance = (
 	isPhotoEssay: boolean,
 ): CAPIElement[] => {
 	if (isPhotoEssay) {
-		return (
-			new Enhancer(elements)
-				// Photo essays by convention have all image captions removed and rely completely on
-				// special captions set using the ul/li trick
-				.stripCaptions()
-				// By convention, photo essays don't include credit for images in the caption
-				.removeCredit()
-				// Replace pairs of halfWidth images with MultiImageBlockElements
-				.addMultiImageElements()
-				// Photo essay have a convention of adding titles to images if the subsequent block is a h2
-				.addTitles()
-				// If any MultiImageBlockElement is followed by a ul/l caption, delete the special caption
-				// element and use the value for the multi image `caption` prop
-				.addCaptionsToMultis()
-				// In photo essays, we also use ul captions for normal images as well
-				.addCaptionsToImages().elements
-		);
+		return new Enhancer(elements)
+			.stripCaptions()
+			.removeCredit()
+			.addMultiImageElements()
+			.addTitles()
+			.addCaptionsToMultis()
+			.addCaptionsToImages().elements;
 	}
 
 	return (

--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -24,7 +24,7 @@ export default {
     credit?: string;
     displayCredit?: boolean;
     shouldLimitWidth?: boolean;
-    isOverlayed?: boolean; // Not tested here as this option only works in the context of the ImageComponent
+    isOverlaid?: boolean; // Not tested here as this option only works in the context of the ImageComponent
  */
 
 export const Article = () => (
@@ -144,7 +144,7 @@ export const Padded = () => (
 );
 Padded.story = { name: 'when padded' };
 
-export const Overlayed = () => (
+export const Overlaid = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -164,8 +164,8 @@ export const Overlayed = () => (
 				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
 			/>
 			<Caption
-				isOverlayed={true}
-				captionText="This is how a caption looks when it's overlayed"
+				isOverlaid={true}
+				captionText="This is how a caption looks when it's overlaid"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -176,9 +176,9 @@ export const Overlayed = () => (
 		</div>
 	</ElementContainer>
 );
-Overlayed.story = { name: 'when overlayed' };
+Overlaid.story = { name: 'when overlaid' };
 
-export const OverlayedWithStars = () => (
+export const OverlaidWithStars = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -198,8 +198,8 @@ export const OverlayedWithStars = () => (
 				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
 			/>
 			<Caption
-				isOverlayed={true}
-				captionText="This is how a caption looks when it's overlayed with stars"
+				isOverlaid={true}
+				captionText="This is how a caption looks when it's overlaid with stars"
 				format={{
 					display: ArticleDisplay.Showcase,
 					design: ArticleDesign.Review,
@@ -219,7 +219,7 @@ export const OverlayedWithStars = () => (
 		</div>
 	</ElementContainer>
 );
-OverlayedWithStars.story = { name: 'when overlayed on stars' };
+OverlaidWithStars.story = { name: 'when overlaid on stars' };
 
 export const VideoCaption = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -19,7 +19,7 @@ type Props = {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 	isLeftCol?: boolean;
 	mediaType?: MediaType;
 	isMainMedia?: boolean;
@@ -42,7 +42,7 @@ const bottomMarginStyles = css`
 	margin-bottom: 6px;
 `;
 
-const overlayedBottomPadding = (format: ArticleFormat) => {
+const overlaidBottomPadding = (format: ArticleFormat) => {
 	if (
 		format.display === ArticleDisplay.Showcase &&
 		format.design === ArticleDesign.Review
@@ -56,7 +56,7 @@ const overlayedBottomPadding = (format: ArticleFormat) => {
 	`;
 };
 
-const overlayedStyles = (palette: Palette, format: ArticleFormat) => css`
+const overlaidStyles = (palette: Palette, format: ArticleFormat) => css`
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -64,21 +64,21 @@ const overlayedStyles = (palette: Palette, format: ArticleFormat) => css`
 	background: rgba(18, 18, 18, 0.8);
 
 	span {
-		color: ${palette.text.overlayedCaption};
+		color: ${palette.text.overlaidCaption};
 		font-size: 0.75rem;
 		line-height: 1rem;
 	}
 
 	svg {
-		fill: ${palette.text.overlayedCaption};
+		fill: ${palette.text.overlaidCaption};
 	}
-	color: ${palette.text.overlayedCaption};
+	color: ${palette.text.overlaidCaption};
 	font-size: 0.75rem;
 	line-height: 1rem;
 	padding-top: 0.375rem;
 	padding-right: 2.5rem;
 	padding-left: 0.75rem;
-	${overlayedBottomPadding(format)};
+	${overlaidBottomPadding(format)};
 
 	flex-grow: 1;
 	min-height: 2.25rem;
@@ -229,7 +229,7 @@ export const Caption = ({
 	credit,
 	displayCredit = true,
 	shouldLimitWidth = false,
-	isOverlayed,
+	isOverlaid,
 	isLeftCol,
 	mediaType = 'Gallery',
 	isMainMedia = false,
@@ -249,8 +249,8 @@ export const Caption = ({
 			css={[
 				captionStyle(palette),
 				shouldLimitWidth && limitedWidth,
-				isOverlayed
-					? overlayedStyles(palette, format)
+				isOverlaid
+					? overlaidStyles(palette, format)
 					: bottomMarginStyles,
 				isMainMedia && isBlog && tabletCaptionPadding,
 				padCaption && captionPadding,

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -234,11 +234,10 @@ export const Caption = ({
 	mediaType = 'Gallery',
 	isMainMedia = false,
 }: Props) => {
-	// Sometimes captions come thorough as a single blank space, so we trim here to ignore those
+	/** Sometimes captions come through as a single blank space, so we trim it */
 	const noCaption = !captionText?.trim();
-	const noCredit = !credit;
-	const hideCredit = !displayCredit;
-	if (noCaption && (noCredit || hideCredit)) return null;
+	const noCredit = !!credit || !!displayCredit;
+	if (noCaption && noCredit) return null;
 
 	const palette = decidePalette(format);
 	const isBlog =
@@ -250,8 +249,9 @@ export const Caption = ({
 			css={[
 				captionStyle(palette),
 				shouldLimitWidth && limitedWidth,
-				!isOverlayed && bottomMarginStyles,
-				isOverlayed && overlayedStyles(palette, format),
+				isOverlayed
+					? overlayedStyles(palette, format)
+					: bottomMarginStyles,
 				isMainMedia && isBlog && tabletCaptionPadding,
 				padCaption && captionPadding,
 				mediaType === 'Video' && videoPadding,
@@ -266,7 +266,7 @@ export const Caption = ({
 				<span
 					css={captionLink(palette)}
 					dangerouslySetInnerHTML={{
-						__html: captionText || '',
+						__html: captionText,
 					}}
 					key="caption"
 				/>
@@ -306,7 +306,7 @@ export const Caption = ({
 						<span
 							css={captionLink(palette)}
 							dangerouslySetInnerHTML={{
-								__html: captionText || '',
+								__html: captionText,
 							}}
 							key="caption"
 						/>

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
@@ -21,7 +21,7 @@ export default {
         credit?: string;
         displayCredit?: boolean;
         shouldLimitWidth?: boolean;
-        isOverlayed?: boolean;
+        isOverlaid?: boolean;
     };
  */
 
@@ -79,7 +79,7 @@ export const PhotoEssay = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -102,7 +102,7 @@ export const PhotoEssayHTML = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -125,7 +125,7 @@ export const Padded = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -148,7 +148,7 @@ export const WidthLimited = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={true}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -171,7 +171,7 @@ export const Credited = () => {
 				credit="Credit text"
 				displayCredit={true}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -180,7 +180,7 @@ Credited.story = {
 	name: 'with credit',
 };
 
-export const Overlayed = () => {
+export const Overlaid = () => {
 	return (
 		<Container>
 			<CaptionBlockComponent
@@ -194,11 +194,11 @@ export const Overlayed = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={true}
+				isOverlaid={true}
 			/>
 		</Container>
 	);
 };
-Overlayed.story = {
-	name: 'when overlayed',
+Overlaid.story = {
+	name: 'when overlaid',
 };

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 };
 
 export const CaptionBlockComponent = ({
@@ -17,7 +17,7 @@ export const CaptionBlockComponent = ({
 	credit,
 	displayCredit = true,
 	shouldLimitWidth = false,
-	isOverlayed,
+	isOverlaid,
 }: Props) => (
 	<Caption
 		format={format}
@@ -26,6 +26,6 @@ export const CaptionBlockComponent = ({
 		credit={credit}
 		displayCredit={displayCredit}
 		shouldLimitWidth={shouldLimitWidth}
-		isOverlayed={isOverlayed}
+		isOverlaid={isOverlaid}
 	/>
 );

--- a/dotcom-rendering/src/web/components/ClickToView.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.tsx
@@ -94,12 +94,10 @@ const shouldDisplayOverlay = ({
 	isOverlayClicked: boolean;
 	isMainMedia?: boolean;
 }) => {
-	if (isMainMedia || !isTracking) {
-		return false;
-	}
-	if (isOverlayClicked) {
-		return false;
-	}
+	if (isMainMedia) return false;
+	if (!isTracking) return false;
+	if (isOverlayClicked) return false;
+
 	return true;
 };
 

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -401,7 +401,7 @@ export const ImageComponent = ({
 										credit={element.data.credit}
 										displayCredit={element.displayCredit}
 										shouldLimitWidth={shouldLimitWidth}
-										isOverlayed={true}
+										isOverlaid={true}
 										isMainMedia={isMainMedia}
 									/>
 								</div>

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -396,7 +396,7 @@ export const ImageComponent = ({
 								<CaptionToggle />{' '}
 								<div id="the-caption">
 									<Caption
-										captionText={element.data.caption || ''}
+										captionText={element.data.caption}
 										format={format}
 										credit={element.data.credit}
 										displayCredit={element.displayCredit}
@@ -419,7 +419,7 @@ export const ImageComponent = ({
 			{isMainMedia ? (
 				<Hide when="below" breakpoint="tablet">
 					<Caption
-						captionText={element.data.caption || ''}
+						captionText={element.data.caption}
 						format={format}
 						credit={element.data.credit}
 						displayCredit={element.displayCredit}
@@ -429,7 +429,7 @@ export const ImageComponent = ({
 				</Hide>
 			) : (
 				<Caption
-					captionText={element.data.caption || ''}
+					captionText={element.data.caption}
 					format={format}
 					credit={element.data.credit}
 					displayCredit={element.displayCredit}

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -42,15 +42,15 @@ const isLongEnough = (html: string): boolean => {
 	// link tag html.
 	// https://stackoverflow.com/questions/822452/strip-html-from-text-javascript is
 	// a good discussion on how this can be done. Of the two approaches, regex and
-	// DOM, both have unikely failure scenarios but the impact for failure with DOM
+	// DOM, both have unlikely failure scenarios but the impact for failure with DOM
 	// manipulation carries a potential security risk so we're using a regex.
 	return html.replace(/(<([^>]+)>)/gi, '').length >= 199;
 };
 
 const decideDropCapLetter = (html: string): string => {
-	const first = html.substr(0, 1);
+	const first = html.slice(0, 1);
 	if (isOpenQuote(first)) {
-		const second = html.substr(1, 1);
+		const second = html.slice(1, 1);
 
 		if (!isLetter(second)) {
 			return '';
@@ -225,7 +225,7 @@ export const TextBlockComponent = ({
 
 			const firstLetter = decideDropCapLetter(unwrappedHtml);
 			const remainingLetters = firstLetter
-				? unwrappedHtml.substr(firstLetter.length)
+				? unwrappedHtml.slice(firstLetter.length)
 				: unwrappedHtml;
 
 			if (

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -220,7 +220,7 @@ export const YoutubeBlockComponent = ({
 			/>
 			{!hideCaption && (
 				<Caption
-					captionText={mediaTitle || ''}
+					captionText={mediaTitle}
 					format={format}
 					displayCredit={false}
 					shouldLimitWidth={shouldLimitWidth}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1213,7 +1213,7 @@ const textNumberedPosition = (): string => {
 	return text.supporting;
 };
 
-const textOverlayed = (): string => {
+const textOverlaid = (): string => {
 	return WHITE;
 };
 
@@ -1383,7 +1383,7 @@ export const decidePalette = (
 			blockquote: textBlockquote(format),
 			numberedTitle: textNumberedTitle(format),
 			numberedPosition: textNumberedPosition(),
-			overlayedCaption: textOverlayed(),
+			overlaidCaption: textOverlaid(),
 			shareCount: textShareCount(),
 			shareCountUntilDesktop: textShareCountUntilDesktop(format),
 			cricketScoreboardLink: textCricketScoreboardLink(),

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -186,7 +186,7 @@ export const renderElement = ({
 					credit={element.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={element.shouldLimitWidth}
-					isOverlayed={element.isOverlayed}
+					isOverlaid={element.isOverlaid}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':


### PR DESCRIPTION
## What does this change?

A series of pass-by refactors and small fixes:

- ea9c764665d751948a040d3c88cac0f65a81bbd4 continues the use of getSoleContributor introduced in #5378 
- 3afb4d7cca3a055ea40ed5f0904a294aa0edf732 applies some suggested ESLint rules.
- bded1263a0b2ddda9af2a88a72aea274e8b07414 removes type assertions in favour of type predicates
- fde6ce1aafd839881b4ff3bf4e3e0c16c74ee922 simplifies an unnecessary nested logic
- 5ebbe782c22898980aa42ebabfe1856e306a10b0 removes deprecated method `String.substr` in favour of `String.slice`
- 8d6c38d7aaf93c5742b114c73c4066a05f8aafcc spells “overlaid” properly

## Why?

- Stronger typings
- Simpler logic
- Less typos