### PR TITLE
Hover styles for cards inside palette containers

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -21,6 +21,7 @@ const cardStyles = (
 	format: ArticleFormat,
 	palette: Palette,
 	isDynamo?: true,
+	containerPalette?: DCRContainerPalette,
 ) => {
 	const baseCardStyles = css`
 		display: flex;
@@ -46,6 +47,39 @@ const cardStyles = (
 		text-decoration: none;
 		background-color: ${isDynamo ? 'transparent' : palette.background.card};
 	`;
+
+	const decidePaletteBrightness = (thePalette: DCRContainerPalette) => {
+		switch (thePalette) {
+			case 'EventPalette':
+				return `96%`;
+			case 'BreakingPalette':
+				return `85%`;
+			case 'EventAltPalette':
+				return `95%`;
+			case 'InvestigationPalette':
+				return `90%`;
+			case 'LongRunningPalette':
+				return `84%`;
+			case 'LongRunningAltPalette':
+				return `95%`;
+			case 'SombrePalette':
+				return `90%`;
+			case 'SombreAltPalette':
+				return `85%`;
+			default:
+				return `90%`;
+		}
+	};
+	if (containerPalette) {
+		return css`
+			${baseCardStyles};
+			:hover {
+				filter: brightness(
+					${decidePaletteBrightness(containerPalette)}
+				);
+			}
+		`;
+	}
 
 	if (format.theme === ArticleSpecial.SpecialReport) {
 		return css`
@@ -138,7 +172,7 @@ export const CardWrapper = ({
 	return (
 		<div
 			css={[
-				cardStyles(format, palette, isDynamo),
+				cardStyles(format, palette, isDynamo, containerPalette),
 				topBarStyles({ isDynamo, palette, containerType }),
 			]}
 		>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
If a `Card` is sitting in a container that has a `containerPalette` applied to it then this PR ensures that this card is given a specific hover style

Closes #5268 

## Why?
Cards inside palette containers have their colours overriden so we need the hover styles to be set based on this.

| Before      | After      |
|-------------|------------|
| ![2022-07-25 17 09 55](https://user-images.githubusercontent.com/1336821/180824870-f1f77d9a-21d3-426b-974b-16e8aab2a8ab.gif) | ![2022-07-25 17 01 55](https://user-images.githubusercontent.com/1336821/180824756-fd2cbb82-4634-4dce-8bec-f9050b8da301.gif) |
