### PR TITLE
Make deadblog standfirst bullets darker

### DIFF
--- a/apps-rendering/src/components/Standfirst/DeadBlogStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/DeadBlogStandfirst.tsx
@@ -5,6 +5,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { headline, neutral, remSpace } from '@guardian/source-foundations';
 import type { Item } from 'item';
 import { getFormat } from 'item';
+import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
 
@@ -58,7 +59,7 @@ interface Props {
 	item: Item;
 }
 
-const DeadBlogStandfirst: React.FC<Props> = ({ item }) => {
+const DeadBlogStandfirst: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	return (

--- a/apps-rendering/src/components/Standfirst/DeadBlogStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/DeadBlogStandfirst.tsx
@@ -25,6 +25,10 @@ const deadblogStyles = (format: ArticleFormat): SerializedStyles => {
 
 		ul {
 			margin-bottom: 0;
+
+			> li::before {
+				background-color: ${neutral[60]};
+			}
 		}
 
 		a {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses `neutral[60]` for deadblog standfirst bullet colour

## Why?

- To fix #4340

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/180836727-169843cb-7fa4-430c-8b84-a686f66a13be.png
[after]: https://user-images.githubusercontent.com/705427/180836732-088818c7-6fe1-430e-99d9-e8b626b63496.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
