### PR TITLE
Improve sole contributor

### DIFF
--- a/dotcom-rendering/src/lib/byline.test.ts
+++ b/dotcom-rendering/src/lib/byline.test.ts
@@ -1,4 +1,4 @@
-import { getBylineComponentsFromTokens } from './byline';
+import { getBylineComponentsFromTokens, getSoleContributor } from './byline';
 
 describe('Byline utilities', () => {
 	it('should link a single tag by linking name tokens with Contributor tag titles', () => {
@@ -73,5 +73,162 @@ describe('Byline utilities', () => {
 			' and ',
 			{ tag: tags[1], token: 'Duncan Campbell' },
 		]);
+	});
+
+	describe('getSoleContributor', () => {
+		describe('returns a contributor', () => {
+			it('Sebastian Köhn, as told to Wilfried Chan', () => {
+				// https://www.theguardian.com/world/2022/jul/23/i-literally-screamed-out-loud-in-pain-my-two-weeks-of-monkeypox-hell
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/wilfred-chan',
+							type: 'Contributor',
+							title: 'Wilfred Chan',
+						},
+					],
+					'Sebastian Köhn, as told to Wilfred Chan',
+				);
+
+				expect(soleContributor?.title).toBe('Wilfred Chan');
+			});
+
+			it('Jim Waterson Media editor', () => {
+				// https://www.theguardian.com/media/2021/nov/17/geordie-greig-ousted-as-editor-of-the-daily-mail
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'media/geordie-greig',
+							type: 'Keyword',
+							title: 'Geordie Greig',
+						},
+						{
+							id: 'profile/jim-waterson',
+							type: 'Contributor',
+							title: 'Jim Waterson',
+							twitterHandle: 'jimwaterson',
+							bylineImageUrl:
+								'https://i.guim.co.uk/img/uploads/2019/01/21/Jim_Waterson.jpg?width=300&quality=85&auto=format&fit=max&s=70dd40e52d9cbe5053f58ad8c4421664',
+						},
+					],
+					'Jim Waterson Media editor',
+				);
+
+				expect(soleContributor?.title).toBe('Jim Waterson');
+			});
+
+			it('First Dog on the Moon', () => {
+				// https://www.theguardian.com/commentisfree/2022/jul/22/europe-is-ablaze-italian-glaciers-are-collapsing-the-climate-crisis-is-here
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/first-dog-on-the-moon',
+							type: 'Contributor',
+							title: 'First Dog on the Moon',
+						},
+					],
+					'First Dog on the Moon',
+				);
+
+				expect(soleContributor?.title).toBe('First Dog on the Moon');
+			});
+
+			it('Sam Levine in New York', () => {
+				// https://www.theguardian.com/us-news/2022/jul/22/january-6-panel-american-democracy-nose-dive
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/sam-levine',
+							type: 'Contributor',
+							title: 'Sam Levine',
+						},
+					],
+					'Sam Levine in New York',
+				);
+
+				expect(soleContributor?.title).toBe('Sam Levine');
+			});
+		});
+
+		describe('returns `undefined`', () => {
+			it('Sam Levin in Los Angeles and Sam Levine in New York', () => {
+				// https://www.theguardian.com/us-news/2020/oct/12/republicans-election-2020-unauthorized-ballot-boxes
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/sam-levin',
+							type: 'Contributor',
+							title: 'Sam Levin',
+							twitterHandle: 'SamTLevin',
+						},
+						{
+							id: 'profile/sam-levine',
+							type: 'Contributor',
+							title: 'Sam Levine',
+						},
+					],
+					'Sam Levin in Los Angeles and Sam Levine in New York',
+				);
+				expect(soleContributor).toBe(undefined);
+			});
+
+			it('Gabriel Smith', () => {
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/ben-beaumont-thomas',
+							type: 'Contributor',
+							title: 'Ben Beaumont-Thomas',
+							twitterHandle: 'ben_bt',
+						},
+					],
+					'Gabriel Smith',
+				);
+				expect(soleContributor).toBe(undefined);
+			});
+
+			it('Zoe Williams and others', () => {
+				// https://www.theguardian.com/commentisfree/2022/jul/20/britain-next-prime-minister-rishi-sunak-liz-truss-conservative-leader
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/zoewilliams',
+							type: 'Contributor',
+							title: 'Zoe Williams',
+							twitterHandle: 'zoesqwilliams',
+						},
+						{
+							id: 'profile/sahil-dutta',
+							type: 'Contributor',
+							title: 'Sahil Dutta',
+						},
+						{
+							id: 'profile/henry-hill',
+							type: 'Contributor',
+							title: 'Henry Hill',
+						},
+						{
+							id: 'profile/simonjenkins',
+							type: 'Contributor',
+							title: 'Simon Jenkins',
+						},
+						{
+							id: 'profile/moya-lothian-mclean',
+							type: 'Contributor',
+							title: 'Moya Lothian-McLean',
+						},
+					],
+					'Zoe Williams and others',
+				);
+
+				expect(soleContributor).toBe(undefined);
+			});
+		});
 	});
 });

--- a/dotcom-rendering/src/lib/byline.ts
+++ b/dotcom-rendering/src/lib/byline.ts
@@ -12,8 +12,9 @@ export const isContributor = (tag: TagType): tag is ContributorTag =>
  * such as their picture, bio or social media handle.
  *
  * An article has a sole contributor only if all of the following are true:
- * - there is only one `Contributor` tag
- * - that tag’s `title` is the same as the article byline
+ * - there is a byline which is not an empty string
+ * - the byline does not include the word “and”
+ * - there is a `Contributor` tag whose title is included in the byline
  *
  * @returns A sole contributor if there is one, `undefined` otherwise.
  */
@@ -21,17 +22,12 @@ export const getSoleContributor = (
 	tags: TagType[],
 	byline: string | undefined,
 ): ContributorTag | undefined => {
-	/**
-	 * Want to read more about array destructuring and the rest syntax?
-	 * Here, soleContributor is of type `ContributorTag | undefined`
-	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#syntax
-	 * @see https://javascript.info/destructuring-assignment#the-rest
-	 */
-	const [soleContributor, ...otherContributors] = tags.filter(isContributor);
+	if (!byline) return undefined;
+	if (byline.includes(' and ')) return undefined;
 
-	if (otherContributors.length !== 0) return undefined;
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- it could be `undefined`, but we don’t have `strictNullChecks` enabled
-	if (soleContributor?.title !== byline) return undefined;
+	const soleContributor = tags
+		.filter(isContributor)
+		.find(({ title }) => byline.includes(title));
 
 	return soleContributor;
 };


### PR DESCRIPTION
## What does this change?

Improves the logic to determine if there should be a sole contributor.
Add test to capture these cases. 

Sole contributor:
- Sebastian Köhn, as told to Wilfried Chan
- Jim Waterson Media editor
- Sam Levine in New York
- First Dog on the Moon
    
No sole contributor:
- Sam Levin in Los Angeles and Sam Levine in New York
- Zoe Williams and others

## Why?

There were a handful of false negatives, where no single contributor could be found:

- Rory Caroll Ireland correspondent
- Sam Levine in New York

[CAPI search for “as told to“ in byline](http://content.guardianapis.com/search?api-key=test&query-fields=byline&q=as+told+to&show-fields=body&page-size=10).

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/180962753-c8a25fbf-992d-43cb-8f95-a4945acbef0e.png
[after]: https://user-images.githubusercontent.com/76776/180962803-c0efedbb-b77f-48b7-a37a-f0688f36f0b9.png