### PR TITLE
Fix earliest key event bullet alignment

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -143,7 +143,7 @@ const listItemStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 		border-left: 1px solid ${neutral[60]};
 	`}
 	&:last-child {
-		border-left: none;
+		border-left-color: transparent;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

This change affects live/dead blogs.

Instead of `border-left: none` for the last `li`, set `border-left-color: transparent` so the spacing/alignment stays consistent.

## Why?

- To fix #5501 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/180975286-d4649b3e-b3c7-40ae-9df3-5708bfe113f6.png
[after]: https://user-images.githubusercontent.com/705427/180975249-3b318513-6b7b-4fa9-a249-226f18f65ea7.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
