### PR TITLE
Ensure `index` is unique when`UnsafeEmbedBlockcomponent`s exist in pinned posts

### DIFF
--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -80,6 +80,7 @@ export const LiveBlock = ({
 					isAdFreeUser={isAdFreeUser}
 					isSensitive={isSensitive}
 					switches={switches}
+					isPinnedPost={isPinnedPost}
 				/>
 			))}
 			<footer

--- a/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
@@ -11,6 +11,7 @@ type Props = {
 	isMainMedia?: boolean;
 	source?: string;
 	sourceDomain?: string;
+	isPinnedPost?: boolean;
 };
 
 const fullWidthStyles = css`
@@ -26,29 +27,34 @@ export const UnsafeEmbedBlockComponent = ({
 	isMainMedia,
 	source,
 	sourceDomain,
-}: Props) => (
-	<ClickToView
-		role={role}
-		isTracking={isTracking}
-		isMainMedia={isMainMedia}
-		source={source}
-		sourceDomain={sourceDomain}
-		onAccept={() =>
-			updateIframeHeight(`iframe[name="unsafe-embed-${index}"]`)
-		}
-	>
-		<iframe
-			css={fullWidthStyles}
-			className="js-embed__iframe"
-			title={alt}
-			// name is used to identify each unique iframe on the page to resize
-			// we therefore use the "unsafe-embed-" prefix followed by index to
-			// construct a unique ID
-			name={`unsafe-embed-${index}`}
-			data-cy="embed-block"
-			srcDoc={`${html}
+	isPinnedPost,
+}: Props) => {
+	// This allows for when a block is duplicated on a live blog inside a pinned post
+	const uniqueIndex = isPinnedPost ? `${index}-pinned` : index;
+	return (
+		<ClickToView
+			role={role}
+			isTracking={isTracking}
+			isMainMedia={isMainMedia}
+			source={source}
+			sourceDomain={sourceDomain}
+			onAccept={() =>
+				updateIframeHeight(`iframe[name="unsafe-embed-${uniqueIndex}"]`)
+			}
+		>
+			<iframe
+				css={fullWidthStyles}
+				className="js-embed__iframe"
+				title={alt}
+				// name is used to identify each unique iframe on the page to resize
+				// we therefore use the "unsafe-embed-" prefix followed by index to
+				// construct a unique ID
+				name={`unsafe-embed-${uniqueIndex}`}
+				data-cy="embed-block"
+				srcDoc={`${html}
             <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
             <gu-script>iframeMessenger.enableAutoResize();</gu-script>`}
-		/>
-	</ClickToView>
-);
+			/>
+		</ClickToView>
+	);
+};

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -79,6 +79,7 @@ type Props = {
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: { [key: string]: boolean };
+	isPinnedPost?: boolean;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -132,6 +133,7 @@ export const renderElement = ({
 	isAdFreeUser,
 	switches,
 	isSensitive,
+	isPinnedPost,
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
 
@@ -269,6 +271,7 @@ export const renderElement = ({
 							isMainMedia={isMainMedia}
 							source={element.source}
 							sourceDomain={element.sourceDomain}
+							isPinnedPost={isPinnedPost}
 						/>
 					</Island>,
 				];
@@ -798,6 +801,7 @@ export const RenderArticleElement = ({
 	isAdFreeUser,
 	isSensitive,
 	switches,
+	isPinnedPost,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -816,6 +820,7 @@ export const RenderArticleElement = ({
 		isAdFreeUser,
 		isSensitive,
 		switches,
+		isPinnedPost,
 	});
 
 	if (!ok) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This ensures that the `UnsafeEmbedBlockcomponent` uses a unique index value when there are two of the same embed on the page, one in a pinned post and the other in the original post in the article body

## Why?
[This article](https://www.theguardian.com/politics/live/2022/jul/26/tory-leadership-race-liz-truss-rishi-sunak-tv-debate-uk-politics-live) has two embeds the same on the page but they both have the same index (`2`) and this is preventing the iframe resizing logic from working


| Before      | After      |
|-------------|------------|
| <img width="753" alt="Screenshot 2022-07-26 at 15 21 04" src="https://user-images.githubusercontent.com/1336821/181029354-afa952c5-42f7-4d45-bdf2-643e4b92265a.png"> | <img width="753" alt="Screenshot 2022-07-26 at 15 20 39" src="https://user-images.githubusercontent.com/1336821/181029283-a56093a3-4467-43e8-854a-f0f4a11c7ff6.png"> |
