### PR TITLE
Eslint refactor: no-fallthough

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -3,7 +3,6 @@ const transitionRules = require('./eslint-guardian');
 /** TODO: Review these */
 const rulesToReview = {
 	'consistent-return': 'warn', // 51 problems
-	'default-case': 'warn', // 50 problems
 	'react/no-danger': 'warn', // 48 problems
 	'react/no-array-index-key': 'warn', // 34 problems
 	'react/button-has-type': 'warn', // 23 problems
@@ -77,6 +76,9 @@ module.exports = {
 
 		/** @see https://github.com/hpersson/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md */
 		'jsx-expressions/strict-logical-expressions': 'error',
+
+		// We use 'noFallthroughCasesInSwitch' in tsconfig.json as this respects types
+		'no-fallthrough': 'off',
 
 		...rulesToReview,
 		...rulesToRemove,

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -20,7 +20,6 @@ import {
 	sport,
 	text,
 } from '@guardian/source-foundations';
-
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../../lib/pillars';
 import type { DCRContainerPalette } from '../../types/front';
@@ -722,7 +721,6 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
 			}
-			break;
 		case ArticleDesign.DeadBlog:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -1,72 +1,72 @@
 {
-    "compilerOptions": {
-        /* Basic Options */
-        "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-        "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-        "lib": ["esnext", "es2015", "dom"],
-        /* Specify library files to be included in the compilation. */
-        "allowJs": true /* Allow javascript files to be compiled. */,
-        // "checkJs": true,                       /* Report errors in .js files. */
-		"jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react-jsx', or 'react'. */,
-		"jsxImportSource": "@emotion/react",
-        // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-        // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-        // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-        // "outFile": "./",                       /* Concatenate and emit output to single file. */
-        // "outDir": "./",                        /* Redirect output structure to the directory. */
-        // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-        // "composite": true,                     /* Enable project compilation */
-        // "removeComments": true,                /* Do not emit comments to output. */
-        "noEmit": true /* Do not emit outputs. */,
-        // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-        // "downlevelIteration": true,            /* Provide full suppotrt for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-        // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-        /* Strict Type-Checking Options */
-        "strict": true /* Enable all strict type-checking options. */,
-        // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-        // "strictNullChecks": true,              /* Enable strict null checks. */
-        // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-        // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-        // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-        // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": ["esnext", "es2015", "dom"],
+    /* Specify library files to be included in the compilation. */
+    "allowJs": true /* Allow javascript files to be compiled. */,
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react-jsx', or 'react'. */,
+    "jsxImportSource": "@emotion/react",
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true /* Do not emit outputs. */,
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full suppotrt for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
-        /* Additional Checks */
-        "noUnusedLocals": true,
-        /* Report errors on unused locals. */
-        // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-        "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    /* Additional Checks */
+    "noUnusedLocals": true,
+    /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
-        /* Module Resolution Options */
-        "moduleResolution": "node",
-        /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-        "baseUrl": "./",
-        /* Base directory to resolve non-absolute module names. */
-        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-        "paths": {
-            /* Aliases should also be added to the webpack, babel and jest configurations */
-            "*": ["node_modules/@types/*", "*"], // Make sure that yarn linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
-        },
-        // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-        // "typeRoots": [],                       /* List of folders to include type definitions from. */
-        // "types": [],                           /* Type declaration files to be included in compilation. */
-        "allowSyntheticDefaultImports": true,
-        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-        "esModuleInterop": true,
-        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-        // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-        /* Source Map Options */
-        // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-        // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-        // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-        // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-        "forceConsistentCasingInFileNames": true,
-        "resolveJsonModule": true,
-        "preserveConstEnums": true
-        /* Experimental Options */
-        // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-        // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    /* Module Resolution Options */
+    "moduleResolution": "node",
+    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./",
+    /* Base directory to resolve non-absolute module names. */
+    /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "paths": {
+      /* Aliases should also be added to the webpack, babel and jest configurations */
+      "*": ["node_modules/@types/*", "*"] // Make sure that yarn linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
     },
-    "exclude": ["cypress", "./cypress.config.js"]
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,
+    /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,
+    /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "preserveConstEnums": true
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": ["cypress", "./cypress.config.js"]
 }


### PR DESCRIPTION
Co-Authored-By: Max Duval <hi@mxdvl.com>

Disabling the ESLINT rules 'default-case' & 'no-fallthrough' as these do not respect / understand typescript - throwing errors when they were not expected.

To replace this rule we turned on `noFallthroughCasesInSwitch` in the tsconfig - ensuring that these rules are still enforced while respecting typescript types!


