### PR TITLE
Fix contrasts for branding on liveblogs mobile

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -327,7 +327,11 @@ export const ArticleMeta = ({
 			<div css={meta(format)}>
 				{branding && (
 					<Island deferUntil="visible">
-						<Branding branding={branding} palette={palette} />
+						<Branding
+							branding={branding}
+							palette={palette}
+							format={format}
+						/>
 					</Island>
 				)}
 				{format.theme === ArticleSpecial.Labs ? (

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { neutral, textSans, until } from '@guardian/source-foundations';
+
 import { trackSponsorLogoLinkClick } from '../browser/ga/ga';
+import { Hide } from './Hide';
 
 const brandingStyle = css`
 	padding-bottom: 10px;
@@ -104,19 +106,6 @@ const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
 	}
 };
 
-const hiddenUntilDesktop = css`
-	${until.desktop} {
-		display: none;
-	}
-`;
-
-const hiddenFromDesktop = css`
-	display: none;
-	${until.desktop} {
-		display: block;
-	}
-`;
-
 type Props = {
 	branding: Branding;
 	palette: Palette;
@@ -140,23 +129,25 @@ export const Branding = ({ branding, palette, format }: Props) => {
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-cy="branding-logo"
 				>
-					<img
-						css={hiddenFromDesktop}
-						width={branding.logo.dimensions.width}
-						height={branding.logo.dimensions.height}
-						src={
-							branding.logoForDarkBackground?.src ??
-							branding.logo.src
-						}
-						alt={branding.sponsorName}
-					/>
-					<img
-						css={hiddenUntilDesktop}
-						width={branding.logo.dimensions.width}
-						height={branding.logo.dimensions.height}
-						src={branding.logo.src}
-						alt={branding.sponsorName}
-					/>
+					<Hide when="above" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={
+								branding.logoForDarkBackground?.src ??
+								branding.logo.src
+							}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
+					<Hide when="below" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={branding.logo.src}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
 				</a>
 			</div>
 

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -58,6 +58,10 @@ const brandingLogoStyle = css`
 	padding: 10px 0;
 
 	display: block;
+
+	& img {
+		display: block;
+	}
 `;
 
 /**

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -1,46 +1,132 @@
 import { css } from '@emotion/react';
-import { neutral, textSans } from '@guardian/source-foundations';
+import { ArticleDesign } from '@guardian/libs';
+import { neutral, textSans, until } from '@guardian/source-foundations';
 import { trackSponsorLogoLinkClick } from '../browser/ga/ga';
 
 const brandingStyle = css`
 	padding-bottom: 10px;
 `;
 
-const brandingLabelStyle = css`
-	${textSans.xxsmall()};
-	color: ${neutral[20]};
-`;
+// for liveblog smaller breakpoints article meta is located in the same
+// container as standfirst and needs the same styling as standfirst
+function brandingLabelStyle(palette: Palette, format: ArticleFormat) {
+	const invariantStyles = css`
+		${textSans.xxsmall()}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			return [
+				invariantStyles,
+				css`
+					color: ${neutral[20]};
+
+					${until.desktop} {
+						color: ${palette.text.standfirst};
+					}
+
+					a {
+						color: ${neutral[20]};
+
+						${until.desktop} {
+							color: ${palette.text.standfirst};
+						}
+					}
+				`,
+			];
+		}
+		default: {
+			return [
+				invariantStyles,
+				css`
+					color: ${neutral[20]};
+
+					a {
+						color: ${neutral[20]};
+					}
+				`,
+			];
+		}
+	}
+}
 
 const brandingLogoStyle = css`
 	padding: 10px 0;
 
 	display: block;
-	img {
+`;
+
+// for liveblog smaller breakpoints article meta is located in the same
+// container as standfirst and needs the same styling as standfirst
+const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
+	const invariantStyles = css`
+		${textSans.xxsmall()}
 		display: block;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			return [
+				invariantStyles,
+				css`
+					color: ${palette.text.branding};
+					${until.desktop} {
+						color: ${palette.text.standfirst};
+					}
+					a {
+						color: ${palette.text.branding};
+						${until.desktop} {
+							color: ${palette.text.standfirst};
+						}
+					}
+				`,
+			];
+		}
+		default: {
+			return [
+				invariantStyles,
+				css`
+					color: ${palette.text.branding};
+					a {
+						color: ${palette.text.branding};
+					}
+				`,
+			];
+		}
+	}
+};
+
+const hiddenUntilDesktop = css`
+	${until.desktop} {
+		display: none;
 	}
 `;
 
-const brandingAboutLink = (palette: Palette) => css`
-	color: ${palette.text.branding};
-	${textSans.xxsmall()}
-	display: block;
-	text-decoration: none;
-	&:hover {
-		text-decoration: underline;
+const hiddenFromDesktop = css`
+	display: none;
+	${until.desktop} {
+		display: block;
 	}
 `;
 
 type Props = {
 	branding: Branding;
 	palette: Palette;
+	format: ArticleFormat;
 };
 
-export const Branding = ({ branding, palette }: Props) => {
+export const Branding = ({ branding, palette, format }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 
 	return (
 		<div css={brandingStyle}>
-			<div css={brandingLabelStyle}>{branding.logo.label}</div>
+			<div css={brandingLabelStyle(palette, format)}>
+				{branding.logo.label}
+			</div>
 			<div css={brandingLogoStyle}>
 				<a
 					href={branding.logo.link}
@@ -51,6 +137,17 @@ export const Branding = ({ branding, palette }: Props) => {
 					data-cy="branding-logo"
 				>
 					<img
+						css={hiddenFromDesktop}
+						width={branding.logo.dimensions.width}
+						height={branding.logo.dimensions.height}
+						src={
+							branding.logoForDarkBackground?.src ??
+							branding.logo.src
+						}
+						alt={branding.sponsorName}
+					/>
+					<img
+						css={hiddenUntilDesktop}
 						width={branding.logo.dimensions.width}
 						height={branding.logo.dimensions.height}
 						src={branding.logo.src}
@@ -59,7 +156,10 @@ export const Branding = ({ branding, palette }: Props) => {
 				</a>
 			</div>
 
-			<a href={branding.aboutThisLink} css={brandingAboutLink(palette)}>
+			<a
+				href={branding.aboutThisLink}
+				css={brandingAboutLink(palette, format)}
+			>
 				About this content
 			</a>
 		</div>

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -7,8 +7,10 @@ const brandingStyle = css`
 	padding-bottom: 10px;
 `;
 
-// for liveblog smaller breakpoints article meta is located in the same
-// container as standfirst and needs the same styling as standfirst
+/**
+ * for liveblog smaller breakpoints article meta is located in the same
+ * container as standfirst and needs the same styling as standfirst
+ **/
 function brandingLabelStyle(palette: Palette, format: ArticleFormat) {
 	const invariantStyles = css`
 		${textSans.xxsmall()}
@@ -56,8 +58,10 @@ const brandingLogoStyle = css`
 	display: block;
 `;
 
-// for liveblog smaller breakpoints article meta is located in the same
-// container as standfirst and needs the same styling as standfirst
+/**
+ * for liveblog smaller breakpoints article meta is located in the same
+ * container as standfirst and needs the same styling as standfirst
+ **/
 const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
 	const invariantStyles = css`
 		${textSans.xxsmall()}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The background colour for the meta on liveblogs is dark on mobile, light
on desktop.

This commit uses light colours and the light variant of the logo on
smaller breakpoints. (Largely following the pattern already used in
`Contributor.tsx`.)

## Why?
Closes #5486 

## Screenshots

https://www.theguardian.com/football/live/2022/jul/26/england-v-sweden-womens-euro-2022-semi-final-live?dcr&live=true

| Before      | After      |
|-------------|------------|
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/37048459/181284794-c8a0b956-d637-46ba-92d2-1987055880cd.png"> | <img width="746" alt="image" src="https://user-images.githubusercontent.com/37048459/181284944-c875db41-c1f0-4dc6-8bcb-9d5c45f5582d.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
