### PR TITLE
Move overflow hidden to interscroller specific class

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -84,15 +84,17 @@ const adStyles = css`
 		}
 
 		.ad-slot {
-			/* this fixes inter-scrollers stealing mouse events */
-			overflow: hidden;
-
 			${from.tablet} {
 				/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
 				flex: 1;
 				/* Ensures slots do not take on 100% of the container height, allowing them to be sticky in containers */
 				align-self: flex-start;
 			}
+		}
+
+		.ad-slot--interscroller {
+			/* this fixes inter-scrollers stealing mouse events */
+			overflow: hidden;
 		}
 
 		/* liveblogs ads have different background colours due the darker page background */


### PR DESCRIPTION
## What does this change?
moves the `overflow: hidden` to a more specific classname.

## Why?

The fix for interscrollers stealing mouse events around them was too broad https://github.com/guardian/dotcom-rendering/pull/5422, tweak the interscroller creative template to add an interscroller specific class name to the slot.
