### PR TITLE
Add fixed/medium/slow-vii container

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
@@ -1,0 +1,37 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+
+import { FixedMediumSlowVII } from './FixedMediumSlowVII';
+import { Section } from './Section';
+
+export default {
+	component: FixedMediumSlowVII,
+	title: 'Components/FixedMediumSlowVII',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<Section
+		title="FixedMediumSlowVII"
+		showTopBorder={true}
+		showSideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowVII trails={trails} showAge={true} />
+	</Section>
+);
+Default.story = { name: 'FixedMediumSlowVII' };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
@@ -1,0 +1,105 @@
+import type { DCRContainerPalette } from '../../types/front';
+import type { TrailType } from '../../types/trails';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedMediumSlowVII = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	const primary = trails[0];
+	const firstSlice = trails.slice(1, 3);
+	const secondSlice = trails.slice(3, 7);
+
+	return (
+		<>
+			<UL direction="row" padBottom={true}>
+				<LI
+					key={primary.url}
+					padSides={true}
+					showDivider={false}
+					padBottomOnMobile={true}
+					percentage="50%"
+				>
+					<FrontCard
+						trail={primary}
+						format={primary.format}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						headlineSize="large"
+						imagePositionOnMobile="top"
+						imageSize="large"
+						supportingContent={primary.supportingContent}
+					/>
+				</LI>
+				{firstSlice.map((trail, index) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={true}
+							padBottomOnMobile={index !== 1}
+							percentage="25%"
+						>
+							<FrontCard
+								trail={trail}
+								format={trail.format}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								headlineSize="medium"
+								imagePositionOnMobile="left"
+								imageSize="medium"
+								trailText={
+									trail.supportingContent &&
+									trail.supportingContent.length > 0
+										? undefined
+										: trail.trailText
+								}
+								supportingContent={
+									trail.supportingContent &&
+									trail.supportingContent.length > 2
+										? trail.supportingContent.slice(0, 2)
+										: trail.supportingContent
+								}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			<UL direction="row" padBottom={true}>
+				{secondSlice.map((trail, index) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={index > 0}
+							padBottomOnMobile={true}
+						>
+							<FrontCard
+								trail={trail}
+								format={trail.format}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								headlineSize="small"
+								supportingContent={
+									trail.supportingContent &&
+									trail.supportingContent.length > 2
+										? trail.supportingContent.slice(0, 2)
+										: trail.supportingContent
+								}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -16,6 +16,7 @@ import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
 import { FixedSmallSlowVMPU } from '../components/FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
+import { FixedMediumSlowVII } from '../components/FixedMediumSlowVII';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -120,6 +121,14 @@ export const DecideContainer = ({
 		case 'fixed/medium/slow-VI':
 			return (
 				<FixedMediumSlowVI
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		case 'fixed/medium/slow-VII':
+			return (
+				<FixedMediumSlowVII
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}


### PR DESCRIPTION
Co-authored-by: Daniel Clifton <daniel.clifton@guardian.co.uk>

Closes #5137 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds support for `fixed/medium/slow-vii` container.

## Why?
As part of the Fronts migration to DCR (see: https://github.com/guardian/dotcom-rendering/issues/4720)

## Screenshots

| Before (Frontend prod)     | After (DCR local) |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/185203577-06ef697f-007f-4f28-8667-ac1c227dc3f8.png) | ![image](https://user-images.githubusercontent.com/19683595/185204972-22d54b95-4175-45f6-9a20-347f27e50d3a.png) |
| ![image](https://user-images.githubusercontent.com/19683595/185203661-afe96fc5-a7ca-461d-be4f-a4e43247e937.png) | ![image](https://user-images.githubusercontent.com/19683595/185205094-6669e656-eb1f-4fc6-8c4d-4bce1cff76d4.png) |
| ![image](https://user-images.githubusercontent.com/19683595/185878208-2d6f3a6e-9d27-4d24-820d-64efb087127f.png) | ![image](https://user-images.githubusercontent.com/19683595/185878288-ea0592e8-0cad-4cb8-be4a-427e2809b857.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
