### PR TITLE
Use `String.prototype.padStart` to pad minutes

### DIFF
--- a/apps-rendering/src/date.ts
+++ b/apps-rendering/src/date.ts
@@ -125,24 +125,24 @@ const month = (date: Date): string => months[date.getUTCMonth()];
 
 const fullMonth = (date: Date): string => fullMonths[date.getUTCMonth()];
 
-const padZero = (n: number): string => String(n).padStart(2, '0');
+const padStart = (n: number): string => String(n).padStart(2, '0');
 
 const time = (date: Date, separator: string): string =>
-	`${padZero(date.getUTCHours())}${separator}${padZero(
+	`${padStart(date.getUTCHours())}${separator}${padStart(
 		date.getUTCMinutes(),
 	)}`;
 
 const time12hr = (date: Date, separator: string): string => {
 	const utcHours = date.getUTCHours();
-	return `${padZero(
+	return `${padStart(
 		utcHours > 12 ? utcHours - 12 : utcHours,
-	)}${separator}${padZero(date.getUTCMinutes())}${
+	)}${separator}${padStart(date.getUTCMinutes())}${
 		utcHours > 12 ? 'pm' : 'am'
 	}`;
 };
 
 const localTime = (date: Date): string =>
-	`${padZero(date.getHours())}.${padZero(date.getMinutes())}`;
+	`${padStart(date.getHours())}.${padStart(date.getMinutes())}`;
 
 const localTime12Hr = (date: Date): string =>
 	date
@@ -244,5 +244,5 @@ export {
 	formatLocalTimeDateTz,
 	formatUTCTimeDateTz,
 	dateToString,
-	padZero,
+	padStart,
 };

--- a/apps-rendering/src/date.ts
+++ b/apps-rendering/src/date.ts
@@ -125,7 +125,7 @@ const month = (date: Date): string => months[date.getUTCMonth()];
 
 const fullMonth = (date: Date): string => fullMonths[date.getUTCMonth()];
 
-const padZero = (n: number): string => (n < 10 ? `0${n}` : n.toString());
+const padZero = (n: number): string => String(n).padStart(2, '0');
 
 const time = (date: Date, separator: string): string =>
 	`${padZero(date.getUTCHours())}${separator}${padZero(

--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -13,7 +13,7 @@ import {
 	some,
 } from '@guardian/types';
 import type { Option, Result } from '@guardian/types';
-import { padZero } from 'date';
+import { padStart } from 'date';
 import { fold, pipe } from 'lib';
 import fetch from 'node-fetch';
 import type { Response } from 'node-fetch';
@@ -39,8 +39,8 @@ const getFootballSelector = (date: Date, [teamA, teamB]: Teams): string => {
 
 	const d = date;
 	const year = d.getUTCFullYear();
-	const month = padZero(d.getUTCMonth() + 1);
-	const day = padZero(d.getUTCDate());
+	const month = padStart(d.getUTCMonth() + 1);
+	const day = padStart(d.getUTCDate());
 
 	return `${year}-${month}-${day}_${teams[0]}_${teams[1]}`;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses `String.prototype.padStart` to pad minutes

## Why?

- A bit easier to read!
