### PR TITLE
Remove "consistent-return" eslint rule

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -2,7 +2,6 @@ const transitionRules = require('./eslint-guardian');
 
 /** TODO: Review these */
 const rulesToReview = {
-	'consistent-return': 'warn', // 51 problems
 	'react/no-danger': 'warn', // 48 problems
 	'react/no-array-index-key': 'warn', // 34 problems
 	'react/button-has-type': 'warn', // 23 problems


### PR DESCRIPTION
eslint's `consistent-return` rule was not respecting typescript, e.g

```ts
const textKeyEvent = (format: ArticleFormat): string => {
	switch (format.theme) {
		case ArticlePillar.News:
			return news[300];
		case ArticlePillar.Sport:
			return sport[300];
		case ArticlePillar.Lifestyle:
			return lifestyle[300];
		case ArticlePillar.Culture:
			return culture[300];
		case ArticlePillar.Opinion:
			return opinion[300];
		case ArticleSpecial.Labs:
			return labs[300];
		case ArticleSpecial.SpecialReport:
			return specialReport[300];
	}
};
```

Was causing this rule to be triggered, as the absence of a `return` at the end of the function was seen as 'inconsistence' - however this is unreachable code, as the `switch` covered all the options.

After speaking to @mxdvl we decided this rule does not provide much value, as typescript will ensure the return type of the function is always met.