### PR TITLE
Refactor decide palette to use type convention & remove unneeded if statements

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1042,26 +1042,23 @@ const hoverHeadlineByline = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].dark;
 };
 
-const textRichLink: (format: ArticleFormat) => string = (format) => {
-	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[400];
-			case ArticlePillar.Culture:
-				return culture[350];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return BLACK;
-			case ArticleSpecial.SpecialReport:
-				return specialReport[400];
-		}
+const textRichLink = (format: ArticleFormat): string => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Culture:
+			return culture[350];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return BLACK;
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
 	}
-	return pillarPalette[ArticlePillar.News][400];
 };
 
 const hoverStandfirstLink = (format: ArticleFormat): string => {
@@ -1115,11 +1112,8 @@ const borderLines = (format: ArticleFormat): string => {
 	return border.secondary;
 };
 
-const backgroundRichLink: (format: ArticleFormat) => string = (format) => {
-	if (format) {
-		return pillarPalette[format.theme].main;
-	}
-	return pillarPalette[ArticlePillar.News][400];
+const backgroundRichLink = (format: ArticleFormat): string => {
+	return pillarPalette[format.theme].main;
 };
 
 const borderCricketScoreboardTop = (): string => {
@@ -1134,33 +1128,27 @@ const borderKeyEvent = (): string => neutral[46];
 
 const borderFilterButton = (): string => neutral[60];
 
-const fillRichLink: (format: ArticleFormat) => string = (format) => {
-	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[400];
-			case ArticlePillar.Culture:
-				return culture[350];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[400];
-			case ArticlePillar.Opinion:
-				return opinion[300];
-			case ArticleSpecial.Labs:
-				return labs[400];
-			case ArticleSpecial.SpecialReport:
-				return specialReport[400];
-		}
+const fillRichLink = (format: ArticleFormat): string => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Culture:
+			return culture[350];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
 	}
-	return pillarPalette[ArticlePillar.News][400];
 };
 
-const fillQuoteIcon: (format: ArticleFormat) => string = (format) => {
-	if (format) {
-		return pillarPalette[format.theme].main;
-	}
-	return pillarPalette[ArticlePillar.News][400];
+const fillQuoteIcon = (format: ArticleFormat): string => {
+	return pillarPalette[format.theme].main;
 };
 
 const textPullQuoteAttribution = (format: ArticleFormat): string =>


### PR DESCRIPTION
decidePalette had some very old (and weird) function declarations. I've switched these over to use what the rest of decidePalette (& DCR) is using:

```ts
// old
const myFunc: (format: ArticleFormat) => string = (format) => {}
// new
const myFunc = (format: ArticleFormat): string => {}
```

In these places we also had unnecessary `if` statements to check that `format` is set - I've now removed these as they were throwing eslint warnings.
