### PR TITLE
Use an article that will expire on 31/12/2022 in paid.content cypress test 

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -4,17 +4,8 @@ import { cmpIframe } from '../../lib/cmpIframe';
 import { privacySettingsIframe } from '../../lib/privacySettingsIframe';
 import { storage } from '@guardian/libs';
 
-// It is important to use this article for this test because its commercialProperties
-// coming from the CAPI object are the same for all editions. This way we are making sure
-// the Branding island the test expects will be in the DOM. If an article with different
-// commercialProperties across editions were to be used, the test would have different
-// outcome when running locally (UK edition) and when running in CI. For example,
-// it could be US edition if the CI server runs in US. The best way to deal with
-// this would be to control the edition in the test whether by setting the GU_EDITION
-// cookie or by selecting the edition in the UI. Unfortunately, the first solution did
-// not work and the second one is not possible at this point of the migration.
 const paidContentPage =
-	'https://www.theguardian.com/the-time-of-your-life-in-croatia/2022/jul/22/from-ancient-ruins-to-contemporary-art-croatias-cultural-highlights';
+	'https://www.theguardian.com/a-vision-for-better-food/2022/jul/22/a-kitchen-in-a-quarry-why-charlie-bighams-food-campus-was-named-a-riba-building-of-the-year';
 
 describe('Paid content tests', function () {
 	beforeEach(function () {
@@ -59,9 +50,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include(
-				'el=croatia%20national%20tourism%20board',
-			);
+			expect(requestURL).to.include('el=charlie%20bigham%27s');
 		});
 	});
 
@@ -102,9 +91,7 @@ describe('Paid content tests', function () {
 			let requestURL = interception.request.url;
 			expect(requestURL).to.include('ec=click');
 			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include(
-				'el=croatia%20national%20tourism%20board',
-			);
+			expect(requestURL).to.include('el=charlie%20bigham%27s');
 		});
 	});
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #5531 

## What does this change?
The URL of the article used for `paid.content` cypress test. Paid content can be removed in articles used for this test and it starts failing. We have asked from Commercial to provide us with a permanent test page. Until then we're using the URL with the longest end date.

Also removing a comment that is no longer relevant. After this PR https://github.com/guardian/dotcom-rendering/pull/4187 we can do `cy.visit(url, { headers : { 'x-gu-geolocation': 'ip.dummytext,country:UK' } })` and the article edition will default to the value in the header. We don't need to do this with this new article we're using because this paid content has the same commercialProperties for all regions.
