### PR TITLE
Immersive Layout - Footer

### DIFF
--- a/apps-rendering/src/components/Footer/Footer.defaults.tsx
+++ b/apps-rendering/src/components/Footer/Footer.defaults.tsx
@@ -1,0 +1,66 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	breakpoints,
+	from,
+	neutral,
+	remSpace,
+	textSans,
+} from '@guardian/source-foundations';
+import FooterContent from 'components/FooterContent';
+import type { FC } from 'react';
+import { darkModeCss } from 'styles';
+
+// ----- Component ----- //
+
+const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
+	border-width: 0 1px;
+	${textSans.small({ lineHeight: 'regular' })};
+	margin-left: 0;
+	margin-right: 0;
+	padding-left: ${remSpace[3]};
+	padding-right: ${remSpace[3]};
+	padding-top: ${remSpace[4]};
+	padding-bottom: ${remSpace[4]};
+
+	${from.wide} {
+		margin: 0 auto;
+		width: ${breakpoints.wide}px;
+	}
+
+	a {
+		${textSans.small({ lineHeight: 'regular' })};
+		color: ${neutral[7]};
+		text-decoration: underline;
+	}
+
+	${darkModeCss`
+        color: ${neutral[60]};
+		background-color: ${background.articleContentDark(format)};
+
+        a {
+            color: ${neutral[60]};
+        }
+    `}
+`;
+
+interface Props {
+	isCcpa: boolean;
+    className?: string;
+	css?: SerializedStyles;
+}
+
+const DefaultFooter: FC<Props> = ({ isCcpa, className }) => (
+	<footer css={className}>
+		<FooterContent isCcpa={isCcpa} />
+	</footer>
+);
+
+// ----- Exports ----- //
+
+export default DefaultFooter;
+export { defaultStyles };

--- a/apps-rendering/src/components/Footer/Footer.defaults.tsx
+++ b/apps-rendering/src/components/Footer/Footer.defaults.tsx
@@ -50,7 +50,7 @@ const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 
 interface Props {
 	isCcpa: boolean;
-    className?: string;
+	className?: string;
 	css?: SerializedStyles;
 }
 

--- a/apps-rendering/src/components/Footer/Footer.defaults.tsx
+++ b/apps-rendering/src/components/Footer/Footer.defaults.tsx
@@ -39,13 +39,13 @@ const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	}
 
 	${darkModeCss`
-        color: ${neutral[60]};
+		color: ${neutral[60]};
 		background-color: ${background.articleContentDark(format)};
 
-        a {
-            color: ${neutral[60]};
-        }
-    `}
+		a {
+			color: ${neutral[60]};
+		}
+	`}
 `;
 
 interface Props {

--- a/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
+++ b/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
@@ -1,0 +1,46 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import type { FC } from 'react';
+import { ArticleFormat } from '@guardian/libs';
+import DefaultFooter, { defaultStyles } from './Footer.defaults';
+import { grid } from 'grid/grid';
+import LeftCentreBorder from 'grid/LeftCentreBorder';
+import { from, neutral } from '@guardian/source-foundations';
+
+// ----- Component ----- //
+
+const styles: SerializedStyles = css`
+    ${grid.container}
+    background-color: ${neutral[97]};
+`;
+
+const footerStyles: SerializedStyles = css`
+    ${grid.column.centre}
+    padding-left: 0;
+    padding-right: 0;
+    grid-row: 1;
+
+    ${from.desktop} {
+        ${grid.between('centre-column-start', 'right-column-end')}
+    }
+`;
+
+interface Props {
+	format: ArticleFormat;
+	isCcpa: boolean;
+}
+
+const ImmersiveFooter: FC<Props> = ({ format, isCcpa }) =>
+    <div css={styles}>
+        <LeftCentreBorder rows={[1, 2]} />
+        <DefaultFooter
+            css={css(defaultStyles(format), footerStyles)}
+            isCcpa={isCcpa}
+        />
+    </div>
+
+// ----- Exports ----- //
+
+export default ImmersiveFooter;

--- a/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
+++ b/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
@@ -2,29 +2,29 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import type { FC } from 'react';
-import { ArticleFormat } from '@guardian/libs';
-import DefaultFooter, { defaultStyles } from './Footer.defaults';
+import type { ArticleFormat } from '@guardian/libs';
+import { from, neutral } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
-import { from, neutral } from '@guardian/source-foundations';
+import type { FC } from 'react';
+import DefaultFooter, { defaultStyles } from './Footer.defaults';
 
 // ----- Component ----- //
 
 const styles: SerializedStyles = css`
-    ${grid.container}
-    background-color: ${neutral[97]};
+	${grid.container}
+	background-color: ${neutral[97]};
 `;
 
 const footerStyles: SerializedStyles = css`
-    ${grid.column.centre}
-    padding-left: 0;
-    padding-right: 0;
-    grid-row: 1;
+	${grid.column.centre}
+	padding-left: 0;
+	padding-right: 0;
+	grid-row: 1;
 
-    ${from.desktop} {
-        ${grid.between('centre-column-start', 'right-column-end')}
-    }
+	${from.desktop} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
 `;
 
 interface Props {
@@ -32,14 +32,15 @@ interface Props {
 	isCcpa: boolean;
 }
 
-const ImmersiveFooter: FC<Props> = ({ format, isCcpa }) =>
-    <div css={styles}>
-        <LeftCentreBorder rows={[1, 2]} />
-        <DefaultFooter
-            css={css(defaultStyles(format), footerStyles)}
-            isCcpa={isCcpa}
-        />
-    </div>
+const ImmersiveFooter: FC<Props> = ({ format, isCcpa }) => (
+	<div css={styles}>
+		<LeftCentreBorder rows={[1, 2]} />
+		<DefaultFooter
+			css={css(defaultStyles(format), footerStyles)}
+			isCcpa={isCcpa}
+		/>
+	</div>
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Footer/index.tsx
+++ b/apps-rendering/src/components/Footer/index.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDisplay } from '@guardian/libs';
 import type { FC } from 'react';
-import { ArticleDisplay, ArticleFormat } from '@guardian/libs';
 import DefaultFooter, { defaultStyles } from './Footer.defaults';
 import ImmersiveFooter from './ImmersiveFooter';
 
@@ -17,8 +18,8 @@ const Footer: FC<Props> = ({ format, isCcpa }) => {
 		return <ImmersiveFooter format={format} isCcpa={isCcpa} />;
 	}
 
-	return <DefaultFooter css={defaultStyles(format)} isCcpa={isCcpa} />
-}
+	return <DefaultFooter css={defaultStyles(format)} isCcpa={isCcpa} />;
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Footer/index.tsx
+++ b/apps-rendering/src/components/Footer/index.tsx
@@ -1,63 +1,24 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from '@emotion/react';
-import { css } from '@emotion/react';
-import { background } from '@guardian/common-rendering/src/editorialPalette';
-import type { ArticleFormat } from '@guardian/libs';
-import {
-	breakpoints,
-	from,
-	neutral,
-	remSpace,
-	textSans,
-} from '@guardian/source-foundations';
-import FooterContent from 'components/FooterContent';
 import type { FC } from 'react';
-import { darkModeCss } from 'styles';
+import { ArticleDisplay, ArticleFormat } from '@guardian/libs';
+import DefaultFooter, { defaultStyles } from './Footer.defaults';
+import ImmersiveFooter from './ImmersiveFooter';
 
 // ----- Component ----- //
 
-const styles = (format: ArticleFormat): SerializedStyles => css`
-	border-width: 0 1px;
-	${textSans.small({ lineHeight: 'regular' })};
-	margin-left: 0;
-	margin-right: 0;
-	padding-left: ${remSpace[3]};
-	padding-right: ${remSpace[3]};
-	padding-top: ${remSpace[4]};
-	padding-bottom: ${remSpace[4]};
-
-	${from.wide} {
-		margin: 0 auto;
-		width: ${breakpoints.wide}px;
-	}
-
-	a {
-		${textSans.small({ lineHeight: 'regular' })};
-		color: ${neutral[7]};
-		text-decoration: underline;
-	}
-
-	${darkModeCss`
-        color: ${neutral[60]};
-		background-color: ${background.articleContentDark(format)};
-
-        a {
-            color: ${neutral[60]};
-        }
-    `}
-`;
-
 interface Props {
-	isCcpa: boolean;
 	format: ArticleFormat;
+	isCcpa: boolean;
 }
 
-const Footer: FC<Props> = ({ isCcpa, format }) => (
-	<footer css={styles(format)}>
-		<FooterContent isCcpa={isCcpa} />
-	</footer>
-);
+const Footer: FC<Props> = ({ format, isCcpa }) => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return <ImmersiveFooter format={format} isCcpa={isCcpa} />;
+	}
+
+	return <DefaultFooter css={defaultStyles(format)} isCcpa={isCcpa} />
+}
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -3,6 +3,7 @@
 import { css } from '@emotion/react';
 import { between, from, remSpace } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
+import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import MainMedia, { ImmersiveCaption } from 'components/MainMedia';
 import Metadata from 'components/Metadata';
@@ -84,8 +85,7 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => (
 			</article>
 		</main>
 		<RelatedContent item={item} />
-		<aside>Comments</aside>
-		<footer>Footer</footer>
+		<Footer isCcpa={false} format={getFormat(item)} />
 	</>
 );
 

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -15,6 +15,7 @@ import DefaultRelatedContent, {
 
 const styles = css`
 	${grid.container}
+	background-color: ${neutral[97]};
 `;
 
 const hrStyles = css`


### PR DESCRIPTION
## Why?

Continuing the work on the new immersive layout, following on from #5438. This adds the footer to the bottom of the article. As with a few components in the previous PRs I've refactored `Footer` to use the new `index`/`defaults` pattern.

I've also tweaked the background colour of the related content component so that it matches the cards. I think the intention of the new card designs is that they're the same colour as the background. I've also applied this new background colour to the footer, so the whole bottom section of the article looks consistent. See the screenshots below.

**Note:** I've removed the placeholder for comments (discussion) in the immersive layout. I think it makes sense to do this work as part of the "Comments" milestone rather than the "Immersive" one, so I've moved #5319 over to that.

## Changes

- Refactored `Footer` to use new index/defaults pattern
- Added an immersive footer
- Set new background colour of related content in immersives

## Screenshots

| Mobile | Tablet | Desktop | Wide |
| - | - | - | - |
| ![footer-mobile] | ![footer-tablet] | ![footer-desktop] | ![footer-wide] |

[footer-desktop]: https://user-images.githubusercontent.com/53781962/181602288-ecada648-b55c-466d-ba9c-f6e675aa7813.jpg
[footer-mobile]: https://user-images.githubusercontent.com/53781962/181602296-973cc8b6-e197-4ff2-84d3-b5ec0216041f.jpg
[footer-wide]: https://user-images.githubusercontent.com/53781962/181602300-a924c357-041a-43be-b9c4-11e7837fb272.jpg
[footer-tablet]: https://user-images.githubusercontent.com/53781962/181602303-77cc7dbe-8265-41f0-9313-b7e164ec303a.jpg

### With Bridget Returning Different Values Of `doesCcpaApply`

Tested in the simulator.

| CCPA | `true` | `false` |
| - | - | - |
| Footer Variant | ![immersive-footer-california] | ![immersive-footer-outside-california] |

[immersive-footer-california]: https://user-images.githubusercontent.com/53781962/181760207-ff169c94-e672-448c-b61f-534a83b3f3df.jpg
[immersive-footer-outside-california]: https://user-images.githubusercontent.com/53781962/181760222-36672c77-824e-4587-9f3f-6ca735559a4a.jpg
