### PR TITLE
Remove size mapping data attrs from ad slots

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	adSizes,
-} from '@guardian/commercial-core';
+import { adSizes } from '@guardian/commercial-core';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	border,

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import {
 	adSizes,
-	slotSizeMappings as sizeMappings,
 } from '@guardian/commercial-core';
 import { ArticleDisplay } from '@guardian/libs';
 import {
@@ -228,10 +227,6 @@ export const AdSlot: React.FC<Props> = ({
 							css={adStyles}
 							data-link-name="ad slot right"
 							data-name="right"
-							// mark: 01303e88-ef1f-462d-9b6e-242419435cec
-							data-mobile={(sizeMappings.right.mobile || [])
-								.map((size) => size.toString())
-								.join('|')}
 							aria-hidden="true"
 						/>
 					);
@@ -280,15 +275,6 @@ export const AdSlot: React.FC<Props> = ({
 						]}
 						data-link-name="ad slot comments"
 						data-name="comments"
-						data-mobile={(sizeMappings.comments.mobile || [])
-							.map((size) => size.toString())
-							.join('|')}
-						data-desktop={(sizeMappings.comments.desktop || [])
-							.map((size) => size.toString())
-							.join('|')}
-						data-phablet={(sizeMappings.comments.phablet || [])
-							.map((size) => size.toString())
-							.join('|')}
 						aria-hidden="true"
 					/>
 				</div>
@@ -318,20 +304,6 @@ export const AdSlot: React.FC<Props> = ({
 						css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
-						// The sizes here come from two places in the frontend code
-						// 1. file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
-						// 2. file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
-						data-tablet={(
-							sizeMappings['top-above-nav'].tablet || []
-						)
-							.map((size) => size.toString())
-							.join('|')}
-						data-desktop={(
-							sizeMappings['top-above-nav'].desktop || []
-						)
-							.map((size) => size.toString())
-							.join('|')}
-						// Values from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
 						aria-hidden="true"
 					/>
 				</>
@@ -356,19 +328,6 @@ export const AdSlot: React.FC<Props> = ({
 					]}
 					data-link-name="ad slot mostpop"
 					data-name="mostpop"
-					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
-					data-mobile={(sizeMappings.mostpop.mobile || [])
-						.map((size) => size.toString())
-						.join('|')}
-					data-tablet={(sizeMappings.mostpop.tablet || [])
-						.map((size) => size.toString())
-						.join('|')}
-					data-phablet={(sizeMappings.mostpop.phablet || [])
-						.map((size) => size.toString())
-						.join('|')}
-					data-desktop={(sizeMappings.mostpop.desktop || [])
-						.map((size) => size.toString())
-						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -391,12 +350,6 @@ export const AdSlot: React.FC<Props> = ({
 					]}
 					data-link-name="ad slot merchandising-high"
 					data-name="merchandising-high"
-					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
-					data-mobile={(
-						sizeMappings['merchandising-high'].mobile || []
-					)
-						.map((size) => size.toString())
-						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -419,10 +372,6 @@ export const AdSlot: React.FC<Props> = ({
 					]}
 					data-link-name="ad slot merchandising"
 					data-name="merchandising"
-					// mirror frontend file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
-					data-mobile={(sizeMappings.merchandising.mobile || [])
-						.map((size) => size.toString())
-						.join('|')}
 					aria-hidden="true"
 				/>
 			);
@@ -442,9 +391,6 @@ export const AdSlot: React.FC<Props> = ({
 					data-label="false"
 					data-refresh="false"
 					data-out-of-page="true"
-					data-desktop={(sizeMappings.survey.desktop || [])
-						.map((size) => size.toString())
-						.join('|')}
 					aria-hidden="true"
 				/>
 			);

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -1,6 +1,5 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { slotSizeMappings as sizeMappings } from '@guardian/commercial-core';
 import { getCookie } from '@guardian/libs';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { ShadyPie } from './ShadyPie';
@@ -74,10 +73,6 @@ export const TopRightAdSlot = ({
 				]}
 				data-link-name="ad slot right"
 				data-name="right"
-				// mark: 01303e88-ef1f-462d-9b6e-242419435cec
-				data-mobile={(sizeMappings.right.mobile || [])
-					.map((size) => size.toString())
-					.join('|')}
 				aria-hidden="true"
 			/>
 		</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove size mapping data attributes from ad slots

## Why?
They are redundant now, size mappings are now loaded from [commercial-core](https://github.com/guardian/commercial-core/blob/main/src/ad-sizes.ts#L143) as of this frontend PR https://github.com/guardian/frontend/pull/25124
