### PR TITLE
Revert: Fix contrasts for branding on liveblogs mobile #5526 

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -327,11 +327,7 @@ export const ArticleMeta = ({
 			<div css={meta(format)}>
 				{branding && (
 					<Island deferUntil="visible">
-						<Branding
-							branding={branding}
-							palette={palette}
-							format={format}
-						/>
+						<Branding branding={branding} palette={palette} />
 					</Island>
 				)}
 				{format.theme === ArticleSpecial.Labs ? (

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -1,129 +1,46 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
-import { neutral, textSans, until } from '@guardian/source-foundations';
-
+import { neutral, textSans } from '@guardian/source-foundations';
 import { trackSponsorLogoLinkClick } from '../browser/ga/ga';
-import { Hide } from './Hide';
 
 const brandingStyle = css`
 	padding-bottom: 10px;
 `;
 
-/**
- * for liveblog smaller breakpoints article meta is located in the same
- * container as standfirst and needs the same styling as standfirst
- **/
-function brandingLabelStyle(palette: Palette, format: ArticleFormat) {
-	const invariantStyles = css`
-		${textSans.xxsmall()}
-	`;
-
-	switch (format.design) {
-		case ArticleDesign.LiveBlog: {
-			return [
-				invariantStyles,
-				css`
-					color: ${neutral[20]};
-
-					${until.desktop} {
-						color: ${palette.text.standfirst};
-					}
-
-					a {
-						color: ${neutral[20]};
-
-						${until.desktop} {
-							color: ${palette.text.standfirst};
-						}
-					}
-				`,
-			];
-		}
-		default: {
-			return [
-				invariantStyles,
-				css`
-					color: ${neutral[20]};
-
-					a {
-						color: ${neutral[20]};
-					}
-				`,
-			];
-		}
-	}
-}
+const brandingLabelStyle = css`
+	${textSans.xxsmall()};
+	color: ${neutral[20]};
+`;
 
 const brandingLogoStyle = css`
 	padding: 10px 0;
 
 	display: block;
-
-	& img {
+	img {
 		display: block;
 	}
 `;
 
-/**
- * for liveblog smaller breakpoints article meta is located in the same
- * container as standfirst and needs the same styling as standfirst
- **/
-const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
-	const invariantStyles = css`
-		${textSans.xxsmall()}
-		display: block;
-		text-decoration: none;
-		&:hover {
-			text-decoration: underline;
-		}
-	`;
-
-	switch (format.design) {
-		case ArticleDesign.LiveBlog: {
-			return [
-				invariantStyles,
-				css`
-					color: ${palette.text.branding};
-					${until.desktop} {
-						color: ${palette.text.standfirst};
-					}
-					a {
-						color: ${palette.text.branding};
-						${until.desktop} {
-							color: ${palette.text.standfirst};
-						}
-					}
-				`,
-			];
-		}
-		default: {
-			return [
-				invariantStyles,
-				css`
-					color: ${palette.text.branding};
-					a {
-						color: ${palette.text.branding};
-					}
-				`,
-			];
-		}
+const brandingAboutLink = (palette: Palette) => css`
+	color: ${palette.text.branding};
+	${textSans.xxsmall()}
+	display: block;
+	text-decoration: none;
+	&:hover {
+		text-decoration: underline;
 	}
-};
+`;
 
 type Props = {
 	branding: Branding;
 	palette: Palette;
-	format: ArticleFormat;
 };
 
-export const Branding = ({ branding, palette, format }: Props) => {
+export const Branding = ({ branding, palette }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 
 	return (
 		<div css={brandingStyle}>
-			<div css={brandingLabelStyle(palette, format)}>
-				{branding.logo.label}
-			</div>
+			<div css={brandingLabelStyle}>{branding.logo.label}</div>
 			<div css={brandingLogoStyle}>
 				<a
 					href={branding.logo.link}
@@ -133,32 +50,16 @@ export const Branding = ({ branding, palette, format }: Props) => {
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-cy="branding-logo"
 				>
-					<Hide when="above" breakpoint="desktop" el="span">
-						<img
-							width={branding.logo.dimensions.width}
-							height={branding.logo.dimensions.height}
-							src={
-								branding.logoForDarkBackground?.src ??
-								branding.logo.src
-							}
-							alt={branding.sponsorName}
-						/>
-					</Hide>
-					<Hide when="below" breakpoint="desktop" el="span">
-						<img
-							width={branding.logo.dimensions.width}
-							height={branding.logo.dimensions.height}
-							src={branding.logo.src}
-							alt={branding.sponsorName}
-						/>
-					</Hide>
+					<img
+						width={branding.logo.dimensions.width}
+						height={branding.logo.dimensions.height}
+						src={branding.logo.src}
+						alt={branding.sponsorName}
+					/>
 				</a>
 			</div>
 
-			<a
-				href={branding.aboutThisLink}
-				css={brandingAboutLink(palette, format)}
-			>
+			<a href={branding.aboutThisLink} css={brandingAboutLink(palette)}>
 				About this content
 			</a>
 		</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Reverts the changes from #5526

[Diff between this branch and pre-merge `main`](https://github.com/guardian/dotcom-rendering/compare/4416ad15772a1cf24d758a9a3636ec2cc2d92872...pf/revert-liveblog-header) shows no differences in the relevant files.

## Why?

The CI was run on an older version of a cypress fixture. With the new fixture it didn't pass on TeamCity, thereby preventing deployment of `main`.

There's at least on genuine bug revealed by the new fixture which wasn't accounted for in the original issue/PR, so I'm going to reopen the issue and revert the changes to unblock Prod.