### PR TITLE
Fix: contrast logo on branded liveblogs

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -327,7 +327,11 @@ export const ArticleMeta = ({
 			<div css={meta(format)}>
 				{branding && (
 					<Island deferUntil="visible">
-						<Branding branding={branding} palette={palette} />
+						<Branding
+							branding={branding}
+							palette={palette}
+							format={format}
+						/>
 					</Island>
 				)}
 				{format.theme === ArticleSpecial.Labs ? (

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -110,6 +110,51 @@ const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
 	}
 };
 
+function decideLogo(branding: Branding, format: ArticleFormat) {
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			/**
+			 * For LiveBlogs, the background colour of the 'meta' section is light
+			 * on desktop but dark on mobile. If the logo has a version designed for
+			 * dark backgrounds, it should be shown on breakpoints below desktop.
+			 */
+			return (
+				<>
+					<Hide when="above" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={
+								branding.logoForDarkBackground?.src ??
+								branding.logo.src
+							}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
+					<Hide when="below" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={branding.logo.src}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
+				</>
+			);
+		}
+		default: {
+			return (
+				<img
+					width={branding.logo.dimensions.width}
+					height={branding.logo.dimensions.height}
+					src={branding.logo.src}
+					alt={branding.sponsorName}
+				/>
+			);
+		}
+	}
+}
+
 type Props = {
 	branding: Branding;
 	palette: Palette;
@@ -133,25 +178,7 @@ export const Branding = ({ branding, palette, format }: Props) => {
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-cy="branding-logo"
 				>
-					<Hide when="above" breakpoint="desktop" el="span">
-						<img
-							width={branding.logo.dimensions.width}
-							height={branding.logo.dimensions.height}
-							src={
-								branding.logoForDarkBackground?.src ??
-								branding.logo.src
-							}
-							alt={branding.sponsorName}
-						/>
-					</Hide>
-					<Hide when="below" breakpoint="desktop" el="span">
-						<img
-							width={branding.logo.dimensions.width}
-							height={branding.logo.dimensions.height}
-							src={branding.logo.src}
-							alt={branding.sponsorName}
-						/>
-					</Hide>
+					{decideLogo(branding, format)}
 				</a>
 			</div>
 

--- a/dotcom-rendering/src/web/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/web/components/Branding.importable.tsx
@@ -1,46 +1,129 @@
 import { css } from '@emotion/react';
-import { neutral, textSans } from '@guardian/source-foundations';
+import { ArticleDesign } from '@guardian/libs';
+import { neutral, textSans, until } from '@guardian/source-foundations';
+
 import { trackSponsorLogoLinkClick } from '../browser/ga/ga';
+import { Hide } from './Hide';
 
 const brandingStyle = css`
 	padding-bottom: 10px;
 `;
 
-const brandingLabelStyle = css`
-	${textSans.xxsmall()};
-	color: ${neutral[20]};
-`;
+/**
+ * for liveblog smaller breakpoints article meta is located in the same
+ * container as standfirst and needs the same styling as standfirst
+ **/
+function brandingLabelStyle(palette: Palette, format: ArticleFormat) {
+	const invariantStyles = css`
+		${textSans.xxsmall()}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			return [
+				invariantStyles,
+				css`
+					color: ${neutral[20]};
+
+					${until.desktop} {
+						color: ${palette.text.standfirst};
+					}
+
+					a {
+						color: ${neutral[20]};
+
+						${until.desktop} {
+							color: ${palette.text.standfirst};
+						}
+					}
+				`,
+			];
+		}
+		default: {
+			return [
+				invariantStyles,
+				css`
+					color: ${neutral[20]};
+
+					a {
+						color: ${neutral[20]};
+					}
+				`,
+			];
+		}
+	}
+}
 
 const brandingLogoStyle = css`
 	padding: 10px 0;
 
 	display: block;
-	img {
+
+	& img {
 		display: block;
 	}
 `;
 
-const brandingAboutLink = (palette: Palette) => css`
-	color: ${palette.text.branding};
-	${textSans.xxsmall()}
-	display: block;
-	text-decoration: none;
-	&:hover {
-		text-decoration: underline;
+/**
+ * for liveblog smaller breakpoints article meta is located in the same
+ * container as standfirst and needs the same styling as standfirst
+ **/
+const brandingAboutLink = (palette: Palette, format: ArticleFormat) => {
+	const invariantStyles = css`
+		${textSans.xxsmall()}
+		display: block;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.LiveBlog: {
+			return [
+				invariantStyles,
+				css`
+					color: ${palette.text.branding};
+					${until.desktop} {
+						color: ${palette.text.standfirst};
+					}
+					a {
+						color: ${palette.text.branding};
+						${until.desktop} {
+							color: ${palette.text.standfirst};
+						}
+					}
+				`,
+			];
+		}
+		default: {
+			return [
+				invariantStyles,
+				css`
+					color: ${palette.text.branding};
+					a {
+						color: ${palette.text.branding};
+					}
+				`,
+			];
+		}
 	}
-`;
+};
 
 type Props = {
 	branding: Branding;
 	palette: Palette;
+	format: ArticleFormat;
 };
 
-export const Branding = ({ branding, palette }: Props) => {
+export const Branding = ({ branding, palette, format }: Props) => {
 	const sponsorId = branding.sponsorName.toLowerCase();
 
 	return (
 		<div css={brandingStyle}>
-			<div css={brandingLabelStyle}>{branding.logo.label}</div>
+			<div css={brandingLabelStyle(palette, format)}>
+				{branding.logo.label}
+			</div>
 			<div css={brandingLogoStyle}>
 				<a
 					href={branding.logo.link}
@@ -50,16 +133,32 @@ export const Branding = ({ branding, palette }: Props) => {
 					onClick={() => trackSponsorLogoLinkClick(sponsorId)}
 					data-cy="branding-logo"
 				>
-					<img
-						width={branding.logo.dimensions.width}
-						height={branding.logo.dimensions.height}
-						src={branding.logo.src}
-						alt={branding.sponsorName}
-					/>
+					<Hide when="above" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={
+								branding.logoForDarkBackground?.src ??
+								branding.logo.src
+							}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
+					<Hide when="below" breakpoint="desktop" el="span">
+						<img
+							width={branding.logo.dimensions.width}
+							height={branding.logo.dimensions.height}
+							src={branding.logo.src}
+							alt={branding.sponsorName}
+						/>
+					</Hide>
 				</a>
 			</div>
 
-			<a href={branding.aboutThisLink} css={brandingAboutLink(palette)}>
+			<a
+				href={branding.aboutThisLink}
+				css={brandingAboutLink(palette, format)}
+			>
 				About this content
 			</a>
 		</div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This re-implements #5526, and adds some logic to check whether the article being rendered has a liveblog format, before deciding whether branded logos in the `meta` header should change between smaller and larger screens. (The background of the `meta` section changes between breakpoints on liveblogs, whereas it's constant on other branded articles.)

## Why?

This fixes a bug which led to the previous PR being reverted in #5544. The underlying bug was that the light version of a branded logo was being used for smaller screens on branded articles of all formats, when this should have been limited to liveblog formats.

## Screenshots

(The first set of screenshots should differ, and they do; the second set shouldn't, and they don't.)

https://www.theguardian.com/football/live/2022/jul/26/england-v-sweden-womens-euro-2022-semi-final-live?dcr&live=true

https://www.theguardian.com/a-vision-for-better-food/2022/jul/22/a-kitchen-in-a-quarry-why-charlie-bighams-food-campus-was-named-a-riba-building-of-the-year

| Before      | After      |
|-------------|------------|
| <img width="752" alt="image" src="https://user-images.githubusercontent.com/37048459/181284794-c8a0b956-d637-46ba-92d2-1987055880cd.png"> | <img width="746" alt="image" src="https://user-images.githubusercontent.com/37048459/181284944-c875db41-c1f0-4dc6-8bcb-9d5c45f5582d.png"> |
|<img width="733" alt="image" src="https://user-images.githubusercontent.com/37048459/181772871-84f87500-f5f0-409c-bf7f-7ebf9733e3ef.png">|<img width="730" alt="image" src="https://user-images.githubusercontent.com/37048459/181772979-ab54313e-e93a-4774-a387-680510863195.png">|