### PR TITLE
Immersive Layout - Dark Mode

### DIFF
--- a/apps-rendering/src/components/Footer/Footer.defaults.tsx
+++ b/apps-rendering/src/components/Footer/Footer.defaults.tsx
@@ -26,6 +26,7 @@ const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 	padding-right: ${remSpace[3]};
 	padding-top: ${remSpace[4]};
 	padding-bottom: ${remSpace[4]};
+	background-color: ${background.footer(format)};
 
 	${from.wide} {
 		margin: 0 auto;
@@ -40,7 +41,7 @@ const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 
 	${darkModeCss`
 		color: ${neutral[60]};
-		background-color: ${background.articleContentDark(format)};
+		background-color: ${background.footerDark(format)};
 
 		a {
 			color: ${neutral[60]};

--- a/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
+++ b/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
@@ -3,17 +3,23 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { from, neutral } from '@guardian/source-foundations';
+import { from } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
 import type { FC } from 'react';
 import DefaultFooter, { defaultStyles } from './Footer.defaults';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const styles: SerializedStyles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.container}
-	background-color: ${neutral[97]};
+	background-color: ${background.footer(format)};
+
+	${darkModeCss`
+		background-color: ${background.footerDark(format)};
+	`}
 `;
 
 const footerStyles: SerializedStyles = css`
@@ -33,7 +39,7 @@ interface Props {
 }
 
 const ImmersiveFooter: FC<Props> = ({ format, isCcpa }) => (
-	<div css={styles}>
+	<div css={styles(format)}>
 		<LeftCentreBorder rows={[1, 2]} />
 		<DefaultFooter
 			css={css(defaultStyles(format), footerStyles)}

--- a/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
+++ b/apps-rendering/src/components/Footer/ImmersiveFooter.tsx
@@ -2,14 +2,14 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
 import type { FC } from 'react';
-import DefaultFooter, { defaultStyles } from './Footer.defaults';
-import { background } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from 'styles';
+import DefaultFooter, { defaultStyles } from './Footer.defaults';
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
+++ b/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
@@ -1,13 +1,13 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
-import { background, text } from '@guardian/common-rendering/src/editorialPalette';
-import type { ArticleFormat } from '@guardian/libs';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
-	from,
-	headline,
-	remSpace,
-} from '@guardian/source-foundations';
+	background,
+	text,
+} from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
+import { from, headline, remSpace } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
 import { darkModeCss } from 'styles';
 

--- a/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
+++ b/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
@@ -1,21 +1,22 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
+import { background, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,
 	headline,
-	neutral,
 	remSpace,
 } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'bold' })}
-	background-color: ${neutral[7]};
-	color: ${neutral[100]};
+	background-color: ${background.headline(format)};
+	color: ${text.headline(format)};
 	padding: 0 ${remSpace[5]} ${remSpace[9]} 0;
 	${grid.between('centre-column-start', 'centre-column-end')}
 	grid-row: 3 / 5;
@@ -28,10 +29,15 @@ const styles = css`
 		${headline.xlarge({ fontWeight: 'bold' })}
 		${grid.span('centre-column-start', 8)}
 	}
+
+	${darkModeCss`
+		background-color: ${background.headlineDark(format)};
+		color: ${text.headlineDark(format)};
+	`}
 `;
 
-const backgroundStyles = css`
-	background-color: ${neutral[7]};
+const backgroundStyles = (format: ArticleFormat): SerializedStyles => css`
+	background-color: ${background.headline(format)};
 	${grid.between('viewport-start', 'centre-column-end')}
 	grid-row: 3 / 5;
 
@@ -43,6 +49,10 @@ const backgroundStyles = css`
 		${grid.between('centre-column-start', 'viewport-end')}
 		margin-left: calc(${grid.columnGap} * -1/2);
 	}
+
+	${darkModeCss`
+		background-color: ${background.headlineDark(format)};
+	`}
 `;
 
 interface Props {
@@ -50,10 +60,10 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const ImmersiveHeadline: React.FC<Props> = ({ headline }) => (
+const ImmersiveHeadline: React.FC<Props> = ({ headline, format }) => (
 	<>
-		<div css={backgroundStyles} />
-		<h1 css={styles}>{headline}</h1>
+		<div css={backgroundStyles(format)} />
+		<h1 css={styles(format)}>{headline}</h1>
 	</>
 );
 

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -1,8 +1,12 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
-import { background, fill } from '@guardian/common-rendering/src/editorialPalette';
-import { ArticleFormat } from '@guardian/libs';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import {
+	background,
+	fill,
+} from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
 import { between, from, remSpace } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import Footer from 'components/Footer';
@@ -80,10 +84,7 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => {
 			<main>
 				<article>
 					<header css={headerStyles(format)}>
-						<MainMedia
-							mainMedia={item.mainMedia}
-							format={format}
-						/>
+						<MainMedia mainMedia={item.mainMedia} format={format} />
 						<Series item={item} />
 						<Headline item={item} />
 						<Standfirst item={item} />

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -1,6 +1,8 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
+import { background, fill } from '@guardian/common-rendering/src/editorialPalette';
+import { ArticleFormat } from '@guardian/libs';
 import { between, from, remSpace } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import Footer from 'components/Footer';
@@ -16,15 +18,24 @@ import LeftCentreBorder from 'grid/LeftCentreBorder';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
-const headerStyles = css`
+const headerStyles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.container}
+
+	${darkModeCss`
+		background-color: ${background.articleContentDark(format)}
+	`}
 `;
 
-const mainContentStyles = css`
+const mainContentStyles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.container}
+
+	${darkModeCss`
+		background-color: ${background.articleContentDark(format)}
+	`}
 `;
 
 const bodyStyles = css`
@@ -39,7 +50,7 @@ const bodyStyles = css`
 	}
 `;
 
-const linesStyles = css`
+const linesStyles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.column.all}
 	margin-top: ${remSpace[1]};
 
@@ -51,43 +62,51 @@ const linesStyles = css`
 		${grid.column.left}
 		margin-top: 0;
 	}
+
+	${darkModeCss`
+		stroke: ${fill.linesDark(format)};
+	`}
 `;
 
 type Props = {
 	item: Item;
 };
 
-const ImmersiveLayout: FC<Props> = ({ item, children }) => (
-	<>
-		<main>
-			<article>
-				<header css={headerStyles}>
-					<MainMedia
-						mainMedia={item.mainMedia}
-						format={getFormat(item)}
-					/>
-					<Series item={item} />
-					<Headline item={item} />
-					<Standfirst item={item} />
-					<ImmersiveCaption
-						mainMedia={item.mainMedia}
-						format={getFormat(item)}
-					/>
-					<LeftCentreBorder rows={[5, 5]} />
-				</header>
-				<div css={mainContentStyles}>
-					<LeftCentreBorder rows={[1, 5]} />
-					<StraightLines cssOverrides={linesStyles} />
-					<Metadata item={item} />
-					<div css={bodyStyles}>{children}</div>
-					<Tags item={item} />
-				</div>
-			</article>
-		</main>
-		<RelatedContent item={item} />
-		<Footer isCcpa={false} format={getFormat(item)} />
-	</>
-);
+const ImmersiveLayout: FC<Props> = ({ item, children }) => {
+	const format = getFormat(item);
+
+	return (
+		<>
+			<main>
+				<article>
+					<header css={headerStyles(format)}>
+						<MainMedia
+							mainMedia={item.mainMedia}
+							format={format}
+						/>
+						<Series item={item} />
+						<Headline item={item} />
+						<Standfirst item={item} />
+						<ImmersiveCaption
+							mainMedia={item.mainMedia}
+							format={format}
+						/>
+						<LeftCentreBorder rows={[5, 5]} />
+					</header>
+					<div css={mainContentStyles(format)}>
+						<LeftCentreBorder rows={[1, 5]} />
+						<StraightLines cssOverrides={linesStyles(format)} />
+						<Metadata item={item} />
+						<div css={bodyStyles}>{children}</div>
+						<Tags item={item} />
+					</div>
+				</article>
+			</main>
+			<RelatedContent item={item} />
+			<Footer isCcpa={false} format={format} />
+		</>
+	);
+};
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -1,10 +1,10 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,
-	neutral,
 	remSpace,
 	textSans,
 } from '@guardian/source-foundations';
@@ -16,13 +16,14 @@ import { maybeRender } from 'lib';
 import type { MainMedia } from 'mainMedia';
 import { MainMediaKind } from 'mainMedia';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 import { immersiveCaptionId } from './MainMedia.defaults';
 
 // ----- Component ----- //
 
-const styles = css`
-	${textSans.xxsmall()}
-	color: ${neutral[46]};
+const styles = (format: ArticleFormat): SerializedStyles => css`
+	${textSans.xsmall()}
+	color: ${text.figCaption(format)};
 	${grid.column.centre}
 
 	${from.leftCol} {
@@ -30,6 +31,10 @@ const styles = css`
 		grid-row: 4;
 		padding-top: ${remSpace[1]};
 	}
+
+	${darkModeCss`
+		color: ${text.figCaptionDark(format)};
+	`}
 `;
 
 type Props = {
@@ -53,7 +58,7 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 		}
 
 		return (
-			<p id={immersiveCaptionId} css={styles}>
+			<p id={immersiveCaptionId} css={styles(format)}>
 				{maybeRender(caption, (cap) => (
 					<Caption caption={cap} format={format} />
 				))}{' '}

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -1,13 +1,10 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import {
-	from,
-	remSpace,
-	textSans,
-} from '@guardian/source-foundations';
+import { from, remSpace, textSans } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import Caption from 'components/caption';

--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -80,6 +80,11 @@ const styles = (
 		${body.medium()}
 		overflow-wrap: break-word;
 		margin: 0 0 ${remSpace[3]};
+		color: ${text.paragraph(format)};
+
+		${darkModeCss`
+			color: ${text.paragraphDark(format)};
+		`}
 		${dropCap}
 		${labs}
 	`;

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -1,8 +1,9 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { background } from '@guardian/common-rendering/src/editorialPalette';
-import { ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { from, neutral, until } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { grid } from 'grid/grid';

--- a/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
+++ b/apps-rendering/src/components/RelatedContent/ImmersiveRelatedContent.tsx
@@ -1,21 +1,28 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { ArticleFormat } from '@guardian/libs';
 import { from, neutral, until } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
 import type { ResizedRelatedContent } from 'item';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 import DefaultRelatedContent, {
 	defaultStyles,
 } from './RelatedContent.defaults';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.container}
-	background-color: ${neutral[97]};
+	background-color: ${background.onwardContent(format)};
+
+	${darkModeCss`
+		background-color: ${background.onwardContentDark(format)};
+	`}
 `;
 
 const hrStyles = css`
@@ -44,10 +51,11 @@ const relatedContentStyles = css`
 
 type Props = {
 	content: Option<ResizedRelatedContent>;
+	format: ArticleFormat;
 };
 
-const ImmersiveRelatedContent: FC<Props> = ({ content }) => (
-	<aside css={styles}>
+const ImmersiveRelatedContent: FC<Props> = ({ content, format }) => (
+	<aside css={styles(format)}>
 		<hr css={hrStyles} />
 		<DefaultRelatedContent
 			content={content}

--- a/apps-rendering/src/components/RelatedContent/index.tsx
+++ b/apps-rendering/src/components/RelatedContent/index.tsx
@@ -19,7 +19,12 @@ const RelatedContent: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	if (format.display === ArticleDisplay.Immersive) {
-		return <ImmersiveRelatedContent content={item.relatedContent} />;
+		return (
+			<ImmersiveRelatedContent
+				content={item.relatedContent}
+				format={format}
+			/>
+		);
 	}
 
 	return (

--- a/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
@@ -9,6 +10,7 @@ import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
 import type { ReactNode } from 'react';
 import { renderStandfirstText } from 'renderer';
+import { darkModeCss } from 'styles';
 
 // ----- Functions ----- //
 
@@ -45,10 +47,11 @@ const renderContent = (
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.span('centre-column-start', 3)}
 	${headline.xsmall({ fontWeight: 'light' })}
 	padding: ${remSpace[4]} 0 ${remSpace[9]};
+	color: ${text.standfirst(format)};
 
 	${from.tablet} {
 		${grid.span('centre-column-start', 8)}
@@ -61,6 +64,10 @@ const styles = css`
 	${from.leftCol} {
 		grid-row: 5;
 	}
+
+	${darkModeCss`
+		color: ${text.standfirstDark(format)};
+	`}
 `;
 
 type Props = {
@@ -77,7 +84,7 @@ const ImmersiveStandfirst: React.FC<Props> = ({
 	bylineHtml,
 }) =>
 	maybeRender(standfirst, (standfirstDoc) => (
-		<div css={styles}>
+		<div css={styles(format)}>
 			{renderContent(standfirstDoc, format, byline, bylineHtml)}
 		</div>
 	));

--- a/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, remSpace } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import {
@@ -14,6 +15,7 @@ import { withDefault } from '@guardian/types';
 import Anchor from 'components/Anchor';
 import type { FC, ReactNode } from 'react';
 import { getHref, renderTextElement } from 'renderer';
+import { darkModeCss } from 'styles';
 
 // ----- Caption Elements ----- //
 
@@ -37,11 +39,15 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles | undefined =>
 		  `
 		: undefined;
 
-const textStyles = css`
+const textStyles = (format: ArticleFormat): SerializedStyles => css`
 	${textSans.xsmall({
 		lineHeight: 'regular',
 	})}
-	color: ${neutral[46]};
+	color: ${text.figCaption(format)};
+
+	${darkModeCss`
+		color: ${text.figCaptionDark(format)};
+	`}
 `;
 
 const captionElement =
@@ -85,7 +91,7 @@ const captionElement =
 				);
 			case '#text':
 				return (
-					<span css={textStyles} key={key}>
+					<span css={textStyles(format)} key={key}>
 						{text}
 					</span>
 				);

--- a/apps-rendering/src/grid/LeftCentreBorder.tsx
+++ b/apps-rendering/src/grid/LeftCentreBorder.tsx
@@ -4,8 +4,8 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import { from, neutral } from '@guardian/source-foundations';
 import type { FC } from 'react';
-import { grid } from './grid';
 import { darkModeCss } from 'styles';
+import { grid } from './grid';
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/grid/LeftCentreBorder.tsx
+++ b/apps-rendering/src/grid/LeftCentreBorder.tsx
@@ -5,6 +5,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { from, neutral } from '@guardian/source-foundations';
 import type { FC } from 'react';
 import { grid } from './grid';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -16,6 +17,10 @@ const styles = (rows: [number, number]): SerializedStyles => css`
 		outline: 0.5px solid ${neutral[86]};
 		width: 0;
 	}
+
+	${darkModeCss`
+		outline-color: ${neutral[20]};
+	`}
 `;
 
 interface Props {

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -83,27 +83,33 @@ const headlineByline = (_format: ArticleFormat): Colour => brandAlt[400];
 const headlineBylineDark = (_format: ArticleFormat): Colour => brandAlt[200];
 
 const headlineDark = (format: ArticleFormat): Colour => {
-	if (format.design === ArticleDesign.DeadBlog) {
+	if (format.display === ArticleDisplay.Immersive) {
 		return neutral[7];
-	} else if (format.design === ArticleDesign.LiveBlog) {
-		switch (format.theme) {
-			case ArticlePillar.Culture:
-				return culture[200];
-			case ArticlePillar.Sport:
-				return sport[200];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[200];
-			case ArticlePillar.Opinion:
-				return opinion[200];
-			case ArticlePillar.News:
-				return news[200];
-			default:
-				return news[200];
-		}
-	} else if (format.design === ArticleDesign.Interview) {
-		return neutral[20];
 	}
-	return neutral[10];
+
+	switch (format.design) {
+		case ArticleDesign.DeadBlog:
+			return neutral[7];
+		case ArticleDesign.LiveBlog: {
+			switch (format.theme) {
+				case ArticlePillar.Culture:
+					return culture[200];
+				case ArticlePillar.Sport:
+					return sport[200];
+				case ArticlePillar.Lifestyle:
+					return lifestyle[200];
+				case ArticlePillar.Opinion:
+					return opinion[200];
+				case ArticlePillar.News:
+				default:
+					return news[200];
+			}
+		}
+		case ArticleDesign.Interview:
+			return neutral[20];
+		default:
+			return neutral[10];
+	}
 };
 
 const richLink = (_format: ArticleFormat): Colour => {
@@ -565,6 +571,14 @@ const pinnedPost = (format: ArticleFormat): string => {
 	}
 };
 
+const onwardContent = (_format: ArticleFormat): Colour => neutral[97];
+
+const onwardContentDark = (_format: ArticleFormat): Colour => neutral[0];
+
+const footer = (_format: ArticleFormat): Colour => neutral[97];
+
+const footerDark = (_format: ArticleFormat): Colour => neutral[0];
+
 // ----- API ----- //
 
 const background = {
@@ -575,6 +589,8 @@ const background = {
 	bullet,
 	bulletDark,
 	calloutSpeechBubble,
+	footer,
+	footerDark,
 	headline,
 	headlineByline,
 	headlineBylineDark,
@@ -586,6 +602,8 @@ const background = {
 	keyEventsWideDark,
 	liveblogMetadata,
 	mediaArticleBody,
+	onwardContent,
+	onwardContentDark,
 	relatedCard,
 	relatedCardDark,
 	relatedCardIcon,

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -202,6 +202,12 @@ const richLinkSvgPreloadDark = (_format: ArticleFormat): Colour => {
 	return neutral[86];
 };
 
+const lines = (_format: ArticleFormat): Colour =>
+	neutral[86];
+
+const linesDark = (_format: ArticleFormat): Colour =>
+	neutral[20];
+
 // ----- API ----- //
 
 const fill = {
@@ -214,6 +220,8 @@ const fill = {
 	iconDark,
 	blockquoteIcon,
 	blockquoteIconDark,
+	lines,
+	linesDark,
 	richLink,
 	richLinkDark,
 	richLinkSvgPreload,

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -955,6 +955,10 @@ const tag = (_format: ArticleFormat): Colour => neutral[7];
 
 const tagDark = (_format: ArticleFormat): Colour => neutral[86];
 
+const paragraph = (_format: ArticleFormat): Colour => neutral[7];
+
+const paragraphDark = (_format: ArticleFormat): Colour => neutral[86];
+
 // ----- API ----- //
 
 const text = {
@@ -1012,6 +1016,8 @@ const text = {
 	tag,
 	tagDark,
 	pagination,
+	paragraph,
+	paragraphDark,
 };
 
 // ----- Exports ----- //


### PR DESCRIPTION
## Why?

Continuing the work on the new immersive layout, following on from #5538. This applies all the dark mode colour variants, and updates a few components to use editorial palette colours.

It also fixes a dark mode bug in all articles where the footer background colour was mismatched with the onward content background. See the second set of screenshots for more details.

## Changes

- Caption component now pulls text colours from palette
- Darkened footer background colour in dark mode for all articles
- Pulled the footer background colour in light mode from palette
- Dark mode and palette colours for immersive headline
- Applied dark mode background to immersive layout
- Applied dark mode colour to immersive lines
- Stored `getFormat` in constant for immersive layout
- Applied figcaption palette colours to immersive caption
- Increased text size of credit in immersive caption
- Added palette colours to main paragraph component
- Added palette background colours to related content component
- Added palette and dark mode colours to immersive standfirst
- Refactored palette headline background to use switch
- Added immersive colours to palette headline background
- Added onward content and footer to background palette
- Added lines colours to fill palette
- Added paragraph colours to text palette

## Screenshots

| Header | Paragraphs | Figure | Rich link | Footer | Wide |
| - | - | - | - | - | - |
| ![immersive-dark-mode-header] | ![immersive-dark-mode-paragraphs] | ![immersive-dark-mode-figure] | ![immersive-dark-mode-rich-link] | ![immersive-dark-mode-footer] | ![immersive-dark-mode-wide] |

[immersive-dark-mode-figure]: https://user-images.githubusercontent.com/53781962/181818795-6d51e3ea-9c3a-46c5-8707-440417d78f6a.jpg
[immersive-dark-mode-paragraphs]: https://user-images.githubusercontent.com/53781962/181818801-d2252aef-43a2-4592-b6a1-847eba1ab87f.jpg
[immersive-dark-mode-footer]: https://user-images.githubusercontent.com/53781962/181818806-88ed1afb-0df4-4d75-bd86-d38beb176efc.jpg
[immersive-dark-mode-wide]: https://user-images.githubusercontent.com/53781962/181818809-22e66cbd-355c-471e-aec6-5a75e973ae4f.jpg
[immersive-dark-mode-header]: https://user-images.githubusercontent.com/53781962/181818811-d88850b1-448f-4a09-bf92-e405887a355a.jpg
[immersive-dark-mode-rich-link]: https://user-images.githubusercontent.com/53781962/181818814-84af5755-d395-40d3-a1e1-40a72bb47a71.jpg

### Dark Mode Footer - All Articles

| Before | After |
| - | - |
| ![footer-dark-mode-before] | ![footer-dark-mode-after] |

[footer-dark-mode-after]: https://user-images.githubusercontent.com/53781962/181819132-5669be77-72ad-4b0b-80f4-2d6350a2bbc3.jpg
[footer-dark-mode-before]: https://user-images.githubusercontent.com/53781962/181819136-dbefb079-39be-446b-b92e-c1f0f8c98936.jpg
