### PR TITLE
`onwardsType`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -790,12 +790,12 @@ type CAPIOnwardsType = {
 	trails: CAPITrailType[];
 	description?: string;
 	url?: string;
-	ophanComponentName: OphanComponentName;
+	onwardsType: OnwardsType;
 	format: CAPIFormat;
 	isCuratedContent?: boolean;
 };
 
-type OphanComponentName =
+type OnwardsType =
 	| 'series'
 	| 'more-on-this-story'
 	| 'related-stories'

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -25,9 +25,8 @@ type Props = {
 	trails: TrailType[];
 	description?: string;
 	url?: string;
-	ophanComponentName: OphanComponentName;
+	onwardsType: OnwardsType;
 	format: ArticleFormat;
-	isCuratedContent?: boolean;
 };
 
 // Carousel icons - need replicating from source for centring
@@ -426,13 +425,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 	</div>
 );
 
-export const Carousel = ({
-	heading,
-	trails,
-	ophanComponentName,
-	format,
-	isCuratedContent,
-}: Props) => {
+export const Carousel = ({ heading, trails, onwardsType, format }: Props) => {
 	const palette = decidePalette(format);
 	const carouselRef = useRef<HTMLUListElement>(null);
 
@@ -440,6 +433,8 @@ export const Carousel = ({
 	const [maxIndex, setMaxIndex] = useState(0);
 
 	const arrowName = 'carousel-small-arrow';
+
+	const isCuratedContent = onwardsType === 'curated-content';
 
 	const notPresentation = (el: HTMLElement): boolean =>
 		el.getAttribute('role') !== 'presentation';
@@ -585,7 +580,7 @@ export const Carousel = ({
 			</div>
 			<div
 				css={[containerStyles, containerMargins]}
-				data-component={ophanComponentName}
+				data-component={onwardsType}
 				data-link={formatAttrString(heading)}
 			>
 				<Hide when="above" breakpoint="leftCol">

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -185,7 +185,7 @@ export const Headlines = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails}
-				ophanComponentName="curated-content"
+				onwardsType="curated-content"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -197,13 +197,12 @@ export const Headlines = () => (
 			<Carousel
 				heading="Sport"
 				trails={trails}
-				ophanComponentName="curated-content"
+				onwardsType="curated-content"
 				format={{
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 					display: ArticleDisplay.Standard,
 				}}
-				isCuratedContent={true}
 			/>
 		</ElementContainer>
 	</>
@@ -217,7 +216,7 @@ export const SingleItemCarousel = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails.slice(1, 2)}
-				ophanComponentName="curated-content"
+				onwardsType="curated-content"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -236,7 +235,7 @@ export const Immersive = () => (
 			<Carousel
 				heading="More on this story"
 				trails={immersiveTrails}
-				ophanComponentName="curated-content"
+				onwardsType="curated-content"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -248,13 +247,12 @@ export const Immersive = () => (
 			<Carousel
 				heading="Sport"
 				trails={immersiveTrails}
-				ophanComponentName="curated-content"
+				onwardsType="curated-content"
 				format={{
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
 					display: ArticleDisplay.Immersive,
 				}}
-				isCuratedContent={true}
 			/>
 		</ElementContainer>
 	</>

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -185,7 +185,7 @@ export const Headlines = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails}
-				onwardsType="curated-content"
+				onwardsType="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -216,7 +216,7 @@ export const SingleItemCarousel = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails.slice(1, 2)}
-				onwardsType="curated-content"
+				onwardsType="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -235,7 +235,7 @@ export const Immersive = () => (
 			<Carousel
 				heading="More on this story"
 				trails={immersiveTrails}
-				onwardsType="curated-content"
+				onwardsType="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/web/components/OnwardsData.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsData.tsx
@@ -9,9 +9,8 @@ import { Placeholder } from './Placeholder';
 type Props = {
 	url: string;
 	limit: number; // Limit the number of items shown (the api often returns more)
-	ophanComponentName: OphanComponentName;
+	onwardsType: OnwardsType;
 	format: ArticleFormat;
-	isCuratedContent?: boolean;
 };
 
 type OnwardsResponse = {
@@ -25,13 +24,7 @@ const minHeight = css`
 	min-height: 300px;
 `;
 
-export const OnwardsData = ({
-	url,
-	limit,
-	ophanComponentName,
-	format,
-	isCuratedContent,
-}: Props) => {
+export const OnwardsData = ({ url, limit, onwardsType, format }: Props) => {
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
 
 	const buildTrails = (
@@ -78,9 +71,8 @@ export const OnwardsData = ({
 						heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
 						trails={buildTrails(data.trails, limit)}
 						description={data.description}
-						ophanComponentName={ophanComponentName}
+						onwardsType={onwardsType}
 						format={format}
-						isCuratedContent={isCuratedContent}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -200,7 +200,7 @@ export const OnwardsUpper = ({
 	);
 
 	let url;
-	let ophanComponentName: OnwardsType = 'default-onwards';
+	let onwardsType: OnwardsType = 'default-onwards';
 
 	if (!showRelatedContent) {
 		// Then don't show related content
@@ -223,7 +223,7 @@ export const OnwardsUpper = ({
 			'series',
 			`${seriesTag.id}.json?dcr&shortUrl=${shortUrlId}`,
 		]);
-		ophanComponentName = 'series';
+		onwardsType = 'series';
 	} else if (!hasRelated) {
 		// There is no related content to show
 	} else if (tagToFilterBy) {
@@ -253,13 +253,13 @@ export const OnwardsUpper = ({
 		}
 
 		url = joinUrl([ajaxUrl, popularInTagUrl]);
-		ophanComponentName = 'related-content';
+		onwardsType = 'related-content';
 	} else {
 		// Default to generic related endpoint
 		const relatedUrl = `/related/${pageId}.json?dcr=true`;
 
 		url = joinUrl([ajaxUrl, relatedUrl]);
-		ophanComponentName = 'related-stories';
+		onwardsType = 'related-stories';
 	}
 
 	const curatedDataUrl = showRelatedContent
@@ -273,7 +273,7 @@ export const OnwardsUpper = ({
 					<OnwardsData
 						url={url}
 						limit={8}
-						onwardsType={ophanComponentName}
+						onwardsType={onwardsType}
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -200,7 +200,7 @@ export const OnwardsUpper = ({
 	);
 
 	let url;
-	let ophanComponentName: OphanComponentName = 'default-onwards';
+	let ophanComponentName: OnwardsType = 'default-onwards';
 
 	if (!showRelatedContent) {
 		// Then don't show related content
@@ -273,7 +273,7 @@ export const OnwardsUpper = ({
 					<OnwardsData
 						url={url}
 						limit={8}
-						ophanComponentName={ophanComponentName}
+						onwardsType={ophanComponentName}
 						format={format}
 					/>
 				</ElementContainer>
@@ -283,8 +283,7 @@ export const OnwardsUpper = ({
 					<OnwardsData
 						url={curatedDataUrl}
 						limit={20}
-						ophanComponentName="curated-content"
-						isCuratedContent={true}
+						onwardsType="curated-content"
 						format={format}
 					/>
 				</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -706,9 +706,8 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -517,9 +517,8 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -618,9 +618,8 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1240,9 +1240,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									trails={CAPIArticle.storyPackage.trails.map(
 										decideTrail,
 									)}
-									ophanComponentName="more-on-this-story"
+									onwardsType="more-on-this-story"
 									format={format}
-									isCuratedContent={false}
 								/>
 							</Island>
 						</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -456,9 +456,8 @@ export const NewsletterSignupLayout = ({
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -661,9 +661,8 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -793,9 +793,8 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								trails={CAPIArticle.storyPackage.trails.map(
 									decideTrail,
 								)}
-								ophanComponentName="more-on-this-story"
+								onwardsType="more-on-this-story"
 								format={format}
-								isCuratedContent={false}
 							/>
 						</Island>
 					</ElementContainer>

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -195,24 +195,15 @@ export const renderOnwards = (
 	res: express.Response,
 ): void => {
 	try {
-		const {
-			heading,
-			description,
-			url,
-			ophanComponentName,
-			trails,
-			format,
-			isCuratedContent,
-		} = body;
+		const { heading, description, url, onwardsType, trails, format } = body;
 
 		const html = onwardsToHtml({
 			heading,
 			description,
 			url,
-			ophanComponentName,
+			onwardsType,
 			trails,
 			format,
-			isCuratedContent,
 		});
 
 		res.status(200).send(html);

--- a/dotcom-rendering/src/web/server/onwardsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/onwardsToHtml.tsx
@@ -20,18 +20,16 @@ export const onwardsToHtml = ({
 	heading,
 	// description,
 	// url,
-	ophanComponentName,
+	onwardsType,
 	trails,
 	format: CAPIFormat,
-	isCuratedContent,
 }: CAPIOnwardsType): string => {
 	const format = decideFormat(CAPIFormat);
 
 	const html = renderToString(
 		<Carousel
 			heading={heading}
-			ophanComponentName={ophanComponentName}
-			isCuratedContent={isCuratedContent}
+			onwardsType={onwardsType}
 			trails={buildTrails(trails, 8)}
 			format={format}
 		/>,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR replaces the property `ophanComponentName` with `onwardsType`.

## Why?
We still use the 'type' of onwards as the string sent to Ophan but this type is also useful in other contexts and makes more sense as a separate property.

For example, we can now remove the `isCuratedContent` prop and replace it with `const isCurated = onwardsType === 'curated-content'`

In addition, we've now renamed the typescript type `OphanComponentName` to `OnwardsType`. We use `ophanComponentName` as a property in other places but in those cases we type it as a string so the name here did not make sense in this new context.

```ts
type OnwardsType =
	| 'series'
	| 'more-on-this-story'
	| 'related-stories'
	| 'related-content'
	| 'more-media-in-section'
	| 'more-galleries'
	| 'curated-content'
	| 'default-onwards'; 
```
