### PR TITLE
Spell “overlaid” correctly

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -129,7 +129,7 @@ type Palette = {
 		blockquote: Colour;
 		numberedTitle: Colour;
 		numberedPosition: Colour;
-		overlayedCaption: Colour;
+		overlaidCaption: Colour;
 		shareCount: Colour;
 		shareCountUntilDesktop: Colour;
 		cricketScoreboardLink: Colour;

--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -38,7 +38,7 @@ interface CaptionBlockElement {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 }
 
 interface CalloutBlockElement {

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -611,7 +611,7 @@
                 "shouldLimitWidth": {
                     "type": "boolean"
                 },
-                "isOverlayed": {
+                "isOverlaid": {
                     "type": "boolean"
                 }
             },

--- a/dotcom-rendering/src/web/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/web/components/Caption.stories.tsx
@@ -24,7 +24,7 @@ export default {
     credit?: string;
     displayCredit?: boolean;
     shouldLimitWidth?: boolean;
-    isOverlayed?: boolean; // Not tested here as this option only works in the context of the ImageComponent
+    isOverlaid?: boolean; // Not tested here as this option only works in the context of the ImageComponent
  */
 
 export const Article = () => (
@@ -144,7 +144,7 @@ export const Padded = () => (
 );
 Padded.story = { name: 'when padded' };
 
-export const Overlayed = () => (
+export const Overlaid = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -164,8 +164,8 @@ export const Overlayed = () => (
 				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
 			/>
 			<Caption
-				isOverlayed={true}
-				captionText="This is how a caption looks when it's overlayed"
+				isOverlaid={true}
+				captionText="This is how a caption looks when it's overlaid"
 				format={{
 					display: ArticleDisplay.Standard,
 					design: ArticleDesign.Standard,
@@ -176,9 +176,9 @@ export const Overlayed = () => (
 		</div>
 	</ElementContainer>
 );
-Overlayed.story = { name: 'when overlayed' };
+Overlaid.story = { name: 'when overlaid' };
 
-export const OverlayedWithStars = () => (
+export const OverlaidWithStars = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>
 		<div
 			css={css`
@@ -198,8 +198,8 @@ export const OverlayedWithStars = () => (
 				src="https://i.guim.co.uk/img/media/eaecb92d15c7e9691274226d0935038bfcc9de53/0_0_6720_4480/master/6720.jpg?width=880&quality=45&auto=format&fit=max&dpr=2&s=452e8da9ad0b2ba274ae8987b3799fd4"
 			/>
 			<Caption
-				isOverlayed={true}
-				captionText="This is how a caption looks when it's overlayed with stars"
+				isOverlaid={true}
+				captionText="This is how a caption looks when it's overlaid with stars"
 				format={{
 					display: ArticleDisplay.Showcase,
 					design: ArticleDesign.Review,
@@ -219,7 +219,7 @@ export const OverlayedWithStars = () => (
 		</div>
 	</ElementContainer>
 );
-OverlayedWithStars.story = { name: 'when overlayed on stars' };
+OverlaidWithStars.story = { name: 'when overlaid on stars' };
 
 export const VideoCaption = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/Caption.tsx
+++ b/dotcom-rendering/src/web/components/Caption.tsx
@@ -19,7 +19,7 @@ type Props = {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 	isLeftCol?: boolean;
 	mediaType?: MediaType;
 	isMainMedia?: boolean;
@@ -42,7 +42,7 @@ const bottomMarginStyles = css`
 	margin-bottom: 6px;
 `;
 
-const overlayedBottomPadding = (format: ArticleFormat) => {
+const overlaidBottomPadding = (format: ArticleFormat) => {
 	if (
 		format.display === ArticleDisplay.Showcase &&
 		format.design === ArticleDesign.Review
@@ -56,7 +56,7 @@ const overlayedBottomPadding = (format: ArticleFormat) => {
 	`;
 };
 
-const overlayedStyles = (palette: Palette, format: ArticleFormat) => css`
+const overlaidStyles = (palette: Palette, format: ArticleFormat) => css`
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -64,21 +64,21 @@ const overlayedStyles = (palette: Palette, format: ArticleFormat) => css`
 	background: rgba(18, 18, 18, 0.8);
 
 	span {
-		color: ${palette.text.overlayedCaption};
+		color: ${palette.text.overlaidCaption};
 		font-size: 0.75rem;
 		line-height: 1rem;
 	}
 
 	svg {
-		fill: ${palette.text.overlayedCaption};
+		fill: ${palette.text.overlaidCaption};
 	}
-	color: ${palette.text.overlayedCaption};
+	color: ${palette.text.overlaidCaption};
 	font-size: 0.75rem;
 	line-height: 1rem;
 	padding-top: 0.375rem;
 	padding-right: 2.5rem;
 	padding-left: 0.75rem;
-	${overlayedBottomPadding(format)};
+	${overlaidBottomPadding(format)};
 
 	flex-grow: 1;
 	min-height: 2.25rem;
@@ -229,7 +229,7 @@ export const Caption = ({
 	credit,
 	displayCredit = true,
 	shouldLimitWidth = false,
-	isOverlayed,
+	isOverlaid,
 	isLeftCol,
 	mediaType = 'Gallery',
 	isMainMedia = false,
@@ -250,8 +250,9 @@ export const Caption = ({
 			css={[
 				captionStyle(palette),
 				shouldLimitWidth && limitedWidth,
-				!isOverlayed && bottomMarginStyles,
-				isOverlayed && overlayedStyles(palette, format),
+				isOverlaid
+					? overlaidStyles(palette, format)
+					: bottomMarginStyles,
 				isMainMedia && isBlog && tabletCaptionPadding,
 				padCaption && captionPadding,
 				mediaType === 'Video' && videoPadding,

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.stories.tsx
@@ -21,7 +21,7 @@ export default {
         credit?: string;
         displayCredit?: boolean;
         shouldLimitWidth?: boolean;
-        isOverlayed?: boolean;
+        isOverlaid?: boolean;
     };
  */
 
@@ -79,7 +79,7 @@ export const PhotoEssay = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -102,7 +102,7 @@ export const PhotoEssayHTML = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -125,7 +125,7 @@ export const Padded = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -148,7 +148,7 @@ export const WidthLimited = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={true}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -171,7 +171,7 @@ export const Credited = () => {
 				credit="Credit text"
 				displayCredit={true}
 				shouldLimitWidth={false}
-				isOverlayed={false}
+				isOverlaid={false}
 			/>
 		</Container>
 	);
@@ -180,7 +180,7 @@ Credited.story = {
 	name: 'with credit',
 };
 
-export const Overlayed = () => {
+export const Overlaid = () => {
 	return (
 		<Container>
 			<CaptionBlockComponent
@@ -194,11 +194,11 @@ export const Overlayed = () => {
 				credit="Credit text"
 				displayCredit={false}
 				shouldLimitWidth={false}
-				isOverlayed={true}
+				isOverlaid={true}
 			/>
 		</Container>
 	);
 };
-Overlayed.story = {
-	name: 'when overlayed',
+Overlaid.story = {
+	name: 'when overlaid',
 };

--- a/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/CaptionBlockComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
 	credit?: string;
 	displayCredit?: boolean;
 	shouldLimitWidth?: boolean;
-	isOverlayed?: boolean;
+	isOverlaid?: boolean;
 };
 
 export const CaptionBlockComponent = ({
@@ -17,7 +17,7 @@ export const CaptionBlockComponent = ({
 	credit,
 	displayCredit = true,
 	shouldLimitWidth = false,
-	isOverlayed,
+	isOverlaid,
 }: Props) => (
 	<Caption
 		format={format}
@@ -26,6 +26,6 @@ export const CaptionBlockComponent = ({
 		credit={credit}
 		displayCredit={displayCredit}
 		shouldLimitWidth={shouldLimitWidth}
-		isOverlayed={isOverlayed}
+		isOverlaid={isOverlaid}
 	/>
 );

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -401,7 +401,7 @@ export const ImageComponent = ({
 										credit={element.data.credit}
 										displayCredit={element.displayCredit}
 										shouldLimitWidth={shouldLimitWidth}
-										isOverlayed={true}
+										isOverlaid={true}
 										isMainMedia={isMainMedia}
 									/>
 								</div>

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1211,7 +1211,7 @@ const textNumberedPosition = (): string => {
 	return text.supporting;
 };
 
-const textOverlayed = (): string => {
+const textOverlaid = (): string => {
 	return WHITE;
 };
 
@@ -1381,7 +1381,7 @@ export const decidePalette = (
 			blockquote: textBlockquote(format),
 			numberedTitle: textNumberedTitle(format),
 			numberedPosition: textNumberedPosition(),
-			overlayedCaption: textOverlayed(),
+			overlaidCaption: textOverlaid(),
 			shareCount: textShareCount(),
 			shareCountUntilDesktop: textShareCountUntilDesktop(format),
 			cricketScoreboardLink: textCricketScoreboardLink(),

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -188,7 +188,7 @@ export const renderElement = ({
 					credit={element.credit}
 					displayCredit={element.displayCredit}
 					shouldLimitWidth={element.shouldLimitWidth}
-					isOverlayed={element.isOverlayed}
+					isOverlaid={element.isOverlaid}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':


### PR DESCRIPTION
## What does this change?

- overlayedCaption -> overlaidCaption
- isOverlayed -> isOverlaid
- overlayedBottomPadding -> overlaidBottomPadding

## Why?

Proper spelling, innit.