### PR TITLE
`Treats`

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,6 +1,7 @@
 import type { DCRCollectionType, FECollectionType } from '../types/front';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
+import { enhanceTreats } from './enhanceTreats';
 
 export const enhanceCollections = (
 	collections: FECollectionType[],
@@ -17,7 +18,7 @@ export const enhanceCollections = (
 			containerPalette,
 			curated: enhanceCards(collection.curated, containerPalette),
 			backfill: enhanceCards(collection.backfill, containerPalette),
-			treats: enhanceCards(collection.treats, containerPalette),
+			treats: enhanceTreats(collection.treats),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
 			},

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -1,9 +1,7 @@
 import type { FEFrontCard, TreatType } from '../types/front';
 
 export const enhanceTreats = (treats: FEFrontCard[]): TreatType[] =>
-	treats.map((treat) => {
-		return {
-			text: treat.header.headline,
-			linkTo: treat.properties.href ?? treat.header.url,
-		};
-	});
+	treats.map((treat) => ({
+		text: treat.header.headline,
+		linkTo: treat.properties.href ?? treat.header.url,
+	}));

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -1,0 +1,9 @@
+import type { FEFrontCard, TreatType } from '../types/front';
+
+export const enhanceTreats = (treats: FEFrontCard[]): TreatType[] =>
+	treats.map((treat) => {
+		return {
+			text: treat.header.headline,
+			linkTo: treat.properties.href ?? treat.header.url,
+		};
+	});

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -758,6 +758,9 @@
                                                             "edition"
                                                         ]
                                                     }
+                                                },
+                                                "href": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -1422,6 +1425,9 @@
                                                             "edition"
                                                         ]
                                                     }
+                                                },
+                                                "href": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -2086,6 +2092,9 @@
                                                             "edition"
                                                         ]
                                                     }
+                                                },
+                                                "href": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -166,6 +166,7 @@ export type FEFrontCard = {
 		linkText?: string;
 		webUrl?: string;
 		editionBrandings: { edition: { id: EditionId } }[];
+		href?: string;
 	};
 	header: {
 		isVideo: boolean;
@@ -300,7 +301,7 @@ export type DCRCollectionType = {
 	containerPalette?: DCRContainerPalette;
 	curated: DCRFrontCard[];
 	backfill: DCRFrontCard[];
-	treats: DCRFrontCard[];
+	treats: TreatType[];
 	href?: string;
 	config: {
 		showDateHeader: boolean;
@@ -425,4 +426,9 @@ export type DCRSupportingContent = {
 	url?: string;
 	kickerText?: string;
 	format: ArticleFormat;
+};
+
+export type TreatType = {
+	text: string;
+	linkTo: string;
 };

--- a/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.stories.tsx
@@ -318,3 +318,26 @@ MultipleStory.story = {
 		},
 	},
 };
+
+export const TreatsStory = () => {
+	return (
+		<ContainerLayout
+			title="Treats"
+			treats={[
+				{
+					text: 'The treat text',
+					linkTo: '',
+				},
+				{
+					text: 'Another piece of text',
+					linkTo: '',
+				},
+			]}
+		>
+			<Grey />
+		</ContainerLayout>
+	);
+};
+TreatsStory.story = {
+	name: 'with treats',
+};

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from, space, until } from '@guardian/source-foundations';
-import type { DCRContainerPalette } from '../../types/front';
+import type { DCRContainerPalette, TreatType } from '../../types/front';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { hiddenStyles } from '../lib/hiddenStyles';
 import { ContainerTitle } from './ContainerTitle';
@@ -11,6 +11,7 @@ import { Flex } from './Flex';
 import { Hide } from './Hide';
 import { LeftColumn } from './LeftColumn';
 import { ShowHideButton } from './ShowHideButton';
+import { Treats } from './Treats';
 
 type Props = {
 	title?: string;
@@ -38,6 +39,7 @@ type Props = {
 	innerBackgroundColour?: string;
 	showDateHeader?: boolean;
 	editionId?: EditionId;
+	treats?: TreatType[];
 };
 
 const containerStyles = css`
@@ -59,9 +61,9 @@ const headlineContainerStyles = css`
 const margins = css`
 	margin-top: ${space[2]}px;
 	/*
-   Keep spacing at the bottom of the container consistent at 36px, regardless of
-   breakpoint, based on chat with Harry Fisher
-*/
+		Keep spacing at the bottom of the container consistent at 36px, regardless of
+		breakpoint, based on chat with Harry Fisher
+	*/
 	margin-bottom: ${space[9]}px;
 `;
 
@@ -140,6 +142,7 @@ export const ContainerLayout = ({
 	innerBackgroundColour,
 	showDateHeader,
 	editionId,
+	treats,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -164,8 +167,16 @@ export const ContainerLayout = ({
 					borderType={centralBorder}
 					borderColour={borderColour || overrides?.border.container}
 					size={leftColSize}
+					verticalMargins={verticalMargins}
 				>
-					<>
+					<div
+						css={css`
+							display: flex;
+							height: 100%;
+							flex-direction: column;
+							justify-content: space-between;
+						`}
+					>
 						<ContainerTitle
 							title={title}
 							fontColour={fontColour || overrides?.text.container}
@@ -176,7 +187,15 @@ export const ContainerLayout = ({
 							editionId={editionId}
 						/>
 						{leftContent}
-					</>
+						{treats && (
+							<Treats
+								treats={treats}
+								borderColour={
+									borderColour ?? overrides?.border.container
+								}
+							/>
+						)}
+					</div>
 				</LeftColumn>
 				<Container
 					padded={padContent}

--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -177,16 +177,20 @@ export const ContainerLayout = ({
 							justify-content: space-between;
 						`}
 					>
-						<ContainerTitle
-							title={title}
-							fontColour={fontColour || overrides?.text.container}
-							description={description}
-							url={url}
-							containerPalette={containerPalette}
-							showDateHeader={showDateHeader}
-							editionId={editionId}
-						/>
-						{leftContent}
+						<div>
+							<ContainerTitle
+								title={title}
+								fontColour={
+									fontColour || overrides?.text.container
+								}
+								description={description}
+								url={url}
+								containerPalette={containerPalette}
+								showDateHeader={showDateHeader}
+								editionId={editionId}
+							/>
+							{leftContent}
+						</div>
 						{treats && (
 							<Treats
 								treats={treats}

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -96,7 +96,7 @@ export const ContainerTitle = ({
 	const locale = editionId && getEditionFromId(editionId).locale;
 
 	return (
-		<>
+		<div>
 			{url ? (
 				<a css={linkStyles} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>
@@ -137,6 +137,6 @@ export const ContainerTitle = ({
 					</span>
 				</div>
 			)}
-		</>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -39,7 +39,9 @@ export const FixedMediumSlowVI = ({
 									index === 0 ? 'top' : 'left'
 								}
 								imageSize={index === 0 ? 'large' : 'medium'}
-								trailText={trail.trailText}
+								trailText={
+									index === 0 ? trail.trailText : undefined
+								}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/web/components/LeftColumn.tsx
@@ -105,13 +105,13 @@ export const LeftColumn = ({
 			]}
 		>
 			<div
-				css={
-					(borderType === 'partial' &&
+				css={[
+					borderType === 'partial' &&
 						partialRightBorder(borderColour),
 					css`
 						height: 100%;
-					`)
-				}
+					`,
+				]}
 			>
 				{children}
 			</div>

--- a/dotcom-rendering/src/web/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/web/components/LeftColumn.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { between, border, from, until } from '@guardian/source-foundations';
+import {
+	between,
+	border,
+	from,
+	space,
+	until,
+} from '@guardian/source-foundations';
 
 const leftWidth = (size: LeftColSize) => {
 	switch (size) {
@@ -72,6 +78,7 @@ type Props = {
 	borderType?: 'full' | 'partial'; // if no borderType provided -> no border
 	borderColour?: string;
 	size?: LeftColSize;
+	verticalMargins?: boolean;
 };
 
 export const LeftColumn = ({
@@ -79,6 +86,7 @@ export const LeftColumn = ({
 	borderType,
 	borderColour = border.secondary,
 	size = 'compact',
+	verticalMargins = true,
 }: Props) => {
 	return (
 		<section
@@ -86,11 +94,23 @@ export const LeftColumn = ({
 				positionRelative,
 				leftWidth(size),
 				borderType === 'full' && fullRightBorder(borderColour),
+				verticalMargins &&
+					css`
+						/*
+			   Keep spacing at the bottom of the container consistent at 36px, regardless of
+			   breakpoint, based on chat with Harry Fisher
+			*/
+						margin-bottom: ${space[9]}px;
+					`,
 			]}
 		>
 			<div
 				css={
-					borderType === 'partial' && partialRightBorder(borderColour)
+					(borderType === 'partial' &&
+						partialRightBorder(borderColour),
+					css`
+						height: 100%;
+					`)
 				}
 			>
 				{children}

--- a/dotcom-rendering/src/web/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/web/components/LeftColumn.tsx
@@ -97,10 +97,10 @@ export const LeftColumn = ({
 				verticalMargins &&
 					css`
 						/*
-			   Keep spacing at the bottom of the container consistent at 36px, regardless of
-			   breakpoint, based on chat with Harry Fisher
-			*/
-						margin-bottom: ${space[9]}px;
+							Keep spacing at the bottom of the container consistent at 36px, regardless of
+							breakpoint, based on chat with Harry Fisher
+						*/
+						padding-bottom: ${space[9]}px;
 					`,
 			]}
 		>

--- a/dotcom-rendering/src/web/components/Treats.stories.tsx
+++ b/dotcom-rendering/src/web/components/Treats.stories.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { Treats } from './Treats';
+
+export default {
+	component: Treats,
+	title: 'Components/Treats',
+};
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			width: 620px;
+			padding: 20px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const Default = () => {
+	return (
+		<Container>
+			<Treats
+				treats={[
+					{
+						text: 'treat 1',
+						linkTo: '',
+					},
+					{
+						text: 'treat 2',
+						linkTo: '',
+					},
+				]}
+			/>
+		</Container>
+	);
+};
+Default.story = { name: 'Default' };

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+import { border, space, textSans } from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
+import type { TreatType } from '../../types/front';
+
+export const Treats = ({
+	treats,
+	borderColour,
+}: {
+	treats: TreatType[];
+	borderColour?: string;
+}) => {
+	return (
+		<ul
+			css={css`
+				display: flex;
+				flex-direction: column;
+			`}
+		>
+			{treats.map((treat) => {
+				return (
+					<li
+						css={css`
+							margin-top: ${space[3]}px;
+							border-left: 1px solid
+								${borderColour ?? border.secondary};
+							border-top: 1px solid
+								${borderColour ?? border.secondary};
+							padding-top: ${space[1]}px;
+							padding-left: ${space[2]}px;
+						`}
+					>
+						<Link
+							priority="secondary"
+							subdued={true}
+							cssOverrides={css`
+								${textSans.xsmall()}
+							`}
+							href={treat.linkTo}
+						>
+							{treat.text}
+						</Link>
+					</li>
+				);
+			})}
+		</ul>
+	);
+};

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -10,6 +10,7 @@ export const Treats = ({
 	treats: TreatType[];
 	borderColour?: string;
 }) => {
+	if (treats.length === 0) return null;
 	return (
 		<ul
 			css={css`

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -167,6 +167,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							sectionId={collection.id}
 							showDateHeader={collection.config.showDateHeader}
 							editionId={front.editionId}
+							treats={collection.treats}
 						>
 							<DecideContainer
 								trails={trails}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Closes #5493 by adding support for `Treats`, those little link thingies in the bottom left of some containers

<img width="226" alt="Screenshot 2022-08-01 at 12 05 55" src="https://user-images.githubusercontent.com/1336821/182135022-772c615e-cb69-4dcc-b0ff-cce9b590b8bb.png">


## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1365" alt="Screenshot 2022-08-01 at 12 00 32" src="https://user-images.githubusercontent.com/1336821/182134544-805cce9d-ec07-45a8-ad55-e8a4144c27d3.png"> | <img width="1365" alt="Screenshot 2022-08-01 at 11 56 59" src="https://user-images.githubusercontent.com/1336821/182134571-ef382dac-1ab8-4325-ac56-5f88cc4b2fb6.png"> |

### Also
I spotted a small issue where the trail text was showing for the second card  on `FixedMediumSlowVI` when it shouldn't, so I added a drive by for that. Here is a screenshot for how the container looked before this fix

<img width="1192" alt="Screenshot 2022-08-01 at 12 01 33" src="https://user-images.githubusercontent.com/1336821/182134909-6423d69f-b18e-467a-8202-1794dd4b037d.png">

