### PR TITLE
Key Events Carousel: underline links on hover

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -42,12 +42,10 @@ const linkStyles = (palette: Palette) => css`
 		span {
 			border-bottom: 1px solid ${palette.hover.keyEventLink};
 		}
-	}
-
-	&:hover > div {
-		text-decoration: underline;
-		text-underline-offset: 3px;
-		text-decoration-color: ${palette.text.keyEvent};
+		div {
+			text-decoration: underline ${palette.text.keyEvent};
+			text-underline-offset: 3px;
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -94,6 +94,7 @@ const textStyles = (palette: Palette) => css`
 
 	&:hover {
 		text-decoration: underline;
+		text-underline-offset: 3px;
 		text-decoration-color: ${palette.text.keyEvent};
 	}
 `;

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -91,6 +91,11 @@ const listItemStyles = (palette: Palette) => css`
 const textStyles = (palette: Palette) => css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
 	color: ${palette.text.keyEvent};
+
+	&:hover {
+		text-decoration: underline;
+		text-decoration-color: ${palette.text.keyEvent};
+	}
 `;
 
 const timeStyles = (palette: Palette) => css`

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -43,6 +43,12 @@ const linkStyles = (palette: Palette) => css`
 			border-bottom: 1px solid ${palette.hover.keyEventLink};
 		}
 	}
+
+	&:hover > div {
+		text-decoration: underline;
+		text-underline-offset: 3px;
+		text-decoration-color: ${palette.text.keyEvent};
+	}
 `;
 
 const summaryStyles = (palette: Palette) => css`
@@ -91,12 +97,6 @@ const listItemStyles = (palette: Palette) => css`
 const textStyles = (palette: Palette) => css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
 	color: ${palette.text.keyEvent};
-
-	&:hover {
-		text-decoration: underline;
-		text-underline-offset: 3px;
-		text-decoration-color: ${palette.text.keyEvent};
-	}
 `;
 
 const timeStyles = (palette: Palette) => css`


### PR DESCRIPTION
## What does this change?
Adds a text-decoration property to `textStyles`.

## Why?
This is a design decision for Key Events Carousel links to be underlined on hover.

## Screenshots

Example1:
<img width="431" alt="Screenshot 2022-08-01 at 15 23 30" src="https://user-images.githubusercontent.com/55602675/182172724-da14d6e4-e6ec-4f88-acc6-f1ac31d88fce.png">


Example2:
<img width="431" alt="Screenshot 2022-08-01 at 15 32 36" src="https://user-images.githubusercontent.com/55602675/182173469-ed4d96f6-fe34-4ab6-9b48-68ecaa0f5d64.png">