### PR TITLE
Reserve space for merchandising & merchandising-high ad slots

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -74,6 +74,11 @@ export const adCollapseStyles = css`
 	}
 `;
 
+const merchandisingAdStyles = css`
+	position: relative;
+	min-height: 250px;
+`;
+
 /**
  * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
  * These styles come mostly from RichLink in DCR.
@@ -340,9 +345,7 @@ export const AdSlot: React.FC<Props> = ({
 						'ad-slot--merchandising-high',
 					].join(' ')}
 					css={[
-						css`
-							position: relative;
-						`,
+						merchandisingAdStyles,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}
@@ -362,9 +365,7 @@ export const AdSlot: React.FC<Props> = ({
 						'ad-slot--merchandising',
 					].join(' ')}
 					css={[
-						css`
-							position: relative;
-						`,
+						merchandisingAdStyles,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -18,6 +18,7 @@ type Props = {
 	position: AdSlotType;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
+	shouldReserveMerchSpace?: boolean;
 };
 
 export const labelHeight = 24;
@@ -76,6 +77,9 @@ export const adCollapseStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
+`;
+
+const merchandisingReservedSpace = css`
 	min-height: 250px;
 `;
 
@@ -209,6 +213,7 @@ export const AdSlot: React.FC<Props> = ({
 	display,
 	shouldHideReaderRevenue = false,
 	isPaidContent = false,
+	shouldReserveMerchSpace = false,
 }) => {
 	switch (position) {
 		case 'right':
@@ -346,6 +351,7 @@ export const AdSlot: React.FC<Props> = ({
 					].join(' ')}
 					css={[
 						merchandisingAdStyles,
+						shouldReserveMerchSpace && merchandisingReservedSpace,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}
@@ -366,6 +372,7 @@ export const AdSlot: React.FC<Props> = ({
 					].join(' ')}
 					css={[
 						merchandisingAdStyles,
+						shouldReserveMerchSpace && merchandisingReservedSpace,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -279,7 +279,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.switches.slotBodyEnd;
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -278,6 +278,9 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
 		CAPIArticle.config.switches.slotBodyEnd;
 
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
+
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
@@ -695,6 +698,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -780,7 +784,11 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot position="merchandising" display={format.display} />
+					<AdSlot
+						position="merchandising"
+						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
+					/>
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -175,15 +175,14 @@ interface Props {
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
 	const caption = [];
-	if (mainMedia && mainMedia.data && mainMedia.data.caption)
+	if (mainMedia?.data?.caption) {
 		caption.push(mainMedia.data.caption);
-	if (
-		mainMedia &&
-		mainMedia.displayCredit &&
-		mainMedia.data &&
-		mainMedia.data.credit
-	)
+	}
+
+	if (mainMedia?.displayCredit && mainMedia?.data?.credit) {
 		caption.push(mainMedia.data.credit);
+	}
+
 	return caption.join(' ');
 };
 
@@ -205,6 +204,9 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const showBodyEndSlot =
 		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
 		CAPIArticle.config.switches.slotBodyEnd;
+
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -506,6 +508,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -591,7 +594,11 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot position="merchandising" display={format.display} />
+					<AdSlot
+						position="merchandising"
+						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
+					/>
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -206,7 +206,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.switches.slotBodyEnd;
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -228,6 +228,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
+
 	return (
 		<>
 			{CAPIArticle.isLegacyInteractive && (
@@ -607,6 +610,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						data-print-layout="hide"
 						position="merchandising-high"
 						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -697,7 +701,11 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot position="merchandising" display={format.display} />
+					<AdSlot
+						position="merchandising"
+						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
+					/>
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -229,7 +229,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -304,6 +304,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.switches.automaticFilters &&
 		CAPIArticle.availableTopics;
 
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
+
 	/*
 	The topic bank on desktop will be positioned where we currently show the key events container.
 	This is dependent on a change made in PR #4896 [https://github.com/guardian/dotcom-rendering/pull/4896] where the key events container will be removed from the left column.
@@ -1229,6 +1232,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							data-print-layout="hide"
 							position="merchandising-high"
 							display={format.display}
+							shouldReserveMerchSpace={shouldReserveMerchSpace}
 						/>
 					</ElementContainer>
 
@@ -1327,6 +1331,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<AdSlot
 							position="merchandising"
 							display={format.display}
+							shouldReserveMerchSpace={shouldReserveMerchSpace}
 						/>
 					</ElementContainer>
 				</div>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -305,7 +305,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.availableTopics;
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	/*
 	The topic bank on desktop will be positioned where we currently show the key events container.

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -237,7 +237,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -236,6 +236,9 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
+
 	return (
 		<>
 			{format.theme !== ArticleSpecial.Labs ? (
@@ -650,6 +653,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -735,7 +739,11 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot position="merchandising" display={format.display} />
+					<AdSlot
+						position="merchandising"
+						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
+					/>
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -337,7 +337,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
 	const shouldReserveMerchSpace =
-		CAPIArticle.config.switches.merchandisingMinHeight;
+		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
 
 	return (
 		<>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -336,6 +336,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
+	const shouldReserveMerchSpace =
+		CAPIArticle.config.switches.merchandisingMinHeight;
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -782,6 +785,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						data-print-layout="hide"
 						position="merchandising-high"
 						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -872,7 +876,11 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot position="merchandising" display={format.display} />
+					<AdSlot
+						position="merchandising"
+						display={format.display}
+						shouldReserveMerchSpace={shouldReserveMerchSpace}
+					/>
 				</ElementContainer>
 			</main>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds a minimum height for the following ad slots: `merchandising` and `merchandising-high`. The functionality is hidden behind a server-side AB test.

[Frontend PR](https://github.com/guardian/frontend/pull/25321/files)

## Why?

The aim is to improve user experience (less page jumpiness) and to improve our CLS score.

## Screenshots

Before - see how the merchandising slot "jumps in"

https://user-images.githubusercontent.com/9574885/182183021-6ee3ed29-8361-436c-9c28-3d257348c823.mp4


After - 250px of space is reserved, so the "jumpiness" is reduced (network: fast 3G for illustration purposes)

https://user-images.githubusercontent.com/9574885/182185723-1d8d347e-244f-43ff-9226-f19a8e0d9511.mov


