### PR TITLE
Add an edition path parameter when serving locally

### DIFF
--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -2,6 +2,7 @@
 
 import 'source-map-support/register'; // activating the source map support
 import path from 'path';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { RelatedContent } from '@guardian/apps-rendering-api-models/relatedContent';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { Content } from '@guardian/content-api-models/v1/content';
@@ -311,6 +312,21 @@ async function serveEditionsArticlePost(
 	}
 }
 
+function getEdition(maybeEdition: string): Edition {
+	switch (maybeEdition) {
+		case 'uk':
+			return Edition.UK;
+		case 'us':
+			return Edition.US;
+		case 'au':
+			return Edition.AU;
+		case 'international':
+			return Edition.INTERNATIONAL;
+		default:
+			return Edition.UK;
+	}
+}
+
 async function serveArticleGet(
 	req: Request,
 	res: ExpressResponse,
@@ -319,6 +335,7 @@ async function serveArticleGet(
 		const articleId = req.params[0] || defaultId;
 		const isEditions = req.query.editions === '';
 		const capiContent = await askCapiFor(articleId);
+		const edition = getEdition(req.params.edition);
 
 		await either(
 			(errorStatus: number) => {
@@ -337,6 +354,7 @@ async function serveArticleGet(
 					commentCount: 30,
 					relatedContent,
 					footballContent: resultToNullable(footballContent),
+					edition,
 				};
 
 				const richLinkDetails = req.query.richlink === '';
@@ -401,7 +419,6 @@ app.get(
 	serveArticleGet,
 );
 app.get('/:edition(uk|us|au|international)/*', express.raw(), serveArticleGet);
-app.get('/*', (req, res) => res.redirect(`/uk${req.originalUrl}`));
 
 app.post('/article', express.raw(), serveArticlePost);
 

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -312,16 +312,15 @@ async function serveEditionsArticlePost(
 	}
 }
 
-function getEdition(maybeEdition: string): Edition {
-	switch (maybeEdition) {
-		case 'uk':
-			return Edition.UK;
+function editionFromString(editionString: string): Edition {
+	switch (editionString) {
 		case 'us':
 			return Edition.US;
 		case 'au':
 			return Edition.AU;
 		case 'international':
 			return Edition.INTERNATIONAL;
+		case 'uk':
 		default:
 			return Edition.UK;
 	}
@@ -335,7 +334,7 @@ async function serveArticleGet(
 		const articleId = req.params[0] || defaultId;
 		const isEditions = req.query.editions === '';
 		const capiContent = await askCapiFor(articleId);
-		const edition = getEdition(req.params.edition);
+		const edition = editionFromString(req.params.edition);
 
 		await either(
 			(errorStatus: number) => {

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -395,8 +395,13 @@ app.get('/healthcheck', (_req, res) => res.send('Ok'));
 app.get('/favicon.ico', (_, res) => res.status(404).end());
 app.get('/fontSize.css', (_, res) => res.status(404).end());
 
-app.get('/rendered-items/*', express.raw(), serveArticleGet);
-app.get('/*', express.raw(), serveArticleGet);
+app.get(
+	'/:edition(uk|us|au|international)/rendered-items/*',
+	express.raw(),
+	serveArticleGet,
+);
+app.get('/:edition(uk|us|au|international)/*', express.raw(), serveArticleGet);
+app.get('/*', (req, res) => res.redirect(`/uk${req.originalUrl}`));
 
 app.post('/article', express.raw(), serveArticlePost);
 

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -413,11 +413,11 @@ app.get('/favicon.ico', (_, res) => res.status(404).end());
 app.get('/fontSize.css', (_, res) => res.status(404).end());
 
 app.get(
-	'/:edition(uk|us|au|international)/rendered-items/*',
+	'/:edition(uk|us|au|international)?/rendered-items/*',
 	express.raw(),
 	serveArticleGet,
 );
-app.get('/:edition(uk|us|au|international)/*', express.raw(), serveArticleGet);
+app.get('/:edition(uk|us|au|international)?/*', express.raw(), serveArticleGet);
 
 app.post('/article', express.raw(), serveArticlePost);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Added an optional `edition` path parameter for the local server GET routes, and include it in the mock `RenderingRequest` model