### PR TITLE
Override commercial bundle URL with an environment variable

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -135,7 +135,9 @@ export const articleToHtml = ({ data }: Props): string => {
 			...getScriptArrayFromFile('bootCmp.js'),
 			...getScriptArrayFromFile('ophan.js'),
 			CAPIArticle.config && {
-				src: CAPIArticle.config.commercialBundleUrl,
+				src:
+					process.env.COMMERCIAL_BUNDLE_URL ??
+					CAPIArticle.config.commercialBundleUrl,
 			},
 			...getScriptArrayFromFile('sentryLoader.js'),
 			...getScriptArrayFromFile('dynamicImport.js'),

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -96,7 +96,11 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 			{ src: polyfillIO },
 			...getScriptArrayFromFile('bootCmp.js'),
 			...getScriptArrayFromFile('ophan.js'),
-			front.config && { src: front.config.commercialBundleUrl },
+			front.config && {
+				src:
+					process.env.COMMERCIAL_BUNDLE_URL ??
+					front.config.commercialBundleUrl,
+			},
 			...getScriptArrayFromFile('sentryLoader.js'),
 			...getScriptArrayFromFile('dynamicImport.js'),
 			...getScriptArrayFromFile('islands.js'),


### PR DESCRIPTION
## What does this change?

Add the ability to override the commercial bundle URL passed in the DCR data model with an environment variable - `COMMERCIAL_BUNDLE_URL`.

Currently this won't be actually used anywhere, but it'll be possible to invoke it via:

```bash
COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js make dev
```

This takes inspiration from the way [support-dotcom-components are developed locally against DCR](https://github.com/guardian/dotcom-rendering/blob/41ab963f48cbd61507c31f6bb614b2ae38329d60/dotcom-rendering/src/web/lib/contributions.ts#L245-L247).

## Why?

This is a step towards becoming more flexible when running our commercial code against various platforms. By allowing use of this environment variable, we can point DCR to use a commercial bundle being served locally, rather than via a local or prod Frontend.

The benefits include:
- Running our commercial code just against DCR and not Frontend. As more content is served by DCR, this will become increasingly useful.
- Running End-to-end tests in CI. By spinning up a production build of DCR and our commercial code, we could run our end-to-end tests in a Github action.
