### PR TITLE
A more flexible `onwards`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -599,7 +599,7 @@ interface CAPIArticleType {
 		trails: CAPITrailType[];
 		heading: string;
 	};
-	onwards: CAPIOnwardsType[];
+	onwards?: CAPIOnwardsType[];
 	beaconURL: string;
 	isCommentable: boolean;
 	commercialProperties: CommercialProperties;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -599,6 +599,7 @@ interface CAPIArticleType {
 		trails: CAPITrailType[];
 		heading: string;
 	};
+	onwards: CAPIOnwardsType[];
 	beaconURL: string;
 	isCommentable: boolean;
 	commercialProperties: CommercialProperties;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -515,7 +515,6 @@
         "main",
         "mainMediaElements",
         "nav",
-        "onwards",
         "openGraphData",
         "pageFooter",
         "pageId",

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -339,6 +339,61 @@
                 "trails"
             ]
         },
+        "onwards": {
+            "type": "array",
+            "items": {
+                "description": "Onwards",
+                "type": "object",
+                "properties": {
+                    "heading": {
+                        "type": "string"
+                    },
+                    "trails": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/CAPITrailType"
+                        }
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "onwardsType": {
+                        "$ref": "#/definitions/OnwardsType"
+                    },
+                    "format": {
+                        "type": "object",
+                        "properties": {
+                            "design": {
+                                "$ref": "#/definitions/CAPIDesign"
+                            },
+                            "theme": {
+                                "$ref": "#/definitions/CAPITheme"
+                            },
+                            "display": {
+                                "$ref": "#/definitions/CAPIDisplay"
+                            }
+                        },
+                        "required": [
+                            "design",
+                            "display",
+                            "theme"
+                        ]
+                    },
+                    "isCuratedContent": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "format",
+                    "heading",
+                    "onwardsType",
+                    "trails"
+                ]
+            }
+        },
         "beaconURL": {
             "type": "string"
         },
@@ -460,6 +515,7 @@
         "main",
         "mainMediaElements",
         "nav",
+        "onwards",
         "openGraphData",
         "pageFooter",
         "pageId",
@@ -4167,6 +4223,19 @@
                 "logo",
                 "sponsorName"
             ]
+        },
+        "OnwardsType": {
+            "enum": [
+                "curated-content",
+                "default-onwards",
+                "more-galleries",
+                "more-media-in-section",
+                "more-on-this-story",
+                "related-content",
+                "related-stories",
+                "series"
+            ],
+            "type": "string"
         },
         "CommercialProperties": {
             "type": "object",

--- a/dotcom-rendering/src/web/components/DecideOnwards.tsx
+++ b/dotcom-rendering/src/web/components/DecideOnwards.tsx
@@ -1,0 +1,53 @@
+import { decideTrail } from '../lib/decideTrail';
+import { Carousel } from './Carousel.importable';
+import { ElementContainer } from './ElementContainer';
+import { FetchOnwardsData } from './FetchOnwardsData.importable';
+import { Island } from './Island';
+
+export const DecideOnwards = ({
+	onwards,
+	format,
+}: {
+	onwards: CAPIOnwardsType[];
+	format: ArticleFormat;
+}) => (
+	<>
+		{onwards.map(({ heading, trails, onwardsType, url }) => {
+			if (trails.length > 0) {
+				return (
+					<ElementContainer key={onwardsType}>
+						<Island deferUntil="visible">
+							<Carousel
+								heading={heading}
+								trails={trails.map(decideTrail)}
+								onwardsType={onwardsType}
+								format={format}
+							/>
+						</Island>
+					</ElementContainer>
+				);
+			}
+
+			if (url) {
+				return (
+					<ElementContainer key={onwardsType}>
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<FetchOnwardsData
+								url={url}
+								limit={8}
+								onwardsType={onwardsType}
+								format={format}
+							/>
+						</Island>
+					</ElementContainer>
+				);
+			}
+
+			return null;
+		})}
+	</>
+);

--- a/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
@@ -24,7 +24,12 @@ const minHeight = css`
 	min-height: 300px;
 `;
 
-export const OnwardsData = ({ url, limit, onwardsType, format }: Props) => {
+export const FetchOnwardsData = ({
+	url,
+	limit,
+	onwardsType,
+	format,
+}: Props) => {
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
 
 	const buildTrails = (

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
 import { joinUrl } from '../../lib/joinUrl';
 import { ElementContainer } from './ElementContainer';
-import { OnwardsData } from './OnwardsData';
+import { FetchOnwardsData } from './FetchOnwardsData.importable';
 
 type PillarForContainer =
 	| 'headlines'
@@ -270,7 +270,7 @@ export const OnwardsUpper = ({
 		<div css={onwardsWrapper}>
 			{!!url && (
 				<ElementContainer>
-					<OnwardsData
+					<FetchOnwardsData
 						url={url}
 						limit={8}
 						onwardsType={onwardsType}
@@ -280,7 +280,7 @@ export const OnwardsUpper = ({
 			)}
 			{!!(!isPaidContent && curatedDataUrl) && (
 				<ElementContainer showTopBorder={true}>
-					<OnwardsData
+					<FetchOnwardsData
 						url={curatedDataUrl}
 						limit={20}
 						onwardsType="curated-content"

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -22,6 +22,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { ContributorAvatar } from '../components/ContributorAvatar';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -698,47 +699,58 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					/>
 				</ElementContainer>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="aside">

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -22,6 +22,7 @@ import { Border } from '../components/Border';
 import { Caption } from '../components/Caption';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -509,47 +510,58 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					/>
 				</ElementContainer>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="aside">

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -25,6 +25,7 @@ import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { ContainerLayout } from '../components/ContainerLayout';
 import { DecideLines } from '../components/DecideLines';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -610,47 +611,58 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					/>
 				</ElementContainer>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 
 				{!isPaidContent && showComments && (
 					<ElementContainer

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -28,6 +28,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Carousel } from '../components/Carousel.importable';
 import { ContainerLayout } from '../components/ContainerLayout';
 import { DecideLines } from '../components/DecideLines';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { FilterKeyEventsToggle } from '../components/FilterKeyEventsToggle.importable';
@@ -1232,47 +1233,61 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						/>
 					</ElementContainer>
 
-					{CAPIArticle.storyPackage && (
-						<ElementContainer>
-							<Island deferUntil="visible">
-								<Carousel
-									heading={CAPIArticle.storyPackage.heading}
-									trails={CAPIArticle.storyPackage.trails.map(
-										decideTrail,
-									)}
-									onwardsType="more-on-this-story"
+					{CAPIArticle.onwards ? (
+						<DecideOnwards
+							onwards={CAPIArticle.onwards}
+							format={format}
+						/>
+					) : (
+						<>
+							{CAPIArticle.storyPackage && (
+								<ElementContainer>
+									<Island deferUntil="visible">
+										<Carousel
+											heading={
+												CAPIArticle.storyPackage.heading
+											}
+											trails={CAPIArticle.storyPackage.trails.map(
+												decideTrail,
+											)}
+											onwardsType="more-on-this-story"
+											format={format}
+										/>
+									</Island>
+								</ElementContainer>
+							)}
+
+							<Island
+								clientOnly={true}
+								deferUntil="visible"
+								placeholderHeight={600}
+							>
+								<OnwardsUpper
+									ajaxUrl={CAPIArticle.config.ajaxUrl}
+									hasRelated={CAPIArticle.hasRelated}
+									hasStoryPackage={
+										CAPIArticle.hasStoryPackage
+									}
+									isAdFreeUser={CAPIArticle.isAdFreeUser}
+									pageId={CAPIArticle.pageId}
+									isPaidContent={
+										CAPIArticle.config.isPaidContent ||
+										false
+									}
+									showRelatedContent={
+										CAPIArticle.config.showRelatedContent
+									}
+									keywordIds={CAPIArticle.config.keywordIds}
+									contentType={CAPIArticle.contentType}
+									tags={CAPIArticle.tags}
 									format={format}
+									pillar={format.theme}
+									editionId={CAPIArticle.editionId}
+									shortUrlId={CAPIArticle.config.shortUrlId}
 								/>
 							</Island>
-						</ElementContainer>
+						</>
 					)}
-
-					<Island
-						clientOnly={true}
-						deferUntil="visible"
-						placeholderHeight={600}
-					>
-						<OnwardsUpper
-							ajaxUrl={CAPIArticle.config.ajaxUrl}
-							hasRelated={CAPIArticle.hasRelated}
-							hasStoryPackage={CAPIArticle.hasStoryPackage}
-							isAdFreeUser={CAPIArticle.isAdFreeUser}
-							pageId={CAPIArticle.pageId}
-							isPaidContent={
-								CAPIArticle.config.isPaidContent || false
-							}
-							showRelatedContent={
-								CAPIArticle.config.showRelatedContent
-							}
-							keywordIds={CAPIArticle.config.keywordIds}
-							contentType={CAPIArticle.contentType}
-							tags={CAPIArticle.tags}
-							format={format}
-							pillar={format.theme}
-							editionId={CAPIArticle.editionId}
-							shortUrlId={CAPIArticle.config.shortUrlId}
-						/>
-					</Island>
 
 					{!isPaidContent && CAPIArticle.isCommentable && (
 						<ElementContainer

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -25,6 +25,7 @@ import { ArticleBody } from '../components/ArticleBody';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { Carousel } from '../components/Carousel.importable';
 import { ContainerLayout } from '../components/ContainerLayout';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
@@ -448,47 +449,58 @@ export const NewsletterSignupLayout = ({
 					</Columns>
 				</ContainerLayout>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="idle"
-					placeholderHeight={304}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 			</main>
 
 			<ElementContainer

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -23,6 +23,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -653,47 +654,58 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					/>
 				</ElementContainer>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 
 				{!isPaidContent && showComments && (
 					<ElementContainer sectionId="comments" element="section">

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -24,6 +24,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
+import { DecideOnwards } from '../components/DecideOnwards';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -785,47 +786,58 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					/>
 				</ElementContainer>
 
-				{CAPIArticle.storyPackage && (
-					<ElementContainer>
-						<Island deferUntil="visible">
-							<Carousel
-								heading={CAPIArticle.storyPackage.heading}
-								trails={CAPIArticle.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsType="more-on-this-story"
+				{CAPIArticle.onwards ? (
+					<DecideOnwards
+						onwards={CAPIArticle.onwards}
+						format={format}
+					/>
+				) : (
+					<>
+						{CAPIArticle.storyPackage && (
+							<ElementContainer>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={
+											CAPIArticle.storyPackage.heading
+										}
+										trails={CAPIArticle.storyPackage.trails.map(
+											decideTrail,
+										)}
+										onwardsType="more-on-this-story"
+										format={format}
+									/>
+								</Island>
+							</ElementContainer>
+						)}
+
+						<Island
+							clientOnly={true}
+							deferUntil="visible"
+							placeholderHeight={600}
+						>
+							<OnwardsUpper
+								ajaxUrl={CAPIArticle.config.ajaxUrl}
+								hasRelated={CAPIArticle.hasRelated}
+								hasStoryPackage={CAPIArticle.hasStoryPackage}
+								isAdFreeUser={CAPIArticle.isAdFreeUser}
+								pageId={CAPIArticle.pageId}
+								isPaidContent={
+									CAPIArticle.config.isPaidContent || false
+								}
+								showRelatedContent={
+									CAPIArticle.config.showRelatedContent
+								}
+								keywordIds={CAPIArticle.config.keywordIds}
+								contentType={CAPIArticle.contentType}
+								tags={CAPIArticle.tags}
 								format={format}
+								pillar={format.theme}
+								editionId={CAPIArticle.editionId}
+								shortUrlId={CAPIArticle.config.shortUrlId}
 							/>
 						</Island>
-					</ElementContainer>
+					</>
 				)}
-
-				<Island
-					clientOnly={true}
-					deferUntil="visible"
-					placeholderHeight={600}
-				>
-					<OnwardsUpper
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						hasRelated={CAPIArticle.hasRelated}
-						hasStoryPackage={CAPIArticle.hasStoryPackage}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						pageId={CAPIArticle.pageId}
-						isPaidContent={
-							CAPIArticle.config.isPaidContent || false
-						}
-						showRelatedContent={
-							CAPIArticle.config.showRelatedContent
-						}
-						keywordIds={CAPIArticle.config.keywordIds}
-						contentType={CAPIArticle.contentType}
-						tags={CAPIArticle.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={CAPIArticle.editionId}
-						shortUrlId={CAPIArticle.config.shortUrlId}
-					/>
-				</Island>
 
 				{!isPaidContent && showComments && (
 					<ElementContainer


### PR DESCRIPTION
## What does this change?
Closes https://github.com/guardian/dotcom-rendering/issues/5571

This PR adds a new property to the article model, `onwards: CAPIOnwardsType[];`

```ts
type CAPIOnwardsType = {
	heading: string;
	trails: CAPITrailType[];
	description?: string;
	url?: string;
	onwardsType: OnwardsType;
	format: CAPIFormat;
};
```

It also adds a new abstraction `Onwards` which accepts this new property and decides how to render the content.

Frontend can now send an array of different styles of onwards data and, if it is present, DCR will dynamically render it based on what's sent. If it isn't sent DCR will default to the old (current) method for onwards content.

Where this new array of onwards data is provided, there are two possible outcomes for each item in the array:

### Server render the trails
If `trails` is a non zero length array of trail objects then `Onwards` will server render these items and then hydrate the `Carousel` on the client

### Fetch the onwards data
If the `trails` array contains no data and a `url` property is provided, then `Onwards` will setup the browser to make an api call to fetch the data and render it from there

### When will the old method be removed?
Once [this ticket](https://github.com/guardian/dotcom-rendering/issues/5566) is complete we will be able to remove the old `OnwardsUpper` component and associated logic and all onwards data can be sent via this new property.