### PR TITLE
Reduce Percy snapshot breakpoints to stay under monthly limit

### DIFF
--- a/dotcom-rendering/cypress/snapshot/standard-layout.e2e.cy.js
+++ b/dotcom-rendering/cypress/snapshot/standard-layout.e2e.cy.js
@@ -18,7 +18,8 @@ describe('Visual regression', function () {
 
 		cy.percySnapshot('Standard Layout', {
 			// TODO decide on the subset of breakpoints we wish to snapshot
-			widths: Object.values(breakpoints),
+			// widths: Object.values(breakpoints),
+			widths: [breakpoints.wide],
 		});
 	});
 });


### PR DESCRIPTION
## What does this change?

We are currently taking snapshots for every breakpoint and browser (Chrome, Firefox, Edge & Safari).

This change reduces snapshot breakpoints to just one breakpoint.

I've also configured the dotcom-rendering project in percy.io to only snapshot for Chrome.

## Why?

<img width="406" alt="Screenshot 2022-08-02 at 15 24 49" src="https://user-images.githubusercontent.com/7014230/182399268-97b44dc5-597a-4adc-8368-c90112edc18b.png">

We have exceeded our monthly limit of snapshots under our current plan.

This is currently blocking commercial from running visual tests as our plan falls under the same organisation.

Until we are using Percy for real we can limit the snapshots without any impact.

I will follow up with Browserstack about our current plan.

