### PR TITLE
Refactor `extract-nav`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -4,6 +4,7 @@
 
 type DCRSnapType = import('./src/types/front').DCRSnapType;
 type DCRSupportingContent = import('./src/types/front').DCRSupportingContent;
+type NavType = import('./src/model/extract-nav').NavType;
 
 // Pillars are used for styling
 // RealPillars have pillar palette colours
@@ -73,7 +74,6 @@ type ArticleDisplay = import('@guardian/libs').ArticleDisplay;
 type ArticleDesign = import('@guardian/libs').ArticleDesign;
 type ArticleTheme = import('@guardian/libs').ArticleTheme;
 type ArticleFormat = import('@guardian/libs').ArticleFormat;
-type ArticlePillar = ArticleTheme;
 
 // This is an object that allows you Type defaults of the designTypes.
 // The return type looks like: { Feature: any, Live: any, ...}
@@ -265,10 +265,6 @@ type SharePlatform =
 	| 'messenger';
 
 // shared type declarations
-interface SimpleLinkType {
-	url: string;
-	title: string;
-}
 
 interface AdTargetParam {
 	name: string;
@@ -318,22 +314,6 @@ interface Branding {
 	logoForDarkBackground?: BrandingLogo;
 }
 
-interface LinkType extends SimpleLinkType {
-	longTitle: string;
-	children?: LinkType[];
-	mobileOnly?: boolean;
-	pillar?: ArticlePillar;
-	more?: boolean;
-}
-
-interface PillarType extends LinkType {
-	pillar: ArticlePillar;
-}
-
-interface MoreType extends LinkType {
-	more: true;
-}
-
 interface ReaderRevenueCategories {
 	contribute: string;
 	subscribe: string;
@@ -351,42 +331,7 @@ interface ReaderRevenuePositions {
 	ampFooter: ReaderRevenueCategories;
 }
 
-type ReaderRevenuePosition =
-	| 'header'
-	| 'footer'
-	| 'sideMenu'
-	| 'ampHeader'
-	| 'ampFooter';
-
-interface BaseNavType {
-	otherLinks: MoreType;
-	brandExtensions: LinkType[];
-	currentNavLink: string;
-	subNavSections?: SubNavType;
-	readerRevenueLinks: ReaderRevenuePositions;
-}
-
-// TODO rename
-interface SimpleNavType {
-	pillars: PillarType[];
-	otherLinks: MoreType;
-	brandExtensions: LinkType[];
-	readerRevenueLinks: ReaderRevenuePositions;
-}
-
-interface NavType extends BaseNavType {
-	pillars: PillarType[];
-}
-
-interface SubNavBrowserType {
-	currentNavLink: string;
-	subNavSections?: SubNavType;
-}
-
-interface SubNavType {
-	parent?: LinkType;
-	links: LinkType[];
-}
+type ReaderRevenuePosition = keyof ReaderRevenuePositions;
 
 interface MembershipPlaceholder {
 	campaignCode?: string;
@@ -576,8 +521,8 @@ interface CAPIArticleType {
 	sectionLabel: string;
 	sectionUrl: string;
 	sectionName?: string;
-	subMetaSectionLinks: SimpleLinkType[];
-	subMetaKeywordLinks: SimpleLinkType[];
+	subMetaSectionLinks: CAPILinkType[];
+	subMetaKeywordLinks: CAPILinkType[];
 	shouldHideAds: boolean;
 	isAdFreeUser: boolean;
 	openGraphData: { [key: string]: string };

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -59,7 +59,7 @@ const decideBackground = (design: Design, pillar: ArticleTheme): string => {
 	}
 };
 
-const body = (pillar: ArticlePillar, design: Design) => {
+const body = (pillar: ArticleTheme, design: Design) => {
 	return css`
 		background-color: ${decideBackground(design, pillar)};
 		${bulletStyle(pillar)}

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -23,7 +23,7 @@ import { Expandable } from './Expandable';
 
 export const Elements = (
 	elements: CAPIElement[],
-	pillar: ArticlePillar,
+	pillar: ArticleTheme,
 	isImmersive: boolean,
 	adTargeting?: AdTargeting,
 	// eslint-disable-next-line @typescript-eslint/ban-types -- the type signature is helpful

--- a/dotcom-rendering/src/amp/components/Header.tsx
+++ b/dotcom-rendering/src/amp/components/Header.tsx
@@ -12,6 +12,7 @@ import {
 import { SvgGuardianBestWebsiteLogo } from '@guardian/source-react-components';
 import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../lib/pillars';
+import type { PillarType } from '../../model/extract-nav';
 import { ReaderRevenueButton } from './ReaderRevenueButton';
 
 const headerStyles = css`

--- a/dotcom-rendering/src/amp/components/MainMedia.tsx
+++ b/dotcom-rendering/src/amp/components/MainMedia.tsx
@@ -130,7 +130,7 @@ const expanded = css`
 
 const asComponent = (
 	element: CAPIElement,
-	pillar: ArticlePillar,
+	pillar: ArticleTheme,
 	adTargeting?: any,
 ) => {
 	switch (element._type) {

--- a/dotcom-rendering/src/amp/components/SubMeta.tsx
+++ b/dotcom-rendering/src/amp/components/SubMeta.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { body, neutral, text, textSans } from '@guardian/source-foundations';
 import React from 'react';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../lib/pillars';
+import type { BaseLinkType } from '../../model/extract-nav';
 import CommentIcon from '../../static/icons/comment.svg';
 import { ShareIcons } from './ShareIcons';
 
@@ -109,8 +110,8 @@ const shareIcons = css`
 
 export const SubMeta: React.FC<{
 	pillar: ArticleTheme;
-	sections: SimpleLinkType[];
-	keywords: SimpleLinkType[];
+	sections: BaseLinkType[];
+	keywords: BaseLinkType[];
 	sharingURLs: {
 		[K in SharePlatform]?: {
 			url: string;

--- a/dotcom-rendering/src/amp/server/index.tsx
+++ b/dotcom-rendering/src/amp/server/index.tsx
@@ -3,7 +3,7 @@ import { Standard as ExampleArticle } from '../../../fixtures/generated/articles
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
 import { findBySubsection } from '../../model/article-sections';
 import { extractNAV } from '../../model/extract-nav';
-import { validateAsCAPIType as validateV2 } from '../../model/validate';
+import { validateAsCAPIType } from '../../model/validate';
 import type { AnalyticsModel } from '../components/Analytics';
 import { generatePermutivePayload } from '../lib/permutive';
 import { extractScripts } from '../lib/scripts';
@@ -13,14 +13,10 @@ import { document } from './document';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
 	try {
-		// TODO remove when migrated to v2
-		const CAPIArticle = validateV2(body);
+		const CAPIArticle = validateAsCAPIType(body);
 		const { linkedData } = CAPIArticle;
 		const { config } = CAPIArticle;
-		const blockElements = CAPIArticle.blocks.map((block) => block.elements);
-
-		// This is simply to flatten the elements
-		const elements = ([] as CAPIElement[]).concat(...blockElements);
+		const elements = CAPIArticle.blocks.flatMap((block) => block.elements);
 
 		const scripts = [
 			...extractScripts(elements, CAPIArticle.mainMediaElements),

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -24,8 +24,8 @@ export interface ArticleModel {
 	sectionUrl?: string;
 	sectionName?: string;
 	tags: TagType[];
-	subMetaSectionLinks: SimpleLinkType[];
-	subMetaKeywordLinks: SimpleLinkType[];
+	subMetaSectionLinks: CAPILinkType[];
+	subMetaKeywordLinks: CAPILinkType[];
 	webURL: string;
 	shouldHideAds: boolean;
 	shouldHideReaderRevenue: boolean;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -260,13 +260,13 @@
         "subMetaSectionLinks": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/SimpleLinkType"
+                "$ref": "#/definitions/CAPILinkType"
             }
         },
         "subMetaKeywordLinks": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/SimpleLinkType"
+                "$ref": "#/definitions/CAPILinkType"
             }
         },
         "shouldHideAds": {
@@ -3754,7 +3754,7 @@
             ],
             "type": "string"
         },
-        "SimpleLinkType": {
+        "CAPILinkType": {
             "type": "object",
             "properties": {
                 "url": {
@@ -3762,6 +3762,30 @@
                 },
                 "title": {
                     "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [
@@ -4308,45 +4332,6 @@
                 "otherLinks",
                 "pillars",
                 "readerRevenueLinks"
-            ]
-        },
-        "CAPILinkType": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "longTitle": {
-                    "type": "string"
-                },
-                "iconName": {
-                    "type": "string"
-                },
-                "children": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/CAPILinkType"
-                    }
-                },
-                "pillar": {
-                    "$ref": "#/definitions/LegacyPillar"
-                },
-                "more": {
-                    "type": "boolean"
-                },
-                "classList": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": [
-                "title",
-                "url"
             ]
         },
         "ReaderRevenuePositions": {

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -17,6 +17,7 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import { clearFix } from '../../lib/mixins';
+import type { PillarType } from '../../model/extract-nav';
 import { BackToTop } from './BackToTop';
 import { Island } from './Island';
 import { Pillars } from './Pillars';

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -8,6 +8,7 @@ import {
 	until,
 	visuallyHidden,
 } from '@guardian/source-foundations';
+import type { PillarType } from '../../../../model/extract-nav';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
 // CSS

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -7,6 +7,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import type { LinkType } from '../../../../model/extract-nav';
 import FacebookIcon from '../../../../static/icons/facebook.svg';
 import TwitterIconPadded from '../../../../static/icons/twitter-padded.svg';
 

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -5,6 +5,7 @@ import {
 	from,
 	textSans,
 } from '@guardian/source-foundations';
+import type { LinkType } from '../../../../model/extract-nav';
 
 export const hideDesktop = css`
 	${from.desktop} {

--- a/dotcom-rendering/src/web/components/Pillars.tsx
+++ b/dotcom-rendering/src/web/components/Pillars.tsx
@@ -8,6 +8,7 @@ import {
 	headline,
 	until,
 } from '@guardian/source-foundations';
+import type { PillarType } from '../../model/extract-nav';
 import { decidePalette } from '../lib/decidePalette';
 import { navInputCheckboxId } from './Nav/config';
 

--- a/dotcom-rendering/src/web/components/SubMeta.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.tsx
@@ -8,6 +8,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { LinkButton } from '@guardian/source-react-components';
+import type { BaseLinkType } from '../../model/extract-nav';
 import { decidePalette } from '../lib/decidePalette';
 import { Badge } from './Badge';
 import { ShareIcons } from './ShareIcons';
@@ -121,8 +122,8 @@ const hideSlash = css`
 
 type Props = {
 	format: ArticleFormat;
-	subMetaSectionLinks: SimpleLinkType[];
-	subMetaKeywordLinks: SimpleLinkType[];
+	subMetaSectionLinks: BaseLinkType[];
+	subMetaKeywordLinks: BaseLinkType[];
 	pageId: string;
 	webUrl: string;
 	webTitle: string;

--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -7,6 +7,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { useEffect, useRef, useState } from 'react';
+import type { SubNavType } from '../../model/extract-nav';
 import { decidePalette } from '../lib/decidePalette';
 
 type Props = {


### PR DESCRIPTION
## What does this change?

Stop parsing the data in `extract-nav`, and instead introduce type signatures on the expected data.

Consolidate Nav-related types in `extract-nav.ts` and update type imports accordingly.

Decouple `SimpleLinkType` and `CAPILinkType` for data pre- and post-transform.

## Why?

We are already parsing/validating the data upstream, so let’s trust the compiler.

A partial clean-up was done in #663 after we moved to v2 of AJV.

Reduce the surface are for bugs. Remove a few `any` and the useless `ObjectType`.