### PR TITLE
Fix Editions Paragraph Dark Mode

### DIFF
--- a/apps-rendering/src/components/Blockquote/Blockquote.stories.tsx
+++ b/apps-rendering/src/components/Blockquote/Blockquote.stories.tsx
@@ -11,7 +11,7 @@ const standard = {
 
 const Default: FC = () => (
 	<Blockquote format={standard}>
-		<Paragraph format={standard} showDropCap={false}>
+		<Paragraph format={standard} showDropCap={false} isEditions={false}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eu
 			nunc dolor. Suspendisse vestibulum non turpis eget porta. Duis
 			pretium est pretium tellus facilisis, eget tempor nibh condimentum.
@@ -19,12 +19,12 @@ const Default: FC = () => (
 			felis nunc. Phasellus a dui tellus. Suspendisse vel tellus porta,
 			tincidunt massa id, tincidunt erat.
 		</Paragraph>
-		<Paragraph format={standard} showDropCap={false}>
+		<Paragraph format={standard} showDropCap={false} isEditions={false}>
 			Donec congue rutrum justo. Mauris condimentum tellus sit amet purus
 			euismod, ac eleifend tortor tempor. Maecenas tristique auctor est,
 			vitae hendrerit dolor elementum non.
 		</Paragraph>
-		<Paragraph format={standard} showDropCap={false}>
+		<Paragraph format={standard} showDropCap={false} isEditions={false}>
 			Pellentesque porttitor finibus interdum. Etiam hendrerit purus quis
 			risus auctor porttitor quis ut nibh. Sed dictum ex non diam
 			vestibulum aliquet. Ut vel enim at diam suscipit sodales eu sed leo.

--- a/apps-rendering/src/components/Paragraph/Paragraph.stories.tsx
+++ b/apps-rendering/src/components/Paragraph/Paragraph.stories.tsx
@@ -24,7 +24,7 @@ const labs = {
 };
 
 const Default: FC = () => (
-	<Paragraph format={standard} showDropCap={false}>
+	<Paragraph format={standard} showDropCap={false} isEditions={false}>
 		Ever since Mexico City was founded on an island in the lake of Texcoco
 		its inhabitants have dreamed of water: containing it, draining it and
 		now retaining it.
@@ -32,7 +32,7 @@ const Default: FC = () => (
 );
 
 const Labs: FC = () => (
-	<Paragraph format={labs} showDropCap={false}>
+	<Paragraph format={labs} showDropCap={false} isEditions={false}>
 		Ever since Mexico City was founded on an island in the lake of Texcoco
 		its inhabitants have dreamed of water: containing it, draining it and
 		now retaining it.

--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -20,6 +20,7 @@ interface Props {
 	children?: ReactNode;
 	format: ArticleFormat;
 	showDropCap: boolean;
+	isEditions: boolean;
 }
 
 const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
@@ -40,6 +41,7 @@ const dropCapWeight = (format: ArticleFormat): SerializedStyles => {
 const styles = (
 	format: ArticleFormat,
 	showDropCap: boolean,
+	isEditions: boolean,
 ): SerializedStyles => {
 	const labs =
 		format.theme === ArticleSpecial.Labs ? textSans.medium() : null;
@@ -82,7 +84,7 @@ const styles = (
 		margin: 0 0 ${remSpace[3]};
 		color: ${text.paragraph(format)};
 
-		${darkModeCss`
+		${isEditions ? null : darkModeCss`
 			color: ${text.paragraphDark(format)};
 		`}
 		${dropCap}
@@ -90,8 +92,8 @@ const styles = (
 	`;
 };
 
-const Paragraph: FC<Props> = ({ children, format, showDropCap }: Props) => (
-	<p css={styles(format, showDropCap)}>{children}</p>
+const Paragraph: FC<Props> = ({ children, format, showDropCap, isEditions }: Props) => (
+	<p css={styles(format, showDropCap, isEditions)}>{children}</p>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -84,7 +84,9 @@ const styles = (
 		margin: 0 0 ${remSpace[3]};
 		color: ${text.paragraph(format)};
 
-		${isEditions ? null : darkModeCss`
+		${isEditions
+			? null
+			: darkModeCss`
 			color: ${text.paragraphDark(format)};
 		`}
 		${dropCap}
@@ -92,9 +94,12 @@ const styles = (
 	`;
 };
 
-const Paragraph: FC<Props> = ({ children, format, showDropCap, isEditions }: Props) => (
-	<p css={styles(format, showDropCap, isEditions)}>{children}</p>
-);
+const Paragraph: FC<Props> = ({
+	children,
+	format,
+	showDropCap,
+	isEditions,
+}: Props) => <p css={styles(format, showDropCap, isEditions)}>{children}</p>;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -265,7 +265,7 @@ const textElement =
 		switch (node.nodeName) {
 			case 'P': {
 				const showDropCap = shouldShowDropCap(text, format, isEditions);
-				return h(Paragraph, { key, format, showDropCap }, children);
+				return h(Paragraph, { key, format, showDropCap, isEditions }, children);
 			}
 			case '#text':
 				return transform(text, format);

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -265,7 +265,11 @@ const textElement =
 		switch (node.nodeName) {
 			case 'P': {
 				const showDropCap = shouldShowDropCap(text, format, isEditions);
-				return h(Paragraph, { key, format, showDropCap, isEditions }, children);
+				return h(
+					Paragraph,
+					{ key, format, showDropCap, isEditions },
+					children,
+				);
 			}
 			case '#text':
 				return transform(text, format);


### PR DESCRIPTION
## Why?

A change in #5537 accidentally added dark mode styles to Editions paragraphs. This opts Editions out of these styles using the `isEditions` flag.

## Changes

- Added `isEditions` prop to `Paragraph`
- Updated stories

## Screenshots

To follow.

