### PR TITLE
Remove fixed font size for richLinkTitle css

### DIFF
--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -86,7 +86,6 @@ const richLinkHeader = css`
 
 const richLinkTitle = css`
 	${headline.xxxsmall()};
-	font-size: 14px;
 	padding-top: 1px;
 	padding-bottom: 1px;
 	font-weight: 400;


### PR DESCRIPTION
It was overriding the headline.xxxsmall() value which is 17px and looks better in below desktop breakpoints.

Test to see Chromatic diffs

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
