### PR TITLE
AR - replace hv by rem to make it work in android

### DIFF
--- a/apps-rendering/src/components/PinnedPost/index.tsx
+++ b/apps-rendering/src/components/PinnedPost/index.tsx
@@ -134,7 +134,7 @@ const fakeButtonStyles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const collapsibleBody = css`
-	max-height: 40vh;
+	max-height: 22.4rem;
 	overflow: hidden;
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR replaces the `40vh` by `22.4rem` for the pinned post collapsible body `max-height` because the `vh` wasn't working properly in android web view. 

## Why?
Making it work in Android devices

## Screenshots
Android:
| Before      | After      |
|-------------|------------|
| <img width="275" alt="image" src="https://user-images.githubusercontent.com/15894063/182628755-cfc75422-a4de-4f03-b162-0644e7e10809.png"> | <img width="275" alt="image" src="https://user-images.githubusercontent.com/15894063/182628820-4c5731cd-b73b-4292-87ea-7b0f47e8ddc8.png"> |

IOS (**Unchanged**):
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/182631197-fce431aa-ece9-48b3-be70-62e592b6b5bf.png) | ![image](https://user-images.githubusercontent.com/15894063/182631277-1a53eb1f-8f9e-4751-bc28-50a63c0129b7.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
