### PR TITLE
Show more trail text in `DynamicFast`

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -458,6 +458,7 @@ export const DynamicFast = ({
 									showAge={showAge}
 									supportingContent={card.supportingContent}
 									headlineSize="large"
+									trailText={card.trailText}
 									imageUrl={card.image}
 									imagePosition="top"
 									imagePositionOnMobile="top"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Big cards in the the dynamic-fast container should show trail text

| Before      | After      |
|-------------|------------|
| <img width="1026" alt="Screenshot 2022-08-03 at 15 29 43" src="https://user-images.githubusercontent.com/1336821/182634141-4c3f5230-e383-4ff0-b6ad-3971a8b80b3e.png"> | <img width="1026" alt="Screenshot 2022-08-03 at 15 29 08" src="https://user-images.githubusercontent.com/1336821/182634008-2c9f14eb-894f-4d0e-8e3a-151d54ec4df0.png"> |
