### PR TITLE
Remove StarRating from default Headline

### DIFF
--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -7,7 +7,6 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from, headline, remSpace } from '@guardian/source-foundations';
-import StarRating from 'components/StarRating';
 import type { Item } from 'item';
 import { articleWidthStyles, darkModeCss } from 'styles';
 
@@ -53,6 +52,5 @@ interface DefaultProps {
 export const DefaultHeadline: React.FC<DefaultProps> = ({ item, styles }) => (
 	<h1 css={styles}>
 		<span>{item.headline}</span>
-		<StarRating item={item} />
 	</h1>
 );

--- a/apps-rendering/src/components/Headline/ReviewHeadline.tsx
+++ b/apps-rendering/src/components/Headline/ReviewHeadline.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import { from, headline } from '@guardian/source-foundations';
+import StarRating from 'components/StarRating';
 import type { Item } from 'item';
-import { DefaultHeadline, defaultStyles } from './Headline.defaults';
+import { defaultStyles } from './Headline.defaults';
 
 const reviewStyles = css`
 	${headline.small({ fontWeight: 'bold' })}
@@ -16,10 +17,10 @@ interface Props {
 }
 
 const ReviewHeadline: React.FC<Props> = ({ item }) => (
-	<DefaultHeadline
-		item={item}
-		styles={css(defaultStyles(item), reviewStyles)}
-	/>
+	<h1 css={css(defaultStyles(item), reviewStyles)}>
+		<span>{item.headline}</span>
+		<StarRating item={item} />
+	</h1>
 );
 
 export default ReviewHeadline;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Removes `StarRating` from the default `Headline`
- adds `StarRating` to `ReviewHeadline`

## Why?

- `StarRating` is not used on the default `Headline`
