### PR TITLE
[WIP] feat: add secondary promoted newsletter section

### DIFF
--- a/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.stories.tsx
+++ b/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.stories.tsx
@@ -1,0 +1,27 @@
+import { SecondaryPromotedNewsletter } from './SecondaryPromotedNewsletter';
+
+export default {
+	component: SecondaryPromotedNewsletter,
+	title: 'Components/Newsletters/SecondaryPromotedNewsletter',
+};
+
+const altPromotedNewsletter = {
+	name: 'Pushing Buttons',
+	description:
+		'Start the day one step ahead. Our email breaks down the key stories of the day and why they matter.',
+	frequency: 'Weekly',
+	mainMedia:
+		'https://i.guim.co.uk/img/uploads/2022/01/11/pushing_buttons_thrasher_hi.png?width=700&quality=50&s=f4be90f0ca470076df70cf895aeecda1',
+	signupPage: 'https://www.google.com',
+	listId: 1234,
+	identityName: 'Pushing buttons',
+	successDescription: 'nice 1',
+	theme: 'culture',
+	group: 'culture',
+};
+
+export const Default = () => {
+	return <SecondaryPromotedNewsletter newsletter={altPromotedNewsletter} />;
+};
+
+Default.story = { name: 'Default' };

--- a/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.tsx
+++ b/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.tsx
@@ -1,0 +1,138 @@
+import { css } from '@emotion/react';
+import {
+	brand,
+	brandAlt,
+	brandBackground,
+	headline,
+	space,
+} from '@guardian/source-foundations';
+import {
+	// Column,
+	// Columns,
+	LinkButton,
+	SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { ContainerLayout } from '../ContainerLayout';
+import { NewsletterDetail } from './NewsletterDetail';
+
+// TODO: Change this when we decide how to get this data through
+const MAIN_MEDIA =
+	'https://i.guim.co.uk/img/uploads/2022/01/11/pushing_buttons_thrasher_hi.png?width=700&quality=50&s=f4be90f0ca470076df70cf895aeecda1';
+
+type Props = {
+	newsletter: Newsletter & {
+		mainMedia?: string; // just optional for now - see MAIN_MEDIA
+		signupPage: string;
+	};
+};
+
+const headingStyle = css`
+	margin-top: ${space[2]}px;
+	margin-bottom: ${space[2]}px;
+
+	span {
+		${headline.small({ fontWeight: 'bold' })}
+		color: ${brandAlt[400]};
+	}
+`;
+
+const flexContainer = css`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background-color: ${brand[500]};
+	color: #f6f6f6;
+	border: 1px dashed;
+	border-radius: 4px;
+	margin: 8px 0;
+	padding: 4px;
+`;
+
+const newsletterImage = css`
+	flex-basis: 20%;
+	min-width: 0;
+	overflow: hidden;
+`;
+
+const newsletterDetail = css`
+	display: flex;
+	flex-direction: column;
+	flex-basis: 50%;
+	margin-left: 8px;
+`;
+const newsletterSignup = css`
+	display: flex;
+	align-self: flex-end;
+	padding: 8px;
+	flex-basis: 25%;
+`;
+
+const newsletterFrequency = css`
+	display: flex;
+	align-self: flex-start;
+	flex-basis: 5%;
+	/* padding: 8px; */
+`;
+
+export const SecondaryPromotedNewsletter: React.FC<Props> = ({
+	newsletter,
+}) => (
+	<ContainerLayout
+		innerBackgroundColour={brandBackground.primary}
+		leftContent={
+			<h2 css={headingStyle}>
+				<span>You might also enjoy</span>
+			</h2>
+		}
+		verticalMargins={false}
+		padContent={false}
+		// padSides={false}
+	>
+		<div css={flexContainer}>
+			{/* <Columns> */}
+			{/* <Column> */}
+			<div css={newsletterImage}>
+				<img src={MAIN_MEDIA} />
+			</div>
+			{/* </Column> */}
+
+			{/* <Column> */}
+			<div css={newsletterDetail}>
+				<h2
+					css={css`
+						${headline.small({ fontWeight: 'bold' })}
+						margin-bottom: 4px;
+					`}
+				>
+					{newsletter.name}
+				</h2>
+				<p
+					css={css`
+						${headline.xxsmall()}
+						margin-bottom: 4px;
+					`}
+				>
+					{newsletter.description}
+				</p>
+			</div>
+			{/* </Column> */}
+
+			<div css={newsletterSignup}>
+				<LinkButton
+					icon={<SvgArrowRightStraight />}
+					iconSide="right"
+					priority="secondary"
+					size="small"
+					href={newsletter.signupPage}
+				>
+					Sign up
+				</LinkButton>
+			</div>
+
+			<div css={newsletterFrequency}>
+				<NewsletterDetail text={newsletter.frequency} />
+			</div>
+		</div>
+		{/* </Columns> */}
+	</ContainerLayout>
+);

--- a/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.tsx
+++ b/dotcom-rendering/src/web/components/Newsletters/SecondaryPromotedNewsletter.tsx
@@ -7,8 +7,8 @@ import {
 	space,
 } from '@guardian/source-foundations';
 import {
-	// Column,
-	// Columns,
+	Column,
+	Columns,
 	LinkButton,
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
@@ -29,11 +29,8 @@ type Props = {
 const headingStyle = css`
 	margin-top: ${space[2]}px;
 	margin-bottom: ${space[2]}px;
-
-	span {
-		${headline.small({ fontWeight: 'bold' })}
-		color: ${brandAlt[400]};
-	}
+	${headline.small({ fontWeight: 'bold' })}
+	color: ${brandAlt[400]};
 `;
 
 const flexContainer = css`
@@ -43,96 +40,93 @@ const flexContainer = css`
 	background-color: ${brand[500]};
 	color: #f6f6f6;
 	border: 1px dashed;
-	border-radius: 4px;
-	margin: 8px 0;
-	padding: 4px;
+	border-radius: ${space[2]}px;
+	margin: ${space[2]}px 0;
+	padding: ${space[2]}px;
 `;
 
 const newsletterImage = css`
-	flex-basis: 20%;
 	min-width: 0;
 	overflow: hidden;
-`;
-
-const newsletterDetail = css`
-	display: flex;
-	flex-direction: column;
-	flex-basis: 50%;
-	margin-left: 8px;
-`;
-const newsletterSignup = css`
-	display: flex;
-	align-self: flex-end;
-	padding: 8px;
-	flex-basis: 25%;
 `;
 
 const newsletterFrequency = css`
 	display: flex;
 	align-self: flex-start;
-	flex-basis: 5%;
-	/* padding: 8px; */
 `;
 
 export const SecondaryPromotedNewsletter: React.FC<Props> = ({
 	newsletter,
-}) => (
-	<ContainerLayout
-		innerBackgroundColour={brandBackground.primary}
-		leftContent={
-			<h2 css={headingStyle}>
-				<span>You might also enjoy</span>
+}) => {
+	const bannerTitle = <h2 css={headingStyle}>You might also enjoy</h2>;
+	const titleAndDescription = (
+		<div>
+			<h2
+				css={css`
+					${headline.small({ fontWeight: 'bold' })}
+					margin-bottom: 4px;
+				`}
+			>
+				{newsletter.name}
 			</h2>
-		}
-		verticalMargins={false}
-		padContent={false}
-		// padSides={false}
-	>
-		<div css={flexContainer}>
-			{/* <Columns> */}
-			{/* <Column> */}
-			<div css={newsletterImage}>
-				<img src={MAIN_MEDIA} />
-			</div>
-			{/* </Column> */}
-
-			{/* <Column> */}
-			<div css={newsletterDetail}>
-				<h2
-					css={css`
-						${headline.small({ fontWeight: 'bold' })}
-						margin-bottom: 4px;
-					`}
-				>
-					{newsletter.name}
-				</h2>
-				<p
-					css={css`
-						${headline.xxsmall()}
-						margin-bottom: 4px;
-					`}
-				>
-					{newsletter.description}
-				</p>
-			</div>
-			{/* </Column> */}
-
-			<div css={newsletterSignup}>
-				<LinkButton
-					icon={<SvgArrowRightStraight />}
-					iconSide="right"
-					priority="secondary"
-					size="small"
-					href={newsletter.signupPage}
-				>
-					Sign up
-				</LinkButton>
-			</div>
-
-			<div css={newsletterFrequency}>
-				<NewsletterDetail text={newsletter.frequency} />
-			</div>
+			<p
+				css={css`
+					${headline.xxsmall()}
+					margin-bottom: 4px;
+				`}
+			>
+				{newsletter.description}
+			</p>
 		</div>
-		{/* </Columns> */}
-	</ContainerLayout>
-);
+	);
+
+	const signupButton = (
+		<LinkButton
+			icon={<SvgArrowRightStraight />}
+			iconSide="right"
+			priority="secondary"
+			size="small"
+			href={newsletter.signupPage}
+			css={css`
+				align-self: flex-end;
+			`}
+		>
+			Sign up
+		</LinkButton>
+	);
+
+	return (
+		<ContainerLayout
+			innerBackgroundColour={brandBackground.primary}
+			leftContent={bannerTitle}
+			showTopBorder={false}
+			padContent={false}
+			stretchRight={true}
+			verticalMargins={false}
+			// padSides={false}
+		>
+			<Columns css={flexContainer}>
+				<Column width={1 / 3}>
+					<div css={newsletterImage}>
+						<img src={MAIN_MEDIA} height="100px" />
+					</div>
+				</Column>
+				<Column width={2 / 3}>
+					<div
+						css={css`
+							display: flex;
+						`}
+					>
+						{titleAndDescription}
+
+						{signupButton}
+					</div>
+				</Column>
+
+				<div css={newsletterFrequency}>
+					<NewsletterDetail text={newsletter.frequency} />
+				</div>
+			</Columns>
+		</ContainerLayout>
+	);
+};

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -38,6 +38,7 @@ import { NewsletterBadge } from '../components/Newsletters/NewsletterBadge';
 import { NewsletterDetail } from '../components/Newsletters/NewsletterDetail';
 import { NewsletterFrequency } from '../components/Newsletters/NewsletterFrequency';
 import { NewsletterPrivacyMessage } from '../components/Newsletters/NewsletterPrivacyMessage';
+import { SecondaryPromotedNewsletter } from '../components/Newsletters/SecondaryPromotedNewsletter';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { SecureSignup } from '../components/SecureSignup';
 import { ShareIcons } from '../components/ShareIcons';
@@ -178,6 +179,21 @@ const getMainMediaCaptions = (
 			? el.data.caption
 			: undefined,
 	);
+
+const altPromotedNewsletter = {
+	name: 'Pushing Buttons',
+	description:
+		'Start the day one step ahead. Our email breaks down the key stories of the day and why they matter.',
+	frequency: 'Weekly',
+	mainMedia:
+		'https://i.guim.co.uk/img/uploads/2022/01/11/pushing_buttons_thrasher_hi.png?width=700&quality=50&s=f4be90f0ca470076df70cf895aeecda1',
+	signupPage: 'https://www.google.com',
+	listId: 1234,
+	identityName: 'Pushing buttons',
+	successDescription: 'nice 1',
+	theme: 'culture',
+	group: 'culture',
+};
 
 export const NewsletterSignupLayout: React.FC<Props> = ({
 	CAPIArticle,
@@ -451,6 +467,10 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 						<NewsletterPrivacyMessage legacy={false} />
 					</div>
 				</ContainerLayout>
+
+				<SecondaryPromotedNewsletter
+					newsletter={altPromotedNewsletter}
+				/>
 
 				{CAPIArticle.onwards ? (
 					<DecideOnwards


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
