### PR TITLE
Revert "AR - replace hv by rem to make it work in android"

### DIFF
--- a/apps-rendering/src/components/PinnedPost/index.tsx
+++ b/apps-rendering/src/components/PinnedPost/index.tsx
@@ -134,7 +134,7 @@ const fakeButtonStyles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const collapsibleBody = css`
-	max-height: 22.4rem;
+	max-height: 40vh;
 	overflow: hidden;
 `;
 


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#5589

In previous PR I had replaced `hv` by `rem`  because it wasn't working on my emulator. But thanks to @georgeblahblah for his comment https://github.com/guardian/dotcom-rendering/pull/5589#issuecomment-1204059856 I realized that I was using a very old version of the app which was running a very old version of the web view. It seems that `vh` is fully supported in `chrome for android` 

After I tested it with the latest version of `android-news-app` , I can now see it's working fine using `hv`
![image](https://user-images.githubusercontent.com/15894063/182808224-75c010e8-a621-4d39-9fcf-0f556cb6930a.png)

