### PR TITLE
Varying webpack bundles for tests

### DIFF
--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -7,6 +7,7 @@
 
 const find = require('find');
 const loadJsonFile = require('load-json-file');
+const { BUILD_VARIANT } = require('../webpack/bundles');
 
 const errorAndThrow = (error) => {
 	console.error(error);
@@ -28,7 +29,7 @@ const fileExists = async (glob) => {
 	// Check that the manifest files exist
 	await fileExists('manifest.modern.json');
 	await fileExists('manifest.legacy.json');
-	await fileExists('manifest.variant.json');
+	if (BUILD_VARIANT) await fileExists('manifest.variant.json');
 
 	// Check that the manifest files return values for all the chunks
 	const manifest = await loadJsonFile('./dist/manifest.modern.json');

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -13,6 +13,7 @@ const errorAndThrow = (error) => {
 	throw new Error(error);
 };
 
+/** @type {(glob: string) => Promise<void>} */
 const fileExists = async (glob) => {
 	await find.file(glob, `./dist/`, (files) => {
 		if (files.length === 1) {
@@ -25,11 +26,12 @@ const fileExists = async (glob) => {
 
 (async () => {
 	// Check that the manifest files exist
-	await fileExists('manifest.json');
+	await fileExists('manifest.modern.json');
 	await fileExists('manifest.legacy.json');
+	await fileExists('manifest.variant.json');
 
 	// Check that the manifest files return values for all the chunks
-	const manifest = await loadJsonFile('./dist/manifest.json');
+	const manifest = await loadJsonFile('./dist/manifest.modern.json');
 	const legacyManifest = await loadJsonFile('./dist/manifest.legacy.json');
 
 	[
@@ -44,7 +46,7 @@ const fileExists = async (glob) => {
 		'newsletterEmbedIframe.js',
 		'relativeTime.js',
 		'initDiscussion.js',
-	].map((name) => {
+	].forEach((name) => {
 		if (manifest[name]) {
 			console.log(`Manifest returned value ${name}`);
 		} else {

--- a/dotcom-rendering/scripts/test/build-check.js
+++ b/dotcom-rendering/scripts/test/build-check.js
@@ -32,8 +32,13 @@ const fileExists = async (glob) => {
 	if (BUILD_VARIANT) await fileExists('manifest.variant.json');
 
 	// Check that the manifest files return values for all the chunks
-	const manifest = await loadJsonFile('./dist/manifest.modern.json');
-	const legacyManifest = await loadJsonFile('./dist/manifest.legacy.json');
+	const manifests = [
+		await loadJsonFile('./dist/manifest.modern.json'),
+		await loadJsonFile('./dist/manifest.legacy.json'),
+	];
+	if (BUILD_VARIANT) {
+		manifests.push(await loadJsonFile('./dist/manifest.variant.json'));
+	}
 
 	[
 		'sentryLoader.js',
@@ -48,18 +53,12 @@ const fileExists = async (glob) => {
 		'relativeTime.js',
 		'initDiscussion.js',
 	].forEach((name) => {
-		if (manifest[name]) {
-			console.log(`Manifest returned value ${name}`);
-		} else {
-			errorAndThrow(`Manifest did not return a value for ${name}`);
-		}
-
-		if (legacyManifest[name]) {
-			console.log(`Legacy manifest returned value ${name}`);
-		} else {
-			errorAndThrow(
-				`Legacy Loadabl manifest did not return a value for ${name}`,
-			);
+		for (const manifest of manifests) {
+			if (manifest[name]) {
+				console.log(`A manifest returned value ${name}`);
+			} else {
+				errorAndThrow(`A manifest did not return a value for ${name}`);
+			}
 		}
 	});
 })();

--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -1,0 +1,14 @@
+/**
+ * Controls whether we should build the variant bundle.
+ * Set this to true if you want to serve a server-side experiment against
+ * the `dcrJsBundleVariant` A/B test.
+ *
+ * @see https://github.com/guardian/frontend/blob/a602273a/common/app/experiments/Experiments.scala#L20-L27
+ *
+ * @type {boolean} prevent TS from narrowing this to its current value
+ */
+const BUILD_VARIANT = false;
+
+module.exports = {
+	BUILD_VARIANT,
+};

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -46,7 +46,7 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
-		case 'modern':
+		case 'variant':
 			return [
 				{
 					loader: 'babel-loader',
@@ -74,7 +74,7 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
-		case 'variant':
+		case 'modern':
 			return [
 				{
 					loader: 'babel-loader',
@@ -84,8 +84,10 @@ const getLoaders = (bundle) => {
 							[
 								'@babel/preset-env',
 								{
-									targets:
-										'extends @guardian/browserslist-config',
+									bugfixes: true,
+									targets: {
+										esmodules: true,
+									},
 								},
 							],
 						],

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -14,6 +14,52 @@ const generateName = (bundle) => {
 };
 
 /**
+ * @param {'modern' | 'legacy' | 'variant'} bundle
+ * @returns {string}
+ */
+const getPresets = (bundle) => {
+	switch (bundle) {
+		case 'modern':
+			return [
+				'@babel/preset-react',
+				[
+					'@babel/preset-env',
+					{
+						bugfixes: true,
+						targets: {
+							esmodules: true,
+						},
+					},
+				],
+			];
+		case 'variant':
+			return [
+				'@babel/preset-react',
+				[
+					'@babel/preset-env',
+					{
+						targets: 'extends @guardian/browserslist-config',
+					},
+				],
+			];
+
+		case 'legacy':
+			return [
+				'@babel/preset-react',
+				[
+					'@babel/preset-env',
+					{
+						targets: {
+							ie: '11',
+						},
+						modules: false,
+					},
+				],
+			];
+	}
+};
+
+/**
  * @param {{ bundle: 'modern' | 'legacy' | 'variant', sessionId: string }} options
  * @returns {import('webpack').Configuration}
  */
@@ -71,28 +117,7 @@ module.exports = ({ bundle, sessionId }) => ({
 					{
 						loader: 'babel-loader',
 						options: {
-							presets: [
-								'@babel/preset-react',
-								bundle === 'legacy'
-									? [
-											'@babel/preset-env',
-											{
-												targets: {
-													ie: '11',
-												},
-												modules: false,
-											},
-									  ]
-									: [
-											'@babel/preset-env',
-											{
-												bugfixes: true,
-												targets: {
-													esmodules: true,
-												},
-											},
-									  ],
-							],
+							presets: getPresets(bundle),
 							compact: true,
 						},
 					},

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -8,9 +8,8 @@ const DEV = process.env.NODE_ENV === 'development';
  * @returns {string}
  */
 const generateName = (bundle) => {
-	const bundleString = bundle === 'modern' ? '' : `.${bundle}`;
 	const chunkhashString = DEV ? '' : '.[chunkhash]';
-	return `[name]${bundleString}${chunkhashString}.js`;
+	return `[name].${bundle}${chunkhashString}.js`;
 };
 
 /**
@@ -135,16 +134,12 @@ module.exports = ({ bundle, sessionId }) => ({
 	},
 	plugins: [
 		new WebpackManifestPlugin({
-			fileName:
-				bundle === 'modern'
-					? 'manifest.json'
-					: `manifest.${bundle}.json`,
+			fileName: `manifest.${bundle}.json`,
 		}),
 		...(DEV
 			? [
 					new GuStatsReportPlugin({
-						buildName:
-							bundle === 'modern' ? 'client' : `${bundle}-client`,
+						buildName: `${bundle}-client`,
 						project: 'dotcom-rendering',
 						team: 'dotcom',
 						sessionId,

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -4,7 +4,7 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 const DEV = process.env.NODE_ENV === 'development';
 
 /**
- * @param {'modern' | 'legacy' | 'variant'} bundle
+ * @param {'legacy' | 'modern' | 'variant'} bundle
  * @returns {string}
  */
 const generateName = (bundle) => {
@@ -14,11 +14,39 @@ const generateName = (bundle) => {
 };
 
 /**
- * @param {'modern' | 'variant' 'legacy' | } bundle
+ * @param {'legacy' | 'modern' | 'variant'} bundle
  * @returns {string}
  */
 const getLoaders = (bundle) => {
 	switch (bundle) {
+		case 'legacy':
+			return [
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										ie: '11',
+									},
+									modules: false,
+								},
+							],
+						],
+						compact: true,
+					},
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
+			];
 		case 'modern':
 			return [
 				{
@@ -73,39 +101,11 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
-		case 'legacy':
-			return [
-				{
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-react',
-							[
-								'@babel/preset-env',
-								{
-									targets: {
-										ie: '11',
-									},
-									modules: false,
-								},
-							],
-						],
-						compact: true,
-					},
-				},
-				{
-					loader: 'ts-loader',
-					options: {
-						configFile: 'tsconfig.build.json',
-						transpileOnly: true,
-					},
-				},
-			];
 	}
 };
 
 /**
- * @param {{ bundle: 'modern' | 'legacy' | 'variant', sessionId: string }} options
+ * @param {{ bundle: 'legacy' | 'modern'  | 'variant', sessionId: string }} options
  * @returns {import('webpack').Configuration}
  */
 module.exports = ({ bundle, sessionId }) => ({

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -14,47 +14,92 @@ const generateName = (bundle) => {
 };
 
 /**
- * @param {'modern' | 'legacy' | 'variant'} bundle
+ * @param {'modern' | 'variant' 'legacy' | } bundle
  * @returns {string}
  */
-const getPresets = (bundle) => {
+const getLoaders = (bundle) => {
 	switch (bundle) {
 		case 'modern':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						bugfixes: true,
-						targets: {
-							esmodules: true,
-						},
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									bugfixes: true,
+									targets: {
+										esmodules: true,
+									},
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
 		case 'variant':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						targets: 'extends @guardian/browserslist-config',
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets:
+										'extends @guardian/browserslist-config',
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
-
 		case 'legacy':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						targets: {
-							ie: '11',
-						},
-						modules: false,
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										ie: '11',
+									},
+									modules: false,
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
 	}
 };
@@ -112,23 +157,7 @@ module.exports = ({ bundle, sessionId }) => ({
 			{
 				test: /\.[jt]sx?|mjs$/,
 				exclude: module.exports.babelExclude,
-
-				use: [
-					{
-						loader: 'babel-loader',
-						options: {
-							presets: getPresets(bundle),
-							compact: true,
-						},
-					},
-					{
-						loader: 'ts-loader',
-						options: {
-							configFile: 'tsconfig.build.json',
-							transpileOnly: true,
-						},
-					},
-				],
+				use: getLoaders(bundle),
 			},
 			{
 				test: /\.css$/,

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require -- we merge configs in the export */
 // @ts-check
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
@@ -6,6 +7,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const { merge } = require('webpack-merge');
 const WebpackMessages = require('webpack-messages');
+const { BUILD_VARIANT } = require('./bundles');
 
 const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
@@ -129,13 +131,17 @@ module.exports = [
 			sessionId,
 		}),
 	),
-	merge(
-		commonConfigs({
-			platform: 'browser.variant',
-		}),
-		require(`./webpack.config.browser`)({
-			bundle: 'variant',
-			sessionId,
-		}),
-	),
+	...(BUILD_VARIANT
+		? [
+				merge(
+					commonConfigs({
+						platform: 'browser.variant',
+					}),
+					require(`./webpack.config.browser`)({
+						bundle: 'variant',
+						sessionId,
+					}),
+				),
+		  ]
+		: []),
 ];

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -129,4 +129,13 @@ module.exports = [
 			sessionId,
 		}),
 	),
+	merge(
+		commonConfigs({
+			platform: 'browser.variant',
+		}),
+		require(`./webpack.config.browser`)({
+			bundle: 'variant',
+			sessionId,
+		}),
+	),
 ];

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -1,10 +1,10 @@
 // @ts-check
 const path = require('path');
+const { v4: uuidv4 } = require('uuid');
 const webpack = require('webpack');
-const { merge } = require('webpack-merge');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
-const { v4: uuidv4 } = require('uuid');
+const { merge } = require('webpack-merge');
 const WebpackMessages = require('webpack-messages');
 
 const PROD = process.env.NODE_ENV === 'production';
@@ -17,7 +17,7 @@ const sessionId = uuidv4();
 let builds = 0;
 
 /**
- * @param {{ platform: 'server' | 'browser' | 'browser.legacy'}} options
+ * @param {{ platform: 'server' | 'browser.modern' | 'browser.legacy' | 'browser.variant'}} options
  * @returns {import('webpack').Configuration}
  */
 const commonConfigs = ({ platform }) => ({
@@ -45,7 +45,7 @@ const commonConfigs = ({ platform }) => ({
 			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 			'process.env.HOSTNAME': JSON.stringify(process.env.HOSTNAME),
 		}),
-		// @ts-ignore -- somehow the type declaration isn’t playing nice
+		// @ts-expect-error -- somehow the type declaration isn’t playing nice
 		new FilterWarningsPlugin({
 			exclude: /export .* was not found in/,
 		}),
@@ -57,7 +57,7 @@ const commonConfigs = ({ platform }) => ({
 		...(DEV
 			? // DEV plugins
 			  [
-					// @ts-ignore -- somehow the type declaration isn’t playing nice
+					// @ts-expect-error -- somehow the type declaration isn’t playing nice
 					new WebpackMessages({
 						name: platform,
 						/** @type {(message: string) => void} */
@@ -114,7 +114,7 @@ module.exports = [
 						platform: 'browser.legacy',
 					}),
 					require(`./webpack.config.browser`)({
-						isLegacyJS: true,
+						bundle: 'legacy',
 						sessionId,
 					}),
 				),
@@ -122,10 +122,10 @@ module.exports = [
 		: []),
 	merge(
 		commonConfigs({
-			platform: 'browser',
+			platform: 'browser.modern',
 		}),
 		require(`./webpack.config.browser`)({
-			isLegacyJS: false,
+			bundle: 'modern',
 			sessionId,
 		}),
 	),

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const sessionId = uuidv4();
 let builds = 0;
 
 /**
- * @param {{ platform: 'server' | 'browser.modern' | 'browser.legacy' | 'browser.variant'}} options
+ * @param {{ platform: 'server' | 'browser.legacy' | 'browser.modern' | 'browser.variant'}} options
  * @returns {import('webpack').Configuration}
  */
 const commonConfigs = ({ platform }) => ({

--- a/dotcom-rendering/src/lib/assets.test.ts
+++ b/dotcom-rendering/src/lib/assets.test.ts
@@ -1,4 +1,9 @@
-import { decideAssetOrigin } from './assets';
+import {
+	decideAssetOrigin,
+	LEGACY_SCRIPT,
+	MODERN_SCRIPT,
+	VARIANT_SCRIPT,
+} from './assets';
 
 describe('decideAssetOrigin for stage', () => {
 	it('PROD', () => {
@@ -35,5 +40,29 @@ describe('decideAssetOrigin for stage', () => {
 		expect(decideAssetOrigin(undefined, true)).toEqual(
 			'http://localhost:3030/',
 		);
+	});
+});
+
+describe('regular expression to match files', () => {
+	it('should handle CI environment', () => {
+		expect('/assets/ophan.modern.eb74205c979f58659ed7.js').toMatch(
+			MODERN_SCRIPT,
+		);
+	});
+
+	it('should handle DEV environment', () => {
+		expect('/assets/ophan.variant.js').toMatch(VARIANT_SCRIPT);
+	});
+
+	it('should handle PROD environment', () => {
+		expect(
+			'https://assets.guim.co.uk/assets/ophan.legacy.eb74205c979f58659ed7.js',
+		).toMatch(LEGACY_SCRIPT);
+	});
+
+	it('should handle http3 query param', () => {
+		expect(
+			'https://assets.guim.co.uk/assets/ophan.modern.eb74205c979f58659ed7.js?http3=true',
+		).toMatch(MODERN_SCRIPT);
 	});
 });

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -53,10 +53,12 @@ const getManifest = (path: string): AssetHash => {
 	}
 };
 
+type Script = { src: string; legacy: boolean };
+
 export const getScriptArrayFromFile = (
 	file: `${string}.js`,
 	manifestPath: `./manifest${string}.json`,
-): { src: string; legacy?: boolean }[] => {
+): Script[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
 
@@ -70,7 +72,7 @@ export const getScriptArrayFromFile = (
 		? file.replace('.js', '.legacy.js')
 		: legacyManifest[file];
 
-	const scripts = [];
+	const scripts: Script[] = [];
 
 	if (filename) {
 		scripts.push({

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -54,7 +54,14 @@ const getManifest = (path: string): AssetHash => {
 	}
 };
 
-export type ManifestPath = `./manifest.${string}.json`;
+const getManifestPaths = (
+	manifests: 'control' | 'variant',
+): [ManifestPath, ManifestPath] =>
+	manifests === 'variant'
+		? ['./manifest.variant.json', './manifest.legacy.json']
+		: ['./manifest.modern.json', './manifest.legacy.json'];
+
+type ManifestPath = `./manifest.${string}.json`;
 
 const getScripts = (
 	manifestPaths: Array<ManifestPath>,
@@ -78,10 +85,19 @@ const getScripts = (
 	});
 };
 
+/**
+ * A curried function that takes an array of manifests.
+ *
+ * The returned function takes a script name and returns
+ * an array of scripts found in the manifests.
+ */
 export const getScriptsFromManifest =
-	(manifestPaths: ManifestPath[]) =>
+	(shouldServeVariantBundle: boolean) =>
 	(file: `${string}.js`): ReturnType<typeof getScripts> =>
-		getScripts(manifestPaths, file);
+		getScripts(
+			getManifestPaths(shouldServeVariantBundle ? 'variant' : 'control'),
+			file,
+		);
 
 export const generateScriptTags = (scripts: Array<string | false>): string[] =>
 	scripts.filter(isString).map((script) => {

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -79,7 +79,7 @@ const getScripts = (
 };
 
 export const getScriptsFromManifest =
-	(manifestPaths: Array<`./manifest.${string}.json`>) =>
+	(manifestPaths: ManifestPath[]) =>
 	(file: `${string}.js`): ReturnType<typeof getScripts> =>
 		getScripts(manifestPaths, file);
 

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -99,12 +99,28 @@ export const getScriptsFromManifest =
 			file,
 		);
 
+/** To ensure this only applies to guardian scripts,
+ * we check that it is served from a asset/ directory
+ * and that it ends with the bundle type and extension,
+ * with an optional hash for local development
+ * and stripped query parameters.
+ */
+const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant') =>
+	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\d{20}\\.)?js(\\?.*)?$`);
+
+const LEGACY_SCRIPT = getScriptRegex('legacy');
+const MODERN_SCRIPT = getScriptRegex('modern');
+const VARIANT_SCRIPT = getScriptRegex('variant');
+
 export const generateScriptTags = (scripts: Array<string | false>): string[] =>
 	scripts.filter(isString).map((script) => {
-		if (script.includes('.legacy.')) {
+		if (script.match(LEGACY_SCRIPT)) {
 			return `<script defer nomodule src="${script}"></script>`;
 		}
-		if (script.includes('.modern.')) {
+		if (script.match(MODERN_SCRIPT)) {
+			return `<script type="module" src="${script}"></script>`;
+		}
+		if (script.match(VARIANT_SCRIPT)) {
 			return `<script type="module" src="${script}"></script>`;
 		}
 

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -55,9 +55,9 @@ const getManifest = (path: string): AssetHash => {
 
 type Script = { src: string; legacy: boolean };
 
-export const getScriptArrayFromFile = (
-	file: `${string}.js`,
+const getScripts = (
 	manifestPath: `./manifest${string}.json`,
+	file: `${string}.js`,
 ): Script[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
@@ -89,3 +89,8 @@ export const getScriptArrayFromFile = (
 
 	return scripts;
 };
+
+export const getScriptsFromManifest =
+	(manifestPath: `./manifest${string}.json`) =>
+	(file: `${string}.js`): ReturnType<typeof getScripts> =>
+		getScripts(manifestPath, file);

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -108,9 +108,9 @@ export const getScriptsFromManifest =
 const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant') =>
 	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\d{20}\\.)?js(\\?.*)?$`);
 
-const LEGACY_SCRIPT = getScriptRegex('legacy');
-const MODERN_SCRIPT = getScriptRegex('modern');
-const VARIANT_SCRIPT = getScriptRegex('variant');
+export const LEGACY_SCRIPT = getScriptRegex('legacy');
+export const MODERN_SCRIPT = getScriptRegex('modern');
+export const VARIANT_SCRIPT = getScriptRegex('variant');
 
 export const generateScriptTags = (scripts: Array<string | false>): string[] =>
 	scripts.filter(isString).map((script) => {

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -106,7 +106,7 @@ export const getScriptsFromManifest =
  * and stripped query parameters.
  */
 const getScriptRegex = (bundle: 'modern' | 'legacy' | 'variant') =>
-	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\d{20}\\.)?js(\\?.*)?$`);
+	new RegExp(`assets\\/\\w+\\.${bundle}\\.(\\w{20}\\.)?js(\\?.*)?$`);
 
 export const LEGACY_SCRIPT = getScriptRegex('legacy');
 export const MODERN_SCRIPT = getScriptRegex('modern');

--- a/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
@@ -1,8 +1,9 @@
+import type { ServerSideTests } from 'src/types/config';
 import { abTestPayload } from './ophan';
 
 describe('abTestPayload', () => {
 	test('constructs payload correctly from config test data', () => {
-		const tests = {
+		const tests: ServerSideTests = {
 			MyTest: 'variant',
 		};
 

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -6,6 +6,7 @@ import type {
 	OphanComponentEvent,
 } from '@guardian/libs';
 import { log } from '@guardian/libs';
+import type { ServerSideTests } from 'src/types/config';
 
 export type OphanRecordFunction = (
 	event: { [key: string]: any },
@@ -74,9 +75,7 @@ export const sendOphanComponentEvent = (
 	submitComponentEvent(componentEvent, ophanRecord);
 };
 
-export const abTestPayload = (tests: {
-	[key: string]: string;
-}): OphanABPayload => {
+export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {
 	const records: { [key: string]: OphanABEvent } = {};
 	Object.entries(tests).forEach(([testName, variantName]) => {
 		records[`ab${testName}`] = {

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -51,6 +51,11 @@ Sentry.init({
 	},
 });
 
+Sentry.setTag(
+	'dcr.bundle',
+	window.guardian.config.page.abTests.jsBundleVariant,
+);
+
 export const reportError = (error: Error, feature?: string): void => {
 	Sentry.withScope(() => {
 		if (feature) {

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
+import { BUILD_VARIANT } from '../../../../scripts/webpack/bundles';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,
@@ -51,7 +52,13 @@ Sentry.init({
 	},
 });
 
-Sentry.setTag('dcr.bundle', window.guardian.config.tests.dcrJsBundleVariant);
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- dcrJsBundleVariant could also be `undefined`
+if (BUILD_VARIANT && !!window.guardian.config.tests.dcrJsBundleVariant) {
+	Sentry.setTag(
+		'dcr.bundle',
+		window.guardian.config.tests.dcrJsBundleVariant,
+	);
+}
 
 export const reportError = (error: Error, feature?: string): void => {
 	Sentry.withScope(() => {

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -51,10 +51,7 @@ Sentry.init({
 	},
 });
 
-Sentry.setTag(
-	'dcr.bundle',
-	window.guardian.config.page.abTests.jsBundleVariant,
-);
+Sentry.setTag('dcr.bundle', window.guardian.config.tests.jsBundleVariant);
 
 export const reportError = (error: Error, feature?: string): void => {
 	Sentry.withScope(() => {

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -51,7 +51,7 @@ Sentry.init({
 	},
 });
 
-Sentry.setTag('dcr.bundle', window.guardian.config.tests.jsBundleVariant);
+Sentry.setTag('dcr.bundle', window.guardian.config.tests.dcrJsBundleVariant);
 
 export const reportError = (error: Error, feature?: string): void => {
 	Sentry.withScope(() => {

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -8,6 +8,9 @@ import {
 	ASSET_ORIGIN,
 	generateScriptTags,
 	getScriptsFromManifest,
+	LEGACY_SCRIPT,
+	MODERN_SCRIPT,
+	VARIANT_SCRIPT,
 } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { extractGA } from '../../model/extract-ga';
@@ -148,10 +151,13 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	);
 
 	const gaChunk = getScriptArrayFromFile('ga.js');
-	const modernScript = gaChunk.find((script) => script.includes('.modern.'));
-	const legacyScript = gaChunk.find((script) => script.includes('.legacy.'));
+	const modernScript = gaChunk.find((script) => script.match(MODERN_SCRIPT));
+	const legacyScript = gaChunk.find((script) => script.match(LEGACY_SCRIPT));
+	const variantScript = gaChunk.find((script) =>
+		script.match(VARIANT_SCRIPT),
+	);
 	const gaPath = {
-		modern: modernScript as string,
+		modern: (modernScript ?? variantScript) as string,
 		legacy: legacyScript as string,
 	};
 

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -163,8 +163,8 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	);
 
 	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath);
-	const modernScript = gaChunk.find((script) => script.legacy === false);
-	const legacyScript = gaChunk.find((script) => script.legacy === true);
+	const modernScript = gaChunk.find((script) => !script.legacy);
+	const legacyScript = gaChunk.find((script) => script.legacy);
 	const gaPath = {
 		modern: modernScript?.src as string,
 		legacy: legacyScript?.src as string,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,6 +3,7 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
+import { BUILD_VARIANT } from '../../../scripts/webpack/bundles';
 import type { ManifestPath } from '../../lib/assets';
 import {
 	ASSET_ORIGIN,
@@ -89,6 +90,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	);
 
 	const manifestPaths: ManifestPath[] =
+		BUILD_VARIANT &&
 		CAPIArticle.config.abTests.dcrJsBundleVariant === 'variant'
 			? ['./manifest.variant.json', './manifest.legacy.json']
 			: ['./manifest.modern.json', './manifest.legacy.json'];

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,7 +3,7 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
-import { ASSET_ORIGIN, getScriptArrayFromFile } from '../../lib/assets';
+import { ASSET_ORIGIN, getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
@@ -113,6 +113,8 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 			? './manifest.variant.json'
 			: './manifest.json';
 
+	const getScripts = getScriptsFromManifest(manifestPath);
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -123,22 +125,20 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js', manifestPath),
-			...getScriptArrayFromFile('ophan.js', manifestPath),
+			...getScripts('bootCmp.js'),
+			...getScripts('ophan.js'),
 			CAPIArticle.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					CAPIArticle.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
-			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
+			...getScripts('sentryLoader.js'),
+			...getScripts('dynamicImport.js'),
 			pageHasNonBootInteractiveElements && {
 				src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
 			},
-			...getScriptArrayFromFile('islands.js', manifestPath),
-			...expeditedIslands.flatMap((name) =>
-				getScriptArrayFromFile(`${name}.js`, manifestPath),
-			),
+			...getScripts('islands.js'),
+			...expeditedIslands.flatMap((name) => getScripts(`${name}.js`)),
 		].map((script) =>
 			offerHttp3 && script
 				? { ...script, src: getHttp3Url(script.src) }
@@ -155,17 +155,17 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js', manifestPath),
-			...getScriptArrayFromFile('embedIframe.js', manifestPath),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
-			...getScriptArrayFromFile('relativeTime.js', manifestPath),
-			...getScriptArrayFromFile('initDiscussion.js', manifestPath),
+			...getScripts('atomIframe.js'),
+			...getScripts('embedIframe.js'),
+			...getScripts('newsletterEmbedIframe.js'),
+			...getScripts('relativeTime.js'),
+			...getScripts('initDiscussion.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath);
+	const gaChunk = getScripts('ga.js');
 	const modernScript = gaChunk.find((script) => !script.legacy);
 	const legacyScript = gaChunk.find((script) => script.legacy);
 	const gaPath = {

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -108,7 +108,10 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 			'model.dotcomrendering.pageElements.TweetBlockElement',
 	);
 
-	const manifestPath = './manifest.json';
+	const manifestPath =
+		CAPIArticle.config.abTests.jsBundleVariant === 'variant'
+			? './manifest.variant.json'
+			: './manifest.json';
 
 	/**
 	 * The highest priority scripts.

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -89,7 +89,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	);
 
 	const manifestPaths: ManifestPath[] =
-		CAPIArticle.config.abTests.jsBundleVariant === 'variant'
+		CAPIArticle.config.abTests.dcrJsBundleVariant === 'variant'
 			? ['./manifest.variant.json', './manifest.legacy.json']
 			: ['./manifest.modern.json', './manifest.legacy.json'];
 

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -108,6 +108,8 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 			'model.dotcomrendering.pageElements.TweetBlockElement',
 	);
 
+	const manifestPath = './manifest.json';
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -118,21 +120,21 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js'),
-			...getScriptArrayFromFile('ophan.js'),
+			...getScriptArrayFromFile('bootCmp.js', manifestPath),
+			...getScriptArrayFromFile('ophan.js', manifestPath),
 			CAPIArticle.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					CAPIArticle.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js'),
-			...getScriptArrayFromFile('dynamicImport.js'),
+			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
+			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
 			pageHasNonBootInteractiveElements && {
 				src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
 			},
-			...getScriptArrayFromFile('islands.js'),
+			...getScriptArrayFromFile('islands.js', manifestPath),
 			...expeditedIslands.flatMap((name) =>
-				getScriptArrayFromFile(`${name}.js`),
+				getScriptArrayFromFile(`${name}.js`, manifestPath),
 			),
 		].map((script) =>
 			offerHttp3 && script
@@ -150,17 +152,17 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js'),
-			...getScriptArrayFromFile('embedIframe.js'),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js'),
-			...getScriptArrayFromFile('relativeTime.js'),
-			...getScriptArrayFromFile('initDiscussion.js'),
+			...getScriptArrayFromFile('atomIframe.js', manifestPath),
+			...getScriptArrayFromFile('embedIframe.js', manifestPath),
+			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
+			...getScriptArrayFromFile('relativeTime.js', manifestPath),
+			...getScriptArrayFromFile('initDiscussion.js', manifestPath),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js');
+	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath);
 	const modernScript = gaChunk.find((script) => script.legacy === false);
 	const legacyScript = gaChunk.find((script) => script.legacy === true);
 	const gaPath = {

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -2,7 +2,7 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { renderToString } from 'react-dom/server';
-import { getScriptArrayFromFile } from '../../lib/assets';
+import { getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
@@ -71,6 +71,8 @@ export const frontToHtml = ({ front }: Props): string => {
 			? './manifest.variant.json'
 			: './manifest.json';
 
+	const getScripts = getScriptsFromManifest(manifestPath);
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -81,16 +83,16 @@ export const frontToHtml = ({ front }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js', manifestPath),
-			...getScriptArrayFromFile('ophan.js', manifestPath),
+			...getScripts('bootCmp.js'),
+			...getScripts('ophan.js'),
 			front.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					front.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
-			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
-			...getScriptArrayFromFile('islands.js', manifestPath),
+			...getScripts('sentryLoader.js'),
+			...getScripts('dynamicImport.js'),
+			...getScripts('islands.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
@@ -105,18 +107,17 @@ export const frontToHtml = ({ front }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js', manifestPath),
-			...getScriptArrayFromFile('embedIframe.js', manifestPath),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
-			...getScriptArrayFromFile('relativeTime.js', manifestPath),
+			...getScripts('atomIframe.js'),
+			...getScripts('embedIframe.js'),
+			...getScripts('newsletterEmbedIframe.js'),
+			...getScripts('relativeTime.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath).map(
-		(script) =>
-			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
+	const gaChunk = getScripts('ga.js').map((script) =>
+		offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 	);
 	const modernScript = gaChunk.find((script) => !script.legacy);
 	const legacyScript = gaChunk.find((script) => script.legacy);

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -66,7 +66,10 @@ export const frontToHtml = ({ front }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
-	const manifestPath = './manifest.json';
+	const manifestPath =
+		front.config.abTests.jsBundleVariant === 'variant'
+			? './manifest.variant.json'
+			: './manifest.json';
 
 	/**
 	 * The highest priority scripts.

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -66,6 +66,8 @@ export const frontToHtml = ({ front }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
+	const manifestPath = './manifest.json';
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -73,20 +75,19 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * Please talk to the dotcom platform team before adding more.
 	 * Scripts will be executed in the order they appear in this array
 	 */
-
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js'),
-			...getScriptArrayFromFile('ophan.js'),
+			...getScriptArrayFromFile('bootCmp.js', manifestPath),
+			...getScriptArrayFromFile('ophan.js', manifestPath),
 			front.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					front.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js'),
-			...getScriptArrayFromFile('dynamicImport.js'),
-			...getScriptArrayFromFile('islands.js'),
+			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
+			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
+			...getScriptArrayFromFile('islands.js', manifestPath),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
@@ -101,20 +102,21 @@ export const frontToHtml = ({ front }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js'),
-			...getScriptArrayFromFile('embedIframe.js'),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js'),
-			...getScriptArrayFromFile('relativeTime.js'),
+			...getScriptArrayFromFile('atomIframe.js', manifestPath),
+			...getScriptArrayFromFile('embedIframe.js', manifestPath),
+			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
+			...getScriptArrayFromFile('relativeTime.js', manifestPath),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js').map((script) =>
-		offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
+	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath).map(
+		(script) =>
+			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 	);
-	const modernScript = gaChunk.find((script) => script.legacy === false);
-	const legacyScript = gaChunk.find((script) => script.legacy === true);
+	const modernScript = gaChunk.find((script) => !script.legacy);
+	const legacyScript = gaChunk.find((script) => script.legacy);
 	const gaPath = {
 		modern: modernScript?.src as string,
 		legacy: legacyScript?.src as string,

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -2,6 +2,7 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { renderToString } from 'react-dom/server';
+import { BUILD_VARIANT } from '../../../scripts/webpack/bundles';
 import type { ManifestPath } from '../../lib/assets';
 import { generateScriptTags, getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
@@ -43,7 +44,7 @@ export const frontToHtml = ({ front }: Props): string => {
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const manifestPaths: ManifestPath[] =
-		front.config.abTests.dcrJsBundleVariant === 'variant'
+		BUILD_VARIANT && front.config.abTests.dcrJsBundleVariant === 'variant'
 			? ['./manifest.variant.json', './manifest.legacy.json']
 			: ['./manifest.modern.json', './manifest.legacy.json'];
 

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -43,7 +43,7 @@ export const frontToHtml = ({ front }: Props): string => {
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const manifestPaths: ManifestPath[] =
-		front.config.abTests.jsBundleVariant === 'variant'
+		front.config.abTests.dcrJsBundleVariant === 'variant'
 			? ['./manifest.variant.json', './manifest.legacy.json']
 			: ['./manifest.modern.json', './manifest.legacy.json'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,11 +2815,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
-"@guardian/browserslist-config@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-1.0.1.tgz#694ab24f6a028646ae752f5e035ea13a0746c30a"
-  integrity sha512-xjQSUXmln96Qr/G8yRCaDWe5HbablzGU9lax1zDUZkfArV/rBj8P34x/RH0ksf3J8BaykVTma97W+g/WRz7Isw==
-
 "@guardian/commercial-core@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.3.0.tgz#f04bc56d4eedef9feb2a4c844142a7b11082d9bd"
@@ -19635,9 +19630,9 @@ supports-color@^9.2.1:
   integrity sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==
 
 supports-hyperlinks@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
-  integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
+  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,10 +2386,24 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.9.2":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.0.tgz#6d77142a19cb6088f0af662af1ada37a604d34ae"
+  integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2576,12 +2590,12 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css-prettifier@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.1.tgz#a3ce1667398e83701f52ec43938208faeef2e0a5"
-  integrity sha512-cA9Dtol47mtvWKasPC+8tkh2DS0wBkX0MMHKieXGSkGyx079V7yFY85KC0pPalcIy+vi0LbMR9DNyiJBqYgJ1Q==
+"@emotion/css-prettifier@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.1.0.tgz#1b5ac1588af9525e583f56fa898abb7edb3c7d9e"
+  integrity sha512-ALZCKBcpC9FeA0D6HLc4Et3bwY06fOG63CqLtWwk4W/u7+bWjorRxS9yikcJ2aTmlKur/ST9eWm5ohzBmWlTOQ==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
+    "@emotion/memoize" "^0.8.0"
     stylis "4.0.13"
 
 "@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
@@ -2617,12 +2631,12 @@
     "@emotion/memoize" "0.7.4"
 
 "@emotion/jest@^11.3.0":
-  version "11.9.4"
-  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.9.4.tgz#7ffb693f05baee5649a167fcb149d85bb655d3c2"
-  integrity sha512-dbV8gAOHyRTsPeARs4hEruHZ1eSgfOsYnShPRM2c+QoUxtKWrFN7toNDq9uwFrTV2lSul5G1HtgxAIQcWKyM/g==
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.10.0.tgz#a39c16d0a5794254e0e4c5caf3f11278a64ae4a4"
+  integrity sha512-jeevEzauWrjDPWt9BGITjKzgLd31Q6kZ35gmH77f+LSaU/Ie1bFfxroum0nQNPEHS+kUxh6unv9DQIw+DEr5Ug==
   dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/css-prettifier" "^1.0.1"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/css-prettifier" "^1.1.0"
     chalk "^4.1.0"
     specificity "^0.4.1"
     stylis "4.0.13"
@@ -2636,6 +2650,11 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
 "@emotion/react@^11.4.1":
   version "11.5.0"
@@ -2784,17 +2803,22 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.6.0":
+"@guardian/atoms-rendering@^23.2.2":
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz#624dc68120f00d47f21bae0ca059f31e65f56f59"
   integrity sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^7.4.0":
+"@guardian/braze-components@^7.3.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
+
+"@guardian/browserslist-config@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-1.0.1.tgz#694ab24f6a028646ae752f5e035ea13a0746c30a"
+  integrity sha512-xjQSUXmln96Qr/G8yRCaDWe5HbablzGU9lax1zDUZkfArV/rBj8P34x/RH0ksf3J8BaykVTma97W+g/WRz7Isw==
 
 "@guardian/commercial-core@^4.3.0":
   version "4.3.0"
@@ -4867,9 +4891,9 @@
     "@babel/types" "^7.3.0"
 
 "@types/babel__traverse@^7.0.4":
-  version "7.17.1"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.17.1.tgz#1a0e73e8c28c7e832656db372b779bfd2ef37314"
-  integrity sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==
+  version "7.18.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.1.tgz#ce5e2c8c272b99b7a9fd69fa39f0b4cd85028bd9"
+  integrity sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -5173,9 +5197,9 @@
     "@types/unist" "*"
 
 "@types/mime@*":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
-  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.0.tgz#e9a9903894405c6a6551f1774df4e64d9804d69c"
+  integrity sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==
 
 "@types/minimatch@*":
   version "3.0.5"
@@ -5249,9 +5273,9 @@
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
 "@types/prettier@^2.0.0":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
-  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
+  integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
 
 "@types/pretty-hrtime@^1.0.0":
   version "1.0.1"
@@ -12682,10 +12706,17 @@ is-core-module@^2.2.0, is-core-module@^2.5.0:
   dependencies:
     has "^1.0.3"
 
-is-core-module@^2.8.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
+is-core-module@^2.8.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -20326,9 +20357,9 @@ type-detect@4.0.8:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.4.0, type-fest@^2.8.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
-  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
+  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
 
 type-is@~1.6.18:
   version "1.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,7 +2393,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9":
+"@babel/runtime@^7.18.3":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -2803,14 +2810,14 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.2.2":
+"@guardian/atoms-rendering@^23.6.0":
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz#624dc68120f00d47f21bae0ca059f31e65f56f59"
   integrity sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^7.3.0":
+"@guardian/braze-components@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Allows us to serve a variant version of the bundle to a subset of users as a server side experiment.

Three bundles can now be generated at build time:
- `modern` – served to most users
- `variant` – served to a small subset of users in a server-side test
- `legacy` – served to browser that don’t support ES modules.

For consistency, the “nameless” default is now clearly labelled as modern: `manifest.json` becomes `manifest.modern.json`.

> **Note**
> In order to build the `variant` bundle, make sure to set the value of `BUILD_VARIANT` to `true` in `bundles.js`.
>
> Currently, the `variant` and `modern` are identical.
> When running an actual test, they should probably differ.

## Why?

We want to test the impact of different bundles on performance.

We have a several projects awaiting a way of testing new bundles:
- #5206 
- #5172 
- #5498
- #5899 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/187447627-0b9b9430-386c-4bba-bee2-b6734e7497b3.png
[after]: https://user-images.githubusercontent.com/76776/187657460-e956ba03-ec65-48c4-b178-57ce39986cea.png

