### PR TITLE
Remove stale comment to deleted document

### DIFF
--- a/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
@@ -1,9 +1,6 @@
 import { css } from '@emotion/react';
 import { Star } from '../../../static/icons/Star';
 
-// https://docs.google.com/spreadsheets/d/1QUa5Kh734J4saFc8ERjCYHZu10_-Hj7llNa2rr8urNg/edit?usp=sharing
-// A list style variations for each breakpoint
-
 const starWrapper = css`
 	display: inline-block;
 	padding: 1px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Removes comment linking to a deleted Google sheet

It's possible the document still exists and I just don't have access, though!