### PR TITLE
limit filters for topics with counts of 3 and more

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -86,7 +86,7 @@ export const TopicFilterBank = ({
 	const selectedTopic = selectedTopics?.[0];
 	const topFiveTopics = availableTopics
 		.slice(0, 5)
-		.filter((topic) => topic.count && topic.count > 2);
+		.filter((topic) => !!topic.count && topic.count > 2);
 
 	if (selectedTopic) {
 		const selectedIndex = availableTopics.findIndex((availableTopic) =>

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -84,7 +84,9 @@ export const TopicFilterBank = ({
 }: Props) => {
 	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
-	const topFiveTopics = availableTopics.slice(0, 5);
+	const topFiveTopics = availableTopics
+		.slice(0, 5)
+		.filter((topic) => topic.count && topic.count > 2);
 
 	if (selectedTopic) {
 		const selectedIndex = availableTopics.findIndex((availableTopic) =>

--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -13,6 +13,14 @@ const availableTopics: Topic[] = [
 	{ type: 'GPE', value: 'Manchester', count: 4 },
 	{ type: 'GPE', value: 'United Kingdom', count: 4 },
 	{ type: 'PERSON', value: 'Anas Sarwar', count: 4 },
+	{ type: 'PERSON', value: 'Cameron', count: 2 },
+];
+
+const availableTopicsWithLowerCount: Topic[] = [
+	{ type: 'GPE', value: 'Manchester', count: 4 },
+	{ type: 'GPE', value: 'United Kingdom', count: 3 },
+	{ type: 'PERSON', value: 'Anas Sarwar', count: 2 },
+	{ type: 'PERSON', value: 'Cameron', count: 1 },
 ];
 
 const selectedTopics: Topic[] = [{ type: 'GPE', value: 'United Kingdom' }];
@@ -91,4 +99,28 @@ export const topicBankSelectedIsNotInTop5 = () => {
 };
 topicBankSelectedIsNotInTop5.story = {
 	name: 'topicBankSelectedIsNotInTop5',
+};
+
+export const notShowingTopicsWithLowerCounts = () => {
+	return (
+		<Wrapper>
+			<TopicFilterBank
+				id="key-events-carousel-desktop"
+				availableTopics={availableTopicsWithLowerCount}
+				selectedTopics={selectedTopics}
+				format={format}
+				keyEvents={[
+					{
+						...baseProperties,
+						blockFirstPublished: 1638279933000,
+						title: 'title',
+					},
+				]}
+				filterKeyEvents={false}
+			/>
+		</Wrapper>
+	);
+};
+notShowingTopicsWithLowerCounts.story = {
+	name: 'notShowingTopicsWithLowerCounts',
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR limits the topic filters to only the topics that have been mentioned in at least 3 blocks. 

## Why?
Requested by the editorials as there's not much point in showing a filter category that only 1 or 2 blocks are mentioning it. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/182841860-48c03e09-7f2d-4493-a074-4278e1568505.png) | ![image](https://user-images.githubusercontent.com/15894063/182841766-174a42e9-ceb6-4618-b07a-7c8cc380633a.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
