### PR TITLE
Add star rating to DCR frontCards

### DIFF
--- a/dotcom-rendering/docs/patterns/switch-on-display-design.md
+++ b/dotcom-rendering/docs/patterns/switch-on-display-design.md
@@ -1,7 +1,8 @@
 # Switch pattern for Display and Design
+
 Every article has a `Display` and a `designType`. These describe the type of article and how it should be laid out on the page. We use these values to make choices about how to style and position elements. They are prop drilled into most components.
 
-To prevent confusing, hard to maintain code, the switch pattern isused when branching based on `Display` and / or `designType`. If branching on both, a nested switch is used. This pattern is intended to be both easy to read and something that will scale well.
+To prevent confusing, hard to maintain code, the switch pattern issued when branching based on `Display` and / or `designType`. If branching on both, a nested switch is used. This pattern is intended to be both easy to read and something that will scale well.
 
 Example usage of switch pattern
 

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -129,6 +129,7 @@ export const trails: TrailType[] = [
 			'Glacial rivers absorb carbon faster than rainforests, scientists find',
 		showByline: false,
 		byline: 'Leyland Cecco',
+		starRating: 4,
 		image: 'https://i.guim.co.uk/img/media/5e8ea90ae9f503aa1c98fd35dbf13235b1207fea/0_490_3264_1958/master/3264.jpg?width=900&quality=85&s=80890967a26cab02bd524331818e6e23',
 		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -135,6 +135,7 @@ export const enhanceCards = (
 			url: faciaCard.header.url,
 			headline: faciaCard.header.headline,
 			trailText: faciaCard.card.trailText,
+			starRating: faciaCard.card.starRating,
 			webPublicationDate: faciaCard.card.webPublicationDateOption
 				? new Date(
 						faciaCard.card.webPublicationDateOption,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -233,6 +233,7 @@ export type DCRFrontCard = {
 	url: string;
 	headline: string;
 	trailText?: string;
+	starRating?: number;
 	webPublicationDate?: string;
 	image?: string;
 	kickerText?: string;

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -68,6 +68,7 @@ const Primaries = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								supportingContent={card.supportingContent}
@@ -112,6 +113,7 @@ const Primaries = ({
 					>
 						<FrontCard
 							trail={card}
+							starRating={card.starRating}
 							containerPalette={containerPalette}
 							showAge={showAge}
 							supportingContent={card.supportingContent}
@@ -186,6 +188,7 @@ const FirstBigBoostedPlusBig = ({
 				>
 					<FrontCard
 						trail={big}
+						starRating={big.starRating}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						supportingContent={big.supportingContent}
@@ -210,6 +213,7 @@ const FirstBigBoostedPlusBig = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								imageUrl={undefined}
@@ -233,6 +237,7 @@ const FirstBigBoostedPlusBig = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								imageUrl={undefined}
@@ -454,6 +459,7 @@ export const DynamicFast = ({
 							>
 								<FrontCard
 									trail={card}
+									starRating={card.starRating}
 									containerPalette={containerPalette}
 									showAge={showAge}
 									supportingContent={card.supportingContent}
@@ -477,6 +483,7 @@ export const DynamicFast = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								supportingContent={card.supportingContent}
@@ -534,6 +541,7 @@ export const DynamicFast = ({
 										>
 											<FrontCard
 												trail={card}
+												starRating={card.starRating}
 												containerPalette={
 													containerPalette
 												}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -23,6 +23,7 @@ export const DynamicPackage = ({
 					<LI padSides={true}>
 						<FrontCard
 							trail={primary}
+							starRating={primary.starRating}
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
@@ -50,6 +51,7 @@ export const DynamicPackage = ({
 							>
 								<FrontCard
 									trail={card}
+									starRating={card.starRating}
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
@@ -68,6 +70,7 @@ export const DynamicPackage = ({
 				<LI padSides={true} percentage="75%">
 					<FrontCard
 						trail={primary}
+						starRating={primary.starRating}
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
@@ -99,6 +102,7 @@ export const DynamicPackage = ({
 								>
 									<FrontCard
 										trail={card}
+										starRating={card.starRating}
 										containerPalette={containerPalette}
 										containerType="dynamic/package"
 										showAge={showAge}

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -26,6 +26,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 				<LI padSides={true} percentage="75%">
 					<FrontCard
 						trail={primary}
+						starRating={primary.starRating}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						headlineSize="large"
@@ -44,6 +45,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 				>
 					<FrontCard
 						trail={secondary}
+						starRating={secondary.starRating}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						supportingContent={secondary.supportingContent}
@@ -67,6 +69,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 								>
 									<FrontCard
 										trail={card}
+										starRating={card.starRating}
 										containerPalette={containerPalette}
 										showAge={showAge}
 										// Overrides
@@ -102,6 +105,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 								>
 									<FrontCard
 										trail={card}
+										starRating={card.starRating}
 										containerPalette={containerPalette}
 										showAge={showAge}
 										headlineSize="small"

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -25,6 +25,7 @@ export const FixedLargeSlowXIV = ({
 				<LI padSides={true} percentage="75%" padBottomOnMobile={true}>
 					<FrontCard
 						trail={primary}
+						starRating={primary.starRating}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						headlineSize="large"
@@ -37,6 +38,7 @@ export const FixedLargeSlowXIV = ({
 				<LI padSides={true} showDivider={true} percentage="25%">
 					<FrontCard
 						trail={secondary}
+						starRating={secondary.starRating}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -54,6 +56,7 @@ export const FixedLargeSlowXIV = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								headlineSize="small"
@@ -81,6 +84,7 @@ export const FixedLargeSlowXIV = ({
 						>
 							<FrontCard
 								trail={card}
+								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
 								headlineSize="small"

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -29,6 +29,7 @@ export const FixedSmallSlowIII = ({
 					>
 						<FrontCard
 							trail={trail}
+							starRating={trail.starRating}
 							containerPalette={containerPalette}
 							showAge={showAge}
 							headlineSize={index === 0 ? 'large' : 'medium'}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -28,6 +28,7 @@ export const FixedSmallSlowIV = ({
 					>
 						<FrontCard
 							trail={trail}
+							starRating={trail.starRating}
 							containerPalette={containerPalette}
 							showAge={showAge}
 							imageSize="medium"

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
@@ -30,6 +30,7 @@ export const FixedSmallSlowVThird = ({
 					>
 						<FrontCard
 							trail={trail}
+							starRating={trail.starRating}
 							containerPalette={containerPalette}
 							showAge={showAge}
 							supportingContent={trail.supportingContent}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change? 
This adds star ratings to DCR front cards

Closes #5532 

## Why? 
This change matches the figma designs: https://www.figma.com/file/5CfbWOeZPRi15lXBD5u1rW/Card-layout-system?node-id=0%3A1

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/182878611-30cd17ee-d45e-4051-8052-6766c15428a9.png
[after]: https://user-images.githubusercontent.com/110032454/182878389-5b14b7ba-e8c4-429d-b04d-a86022786fbd.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
