### PR TITLE
Remove `DCRServerDocumentData`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -841,12 +841,6 @@ interface GADataType {
 // General DataTypes //
 // ----------------- //
 
-interface DCRServerDocumentData {
-	CAPIArticle: CAPIArticleType;
-	NAV: NavType;
-	linkedData: { [key: string]: any };
-}
-
 interface BaseTrailType {
 	url: string;
 	headline: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -842,11 +842,8 @@ interface GADataType {
 // ----------------- //
 
 interface DCRServerDocumentData {
-	page: string;
-	site: string;
 	CAPIArticle: CAPIArticleType;
 	NAV: NavType;
-	GA: GADataType;
 	linkedData: { [key: string]: any };
 }
 

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -104,7 +104,7 @@ const makeWindowGuardianConfig = (
 export const makeWindowGuardian = (
 	CAPIArticle: CAPIArticleType,
 ): {
-	// The 'config' attribute is derived from DCRServerDocumentData and contains
+	// The 'config' attribute is derived from CAPIArticle and contains
 	// all the data that, for legacy reasons, for instance compatibility
 	// with the frontend commercial stack, or other scripts, we want to find
 	// at window.guardian.config
@@ -175,7 +175,7 @@ const makeFrontWindowGuardianConfig = ({
 export const makeFrontWindowGuardian = (
 	front: DCRFrontType,
 ): {
-	// The 'config' attribute is derived from DCRServerDocumentData and contains
+	// The 'config' attribute is derived from CAPIArticle and contains
 	// all the data that, for legacy reasons, for instance compatibility
 	// with the frontend commercial stack, or other scripts, we want to find
 	// at window.guardian.config

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -65,9 +65,9 @@ interface WindowGuardianFrontConfig {
 }
 
 const makeWindowGuardianConfig = (
-	dcrDocumentData: DCRServerDocumentData,
+	CAPIArticle: CAPIArticleType,
 ): WindowGuardianConfig => {
-	const { config } = dcrDocumentData.CAPIArticle;
+	const { config } = CAPIArticle;
 	return {
 		// This indicates to the client side code that we are running a dotcom-rendering rendered page.
 		isDotcomRendering: true,
@@ -76,8 +76,8 @@ const makeWindowGuardianConfig = (
 		frontendAssetsFullURL: config.frontendAssetsFullURL,
 		page: Object.assign(config, {
 			dcrCouldRender: true,
-			contentType: dcrDocumentData.CAPIArticle.contentType,
-			edition: dcrDocumentData.CAPIArticle.editionId,
+			contentType: CAPIArticle.contentType,
+			edition: CAPIArticle.editionId,
 			revisionNumber: config.revisionNumber,
 			dcrSentryDsn:
 				'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
@@ -102,7 +102,7 @@ const makeWindowGuardianConfig = (
 };
 
 export const makeWindowGuardian = (
-	dcrDocumentData: DCRServerDocumentData,
+	CAPIArticle: CAPIArticleType,
 ): {
 	// The 'config' attribute is derived from DCRServerDocumentData and contains
 	// all the data that, for legacy reasons, for instance compatibility
@@ -119,7 +119,7 @@ export const makeWindowGuardian = (
 	GAData: GADataType;
 } => {
 	return {
-		config: makeWindowGuardianConfig(dcrDocumentData),
+		config: makeWindowGuardianConfig(CAPIArticle),
 		polyfilled: false,
 		adBlockers: {
 			active: undefined,
@@ -130,7 +130,7 @@ export const makeWindowGuardian = (
 				reportError: () => null,
 			},
 		},
-		GAData: extractGA(dcrDocumentData.CAPIArticle),
+		GAData: extractGA(CAPIArticle),
 	};
 };
 

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -1,3 +1,4 @@
+import { extract as extractGA } from '../model/extract-ga';
 import type { DCRFrontType } from '../types/front';
 
 export interface WindowGuardianConfig {
@@ -129,7 +130,7 @@ export const makeWindowGuardian = (
 				reportError: () => null,
 			},
 		},
-		GAData: dcrDocumentData.GA,
+		GAData: extractGA(dcrDocumentData.CAPIArticle),
 	};
 };
 

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -4,6 +4,7 @@ import createEmotionServer from '@emotion/server/create-instance';
 import { renderToString } from 'react-dom/server';
 import { getScriptArrayFromFile } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
+import { extractNAV } from '../../model/extract-nav';
 import { makeFrontWindowGuardian } from '../../model/window-guardian';
 import type { DCRFrontType } from '../../types/front';
 import { FrontPage } from '../components/FrontPage';
@@ -12,7 +13,6 @@ import { frontTemplate } from './frontTemplate';
 
 interface Props {
 	front: DCRFrontType;
-	NAV: NavType;
 }
 
 const generateScriptTags = (
@@ -40,8 +40,9 @@ const generateScriptTags = (
 		];
 	}, []);
 
-export const frontToHtml = ({ front, NAV }: Props): string => {
+export const frontToHtml = ({ front }: Props): string => {
 	const title = front.webTitle;
+	const NAV = extractNAV(front.nav);
 	const key = 'dcr';
 	const cache = createCache({ key });
 

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -4,7 +4,6 @@ import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceCollections } from '../../model/enhanceCollections';
 import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
-import { extractNAV } from '../../model/extract-nav';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import { articleToHtml } from './articleToHtml';
@@ -55,13 +54,9 @@ export const renderArticle = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPIArticle = enhanceCAPIType(body);
+		const article = enhanceCAPIType(body);
 		const resp = articleToHtml({
-			data: {
-				CAPIArticle,
-				NAV: extractNAV(CAPIArticle.nav),
-				linkedData: CAPIArticle.linkedData,
-			},
+			article,
 		});
 
 		res.status(200).send(resp);
@@ -79,8 +74,6 @@ export const renderArticleJson = (
 		const resp = {
 			data: {
 				CAPIArticle,
-				NAV: extractNAV(CAPIArticle.nav),
-				linkedData: CAPIArticle.linkedData,
 			},
 		};
 
@@ -103,13 +96,9 @@ export const renderInteractive = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPIArticle = enhanceCAPIType(body);
+		const article = enhanceCAPIType(body);
 		const resp = articleToHtml({
-			data: {
-				CAPIArticle,
-				NAV: extractNAV(CAPIArticle.nav),
-				linkedData: CAPIArticle.linkedData,
-			},
+			article,
 		});
 
 		res.status(200).send(resp);
@@ -213,7 +202,6 @@ export const renderFront = (
 		const front = enhanceFront(body);
 		const html = frontToHtml({
 			front,
-			NAV: extractNAV(front.nav),
 		});
 		res.status(200).send(html);
 	} catch (e) {

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -4,7 +4,6 @@ import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceCollections } from '../../model/enhanceCollections';
 import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
-import { extract as extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
@@ -60,10 +59,7 @@ export const renderArticle = (
 		const resp = articleToHtml({
 			data: {
 				CAPIArticle,
-				site: 'frontend',
-				page: 'Article',
 				NAV: extractNAV(CAPIArticle.nav),
-				GA: extractGA(CAPIArticle),
 				linkedData: CAPIArticle.linkedData,
 			},
 		});
@@ -83,10 +79,7 @@ export const renderArticleJson = (
 		const resp = {
 			data: {
 				CAPIArticle,
-				site: 'frontend',
-				page: 'Article',
 				NAV: extractNAV(CAPIArticle.nav),
-				GA: extractGA(CAPIArticle),
 				linkedData: CAPIArticle.linkedData,
 			},
 		};
@@ -114,10 +107,7 @@ export const renderInteractive = (
 		const resp = articleToHtml({
 			data: {
 				CAPIArticle,
-				site: 'frontend',
-				page: 'Interactive',
 				NAV: extractNAV(CAPIArticle.nav),
-				GA: extractGA(CAPIArticle),
 				linkedData: CAPIArticle.linkedData,
 			},
 		});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR refactors the code around `articleToHtml` and also a bit around `frontToHtml`. It makes it so that we now only pass one property to these functions. By doing this I was able to remove the `DCRServerDocumentData` type

## Why?
Previously, we had the logic to break out values from the data sent to DCR in different places as well as some unused props that were being passed down but never used. This wasn't intentional, it just ended up this way.

Having `index` be the place where functions are simply called and `articleToHtml` the place where data is extracted and set helps rationalise things a bit and will hopefully make future maintenance and expansion easier.