### PR TITLE
`FixedSmallSlowVMPU`

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -197,7 +197,7 @@ const mobileStickyAdStyles = css`
 
 const adStyles = [labelStyles, fluidAdStyles];
 
-const AdSlotLabelToggled: React.FC = () => (
+const AdSlotLabelToggled = () => (
 	<div
 		className={['ad-slot__label', 'ad-slot__label--toggle', 'hidden'].join(
 			' ',
@@ -208,13 +208,13 @@ const AdSlotLabelToggled: React.FC = () => (
 	</div>
 );
 
-export const AdSlot: React.FC<Props> = ({
+export const AdSlot = ({
 	position,
 	display,
 	shouldHideReaderRevenue = false,
 	isPaidContent = false,
 	shouldReserveMerchSpace = false,
-}) => {
+}: Props) => {
 	switch (position) {
 		case 'right':
 			switch (display) {
@@ -406,7 +406,7 @@ export const AdSlot: React.FC<Props> = ({
 	}
 };
 
-export const MobileStickyContainer: React.FC = () => {
+export const MobileStickyContainer = () => {
 	return (
 		<div className="mobilesticky-container" css={mobileStickyAdStyles} />
 	);

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -14,7 +14,7 @@ import { Island } from './Island';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
 type Props = {
-	display: ArticleDisplay;
+	display?: ArticleDisplay;
 	position: AdSlotType;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -1,0 +1,36 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { ContainerLayout } from './ContainerLayout';
+import { FixedSmallSlowVMPU } from './FixedSmallSlowVMPU';
+
+export default {
+	component: FixedSmallSlowVMPU,
+	title: 'Components/FixedSmallSlowVMPU',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<ContainerLayout
+		title="FixedSmallSlowVMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowVMPU trails={trails} showAge={true} />
+	</ContainerLayout>
+);
+Default.story = { name: 'FixedSmallSlowVMPU' };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -1,0 +1,72 @@
+import { Hide } from '@guardian/source-react-components';
+import type { DCRContainerPalette } from '../../types/front';
+import { AdSlot } from './AdSlot';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedSmallSlowVMPU = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	return (
+		<UL direction="row">
+			<LI percentage="33.333%" padSides={true} padBottomOnMobile={true}>
+				<FrontCard
+					trail={trails[0]}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			</LI>
+			<LI
+				percentage="33.333%"
+				padSides={true}
+				showDivider={true}
+				padBottomOnMobile={true}
+			>
+				<UL direction="column">
+					<LI padBottom={true}>
+						<FrontCard
+							trail={trails[1]}
+							containerPalette={containerPalette}
+							showAge={showAge}
+							imageUrl={undefined}
+							headlineSize="small"
+						/>
+					</LI>
+					<LI padBottom={true}>
+						<FrontCard
+							trail={trails[2]}
+							containerPalette={containerPalette}
+							showAge={showAge}
+							imageUrl={undefined}
+							headlineSize="small"
+						/>
+					</LI>
+					<LI>
+						<FrontCard
+							trail={trails[3]}
+							containerPalette={containerPalette}
+							showAge={showAge}
+							imageUrl={undefined}
+							headlineSize="small"
+						/>
+					</LI>
+				</UL>
+			</LI>
+			<LI percentage="33.333%" padSides={true} showDivider={true}>
+				<Hide until="tablet">
+					{/* TODO: Replace mostpop with a more appropriate value */}
+					<AdSlot position="mostpop" />
+				</Hide>
+			</LI>
+		</UL>
+	);
+};

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -11,6 +11,7 @@ import { FixedLargeSlowXIV } from '../components/FixedLargeSlowXIV';
 import { FixedMediumSlowVI } from '../components/FixedMediumSlowVI';
 import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
+import { FixedSmallSlowVMPU } from '../components/FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
 
 type Props = {
@@ -64,6 +65,14 @@ export const DecideContainer = ({
 		case 'fixed/small/slow-IV':
 			return (
 				<FixedSmallSlowIV
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		case 'fixed/small/slow-V-mpu':
+			return (
+				<FixedSmallSlowVMPU
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds support for the `FixedSmallSlowVMPU` container.

<img width="1343" alt="Screenshot 2022-08-05 at 14 20 47" src="https://user-images.githubusercontent.com/1336821/183086029-78c71f3b-5c42-4e8f-a916-612b5f11f0f7.png">


Closes #5138 

### Why isn't the advert showing?
There's [a ticket](https://github.com/guardian/dotcom-rendering/issues/5516) for this.