### PR TITLE
Better sublink colours

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -47,6 +47,17 @@ const decidePresentationFormat = ({
 		containerFormat.design === ArticleDesign.Analysis
 	)
 		return containerFormat;
+
+	// These types of link format designs mean the headline could render
+	// poorly (e.g.: white) so we use the container format
+	if (
+		linkFormat.design === ArticleDesign.LiveBlog ||
+		linkFormat.design === ArticleDesign.Gallery ||
+		linkFormat.design === ArticleDesign.Audio ||
+		linkFormat.design === ArticleDesign.Video
+	)
+		return containerFormat;
+
 	// Otherwise, we can allow the sublink to express its own styling
 	return linkFormat;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes the decision logic for how we decide which `format` property to use on sublinks

## Why?
We were not taking into account the sublink's own `format`

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="473" alt="Screenshot 2022-08-05 at 14 53 37" src="https://user-images.githubusercontent.com/1336821/183092109-0dab5a1c-332f-432f-ac8c-acfae2c268b4.png"> | <img width="473" alt="Screenshot 2022-08-05 at 14 52 45" src="https://user-images.githubusercontent.com/1336821/183092142-5d52534d-348f-46fd-96fe-277b193f5011.png"> |
