### PR TITLE
ESLint: stop warning on danger

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -34,7 +34,6 @@ const rulesToOverrideGuardianConfig = {
 
 /** @TODO Review these */
 const rulesToReview = {
-	'react/no-danger': 'warn', // 48 problems
 	'react/no-array-index-key': 'warn', // 34 problems
 	'react/button-has-type': 'warn', // 23 problems
 	'@typescript-eslint/require-await': 'warn', // 22 problems
@@ -101,6 +100,7 @@ module.exports = {
 		'react-hooks/rules-of-hooks': 'error',
 		'react/jsx-no-target-blank': 'error',
 		'react/jsx-one-expression-per-line': 'off',
+		'react/no-danger': 'off', // We use `dangerouslySetInnerHTML` in several components
 		'jsx-expressions/strict-logical-expressions': 'error',
 
 		'array-callback-return': 'error',

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -92,15 +92,15 @@ module.exports = {
 	],
 	rules: {
 		// React, Hooks & JSX
-		'react/jsx-indent': [2, 'tab'],
-		'react/jsx-indent-props': [2, 'tab'],
-		'react/prop-types': [0],
-		'react/jsx-boolean-value': [2, 'always'],
 		'react-hooks/exhaustive-deps': 'error',
 		'react-hooks/rules-of-hooks': 'error',
+		'react/jsx-boolean-value': [2, 'always'],
+		'react/jsx-indent-props': [2, 'tab'],
+		'react/jsx-indent': [2, 'tab'],
 		'react/jsx-no-target-blank': 'error',
 		'react/jsx-one-expression-per-line': 'off',
 		'react/no-danger': 'off', // We use `dangerouslySetInnerHTML` in several components
+		'react/prop-types': [0],
 		'jsx-expressions/strict-logical-expressions': 'error',
 
 		'array-callback-return': 'error',


### PR DESCRIPTION
## What does this change?

Stop warning on dangerous React methods, like `dangerouslySetInnerHtml`.

## Why?

We use `dangerouslySetInnerHTML` in several components. The function name is explicit enough as it is, and we have valid use cases for it, [including accessibility](https://github.com/guardian/dotcom-rendering/blob/11c68a72d16d093762615d7b686a9a4a2fe1cd3f/dotcom-rendering/docs/architecture/022-NoJS-navigation-and-accessibility.md).