### PR TITLE
Varying webpack bundles for tests II

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -4,7 +4,7 @@ const GuStatsReportPlugin = require('./plugins/gu-stats-report-plugin');
 const DEV = process.env.NODE_ENV === 'development';
 
 /**
- * @param {'modern' | 'legacy' | 'variant'} bundle
+ * @param {'legacy' | 'modern' | 'variant'} bundle
  * @returns {string}
  */
 const generateName = (bundle) => {
@@ -14,11 +14,39 @@ const generateName = (bundle) => {
 };
 
 /**
- * @param {'modern' | 'variant' 'legacy' | } bundle
+ * @param {'legacy' | 'modern' | 'variant'} bundle
  * @returns {string}
  */
 const getLoaders = (bundle) => {
 	switch (bundle) {
+		case 'legacy':
+			return [
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										ie: '11',
+									},
+									modules: false,
+								},
+							],
+						],
+						compact: true,
+					},
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
+			];
 		case 'modern':
 			return [
 				{
@@ -73,39 +101,11 @@ const getLoaders = (bundle) => {
 					},
 				},
 			];
-		case 'legacy':
-			return [
-				{
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-react',
-							[
-								'@babel/preset-env',
-								{
-									targets: {
-										ie: '11',
-									},
-									modules: false,
-								},
-							],
-						],
-						compact: true,
-					},
-				},
-				{
-					loader: 'ts-loader',
-					options: {
-						configFile: 'tsconfig.build.json',
-						transpileOnly: true,
-					},
-				},
-			];
 	}
 };
 
 /**
- * @param {{ bundle: 'modern' | 'legacy' | 'variant', sessionId: string }} options
+ * @param {{ bundle: 'legacy' | 'modern'  | 'variant', sessionId: string }} options
  * @returns {import('webpack').Configuration}
  */
 module.exports = ({ bundle, sessionId }) => ({

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -14,47 +14,92 @@ const generateName = (bundle) => {
 };
 
 /**
- * @param {'modern' | 'legacy' | 'variant'} bundle
+ * @param {'modern' | 'variant' 'legacy' | } bundle
  * @returns {string}
  */
-const getPresets = (bundle) => {
+const getLoaders = (bundle) => {
 	switch (bundle) {
 		case 'modern':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						bugfixes: true,
-						targets: {
-							esmodules: true,
-						},
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									bugfixes: true,
+									targets: {
+										esmodules: true,
+									},
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
 		case 'variant':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						targets: 'extends @guardian/browserslist-config',
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets:
+										'extends @guardian/browserslist-config',
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
-
 		case 'legacy':
 			return [
-				'@babel/preset-react',
-				[
-					'@babel/preset-env',
-					{
-						targets: {
-							ie: '11',
-						},
-						modules: false,
+				{
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-react',
+							[
+								'@babel/preset-env',
+								{
+									targets: {
+										ie: '11',
+									},
+									modules: false,
+								},
+							],
+						],
+						compact: true,
 					},
-				],
+				},
+				{
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.build.json',
+						transpileOnly: true,
+					},
+				},
 			];
 	}
 };
@@ -112,23 +157,7 @@ module.exports = ({ bundle, sessionId }) => ({
 			{
 				test: /\.[jt]sx?|mjs$/,
 				exclude: module.exports.babelExclude,
-
-				use: [
-					{
-						loader: 'babel-loader',
-						options: {
-							presets: getPresets(bundle),
-							compact: true,
-						},
-					},
-					{
-						loader: 'ts-loader',
-						options: {
-							configFile: 'tsconfig.build.json',
-							transpileOnly: true,
-						},
-					},
-				],
+				use: getLoaders(bundle),
 			},
 			{
 				test: /\.css$/,

--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const sessionId = uuidv4();
 let builds = 0;
 
 /**
- * @param {{ platform: 'server' | 'browser.modern' | 'browser.legacy' | 'browser.variant'}} options
+ * @param {{ platform: 'server' | 'browser.legacy' | 'browser.modern' | 'browser.variant'}} options
  * @returns {import('webpack').Configuration}
  */
 const commonConfigs = ({ platform }) => ({

--- a/dotcom-rendering/src/lib/assets.ts
+++ b/dotcom-rendering/src/lib/assets.ts
@@ -55,9 +55,9 @@ const getManifest = (path: string): AssetHash => {
 
 type Script = { src: string; legacy: boolean };
 
-export const getScriptArrayFromFile = (
-	file: `${string}.js`,
+const getScripts = (
 	manifestPath: `./manifest${string}.json`,
+	file: `${string}.js`,
 ): Script[] => {
 	if (!file.endsWith('.js'))
 		throw new Error('Invalid filename: extension must be .js');
@@ -89,3 +89,8 @@ export const getScriptArrayFromFile = (
 
 	return scripts;
 };
+
+export const getScriptsFromManifest =
+	(manifestPath: `./manifest${string}.json`) =>
+	(file: `${string}.js`): ReturnType<typeof getScripts> =>
+		getScripts(manifestPath, file);

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,7 +3,7 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
-import { ASSET_ORIGIN, getScriptArrayFromFile } from '../../lib/assets';
+import { ASSET_ORIGIN, getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { makeWindowGuardian } from '../../model/window-guardian';
 import { Article } from '../components/Article';
@@ -127,6 +127,8 @@ export const articleToHtml = ({ data }: Props): string => {
 			? './manifest.variant.json'
 			: './manifest.json';
 
+	const getScripts = getScriptsFromManifest(manifestPath);
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -137,22 +139,20 @@ export const articleToHtml = ({ data }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js', manifestPath),
-			...getScriptArrayFromFile('ophan.js', manifestPath),
+			...getScripts('bootCmp.js'),
+			...getScripts('ophan.js'),
 			CAPIArticle.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					CAPIArticle.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
-			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
+			...getScripts('sentryLoader.js'),
+			...getScripts('dynamicImport.js'),
 			pageHasNonBootInteractiveElements && {
 				src: `${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
 			},
-			...getScriptArrayFromFile('islands.js', manifestPath),
-			...expeditedIslands.flatMap((name) =>
-				getScriptArrayFromFile(`${name}.js`, manifestPath),
-			),
+			...getScripts('islands.js'),
+			...expeditedIslands.flatMap((name) => getScripts(`${name}.js`)),
 		].map((script) =>
 			offerHttp3 && script
 				? { ...script, src: getHttp3Url(script.src) }
@@ -169,17 +169,17 @@ export const articleToHtml = ({ data }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js', manifestPath),
-			...getScriptArrayFromFile('embedIframe.js', manifestPath),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
-			...getScriptArrayFromFile('relativeTime.js', manifestPath),
-			...getScriptArrayFromFile('initDiscussion.js', manifestPath),
+			...getScripts('atomIframe.js'),
+			...getScripts('embedIframe.js'),
+			...getScripts('newsletterEmbedIframe.js'),
+			...getScripts('relativeTime.js'),
+			...getScripts('initDiscussion.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath);
+	const gaChunk = getScripts('ga.js');
 	const modernScript = gaChunk.find((script) => !script.legacy);
 	const legacyScript = gaChunk.find((script) => script.legacy);
 	const gaPath = {

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -2,7 +2,7 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { renderToString } from 'react-dom/server';
-import { getScriptArrayFromFile } from '../../lib/assets';
+import { getScriptsFromManifest } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { makeFrontWindowGuardian } from '../../model/window-guardian';
 import type { DCRFrontType } from '../../types/front';
@@ -88,6 +88,8 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 			? './manifest.variant.json'
 			: './manifest.json';
 
+	const getScripts = getScriptsFromManifest(manifestPath);
+
 	/**
 	 * The highest priority scripts.
 	 * These scripts have a considerable impact on site performance.
@@ -98,16 +100,16 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getScriptArrayFromFile('bootCmp.js', manifestPath),
-			...getScriptArrayFromFile('ophan.js', manifestPath),
+			...getScripts('bootCmp.js'),
+			...getScripts('ophan.js'),
 			front.config && {
 				src:
 					process.env.COMMERCIAL_BUNDLE_URL ??
 					front.config.commercialBundleUrl,
 			},
-			...getScriptArrayFromFile('sentryLoader.js', manifestPath),
-			...getScriptArrayFromFile('dynamicImport.js', manifestPath),
-			...getScriptArrayFromFile('islands.js', manifestPath),
+			...getScripts('sentryLoader.js'),
+			...getScripts('dynamicImport.js'),
+			...getScripts('islands.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
@@ -122,18 +124,17 @@ export const frontToHtml = ({ front, NAV }: Props): string => {
 	 */
 	const lowPriorityScriptTags = generateScriptTags(
 		[
-			...getScriptArrayFromFile('atomIframe.js', manifestPath),
-			...getScriptArrayFromFile('embedIframe.js', manifestPath),
-			...getScriptArrayFromFile('newsletterEmbedIframe.js', manifestPath),
-			...getScriptArrayFromFile('relativeTime.js', manifestPath),
+			...getScripts('atomIframe.js'),
+			...getScripts('embedIframe.js'),
+			...getScripts('newsletterEmbedIframe.js'),
+			...getScripts('relativeTime.js'),
 		].map((script) =>
 			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 		),
 	);
 
-	const gaChunk = getScriptArrayFromFile('ga.js', manifestPath).map(
-		(script) =>
-			offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
+	const gaChunk = getScripts('ga.js').map((script) =>
+		offerHttp3 ? { ...script, src: getHttp3Url(script.src) } : script,
 	);
 	const modernScript = gaChunk.find((script) => !script.legacy);
 	const legacyScript = gaChunk.find((script) => script.legacy);


### PR DESCRIPTION
## What does this change?

Updates #5598 with

- promote conditional webpack bundling from presets -> loaders (we will need this for #5172 )
- align naming
- partial application of `getScriptsFromManifest` to avoid having to pass `manifestPath` for every call

