### PR TITLE
Reduce email signup sizing

### DIFF
--- a/dotcom-rendering/__mocks__/SecureSignupMock.tsx
+++ b/dotcom-rendering/__mocks__/SecureSignupMock.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral, space } from '@guardian/source-foundations';
+import { neutral, space, textSans } from '@guardian/source-foundations';
 import { Button, Label, TextInput } from '@guardian/source-react-components';
 import { NewsletterPrivacyMessage } from '../src/web/components/NewsletterPrivacyMessage';
 
@@ -9,21 +9,34 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 	return (
 		<div title="This is a mock for the SecureSignup component which is not compatible with storybook. Changes to the real component will not be automatically reflected in this mock.">
 			<form id={`secure-signup-${newsletterId}`}>
-				<Label text="Enter your email address" />
+				<Label
+					text="Enter your email address"
+					css={css`
+						div {
+							${textSans.xsmall({ fontWeight: 'bold' })}
+						}
+					`}
+				/>
 
 				<div
 					css={css`
 						display: flex;
 						flex-direction: row;
-						align-items: flex-end;
+						align-items: flex-start;
 						flex-wrap: wrap;
 					`}
 				>
 					<div
 						css={css`
 							margin-right: ${space[3]}px;
+							margin-bottom: ${space[2]}px;
 							flex-basis: 335px;
 							flex-shrink: 1;
+
+							input {
+								height: 36px;
+								margin-top: 0;
+							}
 						`}
 					>
 						<TextInput
@@ -35,6 +48,7 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 					</div>
 					<Button
 						disabled={true}
+						size="small"
 						cssOverrides={css`
 							justify-content: center;
 							background-color: ${neutral[0]};
@@ -43,7 +57,7 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 							}
 							flex-basis: 118px;
 							flex-shrink: 0;
-							margin-top: ${space[2]}px;
+							margin-bottom: ${space[2]}px;
 						`}
 						type="submit"
 					>
@@ -51,13 +65,7 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 					</Button>
 				</div>
 			</form>
-			<div
-				css={css`
-					margin-top: ${space[2]}px;
-				`}
-			>
-				<NewsletterPrivacyMessage />
-			</div>
+			<NewsletterPrivacyMessage />
 		</div>
 	);
 };

--- a/dotcom-rendering/__mocks__/SecureSignupMock.tsx
+++ b/dotcom-rendering/__mocks__/SecureSignupMock.tsx
@@ -11,7 +11,7 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 			<form id={`secure-signup-${newsletterId}`}>
 				<Label
 					text="Enter your email address"
-					css={css`
+					cssOverrides={css`
 						div {
 							${textSans.xsmall({ fontWeight: 'bold' })}
 						}
@@ -32,11 +32,6 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 							margin-bottom: ${space[2]}px;
 							flex-basis: 335px;
 							flex-shrink: 1;
-
-							input {
-								height: 36px;
-								margin-top: 0;
-							}
 						`}
 					>
 						<TextInput
@@ -44,6 +39,10 @@ export const SecureSignup = ({ newsletterId }: Props) => {
 							name="email"
 							label="Enter your email address"
 							type="email"
+							cssOverrides={css`
+								height: 36px;
+								margin-top: 0;
+							`}
 						/>
 					</div>
 					<Button

--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -50,6 +50,21 @@ const titleStyles = (theme: string) => css`
 	}
 `;
 
+// When in a row with the title, the Icon in the NewsletterFrequency
+// component should not affect the spaceing between the title text and
+// the description text, which should be 4px (space [1]).
+// When stacked below the title, there should be 8px (space[2]) between
+// the title and the Icon and then 8px between the Icon and the description
+const noHeightFromTabletStyles = css`
+	margin-top: ${space[2]}px;
+
+	${from.tablet} {
+		margin-top: 0;
+		max-height: 0;
+		overflow: visible;
+	}
+`;
+
 const descriptionStyles = css`
 	${textSans.xsmall({ lineHeight: 'tight' })}
 	margin-bottom: ${space[2]}px;
@@ -69,7 +84,9 @@ export const EmailSignup = ({
 				<p css={titleStyles(theme)}>
 					Sign up to <span>{name}</span> today
 				</p>
-				<NewsletterFrequency frequency={frequency} />
+				<div css={noHeightFromTabletStyles}>
+					<NewsletterFrequency frequency={frequency} />
+				</div>
 			</div>
 			<p css={descriptionStyles}>{description}</p>
 			<SecureSignup

--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -43,7 +43,7 @@ const stackBelowTabletStyles = css`
 `;
 
 const titleStyles = (theme: string) => css`
-	${headline.xsmall({ fontWeight: 'bold' })}
+	${headline.xxsmall({ fontWeight: 'bold' })}
 	flex-grow: 1;
 	span {
 		color: ${theme === 'news' ? sport[500] : 'inherit'};
@@ -51,7 +51,7 @@ const titleStyles = (theme: string) => css`
 `;
 
 const descriptionStyles = css`
-	${textSans.medium({ lineHeight: 'tight' })}
+	${textSans.xsmall({ lineHeight: 'tight' })}
 	margin-bottom: ${space[2]}px;
 `;
 

--- a/dotcom-rendering/src/web/components/NewsletterFrequency.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterFrequency.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import {
 	brandAltBackground,
-	from,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
@@ -13,10 +12,6 @@ export const NewsletterFrequency = ({ frequency }: { frequency: string }) => {
 			css={css`
 				display: flex;
 				align-items: center;
-				margin-top: ${space[2]}px;
-				${from.tablet} {
-					margin-top: 0;
-				}
 			`}
 		>
 			<div

--- a/dotcom-rendering/src/web/components/NewsletterFrequency.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterFrequency.tsx
@@ -12,6 +12,7 @@ export const NewsletterFrequency = ({ frequency }: { frequency: string }) => {
 		<div
 			css={css`
 				display: flex;
+				align-items: center;
 				margin-top: ${space[2]}px;
 				${from.tablet} {
 					margin-top: 0;
@@ -34,7 +35,10 @@ export const NewsletterFrequency = ({ frequency }: { frequency: string }) => {
 			</div>
 			<div
 				css={css`
-					${textSans.medium({ fontWeight: 'bold' })}
+					${textSans.xsmall({
+						fontWeight: 'bold',
+						lineHeight: 'tight',
+					})}
 				`}
 			>
 				{frequency}

--- a/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
@@ -6,7 +6,7 @@ const termsStyle = css`
 	${textSans.xxsmall()}
 	color: ${text.supporting};
 	a {
-		${textSans.xxsmall({ fontWeight: 'bold' })};
+		${textSans.xxsmall()};
 		color: ${neutral[0]};
 		text-decoration: underline;
 		:hover {

--- a/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
+++ b/dotcom-rendering/src/web/components/NewsletterPrivacyMessage.tsx
@@ -3,7 +3,7 @@ import { neutral, text, textSans } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 
 const termsStyle = css`
-	${textSans.xxsmall()}
+	${textSans.xxsmall({ lineHeight: 'tight' })}
 	color: ${text.supporting};
 	a {
 		${textSans.xxsmall()};

--- a/dotcom-rendering/src/web/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignup.tsx
@@ -45,13 +45,12 @@ const generateForm = (
 			<form id={`secure-signup-${newsletterId}`}>
 				<Label
 					text="Enter your email address"
-					css={css`
+					cssOverrides={css`
 						div {
 							${textSans.xsmall({ fontWeight: 'bold' })}
 						}
 					`}
 				/>
-
 				<div
 					css={css`
 						display: flex;
@@ -66,11 +65,6 @@ const generateForm = (
 							margin-bottom: ${space[2]}px;
 							flex-basis: 335px;
 							flex-shrink: 1;
-
-							input {
-								height: 36px;
-								margin-top: 0;
-							}
 						`}
 					>
 						<TextInput
@@ -78,6 +72,10 @@ const generateForm = (
 							name="email"
 							label="Enter your email address"
 							type="email"
+							cssOverrides={css`
+								height: 36px;
+								margin-top: 0;
+							`}
 						/>
 					</div>
 					<Button

--- a/dotcom-rendering/src/web/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignup.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider, css } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { neutral, space } from '@guardian/source-foundations';
+import { neutral, space, textSans } from '@guardian/source-foundations';
 import { Button, Label, TextInput } from '@guardian/source-react-components';
 import { renderToString } from 'react-dom/server';
 import { Island } from './Island';
@@ -43,21 +43,34 @@ const generateForm = (
 	const html = renderToString(
 		<CacheProvider value={cache}>
 			<form id={`secure-signup-${newsletterId}`}>
-				<Label text="Enter your email address" />
+				<Label
+					text="Enter your email address"
+					css={css`
+						div {
+							${textSans.xsmall({ fontWeight: 'bold' })}
+						}
+					`}
+				/>
 
 				<div
 					css={css`
 						display: flex;
 						flex-direction: row;
-						align-items: flex-end;
+						align-items: flex-start;
 						flex-wrap: wrap;
 					`}
 				>
 					<div
 						css={css`
 							margin-right: ${space[3]}px;
+							margin-bottom: ${space[2]}px;
 							flex-basis: 335px;
 							flex-shrink: 1;
+
+							input {
+								height: 36px;
+								margin-top: 0;
+							}
 						`}
 					>
 						<TextInput
@@ -68,6 +81,7 @@ const generateForm = (
 						/>
 					</div>
 					<Button
+						size="small"
 						cssOverrides={css`
 							justify-content: center;
 							background-color: ${neutral[0]};
@@ -76,7 +90,7 @@ const generateForm = (
 							}
 							flex-basis: 118px;
 							flex-shrink: 0;
-							margin-top: ${space[2]}px;
+							margin-bottom: ${space[2]}px;
 						`}
 						type="submit"
 					>
@@ -100,7 +114,7 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 			<Island
 				clientOnly={true}
 				deferUntil={'idle'}
-				placeholderHeight={75}
+				placeholderHeight={65}
 			>
 				<SecureSignupIframe
 					html={html}
@@ -109,13 +123,7 @@ export const SecureSignup = ({ newsletterId, successDescription }: Props) => {
 					successDescription={successDescription}
 				/>
 			</Island>
-			<div
-				css={css`
-					margin-top: ${space[2]}px;
-				`}
-			>
-				<NewsletterPrivacyMessage />
-			</div>
+			<NewsletterPrivacyMessage />
 		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -293,7 +293,7 @@ export const SecureSignupIframe = ({
 				ref={iframeRef}
 				css={css`
 					width: 100%;
-					min-height: 75px;
+					min-height: 65px;
 					overflow: hidden;
 				`}
 				style={{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Reduces the size of the text and form components used within the EmailSignup Component

## Why?
We've had some feedback that the design should be smaller.

## Screenshots

| Before(218px high)      | After (190px high)      |
|-------------|------------|
| <img width="786" alt="Screenshot 2022-08-05 at 16 02 30" src="https://user-images.githubusercontent.com/30567854/183106901-2a80cebd-7916-4abf-bd54-7b330aae5579.png">| <img width="786" alt="Screenshot 2022-08-05 at 16 02 18" src="https://user-images.githubusercontent.com/30567854/183107121-4cdde8a9-8457-4c6f-9414-3802b14344be.png">|


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
