### PR TITLE
Caption Component Now Handles Missing Caption

### DIFF
--- a/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
@@ -60,9 +60,8 @@ const GalleryCaption: FC<Props> = ({ mainMedia, format }) =>
 
 		return (
 			<p css={styles}>
-				{maybeRender(caption, (cap) => (
-					<Caption caption={cap} format={format} />
-				))}{' '}
+				<Caption caption={caption} format={format} />
+				{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>
 				))}

--- a/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
@@ -60,8 +60,7 @@ const GalleryCaption: FC<Props> = ({ mainMedia, format }) =>
 
 		return (
 			<p css={styles}>
-				<Caption caption={caption} format={format} />
-				{' '}
+				<Caption caption={caption} format={format} />{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>
 				))}

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -56,9 +56,8 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 
 		return (
 			<p id={immersiveCaptionId} css={styles(format)}>
-				{maybeRender(caption, (cap) => (
-					<Caption caption={cap} format={format} />
-				))}{' '}
+				<Caption caption={caption} format={format} />
+				{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>
 				))}

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -56,8 +56,7 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 
 		return (
 			<p id={immersiveCaptionId} css={styles(format)}>
-				<Caption caption={caption} format={format} />
-				{' '}
+				<Caption caption={caption} format={format} />{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>
 				))}

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -11,8 +11,10 @@ import {
 	remSpace,
 	textSans,
 } from '@guardian/source-foundations';
+import type { Option } from '@guardian/types';
 import { withDefault } from '@guardian/types';
 import Anchor from 'components/Anchor';
+import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { getHref, renderTextElement } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -103,13 +105,14 @@ const captionElement =
 // ----- Component ----- //
 
 type Props = {
-	caption: DocumentFragment;
+	caption: Option<DocumentFragment>;
 	format: ArticleFormat;
 };
 
-const Caption: FC<Props> = ({ caption, format }) => (
-	<>{Array.from(caption.childNodes).map(captionElement(format))}</>
-);
+const Caption: FC<Props> = ({ caption, format }) =>
+	maybeRender(caption, cap => (
+		<>{Array.from(cap.childNodes).map(captionElement(format))}</>
+	));
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/caption/caption.tsx
+++ b/apps-rendering/src/components/caption/caption.tsx
@@ -110,7 +110,7 @@ type Props = {
 };
 
 const Caption: FC<Props> = ({ caption, format }) =>
-	maybeRender(caption, cap => (
+	maybeRender(caption, (cap) => (
 		<>{Array.from(cap.childNodes).map(captionElement(format))}</>
 	));
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -424,10 +424,10 @@ const imageRenderer = (
 ): ReactNode => {
 	const { caption, credit, nativeCaption } = element;
 	return h(BodyImage, {
-		caption: map<DocumentFragment, ReactNode>((cap) => [
-			h(Caption, { format, caption: cap }),
+		caption: some([
+			h(Caption, { format, caption }),
 			h(Credit, { credit, format, key }),
-		])(caption),
+		]),
 		format: format,
 		key,
 		supportsDarkMode: true,
@@ -588,9 +588,7 @@ const mediaAtomRenderer = (
 	const figcaption = h(FigCaption, {
 		format: format,
 		supportsDarkMode: true,
-		children: map((cap: DocumentFragment) =>
-			h(Caption, { caption: cap, format }),
-		)(caption),
+		children: some(h(Caption, { caption, format })),
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions


### PR DESCRIPTION
## Why?

Moves the logic for handling a missing caption into the `Caption` component. This change allows body images to display credits as part of the image caption, even when the caption field itself is missing.

## Changes

- Moved the logic for handling missing caption into `Caption` component
- Render credits when caption is missing
