### PR TITLE
A slightly smaller avatar

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -347,13 +347,13 @@ export const WithNoSlash = () => {
 	);
 };
 
-export const WithAnAvatarWhenVertical = () => {
+export const WithAnAvatar = () => {
 	return (
 		<>
 			<CardWrapper>
 				<div
 					css={css`
-						width: 260px;
+						width: 280px;
 					`}
 				>
 					<Card
@@ -366,24 +366,6 @@ export const WithAnAvatarWhenVertical = () => {
 						}}
 					/>
 				</div>
-			</CardWrapper>
-		</>
-	);
-};
-
-export const WithAnAvatarWhenHorizontal = () => {
-	return (
-		<>
-			<CardWrapper>
-				<Card
-					{...basicCardProps}
-					avatarUrl="https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3"
-					format={{
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Comment,
-						theme: ArticlePillar.Opinion,
-					}}
-				/>
 			</CardWrapper>
 		</>
 	);

--- a/dotcom-rendering/src/web/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/AvatarContainer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
@@ -9,9 +9,9 @@ const containerStyles = css`
 	display: flex;
 	flex-direction: row-reverse;
 
-	margin-right: 10px;
+	margin-right: ${space[1]}px;
 	${until.tablet} {
-		margin-top: 5px;
+		margin-top: ${space[1]}px;
 	}
 	${from.tablet} {
 		margin-top: 50px;

--- a/dotcom-rendering/src/web/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/AvatarContainer.tsx
@@ -26,8 +26,8 @@ const sizingStyles = css`
 	}
 	/* Below 740 */
 	${until.tablet} {
-		height: 84px;
-		width: 84px;
+		height: 73px;
+		width: 73px;
 	}
 	/* Otherwise */
 	height: 132px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This reduces the size of the avatar on mobile from `84px` to `73px` and reduces the top and right padding.

Closes #5485 

## Why?
As per designs (@HarryFischer )


| Before      | After      |
|-------------|------------|
| <img width="291" alt="Screenshot 2022-08-08 at 09 32 08" src="https://user-images.githubusercontent.com/1336821/183375215-13514df0-e4b1-42eb-819e-40461f33540d.png"> | <img width="291" alt="Screenshot 2022-08-08 at 09 58 26" src="https://user-images.githubusercontent.com/1336821/183380499-f50c7fe4-3a9f-4fab-8861-489c639f633e.png"> |
