### PR TITLE
Resize key event carousel button

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsCarousel.importable.tsx
@@ -156,6 +156,7 @@ export const KeyEventsCarousel = ({
 								onClick={goPrevious}
 								aria-label="Move key events carousel backwards"
 								data-link-name="key event carousel left chevron"
+								size="small"
 							/>
 							<Button
 								hideLabel={true}
@@ -165,6 +166,7 @@ export const KeyEventsCarousel = ({
 								onClick={goNext}
 								aria-label="Move key events carousel forwards"
 								data-link-name="key event carousel right chevron"
+								size="small"
 							/>
 						</>
 					)}


### PR DESCRIPTION
## What does this change?
Decreases the Key Event Carousel button.

## Why?
Design change.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
https://user-images.githubusercontent.com/55602675/183386318-5720401b-203d-4d90-8125-da26f7036b76.png

[after]: https://user-images.githubusercontent.com/55602675/183386403-8cfb4165-6cc1-4402-856f-62e75cd3ff59.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
