### PR TITLE
Add a new class for blog rich links

### DIFF
--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -84,8 +84,9 @@ const richLinkHeader = css`
 	color: ${neutral[0]};
 `;
 
-const blogRichLinkTitle = css`
+const richLinkTitleStyle = (parent: boolean) => css`
 	${headline.xxxsmall()};
+	font-size: ${!parent ? '14px' : undefined};
 	padding-top: 1px;
 	padding-bottom: 1px;
 	font-weight: 400;
@@ -93,11 +94,6 @@ const blogRichLinkTitle = css`
 		${headline.xxsmall()};
 		padding-bottom: 5px;
 	}
-`;
-
-const richLinkTitle = css`
-	${blogRichLinkTitle};
-	font-size: 14px;
 `;
 
 const labsRichLinkTitle = css`
@@ -237,13 +233,12 @@ export const RichLink = ({
 	const isOpinion = cardStyle === 'comment';
 	const mainContributor = getMainContributor(tags);
 	const isLabs = linkFormat.theme === ArticleSpecial.Labs;
+
 	const richLinkTitlePicker = () => {
 		if (isLabs) {
 			return labsRichLinkTitle;
-		} else if (parentIsBlog) {
-			return blogRichLinkTitle;
 		} else {
-			return richLinkTitle;
+			return richLinkTitleStyle(parentIsBlog);
 		}
 	};
 

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -86,7 +86,7 @@ const richLinkHeader = css`
 
 const richLinkTitleStyle = (parent: boolean) => css`
 	${headline.xxxsmall()};
-	font-size: ${!parent ? '14px' : undefined};
+	${parentIsBlog && 'font-size: 14px'};
 	padding-top: 1px;
 	padding-bottom: 1px;
 	font-weight: 400;

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -84,9 +84,9 @@ const richLinkHeader = css`
 	color: ${neutral[0]};
 `;
 
-const richLinkTitleStyle = (parent: boolean) => css`
+const richLinkTitle = (parentIsBlog: boolean) => css`
 	${headline.xxxsmall()};
-	${parentIsBlog && 'font-size: 14px'};
+	${!parentIsBlog && 'font-size: 14px'};
 	padding-top: 1px;
 	padding-bottom: 1px;
 	font-weight: 400;
@@ -234,13 +234,9 @@ export const RichLink = ({
 	const mainContributor = getMainContributor(tags);
 	const isLabs = linkFormat.theme === ArticleSpecial.Labs;
 
-	const richLinkTitlePicker = () => {
-		if (isLabs) {
-			return labsRichLinkTitle;
-		} else {
-			return richLinkTitleStyle(parentIsBlog);
-		}
-	};
+	const richLinkTitlePicker = isLabs
+		? labsRichLinkTitle
+		: richLinkTitle(parentIsBlog);
 
 	return (
 		<div
@@ -266,7 +262,7 @@ export const RichLink = ({
 					)}
 					<div css={richLinkElements}>
 						<div css={richLinkHeader}>
-							<div css={richLinkTitlePicker()}>
+							<div css={richLinkTitlePicker}>
 								{isOpinion && (
 									<>
 										<Hide when="above" breakpoint="wide">

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -84,9 +84,8 @@ const richLinkHeader = css`
 	color: ${neutral[0]};
 `;
 
-const richLinkTitle = css`
+const blogRichLinkTitle = css`
 	${headline.xxxsmall()};
-	font-size: 14px;
 	padding-top: 1px;
 	padding-bottom: 1px;
 	font-weight: 400;
@@ -94,6 +93,11 @@ const richLinkTitle = css`
 		${headline.xxsmall()};
 		padding-bottom: 5px;
 	}
+`;
+
+const richLinkTitle = css`
+	${blogRichLinkTitle};
+	font-size: 14px;
 `;
 
 const labsRichLinkTitle = css`
@@ -233,6 +237,15 @@ export const RichLink = ({
 	const isOpinion = cardStyle === 'comment';
 	const mainContributor = getMainContributor(tags);
 	const isLabs = linkFormat.theme === ArticleSpecial.Labs;
+	const richLinkTitlePicker = () => {
+		if (isLabs) {
+			return labsRichLinkTitle;
+		} else if (parentIsBlog) {
+			return blogRichLinkTitle;
+		} else {
+			return richLinkTitle;
+		}
+	};
 
 	return (
 		<div
@@ -258,9 +271,7 @@ export const RichLink = ({
 					)}
 					<div css={richLinkElements}>
 						<div css={richLinkHeader}>
-							<div
-								css={isLabs ? labsRichLinkTitle : richLinkTitle}
-							>
+							<div css={richLinkTitlePicker()}>
 								{isOpinion && (
 									<>
 										<Hide when="above" breakpoint="wide">


### PR DESCRIPTION

Co-Authored-By: Joshua <joshuathomaslieberman@gmail.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes text size bug.
## Why?
On smaller screens live blog rich links were too small

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:  https://user-images.githubusercontent.com/110032454/183407276-f06ff566-e859-49fe-b101-6746193ef0b6.png
[after]: https://user-images.githubusercontent.com/110032454/183407168-0e0fc8d3-7855-40f0-bc6d-0202629fc8dd.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
