### PR TITLE
Ban usage of `React.FC` and similar

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -152,6 +152,14 @@ module.exports = {
 						types: {
 							'JSX.Element': 'Prefer type inference',
 							'EmotionJSX.Element': 'Prefer type inference',
+							'React.StatelessComponent':
+								'Please use const MyThing = ({foo, bar}: Props) instead',
+							'React.FunctionalComponent':
+								'Please use const MyThing = ({foo, bar}: Props) instead',
+							'React.SC':
+								'Please use const MyThing = ({foo, bar}: Props) instead',
+							'React.FC':
+								'Please use const MyThing = ({foo, bar}: Props) instead',
 						},
 						extendDefaults: true,
 					},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This bans the `React.FC` type

We're warning for now, but might upgrade to `error` soon (if anyone has the urge to refactor away all existing use cases)

## Why?
[This article](https://kentcdodds.com/blog/how-to-write-a-react-component-in-typescript) provides a good summary and [this Github issue](https://github.com/facebook/create-react-app/pull/8177) has even more details but ultimately because we don't want to add the implicit `children` prop but also because we want one consistent way of doing things in DCR
