### PR TITLE
Use `neutral.100` for liveblog cards metadata

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -473,21 +473,10 @@ const textCardFooter = (format: ArticleFormat): string => {
 			}
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
-				case ArticlePillar.News:
-					return news[600];
-				case ArticlePillar.Sport:
-					return sport[600];
-				case ArticlePillar.Opinion:
-					return WHITE;
-				case ArticlePillar.Culture:
-					return culture[600];
-				case ArticlePillar.Lifestyle:
-					return lifestyle[500];
-				case ArticleSpecial.SpecialReport:
-					return brandAlt[400];
 				case ArticleSpecial.Labs:
-				default:
 					return BLACK;
+				default:
+					return neutral[100];
 			}
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -436,19 +436,10 @@ const textCardKicker = (format: ArticleFormat): string => {
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
-				case ArticlePillar.News:
-					return news[600];
-				case ArticlePillar.Sport:
-					return sport[600];
-				case ArticlePillar.Opinion:
-					return WHITE;
-				case ArticlePillar.Culture:
-					return culture[600];
-				case ArticlePillar.Lifestyle:
-					return lifestyle[500];
 				case ArticleSpecial.Labs:
-				default:
 					return BLACK;
+				default:
+					return neutral[100];
 			}
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:


### PR DESCRIPTION
## What does this change?

Uses `neutral.100` as the colour for liveblog cards metadata, unless the card is a Labs card, or part of a container with a `containerPalette` applied.

## Why?

This improves the contrast between text and background, which is important for accessibility. This is the DCR part of closing #5603 and contributes to #4953.

## Screenshots

**Query:** Without the colour difference, there's not so much variation between the kicker and the standfirst for sublinked stories (e.g. at the bottom of the Sport liveblog card, pictured below). Is this okay? Or do we need to think about adding a `/` here, or other visual cue?

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/37048459/183410655-82d9105b-658a-48e2-a181-b743cfb6cf92.png)| ![image](https://user-images.githubusercontent.com/37048459/183410584-1b99e5bf-1eb0-4e37-83b1-8fe324f84a89.png) |
|![image](https://user-images.githubusercontent.com/37048459/183410783-cdbe07f1-52fb-4403-95ea-ea026bb4d986.png)|![image](https://user-images.githubusercontent.com/37048459/183410954-d66d7a14-f6ed-4ccf-9394-40ea5b1173cc.png)|
|<img width="829" alt="image" src="https://user-images.githubusercontent.com/37048459/183412934-21a9f0ad-3f37-45af-bd2d-e5dc673dc40e.png">|<img width="832" alt="image" src="https://user-images.githubusercontent.com/37048459/183412879-e09a0a50-784b-481f-b06a-82a87f5a5195.png">|