### PR TITLE
Fix padding in `KeyEventCard`

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -71,7 +71,7 @@ const listItemStyles = (palette: Palette) => css`
 	scroll-snap-align: start;
 
 	${from.desktop} {
-		padding-bottom: ${space[5]}px;
+		padding-bottom: 13px;
 		background-color: ${palette.background.keyEventFromDesktop};
 		width: 200px;
 		padding-right: ${space[5]}px;

--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -71,7 +71,7 @@ const listItemStyles = (palette: Palette) => css`
 	scroll-snap-align: start;
 
 	${from.desktop} {
-		padding-bottom: 13px;
+		padding-bottom: ${space[3]}px;
 		background-color: ${palette.background.keyEventFromDesktop};
 		width: 200px;
 		padding-right: ${space[5]}px;


### PR DESCRIPTION
## What does this change?
Changes the `padding-bottom` to 12px for desktop.

## Why?
As part of the redesign, the Key Events Carousel buttons have been resized (#5619) and thus the padding between them and the carousel cards had to be reduced.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: 
https://user-images.githubusercontent.com/55602675/183416034-8b8facaf-1bd6-4ddd-9c2f-f725fdc63dec.png

[after]: 
https://user-images.githubusercontent.com/55602675/183452355-7c864499-e321-4545-a3d6-0d3319ab0991.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
