### PR TITLE
Adds `headlineSizeOnMobile` parameter to Cards

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -36,6 +36,7 @@ export type Props = {
 	format: ArticleFormat;
 	headlineText: string;
 	headlineSize?: SmallHeadlineSize;
+	headlineSizeOnMobile?: SmallHeadlineSize;
 	/** Even with design !== Comment, a piece can be opinion */
 	showQuotes?: boolean;
 	byline?: string;
@@ -169,6 +170,7 @@ export const Card = ({
 	format,
 	headlineText,
 	headlineSize,
+	headlineSizeOnMobile,
 	showQuotes,
 	byline,
 	showByline,
@@ -323,6 +325,7 @@ export const Card = ({
 								format={format}
 								containerPalette={containerPalette}
 								size={headlineSize}
+								sizeOnMobile={headlineSizeOnMobile}
 								showQuotes={showQuotes}
 								kickerText={
 									format.design === ArticleDesign.LiveBlog

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -4,7 +4,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { specialReport } from '@guardian/source-foundations';
+import { breakpoints, specialReport } from '@guardian/source-foundations';
 import { CardHeadline } from './CardHeadline';
 import { ElementContainer } from './ElementContainer';
 
@@ -152,6 +152,36 @@ export const Size = () => (
 	</>
 );
 Size.story = { name: 'Size' };
+
+export const MobileSize = () => (
+	<>
+		{smallHeadlineSizes.map((size) => (
+			<div key={size}>
+				<ElementContainer showTopBorder={false} showSideBorders={false}>
+					<CardHeadline
+						headlineText={`This is how a mobile ${size} card headline looks`}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
+						size="medium"
+						sizeOnMobile={size}
+					/>
+				</ElementContainer>
+				<br />
+			</div>
+		))}
+	</>
+);
+MobileSize.story = {
+	name: 'MobileSize',
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+	},
+};
 
 export const liveStory = () => (
 	<ElementContainer showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -28,6 +28,7 @@ type Props = {
 	showSlash?: boolean;
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
 	size?: SmallHeadlineSize;
+	sizeOnMobile?: SmallHeadlineSize;
 	byline?: string;
 	showByline?: boolean;
 	showLine?: boolean; // If true a short line is displayed above, used for sublinks
@@ -48,12 +49,6 @@ const fontStyles = ({
 	switch (size) {
 		case 'ginormous':
 			return css`
-				${until.mobileLandscape} {
-					${headline.medium(options)};
-				}
-				${between.mobileLandscape.and.desktop} {
-					${headline.large(options)};
-				}
 				${from.desktop} {
 					${headline.large(options)};
 					font-size: 50px;
@@ -62,23 +57,14 @@ const fontStyles = ({
 		case 'huge':
 			return css`
 				${headline.small(options)};
-				${until.desktop} {
-					${headline.xsmall(options)};
-				}
 			`;
 		case 'large':
 			return css`
 				${headline.xsmall(options)};
-				${until.desktop} {
-					${headline.xxsmall(options)};
-				}
 			`;
 		case 'medium':
 			return css`
 				${headline.xxsmall(options)};
-				${until.desktop} {
-					${headline.xxxsmall(options)};
-				}
 			`;
 		case 'small':
 			return css`
@@ -89,6 +75,49 @@ const fontStyles = ({
 				${headline.xxxsmall(options)};
 				font-size: 14px;
 			`;
+	}
+};
+
+const fontStylesOnMobile = ({
+	size,
+	fontWeight,
+}: {
+	size: SmallHeadlineSize;
+	fontWeight?: FontWeight;
+}) => {
+	const options: FontScaleArgs = {};
+	if (fontWeight) options.fontWeight = fontWeight;
+
+	switch (size) {
+		case 'ginormous':
+			return css`
+				${until.mobileLandscape} {
+					${headline.medium(options)};
+				}
+				${between.mobileLandscape.and.desktop} {
+					${headline.large(options)};
+				}
+			`;
+		case 'huge':
+			return css`
+				${until.desktop} {
+					${headline.xsmall(options)};
+				}
+			`;
+		case 'large':
+			return css`
+				${until.desktop} {
+					${headline.xxsmall(options)};
+				}
+			`;
+		case 'medium':
+			return css`
+				${until.desktop} {
+					${headline.xxxsmall(options)};
+				}
+			`;
+		default:
+			return undefined;
 	}
 };
 
@@ -230,6 +259,7 @@ export const CardHeadline = ({
 	showPulsingDot,
 	showSlash,
 	size = 'medium',
+	sizeOnMobile,
 	byline,
 	showByline,
 	showLine,
@@ -252,6 +282,11 @@ export const CardHeadline = ({
 									? 'bold'
 									: 'regular',
 						  }),
+					format.theme !== ArticleSpecial.Labs &&
+						fontStylesOnMobile({
+							size: sizeOnMobile || size,
+							fontWeight: containerPalette ? 'bold' : 'regular',
+						}),
 					format.design === ArticleDesign.Analysis &&
 						!containerPalette &&
 						underlinedStyles(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Allows manually setting the mobile headline size on Cards.

## Why?

On certain front Containers such as `fixed/small/slow-I` some Cards don't follow the usual headline logic of using the next size lower on Mobile.

Part of #5505

## Screenshot

![image](https://user-images.githubusercontent.com/21217225/183438350-95b7a74f-558d-4608-9aba-917e00d35265.png)


(We don't have a mobile size for sizes under Medium)