### PR TITLE
Cards: Only set `discussionId` if `isCommentable`

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -162,7 +162,9 @@ export const enhanceCards = (
 						containerPalette,
 				  )
 				: undefined,
-			discussionId: faciaCard.discussion.discussionId,
+			discussionId: faciaCard.discussion.isCommentable
+				? faciaCard.discussion.discussionId
+				: undefined,
 			// nb. there is a distinct 'byline' property on FEFrontCard, at
 			// card.properties.byline
 			byline:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Set the value of `discussionId` in the `enhanceCards` function for a
card only if `isCommentable` for that card is true.

This means that the `CommentCount` component will no longer be rendered
on cards which don't have a discussion to display.

There are some potential edge-cases where discussion might have been opened and
then closed, so there might be non-zero comment counts which we don't
display. However, because the discussion section on articles is also
controlled by `isCommentable`, the edge cases shouldn't be visible, and
if we did want to show comments and comment counts for these cases, this
seems like a separate issue.

## Why?

Empty `<a>` elements were being rendered on cards which didn't have discussion enabled. This will close #5634.
