### PR TITLE
Inline ads on fronts

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { adSizes } from '@guardian/commercial-core';
+import type { SlotName } from '@guardian/commercial-core';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	border,
@@ -13,13 +14,30 @@ import {
 import { Island } from './Island';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
-type Props = {
+type InlineProps = {
 	display?: ArticleDisplay;
-	position: AdSlotType;
+	position: 'inline';
+	index: number;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
 	shouldReserveMerchSpace?: boolean;
 };
+
+type NonInlineProps = {
+	display?: ArticleDisplay;
+	position: Omit<SlotName, 'inline'>;
+	index?: never;
+	shouldHideReaderRevenue?: boolean;
+	isPaidContent?: boolean;
+	shouldReserveMerchSpace?: boolean;
+};
+
+/**
+ * This union type allows us to conditionally require the index property
+ * based on position. If position = 'inline' then we expect the index
+ * value. If not, then we explictly refuse this property
+ */
+type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
@@ -214,6 +232,7 @@ export const AdSlot = ({
 	shouldHideReaderRevenue = false,
 	isPaidContent = false,
 	shouldReserveMerchSpace = false,
+	index,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -397,6 +416,32 @@ export const AdSlot = ({
 					data-label="false"
 					data-refresh="false"
 					data-out-of-page="true"
+					aria-hidden="true"
+				/>
+			);
+		}
+		case 'inline': {
+			// index will always be defined here but ts isn't as sure
+			// so I'm falling back to 'inline-0' to keep it happy
+			const advertId = index ? `inline${index}` : 'inline-0';
+			return (
+				<div
+					id={`dfp-ad--${advertId}`}
+					className={[
+						'js-ad-slot',
+						'ad-slot',
+						`ad-slot--${advertId}`,
+						'ad-slot--container-inline',
+						'ad-slot--rendered',
+					].join(' ')}
+					css={[
+						css`
+							position: relative;
+						`,
+						adStyles,
+					]}
+					data-link-name={`ad slot ${advertId}`}
+					data-name={`${advertId}`}
 					aria-hidden="true"
 				/>
 			);

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -42,6 +42,7 @@ export const NoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );
@@ -64,6 +65,7 @@ export const OneBig = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );
@@ -86,6 +88,7 @@ export const TwoBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );
@@ -114,6 +117,7 @@ export const FirstBigBoosted = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );
@@ -136,6 +140,7 @@ export const ThreeBigs = () => (
 				standard: standards,
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );
@@ -158,6 +163,7 @@ export const AllBigs = () => (
 				standard: [],
 			}}
 			showAge={true}
+			index={1}
 		/>
 	</ContainerLayout>
 );

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -10,6 +10,7 @@ type Props = {
 	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	index: number;
 };
 
 /* .___________.___________.___________.
@@ -21,10 +22,12 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	cards,
 	containerPalette,
 	showAge,
+	index,
 }: {
 	cards: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	index: number;
 }) => (
 	<UL direction="row">
 		<LI percentage="33.333%" padSides={true}>
@@ -71,8 +74,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 		</LI>
 		<LI percentage="33.333%">
 			<Hide until="tablet">
-				{/* TODO: Replace mostpop with a more appropriate value */}
-				<AdSlot position="mostpop" />
+				<AdSlot position="inline" index={index} />
 			</Hide>
 		</LI>
 	</UL>
@@ -87,10 +89,12 @@ const ColumnOfThree50_Ad50 = ({
 	cards,
 	containerPalette,
 	showAge,
+	index,
 }: {
 	cards: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	index: number;
 }) => (
 	<UL direction="row">
 		<LI percentage="50%">
@@ -126,8 +130,7 @@ const ColumnOfThree50_Ad50 = ({
 		</LI>
 		<LI percentage="50%">
 			<Hide until="tablet">
-				{/* TODO: Replace mostpop with a more appropriate value */}
-				<AdSlot position="mostpop" />
+				<AdSlot position="inline" index={index} />
 			</Hide>
 		</LI>
 	</UL>
@@ -304,6 +307,7 @@ export const DynamicSlowMPU = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
+	index,
 }: Props) => {
 	let layout: 'noBigs' | 'twoBigs' | 'twoBigsBoosted' | 'threeBigs';
 	let bigCards: TrailType[] = [];
@@ -356,6 +360,7 @@ export const DynamicSlowMPU = ({
 					cards={standardCards}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					index={index}
 				/>
 			);
 		}
@@ -371,6 +376,7 @@ export const DynamicSlowMPU = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						index={index}
 					/>
 				</>
 			);
@@ -387,6 +393,7 @@ export const DynamicSlowMPU = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						index={index}
 					/>
 				</>
 			);
@@ -403,6 +410,7 @@ export const DynamicSlowMPU = ({
 						cards={standardCards}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						index={index}
 					/>
 				</>
 			);

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -30,7 +30,7 @@ export const Default = () => (
 		padContent={false}
 		centralBorder="partial"
 	>
-		<FixedSmallSlowVMPU trails={trails} showAge={true} />
+		<FixedSmallSlowVMPU trails={trails} showAge={true} index={1} />
 	</ContainerLayout>
 );
 Default.story = { name: 'FixedSmallSlowVMPU' };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -9,12 +9,14 @@ type Props = {
 	trails: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	index: number;
 };
 
 export const FixedSmallSlowVMPU = ({
 	trails,
 	containerPalette,
 	showAge,
+	index,
 }: Props) => {
 	return (
 		<UL direction="row">
@@ -63,8 +65,7 @@ export const FixedSmallSlowVMPU = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<Hide until="tablet">
-					{/* TODO: Replace mostpop with a more appropriate value */}
-					<AdSlot position="mostpop" />
+					<AdSlot position="inline" index={index} />
 				</Hide>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -173,6 +173,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						>
 							<DecideContainer
 								trails={trails}
+								index={index}
 								groupedTrails={collection.grouped}
 								containerType={collection.collectionType}
 								containerPalette={collection.containerPalette}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -151,7 +151,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					return (
 						<ContainerLayout
-							key={index}
+							key={collection.id}
 							title={collection.displayName}
 							// TODO: This logic should be updated, as this relies
 							// on the first container being 'palette styles do not delete'

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -17,6 +17,7 @@ import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
 
 type Props = {
 	trails: DCRFrontCard[];
+	index: number;
 	groupedTrails: DCRGroupedTrails;
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
@@ -25,6 +26,7 @@ type Props = {
 
 export const DecideContainer = ({
 	trails,
+	index,
 	groupedTrails,
 	containerType,
 	containerPalette,
@@ -53,6 +55,7 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					index={index}
 				/>
 			);
 		case 'dynamic/package':
@@ -85,6 +88,7 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+					index={index}
 				/>
 			);
 		case 'fixed/small/slow-III':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes #5516 by ensuring that inline ad slots are rendered using the correct classes and ids.

In particular, this PR sets up the ability to have a unique div id for each inline slot, regardless for how many there are on the page. This is done using a new `index` property representing the index of the container on the page. This method will only work where there is only one inline ad slot per container.

<img width="1297" alt="Screenshot 2022-08-09 at 12 49 40" src="https://user-images.githubusercontent.com/1336821/183642739-af185637-11d3-4ac9-9ee5-9b8ab9e37403.png">
