### PR TITLE
Add `merchandising` (lower) slot to fronts

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -4,9 +4,11 @@ import {
 	brandBackground,
 	brandBorder,
 	brandLine,
+	neutral,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { DCRFrontType } from '../../types/front';
+import { AdSlot } from '../components/AdSlot';
 import { ContainerLayout } from '../components/ContainerLayout';
 import { ElementContainer } from '../components/ElementContainer';
 import { Footer } from '../components/Footer';
@@ -193,6 +195,23 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					</ElementContainer>
 				)}
 			</main>
+
+			<ElementContainer
+				data-print-layout="hide"
+				padded={false}
+				showTopBorder={false}
+				showSideBorders={false}
+				backgroundColour={neutral[93]}
+				element="aside"
+			>
+				<AdSlot
+					position="merchandising"
+					display={format.display}
+					shouldReserveMerchSpace={
+						!!front.config.abTests.merchandisingMinHeightVariant
+					}
+				/>
+			</ElementContainer>
 
 			{NAV.subNavSections && (
 				<ElementContainer


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Closes #5640 by adding the `merchandising` slot to the bottom of fronts

<img width="1437" alt="Screenshot 2022-08-09 at 14 43 27" src="https://user-images.githubusercontent.com/1336821/183665517-c495aa81-e672-40de-bc16-bd1548bd9e62.png">
