### PR TITLE
Refactor: Add focus styling to Fronts Cards

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -294,12 +294,7 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			<CardLink
-				linkTo={linkTo}
-				dataLinkName={dataLinkName}
-				format={format}
-				containerPalette={containerPalette}
-			/>
+			<CardLink linkTo={linkTo} dataLinkName={dataLinkName} />
 			<CardLayout
 				imagePosition={imagePosition}
 				imagePositionOnMobile={imagePositionOnMobile}

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -10,29 +10,7 @@ const fauxLinkStyles = css`
 	right: 0;
 	bottom: 0;
 	left: 0;
-`;
-
-const baseLinkStyles = css`
-	display: flex;
-	/* a tag specific styles */
-	color: inherit;
-	text-decoration: none;
 	background-color: transparent;
-
-	/* The whole card is one link so we card level styles here */
-	width: 100%;
-
-	/* Sometimes a headline contains it's own link so we use the
-       approach described below to deal with nested links
-       See: https://css-tricks.com/nested-links/ */
-	:before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 0;
-		right: 0;
-		bottom: 0;
-	}
 
 	:focus {
 		${focusHalo};
@@ -47,10 +25,6 @@ type Props = {
 
 export const CardLink = ({ linkTo, dataLinkName = 'article' }: Props) => {
 	return (
-		<a
-			href={linkTo}
-			css={[fauxLinkStyles, baseLinkStyles]}
-			data-link-name={dataLinkName}
-		/>
+		<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName} />
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -1,9 +1,6 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { neutral } from '@guardian/source-foundations';
+import { focusHalo } from '@guardian/source-foundations';
 import type { DCRContainerPalette } from '../../../../types/front';
-import { decidePalette } from '../../../lib/decidePalette';
 import { getZIndex } from '../../../lib/getZIndex';
 
 const fauxLinkStyles = css`
@@ -13,104 +10,46 @@ const fauxLinkStyles = css`
 	right: 0;
 	bottom: 0;
 	left: 0;
-	opacity: 0;
 `;
 
-const linkStyles = (format: ArticleFormat, palette: Palette) => {
-	const baseLinkStyles = css`
-		display: flex;
-		/* a tag specific styles */
-		color: inherit;
-		text-decoration: none;
-		background-color: ${palette.background.card};
+const baseLinkStyles = css`
+	display: flex;
+	/* a tag specific styles */
+	color: inherit;
+	text-decoration: none;
+	background-color: transparent;
 
-		/* The whole card is one link so we card level styles here */
-		width: 100%;
+	/* The whole card is one link so we card level styles here */
+	width: 100%;
 
-		/* Sometimes a headline contains it's own link so we use the
+	/* Sometimes a headline contains it's own link so we use the
        approach described below to deal with nested links
        See: https://css-tricks.com/nested-links/ */
-		:before {
-			content: '';
-			position: absolute;
-			left: 0;
-			top: 0;
-			right: 0;
-			bottom: 0;
-		}
-
-		:hover .image-overlay {
-			position: absolute;
-			top: 0;
-			width: 100%;
-			height: 100%;
-			left: 0;
-			background-color: ${neutral[7]};
-			opacity: 0.1;
-		}
-	`;
-
-	if (format.theme === ArticleSpecial.SpecialReport) {
-		return css`
-			${baseLinkStyles};
-			:hover {
-				filter: brightness(90%);
-			}
-		`;
+	:before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 0;
+		right: 0;
+		bottom: 0;
 	}
 
-	switch (format.design) {
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Comment:
-			return css`
-				${baseLinkStyles};
-				:hover {
-					/* TODO: This colour is hard coded here because it does not yet
-                           exist in source-foundations. Once it's been added, please
-                           remove this. @siadcock is aware. */
-					/* stylelint-disable-next-line color-no-hex */
-					background-color: #fdf0e8;
-				}
-			`;
-		case ArticleDesign.Gallery:
-		case ArticleDesign.Audio:
-		case ArticleDesign.Video:
-		case ArticleDesign.LiveBlog:
-			return css`
-				${baseLinkStyles};
-				:hover {
-					filter: brightness(90%);
-				}
-			`;
-		default:
-			return css`
-				${baseLinkStyles};
-				:hover {
-					background-color: ${neutral[93]};
-				}
-			`;
+	:focus {
+		${focusHalo};
 	}
-};
+`;
 
 type Props = {
 	linkTo: string;
-	format: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
 	dataLinkName?: string;
 };
 
-export const CardLink = ({
-	linkTo,
-	format,
-	containerPalette,
-	dataLinkName = 'article',
-}: Props) => {
-	const palette = decidePalette(format, containerPalette);
+export const CardLink = ({ linkTo, dataLinkName = 'article' }: Props) => {
 	return (
 		<a
 			href={linkTo}
-			css={[fauxLinkStyles, linkStyles(format, palette)]}
+			css={[fauxLinkStyles, baseLinkStyles]}
 			data-link-name={dataLinkName}
 		/>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Add focusHalo to CardLink on focus.
- Remove unneeded styling from CardLink:
  - Styling of CardLink itself was redundant because opacity was set to 0.
  - The styling applied indirectly to `.image-overlay` was redundant because it
  didn't actually select anything (perhaps copied mistakenly from CardWrapper?)

## Why?

There was no visible focus indicator on these cards before. Closes #5177 

## Queries
I couldn't see what the code that I've deleted from `CardLink.tsx` was doing, but that doesn't mean that it wasn't doing anything! If anyone has more information, please let me know!

## Screenshots
Before (no visible styling when focused):
<img width="703" alt="image" src="https://user-images.githubusercontent.com/37048459/183687829-f0c0db9d-0728-41de-b598-40cb2ddcae23.png">

After: 
<img width="709" alt="image" src="https://user-images.githubusercontent.com/37048459/183687554-5ba1ffcc-855a-433e-b89d-ca5ff6b6a74e.png">

