### PR TITLE
`FixedMediumSlowXIIMPU`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -643,7 +643,13 @@ type LineEffectType = 'labs' | 'dotted' | 'straight';
 
 type LeftColSize = 'compact' | 'wide';
 
-type CardPercentageType = '25%' | '33.333%' | '50%' | '66%' | '75%' | '100%';
+type CardPercentageType =
+	| '25%'
+	| '33.333%'
+	| '50%'
+	| '66.666%'
+	| '75%'
+	| '100%';
 
 type HeadlineLink = {
 	to: string; // the href for the anchor tag

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -1,0 +1,176 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { ContainerLayout } from './ContainerLayout';
+import { FixedMediumSlowXIIMPU } from './FixedMediumSlowXIIMPU';
+
+export default {
+	component: FixedMediumSlowXIIMPU,
+	title: 'Components/FixedMediumSlowXIIMPU',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.mobileLandscape,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const OneTrail = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 1)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+OneTrail.story = { name: 'with one trail' };
+
+export const TwoTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 2)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+TwoTrails.story = { name: 'with two trails' };
+
+export const ThreeTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 3)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+ThreeTrails.story = { name: 'with three trails' };
+
+export const FourTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 4)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+FourTrails.story = { name: 'with four trails' };
+
+export const FiveTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 5)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+FiveTrails.story = { name: 'with five trails' };
+
+export const SixTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 6)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+SixTrails.story = { name: 'with six trails' };
+
+export const SevenTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 7)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+SevenTrails.story = { name: 'with seven trails' };
+
+export const EightTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 8)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+EightTrails.story = { name: 'with eight trails' };
+
+export const NineTrails = () => (
+	<ContainerLayout
+		title="FixedMediumSlowXIIMPU"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumSlowXIIMPU
+			trails={trails.slice(0, 9)}
+			showAge={true}
+			index={1}
+		/>
+	</ContainerLayout>
+);
+NineTrails.story = { name: 'with nine trails' };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -1,0 +1,436 @@
+/* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
+import { Hide } from '@guardian/source-react-components';
+import type { DCRContainerPalette } from '../../types/front';
+import { AdSlot } from './AdSlot';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	index: number;
+};
+
+/* .___________________________________.
+ * |         ##########################|
+ * |         ###########(^)>###########|
+ * |         ###########(_)############|
+ * |         ##########################|
+ * |_________##########################|
+ */
+const Card100 = ({
+	trails,
+	containerPalette,
+	showAge,
+}: {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => (
+	<UL>
+		<LI padSides={true}>
+			<FrontCard
+				trail={trails[0]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				imagePosition="right"
+				imagePositionOnMobile="top"
+				imageSize="jumbo"
+				headlineSize="huge"
+				headlineSizeOnMobile="large"
+				trailText={trails[0].trailText}
+			/>
+		</LI>
+	</UL>
+);
+
+/* ._________________._________________.
+ * |#################|#################|
+ * |                 |                 |
+ * |_________________|_________________|
+ */
+const Card50_Card50 = ({
+	trails,
+	containerPalette,
+	showAge,
+}: {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => (
+	<UL direction="row" padBottom={true}>
+		<LI percentage="50%" padSides={true}>
+			<FrontCard
+				trail={trails[0]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[0].trailText}
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+		<LI
+			percentage="50%"
+			padSides={true}
+			showTopMarginWhenStacked={true}
+			showDivider={true}
+		>
+			<FrontCard
+				trail={trails[1]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[1].trailText}
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+	</UL>
+);
+
+/* .___________.___________.___________.
+ * |###########|###########|###########|
+ * |           |           |           |
+ * |___________|___________|___________|
+ */
+const Card33_Card33_Card33 = ({
+	trails,
+	containerPalette,
+	showAge,
+}: {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => (
+	<UL direction="row" padBottom={true}>
+		<LI percentage="33.333%" padSides={true}>
+			<FrontCard
+				trail={trails[0]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[0].trailText}
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+		<LI
+			percentage="33.333%"
+			padSides={true}
+			showTopMarginWhenStacked={true}
+			showDivider={true}
+		>
+			<FrontCard
+				trail={trails[1]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[1].trailText}
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+		<LI
+			percentage="33.333%"
+			padSides={true}
+			showTopMarginWhenStacked={true}
+			showDivider={true}
+		>
+			<FrontCard
+				trail={trails[2]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[2].trailText}
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+	</UL>
+);
+
+/* ._______________________.___________.
+ * |       ################|           |
+ * |       ################|    MPU    |
+ * |_______################|___________|
+ */
+const Card66_Ad33 = ({
+	trails,
+	containerPalette,
+	showAge,
+	index,
+}: {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	index: number;
+}) => (
+	<UL direction="row" padBottom={true}>
+		<LI percentage="66.666%" padSides={true}>
+			<FrontCard
+				trail={trails[0]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={trails[0].trailText}
+				imagePosition="right"
+				imageSize="large"
+				imagePositionOnMobile="top"
+			/>
+		</LI>
+		<LI percentage="33.333%" showDivider={true}>
+			<Hide until="tablet">
+				<AdSlot position="inline" index={index} />
+			</Hide>
+		</LI>
+	</UL>
+);
+
+/* .___________.___________.___________.
+ * |###########|###########|           |
+ * |           |           |    MPU    |
+ * |___________|___________|___________|
+ */
+const Card33_Card33_Ad33 = ({
+	trails,
+	containerPalette,
+	showAge,
+	index,
+}: {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	index: number;
+}) => (
+	<UL direction="row" padBottom={true}>
+		<LI percentage="33.333%" padSides={true}>
+			<FrontCard
+				trail={trails[0]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={
+					trails[0]?.supportingContent &&
+					trails[0].supportingContent.length > 0
+						? undefined
+						: trails[0].trailText
+				}
+				supportingContent={
+					trails[0].trailText
+						? undefined
+						: trails[0].supportingContent
+				}
+			/>
+		</LI>
+		<LI
+			percentage="33.333%"
+			padSides={true}
+			showDivider={true}
+			showTopMarginWhenStacked={true}
+		>
+			<FrontCard
+				trail={trails[1]}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				trailText={
+					trails[1]?.supportingContent &&
+					trails[1].supportingContent.length > 0
+						? undefined
+						: trails[1].trailText
+				}
+				supportingContent={
+					trails[1].trailText
+						? undefined
+						: trails[1].supportingContent
+				}
+			/>
+		</LI>
+		<LI percentage="33.333%" showDivider={true}>
+			<Hide until="tablet">
+				<AdSlot position="inline" index={index} />
+			</Hide>
+		</LI>
+	</UL>
+);
+
+/**
+ * FixedMediumSlowXIIMPU
+ *
+ */
+export const FixedMediumSlowXIIMPU = ({
+	trails,
+	containerPalette,
+	showAge,
+	index,
+}: Props) => {
+	switch (trails.length) {
+		case 0: {
+			return null;
+		}
+		case 1: {
+			return (
+				<Card100
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		}
+		case 2: {
+			return (
+				<Card50_Card50
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		}
+		case 3: {
+			return (
+				<Card33_Card33_Card33
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			);
+		}
+		case 4: {
+			const topThree = trails.slice(0, 3);
+			const remainingCards = trails.slice(3);
+			return (
+				<>
+					<Card33_Card33_Card33
+						trails={topThree}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+
+					<Card66_Ad33
+						trails={remainingCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						index={index}
+					/>
+				</>
+			);
+		}
+		case 5: {
+			const topThree = trails.slice(0, 3);
+			const remainingCards = trails.slice(3);
+			return (
+				<>
+					<Card33_Card33_Card33
+						trails={topThree}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+
+					<Card33_Card33_Ad33
+						trails={remainingCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						index={index}
+					/>
+				</>
+			);
+		}
+		case 6:
+		case 7:
+		case 8:
+		case 9:
+		default: {
+			const topThree = trails.slice(0, 3);
+			const remainingCards = trails.slice(3, 9);
+			const lengthIsEven = remainingCards.length % 2 === 0;
+
+			/**
+			 * If the count of cards is odd there is just a single card on
+			 * the bottom row with nothing under it which does not need
+			 * padding
+			 */
+			function shouldPadWhenOdd(i: number) {
+				return i !== remainingCards.length - 1;
+			}
+
+			/**
+			 * If the count of cards is even the last two sit on the bottom
+			 * row with nothing underneath so we don't want to pad them
+			 */
+			function shouldPadWhenEven(i: number) {
+				return (
+					i !== remainingCards.length - 1 &&
+					i !== remainingCards.length - 2
+				);
+			}
+
+			/**
+			 *
+			 * When there is an odd number of cards the last card spans
+			 * both columns so we don't want to push the divider for the
+			 * previous two cards above it down. If we did it would
+			 * touch
+			 */
+			function shouldOffsetWhenOdd(i: number) {
+				return (
+					i !== remainingCards.length - 2 &&
+					i !== remainingCards.length - 3
+				);
+			}
+
+			return (
+				<>
+					<Card33_Card33_Card33
+						trails={topThree}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<UL direction="row">
+						<LI
+							percentage="66.666%"
+							showTopMarginWhenStacked={true}
+						>
+							{/*
+							 *	This pattern of using wrapCards on the UL + percentage=50 and stretch=true
+							 * on the LI creates a dynanic list of cards over two columns. Crucially,
+							 * cards align horizontally in rows. If the number of trails is odd the last
+							 * card stretches full width.
+							 *
+							 * E.g:
+							 * .___________.___________.
+							 * |___________|___________|
+							 * |___________|___________|
+							 * |_______________________|
+							 */}
+							<UL direction="row" wrapCards={true}>
+								{remainingCards.map((trail, trailIndex) => (
+									<LI
+										padSides={true}
+										padBottom={
+											lengthIsEven
+												? shouldPadWhenEven(trailIndex)
+												: shouldPadWhenOdd(trailIndex)
+										}
+										offsetBottomPaddingOnDivider={
+											lengthIsEven
+												? false
+												: shouldOffsetWhenOdd(
+														trailIndex,
+												  )
+										}
+										showDivider={trailIndex % 2 !== 0}
+										percentage="50%"
+										stretch={true}
+									>
+										<FrontCard
+											trail={trail}
+											containerPalette={containerPalette}
+											showAge={showAge}
+											imageUrl={undefined}
+											headlineSize="small"
+										/>
+									</LI>
+								))}
+							</UL>
+						</LI>
+						<LI percentage="33.333%" showDivider={true}>
+							<Hide until="tablet">
+								<AdSlot position="inline" index={index} />
+							</Hide>
+						</LI>
+					</UL>
+				</>
+			);
+		}
+	}
+};

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -245,6 +245,34 @@ const Card33_Card33_Ad33 = ({
 );
 
 /**
+ * If the count of cards is odd there is just a single card on
+ * the bottom row with nothing under it which does not need
+ * padding
+ */
+function shouldPadWhenOdd(i: number, noOfCards: number) {
+	return i !== noOfCards - 1;
+}
+
+/**
+ * If the count of cards is even the last two sit on the bottom
+ * row with nothing underneath so we don't want to pad them
+ */
+function shouldPadWhenEven(i: number, noOfCards: number) {
+	return i !== noOfCards - 1 && i !== noOfCards - 2;
+}
+
+/**
+ *
+ * When there is an odd number of cards the last card spans
+ * both columns so we don't want to push the divider for the
+ * previous two cards above it down. If we did it would
+ * touch
+ */
+function shouldOffsetWhenOdd(i: number, noOfCards: number) {
+	return i !== noOfCards - 2 && i !== noOfCards - 3;
+}
+
+/**
  * FixedMediumSlowXIIMPU
  *
  */
@@ -333,41 +361,6 @@ export const FixedMediumSlowXIIMPU = ({
 			const topThree = trails.slice(0, 3);
 			const remainingCards = trails.slice(3, 9);
 			const lengthIsEven = remainingCards.length % 2 === 0;
-
-			/**
-			 * If the count of cards is odd there is just a single card on
-			 * the bottom row with nothing under it which does not need
-			 * padding
-			 */
-			function shouldPadWhenOdd(i: number) {
-				return i !== remainingCards.length - 1;
-			}
-
-			/**
-			 * If the count of cards is even the last two sit on the bottom
-			 * row with nothing underneath so we don't want to pad them
-			 */
-			function shouldPadWhenEven(i: number) {
-				return (
-					i !== remainingCards.length - 1 &&
-					i !== remainingCards.length - 2
-				);
-			}
-
-			/**
-			 *
-			 * When there is an odd number of cards the last card spans
-			 * both columns so we don't want to push the divider for the
-			 * previous two cards above it down. If we did it would
-			 * touch
-			 */
-			function shouldOffsetWhenOdd(i: number) {
-				return (
-					i !== remainingCards.length - 2 &&
-					i !== remainingCards.length - 3
-				);
-			}
-
 			return (
 				<>
 					<Card33_Card33_Card33
@@ -398,14 +391,21 @@ export const FixedMediumSlowXIIMPU = ({
 										padSides={true}
 										padBottom={
 											lengthIsEven
-												? shouldPadWhenEven(trailIndex)
-												: shouldPadWhenOdd(trailIndex)
+												? shouldPadWhenEven(
+														trailIndex,
+														remainingCards.length,
+												  )
+												: shouldPadWhenOdd(
+														trailIndex,
+														remainingCards.length,
+												  )
 										}
 										offsetBottomPaddingOnDivider={
 											lengthIsEven
 												? false
 												: shouldOffsetWhenOdd(
 														trailIndex,
+														remainingCards.length,
 												  )
 										}
 										showDivider={trailIndex % 2 !== 0}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -269,7 +269,7 @@ function shouldPadWhenEven(i: number, noOfCards: number) {
  * touch
  */
 function shouldOffsetWhenOdd(i: number, noOfCards: number) {
-	return i !== noOfCards - 2 && i !== noOfCards - 3;
+	return i === noOfCards - 2 || i === noOfCards - 3;
 }
 
 /**

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -411,6 +411,11 @@ export const FixedMediumSlowXIIMPU = ({
 										showDivider={trailIndex % 2 !== 0}
 										percentage="50%"
 										stretch={true}
+										showTopMarginWhenStacked={
+											lengthIsEven &&
+											remainingCards.length ===
+												trailIndex + 1
+										}
 									>
 										<FrontCard
 											trail={trail}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -122,7 +122,7 @@ const Card33_Card33_Card33 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={trails[1].trailText}
-				imagePositionOnMobile="top"
+				imagePositionOnMobile="left"
 			/>
 		</LI>
 		<LI
@@ -136,7 +136,7 @@ const Card33_Card33_Card33 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={trails[2].trailText}
-				imagePositionOnMobile="top"
+				imagePositionOnMobile="left"
 			/>
 		</LI>
 	</UL>

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -369,10 +369,7 @@ export const FixedMediumSlowXIIMPU = ({
 						showAge={showAge}
 					/>
 					<UL direction="row">
-						<LI
-							percentage="66.666%"
-							showTopMarginWhenStacked={true}
-						>
+						<LI percentage="66.666%">
 							{/*
 							 *	This pattern of using wrapCards on the UL + percentage=50 and stretch=true
 							 * on the LI creates a dynanic list of cards over two columns. Crucially,

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -10,6 +10,7 @@ import { DynamicSlow } from '../components/DynamicSlow';
 import { DynamicSlowMPU } from '../components/DynamicSlowMPU';
 import { FixedLargeSlowXIV } from '../components/FixedLargeSlowXIV';
 import { FixedMediumSlowVI } from '../components/FixedMediumSlowVI';
+import { FixedMediumSlowXIIMPU } from '../components/FixedMediumSlowXIIMPU';
 import { FixedSmallSlowI } from '../components/FixedSmallSlowI';
 import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
@@ -122,6 +123,15 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
+				/>
+			);
+		case 'fixed/medium/slow-XII-mpu':
+			return (
+				<FixedMediumSlowXIIMPU
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					index={index}
 				/>
 			);
 		default:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This closes #5141 by adding support for the `FixedMediumSlowXIIMPU` container.

![2022-08-10 09 44 53](https://user-images.githubusercontent.com/1336821/183872454-e282925f-df48-402e-aa4d-bea232d51d39.gif)

This is a fixed container so in theory we would only expect a fixed number of trails passed in but looking at how Frontend and the fronts tool currently works there is support for rendering this container with fewer cards. So this PR aligns with that, supporting all possible counts from 1-9. After nine, the additional cards overflow to backfill.