### PR TITLE
fix: Don't show images on cards that have images disabled

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -152,8 +152,10 @@ export const enhanceCards = (
 						faciaCard.card.webPublicationDateOption,
 				  ).toISOString()
 				: undefined,
-			image: faciaCard.properties.maybeContent?.trail.trailPicture
-				?.allImages[0].url,
+			image: faciaCard.display.imageHide
+				? undefined
+				: faciaCard.properties.maybeContent?.trail.trailPicture
+						?.allImages[0].url,
 			kickerText: faciaCard.header.kicker?.item?.properties.kickerText,
 			supportingContent: faciaCard.supportingContent
 				? enhanceSupportingContent(

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -301,15 +301,23 @@ export const Card = ({
 				containerPalette={containerPalette}
 			/>
 			<CardLayout
-				imagePosition={imagePosition}
-				imagePositionOnMobile={imagePositionOnMobile}
+				imagePosition={imageUrl !== undefined ? imagePosition : 'top'}
+				imagePositionOnMobile={
+					imageUrl !== undefined ? imagePositionOnMobile : 'top'
+				}
 				minWidthInPixels={minWidthInPixels}
 			>
 				{imageType === 'mainmedia' && (
 					<ImageWrapper
 						imageSize={imageSize}
-						imagePosition={imagePosition}
-						imagePositionOnMobile={imagePositionOnMobile}
+						imagePosition={
+							imageUrl !== undefined ? imagePosition : 'top'
+						}
+						imagePositionOnMobile={
+							imageUrl !== undefined
+								? imagePositionOnMobile
+								: 'top'
+						}
 					>
 						<img src={imageUrl} alt="" role="presentation" />
 					</ImageWrapper>
@@ -420,7 +428,9 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					alignment={
-						imagePosition === 'top' || imagePosition === 'bottom'
+						imagePosition === 'top' ||
+						imagePosition === 'bottom' ||
+						imageUrl === undefined
 							? 'vertical'
 							: 'horizontal'
 					}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for the `Show Media` display option in the Fronts tool.

## Why?

Fixes #5668

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/183924044-e511f446-7252-4b80-9178-2ee8f871ef94.png
[after]: https://user-images.githubusercontent.com/21217225/183923793-82d453a2-5a41-4a68-8be9-ea2227618589.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
