### PR TITLE
Accessibility colour improvements on special comment cards

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -431,7 +431,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
 	)
-		return opinion[550];
+		return brandAlt[400];
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -476,7 +476,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 		case ArticleDesign.Letter:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:
-					return opinion[550];
+					return neutral[86];
 				default:
 					return neutral[46];
 			}
@@ -1109,6 +1109,12 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 
 const borderLines = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return border.primary;
+	if (
+		format.theme === ArticleSpecial.SpecialReport &&
+		(format.design === ArticleDesign.Comment ||
+			format.design === ArticleDesign.Letter)
+	)
+		return neutral[46];
 	return border.secondary;
 };
 


### PR DESCRIPTION
Co-Authored-By: Pete F <37048459+bryophyta@users.noreply.github.com>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Accessibility colour improvements re: https://github.com/guardian/dotcom-rendering/issues/4953


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/183929082-5e647ef5-07e8-4b8c-b7a8-425093ad96a1.png
[after]: https://user-images.githubusercontent.com/110032454/183929200-1e2f69a4-3417-434e-a499-de35d1c01ede.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
