### PR TITLE
textCardFooter for media cards returns neutral.86

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -481,20 +481,7 @@ const textCardFooter = (format: ArticleFormat): string => {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-			switch (format.theme) {
-				case ArticleSpecial.SpecialReport:
-					return brandAlt[400];
-				case ArticlePillar.News:
-					return news[600];
-				case ArticlePillar.Sport:
-					return sport[600];
-				case ArticlePillar.Opinion:
-					return opinion[550];
-				case ArticlePillar.Lifestyle:
-				case ArticlePillar.Culture:
-				default:
-					return pillarPalette[format.theme][500];
-			}
+			return neutral[86];
 		default:
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:


### PR DESCRIPTION
Co-authored by Daniel Clifton <daniel.clifton@theguardian.com>

## What does this change?

It changes the colour for footer text in media Fronts cards to `neutral.86`.

## Why?

Increase the contrast with the background, for accessibility purposes. Closes #5604 as part of #4953.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="227" alt="image" src="https://user-images.githubusercontent.com/37048459/183960827-0d6e72e5-37c7-4d54-87cc-101553b8d6cd.png">|<img width="228" alt="image" src="https://user-images.githubusercontent.com/37048459/183960351-c1a3cc97-fad4-4974-ab17-9535267974f7.png">|
