### PR TITLE
Remove horizontal lines of expanded pillar sections and update background colours

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -112,6 +112,9 @@ const firstColumnLinks = css`
 	${from.desktop} {
 		padding-left: 0;
 	}
+	${until.tablet} {
+		background: ${brand[300]};
+	}
 `;
 
 const pillarColumnLinks = css`

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -126,7 +126,6 @@ const pillarColumnLinks = css`
 const hideStyles = (columnInputId: string) => css`
 	${until.desktop} {
 		/* stylelint-disable-next-line selector-type-no-unknown */
-
 		${`#${columnInputId}`}:checked ~ & {
 			display: none;
 		}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -123,7 +123,7 @@ const pillarColumnLinks = css`
 	}
 `;
 
-const hideStyles = (columnInputId: string) => css`
+const hideWhenChecked = (columnInputId: string) => css`
 	${until.desktop} {
 		/* stylelint-disable-next-line selector-type-no-unknown */
 		${`#${columnInputId}`}:checked ~ & {
@@ -132,7 +132,7 @@ const hideStyles = (columnInputId: string) => css`
 	}
 `;
 
-const notHideStyles = (columnInputId: string) => css`
+const hideWhenNotChecked = (columnInputId: string) => css`
 	${until.desktop} {
 		/* stylelint-disable-next-line selector-type-no-unknown */
 		${`#${columnInputId}`}:not(:checked) ~ & {
@@ -143,7 +143,6 @@ const notHideStyles = (columnInputId: string) => css`
 
 const lineStyle = css`
 	background-color: ${brand[600]};
-	/* top: 0; */
 	content: '';
 	display: block;
 	height: 1px;
@@ -168,11 +167,6 @@ const columnStyle = css`
 	margin: 0;
 	padding-bottom: 10px;
 	position: relative;
-
-	/* Remove the border from the top item on mobile */
-	/* :first-of-type:after {
-		content: none;
-	} */
 
 	${from.desktop} {
 		width: 134px;
@@ -266,7 +260,7 @@ export const Column = ({
 					columnLinks,
 					index === 0 && firstColumnLinks,
 					!!column.pillar && pillarColumnLinks,
-					notHideStyles(columnInputId),
+					hideWhenNotChecked(columnInputId),
 				]}
 				role="menu"
 				id={`${column.title.toLowerCase()}Links`}
@@ -295,7 +289,7 @@ export const Column = ({
 					</li>
 				))}
 			</ul>
-			<div css={[hideStyles(columnInputId), lineStyle]}></div>
+			<div css={[hideWhenChecked(columnInputId), lineStyle]}></div>
 		</li>
 	);
 };

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -132,7 +132,7 @@ const hideStyles = (columnInputId: string) => css`
 	}
 `;
 
-const columnStyle = css`
+const columnStyle = (columnInputIdMinusOne: string) => css`
 	${textSans.medium()};
 	list-style: none;
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
@@ -147,15 +147,17 @@ const columnStyle = css`
 	padding-bottom: 10px;
 	position: relative;
 
-	:after {
-		background-color: ${brand[600]};
-		top: 0;
-		content: '';
-		display: block;
-		height: 1px;
-		left: 50px;
-		position: absolute;
-		right: 0;
+	${`#${columnInputIdMinusOne}`}:checked ~ & {
+		:after {
+			background-color: ${brand[600]};
+			top: 0;
+			content: '';
+			display: block;
+			height: 1px;
+			left: 50px;
+			position: absolute;
+			right: 0;
+		}
 	}
 
 	/* Remove the border from the top item on mobile */
@@ -195,11 +197,15 @@ export const Column = ({
 	index: number;
 }) => {
 	// As the elements are dynamic we need to specify the IDs here
-	const columnInputId = `${column.title}-checkbox-input`;
-	const collapseColumnInputId = `${column.title}-button`;
+	const columnInputId = `${index}-checkbox-input`;
+	const columnInputIdMinusOne = `${index - 1}-checkbox-input`;
+	const collapseColumnInputId = `${index}-button`;
 
 	return (
-		<li css={[columnStyle, pillarDivider]} role="none">
+		<li
+			css={[columnStyle(columnInputIdMinusOne), pillarDivider]}
+			role="none"
+		>
 			{/*
                 IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
 

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -126,44 +126,54 @@ const pillarColumnLinks = css`
 const hideStyles = (columnInputId: string) => css`
 	${until.desktop} {
 		/* stylelint-disable-next-line selector-type-no-unknown */
+
+		${`#${columnInputId}`}:checked ~ & {
+			display: none;
+		}
+	}
+`;
+
+const notHideStyles = (columnInputId: string) => css`
+	${until.desktop} {
+		/* stylelint-disable-next-line selector-type-no-unknown */
 		${`#${columnInputId}`}:not(:checked) ~ & {
 			display: none;
 		}
 	}
 `;
 
-const columnStyle = (columnInputIdMinusOne: string) => css`
+const lineStyle = css`
+	background-color: ${brand[600]};
+	/* top: 0; */
+	content: '';
+	display: block;
+	height: 1px;
+	left: 50px;
+	position: absolute;
+	right: 0;
+`;
+
+const columnStyle = css`
 	${textSans.medium()};
 	list-style: none;
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns */
 	/* Needs double escape char: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#es2018_revision_of_illegal_escape_sequences */
+
 	&::before {
 		content: '\\200B'; /* Zero width space */
 		display: block;
 		height: 0;
 		width: 0;
 	}
+
 	margin: 0;
 	padding-bottom: 10px;
 	position: relative;
 
-	${`#${columnInputIdMinusOne}`}:checked ~ & {
-		:after {
-			background-color: ${brand[600]};
-			top: 0;
-			content: '';
-			display: block;
-			height: 1px;
-			left: 50px;
-			position: absolute;
-			right: 0;
-		}
-	}
-
 	/* Remove the border from the top item on mobile */
-	:first-of-type:after {
+	/* :first-of-type:after {
 		content: none;
-	}
+	} */
 
 	${from.desktop} {
 		width: 134px;
@@ -197,15 +207,11 @@ export const Column = ({
 	index: number;
 }) => {
 	// As the elements are dynamic we need to specify the IDs here
-	const columnInputId = `${index}-checkbox-input`;
-	const columnInputIdMinusOne = `${index - 1}-checkbox-input`;
-	const collapseColumnInputId = `${index}-button`;
+	const columnInputId = `${column.title}-checkbox-input`;
+	const collapseColumnInputId = `${column.title}-button`;
 
 	return (
-		<li
-			css={[columnStyle(columnInputIdMinusOne), pillarDivider]}
-			role="none"
-		>
+		<li css={[columnStyle, pillarDivider]} role="none">
 			{/*
                 IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
 
@@ -261,7 +267,7 @@ export const Column = ({
 					columnLinks,
 					index === 0 && firstColumnLinks,
 					!!column.pillar && pillarColumnLinks,
-					columnInputId && hideStyles(columnInputId),
+					notHideStyles(columnInputId),
 				]}
 				role="menu"
 				id={`${column.title.toLowerCase()}Links`}
@@ -290,6 +296,7 @@ export const Column = ({
 					</li>
 				))}
 			</ul>
+			<div css={[hideStyles(columnInputId), lineStyle]}></div>
 		</li>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes horizontal line on expand. This was achieved by moving the horizontal line css into a div at the bottom of each UL component. 
Also changes the background colour of firstColumnLinks section until.tablet.
Resolves issue: https://github.com/guardian/dotcom-rendering/issues/4435

## Why?
Bring in line with frontend
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/184638919-df3efe2f-341d-4c3e-859f-52e31fd3ac36.png
[after]:https://user-images.githubusercontent.com/110032454/184638962-665dadf4-3dc7-4e7f-9268-f72ec1bec793.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
