### PR TITLE
Remove Merchandising min-height AB test. Roll out min-height change

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -20,7 +20,6 @@ type InlineProps = {
 	index: number;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
-	shouldReserveMerchSpace?: boolean;
 };
 
 type NonInlineProps = {
@@ -29,7 +28,6 @@ type NonInlineProps = {
 	index?: never;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
-	shouldReserveMerchSpace?: boolean;
 };
 
 /**
@@ -95,9 +93,6 @@ export const adCollapseStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
-`;
-
-const merchandisingReservedSpace = css`
 	min-height: 250px;
 `;
 
@@ -231,7 +226,6 @@ export const AdSlot = ({
 	display,
 	shouldHideReaderRevenue = false,
 	isPaidContent = false,
-	shouldReserveMerchSpace = false,
 	index,
 }: Props) => {
 	switch (position) {
@@ -370,7 +364,6 @@ export const AdSlot = ({
 					].join(' ')}
 					css={[
 						merchandisingAdStyles,
-						shouldReserveMerchSpace && merchandisingReservedSpace,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}
@@ -391,7 +384,6 @@ export const AdSlot = ({
 					].join(' ')}
 					css={[
 						merchandisingAdStyles,
-						shouldReserveMerchSpace && merchandisingReservedSpace,
 						adStyles,
 						fluidFullWidthAdStyles,
 					]}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -279,9 +279,6 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
 		CAPIArticle.config.switches.slotBodyEnd;
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
@@ -699,7 +696,6 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -795,11 +791,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot
-						position="merchandising"
-						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
-					/>
+					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -221,13 +221,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				backgroundColour={neutral[93]}
 				element="aside"
 			>
-				<AdSlot
-					position="merchandising"
-					display={format.display}
-					shouldReserveMerchSpace={
-						!!front.config.abTests.merchandisingMinHeightVariant
-					}
-				/>
+				<AdSlot position="merchandising" display={format.display} />
 			</ElementContainer>
 
 			{NAV.subNavSections && (

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -206,9 +206,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		parse(CAPIArticle.slotMachineFlags || '').showBodyEnd ||
 		CAPIArticle.config.switches.slotBodyEnd;
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
@@ -509,7 +506,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -605,11 +601,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot
-						position="merchandising"
-						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
-					/>
+					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -229,9 +229,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	return (
 		<>
 			{CAPIArticle.isLegacyInteractive && (
@@ -611,7 +608,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						data-print-layout="hide"
 						position="merchandising-high"
 						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -712,11 +708,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot
-						position="merchandising"
-						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
-					/>
+					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -305,9 +305,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.switches.automaticFilters &&
 		CAPIArticle.availableTopics;
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	/*
 	The topic bank on desktop will be positioned where we currently show the key events container.
 	This is dependent on a change made in PR #4896 [https://github.com/guardian/dotcom-rendering/pull/4896] where the key events container will be removed from the left column.
@@ -1233,7 +1230,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							data-print-layout="hide"
 							position="merchandising-high"
 							display={format.display}
-							shouldReserveMerchSpace={shouldReserveMerchSpace}
 						/>
 					</ElementContainer>
 
@@ -1345,7 +1341,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<AdSlot
 							position="merchandising"
 							display={format.display}
-							shouldReserveMerchSpace={shouldReserveMerchSpace}
 						/>
 					</ElementContainer>
 				</div>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -237,9 +237,6 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	return (
 		<>
 			{format.theme !== ArticleSpecial.Labs ? (
@@ -654,7 +651,6 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<AdSlot
 						position="merchandising-high"
 						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -750,11 +746,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot
-						position="merchandising"
-						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
-					/>
+					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>
 			</main>
 

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -337,9 +337,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
-	const shouldReserveMerchSpace =
-		!!CAPIArticle.config.abTests.merchandisingMinHeightVariant;
-
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -786,7 +783,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						data-print-layout="hide"
 						position="merchandising-high"
 						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
 					/>
 				</ElementContainer>
 
@@ -887,11 +883,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					backgroundColour={neutral[93]}
 					element="aside"
 				>
-					<AdSlot
-						position="merchandising"
-						display={format.display}
-						shouldReserveMerchSpace={shouldReserveMerchSpace}
-					/>
+					<AdSlot position="merchandising" display={format.display} />
 				</ElementContainer>
 			</main>
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes merchandising-min-height AB test.

This change can now be rolled out without being hidden behind an AB test

## Why?

See [this PR](https://github.com/guardian/dotcom-rendering/pull/5561)
