### PR TITLE
fix pinned post bug on twitter posts

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -18,17 +18,19 @@ const pinnedPostContent: HTMLElement | null = !isServer
 	: null;
 
 /**
- * hide show more button and overlay on pinned post
+ * toggle show more button and overlay on pinned post
  */
-function hideShowMore() {
+function toggleShowMore(show: boolean) {
 	const pinnedPostButton = document.querySelector<HTMLElement>(
 		'#pinned-post-button',
 	);
 	const pinnedPostOverlay = document.querySelector<HTMLElement>(
 		'#pinned-post-overlay',
 	);
-	if (pinnedPostButton) pinnedPostButton.style.display = 'none';
-	if (pinnedPostOverlay) pinnedPostOverlay.style.display = 'none';
+	if (pinnedPostButton)
+		pinnedPostButton.style.display = show ? 'inline-flex' : 'none';
+	if (pinnedPostOverlay)
+		pinnedPostOverlay.style.display = show ? 'block' : 'none';
 }
 
 /**
@@ -79,10 +81,13 @@ export const EnhancePinnedPost = () => {
 	const pinnedPostTiming = useRef<ReturnType<typeof initPerf>>();
 
 	const checkContentHeight = () => {
-		const contentFitsContainer =
-			pinnedPostContent &&
-			pinnedPostContent.scrollHeight <= pinnedPostContent.clientHeight;
-		if (contentFitsContainer) hideShowMore();
+		if (pinnedPostContent) {
+			const contentFitsContainer =
+				pinnedPostContent.scrollHeight <=
+				pinnedPostContent.clientHeight;
+			if (contentFitsContainer) toggleShowMore(false);
+			else toggleShowMore(true);
+		}
 	};
 
 	/**
@@ -94,7 +99,10 @@ export const EnhancePinnedPost = () => {
 		checkContentHeight();
 
 		const observer = new MutationObserver(checkContentHeight);
-		const config = { childList: true };
+		const config = {
+			childList: true,
+			subtree: true,
+		};
 
 		observer.observe(pinnedPost, config);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes a bug where the pinned post `show more` button would have become hidden on some tweeter posts. 

# changes: 
1- We were using the `MutationObserver` to observe the `pinnedPost` element, but when I was testing locally, I realised that this observer is not really getting triggered on twitter blocks. Updating the config from `{ childList: true }` to `{ childList: true, subtree: true }`, fixed the triggering issue for the observer. 
-  childList: Set to true if additions and removals of the target node's child elements
-  subtree: Set to true if mutations to not just target, but also target's descendants are to be observed

2- This was not enough to fix the issue. Because for some twitter posts, at first, the scroll height of the component was less than the client height, so the `show more` button would get hidden. After twitter enhancement, the `MutationObserver` would get triggered, but in the call back we were only taking action for hiding the `show more` button, not for showing the hidden `show more` button. 

I refactored `hideShowMore` function into `toggleShowMore` so that it can now show the hidden button, depending on the boolean `show` parameter. 


## Screenshots


| Before      | After      |
|-------------|------------|
|  ![image](https://user-images.githubusercontent.com/15894063/184112337-a0d637ba-3c93-4c9f-9b18-3e7fddeb44aa.png) | ![image](https://user-images.githubusercontent.com/15894063/184112459-089fc39e-f853-4bb0-9844-d2b494d6e834.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
