### PR TITLE
fix: Remove unused WitnessBlockElement prop, fixes #5593

### DIFF
--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -493,7 +493,6 @@ interface YoutubeBlockElement {
 
 interface WitnessTypeDataBase {
 	authorUsername: string;
-	authorGuardianProfileUrl: string;
 	originalUrl: string;
 	source: string;
 	title: string;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3266,9 +3266,6 @@
                 "authorUsername": {
                     "type": "string"
                 },
-                "authorGuardianProfileUrl": {
-                    "type": "string"
-                },
                 "originalUrl": {
                     "type": "string"
                 },
@@ -3304,7 +3301,6 @@
                 "_type",
                 "alt",
                 "apiUrl",
-                "authorGuardianProfileUrl",
                 "authorName",
                 "authorUsername",
                 "authorWitnessProfileUrl",
@@ -3365,9 +3361,6 @@
                 "authorUsername": {
                     "type": "string"
                 },
-                "authorGuardianProfileUrl": {
-                    "type": "string"
-                },
                 "originalUrl": {
                     "type": "string"
                 },
@@ -3402,7 +3395,6 @@
             "required": [
                 "_type",
                 "apiUrl",
-                "authorGuardianProfileUrl",
                 "authorName",
                 "authorUsername",
                 "authorWitnessProfileUrl",
@@ -3472,9 +3464,6 @@
                 "authorWitnessProfileUrl": {
                     "type": "string"
                 },
-                "authorGuardianProfileUrl": {
-                    "type": "string"
-                },
                 "html": {
                     "type": "string"
                 }
@@ -3482,7 +3471,6 @@
             "required": [
                 "_type",
                 "apiUrl",
-                "authorGuardianProfileUrl",
                 "authorName",
                 "authorUsername",
                 "authorWitnessProfileUrl",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes authorGuardianProfileUrl from the WitnessTypeDataBase model as its not used anywhere and is causing some older pages to error.

Fixes #5593

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/184168666-8daed6ab-4b10-4bff-b7e0-beab5b9e2b25.png
[after]: https://user-images.githubusercontent.com/21217225/184168540-d8344d23-5cf8-4e0d-b292-f0e9f39f54f8.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
