### PR TITLE
`getHttp3Url()` catch malformed URL exception

### DIFF
--- a/dotcom-rendering/src/web/lib/getHttp3Url.ts
+++ b/dotcom-rendering/src/web/lib/getHttp3Url.ts
@@ -6,6 +6,9 @@ export const getHttp3Url = (url: string): string => {
 		urlObject.searchParams.append('http3', 'true');
 		return urlObject.toString();
 	} catch (e) {
+		// if we are given an invalid url, `new URL()` will throw a
+		// `TypeError` exception. In which case we can't safely apply
+		// the http3 param anyway so just return it unchanged.
 		if (e instanceof TypeError) {
 			return url;
 		} else {

--- a/dotcom-rendering/src/web/lib/getHttp3Url.ts
+++ b/dotcom-rendering/src/web/lib/getHttp3Url.ts
@@ -1,7 +1,15 @@
 // Evaluating the performance of HTTP3 over HTTP2, this file can be removed once the experiment is concluded.
 // See: https://github.com/guardian/dotcom-rendering/pull/5394
 export const getHttp3Url = (url: string): string => {
-	const urlObject = new URL(url);
-	urlObject.searchParams.append('http3', 'true');
-	return urlObject.toString();
+	try {
+		const urlObject = new URL(url);
+		urlObject.searchParams.append('http3', 'true');
+		return urlObject.toString();
+	} catch (e) {
+		if (e instanceof TypeError) {
+			return url;
+		} else {
+			throw e;
+		}
+	}
 };


### PR DESCRIPTION
## What does this change?

When the `serve-http3` feature switch is on, it causes most asset URLs to be passed through `getHttp3Url()`. The first thing this function does is to create a URL object from the asset URL string that was passed in. Normally this is not a problem, but when we are doing our CI tests, because `stage` is not set to anything, we end up with URLs which have no domain, just a path:

```typescript
/**
 * Decides the url to use for fetching assets
 *
 * @param {'PROD' | 'CODE' | undefined} stage the environment code is executing in
 * @returns {string}
 */
export const decideAssetOrigin = (
	stage: string | undefined,
	isDev: boolean,
): string => {
	switch (stage?.toUpperCase()) {
		case 'PROD':
			return 'https://assets.guim.co.uk/';
		case 'CODE':
			return 'https://assets-code.guim.co.uk/';
		default: {
			if (isDev) {
				// Use absolute asset paths in development mode
				// This is so paths are correct when treated as relative to Frontend
				return 'http://localhost:3030/';
			} else {
				return '/';
			}
		}
	}
};
```

These are not valid URLs and therefore the URL constructor throws an exception in this instance. As a result, we cannot currently turn on this feature switch without breaking the CI environment.

This fix proposes to correct this issue by catching this specific exception and in that case &mdash; because we can't actually to anything useful &mdash; we just return the original string unmodified.

## Testing

This has been tested by running dotcom-rendering locally in CI mode, using `make run-ci` and loading articles. Without this fix that triggers an exception, but with the fix it loads the page correctly (without some of the assets, which is expected, because of the invalid URLs).