### PR TITLE
Immersive Header Layout Tweaks

### DIFF
--- a/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
+++ b/apps-rendering/src/components/Headline/ImmersiveHeadline.tsx
@@ -17,17 +17,26 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'bold' })}
 	background-color: ${background.headline(format)};
 	color: ${text.headline(format)};
-	padding: 0 ${remSpace[5]} ${remSpace[9]} 0;
+	padding: ${remSpace[1]} ${remSpace[5]} ${remSpace[9]} 0;
 	${grid.between('centre-column-start', 'centre-column-end')}
 	grid-row: 3 / 5;
+
+	${from.mobileLandscape} {
+		padding-top: ${remSpace[3]};
+	}
 
 	${from.tablet} {
 		${grid.span('centre-column-start', 12)}
 	}
 
+	${from.tablet} {
+		padding-top: ${remSpace[1]};
+	}
+
 	${from.desktop} {
 		${headline.xlarge({ fontWeight: 'bold' })}
 		${grid.span('centre-column-start', 8)}
+		padding-top: 0;
 	}
 
 	${darkModeCss`

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -26,7 +26,7 @@ const styles = css`
 	margin: 0;
 	${grid.between('viewport-start', 'viewport-end')}
 	grid-row: 1 / 4;
-	height: 70vh;
+	height: 63vh;
 
 	${from.desktop} {
 		height: 100vh;
@@ -40,7 +40,7 @@ const getSizes = (image: Image): Sizes => ({
 			size: `${100 * (image.width / image.height)}vh`,
 		},
 	],
-	default: `${70 * (image.width / image.height)}vh`,
+	default: `${63 * (image.width / image.height)}vh`,
 });
 
 interface Props {

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -26,7 +26,7 @@ const styles = css`
 	margin: 0;
 	${grid.between('viewport-start', 'viewport-end')}
 	grid-row: 1 / 4;
-	height: 80vh;
+	height: 70vh;
 
 	${from.desktop} {
 		height: 100vh;
@@ -40,7 +40,7 @@ const getSizes = (image: Image): Sizes => ({
 			size: `${100 * (image.width / image.height)}vh`,
 		},
 	],
-	default: `${80 * (image.width / image.height)}vh`,
+	default: `${70 * (image.width / image.height)}vh`,
 });
 
 interface Props {

--- a/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
@@ -49,17 +49,17 @@ const renderContent = (
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${grid.span('centre-column-start', 3)}
+	${grid.column.centre}
 	${headline.xsmall({ fontWeight: 'light' })}
-	padding: ${remSpace[4]} 0 ${remSpace[9]};
+	padding: ${remSpace[2]} ${remSpace[5]} ${remSpace[9]} 0;
 	color: ${text.standfirst(format)};
 
-	${from.tablet} {
-		${grid.span('centre-column-start', 8)}
+	${from.mobileLandscape} {
+		padding-top: ${remSpace[4]};
 	}
 
-	${from.desktop} {
-		${grid.span('centre-column-start', 6)}
+	${from.tablet} {
+		padding-top: ${remSpace[1]};
 	}
 
 	${from.leftCol} {


### PR DESCRIPTION
## Why?

Made some design changes to the header of immersives based on feedback from @ajbreuer. Part of the work from #5540.

## Changes

### Headline

Made sure that the top padding matches the left padding across all breakpoints.

| Mobile | Mobile Landscape | Tablet | Wide |
| - | - | - | - |
| ![headline-mobile] | ![headline-mobile-landscape] | ![headline-tablet] | ![headline-wide] |

[headline-mobile-landscape]: https://user-images.githubusercontent.com/53781962/184195466-0eb16c44-815a-4c10-abaa-ccc28a898a75.jpg
[headline-tablet]: https://user-images.githubusercontent.com/53781962/184195475-7e40e880-0887-46fe-a420-f4c518ce10f9.jpg
[headline-mobile]: https://user-images.githubusercontent.com/53781962/184195478-89b1d263-9b70-468f-b967-9f9a027b9f72.jpg
[headline-wide]: https://user-images.githubusercontent.com/53781962/184195482-b8202857-38a5-4b25-b2f0-037a0eedc54a.jpg

Also reduced the height of the main media so that more of the headline is visible above the fold on the app (the app chrome takes up a lot of vertical space). These were taken on an iPhone 13 Pro (same dimensions as a 12, 12 Pro and 13):

| Before | After |
| - | - |
| ![immersive-before] | ![immersive-after] |

[immersive-after]: https://user-images.githubusercontent.com/53781962/184191725-fb154c9b-fd1a-4308-bd99-70aaf06efbe0.jpg
[immersive-before]: https://user-images.githubusercontent.com/53781962/184191734-392084fc-9143-4589-bf4f-2ce6b67414a0.jpg

### Standfirst

Made sure that the top padding matches the left padding across all breakpoints. Also changed the width of the standfirst to make it consistent with the headline text (centre column, 20px right padding) across all breakpoints.

| Mobile | Mobile Landscape | Tablet | Wide |
| - | - | - | - |
| ![standfirst-mobile] | ![standfirst-mobile-landscape] | ![standfirst-tablet] | ![standfirst-wide] |

[standfirst-mobile]: https://user-images.githubusercontent.com/53781962/184196526-59144a02-bca0-4cea-85de-26227244cc06.jpg
[standfirst-mobile-landscape]: https://user-images.githubusercontent.com/53781962/184196537-8276f04b-6508-42b0-9673-fa7d439c8a87.jpg
[standfirst-tablet]: https://user-images.githubusercontent.com/53781962/184196544-28a76547-6394-4dcd-93db-ae6eb911ca24.jpg
[standfirst-wide]: https://user-images.githubusercontent.com/53781962/184196546-5ce2884f-824d-41e1-b708-b9e4174bbcd3.jpg
