### PR TITLE
`dynamic/package` - support snap

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ContentWrapper.tsx
@@ -31,15 +31,21 @@ const flexBasisStyles = ({
 			`;
 		case 'medium':
 			return css`
-				flex-basis: 50%;
+				${from.tablet} {
+					flex-basis: 50%;
+				}
 			`;
 		case 'large':
 			return css`
-				flex-basis: 34%;
+				${from.tablet} {
+					flex-basis: 34%;
+				}
 			`;
 		case 'jumbo':
 			return css`
-				flex-basis: 25%;
+				${from.tablet} {
+					flex-basis: 25%;
+				}
 			`;
 	}
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -1,7 +1,16 @@
 import { breakpoints } from '@guardian/source-foundations';
+import type { DCRGroupedTrails } from 'src/types/front';
 import { trails } from '../../../fixtures/manual/trails';
 import { ContainerLayout } from './ContainerLayout';
 import { DynamicPackage } from './DynamicPackage';
+
+const defaultGroupedTrails: DCRGroupedTrails = {
+	huge: [],
+	veryBig: [],
+	big: [],
+	standard: [],
+	snap: [],
+};
 
 export default {
 	component: DynamicPackage,
@@ -31,13 +40,17 @@ export const Three = () => (
 		centralBorder="partial"
 	>
 		<DynamicPackage
-			trails={[...trails].slice(0, 3)}
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 3),
+			}}
 			containerPalette="LongRunningPalette"
 		/>
 	</ContainerLayout>
 );
 Three.story = {
-	name: 'With three cards',
+	name: 'With three standard cards',
 };
 
 export const Four = () => (
@@ -49,13 +62,17 @@ export const Four = () => (
 		centralBorder="partial"
 	>
 		<DynamicPackage
-			trails={[...trails].slice(0, 4)}
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 4),
+			}}
 			containerPalette="LongRunningPalette"
 		/>
 	</ContainerLayout>
 );
 Four.story = {
-	name: 'With four cards',
+	name: 'With four standard cards',
 };
 
 export const Five = () => (
@@ -67,13 +84,17 @@ export const Five = () => (
 		centralBorder="partial"
 	>
 		<DynamicPackage
-			trails={[...trails].slice(0, 5)}
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 5),
+			}}
 			containerPalette="LongRunningPalette"
 		/>
 	</ContainerLayout>
 );
 Five.story = {
-	name: 'With five cards',
+	name: 'With five standard cards',
 };
 
 export const Boosted3 = () => {
@@ -89,7 +110,11 @@ export const Boosted3 = () => {
 			centralBorder="partial"
 		>
 			<DynamicPackage
-				trails={[{ ...primary, isBoosted: true }, ...remaining]}
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
 			/>
@@ -97,7 +122,7 @@ export const Boosted3 = () => {
 	);
 };
 Boosted3.story = {
-	name: 'With three cards - boosted',
+	name: 'With three standard cards - boosted',
 };
 
 export const Boosted4 = () => {
@@ -113,7 +138,11 @@ export const Boosted4 = () => {
 			centralBorder="partial"
 		>
 			<DynamicPackage
-				trails={[{ ...primary, isBoosted: true }, ...remaining]}
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
 			/>
@@ -121,7 +150,7 @@ export const Boosted4 = () => {
 	);
 };
 Boosted4.story = {
-	name: 'With four cards - boosted',
+	name: 'With four standard cards - boosted',
 };
 
 export const Boosted5 = () => {
@@ -137,7 +166,11 @@ export const Boosted5 = () => {
 			centralBorder="partial"
 		>
 			<DynamicPackage
-				trails={[{ ...primary, isBoosted: true }, ...remaining]}
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
 				showAge={true}
 				containerPalette="LongRunningPalette"
 			/>
@@ -145,5 +178,71 @@ export const Boosted5 = () => {
 	);
 };
 Boosted5.story = {
-	name: 'With five cards - boosted',
+	name: 'With five standard cards - boosted',
+};
+
+export const OneSnapThreeStandard = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [trails[0]],
+				standard: [...trails].slice(1, 4),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+OneSnapThreeStandard.story = {
+	name: 'With one snap - three standard cards',
+};
+
+export const ThreeSnapTwoStandard = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [...trails].slice(0, 3),
+				standard: [...trails].slice(3, 5),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+OneSnapThreeStandard.story = {
+	name: 'With three snaps - two standard cards',
+};
+
+export const ThreeSnapTwoStandard2ndBoosted = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [trails[0], { ...trails[1], isBoosted: true }, trails[2]],
+				standard: [...trails].slice(3, 5),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+OneSnapThreeStandard.story = {
+	name: 'With three snaps (2nd boosted) - two standard cards',
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -19,7 +19,7 @@ const Snap100 = ({
 	showAge?: boolean;
 }) => {
 	return (
-		<UL direction="row">
+		<UL>
 			<LI padSides={true} padBottom={true}>
 				<FrontCard
 					trail={snap}
@@ -62,7 +62,7 @@ export const DynamicPackage = ({
 						showAge={showAge}
 					/>
 				)}
-				<UL direction="row">
+				<UL>
 					<LI padSides={true}>
 						<FrontCard
 							trail={primary}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -44,7 +44,7 @@ export const DynamicPackage = ({
 	showAge,
 }: Props) => {
 	// Take the first 'snap' - all others are treated as standards
-	const snaps = groupedTrails.snap.slice(0, 1);
+	const snap = [...groupedTrails.snap].shift();
 	const [primary, ...remaining] = [
 		...groupedTrails.snap.slice(1),
 		...groupedTrails.standard,
@@ -55,9 +55,9 @@ export const DynamicPackage = ({
 	if (primary.isBoosted) {
 		return (
 			<>
-				{snaps.length > 0 && (
+				{!!snap && (
 					<Snap100
-						snap={snaps[0]}
+						snap={snap}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -107,9 +107,9 @@ export const DynamicPackage = ({
 	}
 	return (
 		<>
-			{snaps.length > 0 && (
+			{!!snap && (
 				<Snap100
-					snap={snaps[0]}
+					snap={snap}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -23,7 +23,6 @@ const Snap100 = ({
 			<LI padSides={true} padBottom={true}>
 				<FrontCard
 					trail={snap}
-					starRating={snap.starRating}
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
@@ -67,7 +66,6 @@ export const DynamicPackage = ({
 					<LI padSides={true}>
 						<FrontCard
 							trail={primary}
-							starRating={primary.starRating}
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
@@ -95,7 +93,6 @@ export const DynamicPackage = ({
 							>
 								<FrontCard
 									trail={card}
-									starRating={card.starRating}
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -118,7 +118,6 @@ export const DynamicPackage = ({
 				<LI padSides={true} percentage="75%">
 					<FrontCard
 						trail={primary}
-						starRating={primary.starRating}
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
@@ -150,7 +149,6 @@ export const DynamicPackage = ({
 								>
 									<FrontCard
 										trail={card}
-										starRating={card.starRating}
 										containerPalette={containerPalette}
 										containerType="dynamic/package"
 										showAge={showAge}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -44,9 +44,9 @@ export const DynamicPackage = ({
 	showAge,
 }: Props) => {
 	// Take the first 'snap' - all others are treated as standards
-	const snap = groupedTrails.snap.shift();
+	const snaps = groupedTrails.snap.slice(0, 1);
 	const [primary, ...remaining] = [
-		...groupedTrails.snap,
+		...groupedTrails.snap.slice(1),
 		...groupedTrails.standard,
 	];
 
@@ -55,9 +55,9 @@ export const DynamicPackage = ({
 	if (primary.isBoosted) {
 		return (
 			<>
-				{!!snap && (
+				{snaps.length > 0 && (
 					<Snap100
-						snap={snap}
+						snap={snaps[0]}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -107,9 +107,9 @@ export const DynamicPackage = ({
 	}
 	return (
 		<>
-			{!!snap && (
+			{snaps.length > 0 && (
 				<Snap100
-					snap={snap}
+					snap={snaps[0]}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -1,24 +1,68 @@
-import type { DCRContainerPalette } from '../../types/front';
+import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
 
 type Props = {
-	trails: TrailType[];
+	groupedTrails: DCRGroupedTrails;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 };
 
+const SnapRow = ({
+	snap,
+	containerPalette,
+	showAge,
+}: {
+	snap: TrailType;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	return (
+		<UL direction="row">
+			<LI padSides={true} padBottom={true}>
+				<FrontCard
+					trail={snap}
+					starRating={snap.starRating}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+					headlineSize="large"
+					headlineSizeOnMobile="medium"
+					imagePosition="right"
+					imagePositionOnMobile="left"
+					imageSize="medium"
+					trailText={snap.trailText}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
 export const DynamicPackage = ({
-	trails,
+	groupedTrails,
 	containerPalette,
 	showAge,
 }: Props) => {
-	const [primary, ...remaining] = trails;
+	// Take the first 'snap' - all others are treated as standards
+	const snap = groupedTrails.snap.shift();
+	const [primary, ...remaining] = [
+		...groupedTrails.snap,
+		...groupedTrails.standard,
+	];
 
+	// TODO: Different layouts are required when there are 4+ 'remaining' cards
+	// dynamic/package will display up to 8 'remaining' cards before moving to 'show more'
 	if (primary.isBoosted) {
 		return (
 			<>
+				{!!snap && (
+					<SnapRow
+						snap={snap}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				)}
 				<UL direction="row">
 					<LI padSides={true}>
 						<FrontCard
@@ -66,6 +110,13 @@ export const DynamicPackage = ({
 	}
 	return (
 		<>
+			{!!snap && (
+				<SnapRow
+					snap={snap}
+					containerPalette={containerPalette}
+					showAge={showAge}
+				/>
+			)}
 			<UL direction="row">
 				<LI padSides={true} percentage="75%">
 					<FrontCard

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -9,7 +9,7 @@ type Props = {
 	showAge?: boolean;
 };
 
-const SnapRow = ({
+const Snap100 = ({
 	snap,
 	containerPalette,
 	showAge,
@@ -57,7 +57,7 @@ export const DynamicPackage = ({
 		return (
 			<>
 				{!!snap && (
-					<SnapRow
+					<Snap100
 						snap={snap}
 						containerPalette={containerPalette}
 						showAge={showAge}
@@ -111,7 +111,7 @@ export const DynamicPackage = ({
 	return (
 		<>
 			{!!snap && (
-				<SnapRow
+				<Snap100
 					snap={snap}
 					containerPalette={containerPalette}
 					showAge={showAge}

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -19,6 +19,7 @@ type Props = {
  * @param [imagePositionOnMobile] - Defaults to "left"
  * @param [imageSize] - Defaults to "medium"
  * @param [supportingContent] - Defaults to undefined, set to trail.supportingContent if you want this card to show sublinks.
+ * @param [trailText] - Defailts to undefined, set to trail.trailTrext if you want this card to show trail text.
  */
 export const FrontCard = (props: Props) => {
 	const { trail, ...cardProps } = props;

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -62,7 +62,7 @@ export const DecideContainer = ({
 		case 'dynamic/package':
 			return (
 				<DynamicPackage
-					trails={trails}
+					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR updates `dynamic/package` to support grouping.

`dynamic/package` supports 2 card groups, 'snap' and 'standard'. Currently it is written to assume all cards are 'standard', so this PR updates the container to also consume the 'snap' which is placed on top of all standard cards.

Only one 'snap' is supported, so additional snap grouped cards will fall through to the top of 'standards'

## Why?

We're on the way to ✨ _parity_ ✨

## Screenshots

| Frontend      | DCR Before      | DCR After   |
|-------------|------------|------------|
| ![frontend][] | ![before][] | ![after][] |

[frontend]: https://user-images.githubusercontent.com/9575458/184338959-74d8c294-e2ed-443c-9e1b-ca09b73471eb.png
[before]: https://user-images.githubusercontent.com/9575458/184339158-1b48724c-eb22-450d-91ff-a1e2888f69d7.png
[after]: https://user-images.githubusercontent.com/9575458/184339393-9c99bef6-7192-4fbe-b9e6-43157cdd2103.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
