### PR TITLE
Better behaviour around Braze switch

### DIFF
--- a/dotcom-rendering/src/web/lib/braze/buildBrazeMessaging.ts
+++ b/dotcom-rendering/src/web/lib/braze/buildBrazeMessaging.ts
@@ -24,11 +24,14 @@ const maybeWipeUserData = async (
 	apiKey?: string,
 	brazeUuid?: null | string,
 	consent?: boolean,
+	brazeSwitch?: boolean,
 ): Promise<void> => {
-	const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
-	const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
+	const hasCurrentBrazeUserValue = hasCurrentBrazeUser();
+	const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUserValue;
+	const userHasRemovedConsent = !consent && hasCurrentBrazeUserValue;
+	const brazeHasBeenDisabled = !brazeSwitch && hasCurrentBrazeUserValue;
 
-	if (userHasLoggedOut || userHasRemovedConsent) {
+	if (userHasLoggedOut || userHasRemovedConsent || brazeHasBeenDisabled) {
 		try {
 			if (apiKey) {
 				const appboy = await getInitialisedAppboy(apiKey);
@@ -82,6 +85,7 @@ export const buildBrazeMessaging = async (
 			data.apiKey as string | undefined,
 			data.brazeUuid as string | null | undefined,
 			data.consent as boolean | undefined,
+			data.brazeSwitch as boolean | undefined,
 		);
 
 		return {

--- a/dotcom-rendering/src/web/lib/braze/checkBrazeDependencies.test.ts
+++ b/dotcom-rendering/src/web/lib/braze/checkBrazeDependencies.test.ts
@@ -88,11 +88,40 @@ describe('checkBrazeDependecies', () => {
 		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
 
 		expect(got.isSuccessful).toEqual(false);
-		expect(got.data).toEqual({});
 		// Condition to keep TypeScript happy
 		if (!got.isSuccessful) {
 			expect(got.failure.field).toEqual('brazeSwitch');
 			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('returns the apiKey if the switch is disabled', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: false,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			apiKey: 'fake-api-key',
+		});
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeSwitch');
 		}
 	});
 
@@ -118,9 +147,6 @@ describe('checkBrazeDependecies', () => {
 		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
 
 		expect(got.isSuccessful).toEqual(false);
-		expect(got.data).toEqual({
-			brazeSwitch: true,
-		});
 		// Condition to keep TypeScript happy
 		if (!got.isSuccessful) {
 			expect(got.failure.field).toEqual('apiKey');

--- a/dotcom-rendering/src/web/lib/braze/checkBrazeDependencies.ts
+++ b/dotcom-rendering/src/web/lib/braze/checkBrazeDependencies.ts
@@ -38,12 +38,12 @@ const buildDependencies = (
 ): DependencyResult[] => {
 	return [
 		{
-			name: 'brazeSwitch',
-			value: Promise.resolve(window.guardian.config.switches.brazeSwitch),
-		},
-		{
 			name: 'apiKey',
 			value: Promise.resolve(window.guardian.config.page.brazeApiKey),
+		},
+		{
+			name: 'brazeSwitch',
+			value: Promise.resolve(window.guardian.config.switches.brazeSwitch),
 		},
 		{
 			name: 'brazeUuid',


### PR DESCRIPTION
## What does this change?

When checking the dependencies for loading the Braze web SDK, check for the Braze API key before the switch.

## Why?

So that if the switch is ever turned off, we still have access to the API key in the caller in order to use the SDK wipe local data.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
