### PR TITLE
Bug fix: newsletter signup next to adslot

### DIFF
--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -10,7 +10,7 @@ type PlaceInArticle = {
 const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
 // This value is an approximation - the aim is to avoid a blank space between
 // the element before the SignUp and the end of the floating element.
-// The SignUp block css uses 'clear:both' so a floating element won't interfer
+// The SignUp block css uses 'clear:left' so a left floating element won't interfer
 // with its layout.
 // However, the actual heights of the elements when rendered is not taken into
 // account. 4 paragraphs should be enough, but if the floating element was
@@ -32,9 +32,25 @@ const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
 //  |float|
 //  |float|
 //  +-----+
-//    |   +---------------------+
-//    |   |      SignUp         |
-//    |   +---------------------+
+//    |  +----------------------+
+//    |  |      SignUp          |
+//    |  +----------------------+
+
+// Note this logic does need to account for adslots in the righthand
+// column, because having clear:left (not clear:both) allows the adslot
+// to float around the SignUp block.
+// The elements in the right hand colomn don't 'hang over' into the
+// main coloum as left coloumn element can.
+//    | TextTextTextTextTextText  | +------+
+//    | TextTextTextText          | |adslot|
+//    |                           | |adslot|
+//    | TextTextTextTextTextText  | |adslot|
+//    | TextTextTextText          | |      |
+//    |  +----------------------+ | |      |
+//    |  |      SignUp          | | |      |
+//    |  +----------------------+ | |      |
+//    | TextTextTextTextTextText  | +------+
+//    | TextTextTextText          |
 
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 

--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -22,7 +22,7 @@ type Props = {
 };
 
 const containerStyles = css`
-	clear: both;
+	clear: left;
 	border: ${neutral[0]} 3px dashed;
 	border-radius: 12px;
 	margin-bottom: ${space[3]}px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
 - Changes the css for the `EmailSignup` container from `clear:both` to `clear:left`

## Why?
The block need to always be clear on the left for the reasons outlined here: https://github.com/guardian/dotcom-rendering/pull/5410#discussion_r930899305, but using `clear:both` causes unnecessary gaps when an adslot floats to the right column.

As there are no elements which cross the main/right column borders, there isn't a need to prevent *right* floating wrapping round the `EmailSignup`

Thanks to @simonbyford  for pointing this out.

## Screenshots (backgrounds added on the adslots to illustrate)

| Before      | After      |
|-------------|------------|
| <img width="1279" alt="Screenshot 2022-08-12 at 13 09 41" src="https://user-images.githubusercontent.com/30567854/184355155-e11d37fb-a281-413d-b636-df1153c59191.png">| <img width="1279" alt="Screenshot 2022-08-12 at 13 09 55" src="https://user-images.githubusercontent.com/30567854/184355049-c7870f84-7318-40f7-a75e-f3c551b4c94e.png"> |


