### PR TITLE
Apps newsletter signup placement logic

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -5,7 +5,6 @@ import type { TimelineEvent } from '@guardian/atoms-rendering/dist/types/types';
 import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
-import type { ArticleTheme } from '@guardian/libs';
 import type { Option, Result } from '@guardian/types';
 import {
 	err,
@@ -23,6 +22,7 @@ import type { Embed } from 'embed';
 import type { Image as ImageData } from 'image';
 import { parseImage } from 'image';
 import { compose, pipe } from 'lib';
+import type { Newsletter } from 'newsletter';
 import type { Context } from 'parserContext';
 import type { KnowledgeQuizAtom, PersonalityQuizAtom } from 'quizAtom';
 
@@ -111,14 +111,8 @@ interface AudioAtom {
 	title: string;
 }
 
-interface NewsletterSignUp {
+interface NewsletterSignUp extends Newsletter {
 	kind: ElementKind.NewsletterSignUp;
-	id: string;
-	displayName: string;
-	frequency: string;
-	description: string;
-	group: string;
-	theme: ArticleTheme;
 }
 
 type BodyElement =

--- a/apps-rendering/src/newsletter.ts
+++ b/apps-rendering/src/newsletter.ts
@@ -1,0 +1,31 @@
+// ----- Imports ----- //
+
+import { ArticlePillar } from '@guardian/libs';
+import type { ArticleTheme } from '@guardian/libs';
+
+// ----- Item Type ----- //
+
+interface Newsletter {
+	id: string;
+	displayName: string;
+	frequency: string;
+	description: string;
+	group: string;
+	theme: ArticleTheme;
+}
+
+// ----- constants ----- //
+
+const TEST_NEWSLETTER = {
+	id: 'patriarchy',
+	description:
+		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
+	displayName: 'The Week in Patriarchy',
+	frequency: 'Weekly',
+	theme: ArticlePillar.Opinion,
+	group: 'opinion',
+};
+
+// ----- Exports ----- //
+
+export { Newsletter, TEST_NEWSLETTER };

--- a/apps-rendering/src/newsletter.ts
+++ b/apps-rendering/src/newsletter.ts
@@ -1,6 +1,4 @@
 // ----- Imports ----- //
-
-import { ArticlePillar } from '@guardian/libs';
 import type { ArticleTheme } from '@guardian/libs';
 
 // ----- Item Type ----- //
@@ -14,18 +12,6 @@ interface Newsletter {
 	theme: ArticleTheme;
 }
 
-// ----- constants ----- //
-
-const TEST_NEWSLETTER = {
-	id: 'patriarchy',
-	description:
-		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
-	displayName: 'The Week in Patriarchy',
-	frequency: 'Weekly',
-	theme: ArticlePillar.Opinion,
-	group: 'opinion',
-};
-
 // ----- Exports ----- //
 
-export { Newsletter, TEST_NEWSLETTER };
+export { Newsletter };

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -68,6 +68,7 @@ import InteractiveAtom, {
 import List from 'components/List';
 import ListItem from 'components/ListItem';
 import LiveEventLink from 'components/LiveEventLink';
+import NewsletterSignup from 'components/NewsletterSignup';
 import OrderedList from 'components/OrderedList';
 import Paragraph from 'components/Paragraph';
 import Pullquote from 'components/Pullquote';
@@ -701,6 +702,9 @@ const render =
 			case ElementKind.KnowledgeQuizAtom:
 			case ElementKind.PersonalityQuizAtom:
 				return h(Quiz, { format, element });
+
+			case ElementKind.NewsletterSignUp:
+				return h(NewsletterSignup, { format, element });
 		}
 	};
 

--- a/apps-rendering/src/server/insertNewsletter.test.ts
+++ b/apps-rendering/src/server/insertNewsletter.test.ts
@@ -1,0 +1,101 @@
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { Result, ResultKind, some } from '@guardian/types';
+import { Text } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import type { Standard, LiveBlog, Quiz } from 'item';
+import { JSDOM } from 'jsdom';
+import { Newsletter } from '../newsletter';
+import { insertNewsletterIntoItem } from './insertNewsletter';
+
+const NEWSLETTER: Newsletter = {
+	id: 'patriarchy',
+	description:
+		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
+	displayName: 'The Week in Patriarchy',
+	frequency: 'Weekly',
+	theme: ArticlePillar.Opinion,
+	group: 'Opinion',
+};
+
+const makeTextElement = (html: string): Result<string, Text> => ({
+	kind: ResultKind.Ok,
+	value: { kind: ElementKind.Text, doc: JSDOM.fragment(html) },
+});
+
+const CONTENT_1 = `
+<p>paragraph one</p>
+<p>paragraph two</p>
+<p>paragraph three</p>
+<p>paragraph four</p>
+`;
+const CONTENT_2 = `
+<p>paragraph five</p>
+`;
+
+const makeStandard = (): Standard =>
+	({
+		design: ArticleDesign.Standard,
+		body: [makeTextElement(CONTENT_1), makeTextElement(CONTENT_2)],
+		internalShortId: some('standard article id'),
+	} as Standard);
+
+const makeBlog = (): LiveBlog =>
+	({
+		design: ArticleDesign.LiveBlog,
+		internalShortId: some('Blog id'),
+	} as LiveBlog);
+
+const makeQuiz =(): Quiz =>
+({
+	design: ArticleDesign.Quiz,
+	body: [makeTextElement(CONTENT_1), makeTextElement(CONTENT_2)],
+	internalShortId: some('quiz id'),
+} as Quiz)
+
+describe('Insert Newsletter Signups', () => {
+	it('makes no change if there is no newsletter', () => {
+		const before = makeStandard();
+		const after = insertNewsletterIntoItem(
+			makeStandard(),
+			undefined,
+		) as Standard;
+
+		expect(after.body.length).toBe(before.body.length);
+	});
+
+	it('inserts a NewsletterSignupBlockElement to a standard article if there is a newsletter', () => {
+		const before = makeStandard();
+		const after = insertNewsletterIntoItem(
+			makeStandard(),
+			NEWSLETTER,
+		) as Standard;
+
+		expect(after.body.length).toBe(before.body.length + 2);
+		expect(
+			after.body.some(
+				(bodyElement) =>
+					bodyElement.kind === ResultKind.Ok &&
+					bodyElement.value.kind === ElementKind.NewsletterSignUp,
+			),
+		).toBeTruthy();
+	});
+
+	it('will not insert a NewsletterSignupBlockElement into a blog', () => {
+		const before = makeBlog();
+		const after = insertNewsletterIntoItem(makeBlog(), NEWSLETTER);
+		expect(after).toEqual(before)
+	});
+
+	it('will not insert a NewsletterSignupBlockElement into a quiz', () => {
+		const before = makeQuiz();
+		const after = insertNewsletterIntoItem(makeQuiz(), NEWSLETTER) as Quiz;
+		expect(after).toEqual(before);
+		expect(
+			after.body.some(
+				(bodyElement) =>
+					bodyElement.kind === ResultKind.Ok &&
+					bodyElement.value.kind === ElementKind.NewsletterSignUp,
+			),
+		).toBeFalsy();
+	});
+});

--- a/apps-rendering/src/server/insertNewsletter.test.ts
+++ b/apps-rendering/src/server/insertNewsletter.test.ts
@@ -1,6 +1,6 @@
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
-import { Result, ResultKind, some } from '@guardian/types';
-import { Text } from 'bodyElement';
+import { Result, ResultKind, some, ok } from '@guardian/types';
+import type { NewsletterSignUp, Text } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
 import type { Standard, LiveBlog, Quiz } from 'item';
 import { JSDOM } from 'jsdom';
@@ -45,12 +45,12 @@ const makeBlog = (): LiveBlog =>
 		internalShortId: some('Blog id'),
 	} as LiveBlog);
 
-const makeQuiz =(): Quiz =>
-({
-	design: ArticleDesign.Quiz,
-	body: [makeTextElement(CONTENT_1), makeTextElement(CONTENT_2)],
-	internalShortId: some('quiz id'),
-} as Quiz)
+const makeQuiz = (): Quiz =>
+	({
+		design: ArticleDesign.Quiz,
+		body: [makeTextElement(CONTENT_1), makeTextElement(CONTENT_2)],
+		internalShortId: some('quiz id'),
+	} as Quiz);
 
 describe('Insert Newsletter Signups', () => {
 	it('makes no change if there is no newsletter', () => {
@@ -70,32 +70,28 @@ describe('Insert Newsletter Signups', () => {
 			NEWSLETTER,
 		) as Standard;
 
+		const expectedElement: NewsletterSignUp = {
+			kind: ElementKind.NewsletterSignUp,
+			...NEWSLETTER,
+		};
+
 		expect(after.body.length).toBe(before.body.length + 2);
-		expect(
-			after.body.some(
-				(bodyElement) =>
-					bodyElement.kind === ResultKind.Ok &&
-					bodyElement.value.kind === ElementKind.NewsletterSignUp,
-			),
-		).toBeTruthy();
+
+		expect(after.body).toEqual(
+			expect.arrayContaining([ok(expectedElement)]),
+		);
+
 	});
 
 	it('will not insert a NewsletterSignupBlockElement into a blog', () => {
 		const before = makeBlog();
 		const after = insertNewsletterIntoItem(makeBlog(), NEWSLETTER);
-		expect(after).toEqual(before)
+		expect(after).toEqual(before);
 	});
 
 	it('will not insert a NewsletterSignupBlockElement into a quiz', () => {
 		const before = makeQuiz();
-		const after = insertNewsletterIntoItem(makeQuiz(), NEWSLETTER) as Quiz;
+		const after = insertNewsletterIntoItem(makeQuiz(), NEWSLETTER);
 		expect(after).toEqual(before);
-		expect(
-			after.body.some(
-				(bodyElement) =>
-					bodyElement.kind === ResultKind.Ok &&
-					bodyElement.value.kind === ElementKind.NewsletterSignUp,
-			),
-		).toBeFalsy();
 	});
 });

--- a/apps-rendering/src/server/insertNewsletter.ts
+++ b/apps-rendering/src/server/insertNewsletter.ts
@@ -188,7 +188,7 @@ const tryToinsertNewsletterIntoStandard = (
 	return [
 		...body.slice(0, bodyResultIndex),
 		...textWithNewsletter.map(wrapInResult),
-		...body.slice(bodyResultIndex),
+		...body.slice(bodyResultIndex + 1), // +1 so the original Text that was split is left out
 	];
 };
 

--- a/apps-rendering/src/server/insertNewsletter.ts
+++ b/apps-rendering/src/server/insertNewsletter.ts
@@ -1,6 +1,6 @@
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import type { ArticleTheme } from '@guardian/libs';
-import type { Option, Result } from '@guardian/types';
+import { Option, OptionKind, Result } from '@guardian/types';
 import { ResultKind } from '@guardian/types';
 import type { BodyElement, Text } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
@@ -121,6 +121,15 @@ const findWhereToInsert = (
 	return null;
 };
 
+/**
+ * Splits a Text BodyElement into to parts after a give number of
+ * nodes in the html and puts another BodyElement between them.
+ *
+ * @param textElement a Text BodyElement from the original Item Body
+ * @param elementToInsert A Body element to place inside the text
+ * @param splitPoint the index of the node in the textElement to split before
+ * @returns a Tupple of three BodyElements
+ */
 const splitTextElementAndInsertBetweenParts = (
 	textElement: Text,
 	elementToInsert: BodyElement,
@@ -157,6 +166,17 @@ const splitTextElementAndInsertBetweenParts = (
 	];
 };
 
+/**
+ * Tries to insert a NewsletterSignUp BodyElement into the middle of an article.
+ *
+ * @param body the array of BodyElement Results for the item
+ * @param newsletter The newsletter to create a NewsletterSignUp BodyElement for
+ * @param internalShortId The Optional id for the Item
+ * @returns a new array of BodyElement Results with the NewsletterSignUp BodyElement
+ * inserted in the middle of the article, or the unmodifed body if the placement logic
+ * does not identify a suitable place
+ * @sideEffect logs a warning if the placement logic does not identify a suitable place
+ */
 const tryToinsertNewsletterIntoStandard = (
 	body: Array<Result<string, BodyElement>>,
 	newsletter: Newsletter,
@@ -167,13 +187,12 @@ const tryToinsertNewsletterIntoStandard = (
 	if (!insertPlace) {
 		logger.warn(
 			`Unable to find suitable place for NewsletterSignupBlockElement`,
-			internalShortId,
+			internalShortId.kind === OptionKind.Some ? internalShortId.value : '[undefined internalShortId]'
 		);
 		return body;
 	}
 
 	const { bodyResultIndex, bodyResultParagraphIndex, text } = insertPlace;
-
 	const textWithNewsletter = splitTextElementAndInsertBetweenParts(
 		text,
 		{

--- a/apps-rendering/src/server/insertNewsletter.ts
+++ b/apps-rendering/src/server/insertNewsletter.ts
@@ -1,0 +1,224 @@
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import type { ArticleTheme } from '@guardian/libs';
+import type { Option, Result } from '@guardian/types';
+import { ResultKind } from '@guardian/types';
+import type { BodyElement, Text } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import type { Item } from 'item';
+import { JSDOM } from 'jsdom';
+import { logger } from 'logger';
+
+export interface Newsletter {
+	id: string;
+	displayName: string;
+	frequency: string;
+	description: string;
+	group: string;
+	theme: ArticleTheme;
+}
+
+export const TEST_NEWSLETTER = {
+	id: 'patriarchy',
+	description:
+		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
+	displayName: 'The Week in Patriarchy',
+	frequency: 'Weekly',
+	theme: ArticlePillar.Opinion,
+	group: 'opinion',
+};
+
+type TextElementDescription = {
+	isError: false;
+	kind: ElementKind.Text;
+	paragraphs: number;
+	text: Text;
+};
+type OtherElementDescription = {
+	isError: false;
+	paragraphs: 0;
+	kind: Exclude<ElementKind, ElementKind.Text>;
+};
+type ErrorDescription = {
+	isError: true;
+	paragraphs: 0;
+};
+
+type BodyElementDescription =
+	| TextElementDescription
+	| OtherElementDescription
+	| ErrorDescription;
+
+const wrapInResult = (element: BodyElement): Result<string, BodyElement> => ({
+	kind: ResultKind.Ok,
+	value: element,
+});
+
+const getBodyDescription = (
+	body: Array<Result<string, BodyElement>>,
+): BodyElementDescription[] => {
+	return body.map((_) => {
+		if (_.kind === ResultKind.Err) {
+			return {
+				isError: true,
+				paragraphs: 0,
+			};
+		}
+
+		if (_.value.kind === ElementKind.Text) {
+			const paragraphs = _.value.doc.childElementCount;
+			return {
+				isError: false,
+				kind: _.value.kind,
+				paragraphs,
+				text: _.value,
+			};
+		}
+
+		return {
+			isError: false,
+			kind: _.value.kind,
+			paragraphs: 0,
+		};
+	});
+};
+
+const findWhereToInsert = (
+	body: Array<Result<string, BodyElement>>,
+	fraction = 1 / 2,
+): {
+	bodyResultIndex: number;
+	bodyResultParagraphIndex: number;
+	text: Text;
+} | null => {
+	const bodyDescription = getBodyDescription(body);
+	const totalParagraphs = bodyDescription.reduce(
+		(previous: number, current) => previous + current.paragraphs,
+		0,
+	);
+	const targetPlace = Math.floor(totalParagraphs * fraction);
+
+	let paragraphsFromPreviousElements = 0;
+	for (let i = 0; i < bodyDescription.length; i++) {
+		const current = bodyDescription[i];
+
+		if (current.isError || current.kind !== ElementKind.Text) {
+			continue;
+		}
+
+		if (paragraphsFromPreviousElements + current.paragraphs < targetPlace) {
+			paragraphsFromPreviousElements += current.paragraphs;
+			continue;
+		}
+
+		return {
+			bodyResultIndex: i,
+			bodyResultParagraphIndex:
+				targetPlace - paragraphsFromPreviousElements,
+			text: current.text,
+		};
+	}
+
+	return null;
+};
+
+const splitTextElementAndInsertBetweenParts = (
+	textElement: Text,
+	elementToInsert: BodyElement,
+	splitPoint = 1,
+): [Text, BodyElement, Text] => {
+	// uses a clone of the original doc to avoid mutations
+	const childNodeArray = Array.from(
+		textElement.doc.cloneNode(true).childNodes,
+	);
+
+	const newDocs: [DocumentFragment, DocumentFragment] = [
+		JSDOM.fragment(''),
+		JSDOM.fragment(''),
+	];
+
+	childNodeArray.slice(0, Math.floor(splitPoint)).forEach((element) => {
+		newDocs[0].appendChild(element);
+	});
+
+	childNodeArray.slice(Math.floor(splitPoint)).forEach((element) => {
+		newDocs[1].appendChild(element);
+	});
+
+	return [
+		{
+			kind: ElementKind.Text,
+			doc: newDocs[0],
+		},
+		elementToInsert,
+		{
+			kind: ElementKind.Text,
+			doc: newDocs[1],
+		},
+	];
+};
+
+const tryToinsertNewsletterIntoStandard = (
+	body: Array<Result<string, BodyElement>>,
+	newsletter: Newsletter,
+	internalShortId: Option<string>,
+): Array<Result<string, BodyElement>> => {
+	const insertPlace = findWhereToInsert(body);
+
+	if (!insertPlace) {
+		logger.warn(
+			`Unable to find suitable place for NewsletterSignupBlockElement`,
+			internalShortId,
+		);
+		return body;
+	}
+
+	const { bodyResultIndex, bodyResultParagraphIndex, text } = insertPlace;
+
+	const textWithNewsletter = splitTextElementAndInsertBetweenParts(
+		text,
+		{
+			kind: ElementKind.NewsletterSignUp,
+			...newsletter,
+		},
+		bodyResultParagraphIndex || 1, // don't place at zero (before first paragraph)
+	);
+
+	return [
+		...body.slice(0, bodyResultIndex),
+		...textWithNewsletter.map(wrapInResult),
+		...body.slice(bodyResultIndex),
+	];
+};
+
+export const insertNewsletterIntoItem = (
+	item: Item,
+	promotedNewsletter?: Newsletter,
+): Item => {
+	if (!promotedNewsletter) {
+		return item;
+	}
+
+	switch (item.design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+		case ArticleDesign.Review:
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Recipe:
+		case ArticleDesign.MatchReport:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Obituary:
+			item.body = tryToinsertNewsletterIntoStandard(
+				item.body,
+				promotedNewsletter,
+				item.internalShortId,
+			);
+			break;
+	}
+
+	return item;
+};

--- a/apps-rendering/src/server/insertNewsletter.ts
+++ b/apps-rendering/src/server/insertNewsletter.ts
@@ -1,12 +1,12 @@
 import { ArticleDesign } from '@guardian/libs';
-import { Option, OptionKind, Result } from '@guardian/types';
-import { ResultKind } from '@guardian/types';
+import { OptionKind, ResultKind } from '@guardian/types';
+import type { Option, Result } from '@guardian/types';
 import type { BodyElement, Text } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
 import type { Item } from 'item';
 import { JSDOM } from 'jsdom';
 import { logger } from 'logger';
-import { Newsletter } from 'newsletter';
+import type { Newsletter } from 'newsletter';
 
 type TextElementDescription = {
 	isError: false;
@@ -168,7 +168,9 @@ const tryToinsertNewsletterIntoStandard = (
 	if (!insertPlace) {
 		logger.warn(
 			`Unable to find suitable place for NewsletterSignupBlockElement`,
-			internalShortId.kind === OptionKind.Some ? internalShortId.value : '[undefined internalShortId]'
+			internalShortId.kind === OptionKind.Some
+				? internalShortId.value
+				: '[undefined internalShortId]',
 		);
 		return body;
 	}

--- a/apps-rendering/src/server/insertNewsletter.ts
+++ b/apps-rendering/src/server/insertNewsletter.ts
@@ -1,5 +1,4 @@
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
-import type { ArticleTheme } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { Option, OptionKind, Result } from '@guardian/types';
 import { ResultKind } from '@guardian/types';
 import type { BodyElement, Text } from 'bodyElement';
@@ -7,25 +6,7 @@ import { ElementKind } from 'bodyElementKind';
 import type { Item } from 'item';
 import { JSDOM } from 'jsdom';
 import { logger } from 'logger';
-
-export interface Newsletter {
-	id: string;
-	displayName: string;
-	frequency: string;
-	description: string;
-	group: string;
-	theme: ArticleTheme;
-}
-
-export const TEST_NEWSLETTER = {
-	id: 'patriarchy',
-	description:
-		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
-	displayName: 'The Week in Patriarchy',
-	frequency: 'Weekly',
-	theme: ArticlePillar.Opinion,
-	group: 'opinion',
-};
+import { Newsletter } from 'newsletter';
 
 type TextElementDescription = {
 	isError: false;

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -23,7 +23,8 @@ import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
-// import { insertNewsletterIntoItem, TEST_NEWSLETTER } from './insertNewsletter';
+// import { insertNewsletterIntoItem } from './insertNewsletter';
+// import { TEST_NEWSLETTER } from '../newsletter';
 
 // ----- Types ----- //
 

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -23,8 +23,6 @@ import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
-// import { insertNewsletterIntoItem } from './insertNewsletter';
-// import { TEST_NEWSLETTER } from '../newsletter';
 
 // ----- Types ----- //
 
@@ -171,7 +169,6 @@ function render(
 	const item = fromCapi({ docParser, salt: imageSalt })(request, page);
 	const clientScript = map(getAssetLocation)(scriptName(item));
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
-	// insertNewsletterIntoItem(item, TEST_NEWSLETTER)
 	const body = renderBody(item, request);
 	const inlineStyles = requiresInlineStyles(request.content);
 	const head = renderHead(

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -23,6 +23,7 @@ import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
+// import { insertNewsletterIntoItem, TEST_NEWSLETTER } from './insertNewsletter';
 
 // ----- Types ----- //
 
@@ -169,6 +170,7 @@ function render(
 	const item = fromCapi({ docParser, salt: imageSalt })(request, page);
 	const clientScript = map(getAssetLocation)(scriptName(item));
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
+	// insertNewsletterIntoItem(item, TEST_NEWSLETTER)
 	const body = renderBody(item, request);
 	const inlineStyles = requiresInlineStyles(request.content);
 	const head = renderHead(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
(No public-facing changes).
Adds the module to insert a `NewsletterSignup` component into an article on Apps rendering. The exported `insertNewsletterIntoItem` function will:
 - do nothing if the Article is not "Standard" (IE does nothing with blogs, interactive pages etc)
 - For standard Articles:
   - Sum the total number of child HTML nodes in each `Text BodyElement` and find which `Text` contains the middle of the article (going only by the number of top level children, not the amount of text in each)
   -   If the function cannot identify the right place to insert the `NewsletterSignup BodyElement` it will return the unmodified `Item.Body`
   - Divide this `Text` into two and put the `NewsletterSignup BodyElement` between them
   - Replace the original `Text` with the three new `bodyElements` in the `Item.Body`



## How to Test

In **./apps-rendering/src/server/page.tsx**, import the `insertNewsletterIntoItem` function and add the following before call to `renderBody` on line 174:
```
insertNewsletterIntoItem(item,{
	id: 'patriarchy',
	description:
		'Reviewing the most important stories on feminism and sexism and those fighting for equality',
	displayName: 'The Week in Patriarchy',
	frequency: 'Weekly',
	theme: 1,
	group: 'opinion',
})
```
Run the project locally with `npm run watch` and open any standard article- the `NewsletterSignup` component should be placed in the middle of the article (Note that the components are not currently functional - only the visual design is implemented).

## Why?
The new sign-up blocks are implemented on DCR and the equivalent feature is being rolled out on App-rendering. 
When the `NewsletterSignup` is functional and has dark mode implemented and MAPI has been updated to provide the newsletter data (when the article is tagged to include a newsletter promotion), the placement logic can be used to add the  `NewsletterSignUp BodyElement` to the `Item`.

The logic is significantly different to the equivalent for DCR because:
 -  it does not need to take account of floating elements in the left column
 - The article data for DCR is processed by frontend to break each child node of a CAPI Text element into it's own DCR element, so the structure of a DCR article and an App-rendering Item are different.
