### PR TITLE
Dynamic Package refactor

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -31,6 +31,50 @@ export default {
 	},
 };
 
+export const One = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 1),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+One.story = {
+	name: 'With one standard card',
+};
+
+export const Two = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 2),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+Two.story = {
+	name: 'With two standard cards',
+};
+
 export const Three = () => (
 	<ContainerLayout
 		title="DynamicPackage"
@@ -183,6 +227,61 @@ export const Nine = () => (
 );
 Nine.story = {
 	name: 'With nine standard cards',
+};
+
+export const Boosted1 = () => {
+	const primary = [...trails].slice(0)[0];
+
+	return (
+		<ContainerLayout
+			title="DynamicPackage"
+			showTopBorder={true}
+			sideBorders={true}
+			padContent={false}
+			centralBorder="partial"
+		>
+			<DynamicPackage
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }],
+				}}
+				showAge={true}
+				containerPalette="LongRunningPalette"
+			/>
+		</ContainerLayout>
+	);
+};
+Boosted1.story = {
+	name: 'With one standard card - boosted',
+};
+
+export const Boosted2 = () => {
+	const primary = [...trails].slice(0)[0];
+	const remaining = [...trails].slice(1, 2);
+
+	return (
+		<ContainerLayout
+			title="DynamicPackage"
+			showTopBorder={true}
+			sideBorders={true}
+			padContent={false}
+			centralBorder="partial"
+		>
+			<DynamicPackage
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
+				showAge={true}
+				containerPalette="LongRunningPalette"
+			/>
+		</ContainerLayout>
+	);
+};
+Boosted2.story = {
+	name: 'With two standard cards - boosted',
 };
 
 export const Boosted3 = () => {

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -97,6 +97,94 @@ Five.story = {
 	name: 'With five standard cards',
 };
 
+export const Six = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 6),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+Six.story = {
+	name: 'With six standard cards',
+};
+
+export const Seven = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 7),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+Seven.story = {
+	name: 'With seven standard cards',
+};
+
+export const Eight = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 8),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+Eight.story = {
+	name: 'With eight standard cards',
+};
+
+export const Nine = () => (
+	<ContainerLayout
+		title="DynamicPackage"
+		showTopBorder={true}
+		sideBorders={true}
+		padContent={false}
+		centralBorder="partial"
+	>
+		<DynamicPackage
+			groupedTrails={{
+				...defaultGroupedTrails,
+				snap: [],
+				standard: [...trails].slice(0, 9),
+			}}
+			containerPalette="LongRunningPalette"
+		/>
+	</ContainerLayout>
+);
+Nine.story = {
+	name: 'With nine standard cards',
+};
+
 export const Boosted3 = () => {
 	const primary = [...trails].slice(0)[0];
 	const remaining = [...trails].slice(1, 3);
@@ -181,6 +269,62 @@ Boosted5.story = {
 	name: 'With five standard cards - boosted',
 };
 
+export const Boosted8 = () => {
+	const primary = [...trails].slice(0)[0];
+	const remaining = [...trails].slice(1, 8);
+
+	return (
+		<ContainerLayout
+			title="DynamicPackage"
+			showTopBorder={true}
+			sideBorders={true}
+			padContent={false}
+			centralBorder="partial"
+		>
+			<DynamicPackage
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
+				showAge={true}
+				containerPalette="LongRunningPalette"
+			/>
+		</ContainerLayout>
+	);
+};
+Boosted8.story = {
+	name: 'With eight standard cards - boosted',
+};
+
+export const Boosted9 = () => {
+	const primary = [...trails].slice(0)[0];
+	const remaining = [...trails].slice(1, 9);
+
+	return (
+		<ContainerLayout
+			title="DynamicPackage"
+			showTopBorder={true}
+			sideBorders={true}
+			padContent={false}
+			centralBorder="partial"
+		>
+			<DynamicPackage
+				groupedTrails={{
+					...defaultGroupedTrails,
+					snap: [],
+					standard: [{ ...primary, isBoosted: true }, ...remaining],
+				}}
+				showAge={true}
+				containerPalette="LongRunningPalette"
+			/>
+		</ContainerLayout>
+	);
+};
+Boosted9.story = {
+	name: 'With nine standard cards - boosted',
+};
+
 export const OneSnapThreeStandard = () => (
 	<ContainerLayout
 		title="DynamicPackage"
@@ -221,7 +365,7 @@ export const ThreeSnapTwoStandard = () => (
 		/>
 	</ContainerLayout>
 );
-OneSnapThreeStandard.story = {
+ThreeSnapTwoStandard.story = {
 	name: 'With three snaps - two standard cards',
 };
 
@@ -243,6 +387,6 @@ export const ThreeSnapTwoStandard2ndBoosted = () => (
 		/>
 	</ContainerLayout>
 );
-OneSnapThreeStandard.story = {
+ThreeSnapTwoStandard2ndBoosted.story = {
 	name: 'With three snaps (2nd boosted) - two standard cards',
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -70,6 +70,45 @@ const Card100 = ({
 	);
 };
 
+const Card75_Card25 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	if (cards.length < 2) return null;
+
+	return (
+		<UL direction="row">
+			<LI padSides={true} padBottomOnMobile={true} percentage="75%">
+				<FrontCard
+					trail={cards[0]}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+					headlineSize="large"
+					headlineSizeOnMobile="huge"
+					imagePosition="right"
+					imagePositionOnMobile="bottom"
+					imageSize="medium"
+					trailText={cards[0].trailText}
+				/>
+			</LI>
+			<LI padSides={true} padBottomOnMobile={false} percentage="25%">
+				<FrontCard
+					trail={cards[1]}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
 const Card25_Card25_Card25_Card25 = ({
 	cards,
 	containerPalette,
@@ -403,8 +442,10 @@ export const DynamicPackage = ({
 	showAge,
 }: Props) => {
 	let layout:
-		| 'primaryBoosted'
-		| 'fourOrLessStandards'
+		| 'oneStandard'
+		| 'twoStandards'
+		| 'threeOrFourStandardsBoosted'
+		| 'threeOrFourStandards'
 		| 'fiveStandards'
 		| 'sixStandards'
 		| 'sevenStandards'
@@ -456,21 +497,64 @@ export const DynamicPackage = ({
 			secondSlice = cards.slice(0, 1);
 			thirdSlice = cards.slice(1);
 			break;
+		case 2:
+			layout = 'twoStandards';
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 2);
+			break;
+		case 1:
+			layout = 'oneStandard';
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			break;
 		default:
 			if (cards[0].isBoosted) {
-				layout = 'primaryBoosted';
+				layout = 'threeOrFourStandardsBoosted';
 				firstSlice = snaps;
 				secondSlice = cards.slice(0, 1);
 				thirdSlice = cards.slice(1);
 			} else {
-				layout = 'fourOrLessStandards';
+				layout = 'threeOrFourStandards';
 				firstSlice = snaps;
 				secondSlice = cards;
 			}
 	}
 
 	switch (layout) {
-		case 'primaryBoosted':
+		case 'oneStandard':
+			return (
+				<>
+					<Snap100
+						snaps={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case 'twoStandards':
+			return (
+				<>
+					<Snap100
+						snaps={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					{/* Card75_Card25 does not support the first card being boosted - on Frontend the 75% card would
+						receive a ginourmous headline size - however this broke the layout visually, so we decided not
+						to support boosting for the twoStandards layout */}
+					<Card75_Card25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case 'threeOrFourStandardsBoosted':
 			return (
 				<>
 					<Snap100
@@ -490,7 +574,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case 'fourOrLessStandards':
+		case 'threeOrFourStandards':
 			return (
 				<>
 					<Snap100

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -405,12 +405,12 @@ export const DynamicPackage = ({
 }: Props) => {
 	let layout:
 		| 'primaryBoosted'
-		| '4orLessStandards'
-		| '5Standards'
-		| '6Standards'
-		| '7Standards'
-		| '8Standards'
-		| '9Standards';
+		| 'fourOrLessStandards'
+		| 'fiveStandards'
+		| 'sixStandards'
+		| 'sevenStandards'
+		| 'eightStandards'
+		| 'nineStandards';
 
 	const snaps = [...groupedTrails.snap].slice(0, 1);
 
@@ -425,29 +425,29 @@ export const DynamicPackage = ({
 	let thirdSlice: TrailType[] = [];
 	switch (cards.length) {
 		case 9: {
+			layout = 'nineStandards';
 			firstSlice = cards.slice(0, 1);
 			secondSlice = cards.slice(1, 5);
 			thirdSlice = cards.slice(5);
-			layout = '9Standards';
 			break;
 		}
 		case 8:
-			layout = '8Standards';
+			layout = 'eightStandards';
 			firstSlice = cards.slice(0, 1);
 			secondSlice = cards.slice(1);
 			break;
 		case 7:
-			layout = '7Standards';
+			layout = 'sevenStandards';
 			firstSlice = cards.slice(0, 1);
 			secondSlice = cards.slice(1);
 			break;
 		case 6:
-			layout = '6Standards';
+			layout = 'sixStandards';
 			firstSlice = cards.slice(0, 1);
 			secondSlice = cards.slice(1);
 			break;
 		case 5:
-			layout = '5Standards';
+			layout = 'fiveStandards';
 			firstSlice = cards.slice(0, 1);
 			secondSlice = cards.slice(1);
 			break;
@@ -457,8 +457,8 @@ export const DynamicPackage = ({
 				firstSlice = cards.slice(0, 1);
 				secondSlice = cards.slice(1);
 			} else {
+				layout = 'fourOrLessStandards';
 				firstSlice = cards;
-				layout = '4orLessStandards';
 			}
 	}
 
@@ -484,7 +484,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '4orLessStandards':
+		case 'fourOrLessStandards':
 			return (
 				<>
 					<Snap100
@@ -499,7 +499,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '5Standards':
+		case 'fiveStandards':
 			return (
 				<>
 					<Snap100
@@ -520,7 +520,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '6Standards':
+		case 'sixStandards':
 			return (
 				<>
 					<Snap100
@@ -541,7 +541,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '7Standards':
+		case 'sevenStandards':
 			return (
 				<>
 					<Snap100
@@ -562,7 +562,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '8Standards':
+		case 'eightStandards':
 			return (
 				<>
 					<Snap100
@@ -583,7 +583,7 @@ export const DynamicPackage = ({
 					/>
 				</>
 			);
-		case '9Standards':
+		case 'nineStandards':
 			return (
 				<>
 					<Snap100

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -330,7 +330,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	);
 };
 
-const Card75_ColumnOfX25 = ({
+const Card75_ColumnOfCards25 = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -500,7 +500,7 @@ export const DynamicPackage = ({
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
-					<Card75_ColumnOfX25
+					<Card75_ColumnOfCards25
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -540,7 +540,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={firstSlice[0].isBoosted}
+						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -561,7 +561,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={firstSlice[0].isBoosted}
+						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -582,7 +582,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={firstSlice[0].isBoosted}
+						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -603,7 +603,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={firstSlice[0].isBoosted}
+						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -423,42 +423,50 @@ export const DynamicPackage = ({
 	let firstSlice: TrailType[] = [];
 	let secondSlice: TrailType[] = [];
 	let thirdSlice: TrailType[] = [];
+	let fourthSlice: TrailType[] = [];
 	switch (cards.length) {
 		case 9: {
 			layout = 'nineStandards';
-			firstSlice = cards.slice(0, 1);
-			secondSlice = cards.slice(1, 5);
-			thirdSlice = cards.slice(5);
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			thirdSlice = cards.slice(1, 5);
+			fourthSlice = cards.slice(5);
 			break;
 		}
 		case 8:
 			layout = 'eightStandards';
-			firstSlice = cards.slice(0, 1);
-			secondSlice = cards.slice(1);
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			thirdSlice = cards.slice(1);
 			break;
 		case 7:
 			layout = 'sevenStandards';
-			firstSlice = cards.slice(0, 1);
-			secondSlice = cards.slice(1);
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			thirdSlice = cards.slice(1);
 			break;
 		case 6:
 			layout = 'sixStandards';
-			firstSlice = cards.slice(0, 1);
-			secondSlice = cards.slice(1);
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			thirdSlice = cards.slice(1);
 			break;
 		case 5:
 			layout = 'fiveStandards';
-			firstSlice = cards.slice(0, 1);
-			secondSlice = cards.slice(1);
+			firstSlice = snaps;
+			secondSlice = cards.slice(0, 1);
+			thirdSlice = cards.slice(1);
 			break;
 		default:
 			if (cards[0].isBoosted) {
 				layout = 'primaryBoosted';
-				firstSlice = cards.slice(0, 1);
-				secondSlice = cards.slice(1);
+				firstSlice = snaps;
+				secondSlice = cards.slice(0, 1);
+				thirdSlice = cards.slice(1);
 			} else {
 				layout = 'fourOrLessStandards';
-				firstSlice = cards;
+				firstSlice = snaps;
+				secondSlice = cards;
 			}
 	}
 
@@ -467,18 +475,18 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={true}
 					/>
 					<Card25_Card25_Card25_Card25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -488,12 +496,12 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card75_ColumnOfX25
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -503,18 +511,18 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -524,18 +532,18 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -545,18 +553,18 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -566,18 +574,18 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={firstSlice[0].isBoosted}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
@@ -587,24 +595,24 @@ export const DynamicPackage = ({
 			return (
 				<>
 					<Snap100
-						snaps={snaps}
+						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 					/>
 					<Card100
-						cards={firstSlice}
+						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						ginormousHeadline={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
-						cards={secondSlice}
+						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						padBottom={true}
 					/>
 					<Card25_Card25_Card25_Card25
-						cards={thirdSlice}
+						cards={fourthSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
 						showImage={false}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -10,19 +11,20 @@ type Props = {
 };
 
 const Snap100 = ({
-	snap,
+	snaps,
 	containerPalette,
 	showAge,
 }: {
-	snap: TrailType;
+	snaps: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
+	if (!snaps[0]) return null;
 	return (
 		<UL>
 			<LI padSides={true} padBottom={true}>
 				<FrontCard
-					trail={snap}
+					trail={snaps[0]}
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
@@ -31,8 +33,366 @@ const Snap100 = ({
 					imagePosition="right"
 					imagePositionOnMobile="left"
 					imageSize="medium"
-					trailText={snap.trailText}
+					trailText={snaps[0].trailText}
 				/>
+			</LI>
+		</UL>
+	);
+};
+
+const Card100 = ({
+	cards,
+	containerPalette,
+	showAge,
+	ginormousHeadline,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	ginormousHeadline?: boolean;
+}) => {
+	return (
+		<UL>
+			<LI padSides={true} padBottom={true}>
+				<FrontCard
+					trail={cards[0]}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+					headlineSize={ginormousHeadline ? 'ginormous' : 'huge'}
+					imagePosition="bottom"
+					imagePositionOnMobile="bottom"
+					imageSize="large"
+					isDynamo={true}
+					supportingContent={cards[0].supportingContent}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
+const Card25_Card25_Card25_Card25 = ({
+	cards,
+	containerPalette,
+	showAge,
+	showImage = true,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	showImage?: boolean;
+}) => {
+	return (
+		<UL direction="row">
+			{cards.map((card) => {
+				return (
+					<LI
+						key={card.url}
+						padSides={true}
+						showTopMarginWhenStacked={false}
+						padBottom={false}
+						padBottomOnMobile={true}
+						showDivider={true}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="dynamic/package"
+							showAge={showAge}
+							supportingContent={card.supportingContent}
+							imageUrl={showImage ? card.image : undefined}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
+
+const Card25_Card25_Card25_ColumnOfTwo25 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	const bigs = cards.slice(0, 3);
+	const column = cards.slice(3);
+
+	return (
+		<UL direction="row">
+			{bigs.map((card) => {
+				return (
+					<LI
+						key={card.url}
+						padSides={true}
+						showTopMarginWhenStacked={false}
+						padBottom={false}
+						padBottomOnMobile={true}
+						showDivider={true}
+						percentage="25%"
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="dynamic/package"
+							showAge={showAge}
+							supportingContent={card.supportingContent}
+						/>
+					</LI>
+				);
+			})}
+			<LI
+				showDivider={true}
+				showTopMarginWhenStacked={true}
+				percentage="25%"
+			>
+				<UL direction="column">
+					{column.map((card, cardIndex) => {
+						return (
+							<LI
+								key={card.url}
+								padSides={true}
+								showTopMarginWhenStacked={false}
+								padBottom={
+									// No bottom margin on the last card
+									cardIndex < cards.length - 1
+								}
+								padBottomOnMobile={false}
+							>
+								<FrontCard
+									trail={card}
+									containerPalette={containerPalette}
+									containerType="dynamic/package"
+									showAge={showAge}
+									supportingContent={card.supportingContent}
+									imageUrl={undefined}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
+			</LI>
+		</UL>
+	);
+};
+
+const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	const bigs = cards.slice(0, 2);
+	const columns = [cards.slice(2, 4), cards.slice(4, 6)];
+
+	return (
+		<UL direction="row">
+			{bigs.map((card) => {
+				return (
+					<LI
+						key={card.url}
+						padSides={true}
+						showTopMarginWhenStacked={false}
+						padBottom={false}
+						padBottomOnMobile={true}
+						percentage="25%"
+						showDivider={true}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="dynamic/package"
+							showAge={showAge}
+							supportingContent={card.supportingContent}
+						/>
+					</LI>
+				);
+			})}
+			{columns.map((columnCards) => {
+				return (
+					<LI
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+						percentage="25%"
+					>
+						<UL direction="column">
+							{columnCards.map((card, cardIndex) => {
+								return (
+									<LI
+										key={card.url}
+										padSides={true}
+										showTopMarginWhenStacked={false}
+										padBottom={
+											// No bottom margin on the last card
+											cardIndex < cards.length - 1
+										}
+										padBottomOnMobile={false}
+									>
+										<FrontCard
+											trail={card}
+											containerPalette={containerPalette}
+											containerType="dynamic/package"
+											showAge={showAge}
+											supportingContent={
+												card.supportingContent
+											}
+											imageUrl={undefined}
+										/>
+									</LI>
+								);
+							})}
+						</UL>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
+
+const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	const bigs = cards.slice(0, 1);
+	const columns = [cards.slice(1, 3), cards.slice(3, 5), cards.slice(5, 7)];
+
+	return (
+		<UL direction="row">
+			{bigs.map((card) => {
+				return (
+					<LI
+						key={card.url}
+						padSides={true}
+						showTopMarginWhenStacked={false}
+						padBottom={false}
+						padBottomOnMobile={true}
+						percentage="25%"
+						showDivider={true}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="dynamic/package"
+							showAge={showAge}
+							supportingContent={card.supportingContent}
+						/>
+					</LI>
+				);
+			})}
+			{columns.map((columnCards) => {
+				return (
+					<LI
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+						percentage="25%"
+					>
+						<UL direction="column">
+							{columnCards.map((card, cardIndex) => {
+								return (
+									<LI
+										key={card.url}
+										padSides={true}
+										showTopMarginWhenStacked={false}
+										padBottom={
+											// No bottom margin on the last card
+											cardIndex < cards.length - 1
+										}
+										padBottomOnMobile={false}
+									>
+										<FrontCard
+											trail={card}
+											containerPalette={containerPalette}
+											containerType="dynamic/package"
+											showAge={showAge}
+											supportingContent={
+												card.supportingContent
+											}
+											imageUrl={undefined}
+										/>
+									</LI>
+								);
+							})}
+						</UL>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
+
+const Card75_ColumnOfX25 = ({
+	cards,
+	containerPalette,
+	showAge,
+}: {
+	cards: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+}) => {
+	const [primary, ...remaining] = cards;
+	return (
+		<UL direction="row">
+			<LI padSides={true} percentage="75%">
+				<FrontCard
+					trail={primary}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+					headlineSize="huge"
+					imagePosition="bottom"
+					imagePositionOnMobile="bottom"
+					imageSize="large"
+					supportingContent={primary.supportingContent}
+					isDynamo={true}
+				/>
+			</LI>
+			<LI
+				showDivider={true}
+				showTopMarginWhenStacked={true}
+				percentage="25%"
+			>
+				<UL direction="column">
+					{remaining.map((card, cardIndex) => {
+						return (
+							<LI
+								key={card.url}
+								padSides={true}
+								showTopMarginWhenStacked={false}
+								padBottom={
+									// No bottom margin on the last card
+									cardIndex < cards.length - 1
+								}
+								padBottomOnMobile={false}
+							>
+								<FrontCard
+									trail={card}
+									containerPalette={containerPalette}
+									containerType="dynamic/package"
+									showAge={showAge}
+									imageUrl={
+										// Always show the image on the first card and only
+										// on the second if there are two items in two
+										cardIndex === 0 || cards.length === 2
+											? card.image
+											: undefined
+									}
+									supportingContent={card.supportingContent}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
 			</LI>
 		</UL>
 	);
@@ -43,133 +403,212 @@ export const DynamicPackage = ({
 	containerPalette,
 	showAge,
 }: Props) => {
-	// Take the first 'snap' - all others are treated as standards
-	const snap = [...groupedTrails.snap].shift();
-	const [primary, ...remaining] = [
+	let layout:
+		| 'primaryBoosted'
+		| '4orLessStandards'
+		| '5Standards'
+		| '6Standards'
+		| '7Standards'
+		| '8Standards'
+		| '9Standards';
+
+	const snaps = [...groupedTrails.snap].slice(0, 1);
+
+	// We support up to 9 cards
+	const cards = [
 		...groupedTrails.snap.slice(1),
 		...groupedTrails.standard,
-	];
+	].slice(0, 9);
 
-	// TODO: Different layouts are required when there are 4+ 'remaining' cards
-	// dynamic/package will display up to 8 'remaining' cards before moving to 'show more'
-	if (primary.isBoosted) {
-		return (
-			<>
-				{!!snap && (
-					<Snap100
-						snap={snap}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				)}
-				<UL>
-					<LI padSides={true}>
-						<FrontCard
-							trail={primary}
-							containerPalette={containerPalette}
-							containerType="dynamic/package"
-							showAge={showAge}
-							headlineSize="ginormous"
-							imagePosition="bottom"
-							imagePositionOnMobile="bottom"
-							imageSize="large"
-							isDynamo={true}
-							supportingContent={primary.supportingContent}
-						/>
-					</LI>
-				</UL>
-				<UL direction="row">
-					{remaining.map((card, cardIndex) => {
-						return (
-							<LI
-								key={card.url}
-								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={
-									// No bottom margin on the last card
-									cardIndex < remaining.length - 1
-								}
-								padBottomOnMobile={false}
-							>
-								<FrontCard
-									trail={card}
-									containerPalette={containerPalette}
-									containerType="dynamic/package"
-									showAge={showAge}
-									supportingContent={card.supportingContent}
-								/>
-							</LI>
-						);
-					})}
-				</UL>
-			</>
-		);
+	let firstSlice: TrailType[] = [];
+	let secondSlice: TrailType[] = [];
+	let thirdSlice: TrailType[] = [];
+	switch (cards.length) {
+		case 9: {
+			firstSlice = cards.slice(0, 1);
+			secondSlice = cards.slice(1, 5);
+			thirdSlice = cards.slice(5);
+			layout = '9Standards';
+			break;
+		}
+		case 8:
+			layout = '8Standards';
+			firstSlice = cards.slice(0, 1);
+			secondSlice = cards.slice(1);
+			break;
+		case 7:
+			layout = '7Standards';
+			firstSlice = cards.slice(0, 1);
+			secondSlice = cards.slice(1);
+			break;
+		case 6:
+			layout = '6Standards';
+			firstSlice = cards.slice(0, 1);
+			secondSlice = cards.slice(1);
+			break;
+		case 5:
+			layout = '5Standards';
+			firstSlice = cards.slice(0, 1);
+			secondSlice = cards.slice(1);
+			break;
+		default:
+			if (cards[0].isBoosted) {
+				layout = 'primaryBoosted';
+				firstSlice = cards.slice(0, 1);
+				secondSlice = cards.slice(1);
+			} else {
+				firstSlice = cards;
+				layout = '4orLessStandards';
+			}
 	}
-	return (
-		<>
-			{!!snap && (
-				<Snap100
-					snap={snap}
-					containerPalette={containerPalette}
-					showAge={showAge}
-				/>
-			)}
-			<UL direction="row">
-				<LI padSides={true} percentage="75%">
-					<FrontCard
-						trail={primary}
+
+	switch (layout) {
+		case 'primaryBoosted':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
 						containerPalette={containerPalette}
-						containerType="dynamic/package"
 						showAge={showAge}
-						headlineSize="huge"
-						imagePosition="bottom"
-						imagePositionOnMobile="bottom"
-						imageSize="large"
-						supportingContent={primary.supportingContent}
-						isDynamo={true}
 					/>
-				</LI>
-				<LI
-					showDivider={true}
-					showTopMarginWhenStacked={true}
-					percentage="25%"
-				>
-					<UL direction="column">
-						{remaining.map((card, cardIndex) => {
-							return (
-								<LI
-									key={card.url}
-									padSides={true}
-									showTopMarginWhenStacked={false}
-									padBottom={
-										// No bottom margin on the last card
-										cardIndex < remaining.length - 1
-									}
-									padBottomOnMobile={false}
-								>
-									<FrontCard
-										trail={card}
-										containerPalette={containerPalette}
-										containerType="dynamic/package"
-										showAge={showAge}
-										imageUrl={
-											// Always show the image on the first card and only
-											// on the second if there are two items in two
-											cardIndex === 0 ||
-											remaining.length === 2
-												? card.image
-												: undefined
-										}
-										supportingContent={
-											card.supportingContent
-										}
-									/>
-								</LI>
-							);
-						})}
-					</UL>
-				</LI>
-			</UL>
-		</>
-	);
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={true}
+					/>
+					<Card25_Card25_Card25_Card25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '4orLessStandards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card75_ColumnOfX25
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '5Standards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={firstSlice[0].isBoosted}
+					/>
+					<Card25_Card25_Card25_Card25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '6Standards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={firstSlice[0].isBoosted}
+					/>
+					<Card25_Card25_Card25_ColumnOfTwo25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '7Standards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={firstSlice[0].isBoosted}
+					/>
+					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '8Standards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={firstSlice[0].isBoosted}
+					/>
+					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+				</>
+			);
+		case '9Standards':
+			return (
+				<>
+					<Snap100
+						snaps={snaps}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card100
+						cards={firstSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						ginormousHeadline={firstSlice[0].isBoosted}
+					/>
+					<Card25_Card25_Card25_Card25
+						cards={secondSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<Card25_Card25_Card25_Card25
+						cards={thirdSlice}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						showImage={false}
+					/>
+				</>
+			);
+	}
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -76,22 +76,23 @@ const Card25_Card25_Card25_Card25 = ({
 	containerPalette,
 	showAge,
 	showImage = true,
+	padBottom,
 }: {
 	cards: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	showImage?: boolean;
+	padBottom?: boolean;
 }) => {
 	return (
-		<UL direction="row">
-			{cards.map((card) => {
+		<UL direction="row" padBottom={padBottom}>
+			{cards.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
-						showTopMarginWhenStacked={false}
 						padBottom={false}
-						padBottomOnMobile={true}
+						padBottomOnMobile={cardIndex < cards.length - 1}
 						showDivider={true}
 					>
 						<FrontCard
@@ -119,18 +120,18 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 	showAge?: boolean;
 }) => {
 	const bigs = cards.slice(0, 3);
-	const column = cards.slice(3);
+	const remaining = cards.slice(3);
 
 	return (
 		<UL direction="row">
-			{bigs.map((card) => {
+			{bigs.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
 						showTopMarginWhenStacked={false}
 						padBottom={false}
-						padBottomOnMobile={true}
+						padBottomOnMobile={cardIndex < bigs.length - 1}
 						showDivider={true}
 						percentage="25%"
 					>
@@ -149,18 +150,21 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 				showTopMarginWhenStacked={true}
 				percentage="25%"
 			>
-				<UL direction="column">
-					{column.map((card, cardIndex) => {
+				<UL direction="row" wrapCards={true}>
+					{remaining.map((card, cardIndex) => {
 						return (
 							<LI
+								percentage="100%"
 								key={card.url}
 								padSides={true}
 								showTopMarginWhenStacked={false}
 								padBottom={
 									// No bottom margin on the last card
-									cardIndex < cards.length - 1
+									cardIndex < 3
 								}
-								padBottomOnMobile={false}
+								padBottomOnMobile={
+									cardIndex < remaining.length - 1
+								}
 							>
 								<FrontCard
 									trail={card}
@@ -189,18 +193,18 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	showAge?: boolean;
 }) => {
 	const bigs = cards.slice(0, 2);
-	const columns = [cards.slice(2, 4), cards.slice(4, 6)];
+	const remaining = cards.slice(2, 6);
 
 	return (
 		<UL direction="row">
-			{bigs.map((card) => {
+			{bigs.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
 						showTopMarginWhenStacked={false}
 						padBottom={false}
-						padBottomOnMobile={true}
+						padBottomOnMobile={cardIndex < bigs.length - 1}
 						percentage="25%"
 						showDivider={true}
 					>
@@ -214,43 +218,40 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			{columns.map((columnCards) => {
-				return (
-					<LI
-						showDivider={true}
-						showTopMarginWhenStacked={true}
-						percentage="25%"
-					>
-						<UL direction="column">
-							{columnCards.map((card, cardIndex) => {
-								return (
-									<LI
-										key={card.url}
-										padSides={true}
-										showTopMarginWhenStacked={false}
-										padBottom={
-											// No bottom margin on the last card
-											cardIndex < cards.length - 1
-										}
-										padBottomOnMobile={false}
-									>
-										<FrontCard
-											trail={card}
-											containerPalette={containerPalette}
-											containerType="dynamic/package"
-											showAge={showAge}
-											supportingContent={
-												card.supportingContent
-											}
-											imageUrl={undefined}
-										/>
-									</LI>
-								);
-							})}
-						</UL>
-					</LI>
-				);
-			})}
+			<LI
+				showDivider={true}
+				showTopMarginWhenStacked={true}
+				percentage="50%"
+			>
+				<UL direction="row" wrapCards={true}>
+					{remaining.map((card, cardIndex) => {
+						return (
+							<LI
+								percentage="50%"
+								key={card.url}
+								padSides={true}
+								showTopMarginWhenStacked={false}
+								padBottom={
+									// No bottom margin on the last card
+									cardIndex < 3
+								}
+								padBottomOnMobile={
+									cardIndex < remaining.length - 1
+								}
+							>
+								<FrontCard
+									trail={card}
+									containerPalette={containerPalette}
+									containerType="dynamic/package"
+									showAge={showAge}
+									supportingContent={card.supportingContent}
+									imageUrl={undefined}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
+			</LI>
 		</UL>
 	);
 };
@@ -265,18 +266,18 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	showAge?: boolean;
 }) => {
 	const bigs = cards.slice(0, 1);
-	const columns = [cards.slice(1, 3), cards.slice(3, 5), cards.slice(5, 7)];
+	const remaining = cards.slice(1, 7);
 
 	return (
 		<UL direction="row">
-			{bigs.map((card) => {
+			{bigs.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
 						showTopMarginWhenStacked={false}
 						padBottom={false}
-						padBottomOnMobile={true}
+						padBottomOnMobile={cardIndex < bigs.length - 1}
 						percentage="25%"
 						showDivider={true}
 					>
@@ -290,43 +291,41 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			{columns.map((columnCards) => {
-				return (
-					<LI
-						showDivider={true}
-						showTopMarginWhenStacked={true}
-						percentage="25%"
-					>
-						<UL direction="column">
-							{columnCards.map((card, cardIndex) => {
-								return (
-									<LI
-										key={card.url}
-										padSides={true}
-										showTopMarginWhenStacked={false}
-										padBottom={
-											// No bottom margin on the last card
-											cardIndex < cards.length - 1
-										}
-										padBottomOnMobile={false}
-									>
-										<FrontCard
-											trail={card}
-											containerPalette={containerPalette}
-											containerType="dynamic/package"
-											showAge={showAge}
-											supportingContent={
-												card.supportingContent
-											}
-											imageUrl={undefined}
-										/>
-									</LI>
-								);
-							})}
-						</UL>
-					</LI>
-				);
-			})}
+			<LI
+				showDivider={true}
+				showTopMarginWhenStacked={true}
+				percentage="75%"
+			>
+				<UL direction="row" wrapCards={true}>
+					{remaining.map((card, cardIndex) => {
+						return (
+							<LI
+								percentage="33.333%"
+								key={card.url}
+								padSides={true}
+								showTopMarginWhenStacked={false}
+								padBottom={
+									// No bottom margin on the last card
+									cardIndex < 3
+								}
+								showDivider={true}
+								padBottomOnMobile={
+									cardIndex < remaining.length - 1
+								}
+							>
+								<FrontCard
+									trail={card}
+									containerPalette={containerPalette}
+									containerType="dynamic/package"
+									showAge={showAge}
+									supportingContent={card.supportingContent}
+									imageUrl={undefined}
+								/>
+							</LI>
+						);
+					})}
+				</UL>
+			</LI>
 		</UL>
 	);
 };
@@ -602,6 +601,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						padBottom={true}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -44,12 +44,12 @@ const Card100 = ({
 	cards,
 	containerPalette,
 	showAge,
-	ginormousHeadline,
+	isBoosted,
 }: {
 	cards: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	ginormousHeadline?: boolean;
+	isBoosted?: boolean;
 }) => {
 	return (
 		<UL>
@@ -59,7 +59,7 @@ const Card100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
-					headlineSize={ginormousHeadline ? 'ginormous' : 'huge'}
+					headlineSize={isBoosted ? 'ginormous' : 'huge'}
 					imagePosition="bottom"
 					imagePositionOnMobile="bottom"
 					imageSize="large"
@@ -483,7 +483,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={true}
+						isBoosted={true}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
@@ -519,7 +519,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={firstSlice[0].isBoosted}
+						isBoosted={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
@@ -540,7 +540,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={firstSlice[0].isBoosted}
+						isBoosted={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -561,7 +561,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={firstSlice[0].isBoosted}
+						isBoosted={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -582,7 +582,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={firstSlice[0].isBoosted}
+						isBoosted={firstSlice[0].isBoosted}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -603,7 +603,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						ginormousHeadline={firstSlice[0].isBoosted}
+						isBoosted={firstSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -371,7 +371,7 @@ const Card75_ColumnOfX25 = ({
 								showTopMarginWhenStacked={false}
 								padBottom={
 									// No bottom margin on the last card
-									cardIndex < cards.length - 1
+									cardIndex < remaining.length - 1
 								}
 								padBottomOnMobile={false}
 							>
@@ -383,7 +383,8 @@ const Card75_ColumnOfX25 = ({
 									imageUrl={
 										// Always show the image on the first card and only
 										// on the second if there are two items in two
-										cardIndex === 0 || cards.length === 2
+										cardIndex === 0 ||
+										remaining.length === 2
 											? card.image
 											: undefined
 									}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -519,7 +519,7 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={firstSlice[0].isBoosted}
+						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -160,7 +160,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 								showTopMarginWhenStacked={false}
 								padBottom={
 									// No bottom margin on the last card
-									cardIndex < 3
+									cardIndex < 1
 								}
 								padBottomOnMobile={
 									cardIndex < remaining.length - 1
@@ -233,7 +233,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 								showTopMarginWhenStacked={false}
 								padBottom={
 									// No bottom margin on the last card
-									cardIndex < 3
+									cardIndex < 2
 								}
 								padBottomOnMobile={
 									cardIndex < remaining.length - 1

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -44,13 +44,12 @@ const Card100 = ({
 	cards,
 	containerPalette,
 	showAge,
-	isBoosted,
 }: {
 	cards: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	isBoosted?: boolean;
 }) => {
+	if (!cards[0]) return null;
 	return (
 		<UL>
 			<LI padSides={true} padBottom={true}>
@@ -59,7 +58,7 @@ const Card100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
-					headlineSize={isBoosted ? 'ginormous' : 'huge'}
+					headlineSize={cards[0].isBoosted ? 'ginormous' : 'huge'}
 					imagePosition="bottom"
 					imagePositionOnMobile="bottom"
 					imageSize="large"
@@ -483,7 +482,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={true}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
@@ -519,7 +517,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
@@ -540,7 +537,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -561,7 +557,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -582,7 +577,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
@@ -603,7 +597,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						isBoosted={secondSlice[0].isBoosted}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}


### PR DESCRIPTION
This PR refactors the `dynamic/package` component to use conventions similar to that of https://github.com/guardian/dotcom-rendering/pull/5617

This builds on the use of **slices** seen in #5617:

A horizontal 'row' of cards can be described a a `slice`. This comes straight from Frontend & is helpful as it allows us to break down cards into more simple chunks to be consumed by rendering logic which is unaware of any upstream logic.

`dynamic/fast` can have _up to_ four slices, the first always being an option `snap`, with the remaining three being available for cards marked as 'standard'.

**'The file is so large!'**

A side effect of adopting the conventions proposed is that the rendering logic leans on the side of over-verbose. There would be room to abstract down some of these rendering-only components into multi-functioning forms that could do many different types of layouts - but the risk if that we create our own business logic that requires additional cognitive load & time to understand, while verbose, working on this component is very easy & approachable, and there are minimal side effects when making changes or fixing bugs! 

## Layouts

`dynamic/package` supports seven different layouts; each is variable as it can also support a single `snap` as demonstrated in: https://github.com/guardian/dotcom-rendering/pull/5694

This PR also introduces new layouts for when there are 1, 2 or 5+ standard cards - previously all of these would have fallen into the `fourOrLessStandards` layout. This brings us up to parity with Frontend, with any more than 9 cards being moved to 'show more'

**oneStandard**

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/9575458/184918653-da1af4df-620a-4a6d-8933-2004df48b154.png">

**twoStandards**

> ⚠️ Note: I deliberately did not implement 'boosting' on the twoStandards layout. This is because it looks very broken on frontend - I imagine it was never used.

<details closed>
<summary>(How it looked boosted on frontend):</summary>
<br>
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/9575458/184919239-45cf83af-24cb-41b1-8691-df41669639b6.png">

Because of how bad it looks - boosting simply will not work on this layout. I've added a comment in the code to signal this.
</details>

<img width="993" alt="image" src="https://user-images.githubusercontent.com/9575458/184918716-1de4f446-af2c-4004-811f-c7e2bdf3f9ac.png">




**threeOrFourStandards**

Three standards:
<img width="983" alt="image" src="https://user-images.githubusercontent.com/9575458/184667294-ca3ec1d7-d727-4a4c-b229-f8581c4be0b6.png">

Four standards:
<img width="970" alt="image" src="https://user-images.githubusercontent.com/9575458/184667028-f4fddfb9-d254-4412-b4a6-f50cf89688d2.png">

**threeOrFourStandardsBoosted**

Three standards:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/9575458/184667844-ae36ec0e-1829-4a65-9343-b46b913e499c.png">

Four standards:
<img width="808" alt="image" src="https://user-images.githubusercontent.com/9575458/184667905-1211cd1b-3133-45b9-a2dd-d066ccbcfa6d.png">


**fiveStandards**

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/9575458/184667443-8b517ddb-1bde-40b1-b126-50dfed84965c.png">

**sixStandards**

<img width="879" alt="image" src="https://user-images.githubusercontent.com/9575458/184667504-4f1b9bd2-7cb2-4c5f-bf11-9781d0ee1114.png">

**sevenStandards**

<img width="905" alt="image" src="https://user-images.githubusercontent.com/9575458/184667546-05bc9d56-0730-4091-928c-7300535c67fe.png">


**eightStandards**

<img width="880" alt="image" src="https://user-images.githubusercontent.com/9575458/184667578-b64d4271-2616-4d7f-b1ec-d7d528ac1acc.png">


**nineStandards**
<img width="786" alt="image" src="https://user-images.githubusercontent.com/9575458/184667622-74633df7-d1db-4d6e-8809-7a3ccae94a68.png">

each of `[five-nine]Standards` layouts supports the first standard being boosted, adding a larger headline font:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/9575458/184668089-d177c8fb-b319-4b5f-ae22-3eb32de31892.png">

## Why this way?

This convention for writing dynamic components helps separate out the business logic & rendering - and breaks down the rendering into reusable chunks which are approachable for development.

With it already used for `dynamic/slow-mpu` - this PR stands almost as a proposal to use it for _all_ dynamic container types - avoiding a segmented world where each dynamic container has its own style of logic & rendering, as well as hopefully providing the most simple & approachable solution we can currently find for working on these components





