### PR TITLE
Consistent container padding

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -154,7 +154,7 @@ export const ContainerLayout = ({
 			sectionId={sectionId}
 			showSideBorders={sideBorders}
 			showTopBorder={showTopBorder}
-			padded={padSides}
+			padSides={padSides}
 			borderColour={borderColour || overrides?.border.container}
 			backgroundColour={
 				backgroundColour || overrides?.background.container

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -440,7 +440,7 @@ export const DynamicFast = ({
 					containerPalette={containerPalette}
 				/>
 			)}
-			<UL direction="row" padBottom={true}>
+			<UL direction="row">
 				{/* Leftover huges, very bigs & all bigs */}
 				{bigs.map((card, cardIndex) => {
 					if (firstBigBoosted) {

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -52,7 +52,7 @@ export const DynamicSlow = ({ trails, containerPalette, showAge }: Props) => {
 					/>
 				</LI>
 			</UL>
-			<UL direction="row-reverse" padBottom={true}>
+			<UL direction="row-reverse">
 				<LI percentage="50%" showTopMarginWhenStacked={true}>
 					<UL direction="row" wrapCards={true} showDivider={true}>
 						{bigCards.map((card, cardIndex) => {

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -1,5 +1,5 @@
 import { ClassNames, css as emoCss } from '@emotion/react';
-import { border, from } from '@guardian/source-foundations';
+import { border, from, space } from '@guardian/source-foundations';
 // @ts-expect-error
 import { jsx as _jsx } from 'react/jsx-runtime';
 import { center } from '../lib/center';
@@ -12,6 +12,10 @@ const sidePadding = emoCss`
 		padding-left: 20px;
 		padding-right: 20px;
 	}
+`;
+
+const bottomPadding = emoCss`
+	padding-bottom: ${space[9]}px;
 `;
 
 const sideBorders = (colour: string) => emoCss`
@@ -34,6 +38,7 @@ type Props = {
 	showSideBorders?: boolean;
 	showTopBorder?: boolean;
 	padSides?: boolean;
+	padBottom?: boolean;
 	backgroundColour?: string;
 	innerBackgroundColour?: string;
 	borderColour?: string;
@@ -59,6 +64,7 @@ export const ElementContainer = ({
 	showSideBorders = true,
 	showTopBorder = true,
 	padSides = true,
+	padBottom = false,
 	borderColour = border.secondary,
 	backgroundColour,
 	innerBackgroundColour,
@@ -82,6 +88,7 @@ export const ElementContainer = ({
 						innerBackgroundColour &&
 							setBackgroundColour(innerBackgroundColour),
 						padSides && sidePadding,
+						padBottom && bottomPadding,
 					]}
 				>
 					{children}

--- a/dotcom-rendering/src/web/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/web/components/ElementContainer.tsx
@@ -4,11 +4,13 @@ import { border, from } from '@guardian/source-foundations';
 import { jsx as _jsx } from 'react/jsx-runtime';
 import { center } from '../lib/center';
 
-const padding = emoCss`
-	padding: 0 10px;
+const sidePadding = emoCss`
+	padding-left: 10px;
+	padding-right: 10px;
 
 	${from.mobileLandscape} {
-		padding: 0 20px;
+		padding-left: 20px;
+		padding-right: 20px;
 	}
 `;
 
@@ -31,7 +33,7 @@ type Props = {
 	sectionId?: string;
 	showSideBorders?: boolean;
 	showTopBorder?: boolean;
-	padded?: boolean;
+	padSides?: boolean;
 	backgroundColour?: string;
 	innerBackgroundColour?: string;
 	borderColour?: string;
@@ -56,7 +58,7 @@ export const ElementContainer = ({
 	sectionId,
 	showSideBorders = true,
 	showTopBorder = true,
-	padded = true,
+	padSides = true,
 	borderColour = border.secondary,
 	backgroundColour,
 	innerBackgroundColour,
@@ -79,7 +81,7 @@ export const ElementContainer = ({
 						showTopBorder && topBorder(borderColour),
 						innerBackgroundColour &&
 							setBackgroundColour(innerBackgroundColour),
-						padded && padding,
+						padSides && sidePadding,
 					]}
 				>
 					{children}

--- a/dotcom-rendering/src/web/components/MatchNav.stories.tsx
+++ b/dotcom-rendering/src/web/components/MatchNav.stories.tsx
@@ -76,7 +76,7 @@ NoComments.story = { name: 'with no comments' };
 
 export const InContext = () => {
 	return (
-		<ElementContainer padded={false}>
+		<ElementContainer padSides={false}>
 			<Flex>
 				<LeftColumn borderType="full">
 					<></>

--- a/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRight.stories.tsx
@@ -41,7 +41,7 @@ export const defaultStory = () => {
 					<ElementContainer
 						showSideBorders={false}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 					>
 						<MostViewedRight
 							isAdFreeUser={false}
@@ -80,7 +80,7 @@ export const limitItemsStory = () => {
 					<ElementContainer
 						showSideBorders={false}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 					>
 						<MostViewedRight
 							limitItems={3}

--- a/dotcom-rendering/src/web/components/Nav/Nav.stories.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.stories.tsx
@@ -15,7 +15,7 @@ export const StandardStory = () => {
 			showSideBorders={true}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
-			padded={false}
+			padSides={false}
 			backgroundColour={brandBackground.primary}
 		>
 			<Nav
@@ -39,7 +39,7 @@ export const OpinionStory = () => {
 			showSideBorders={true}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
-			padded={false}
+			padSides={false}
 			backgroundColour={brandBackground.primary}
 		>
 			<Nav
@@ -63,7 +63,7 @@ export const ImmersiveStory = () => {
 			showSideBorders={false}
 			borderColour={brandBorder.primary}
 			showTopBorder={false}
-			padded={false}
+			padSides={false}
 			backgroundColour={brandBackground.primary}
 		>
 			<Nav

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -304,7 +304,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						shouldCenter={false}
 					>
 						<HeaderAdSlot
@@ -319,7 +319,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							backgroundColour={brandBackground.primary}
 							element="header"
 						>
@@ -350,7 +350,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="nav"
 					>
@@ -371,7 +371,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					{NAV.subNavSections && (
 						<ElementContainer
 							backgroundColour={palette.background.article}
-							padded={false}
+							padSides={false}
 							element="aside"
 						>
 							<Island deferUntil="idle">
@@ -386,7 +386,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 					<ElementContainer
 						backgroundColour={palette.background.article}
-						padded={false}
+						padSides={false}
 						showTopBorder={false}
 					>
 						<StraightLines
@@ -687,7 +687,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</ElementContainer>
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -785,7 +785,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				)}
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -796,7 +796,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			</main>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} element="aside">
+				<ElementContainer padSides={false} element="aside">
 					<Island deferUntil="visible">
 						<SubNav
 							subNavSections={NAV.subNavSections}
@@ -808,7 +808,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			)}
 
 			<ElementContainer
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -56,7 +56,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							shouldCenter={false}
 						>
 							<HeaderAdSlot
@@ -70,7 +70,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="header"
 					>
@@ -92,7 +92,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="nav"
 					>
@@ -109,7 +109,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<>
 							<ElementContainer
 								backgroundColour={palette.background.article}
-								padded={false}
+								padSides={false}
 								element="aside"
 							>
 								<Island deferUntil="idle">
@@ -122,7 +122,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							</ElementContainer>
 							<ElementContainer
 								backgroundColour={palette.background.article}
-								padded={false}
+								padSides={false}
 								showTopBorder={false}
 							>
 								<StraightLines
@@ -155,7 +155,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
 							<ElementContainer
-								padded={false}
+								padSides={false}
 								showTopBorder={false}
 								showSideBorders={false}
 								ophanComponentLink={ophanComponentLink}
@@ -215,7 +215,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				showTopBorder={false}
 				showSideBorders={false}
 				backgroundColour={neutral[93]}
@@ -227,7 +227,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			{NAV.subNavSections && (
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					element="aside"
 				>
 					<Island deferUntil="visible">
@@ -242,7 +242,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -147,6 +147,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (trails.length === 0) return null;
 
+					// This is a legacy container used to add palette styling on Frontend. DCR ignores it
+					if (
+						collection.displayName ===
+						'Palette styles new do not delete'
+					) {
+						return null;
+					}
+
 					const ophanName = ophanComponentId(collection.displayName);
 					const ophanComponentLink = `container-${
 						index + 1
@@ -156,8 +164,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						return (
 							<ElementContainer
 								padSides={false}
+								padBottom={true}
 								showTopBorder={false}
-								showSideBorders={false}
+								showSideBorders={true}
 								ophanComponentLink={ophanComponentLink}
 								ophanComponentName={ophanName}
 								containerName={collection.collectionType}

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -145,7 +145,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 					showSideBorders={true}
 					borderColour={brandLine.primary}
 					showTopBorder={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={brandBackground.primary}
 					element="nav"
 				>
@@ -179,7 +179,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						shouldCenter={false}
 						element="aside"
 					>
@@ -197,7 +197,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="header"
 					>
@@ -229,7 +229,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 				showSideBorders={true}
 				borderColour={brandLine.primary}
 				showTopBorder={false}
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				element="nav"
 			>
@@ -250,7 +250,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 			{NAV.subNavSections && format.theme !== ArticleSpecial.Labs && (
 				<ElementContainer
 					backgroundColour={neutral[100]}
-					padded={false}
+					padSides={false}
 					element="aside"
 				>
 					<Island deferUntil="idle">
@@ -314,7 +314,7 @@ export const FullPageInteractiveLayout = ({
 				showTopBorder={false}
 				showSideBorders={false}
 				shouldCenter={false}
-				padded={false}
+				padSides={false}
 				backgroundColour={palette.background.article}
 				element="main"
 			>
@@ -339,7 +339,7 @@ export const FullPageInteractiveLayout = ({
 
 			{NAV.subNavSections && (
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					backgroundColour={neutral[100]}
 					element="aside"
 				>
@@ -354,7 +354,7 @@ export const FullPageInteractiveLayout = ({
 			)}
 
 			<ElementContainer
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -176,11 +176,11 @@ interface Props {
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
 	const caption = [];
-	if (mainMedia?.data?.caption) {
+	if (mainMedia.data?.caption) {
 		caption.push(mainMedia.data.caption);
 	}
 
-	if (mainMedia?.displayCredit && mainMedia?.data?.credit) {
+	if (mainMedia.displayCredit && mainMedia.data?.credit) {
 		caption.push(mainMedia.data.credit);
 	}
 
@@ -497,7 +497,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</ElementContainer>
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -595,7 +595,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				)}
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -606,7 +606,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			</main>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} element="aside">
+				<ElementContainer padSides={false} element="aside">
 					<Island deferUntil="visible">
 						<SubNav
 							subNavSections={NAV.subNavSections}
@@ -618,7 +618,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			)}
 
 			<ElementContainer
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -176,11 +176,13 @@ interface Props {
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
 	const caption = [];
-	if (mainMedia.data?.caption) {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- because sometimes mainMedia isn't an image
+	if (mainMedia?.data?.caption) {
 		caption.push(mainMedia.data.caption);
 	}
 
-	if (mainMedia.displayCredit && mainMedia.data?.credit) {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- because sometimes mainMedia isn't an image
+	if (mainMedia?.displayCredit && mainMedia?.data?.credit) {
 		caption.push(mainMedia.data.credit);
 	}
 

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -443,7 +443,7 @@ export const InteractiveImmersiveLayout = ({
 					showTopBorder={false}
 					showSideBorders={false}
 					shouldCenter={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={palette.background.article}
 					element="main"
 				>
@@ -469,7 +469,7 @@ export const InteractiveImmersiveLayout = ({
 
 			{NAV.subNavSections && (
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					backgroundColour={neutral[100]}
 					element="aside"
 				>
@@ -484,7 +484,7 @@ export const InteractiveImmersiveLayout = ({
 			)}
 
 			<ElementContainer
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -241,7 +241,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							shouldCenter={false}
 						>
 							<HeaderAdSlot
@@ -258,7 +258,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							backgroundColour={brandBackground.primary}
 							element="header"
 						>
@@ -290,7 +290,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					showSideBorders={true}
 					borderColour={brandLine.primary}
 					showTopBorder={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={brandBackground.primary}
 					element="nav"
 				>
@@ -310,7 +310,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				{NAV.subNavSections && format.theme !== ArticleSpecial.Labs && (
 					<ElementContainer
 						backgroundColour={palette.background.article}
-						padded={false}
+						padSides={false}
 						element="aside"
 					>
 						<Island deferUntil="idle">
@@ -326,7 +326,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				{format.theme !== ArticleSpecial.Labs && (
 					<ElementContainer
 						backgroundColour={palette.background.article}
-						padded={false}
+						padSides={false}
 						showTopBorder={false}
 					>
 						<StraightLines
@@ -566,7 +566,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 				<ElementContainer
 					showTopBorder={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={palette.background.article}
 				>
 					<StraightLines
@@ -598,7 +598,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -702,7 +702,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -715,7 +715,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			{NAV.subNavSections && (
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					element="aside"
 				>
 					<Island deferUntil="visible">
@@ -730,7 +730,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -325,7 +325,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						shouldCenter={false}
 						element="aside"
 					>
@@ -340,7 +340,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="header"
 					>
@@ -368,7 +368,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="nav"
 					>
@@ -389,7 +389,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					{NAV.subNavSections && (
 						<ElementContainer
 							backgroundColour={palette.background.article}
-							padded={false}
+							padSides={false}
 							borderColour={palette.border.article}
 							element="aside"
 						>
@@ -405,7 +405,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 					<ElementContainer
 						backgroundColour={palette.background.article}
-						padded={false}
+						padSides={false}
 						showTopBorder={false}
 						borderColour={palette.border.article}
 					>
@@ -682,7 +682,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showTopBorder={false}
 						backgroundColour={palette.background.article}
 						borderColour={palette.border.article}
-						padded={false}
+						padSides={false}
 					>
 						<LiveGrid>
 							<GridItem area="media">
@@ -1220,7 +1220,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 					<ElementContainer
 						data-print-layout="hide"
-						padded={false}
+						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
 						backgroundColour={neutral[93]}
@@ -1332,7 +1332,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 					<ElementContainer
 						data-print-layout="hide"
-						padded={false}
+						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
 						backgroundColour={neutral[93]}
@@ -1349,7 +1349,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			{NAV.subNavSections && (
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					element="aside"
 				>
 					<Island deferUntil="visible">
@@ -1364,7 +1364,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -218,7 +218,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 					<ElementContainer
 						showTopBorder={false}
 						showSideBorders={false}
-						padded={false}
+						padSides={false}
 						shouldCenter={false}
 					>
 						<HeaderAdSlot
@@ -232,7 +232,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 				<ElementContainer
 					showTopBorder={false}
 					showSideBorders={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={brandBackground.primary}
 					element="header"
 				>
@@ -255,7 +255,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 					showSideBorders={true}
 					borderColour={brandLine.primary}
 					showTopBorder={false}
-					padded={false}
+					padSides={false}
 					backgroundColour={brandBackground.primary}
 					element="nav"
 				>
@@ -276,7 +276,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 					<>
 						<ElementContainer
 							backgroundColour={palette.background.article}
-							padded={false}
+							padSides={false}
 							element="aside"
 						>
 							<Island deferUntil="idle">
@@ -289,7 +289,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 						</ElementContainer>
 						<ElementContainer
 							backgroundColour={palette.background.article}
-							padded={false}
+							padSides={false}
 							showTopBorder={false}
 						>
 							<StraightLines
@@ -509,7 +509,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -246,7 +246,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ElementContainer
 								showTopBorder={false}
 								showSideBorders={false}
-								padded={false}
+								padSides={false}
 								shouldCenter={false}
 							>
 								<HeaderAdSlot
@@ -260,7 +260,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ElementContainer
 								showTopBorder={false}
 								showSideBorders={false}
-								padded={false}
+								padSides={false}
 								backgroundColour={brandBackground.primary}
 								element="header"
 							>
@@ -292,7 +292,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								showSideBorders={true}
 								borderColour={brandLine.primary}
 								showTopBorder={false}
-								padded={false}
+								padSides={false}
 								backgroundColour={brandBackground.primary}
 								element="nav"
 							>
@@ -315,7 +315,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									backgroundColour={
 										palette.background.article
 									}
-									padded={false}
+									padSides={false}
 									element="aside"
 								>
 									<Island deferUntil="idle">
@@ -330,7 +330,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 							<ElementContainer
 								backgroundColour={palette.background.article}
-								padded={false}
+								padSides={false}
 								showTopBorder={false}
 							>
 								<StraightLines
@@ -351,7 +351,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							<ElementContainer
 								showTopBorder={false}
 								showSideBorders={false}
-								padded={false}
+								padSides={false}
 							>
 								<HeaderAdSlot
 									isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -365,7 +365,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								showSideBorders={true}
 								borderColour={brandLine.primary}
 								showTopBorder={false}
-								padded={false}
+								padSides={false}
 								backgroundColour={brandBackground.primary}
 								element="nav"
 							>
@@ -642,7 +642,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</ElementContainer>
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -740,7 +740,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				)}
 
 				<ElementContainer
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -751,7 +751,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			</main>
 
 			{NAV.subNavSections && (
-				<ElementContainer padded={false} element="aside">
+				<ElementContainer padSides={false} element="aside">
 					<Island deferUntil="visible">
 						<SubNav
 							subNavSections={NAV.subNavSections}
@@ -763,7 +763,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			)}
 
 			<ElementContainer
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -345,7 +345,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							shouldCenter={false}
 						>
 							<HeaderAdSlot
@@ -359,7 +359,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showTopBorder={false}
 							showSideBorders={false}
-							padded={false}
+							padSides={false}
 							backgroundColour={brandBackground.primary}
 							element="header"
 						>
@@ -389,7 +389,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						showSideBorders={true}
 						borderColour={brandLine.primary}
 						showTopBorder={false}
-						padded={false}
+						padSides={false}
 						backgroundColour={brandBackground.primary}
 						element="nav"
 					>
@@ -410,7 +410,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									backgroundColour={
 										palette.background.article
 									}
-									padded={false}
+									padSides={false}
 									element="aside"
 								>
 									<Island deferUntil="idle">
@@ -425,7 +425,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									backgroundColour={
 										palette.background.article
 									}
-									padded={false}
+									padSides={false}
 									showTopBorder={false}
 								>
 									<StraightLines
@@ -773,7 +773,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -877,7 +877,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
 					backgroundColour={neutral[93]}
@@ -890,7 +890,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 			{NAV.subNavSections && (
 				<ElementContainer
 					data-print-layout="hide"
-					padded={false}
+					padSides={false}
 					element="aside"
 				>
 					<Island deferUntil="visible">
@@ -905,7 +905,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 			<ElementContainer
 				data-print-layout="hide"
-				padded={false}
+				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}
 				showSideBorders={false}

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -163,7 +163,7 @@ export const ImmersiveHeader = ({ CAPIArticle, NAV, format }: Props) => {
 						<ElementContainer
 							showSideBorders={false}
 							showTopBorder={false}
-							padded={false}
+							padSides={false}
 							backgroundColour={brandBackground.primary}
 							element="nav"
 						>


### PR DESCRIPTION
## What?
This PR ensures consistent spacing of 36px below each container on fronts

## Why?
Previously, we sometimes had different levels of padding below each container and sometimes none at all

### Before
<img width="1371" alt="Screenshot 2022-08-12 at 17 51 27" src="https://user-images.githubusercontent.com/1336821/184406312-856ffb97-7f17-48ac-b7aa-b0f329213262.png">


### After
<img width="1371" alt="Screenshot 2022-08-12 at 17 48 01" src="https://user-images.githubusercontent.com/1336821/184406240-e2aac541-945d-4ca1-81ce-ba28d5e92d91.png">
