### PR TITLE
Add support for the `culture-treat`

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerLayout.tsx
+++ b/dotcom-rendering/src/web/components/ContainerLayout.tsx
@@ -41,6 +41,7 @@ type Props = {
 	showDateHeader?: boolean;
 	editionId?: EditionId;
 	treats?: TreatType[];
+	legacyClassName?: string;
 };
 
 const containerStyles = css`
@@ -145,6 +146,7 @@ export const ContainerLayout = ({
 	editionId,
 	containerName,
 	treats,
+	legacyClassName,
 }: Props) => {
 	const overrides =
 		containerPalette && decideContainerOverrides(containerPalette);
@@ -164,6 +166,7 @@ export const ContainerLayout = ({
 			ophanComponentName={ophanComponentName}
 			containerName={containerName}
 			innerBackgroundColour={innerBackgroundColour}
+			className={legacyClassName}
 		>
 			<Flex>
 				<LeftColumn

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -55,7 +55,7 @@ export const Treats = ({
 								a later date after we've migrated, but for now a little bit
 								of evil is a good thing.
 							*/
-							padding-top: ${space[1]}px !important;
+							padding-top: ${space[1]}px !important; /* stylelint-disable-line declaration-no-important */
 							padding-left: ${space[2]}px;
 						`}
 					>

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -10,13 +10,24 @@ export const Treats = ({
 	treats: TreatType[];
 	borderColour?: string;
 }) => {
-	if (treats.length === 0) return null;
 	return (
 		<ul
 			css={css`
 				display: flex;
 				flex-direction: column;
+				/*
+				   The legacy javascript executed by the culture-treat adds
+				   css to show a line below the li element, presumably because
+				   on Frontend this was needed. This css removes this line
+				   because we don't need it on DCR
+				*/
+				.treat-separator:before {
+					display: none;
+				}
 			`}
+			// The legacy javascript executed by the culture-treat depends
+			// on this class existing
+			className="treats__container"
 		>
 			{treats.map((treat) => {
 				return (
@@ -27,7 +38,24 @@ export const Treats = ({
 								${borderColour ?? border.secondary};
 							border-top: 1px solid
 								${borderColour ?? border.secondary};
-							padding-top: ${space[1]}px;
+							/*
+								Why are we using !important below, isn't that bad?
+
+								We need to use the !important override to fight against the
+								css being set by the culture-treat. The javascript in that
+								thrasher sets padding-top to be 12px but our designs call for
+								4px.
+
+								See: https://github.com/guardian/thrashers/blob/master/embeds/culture-nugget/style.scss#L29
+
+								Yes, I know, this is not a great solution. But it's pragmatic.
+								We're keen to move the migration forward and the alternative
+								here would be to rework this thrasher, which would be time
+								consuming. We should look at revisiting all thrashers at
+								a later date after we've migrated, but for now a little bit
+								of evil is a good thing.
+							*/
+							padding-top: ${space[1]}px !important;
 							padding-left: ${space[2]}px;
 						`}
 					>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -139,7 +139,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<main data-layout="FrontLayout">
 				{front.pressedPage.collections.map((collection, index) => {
-					// TODO: We also need to support treats containers
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(
 						collection.backfill,

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -152,19 +152,47 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					} | ${ophanName}`;
 
 					if (collection.collectionType === 'fixed/thrasher') {
-						return (
-							<ElementContainer
-								padded={false}
-								showTopBorder={false}
-								showSideBorders={false}
-								ophanComponentLink={ophanComponentLink}
-								ophanComponentName={ophanName}
-								containerName={collection.collectionType}
-								element="section"
-							>
-								<Snap snapData={trails[0].snapData} />
-							</ElementContainer>
-						);
+						switch (collection.displayName) {
+							case 'Palette styles new do not delete':
+								return null;
+							case 'culture-treat':
+								/**
+								 * The legacy culture-treat works by cloning itself and inserting
+								 * that clone in the section above. But on DCR this approach is
+								 * leading to the original content also showing. We still need to
+								 * 'render' the component in DCR so that the javascript gets executed
+								 * but we don't want to render two version so to get around this
+								 * we wrap the original Snap component in a section and hide
+								 * it.
+								 */
+								return (
+									// This *needs* to be a section because the culture-treat
+									// code is epxecting that
+									<section
+										css={css`
+											display: none;
+										`}
+									>
+										<Snap snapData={trails[0].snapData} />
+									</section>
+								);
+							default:
+								return (
+									<ElementContainer
+										padded={false}
+										showTopBorder={false}
+										showSideBorders={false}
+										ophanComponentLink={ophanComponentLink}
+										ophanComponentName={ophanName}
+										containerName={
+											collection.collectionType
+										}
+										element="section"
+									>
+										<Snap snapData={trails[0].snapData} />
+									</ElementContainer>
+								);
+						}
 					}
 
 					return (

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -151,9 +151,26 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						index + 1
 					} | ${ophanName}`;
 
+					/**
+					 * We have code that runs on the platforms which is expecting certain classnames
+					 * to exist. An example of such code can be seen here:
+					 *
+					 * https://github.com/guardian/thrashers/blame/master/embeds/culture-nugget/_source/main.js#L4
+					 */
+					let legacyClassName;
+					switch (collection.collectionType) {
+						case 'fixed/thrasher':
+							legacyClassName = 'fc-container--thrasher';
+							break;
+						case 'fixed/video':
+							legacyClassName = 'fc-container--video';
+							break;
+					}
+
 					if (collection.collectionType === 'fixed/thrasher') {
 						switch (collection.displayName) {
 							case 'Palette styles new do not delete':
+								// We no longer use this legacy thrasher. We have containerPalette instead
 								return null;
 							case 'culture-treat':
 								/**
@@ -188,6 +205,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.collectionType
 										}
 										element="section"
+										className={legacyClassName}
 									>
 										<Snap snapData={trails[0].snapData} />
 									</ElementContainer>
@@ -216,6 +234,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							showDateHeader={collection.config.showDateHeader}
 							editionId={front.editionId}
 							treats={collection.treats}
+							legacyClassName={legacyClassName}
 						>
 							<DecideContainer
 								trails={trails}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR closes #5515 by adding support for the culture treat

## How?
We're achieving the goal of supporting this special thrasher by moving the contract that existed between the thrasher code and Frontend into DCR. This contract broadly states:

That each container on a front would use a `section` tag and that the `ul` element wrapping treats would have the class `treats__container`. In addition, video, thrasher and mobile ad slot containers are marked with `fc-container--thrasher `, `fc-container--video` and `fc-container__mpu--mobile` respectively so that they can be [ignored by the treats thrasher code](https://github.com/guardian/thrashers/blame/master/embeds/culture-nugget/_source/main.js#L4) when deciding where to insert the nugget.

### Is coupling code like this a good idea?
Ultimately, no. There have long been issues with this approach - I found [this one](https://github.com/guardian/frontend/pull/7044#issuecomment-62557428) from back in 2014 - and these problems will continue for as long as we continue to add brittle code couplings like this.

The problem is these sorts of dependencies are undocumented. Short of reading every line of thrasher code it's not possible to know what couplings there are or what might break so when making changes to the DCR platform it's very difficult to be sure you won't have external impacts.

### So what could we do instead?
The goal here is to be able to insert an image with some associated text and have that link out to a page. This image and text should sit at the bottom of the left column.

This requirement could be achieved via tools. A change to the fronts to could perhaps allow the image, text and url to be specified directly. Or perhaps it could allow a snap url to be given that returns the nugget. Either way, a tools change would allow this as an enhancement made to a specific container. This would be preferable to running code in a thrasher and expecting that to be able to find and insert content into another container.

### So why don't we implement the better solution?
Because changes to the tools is hard and it's easier for the Dotcom team to move forward with our migration when we're only changing code that we control 😐 


| Before      | After      |
|-------------|------------|
| <img width="1393" alt="Screenshot 2022-08-15 at 10 22 29" src="https://user-images.githubusercontent.com/1336821/184610595-12ea3237-b2cb-4941-866e-1d1bff4c6e08.png"> | <img width="1393" alt="Screenshot 2022-08-15 at 10 22 10" src="https://user-images.githubusercontent.com/1336821/184610614-f2a3fa4e-f85c-41a4-90b5-ae676cead5ab.png"> |
