### PR TITLE
Email signup style changes

### DIFF
--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -48,7 +48,7 @@ const titleStyles = (theme: string) => css`
 	${headline.xxsmall({ fontWeight: 'bold' })}
 	flex-grow: 1;
 	span {
-		color: ${theme === 'news' ? sport[500] : 'inherit'};
+		color: ${theme === 'news' ? sport[400] : 'inherit'};
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -40,7 +40,7 @@ const stackBelowTabletStyles = css`
 
 	${from.tablet} {
 		flex-direction: row;
-		margin-bottom: ${space[1]}px;
+		margin-bottom: 6px;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -67,9 +67,11 @@ const noHeightFromTabletStyles = css`
 	}
 `;
 
+// max-width is the wdith of the text field, the button and the margin between them
 const descriptionStyles = css`
 	${textSans.xsmall({ lineHeight: 'tight' })}
 	margin-bottom: ${space[2]}px;
+	max-width: ${335 + space[3] + 118}px;
 `;
 
 export const EmailSignup = ({

--- a/dotcom-rendering/src/web/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignup.tsx
@@ -1,7 +1,6 @@
 import createCache from '@emotion/cache';
-import { CacheProvider, css } from '@emotion/react';
+import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { space } from '@guardian/source-foundations';
 import { renderToString } from 'react-dom/server';
 import { Island } from './Island';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
@@ -14,10 +13,6 @@ export type Props = {
 	/** Override this with caution: you _must_ ensure this wording exists nearby if not included in this component */
 	hidePrivacyMessage?: boolean;
 };
-
-const marginTopStyle = css`
-	margin-top: ${space[2]}px;
-`;
 
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. <SecureSignupIframe> hides the
@@ -83,11 +78,7 @@ export const SecureSignup = ({
 					successDescription={successDescription}
 				/>
 			</Island>
-			{!hidePrivacyMessage && (
-				<div css={marginTopStyle}>
-					<NewsletterPrivacyMessage />
-				</div>
-			)}
+			{!hidePrivacyMessage && <NewsletterPrivacyMessage />}
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes minor adjustments to the appearance of the EmailSignup Component
- change title colour to a darker blue for newsletters with the "news theme" 
- limit width of the description text to the width of the form (the field + the signup button)
- Icons: extra spacing 2px between (title and description)
- remove extra margin above privacy text 

## Why?
Responding to feedback on the layout and colour contrast

## Screenshots

<img width="1755" alt="Screenshot 2022-08-15 at 15 35 40" src="https://user-images.githubusercontent.com/30567854/184655843-4d70de86-a5e1-409b-9f0d-ec044c49e2a8.png">
