### PR TITLE
Integrate Interactive Media Ads to first party video players as 0% test

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -60,7 +60,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.4.0",
+    "@guardian/atoms-rendering": "^23.6.0",
     "@guardian/braze-components": "^7.3.0",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.11.1",

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { YoutubeAtom } from '@guardian/atoms-rendering';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
-import { log } from '@guardian/libs';
 import { body, neutral, space } from '@guardian/source-foundations';
 import { SvgAlertRound } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
@@ -100,7 +99,6 @@ export const YoutubeBlockComponent = ({
 		'IntegrateIMA',
 		'variant',
 	);
-	log('commercial', { userInImaTestVariant });
 	const imaAdTagUrl =
 		'https://pubads.g.doubleclick.net/gampad/live/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&cust_params=at%3Dfixed-puppies';
 

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -99,8 +99,11 @@ export const YoutubeBlockComponent = ({
 		'IntegrateIMA',
 		'variant',
 	);
-	const imaAdTagUrl =
-		'https://pubads.g.doubleclick.net/gampad/live/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&cust_params=at%3Dfixed-puppies';
+	const imaAdTagUrl = userInImaTestVariant
+		? 'https://pubads.g.doubleclick.net/gampad/live/ads?iu=/59666047/theguardian.com&' +
+		  'description_url=[placeholder]&tfcd=0&npa=0&sz=400x300&gdfp_req=1&output=vast&' +
+		  'unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&cust_params=at%3Dfixed-puppies'
+		: undefined;
 
 	useEffect(() => {
 		const defineConsentState = async () => {

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -6,6 +6,7 @@ import { SvgAlertRound } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import { trackVideoInteraction } from '../browser/ga/ga';
 import { record } from '../browser/ophan/ophan';
+import { useAB } from '../lib/useAB';
 import { Caption } from './Caption';
 
 type Props = {
@@ -92,6 +93,15 @@ export const YoutubeBlockComponent = ({
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
 	);
+
+	const ABTestAPI = useAB();
+	const userInImaTestVariant = ABTestAPI?.isUserInVariant(
+		'IntegrateIMA',
+		'variant',
+	);
+	// fixed-puppies
+	const imaAdTagUrl =
+		'https://pubads.g.doubleclick.net/gampad/live/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&cust_params=at%3Dfixed-puppies';
 
 	useEffect(() => {
 		const defineConsentState = async () => {
@@ -217,6 +227,7 @@ export const YoutubeBlockComponent = ({
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
 				shouldStick={stickyVideos}
 				isMainMedia={isMainMedia}
+				imaAdTagUrl={imaAdTagUrl}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { YoutubeAtom } from '@guardian/atoms-rendering';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { log } from '@guardian/libs';
 import { body, neutral, space } from '@guardian/source-foundations';
 import { SvgAlertRound } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
@@ -99,7 +100,7 @@ export const YoutubeBlockComponent = ({
 		'IntegrateIMA',
 		'variant',
 	);
-	// fixed-puppies
+	log('commercial', { userInImaTestVariant });
 	const imaAdTagUrl =
 		'https://pubads.g.doubleclick.net/gampad/live/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&cust_params=at%3Dfixed-puppies';
 

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { consentlessAds } from './tests/consentless-ads';
+import { integrateIMA } from './tests/integrate-ima';
 import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	consentlessAds,
+	integrateIMA,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/integrate-ima.ts
+++ b/dotcom-rendering/src/web/experiments/tests/integrate-ima.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const integrateIMA: ABTest = {
+	id: 'IntegrateIMA',
+	start: '2022-07-14',
+	expiry: '2022-12-31',
+	author: 'Zeke Hunter-Green',
+	description:
+		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: 'Opt in',
+	successMeasure:
+		'IMA integration works as expected without adversely affecting pages with videos',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: (): void => {},
+		},
+	],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -20318,9 +20318,9 @@ type-detect@4.0.8:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.4.0, type-fest@^2.8.0:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.1.tgz#a94f068c60b5a2d6beccccffa711210d7dd99b38"
-  integrity sha512-UKCINsd4qiATXD6OIlnQw9t1ux/n2ld+Nl0kzPbCONhCaUIS/BhJbNw14w6584HCQWf3frBK8vmWnGZq/sbPHQ==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
+  integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
 
 type-is@~1.6.18:
   version "1.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,10 +2784,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.4.0":
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.4.0.tgz#5d875d719a994c6b255c71f5a9105af26aae60ce"
-  integrity sha512-d2EhP5WKv01p6fVNfAmyiS81ys4omfdHMFi1cL27YBqGDU2yKcyxjEPdlJknuN+Mv1V/C3+9+nDRSgDSYytfxQ==
+"@guardian/atoms-rendering@^23.6.0":
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz#624dc68120f00d47f21bae0ca059f31e65f56f59"
+  integrity sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
## What does this change?
- adds a zero percent test so that users can opt in to see the [PfP / Interactive Media Ads integration](https://github.com/guardian/atoms-rendering/pull/447)
- users who aren't in the 0% test should see no change in youtube players' behaviour
- Frontend PR: https://github.com/guardian/frontend/pull/25485

## Why?
- We would like to test the IMA integration in production before testing on a larger audience.

## Screenshots

![ima demo 480p](https://user-images.githubusercontent.com/17057932/185203958-8f259f74-d15b-486d-815f-5ab754485895.gif)
