### PR TITLE
`PLATFORM_TREATS`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -170,6 +170,7 @@ type Palette = {
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
+		treat: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -4,10 +4,19 @@ import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
 
+const supportedContainers = (collection: FECollectionType) => {
+	switch (collection.displayName) {
+		case 'Palette styles new do not delete':
+			return false;
+		default:
+			return true;
+	}
+};
+
 export const enhanceCollections = (
 	collections: FECollectionType[],
 ): DCRCollectionType[] => {
-	return collections.map((collection) => {
+	return collections.filter(supportedContainers).map((collection) => {
 		const { id, displayName, collectionType } = collection;
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -4,23 +4,20 @@ import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
 import { groupCards } from './groupCards';
 
-const supportedContainers = (collection: FECollectionType) => {
-	switch (collection.displayName) {
-		case 'Palette styles new do not delete':
-		case 'culture-treat':
-		case 'newsletter treat':
-			return false;
-		default:
-			return true;
-	}
-};
+const FORBIDDEN_CONTAINERS = [
+	'Palette styles new do not delete',
+	'culture-treat',
+	'newsletter treat',
+];
+const isSupported = (collection: FECollectionType): boolean =>
+	!FORBIDDEN_CONTAINERS.includes(collection.displayName);
 
 export const enhanceCollections = (
 	collections: FECollectionType[],
 	editionId: EditionId,
 	pageId: string,
 ): DCRCollectionType[] => {
-	return collections.filter(supportedContainers).map((collection) => {
+	return collections.filter(isSupported).map((collection) => {
 		const { id, displayName, collectionType } = collection;
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -18,6 +18,7 @@ const supportedContainers = (collection: FECollectionType) => {
 export const enhanceCollections = (
 	collections: FECollectionType[],
 	editionId: EditionId,
+	pageId: string,
 ): DCRCollectionType[] => {
 	return collections.filter(supportedContainers).map((collection) => {
 		const { id, displayName, collectionType } = collection;
@@ -37,7 +38,12 @@ export const enhanceCollections = (
 			),
 			curated: enhanceCards(collection.curated, containerPalette),
 			backfill: enhanceCards(collection.backfill, containerPalette),
-			treats: enhanceTreats(collection.treats, editionId, displayName),
+			treats: enhanceTreats(
+				collection.treats,
+				displayName,
+				editionId,
+				pageId,
+			),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
 			},

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -7,6 +7,8 @@ import { groupCards } from './groupCards';
 const supportedContainers = (collection: FECollectionType) => {
 	switch (collection.displayName) {
 		case 'Palette styles new do not delete':
+		case 'culture-treat':
+		case 'newsletter treat':
 			return false;
 		default:
 			return true;
@@ -15,6 +17,7 @@ const supportedContainers = (collection: FECollectionType) => {
 
 export const enhanceCollections = (
 	collections: FECollectionType[],
+	editionId: EditionId,
 ): DCRCollectionType[] => {
 	return collections.filter(supportedContainers).map((collection) => {
 		const { id, displayName, collectionType } = collection;
@@ -34,7 +37,7 @@ export const enhanceCollections = (
 			),
 			curated: enhanceCards(collection.curated, containerPalette),
 			backfill: enhanceCards(collection.backfill, containerPalette),
-			treats: enhanceTreats(collection.treats),
+			treats: enhanceTreats(collection.treats, editionId, displayName),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
 			},

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -36,21 +36,22 @@ const PLATFORM_TREATS: TreatType[] = [
 
 const getPlatformTreats = (
 	editionId: EditionId,
-	containerTitle: string,
+	displayName: string,
 ): TreatType[] => {
 	return PLATFORM_TREATS.filter((treat) => {
 		// We decide if a treat should be shown for a container based on
 		// if the editionId matches and if the containerTitle text is the same.
 		return (
-			treat.containerTitle === containerTitle &&
+			treat.containerTitle === displayName &&
 			treat.editionId === editionId
 		);
 	});
 };
+
 export const enhanceTreats = (
 	treats: FEFrontCard[],
 	editionId: EditionId,
-	containerTitle: string,
+	displayName: string,
 ): TreatType[] => {
 	const classicTreats = treats.map((treat) => ({
 		text: treat.header.headline,
@@ -59,7 +60,7 @@ export const enhanceTreats = (
 	}));
 
 	// Add any platform treats that we can find for this container
-	const platformTreats = getPlatformTreats(editionId, containerTitle);
+	const platformTreats = getPlatformTreats(editionId, displayName);
 
 	return [...platformTreats, ...classicTreats];
 };

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -7,7 +7,7 @@ import type { FEFrontCard, TreatType } from '../types/front';
  *
  * This list controls treats that will appear in the bottom of the left column for a
  * particular container. The actual container that a treat appears in is decided
- * based on the values of displayName and editionId
+ * based on the values of containerTitle and editionId
  *
  * If both imageUrl and altText are provided, then an image will be shown. Otherwise,
  * if no imageUrl or altText are given, then a basic text treat will be shown
@@ -16,7 +16,7 @@ import type { FEFrontCard, TreatType } from '../types/front';
 const PLATFORM_TREATS: TreatType[] = [
 	{
 		linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
-		displayName: 'Spotlight',
+		containerTitle: 'Spotlight',
 		editionId: 'US',
 		imageUrl:
 			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
@@ -25,7 +25,7 @@ const PLATFORM_TREATS: TreatType[] = [
 	},
 	{
 		linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
-		displayName: 'Culture',
+		containerTitle: 'Culture',
 		editionId: 'UK',
 		imageUrl:
 			'https://interactive.guim.co.uk/thrashers/culture-nugget/hashed/thrasher_img_55.1c0762e5.png',
@@ -36,20 +36,21 @@ const PLATFORM_TREATS: TreatType[] = [
 
 const getPlatformTreats = (
 	editionId: EditionId,
-	displayName: string,
+	containerTitle: string,
 ): TreatType[] => {
 	return PLATFORM_TREATS.filter((treat) => {
 		// We decide if a treat should be shown for a container based on
-		// if the editionId matches and if the displayName text is the same.
+		// if the editionId matches and if the containerTitle text is the same.
 		return (
-			treat.displayName === displayName && treat.editionId === editionId
+			treat.containerTitle === containerTitle &&
+			treat.editionId === editionId
 		);
 	});
 };
 export const enhanceTreats = (
 	treats: FEFrontCard[],
 	editionId: EditionId,
-	displayName: string,
+	containerTitle: string,
 ): TreatType[] => {
 	const classicTreats = treats.map((treat) => ({
 		text: treat.header.headline,
@@ -58,7 +59,7 @@ export const enhanceTreats = (
 	}));
 
 	// Add any platform treats that we can find for this container
-	const platformTreats = getPlatformTreats(editionId, displayName);
+	const platformTreats = getPlatformTreats(editionId, containerTitle);
 
 	return [...platformTreats, ...classicTreats];
 };

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -1,7 +1,64 @@
 import type { FEFrontCard, TreatType } from '../types/front';
 
-export const enhanceTreats = (treats: FEFrontCard[]): TreatType[] =>
-	treats.map((treat) => ({
+/**
+ * PLATFORM_TREATS
+ *
+ * 👉 Edit this list below to change, remove or add new treats to front pages 👈
+ *
+ * This list controls treats that will appear in the bottom of the left column for a
+ * particular container. The actual container that a treat appears in is decided
+ * based on the values of displayName and editionId
+ *
+ * If both imageUrl and altText are provided, then an image will be shown. Otherwise,
+ * if no imageUrl or altText are given, then a basic text treat will be shown
+ * instead
+ */
+const PLATFORM_TREATS: TreatType[] = [
+	{
+		linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
+		displayName: 'Spotlight',
+		editionId: 'US',
+		imageUrl:
+			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
+		altText: 'The White House',
+		text: 'Guardian Today US: Get the headlines & more in a daily email',
+	},
+	{
+		linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
+		displayName: 'Culture',
+		editionId: 'UK',
+		imageUrl:
+			'https://interactive.guim.co.uk/thrashers/culture-nugget/hashed/thrasher_img_55.1c0762e5.png',
+		altText: "What's on Netflix and Amazon this month",
+		text: "What's on Netflix & Amazon this month",
+	},
+];
+
+const getPlatformTreats = (
+	editionId: EditionId,
+	displayName: string,
+): TreatType[] => {
+	return PLATFORM_TREATS.filter((treat) => {
+		// We decide if a treat should be shown for a container based on
+		// if the editionId matches and if the displayName text is the same.
+		return (
+			treat.displayName === displayName && treat.editionId === editionId
+		);
+	});
+};
+export const enhanceTreats = (
+	treats: FEFrontCard[],
+	editionId: EditionId,
+	displayName: string,
+): TreatType[] => {
+	const classicTreats = treats.map((treat) => ({
 		text: treat.header.headline,
 		linkTo: treat.properties.href ?? treat.header.url,
+		editionId,
 	}));
+
+	// Add any platform treats that we can find for this container
+	const platformTreats = getPlatformTreats(editionId, displayName);
+
+	return [...platformTreats, ...classicTreats];
+};

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -75,7 +75,7 @@ export const enhanceTreats = (
 	editionId: EditionId,
 	pageId: string,
 ): TreatType[] => {
-	const classicTreats = treats.map((treat) => ({
+	const existingTreats = treats.map((treat) => ({
 		links: [
 			{
 				text: treat.header.headline,
@@ -88,5 +88,5 @@ export const enhanceTreats = (
 	// Add any platform treats that we can find for this container
 	const platformTreats = getPlatformTreats(displayName, editionId, pageId);
 
-	return [...platformTreats, ...classicTreats];
+	return [...platformTreats, ...existingTreats];
 };

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -31,27 +31,37 @@ const PLATFORM_TREATS: TreatType[] = [
 			'https://interactive.guim.co.uk/thrashers/culture-nugget/hashed/thrasher_img_55.1c0762e5.png',
 		altText: "What's on Netflix and Amazon this month",
 		text: "What's on Netflix & Amazon this month",
+		pageId: 'uk',
 	},
 ];
 
 const getPlatformTreats = (
-	editionId: EditionId,
 	displayName: string,
+	editionId: EditionId,
+	pageId: string,
 ): TreatType[] => {
 	return PLATFORM_TREATS.filter((treat) => {
-		// We decide if a treat should be shown for a container based on
-		// if the editionId matches and if the containerTitle text is the same.
-		return (
-			treat.containerTitle === displayName &&
-			treat.editionId === editionId
-		);
+		/**
+		 * We decide if a treat should be shown for a container based on the container
+		 * name, the edition and the page id.
+		 *
+		 * Matching on edition or page id is optional. If either of these are not
+		 * provided then we return true for that check
+		 */
+		const matchesContainer = treat.containerTitle === displayName;
+		const matchesEdition =
+			!treat.editionId || treat.editionId === editionId;
+		const matchesPage = !treat.pageId || treat.pageId === pageId;
+
+		return matchesContainer && matchesEdition && matchesPage;
 	});
 };
 
 export const enhanceTreats = (
 	treats: FEFrontCard[],
-	editionId: EditionId,
 	displayName: string,
+	editionId: EditionId,
+	pageId: string,
 ): TreatType[] => {
 	const classicTreats = treats.map((treat) => ({
 		text: treat.header.headline,
@@ -60,7 +70,7 @@ export const enhanceTreats = (
 	}));
 
 	// Add any platform treats that we can find for this container
-	const platformTreats = getPlatformTreats(editionId, displayName);
+	const platformTreats = getPlatformTreats(displayName, editionId, pageId);
 
 	return [...platformTreats, ...classicTreats];
 };

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -1,3 +1,4 @@
+import { ArticlePillar } from '@guardian/libs';
 import type { FEFrontCard, TreatType } from '../types/front';
 
 /**
@@ -15,22 +16,40 @@ import type { FEFrontCard, TreatType } from '../types/front';
  */
 const PLATFORM_TREATS: TreatType[] = [
 	{
-		linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
+		links: [
+			{
+				linkTo: '/info/2015/dec/08/daily-email-us?INTCMP=gdnwb_treat_election_today_us',
+				text: 'Guardian Today US: Get the headlines & more in a daily email',
+			},
+		],
+		theme: ArticlePillar.News,
 		containerTitle: 'Spotlight',
 		editionId: 'US',
 		imageUrl:
 			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
 		altText: 'The White House',
-		text: 'Guardian Today US: Get the headlines & more in a daily email',
 	},
 	{
-		linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
+		links: [
+			{
+				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
+				text: "What's on Netflix & Amazon this month",
+			},
+			{
+				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
+				text: 'Second link',
+			},
+			{
+				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
+				text: 'This is a third link with some longer text',
+			},
+		],
+		theme: ArticlePillar.Culture,
 		containerTitle: 'Culture',
 		editionId: 'UK',
 		imageUrl:
 			'https://interactive.guim.co.uk/thrashers/culture-nugget/hashed/thrasher_img_55.1c0762e5.png',
 		altText: "What's on Netflix and Amazon this month",
-		text: "What's on Netflix & Amazon this month",
 		pageId: 'uk',
 	},
 ];
@@ -64,8 +83,12 @@ export const enhanceTreats = (
 	pageId: string,
 ): TreatType[] => {
 	const classicTreats = treats.map((treat) => ({
-		text: treat.header.headline,
-		linkTo: treat.properties.href ?? treat.header.url,
+		links: [
+			{
+				text: treat.header.headline,
+				linkTo: treat.properties.href ?? treat.header.url,
+			},
+		],
 		editionId,
 	}));
 

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -28,6 +28,7 @@ const PLATFORM_TREATS: TreatType[] = [
 		imageUrl:
 			'https://uploads.guim.co.uk/2020/10/22/newsletter-treat-img.png',
 		altText: 'The White House',
+		pageId: 'us',
 	},
 	{
 		links: [

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -59,6 +59,9 @@ const getPlatformTreats = (
 		 *
 		 * Matching on edition or page id is optional. If either of these are not
 		 * provided then we return true for that check
+		 *
+		 * If editionId is given without pageId it will match against all readers who
+		 * have that edition cookie, regardless of which page they are viewing
 		 */
 		const matchesContainer = treat.containerTitle === displayName;
 		const matchesEdition =

--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -35,14 +35,6 @@ const PLATFORM_TREATS: TreatType[] = [
 				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
 				text: "What's on Netflix & Amazon this month",
 			},
-			{
-				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
-				text: 'Second link',
-			},
-			{
-				linkTo: '/tv-and-radio/ng-interactive/2022/aug/01/whats-on-netflix-and-amazon-this-month-august',
-				text: 'This is a third link with some longer text',
-			},
 		],
 		theme: ArticlePillar.Culture,
 		containerTitle: 'Culture',

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -447,5 +447,5 @@ export type TreatType = {
 	imageUrl?: string;
 	altText?: string;
 	/** The container display name where this treat should show */
-	displayName?: string;
+	containerTitle?: string;
 };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -443,9 +443,15 @@ export type DCRSupportingContent = {
 export type TreatType = {
 	text: string;
 	linkTo: string;
-	editionId: EditionId;
+	editionId?: EditionId;
 	imageUrl?: string;
 	altText?: string;
 	/** The container display name where this treat should show */
 	containerTitle?: string;
+	/**
+	 * `pageId` is the part of the url that comes after the slash
+	 *
+	 * So for https://www.theguardian.com/uk it would be 'uk'
+	 */
+	pageId?: string;
 };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -443,4 +443,9 @@ export type DCRSupportingContent = {
 export type TreatType = {
 	text: string;
 	linkTo: string;
+	editionId: EditionId;
+	imageUrl?: string;
+	altText?: string;
+	/** The container display name where this treat should show */
+	displayName?: string;
 };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -1,3 +1,5 @@
+import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+
 export interface FEFrontType {
 	pressedPage: FEPressedPageType;
 	nav: CAPINavType;
@@ -441,8 +443,8 @@ export type DCRSupportingContent = {
 };
 
 export type TreatType = {
-	text: string;
-	linkTo: string;
+	links: { text: string; linkTo: string }[];
+	theme?: ArticlePillar | ArticleSpecial;
 	editionId?: EditionId;
 	imageUrl?: string;
 	altText?: string;

--- a/dotcom-rendering/src/web/components/Section.stories.tsx
+++ b/dotcom-rendering/src/web/components/Section.stories.tsx
@@ -295,10 +295,12 @@ export const TreatsStory = () => {
 				{
 					text: 'The treat text',
 					linkTo: '',
+					editionId: 'UK',
 				},
 				{
 					text: 'Another piece of text',
 					linkTo: '',
+					editionId: 'UK',
 				},
 			]}
 			showTopBorder={false}

--- a/dotcom-rendering/src/web/components/Section.stories.tsx
+++ b/dotcom-rendering/src/web/components/Section.stories.tsx
@@ -293,13 +293,21 @@ export const TreatsStory = () => {
 			title="Treats"
 			treats={[
 				{
-					text: 'The treat text',
-					linkTo: '',
+					links: [
+						{
+							text: 'The treat text',
+							linkTo: '',
+						},
+					],
 					editionId: 'UK',
 				},
 				{
-					text: 'Another piece of text',
-					linkTo: '',
+					links: [
+						{
+							text: 'Another piece of text',
+							linkTo: '',
+						},
+					],
 					editionId: 'UK',
 				},
 			]}

--- a/dotcom-rendering/src/web/components/SvgCrossword.tsx
+++ b/dotcom-rendering/src/web/components/SvgCrossword.tsx
@@ -1,0 +1,41 @@
+export const SvgCrossword = () => (
+	<svg viewBox="0, 0, 106, 106" width="106px" height="106px">
+		<rect x="0" y="0" fill="#000000" width="106" height="106"></rect>
+		<rect x="16" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="1" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="46" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="46" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="46" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="76" y="1" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="46" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="46" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="46" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="76" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="76" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="16" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="16" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="76" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="16" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="16" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="1" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="46" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="76" y="91" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="31" y="1" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="46" y="1" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="1" y="16" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="16" y="31" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="61" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="61" y="76" width="14" height="14" fill="#ffffff"></rect>
+		<rect x="91" y="91" width="14" height="14" fill="#ffffff"></rect>
+	</svg>
+);

--- a/dotcom-rendering/src/web/components/Treats.stories.tsx
+++ b/dotcom-rendering/src/web/components/Treats.stories.tsx
@@ -25,10 +25,12 @@ export const Default = () => {
 					{
 						text: 'treat 1',
 						linkTo: '',
+						editionId: 'UK',
 					},
 					{
 						text: 'treat 2',
 						linkTo: '',
+						editionId: 'UK',
 					},
 				]}
 			/>

--- a/dotcom-rendering/src/web/components/Treats.stories.tsx
+++ b/dotcom-rendering/src/web/components/Treats.stories.tsx
@@ -23,13 +23,21 @@ export const Default = () => {
 			<Treats
 				treats={[
 					{
-						text: 'treat 1',
-						linkTo: '',
+						links: [
+							{
+								text: 'treat 1',
+								linkTo: '',
+							},
+						],
 						editionId: 'UK',
 					},
 					{
-						text: 'treat 2',
-						linkTo: '',
+						links: [
+							{
+								text: 'treat 2',
+								linkTo: '',
+							},
+						],
 						editionId: 'UK',
 					},
 				]}

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import {
 	border,
 	headline,
@@ -8,6 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import type { TreatType } from '../../types/front';
+import { decidePalette } from '../lib/decidePalette';
 import { SvgCrossword } from './SvgCrossword';
 
 const TextTreat = ({
@@ -43,52 +45,53 @@ const TextTreat = ({
 
 const ImageTreat = ({
 	imageUrl,
-	linkTo,
+	links,
 	altText,
-	text,
+	backgroundColour,
 }: {
 	imageUrl: string;
-	linkTo: string;
+	links: { text: string; linkTo: string }[];
 	altText?: string;
-	text: string;
+	backgroundColour: string;
 }) => (
 	<li>
-		<a
-			href={linkTo}
-			data-ignore="global-link-styling"
-			css={css`
-				text-decoration: none;
-				:hover {
-					/* We target the span from here like this so that hovering the image also
-					   adds the underline to the text */
-					span {
-						text-decoration: underline;
-					}
-				}
-			`}
-		>
-			<img src={imageUrl} alt={altText} width="130px" height="130px" />
-			<div
+		<img src={imageUrl} alt={altText} width="130px" height="130px" />
+		{links.map((link, index) => (
+			<a
+				href={link.linkTo}
+				data-ignore="global-link-styling"
 				css={css`
-					margin-bottom: 8px;
-					display: block;
-					width: 80%;
+					text-decoration: none;
 				`}
 			>
-				<span
+				<div
 					css={css`
-						${headline.xxxsmall({ fontWeight: 'bold' })};
-						background-color: ${neutral[0]};
-						padding: 0 5px 4px;
-						box-decoration-break: clone;
-						position: relative;
-						color: ${neutral[100]};
+						margin-bottom: 8px;
+						display: block;
+						width: 80%;
 					`}
 				>
-					{text}
-				</span>
-			</div>
-		</a>
+					<span
+						css={css`
+							${headline.xxxsmall({ fontWeight: 'bold' })};
+							background-color: ${index % 2 === 0
+								? neutral[0]
+								: backgroundColour};
+							padding: 0 5px 4px;
+							box-decoration-break: clone;
+							position: relative;
+							color: ${neutral[100]};
+							text-decoration: none;
+							:hover {
+								text-decoration: underline;
+							}
+						`}
+					>
+						{link.text}
+					</span>
+				</div>
+			</a>
+		))}
 	</li>
 );
 
@@ -108,43 +111,61 @@ export const Treats = ({
 			`}
 		>
 			{treats.map((treat) => {
-				if (treat.linkTo === '/crosswords' && treat.text) {
+				if (
+					treat.links[0].linkTo === '/crosswords' &&
+					treat.links[0].text
+				) {
 					// Treats that link to /crosswords are special. If any
 					// treat has this exact url then an svg of a crossword
 					// is displayed above the text
 					return (
 						<>
 							<li>
-								<a href={treat.linkTo}>
+								<a href={treat.links[0].linkTo}>
 									<SvgCrossword />
 								</a>
 							</li>
-							<TextTreat
-								text={treat.text}
-								linkTo={treat.linkTo}
-								borderColour={borderColour}
-							/>
+							{treat.links.map((link) => (
+								<TextTreat
+									text={link.text}
+									linkTo={link.linkTo}
+									borderColour={borderColour}
+								/>
+							))}
 						</>
 					);
 				}
 
-				if (treat.imageUrl && treat.altText) {
+				if (
+					treat.imageUrl &&
+					treat.altText &&
+					(treat.theme || treat.theme === 0) // ArticlePillar.News is zero
+				) {
+					const palette = decidePalette({
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: treat.theme,
+					});
 					return (
 						<ImageTreat
 							imageUrl={treat.imageUrl}
-							linkTo={treat.linkTo}
+							links={treat.links}
 							altText={treat.altText}
-							text={treat.text}
+							backgroundColour={palette.background.treat}
 						/>
 					);
 				}
 
 				return (
-					<TextTreat
-						text={treat.text}
-						linkTo={treat.linkTo}
-						borderColour={borderColour}
-					/>
+					<>
+						{treat.links.map((link) => (
+							<TextTreat
+								text={link.text}
+								linkTo={link.linkTo}
+								borderColour={borderColour}
+							/>
+						))}
+					</>
 				);
 			})}
 		</ul>

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import {
 	border,
 	headline,
+	neutral,
 	space,
 	textSans,
 } from '@guardian/source-foundations';
@@ -77,11 +78,11 @@ const ImageTreat = ({
 				<span
 					css={css`
 						${headline.xxxsmall({ fontWeight: 'bold' })};
-						background-color: #121212;
+						background-color: ${neutral[0]};
 						padding: 0 5px 4px;
 						box-decoration-break: clone;
 						position: relative;
-						color: #fff;
+						color: ${neutral[100]};
 					`}
 				>
 					{text}

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -139,7 +139,7 @@ export const Treats = ({
 				if (
 					treat.imageUrl &&
 					treat.altText &&
-					(treat.theme || treat.theme === 0) // ArticlePillar.News is zero
+					treat.theme !== undefined
 				) {
 					const palette = decidePalette({
 						display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -1,7 +1,95 @@
 import { css } from '@emotion/react';
-import { border, space, textSans } from '@guardian/source-foundations';
+import {
+	border,
+	headline,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import type { TreatType } from '../../types/front';
+import { SvgCrossword } from './SvgCrossword';
+
+const TextTreat = ({
+	text,
+	linkTo,
+	borderColour,
+}: {
+	text: string;
+	linkTo: string;
+	borderColour?: string;
+}) => (
+	<li
+		css={css`
+			margin-top: ${space[3]}px;
+			border-left: 1px solid ${borderColour ?? border.secondary};
+			border-top: 1px solid ${borderColour ?? border.secondary};
+			padding-top: ${space[1]}px;
+			padding-left: ${space[2]}px;
+		`}
+	>
+		<Link
+			priority="secondary"
+			subdued={true}
+			cssOverrides={css`
+				${textSans.xsmall()}
+			`}
+			href={linkTo}
+		>
+			{text}
+		</Link>
+	</li>
+);
+
+const ImageTreat = ({
+	imageUrl,
+	linkTo,
+	altText,
+	text,
+}: {
+	imageUrl: string;
+	linkTo: string;
+	altText?: string;
+	text: string;
+}) => (
+	<li>
+		<a
+			href={linkTo}
+			data-ignore="global-link-styling"
+			css={css`
+				text-decoration: none;
+				:hover {
+					/* We target the span from here like this so that hovering the image also
+					   adds the underline to the text */
+					span {
+						text-decoration: underline;
+					}
+				}
+			`}
+		>
+			<img src={imageUrl} alt={altText} width="130px" height="130px" />
+			<div
+				css={css`
+					margin-bottom: 8px;
+					display: block;
+					width: 80%;
+				`}
+			>
+				<span
+					css={css`
+						${headline.xxxsmall({ fontWeight: 'bold' })};
+						background-color: #121212;
+						padding: 0 5px 4px;
+						box-decoration-break: clone;
+						position: relative;
+						color: #fff;
+					`}
+				>
+					{text}
+				</span>
+			</div>
+		</a>
+	</li>
+);
 
 export const Treats = ({
 	treats,
@@ -19,29 +107,43 @@ export const Treats = ({
 			`}
 		>
 			{treats.map((treat) => {
+				if (treat.linkTo === '/crosswords' && treat.text) {
+					// Treats that link to /crosswords are special. If any
+					// treat has this exact url then an svg of a crossword
+					// is displayed above the text
+					return (
+						<>
+							<li>
+								<a href={treat.linkTo}>
+									<SvgCrossword />
+								</a>
+							</li>
+							<TextTreat
+								text={treat.text}
+								linkTo={treat.linkTo}
+								borderColour={borderColour}
+							/>
+						</>
+					);
+				}
+
+				if (treat.imageUrl && treat.altText) {
+					return (
+						<ImageTreat
+							imageUrl={treat.imageUrl}
+							linkTo={treat.linkTo}
+							altText={treat.altText}
+							text={treat.text}
+						/>
+					);
+				}
+
 				return (
-					<li
-						css={css`
-							margin-top: ${space[3]}px;
-							border-left: 1px solid
-								${borderColour ?? border.secondary};
-							border-top: 1px solid
-								${borderColour ?? border.secondary};
-							padding-top: ${space[1]}px;
-							padding-left: ${space[2]}px;
-						`}
-					>
-						<Link
-							priority="secondary"
-							subdued={true}
-							cssOverrides={css`
-								${textSans.xsmall()}
-							`}
-							href={treat.linkTo}
-						>
-							{treat.text}
-						</Link>
-					</li>
+					<TextTreat
+						text={treat.text}
+						linkTo={treat.linkTo}
+						borderColour={borderColour}
+					/>
 				);
 			})}
 		</ul>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -143,7 +143,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<main data-layout="FrontLayout">
 				{front.pressedPage.collections.map((collection, index) => {
-					// TODO: We also need to support treats containers
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(
 						collection.backfill,

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -165,7 +165,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								ophanComponentLink={ophanComponentLink}
 								ophanComponentName={ophanName}
 								containerName={collection.collectionType}
-								element="section"
 							>
 								<Snap snapData={trails[0].snapData} />
 							</Section>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -151,18 +151,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					// There are some containers that have zero trails. We don't want to render these
 					if (trails.length === 0) return null;
 
-					// This is a legacy container used to add palette styling on Frontend. DCR ignores it
-					if (
-						collection.displayName ===
-						'Palette styles new do not delete'
-					) {
-						return null;
-					}
-
 					const ophanName = ophanComponentId(collection.displayName);
-					const ophanComponentLink = `container-${
-						index + 1
-					} | ${ophanName}`;
+					const ophanComponentLink = `container-${index} | ${ophanName}`;
 
 					if (collection.collectionType === 'fixed/thrasher') {
 						return (
@@ -186,13 +176,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						<Section
 							key={collection.id}
 							title={collection.displayName}
-							// TODO: This logic should be updated, as this relies
-							// on the first container being 'palette styles do not delete'
-							showTopBorder={index > 1}
+							showTopBorder={index > 0}
 							padContent={false}
 							centralBorder="partial"
 							url={collection.href}
-							// same as above re 'palette styles' for index increment
 							ophanComponentLink={ophanComponentLink}
 							ophanComponentName={ophanName}
 							containerName={collection.collectionType}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1247,6 +1247,25 @@ const backgroundSummaryEventBullet = (format: ArticleFormat): string => {
 	}
 };
 
+const backgroundTreat = (format: ArticleFormat): string => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+	}
+};
+
 const hoverKeyEventLink = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.News:
@@ -1384,6 +1403,7 @@ export const decidePalette = (
 			filterButton: backgroundFilterButton(),
 			filterButtonHover: backgroundFilterButtonHover(format),
 			filterButtonActive: backgroundFilterButtonActive(format),
+			treat: backgroundTreat(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -44,7 +44,10 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 		...data,
 		pressedPage: {
 			...data.pressedPage,
-			collections: enhanceCollections(data.pressedPage.collections),
+			collections: enhanceCollections(
+				data.pressedPage.collections,
+				data.editionId,
+			),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -47,6 +47,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 			collections: enhanceCollections(
 				data.pressedPage.collections,
 				data.editionId,
+				data.pageId,
 			),
 		},
 	};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the `PLATFORM_TREATS` pattern which offers the ability to control treats from within the DCR platform.

To add a new treat you only need to edit the value of `PLATFORM_TREATS` in the [enhanceTreats.ts](https://github.com/guardian/dotcom-rendering/compare/oliver/platform-treats?expand=1#diff-e5ce3bd6173d3c49874329ef2365cee9f0305f48a9123489569cc746f284163e) file. Treats will be inserted in every container that has the same `displayName` value, you can optionally also filter further using `editionId` and `pageId`

If more than one link is passed in the `links` array then this will be shown underneath and the background colour will alternate between black and piller 300.

### What about that little Don't Miss arrow thing?
This arrow is an additional image which was positioned alongside the main one using the thrasher code. I'm removing this here for now as I don't think the complexity of supporting two images and deciding when to show the arrow image or not is justified. Perhaps we can put the arrow into the main image?

### What about image width, will it always be 130 pixels?
This width seems to work for the use cases I can see at the moment but if we need more flexibility in the future we could add `imageWidth` and `imageHeight` to `TreatType` and allow this to be specified

## Why?
This PR replaces #5704. Rather than trying to support the existing treats by adding brittle contracts this PR creates a platform based solution that does not have any external dependencies.

### Alternatives
Another solution would be to configure these treats using the fronts tool. This is preferable because it gives the greatest control and flexibility and avoids having to use `displayName` to target containers and avoids the need to merge PRs to make changes. The work in this PR should be seen a step towards this; in the event the tools were to offer this ability then so long as we keep the same model then no (or very few) changes would be needed in DCR

| Before      | After      |
|-------------|------------|
| <img width="776" alt="Screenshot 2022-08-16 at 10 09 20" src="https://user-images.githubusercontent.com/1336821/184842622-2dee5105-e63f-439f-b9b9-ae13182fd76f.png"> | <img width="766" alt="Screenshot 2022-08-17 at 17 01 53" src="https://user-images.githubusercontent.com/1336821/185188040-145eb356-8d26-4f9e-8b87-915cd7febbe2.png"> |
