### PR TITLE
Remove legacy key events container from live layout

### DIFF
--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -31,8 +31,6 @@ type Props = {
  * @param {ArticleFormat} props.format - The format model for the article
  * */
 export const Article = ({ CAPIArticle, NAV, format }: Props) => {
-	const showKeyEventsCarousel = CAPIArticle.config.switches.keyEventsCarousel;
-
 	return (
 		<StrictMode>
 			<Global
@@ -52,14 +50,7 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 			<SkipTo id="navigation" label="Skip to navigation" />
 			{(format.design === ArticleDesign.LiveBlog ||
 				format.design === ArticleDesign.DeadBlog) && (
-				<SkipTo
-					id={
-						showKeyEventsCarousel
-							? 'key-events-carousel'
-							: 'keyevents'
-					}
-					label="Skip to key events"
-				/>
+				<SkipTo id={'key-events-carousel'} label="Skip to key events" />
 			)}
 			<Island clientOnly={true} deferUntil="idle">
 				<AlreadyVisited />

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -32,7 +32,6 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
-	showKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
 };
@@ -117,7 +116,6 @@ export const ArticleBody = ({
 	onFirstPage,
 	keyEvents,
 	filterKeyEvents,
-	showKeyEventsCarousel,
 	availableTopics,
 	selectedTopics,
 }: Props) => {
@@ -167,7 +165,6 @@ export const ArticleBody = ({
 						onFirstPage={onFirstPage}
 						keyEvents={keyEvents}
 						filterKeyEvents={filterKeyEvents}
-						isKeyEventsCarousel={showKeyEventsCarousel}
 						availableTopics={availableTopics}
 						selectedTopics={selectedTopics}
 					/>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -916,9 +916,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
 													}
-													showKeyEventsCarousel={
-														showKeyEventsCarousel
-													}
 													availableTopics={
 														CAPIArticle.availableTopics
 													}
@@ -1069,9 +1066,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													}
 													filterKeyEvents={
 														CAPIArticle.filterKeyEvents
-													}
-													showKeyEventsCarousel={
-														showKeyEventsCarousel
 													}
 													availableTopics={
 														CAPIArticle.availableTopics

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -303,16 +303,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.config.switches.automaticFilters &&
 		CAPIArticle.availableTopics;
 
-	/*
-	The topic bank on desktop will be positioned where we currently show the key events container.
-	This is dependent on a change made in PR #4896 [https://github.com/guardian/dotcom-rendering/pull/4896] where the key events container will be removed from the left column.
-	This change currently lives behind the key-events-carousel A/B test.
-	Until this change is moved from behind the a/b test, we need to add an additional condition
-	here to see if the user is within this test, meaning we can therefore position the filter bank in the empty space.
-	Once the key-event-carousel test is completed and this change is productionised, we can remove the final `showKeyEventsCarousel` condition.
-	*/
-	const showTopicFilterBank =
-		CAPIArticle.config.switches.automaticFilters && showKeyEventsCarousel;
+	const showTopicFilterBank = CAPIArticle.config.switches.automaticFilters;
 
 	const showToggle = !showTopicFilterBank || !CAPIArticle.availableTopics;
 
@@ -833,21 +824,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									)}
 									{isInFilteringBeta ? (
 										<div css={paddingBody}>
-											{!showKeyEventsCarousel &&
-											CAPIArticle.keyEvents.length ? (
-												<Hide above="desktop">
-													<Island deferUntil="visible">
-														<FilterKeyEventsToggle
-															filterKeyEvents={
-																CAPIArticle.filterKeyEvents
-															}
-															id="filter-toggle-mobile"
-														/>
-													</Island>
-												</Hide>
-											) : (
-												<></>
-											)}
 											<ArticleContainer format={format}>
 												{pagination.currentPage !==
 													1 && (
@@ -1002,21 +978,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											accordionTitle="Live feed"
 											context="liveFeed"
 										>
-											{!showKeyEventsCarousel &&
-											CAPIArticle.keyEvents.length ? (
-												<Hide above="desktop">
-													<Island deferUntil="visible">
-														<FilterKeyEventsToggle
-															filterKeyEvents={
-																CAPIArticle.filterKeyEvents
-															}
-															id="filter-toggle-mobile"
-														/>
-													</Island>
-												</Hide>
-											) : (
-												<></>
-											)}
 											<ArticleContainer format={format}>
 												{pagination.currentPage !==
 													1 && (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -41,7 +41,6 @@ import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { KeyEventsCarousel } from '../components/KeyEventsCarousel.importable';
-import { KeyEventsContainer } from '../components/KeyEventsContainer';
 import { Liveness } from '../components/Liveness.importable';
 import { MainMedia } from '../components/MainMedia';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
@@ -773,24 +772,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										/>
 									</div>
 								</Hide>
-								{/* Key events */}
-								{!showKeyEventsCarousel && (
-									<div
-										css={[
-											!footballMatchUrl && sticky,
-											keyEventsMargins,
-											sidePaddingDesktop,
-										]}
-									>
-										<KeyEventsContainer
-											format={format}
-											keyEvents={CAPIArticle.keyEvents}
-											filterKeyEvents={
-												CAPIArticle.filterKeyEvents
-											}
-										/>
-									</div>
-								)}
 
 								{showTopicFilterBank &&
 									CAPIArticle.availableTopics && (

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -198,21 +198,6 @@ const maxWidth = css`
 	}
 `;
 
-const sticky = css`
-	${from.desktop} {
-		position: sticky;
-		top: 10px;
-	}
-`;
-
-const keyEventsMargins = css`
-	margin-bottom: ${space[3]}px;
-	${from.desktop} {
-		margin-top: ${space[1]}px;
-		margin-bottom: 0;
-	}
-`;
-
 const sidePaddingDesktop = css`
 	${from.desktop} {
 		padding-left: ${space[5]}px;

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -29,7 +29,6 @@ type Props = {
 	onFirstPage?: boolean;
 	keyEvents?: Block[];
 	filterKeyEvents?: boolean;
-	isKeyEventsCarousel?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
 };
@@ -55,7 +54,6 @@ export const LiveBlogRenderer = ({
 	onFirstPage,
 	keyEvents,
 	filterKeyEvents = false,
-	isKeyEventsCarousel = false,
 	availableTopics,
 	selectedTopics,
 }: Props) => {
@@ -87,7 +85,7 @@ export const LiveBlogRenderer = ({
 					</PinnedPost>
 				</>
 			)}
-			{isKeyEventsCarousel && keyEvents?.length ? (
+			{switches.keyEventsCarousel && keyEvents?.length ? (
 				<Hide above="desktop">
 					<Island deferUntil="visible">
 						<KeyEventsCarousel


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the key events container as the key events carousel is now production ready.  It also removes the switch to show the key events toggle in its old position on mobile and refactors the live blog renderer to remove unnecessary prop drilling and use the switches property instead.
## Why?
When we were testing the key events carousel in production, we kept the previous key events container in the live layout behind the key events carousel switch. This is no longer needed as the carousel is production ready.
