### PR TITLE
Feat: Hardcode "Analysis" title above standfirst on DCR

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -16,6 +16,23 @@ type Props = {
 	standfirst: string;
 };
 
+const titleStyles = (format: ArticleFormat, palette: Palette) => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return css`
+			${headline.xsmall({
+				fontWeight: 'light',
+			})};
+			padding-top: ${space[4]}px;
+			color: ${palette.text.standfirst};
+		`;
+	}
+	return css`
+		${headline.xxxsmall({
+			fontWeight: 'bold',
+		})};
+	`;
+};
+
 const nestedStyles = (format: ArticleFormat, palette: Palette) => {
 	const offset = format.display === ArticleDisplay.Immersive ? space[6] : 19;
 	return css`
@@ -88,6 +105,23 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						line-height: 22px;
 						max-width: 540px;
 						color: ${palette.text.standfirst};
+					`;
+				case ArticleDesign.Analysis:
+					return css`
+						${format.theme === ArticleSpecial.Labs
+							? textSans.medium()
+							: headline.xsmall({
+									fontWeight: 'light',
+							  })};
+						max-width: 280px;
+						${from.tablet} {
+							max-width: 460px;
+						}
+						color: ${palette.text.standfirst};
+						li:before {
+							height: 17px;
+							width: 17px;
+						}
 					`;
 				default:
 					return css`
@@ -199,15 +233,7 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 	return (
 		<>
 			{format.design === ArticleDesign.Analysis && (
-				<p
-					css={css`
-						${headline.xxxsmall({
-							fontWeight: 'bold',
-						})};
-					`}
-				>
-					Analysis
-				</p>
+				<p css={titleStyles(format, palette)}>Analysis</p>
 			)}
 			<div
 				css={[

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -193,19 +193,21 @@ const hoverStyles = (palette: Palette) => {
 	`;
 };
 
-const titleStyles = css`
-	${headline.xxxsmall({
-		fontWeight: 'bold',
-	})};
-`;
-
 export const Standfirst = ({ format, standfirst }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
 		<>
 			{format.design === ArticleDesign.Analysis && (
-				<p css={titleStyles}>Analysis</p>
+				<p
+					css={css`
+						${headline.xxxsmall({
+							fontWeight: 'bold',
+						})};
+					`}
+				>
+					Analysis
+				</p>
 			)}
 			<div
 				css={[

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -193,36 +193,47 @@ const hoverStyles = (palette: Palette) => {
 	`;
 };
 
+const titleStyles = css`
+	${headline.xxxsmall({
+		fontWeight: 'bold',
+	})};
+`;
+
 export const Standfirst = ({ format, standfirst }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
-		<div
-			css={[
-				nestedStyles(format, palette),
-				standfirstStyles(format, palette),
-				hoverStyles(palette),
-			]}
-			className={
-				format.design === ArticleDesign.Interactive
-					? interactiveLegacyClasses.standFirst
-					: ''
-			}
-			dangerouslySetInnerHTML={{
-				__html: sanitise(standfirst, {
-					allowedTags: false, // Leave tags from CAPI alone
-					allowedAttributes: false, // Leave attributes from CAPI alone
-					transformTags: {
-						a: (tagName, attribs) => ({
-							tagName, // Just return anchors as is
-							attribs: {
-								...attribs, // Merge into the existing attributes
-								'data-link-name': 'in standfirst link', // Add the data-link-name for Ophan to anchors
-							},
-						}),
-					},
-				}),
-			}}
-		/>
+		<>
+			{format.design === ArticleDesign.Analysis && (
+				<p css={titleStyles}>Analysis</p>
+			)}
+			<div
+				css={[
+					nestedStyles(format, palette),
+					standfirstStyles(format, palette),
+					hoverStyles(palette),
+				]}
+				className={
+					format.design === ArticleDesign.Interactive
+						? interactiveLegacyClasses.standFirst
+						: ''
+				}
+				dangerouslySetInnerHTML={{
+					__html: sanitise(standfirst, {
+						allowedTags: false, // Leave tags from CAPI alone
+						allowedAttributes: false, // Leave attributes from CAPI alone
+						transformTags: {
+							a: (tagName, attribs) => ({
+								tagName, // Just return anchors as is
+								attribs: {
+									...attribs, // Merge into the existing attributes
+									'data-link-name': 'in standfirst link', // Add the data-link-name for Ophan to anchors
+								},
+							}),
+						},
+					}),
+				}}
+			/>
+		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hardcode an analysis title above standfirst when article design is analysis.

It also adds styling variations to the standfirst when it is immersive.
## Why?
This aligns with the new editorial designs

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/184864420-58186a78-41eb-4cb9-9ceb-484eeccc28e6.png
[after]: https://user-images.githubusercontent.com/20416599/184864429-f1085ad2-344c-451a-b061-9b08a96521e5.png


Immersive Variant
| Before      | After      |
|-------------|------------|
| ![before-immersive][] | ![after-immersive][] |

[before-immersive]: https://user-images.githubusercontent.com/20416599/184870821-f52c270e-d4bd-419f-8a76-c9729c5bcd5c.png
[after-immersive]: https://user-images.githubusercontent.com/20416599/184870835-1a3a6ebd-cad7-4bf7-9d8c-9c4e648a29a5.png



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
