### PR TITLE
remove underline from header in analysis design

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -96,12 +96,6 @@ const lightFont = css`
 `;
 
 const underlinedStyles = (colour: string) => css`
-	background-image: repeating-linear-gradient(
-		to bottom,
-		transparent,
-		transparent 47px,
-		${colour}
-	);
 	line-height: 48px;
 	background-size: 1rem 48px;
 	${until.tablet} {

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -491,7 +491,6 @@ export const ArticleHeadline = ({
 			switch (format.design) {
 				case ArticleDesign.Review:
 				case ArticleDesign.Recipe:
-
 				case ArticleDesign.Feature:
 					return (
 						<div

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -95,25 +95,6 @@ const lightFont = css`
 	}
 `;
 
-const underlinedStyles = (colour: string) => css`
-	line-height: 48px;
-	background-size: 1rem 48px;
-	${until.tablet} {
-		background-image: repeating-linear-gradient(
-			to bottom,
-			transparent,
-			transparent 39px,
-			${colour}
-		);
-		line-height: 40px;
-		background-size: 1px 40px;
-	}
-
-	background-position: top left;
-	background-clip: content-box;
-	background-origin: content-box;
-`;
-
 const displayBlock = css`
 	display: block;
 `;
@@ -510,6 +491,7 @@ export const ArticleHeadline = ({
 			switch (format.design) {
 				case ArticleDesign.Review:
 				case ArticleDesign.Recipe:
+
 				case ArticleDesign.Feature:
 					return (
 						<div
@@ -627,12 +609,8 @@ export const ArticleHeadline = ({
 							>
 								<h1
 									css={[
-										standardFont,
+										boldFont,
 										topPadding,
-										underlinedStyles(
-											palette.background
-												.analysisUnderline,
-										),
 										css`
 											color: ${palette.text.headline};
 										`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR removed the article header underline styling in non-immersive analysis articles, and make header font bold.

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="727" alt="image" src="https://user-images.githubusercontent.com/15894063/184869449-1c21fd22-ec7a-4a0a-b395-88ae63428657.png"> | <img width="727" alt="image" src="https://user-images.githubusercontent.com/15894063/184869344-0c8b0ef5-f012-4d7e-9f00-4293a861ed20.png"> |
