### PR TITLE
Bump Snyk Action Node Version

### DIFF
--- a/.github/workflows/ar-snyk.yml
+++ b/.github/workflows/ar-snyk.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x]
+                node-version: [14.x]
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
## Why?

Use a more recent Node version.
