### PR TITLE
Analysis byline

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -646,6 +646,13 @@ export const ArticleHeadline = ({
 								>
 									{curly(headlineString)}
 								</h1>
+								{!!byline && (
+									<HeadlineByline
+										format={format}
+										byline={byline}
+										tags={tags}
+									/>
+								)}
 							</WithAgeWarning>
 						</div>
 					);

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -231,6 +231,7 @@ const shouldShowContributor = (format: ArticleFormat) => {
 			switch (format.design) {
 				case ArticleDesign.Comment:
 				case ArticleDesign.Editorial:
+				case ArticleDesign.Analysis:
 					return false;
 				default:
 					return true;

--- a/dotcom-rendering/src/web/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/web/components/BylineLink.test.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { render } from '@testing-library/react';
 import { getContributorTagsForToken } from '../../lib/byline';
 import { bylineAsTokens, BylineLink } from './BylineLink';
@@ -87,7 +88,15 @@ describe('BylineLink', () => {
 		];
 
 		const { container } = render(
-			<BylineLink byline={byline} tags={tags} />,
+			<BylineLink
+				byline={byline}
+				tags={tags}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+			/>,
 		);
 
 		const links = container.querySelectorAll('a');
@@ -112,7 +121,15 @@ describe('BylineLink', () => {
 			},
 		];
 		const { container } = render(
-			<BylineLink byline={byline} tags={tags} />,
+			<BylineLink
+				byline={byline}
+				tags={tags}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+			/>,
 		);
 
 		const links = container.querySelectorAll('a');
@@ -139,7 +156,15 @@ describe('BylineLink', () => {
 		];
 
 		const { container } = render(
-			<BylineLink byline={byline} tags={tags} />,
+			<BylineLink
+				byline={byline}
+				tags={tags}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+			/>,
 		);
 
 		const links = container.querySelectorAll('a');

--- a/dotcom-rendering/src/web/components/BylineLink.tsx
+++ b/dotcom-rendering/src/web/components/BylineLink.tsx
@@ -1,8 +1,10 @@
+import { ArticleDesign } from '@guardian/libs';
 import { getBylineComponentsFromTokens, isContributor } from '../../lib/byline';
 
 type Props = {
 	byline: string;
 	tags: TagType[];
+	format: ArticleFormat;
 };
 
 const applyCleverOrderingForMatching = (titles: string[]): string[] => {
@@ -59,10 +61,13 @@ export const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
 	return byline.split(regex);
 };
 
-const ContributorLink: React.FC<{
+const ContributorLink = ({
+	contributor,
+	contributorTagId,
+}: {
 	contributor: string;
 	contributorTagId: string;
-}> = ({ contributor, contributorTagId }) => (
+}) => (
 	<a
 		rel="author"
 		data-link-name="auto tag link"
@@ -72,14 +77,23 @@ const ContributorLink: React.FC<{
 	</a>
 );
 
-export const BylineLink = ({ byline, tags }: Props) => {
+function removeComma(bylinePart: string) {
+	return bylinePart.startsWith(',')
+		? bylinePart.slice(1).trimStart()
+		: bylinePart;
+}
+
+export const BylineLink = ({ byline, tags, format }: Props) => {
 	const tokens = bylineAsTokens(byline, tags);
 
 	const bylineComponents = getBylineComponentsFromTokens(tokens, tags);
-
 	const renderedTokens = bylineComponents.map((bylineComponent) => {
 		if (typeof bylineComponent === 'string') {
-			return bylineComponent;
+			const displayString =
+				format.design === ArticleDesign.Analysis
+					? removeComma(bylineComponent)
+					: bylineComponent;
+			return displayString ? <span>{displayString}</span> : null;
 		}
 		return (
 			<ContributorLink

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -132,7 +132,7 @@ export const Contributor = ({ byline, tags, format }: Props) => {
 						bylineColorStyles(palette, format),
 					]}
 				>
-					<BylineLink byline={byline} tags={tags} />
+					<BylineLink byline={byline} tags={tags} format={format} />
 				</div>
 			)}
 			{!!twitterHandle && (

--- a/dotcom-rendering/src/web/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineByline.tsx
@@ -4,6 +4,7 @@ import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
 	brandAltBackground,
 	headline,
+	neutral,
 	space,
 	textSans,
 	until,
@@ -74,6 +75,35 @@ const opinionStyles = (palette: Palette, format: ArticleFormat) => css`
 	}
 `;
 
+const analysisStyles = (palette: Palette) => css`
+	${headline.medium({
+		fontWeight: 'light',
+	})}
+	line-height: 38px;
+	display: flex;
+	flex-direction: column;
+	font-style: italic;
+	color: ${palette.text.headlineByline};
+	background: ${palette.background.headlineByline};
+
+	${until.mobileMedium} {
+		${headline.small({
+			fontWeight: 'light',
+		})}
+	}
+
+	a {
+		color: inherit;
+		text-decoration: none;
+		:hover {
+			text-decoration: underline;
+		}
+	}
+	span {
+		color: ${neutral[46]};
+	}
+`;
+
 const immersiveStyles = (format: ArticleFormat) => css`
 	${format.theme === ArticleSpecial.Labs
 		? textSans.large({ lineHeight: 'tight' })
@@ -125,7 +155,11 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				<div css={immersiveStyles(format)}>
 					by{' '}
 					<span css={immersiveLinkStyles(palette, format)}>
-						<BylineLink byline={byline} tags={tags} />
+						<BylineLink
+							byline={byline}
+							tags={tags}
+							format={format}
+						/>
 					</span>
 				</div>
 			);
@@ -138,7 +172,11 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 					return (
 						<div css={wrapperStyles}>
 							<div css={yellowBoxStyles(format)}>
-								<BylineLink byline={byline} tags={tags} />
+								<BylineLink
+									byline={byline}
+									tags={tags}
+									format={format}
+								/>
 							</div>
 						</div>
 					);
@@ -153,7 +191,23 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 							]}
 						>
 							<div css={opinionStyles(palette, format)}>
-								<BylineLink byline={byline} tags={tags} />
+								<BylineLink
+									byline={byline}
+									tags={tags}
+									format={format}
+								/>
+							</div>
+						</div>
+					);
+				case ArticleDesign.Analysis:
+					return (
+						<div css={opinionWrapperStyles}>
+							<div css={analysisStyles(palette)}>
+								<BylineLink
+									byline={byline}
+									tags={tags}
+									format={format}
+								/>
 							</div>
 						</div>
 					);

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -161,6 +161,8 @@ const textByline = (format: ArticleFormat): string => {
 };
 
 const textHeadlineByline = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.Analysis)
+		return pillarPalette[format.theme].main;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
@@ -616,6 +618,7 @@ const backgroundAgeWarning = (format: ArticleFormat): string => {
 };
 
 const backgroundHeadlineByline = (format: ArticleFormat): string => {
+	if (format.design === ArticleDesign.Analysis) return 'transparent';
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
 	return 'transparent';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds a new style of byline especially for `Design.Analysis`

## Why?
This is part of a wider effort to redesign these articles


| Before      | After      |
|-------------|------------|
| <img width="941" alt="Screenshot 2022-08-16 at 14 28 52" src="https://user-images.githubusercontent.com/1336821/184891503-eb0c53a4-1937-49e0-bb1d-3b4bf7e73578.png"> | <img width="941" alt="Screenshot 2022-08-16 at 14 26 42" src="https://user-images.githubusercontent.com/1336821/184891198-02729ae5-7705-4fe3-b1ae-215caf70629c.png"> |
