### PR TITLE
Remove underline styles from card headlines

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -120,7 +120,7 @@ export const Analysis = () => (
 		</Section>
 	</>
 );
-Analysis.story = { name: 'Analysis (Underline)' };
+Analysis.story = { name: 'Analysis' };
 
 export const Feature = () => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable default-case */
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
+import { ArticleSpecial } from '@guardian/libs';
 import type { FontScaleArgs, FontWeight } from '@guardian/source-foundations';
 import {
 	between,
@@ -152,52 +151,6 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 	}
 };
 
-const underlinedStyles = (size: SmallHeadlineSize, colour: string) => {
-	function underlinedCss(baseSize: number) {
-		return css`
-			background-image: linear-gradient(
-				to bottom,
-				transparent,
-				transparent ${baseSize - 1}px,
-				${colour}
-			);
-			line-height: ${baseSize}px;
-			background-size: 1px ${baseSize}px;
-			background-origin: content-box;
-			background-clip: content-box;
-			margin-right: -5px;
-		`;
-	}
-
-	function underlinedCssWithMediaQuery(
-		baseSize: number,
-		untilDesktopSize: number,
-	) {
-		return css`
-			${until.desktop} {
-				${underlinedCss(untilDesktopSize)}
-			}
-
-			${underlinedCss(baseSize)}
-		`;
-	}
-
-	switch (size) {
-		case 'ginormous':
-			return underlinedCssWithMediaQuery(50, 50);
-		case 'huge':
-			return underlinedCssWithMediaQuery(34, 34);
-		case 'large':
-			return underlinedCssWithMediaQuery(29, 29);
-		case 'medium':
-			return underlinedCssWithMediaQuery(25, 25);
-		case 'small':
-			return underlinedCss(22);
-		case 'tiny':
-			return underlinedCss(24);
-	}
-};
-
 const lineStyles = (palette: Palette) => css`
 	padding-top: 1px;
 	:before {
@@ -225,7 +178,7 @@ const WithLink = ({
 				subdued={true}
 				cssOverrides={css`
 					/* See: https://css-tricks.com/nested-links/ */
-					${getZIndex('card-nested-link')};
+					${getZIndex('card-nested-link')}
 					/* The following styles turn off those provided by Link */
 					color: inherit;
 					/* stylelint-disable-next-line property-disallowed-list */
@@ -284,15 +237,9 @@ export const CardHeadline = ({
 						  }),
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
-							size: sizeOnMobile || size,
+							size: sizeOnMobile ?? size,
 							fontWeight: containerPalette ? 'bold' : 'regular',
 						}),
-					format.design === ArticleDesign.Analysis &&
-						!containerPalette &&
-						underlinedStyles(
-							size,
-							palette.background.analysisUnderline,
-						),
 					showLine && lineStyles(palette),
 				]}
 			>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes the underline styling from card headlines on `Analysis` pieces

## Why?
This is part of a wider effort to redesign Analysis articles

| Before      | After      |
|-------------|------------|
| <img width="641" alt="Screenshot 2022-08-16 at 14 55 27" src="https://user-images.githubusercontent.com/1336821/184897491-356f3035-425c-4ebe-b26d-3f713e6f7570.png"> | <img width="630" alt="Screenshot 2022-08-16 at 14 53 52" src="https://user-images.githubusercontent.com/1336821/184897150-501339bf-fe72-42ca-9186-f82724215d72.png"> |