### PR TITLE
AR analysis design tweaks

### DIFF
--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -12,9 +12,13 @@ import { articleWidthStyles, darkModeCss } from 'styles';
 
 export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 	const baseStyles = css`
-		${standardFont}
+		${headline.small()}
 		color: ${text.headline(format)};
 		margin: 0;
+
+		${from.tablet} {
+			${headline.medium()}
+		}
 
 		${darkModeCss`
 			color: ${text.headlineDark(format)};
@@ -57,14 +61,7 @@ interface DefaultProps {
 	styles: SerializedStyles;
 }
 
-export const standardFont = css`
-	${headline.small()};
-	${from.tablet} {
-		${headline.medium()};
-	}
-`;
-
-export const boldFont = css`
+const boldFont = css`
 	${headline.small({ fontWeight: 'bold' })};
 	${from.tablet} {
 		${headline.medium({ fontWeight: 'bold' })};

--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -12,13 +12,9 @@ import { articleWidthStyles, darkModeCss } from 'styles';
 
 export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 	const baseStyles = css`
-		${headline.small()}
+		${standardFont}
 		color: ${text.headline(format)};
 		margin: 0;
-
-		${from.tablet} {
-			${headline.medium()}
-		}
 
 		${darkModeCss`
 			color: ${text.headlineDark(format)};
@@ -30,6 +26,18 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 			return css`
 				${baseStyles}
 				padding-bottom: ${remSpace[1]};
+			`;
+		case ArticleDesign.Analysis:
+			return css`
+				${baseStyles}
+				${articleWidthStyles}
+				${boldFont}
+				background-color: ${background.headline(format)};
+				padding-bottom: ${remSpace[6]};
+
+				${darkModeCss`
+					background-color: ${background.headlineDark(format)};
+				`}
 			`;
 		default:
 			return css`
@@ -48,6 +56,20 @@ interface DefaultProps {
 	item: Item;
 	styles: SerializedStyles;
 }
+
+export const standardFont = css`
+	${headline.small()};
+	${from.tablet} {
+		${headline.medium()};
+	}
+`;
+
+export const boldFont = css`
+	${headline.small({ fontWeight: 'bold' })};
+	${from.tablet} {
+		${headline.medium({ fontWeight: 'bold' })};
+	}
+`;
 
 export const DefaultHeadline: React.FC<DefaultProps> = ({ item, styles }) => (
 	<h1 css={styles}>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -2,13 +2,9 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
-import {
-	background,
-	breakpoints,
-	from,
-	neutral,
-} from '@guardian/source-foundations';
+import { background } from '@guardian/common-rendering/src/editorialPalette';
+import { ArticleDesign, ArticleFormat, ArticlePillar } from '@guardian/libs';
+import { breakpoints, from } from '@guardian/source-foundations';
 import {
 	DottedLines,
 	StraightLines,
@@ -44,19 +40,15 @@ import {
 import { themeToPillarString } from 'themeStyles';
 
 // ----- Styles ----- //
+const backgroundStyles = (format: ArticleFormat): SerializedStyles => css`
+	background-color: ${background.articleContent(format)};
 
-const Styles = css`
-	background: ${neutral[97]};
-`;
-
-const DarkStyles = darkModeCss`
-    background: ${background.inverse};
+	${darkModeCss`
+        background-color: ${background.articleContentDark(format)}
+    `}
 `;
 
 const BorderStyles = css`
-	background: ${neutral[100]};
-	${darkModeCss`background: ${background.inverse};`}
-
 	${from.wide} {
 		width: ${breakpoints.wide}px;
 		margin: 0 auto;
@@ -82,6 +74,7 @@ interface Props {
 }
 
 const StandardLayout: FC<Props> = ({ item, children }) => {
+	const format = getFormat(item);
 	// client side code won't render an Epic if there's an element with this id
 	const epicContainer = item.shouldHideReaderRevenue ? null : (
 		<div css={articleWidthStyles}>
@@ -108,7 +101,7 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 	const matchScores = 'football' in item ? item.football : none;
 
 	return (
-		<main css={[Styles, DarkStyles]}>
+		<main css={backgroundStyles(format)}>
 			<article className="js-article" css={BorderStyles}>
 				{maybeRender(matchScores, (scores) => (
 					<div id="js-football-scores">

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -73,6 +73,8 @@ const headline = (format: ArticleFormat): Colour => {
 		return neutral[10];
 	} else if (format.design === ArticleDesign.Interview) {
 		return neutral[0];
+	} else if (format.design === ArticleDesign.Analysis) {
+		return news[800];
 	}
 
 	return neutral[100];
@@ -180,6 +182,10 @@ const richLinkSvgDark = (format: ArticleFormat): Colour => {
 const standfirst = ({ design, theme }: ArticleFormat): Colour => {
 	if (design === ArticleDesign.DeadBlog) {
 		return neutral[93];
+	}
+
+	if (design === ArticleDesign.Analysis) {
+		return news[800];
 	}
 
 	if (design === ArticleDesign.LiveBlog) {
@@ -581,6 +587,15 @@ const footer = (_format: ArticleFormat): Colour => neutral[97];
 
 const footerDark = (_format: ArticleFormat): Colour => neutral[0];
 
+const articleContent = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Analysis:
+			return news[800];
+		default:
+			return neutral[100];
+	}
+};
+
 // ----- API ----- //
 
 const background = {
@@ -624,6 +639,7 @@ const background = {
 	tag,
 	tagDark,
 	pinnedPost,
+	articleContent,
 };
 
 // ----- Exports ----- //


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR makes AR headline bold in Standard Analysis articles. 
It also changes the background colour for the Analysis articles. 

This is part of work for the Editorial Design team detailed here: https://docs.google.com/document/d/1MqSldxfgR86kOJaXTFNaBs5LzPzSa7jC4D4YwqqMFwg/edit# 

Note:
Background colour is always news[800] for light mode no matter which pillar. and is always the 1A1A1A for dark mode which is neutral[10]

TODO: 
The background colour of the tag items at the bottom of article also needs to change. 
## Why?
This is part of the changes requested by the Editorial Design team. 
## Screenshots




| Before      | After      |
|-------------|------------|
| <img width="1056" alt="image" src="https://user-images.githubusercontent.com/15894063/184928673-b993623b-1ff5-4fd6-8b07-3e36354d3f6f.png"> | <img width="1056" alt="image" src="https://user-images.githubusercontent.com/15894063/184928538-9aff13c1-a7a4-4cc0-aad3-c93855536e5f.png"> |
