### PR TITLE
AR: Create Analysis standfirst

### DIFF
--- a/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
@@ -8,6 +8,12 @@ interface Props {
 	item: Item;
 }
 
+const analysisStandfirstStyles = css`
+	${headline.xxxsmall()}
+	p:first-child {
+		padding-top: 0;
+	}
+`;
 const AnalysisStandfirst: React.FC<Props> = ({ item }) => (
 	<>
 		<p
@@ -19,14 +25,7 @@ const AnalysisStandfirst: React.FC<Props> = ({ item }) => (
 		</p>
 		<DefaultStandfirst
 			item={item}
-			css={css(
-				defaultStyles(getFormat(item)),
-				css`
-					p:first-child {
-						padding-top: 0;
-					}
-				`,
-			)}
+			css={css(defaultStyles(getFormat(item)), analysisStandfirstStyles)}
 		/>
 	</>
 );

--- a/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+import { headline } from '@guardian/source-foundations';
+import type { Item } from 'item';
+import { getFormat } from 'item';
+import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
+
+interface Props {
+	item: Item;
+}
+
+const AnalysisStandfirst: React.FC<Props> = ({ item }) => (
+	<>
+		<p
+			css={css`
+				${headline.xxxsmall({ fontWeight: 'bold' })}
+			`}
+		>
+			Analysis
+		</p>
+		<DefaultStandfirst
+			item={item}
+			css={css(defaultStyles(getFormat(item)))}
+		/>
+	</>
+);
+
+export default AnalysisStandfirst;

--- a/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
@@ -8,7 +8,7 @@ interface Props {
 	item: Item;
 }
 
-const analysisStandfirstStyles = css`
+const styles = css`
 	${headline.xxxsmall()}
 	p:first-child {
 		padding-top: 0;
@@ -25,7 +25,7 @@ const AnalysisStandfirst: React.FC<Props> = ({ item }) => (
 		</p>
 		<DefaultStandfirst
 			item={item}
-			css={css(defaultStyles(getFormat(item)), analysisStandfirstStyles)}
+			css={css(defaultStyles(getFormat(item)), styles)}
 		/>
 	</>
 );

--- a/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/AnalysisStandfirst.tsx
@@ -19,7 +19,14 @@ const AnalysisStandfirst: React.FC<Props> = ({ item }) => (
 		</p>
 		<DefaultStandfirst
 			item={item}
-			css={css(defaultStyles(getFormat(item)))}
+			css={css(
+				defaultStyles(getFormat(item)),
+				css`
+					p:first-child {
+						padding-top: 0;
+					}
+				`,
+			)}
 		/>
 	</>
 );

--- a/apps-rendering/src/components/Standfirst/Standfirst.stories.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.stories.tsx
@@ -7,6 +7,7 @@ import {
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import {
+	analysis,
 	article,
 	articleWithStandfirstLink,
 	comment,
@@ -17,6 +18,7 @@ import { deadBlog } from 'fixtures/live';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from './';
+import AnalysisStandfirst from './AnalysisStandfirst';
 
 // ----- Stories ----- //
 
@@ -100,6 +102,18 @@ const Deadblog = (): ReactElement => {
 	);
 };
 
+const Analysis = (): ReactElement => (
+	<AnalysisStandfirst
+		item={{
+			...analysis,
+			display: boolean('Immersive', false)
+				? ArticleDisplay.Immersive
+				: ArticleDisplay.Standard,
+			theme: selectPillar(ArticlePillar.Culture),
+		}}
+	/>
+);
+
 // ----- Exports ----- //
 
 export default {
@@ -108,4 +122,4 @@ export default {
 	decorators: [withKnobs],
 };
 
-export { Default, Review, Feature, Comment, Link, Deadblog };
+export { Default, Review, Feature, Comment, Link, Deadblog, Analysis };

--- a/apps-rendering/src/components/Standfirst/index.tsx
+++ b/apps-rendering/src/components/Standfirst/index.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { Item } from 'item';
 import { getFormat } from 'item';
+import AnalysisStandfirst from './AnalysisStandfirst';
 import DeadBlogStandfirst from './DeadBlogStandfirst';
 import GalleryStandfirst from './GalleryStandfirst';
 import ImmersiveLabsStandfirst from './ImmersiveLabsStandfirst';
@@ -60,6 +61,8 @@ const Standfirst: React.FC<Props> = ({ item }) => {
 			return <ReviewStandfirst item={item} />;
 		case ArticleDesign.Interview:
 			return <InterviewStandfirst item={item} />;
+		case ArticleDesign.Analysis:
+			return <AnalysisStandfirst item={item} />;
 		default:
 			return (
 				<DefaultStandfirst

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -193,19 +193,21 @@ const hoverStyles = (palette: Palette) => {
 	`;
 };
 
-const titleStyles = css`
-	${headline.xxxsmall({
-		fontWeight: 'bold',
-	})};
-`;
-
 export const Standfirst = ({ format, standfirst }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
 		<>
 			{format.design === ArticleDesign.Analysis && (
-				<p css={titleStyles}>Analysis</p>
+				<p
+					css={css`
+						${headline.xxxsmall({
+							fontWeight: 'bold',
+						})};
+					`}
+				>
+					Analysis
+				</p>
 			)}
 			<div
 				css={[

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -193,36 +193,47 @@ const hoverStyles = (palette: Palette) => {
 	`;
 };
 
+const titleStyles = css`
+	${headline.xxxsmall({
+		fontWeight: 'bold',
+	})};
+`;
+
 export const Standfirst = ({ format, standfirst }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
-		<div
-			css={[
-				nestedStyles(format, palette),
-				standfirstStyles(format, palette),
-				hoverStyles(palette),
-			]}
-			className={
-				format.design === ArticleDesign.Interactive
-					? interactiveLegacyClasses.standFirst
-					: ''
-			}
-			dangerouslySetInnerHTML={{
-				__html: sanitise(standfirst, {
-					allowedTags: false, // Leave tags from CAPI alone
-					allowedAttributes: false, // Leave attributes from CAPI alone
-					transformTags: {
-						a: (tagName, attribs) => ({
-							tagName, // Just return anchors as is
-							attribs: {
-								...attribs, // Merge into the existing attributes
-								'data-link-name': 'in standfirst link', // Add the data-link-name for Ophan to anchors
-							},
-						}),
-					},
-				}),
-			}}
-		/>
+		<>
+			{format.design === ArticleDesign.Analysis && (
+				<p css={titleStyles}>Analysis</p>
+			)}
+			<div
+				css={[
+					nestedStyles(format, palette),
+					standfirstStyles(format, palette),
+					hoverStyles(palette),
+				]}
+				className={
+					format.design === ArticleDesign.Interactive
+						? interactiveLegacyClasses.standFirst
+						: ''
+				}
+				dangerouslySetInnerHTML={{
+					__html: sanitise(standfirst, {
+						allowedTags: false, // Leave tags from CAPI alone
+						allowedAttributes: false, // Leave attributes from CAPI alone
+						transformTags: {
+							a: (tagName, attribs) => ({
+								tagName, // Just return anchors as is
+								attribs: {
+									...attribs, // Merge into the existing attributes
+									'data-link-name': 'in standfirst link', // Add the data-link-name for Ophan to anchors
+								},
+							}),
+						},
+					}),
+				}}
+			/>
+		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -233,15 +233,7 @@ export const Standfirst = ({ format, standfirst }: Props) => {
 	return (
 		<>
 			{format.design === ArticleDesign.Analysis && (
-				<p
-					css={css`
-						${headline.xxxsmall({
-							fontWeight: 'bold',
-						})};
-					`}
-				>
-					Analysis
-				</p>
+				<p css={titleStyles(format, palette)}>Analysis</p>
 			)}
 			<div
 				css={[


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a new standfirst component for design.analysis with

- A title of `Analysis`
- Specific `analysis` font styling
- relevant story


## Why?
This is to align the AR templates with the new template designs from Editorial Design.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/184913152-e540cc19-8297-471a-aced-9f9ab3a328ee.png
[after]: https://user-images.githubusercontent.com/20416599/184913195-93415edd-8136-4229-9267-4993ffdf3479.png

<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
