### PR TITLE
Add Analysis standfirst styling

### DIFF
--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -190,6 +190,13 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 						max-width: 540px;
 						color: ${palette.text.standfirst};
 					`;
+				case ArticleDesign.Analysis:
+					return css`
+						${headline.xxxsmall()};
+						margin-bottom: ${space[3]}px;
+						max-width: 540px;
+						color: ${palette.text.standfirst};
+					`;
 				default:
 					switch (format.theme) {
 						case ArticleSpecial.Labs:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Gives the standfirst medium weighting for Analysis design.

## Why?
Aligns with the new editorial designs for Analysis articles.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/184907034-e00b0c7f-44dc-45a8-94cf-54ca807a289b.png
[after]: https://user-images.githubusercontent.com/20416599/184907055-e8a3eba0-9c48-4627-8401-ca7eeadf2148.png
