### PR TITLE
feat: add newsletter data to thrift

### DIFF
--- a/apps-rendering/api-models/thrift/src/main/thrift/appsRendering.thrift
+++ b/apps-rendering/api-models/thrift/src/main/thrift/appsRendering.thrift
@@ -126,9 +126,7 @@ struct Newsletter {
     3: required string theme
     4: required string description
     5: required string frequency
-    6: required i32 listId
-    7: required string group
-    8: required string successDescription
+    6: required string successDescription
 }
 
 struct RenderingRequest {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds newsletter data to the thrift model for MAPI

## Why?

As part of a project to implement the new newsletter signup forms (embeds) in the apps, we need to allow the `RenderingRequest` from MAPI to expect the `promotedNewsletter` field which contains the data required to render the newsletter signup form.
