### PR TITLE
a11y: Don't use an empty link to wrap Cards.

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -294,7 +294,11 @@ export const Card = ({
 			containerType={containerType}
 			isDynamo={isDynamo}
 		>
-			<CardLink linkTo={linkTo} dataLinkName={dataLinkName} />
+			<CardLink
+				linkTo={linkTo}
+				headlineText={headlineText}
+				dataLinkName={dataLinkName}
+			/>
 			<CardLayout
 				imagePosition={imageUrl !== undefined ? imagePosition : 'top'}
 				imagePositionOnMobile={

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -12,6 +12,10 @@ const fauxLinkStyles = css`
 	left: 0;
 	background-color: transparent;
 
+	opacity: 0;
+	text-indent: 200%;
+	overflow: hidden;
+
 	:focus {
 		${focusHalo};
 	}
@@ -19,12 +23,19 @@ const fauxLinkStyles = css`
 
 type Props = {
 	linkTo: string;
+	headlineText: string;
 	containerPalette?: DCRContainerPalette;
 	dataLinkName?: string;
 };
 
-export const CardLink = ({ linkTo, dataLinkName = 'article' }: Props) => {
+export const CardLink = ({
+	linkTo,
+	headlineText,
+	dataLinkName = 'article',
+}: Props) => {
 	return (
-		<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName} />
+		<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName}>
+			{headlineText}
+		</a>
 	);
 };

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -12,10 +12,6 @@ const fauxLinkStyles = css`
 	left: 0;
 	background-color: transparent;
 
-	opacity: 0;
-	text-indent: 200%;
-	overflow: hidden;
-
 	:focus {
 		${focusHalo};
 	}
@@ -34,8 +30,11 @@ export const CardLink = ({
 	dataLinkName = 'article',
 }: Props) => {
 	return (
-		<a href={linkTo} css={fauxLinkStyles} data-link-name={dataLinkName}>
-			{headlineText}
-		</a>
+		<a
+			href={linkTo}
+			css={fauxLinkStyles}
+			data-link-name={dataLinkName}
+			aria-label={headlineText}
+		/>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds text to the wrapper links used by Cards.

Tested on the [uk front](https://www.theguardian.com/uk) using https://wave.webaim.org/

## Why?

This link is positioned to cover the entire card so that you can click anywhere on the card and be linked to the article. Because its used like this visually there was no need to have any text in the link, however, any screen reader that tries to read the link will have issues because it can't find any meaningful text to explain where the link goes.

Alternatively we could add `aria-hidden` and `tabindex="-1"` to the Link but this doesn't seem to hide the errors from wave. Interestingly Frontend adds text to the link AND makes it aria-hidden.

https://webaim.org/standards/wcag/checklist#sc2.4.4


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/185096813-434b2c42-f155-4017-81ee-8e3f5880ae9e.png
[after]: https://user-images.githubusercontent.com/21217225/185096669-5020bf23-4db0-4587-af68-51f296d381d9.png
