### PR TITLE
fix pinned post overlay visibilitty

### DIFF
--- a/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
+++ b/dotcom-rendering/src/web/components/EnhancePinnedPost.importable.tsx
@@ -27,10 +27,22 @@ function toggleShowMore(show: boolean) {
 	const pinnedPostOverlay = document.querySelector<HTMLElement>(
 		'#pinned-post-overlay',
 	);
-	if (pinnedPostButton)
-		pinnedPostButton.style.display = show ? 'inline-flex' : 'none';
-	if (pinnedPostOverlay)
-		pinnedPostOverlay.style.display = show ? 'block' : 'none';
+
+	if (pinnedPostButton) {
+		if (show) {
+			pinnedPostButton.style.removeProperty('display');
+		} else {
+			pinnedPostButton.style.display = 'none';
+		}
+	}
+
+	if (pinnedPostOverlay) {
+		if (show) {
+			pinnedPostOverlay.style.removeProperty('display');
+		} else {
+			pinnedPostOverlay.style.display = 'none';
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR is fixing the bug that's showing an overlay on top of share buttons which is preventing the user from clicking the share buttons. 
![image](https://user-images.githubusercontent.com/15894063/185097338-95272c07-17be-47e9-9eb9-8c26ee0e0cf6.png)


A while ago a PR was made to fix the visibility of the `Show More` button in pinned post when pinned post contains twitter embed https://github.com/guardian/dotcom-rendering/pull/5682 This PR fixed the visibility of the button, but caused another bug on the overlay section that's the bottom of the collapsed pinned post. 

![image](https://user-images.githubusercontent.com/15894063/185096169-c4f438fa-ea9c-4514-9af3-2039578b6195.png)

The pinned post enhancer, was adding the `display: none` when the scroll height of the pinned post was less than the client height. Then as part of that PR, `display: none` was replaced by `display: block` when after the twitter enhancement, the scroll hight was changed and became larger than the client height. 

But because  `display: block` was added through js, it would go as an inline element styles, which would then have priority over the actual component styles. 


## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/185097539-49e8d6b6-b9e9-4f73-be5d-5f0eef921376.png) | ![image](https://user-images.githubusercontent.com/15894063/185097665-3078c19e-9b70-46dd-8e47-cfd32e3e0aa8.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
