### PR TITLE
Signup layout promoted newsletter data

### DIFF
--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -791,4 +791,5 @@ type Newsletter = {
 	successDescription: string;
 	theme: string;
 	group: string;
+	regionalFocus?: string;
 };

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -178,11 +178,7 @@ const getMainMediaCaptions = (
 			: undefined,
 	);
 
-export const NewsletterSignupLayout: React.FC<Props> = ({
-	CAPIArticle,
-	NAV,
-	format,
-}) => {
+export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const {
 		promotedNewsletter,
 		config: { host },
@@ -208,7 +204,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 		.find((caption) => !!caption && isValidUrl(caption));
 	const showNewsletterPreview = Boolean(newsletterPreviewUrl);
 
-	/** TODO: decide on the fallback value if not defined in newsletters API */
+	// TODO: decide on the fallback value if not defined in newsletters API
 	const newsletterRegionFocus =
 		promotedNewsletter?.regionalFocus ?? 'UK Focused';
 
@@ -507,7 +503,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 								isAdFreeUser={CAPIArticle.isAdFreeUser}
 								pageId={CAPIArticle.pageId}
 								isPaidContent={
-									CAPIArticle.config.isPaidContent || false
+									CAPIArticle.config.isPaidContent ?? false
 								}
 								showRelatedContent={
 									CAPIArticle.config.showRelatedContent

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -185,6 +185,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 	format,
 }) => {
 	const {
+		promotedNewsletter,
 		config: { host },
 	} = CAPIArticle;
 
@@ -208,8 +209,9 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 		.find((caption) => !!caption && isValidUrl(caption));
 	const showNewsletterPreview = Boolean(newsletterPreviewUrl);
 
-	/** TODO: this data needs to come from the newsletters API */
-	const newsletterRegionFocus = 'UK Focused';
+	/** TODO: decide on the fallback value if not defined in newsletters API */
+	const newsletterRegionFocus =
+		promotedNewsletter?.regionalFocus ?? 'UK Focused';
 
 	return (
 		<>
@@ -386,13 +388,23 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 								</div>
 							)}
 
-							<SecureSignup
-								newsletterId="1234"
-								successDescription="nice"
-								hidePrivacyMessage={true}
-							/>
+							{promotedNewsletter && (
+								<>
+									<SecureSignup
+										newsletterId={
+											promotedNewsletter.identityName
+										}
+										successDescription={
+											promotedNewsletter.successDescription
+										}
+										hidePrivacyMessage={true}
+									/>
 
-							<NewsletterFrequency frequency="Weekly" />
+									<NewsletterFrequency
+										frequency={promotedNewsletter.frequency}
+									/>
+								</>
+							)}
 
 							<div css={shareDivStyle}>
 								<span css={shareSpanStyle}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
(no visible changes) Updates the WIP `NewsletterSignupLayout` to use data (eg newsletter frequency, sign-up form parameters) from the `promotedNewsletter` object on the CAPIArticle instead of hard-coded values

## Why?
The change in https://github.com/guardian/frontend/pull/25391 will add the `promotedNewsletter` to the DCR requests for sign-up pages. This change is to make use of that data. 

