### PR TITLE
Adds `tableOfContents`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -577,6 +577,7 @@ interface CAPIArticleType {
 	selectedTopics?: Topic[];
 
 	promotedNewsletter?: Newsletter;
+	tableOfContents?: TOCType[];
 }
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
@@ -589,6 +590,15 @@ interface TagType {
 	paidContentType?: string;
 	bylineImageUrl?: string;
 	bylineLargeImageUrl?: string;
+}
+
+interface TOCItem {
+	id: string;
+	title: string;
+	subtitle?: string;
+}
+interface TOCType extends TOCItem {
+	nested: TOCItem[];
 }
 
 /**

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -527,6 +527,12 @@
                 "successDescription",
                 "theme"
             ]
+        },
+        "tableOfContents": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/TOCType"
+            }
         }
     },
     "required": [
@@ -4567,6 +4573,49 @@
                 "WORK_OF_ART"
             ],
             "type": "string"
+        },
+        "TOCType": {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TOCItem"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "nested",
+                "title"
+            ]
+        },
+        "TOCItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "title"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
@@ -1,0 +1,405 @@
+import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
+import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import { enhanceTableOfContents } from './enhanceTableOfContents';
+
+describe('Enhance Table of Contents', () => {
+	it('does not generate a toc where an existing table of contents exists', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+						elementId: 'mocOne',
+						subheadingLinks: [],
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual(
+			undefined,
+		);
+	});
+	it('correctly generate a toc from h2s and h3s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{ id: 'h2One', nested: [], title: 'This is the h2 text' },
+			{
+				id: 'h2Two',
+				nested: [{ id: 'h3One', title: 'This is the h3 text' }],
+				title: 'This is the h2 text',
+			},
+		]);
+	});
+	it('will ignore any h4s if there are h2s present in the document', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4One',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Two',
+						html: '<h4>This is the h4 text</h4>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{ id: 'h2One', nested: [], title: 'This is the h2 text' },
+			{
+				id: 'h2Two',
+				nested: [{ id: 'h3One', title: 'This is the h3 text' }],
+				title: 'This is the h2 text',
+			},
+		]);
+	});
+	it('will ignore orphan h3s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>I am an orphan h3</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Two',
+						html: '<h3>This is the h3 text</h3>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{ id: 'h2One', nested: [], title: 'This is the h2 text' },
+			{
+				id: 'h2Two',
+				nested: [{ id: 'h3Two', title: 'This is the h3 text' }],
+				title: 'This is the h2 text',
+			},
+		]);
+	});
+	it('will use h3s and h4s if no h2s exist', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Two',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4One',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Three',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Two',
+						html: '<h4>This is the h4 text</h4>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{ id: 'h3One', nested: [], title: 'This is the h3 text' },
+			{
+				id: 'h3Two',
+				nested: [{ id: 'h4One', title: 'This is the h4 text' }],
+				title: 'This is the h3 text',
+			},
+			{
+				id: 'h3Three',
+				nested: [{ id: 'h4Two', title: 'This is the h4 text' }],
+				title: 'This is the h3 text',
+			},
+		]);
+	});
+	it('will ignore orphan h4s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Id',
+						html: '<h4>This is the h4 text - this h4 will be ignored</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Two',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4One',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Three',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Two',
+						html: '<h4>This is the h4 text</h4>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{ id: 'h3One', nested: [], title: 'This is the h3 text' },
+			{
+				id: 'h3Two',
+				nested: [{ id: 'h4One', title: 'This is the h4 text' }],
+				title: 'This is the h3 text',
+			},
+			{
+				id: 'h3Three',
+				nested: [{ id: 'h4Two', title: 'This is the h4 text' }],
+				title: 'This is the h3 text',
+			},
+		]);
+	});
+	it('will handle multiple nested h4 links', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4One',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Two',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Three',
+						html: '<h4>This is the h4 text</h4>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{
+				id: 'h3One',
+				nested: [
+					{ id: 'h4One', title: 'This is the h4 text' },
+					{ id: 'h4Two', title: 'This is the h4 text' },
+					{ id: 'h4Three', title: 'This is the h4 text' },
+				],
+				title: 'This is the h3 text',
+			},
+		]);
+	});
+	it('will handle multiple nested h3 links', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Two',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Three',
+						html: '<h3>This is the h3 text</h3>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{
+				id: 'h2One',
+				nested: [
+					{ id: 'h3One', title: 'This is the h3 text' },
+					{ id: 'h3Two', title: 'This is the h3 text' },
+					{ id: 'h3Three', title: 'This is the h3 text' },
+				],
+				title: 'This is the h2 text',
+			},
+		]);
+	});
+	it('will generate a toc if there are only h3s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3One',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Two',
+						html: '<h3>This is the h3 text</h3>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h3Three',
+						html: '<h3>This is the h3 text</h3>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{
+				id: 'h3One',
+				nested: [],
+				title: 'This is the h3 text',
+			},
+			{
+				id: 'h3Two',
+				nested: [],
+				title: 'This is the h3 text',
+			},
+			{
+				id: 'h3Three',
+				nested: [],
+				title: 'This is the h3 text',
+			},
+		]);
+	});
+	it('will generate a toc if there are only h2s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Three',
+						html: '<h2>This is the h2 text</h2>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{
+				id: 'h2One',
+				nested: [],
+				title: 'This is the h2 text',
+			},
+			{
+				id: 'h2Two',
+				nested: [],
+				title: 'This is the h2 text',
+			},
+			{
+				id: 'h2Three',
+				nested: [],
+				title: 'This is the h2 text',
+			},
+		]);
+	});
+});

--- a/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
@@ -41,6 +41,11 @@ describe('Enhance Table of Contents', () => {
 						elementId: 'h3One',
 						html: '<h3>This is the h3 text</h3>',
 					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Three',
+						html: '<h2>This is the h2 text</h2>',
+					},
 				],
 			},
 		];
@@ -52,6 +57,7 @@ describe('Enhance Table of Contents', () => {
 				nested: [{ id: 'h3One', title: 'This is the h3 text' }],
 				title: 'This is the h2 text',
 			},
+			{ id: 'h2Three', nested: [], title: 'This is the h2 text' },
 		]);
 	});
 	it('will ignore any h4s if there are h2s present in the document', () => {
@@ -84,6 +90,11 @@ describe('Enhance Table of Contents', () => {
 						elementId: 'h4Two',
 						html: '<h4>This is the h4 text</h4>',
 					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Three',
+						html: '<h2>This is the h2 text</h2>',
+					},
 				],
 			},
 		];
@@ -95,6 +106,7 @@ describe('Enhance Table of Contents', () => {
 				nested: [{ id: 'h3One', title: 'This is the h3 text' }],
 				title: 'This is the h2 text',
 			},
+			{ id: 'h2Three', nested: [], title: 'This is the h2 text' },
 		]);
 	});
 	it('will ignore orphan h3s', () => {
@@ -122,6 +134,11 @@ describe('Enhance Table of Contents', () => {
 						elementId: 'h3Two',
 						html: '<h3>This is the h3 text</h3>',
 					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Three',
+						html: '<h2>This is the h2 text</h2>',
+					},
 				],
 			},
 		];
@@ -133,9 +150,10 @@ describe('Enhance Table of Contents', () => {
 				nested: [{ id: 'h3Two', title: 'This is the h3 text' }],
 				title: 'This is the h2 text',
 			},
+			{ id: 'h2Three', nested: [], title: 'This is the h2 text' },
 		]);
 	});
-	it('will use h3s and h4s if no h2s exist', () => {
+	it('will only use h3s if no h2s exist', () => {
 		const input: Block[] = [
 			{
 				...blockMetaData,
@@ -173,106 +191,12 @@ describe('Enhance Table of Contents', () => {
 			{ id: 'h3One', nested: [], title: 'This is the h3 text' },
 			{
 				id: 'h3Two',
-				nested: [{ id: 'h4One', title: 'This is the h4 text' }],
+				nested: [],
 				title: 'This is the h3 text',
 			},
 			{
 				id: 'h3Three',
-				nested: [{ id: 'h4Two', title: 'This is the h4 text' }],
-				title: 'This is the h3 text',
-			},
-		]);
-	});
-	it('will ignore orphan h4s', () => {
-		const input: Block[] = [
-			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4Id',
-						html: '<h4>This is the h4 text - this h4 will be ignored</h4>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h3One',
-						html: '<h3>This is the h3 text</h3>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h3Two',
-						html: '<h3>This is the h3 text</h3>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4One',
-						html: '<h4>This is the h4 text</h4>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h3Three',
-						html: '<h3>This is the h3 text</h3>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4Two',
-						html: '<h4>This is the h4 text</h4>',
-					},
-				],
-			},
-		];
-
-		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
-			{ id: 'h3One', nested: [], title: 'This is the h3 text' },
-			{
-				id: 'h3Two',
-				nested: [{ id: 'h4One', title: 'This is the h4 text' }],
-				title: 'This is the h3 text',
-			},
-			{
-				id: 'h3Three',
-				nested: [{ id: 'h4Two', title: 'This is the h4 text' }],
-				title: 'This is the h3 text',
-			},
-		]);
-	});
-	it('will handle multiple nested h4 links', () => {
-		const input: Block[] = [
-			{
-				...blockMetaData,
-				elements: [
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h3One',
-						html: '<h3>This is the h3 text</h3>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4One',
-						html: '<h4>This is the h4 text</h4>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4Two',
-						html: '<h4>This is the h4 text</h4>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-						elementId: 'h4Three',
-						html: '<h4>This is the h4 text</h4>',
-					},
-				],
-			},
-		];
-
-		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
-			{
-				id: 'h3One',
-				nested: [
-					{ id: 'h4One', title: 'This is the h4 text' },
-					{ id: 'h4Two', title: 'This is the h4 text' },
-					{ id: 'h4Three', title: 'This is the h4 text' },
-				],
+				nested: [],
 				title: 'This is the h3 text',
 			},
 		]);
@@ -302,6 +226,16 @@ describe('Enhance Table of Contents', () => {
 						elementId: 'h3Three',
 						html: '<h3>This is the h3 text</h3>',
 					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Three',
+						html: '<h2>This is the h2 text</h2>',
+					},
 				],
 			},
 		];
@@ -315,6 +249,50 @@ describe('Enhance Table of Contents', () => {
 					{ id: 'h3Three', title: 'This is the h3 text' },
 				],
 				title: 'This is the h2 text',
+			},
+			{ id: 'h2Two', nested: [], title: 'This is the h2 text' },
+			{ id: 'h2Three', nested: [], title: 'This is the h2 text' },
+		]);
+	});
+	it('will generate a toc if there are only h4s', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4One',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Two',
+						html: '<h4>This is the h4 text</h4>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'h4Three',
+						html: '<h4>This is the h4 text</h4>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual([
+			{
+				id: 'h4One',
+				nested: [],
+				title: 'This is the h4 text',
+			},
+			{
+				id: 'h4Two',
+				nested: [],
+				title: 'This is the h4 text',
+			},
+			{
+				id: 'h4Three',
+				nested: [],
+				title: 'This is the h4 text',
 			},
 		]);
 	});
@@ -401,5 +379,28 @@ describe('Enhance Table of Contents', () => {
 				title: 'This is the h2 text',
 			},
 		]);
+	});
+	it('will not return a toc if the are fewer than 3 headings', () => {
+		const input: Block[] = [
+			{
+				...blockMetaData,
+				elements: [
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2One',
+						html: '<h2>This is the h2 text</h2>',
+					},
+					{
+						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
+						elementId: 'h2Two',
+						html: '<h2>This is the h2 text</h2>',
+					},
+				],
+			},
+		];
+
+		expect(enhanceTableOfContents(ExampleArticle.format, input)).toEqual(
+			undefined,
+		);
 	});
 });

--- a/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
@@ -1,4 +1,4 @@
-import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
+import { Analysis as ExampleArticle } from '../../fixtures/generated/articles/Analysis';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
 import { enhanceTableOfContents } from './enhanceTableOfContents';
 

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -46,6 +46,10 @@ const hasH3s = (blocks: Block[]) => {
 	return blocks.find((block) => block.elements.find(isH3));
 };
 
+const hasH4s = (blocks: Block[]) => {
+	return blocks.find((block) => block.elements.find(isH4));
+};
+
 const hasInteractiveContentsElement = (blocks: Block[]): boolean => {
 	return !!blocks.find((block) =>
 		block.elements.find(
@@ -87,7 +91,7 @@ export const enhanceTableOfContents = (
 						});
 					} else {
 						// This is an orphan h3 with no parent h2 element to assign it to
-						// so we drop it from the table
+						// so we don't show it in the table
 					}
 				}
 			});
@@ -102,21 +106,21 @@ export const enhanceTableOfContents = (
 						nested: [],
 					});
 				}
+			});
+		});
+	} else if (hasH4s(blocks)) {
+		blocks.forEach((block) => {
+			block.elements.forEach((element) => {
 				if (isH4(element)) {
-					if (tocs.length > 0) {
-						const lastItem = tocs[tocs.length - 1];
-						lastItem.nested.push({
-							id: element.elementId,
-							title: extractText(element),
-						});
-					} else {
-						// This is an orphan h4 with no parent h3 element to assign it to
-						// so we drop it from the table
-					}
+					tocs.push({
+						id: element.elementId,
+						title: extractText(element),
+						nested: [],
+					});
 				}
 			});
 		});
 	}
 
-	return tocs.length > 0 ? tocs : undefined;
+	return tocs.length >= 3 ? tocs : undefined;
 };

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -1,0 +1,122 @@
+import { JSDOM } from 'jsdom';
+
+const isHeading = (element: CAPIElement, level: 'H2' | 'H3' | 'H4') => {
+	if (
+		element._type !==
+			'model.dotcomrendering.pageElements.TextBlockElement' &&
+		element._type !==
+			'model.dotcomrendering.pageElements.SubheadingBlockElement'
+	)
+		return false;
+	const frag = JSDOM.fragment(element.html);
+	return frag.firstElementChild?.nodeName === level;
+};
+
+const isH2 = (
+	element: CAPIElement,
+): element is SubheadingBlockElement | TextBlockElement => {
+	return isHeading(element, 'H2');
+};
+
+const isH3 = (
+	element: CAPIElement,
+): element is SubheadingBlockElement | TextBlockElement => {
+	return isHeading(element, 'H3');
+};
+
+const isH4 = (
+	element: CAPIElement,
+): element is SubheadingBlockElement | TextBlockElement => {
+	return isHeading(element, 'H4');
+};
+
+const extractText = (
+	element: SubheadingBlockElement | TextBlockElement,
+): string => {
+	const frag = JSDOM.fragment(element.html);
+	if (!frag.firstElementChild) return '';
+	return frag.textContent?.trim() ?? '';
+};
+
+const hasH2s = (blocks: Block[]) => {
+	return blocks.find((block) => block.elements.find(isH2));
+};
+
+const hasH3s = (blocks: Block[]) => {
+	return blocks.find((block) => block.elements.find(isH3));
+};
+
+const hasInteractiveContentsElement = (blocks: Block[]): boolean => {
+	return !!blocks.find((block) =>
+		block.elements.find(
+			(element) =>
+				element._type ===
+				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+		),
+	);
+};
+
+export const enhanceTableOfContents = (
+	format: CAPIFormat,
+	blocks: Block[],
+): TOCType[] | undefined => {
+	if (
+		format.design !== 'ArticleDesign' ||
+		hasInteractiveContentsElement(blocks)
+	) {
+		return undefined;
+	}
+
+	const tocs: TOCType[] = [];
+	if (hasH2s(blocks)) {
+		blocks.forEach((block) => {
+			block.elements.forEach((element) => {
+				if (isH2(element)) {
+					tocs.push({
+						id: element.elementId,
+						title: extractText(element),
+						nested: [],
+					});
+				}
+				if (isH3(element)) {
+					if (tocs.length > 0) {
+						const lastItem = tocs[tocs.length - 1];
+						lastItem.nested.push({
+							id: element.elementId,
+							title: extractText(element),
+						});
+					} else {
+						// This is an orphan h3 with no parent h2 element to assign it to
+						// so we drop it from the table
+					}
+				}
+			});
+		});
+	} else if (hasH3s(blocks)) {
+		blocks.forEach((block) => {
+			block.elements.forEach((element) => {
+				if (isH3(element)) {
+					tocs.push({
+						id: element.elementId,
+						title: extractText(element),
+						nested: [],
+					});
+				}
+				if (isH4(element)) {
+					if (tocs.length > 0) {
+						const lastItem = tocs[tocs.length - 1];
+						lastItem.nested.push({
+							id: element.elementId,
+							title: extractText(element),
+						});
+					} else {
+						// This is an orphan h4 with no parent h3 element to assign it to
+						// so we drop it from the table
+					}
+				}
+			});
+		});
+	}
+
+	return tocs.length > 0 ? tocs : undefined;
+};

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -65,7 +65,7 @@ export const enhanceTableOfContents = (
 	blocks: Block[],
 ): TOCType[] | undefined => {
 	if (
-		format.design !== 'ArticleDesign' ||
+		format.design !== 'AnalysisDesign' ||
 		hasInteractiveContentsElement(blocks)
 	) {
 		return undefined;

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -4,6 +4,7 @@ import { enhanceBlocks } from '../../model/enhanceBlocks';
 import { enhanceCollections } from '../../model/enhanceCollections';
 import { enhanceCommercialProperties } from '../../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../../model/enhanceStandfirst';
+import { enhanceTableOfContents } from '../../model/enhanceTableOfContents';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import { articleToHtml } from './articleToHtml';
@@ -19,18 +20,23 @@ function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 const enhanceCAPIType = (body: unknown): CAPIArticleType => {
 	const data = validateAsCAPIType(body);
 
+	const enhancedBlocks = enhanceBlocks(
+		data.blocks,
+		data.format,
+		data.promotedNewsletter,
+	);
+
 	const CAPIArticle: CAPIArticleType = {
 		...data,
-		blocks: enhanceBlocks(
-			data.blocks,
-			data.format,
-			data.promotedNewsletter,
-		),
+		blocks: enhancedBlocks,
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),
 		standfirst: enhanceStandfirst(data.standfirst),
 		commercialProperties: enhanceCommercialProperties(
 			data.commercialProperties,
 		),
+		tableOfContents: data.config.switches.tableOfContents
+			? enhanceTableOfContents(data.format, enhancedBlocks)
+			: undefined,
 	};
 	return CAPIArticle;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds the `enhanceTableOfContents` enhancer

## But we don't have any h3s or h4s
The code here is assuming that the document will contain pure `<h3>` or `<h4>` tags but these do not natively come from Composer. However there is work in play to support enhancing faux h3s (`<p><strong>I'm a faux h3</strong></p>`) so that they become h3 tags and also potential work to add h4 tag support as well

## Why?
We want to extract an object containing a nested stack of all h2/h3s or h3/h4s so that we can later render them in a `<TableOfContents />` component

## Isn't there already code to do this?
There is [another enhancer](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts) which does a similar heading extraction. This code is designed to add support for a legacy table of contents element. It looks for articles that contain this element and replaces it with a [new element](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.tsx).

The goal for our table is to add support for *all* analysis articles dynamically , without a dependency on inserting a special atom element. At a later stage we could look to migrate all articles that contain this legacy element to our new dynamic pattern.

