### PR TITLE
Increment apps-rendering-api-models version to 1.1.0

### DIFF
--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.1.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Increment the version number of `@guardian/apps-rendering-api-models` to `1.1.0` as part of releasing #5735 