### PR TITLE
docs: correct link wording to `common-rendering`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
 
 ## `common rendering`
 
-Go to [apps rendering](common-rendering/README.md) for more details.
+Go to [common rendering](common-rendering/README.md) for more details.
 
 ## Root actions
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Corrects the link wording to `common-rendering`
