### PR TITLE
Make Analysis headline medium weight

### DIFF
--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -35,7 +35,6 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 			return css`
 				${baseStyles}
 				${articleWidthStyles}
-				${boldFont}
 				background-color: ${background.headline(format)};
 				padding-bottom: ${remSpace[6]};
 

--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -60,13 +60,6 @@ interface DefaultProps {
 	styles: SerializedStyles;
 }
 
-const boldFont = css`
-	${headline.small({ fontWeight: 'bold' })};
-	${from.tablet} {
-		${headline.medium({ fontWeight: 'bold' })};
-	}
-`;
-
 export const DefaultHeadline: React.FC<DefaultProps> = ({ item, styles }) => (
 	<h1 css={styles}>
 		<span>{item.headline}</span>

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -608,7 +608,7 @@ export const ArticleHeadline = ({
 							>
 								<h1
 									css={[
-										boldFont,
+										standardFont,
 										topPadding,
 										css`
 											color: ${palette.text.headline};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes the Analysis headline medium weight on AR and DCR
## Why?
This aligns with new editorial design.

## Screenshots

DCR
| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


AR
| Before      | After      |
|-------------|------------|
| ![before-ar][] | ![after-ar][] |

[before-ar]: https://example.com/before.png
[after-ar]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
