### PR TITLE
Use editionalised timestamps

### DIFF
--- a/apps-rendering/src/components/Dateline/Dateline.stories.tsx
+++ b/apps-rendering/src/components/Dateline/Dateline.stories.tsx
@@ -34,7 +34,7 @@ const LiveBlogDateline: FC = () => (
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
 		)}
-		edition={Edition.UK}
+		edition={Edition.US}
 	/>
 );
 
@@ -48,7 +48,7 @@ const DeadBlogDateline: FC = () => (
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
 		)}
-		edition={Edition.UK}
+		edition={Edition.AU}
 	/>
 );
 

--- a/apps-rendering/src/components/Dateline/Dateline.stories.tsx
+++ b/apps-rendering/src/components/Dateline/Dateline.stories.tsx
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
 import { date, withKnobs } from '@storybook/addon-knobs';
@@ -19,6 +20,7 @@ const Default: FC = () => (
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
 		)}
+		edition={Edition.UK}
 	/>
 );
 
@@ -32,6 +34,7 @@ const LiveBlogDateline: FC = () => (
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
 		)}
+		edition={Edition.UK}
 	/>
 );
 
@@ -45,6 +48,7 @@ const DeadBlogDateline: FC = () => (
 		date={some(
 			new Date(date('Publish Date', new Date('2019-12-17T03:24:00'))),
 		)}
+		edition={Edition.UK}
 	/>
 );
 

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -83,10 +83,7 @@ const Dateline: FC<Props> = ({ date, format, edition }) =>
 		date,
 		map((d) => (
 			<time css={getDatelineStyles(format)}>
-				{format.design === ArticleDesign.LiveBlog ||
-				format.design === ArticleDesign.DeadBlog
-					? datetimeFormat(edition ?? Edition.UK)(d)
-					: formatDate(d)}
+				{datetimeFormat(edition ?? Edition.UK)(d)}
 			</time>
 		)),
 		withDefault<ReactElement | null>(null),

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -83,7 +83,7 @@ const Dateline: FC<Props> = ({ date, format, edition }) =>
 		date,
 		map((d) => (
 			<time css={getDatelineStyles(format)}>
-				{datetimeFormat(edition ?? Edition.UK)(d)}
+				{datetimeFormat(edition)(d)}
 			</time>
 		)),
 		withDefault<ReactElement | null>(null),

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -19,7 +19,7 @@ import { darkModeCss as darkMode } from 'styles';
 interface Props {
 	date: Option<Date>;
 	format: ArticleFormat;
-	edition?: Edition;
+	edition: Edition;
 }
 
 const darkStyles = darkMode`

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, neutral, text, textSans } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -8,7 +8,6 @@ import type { ArticleFormat } from '@guardian/libs';
 import { from, neutral, text, textSans } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
-import { formatDate } from 'date';
 import { datetimeFormat } from 'datetime';
 import { pipe } from 'lib';
 import type { FC, ReactElement } from 'react';

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -31,6 +31,7 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 
@@ -72,9 +73,10 @@ const commentLineStylePosition = css`
 interface Props {
 	item: CommentItem | Letter | Editorial;
 	children: ReactNode[];
+	edition: Edition;
 }
 
-const CommentLayout: FC<Props> = ({ item, children }) => (
+const CommentLayout: FC<Props> = ({ item, children, edition }) => (
 	<main css={[Styles, DarkStyles]}>
 		<article css={BorderStyles}>
 			<header>
@@ -97,7 +99,7 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 				</div>
 
 				<section css={[articleWidthStyles, topBorder]}>
-					<Metadata item={item} />
+					<Metadata item={item} edition={edition} />
 				</section>
 
 				<MainMedia

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import {
 	background,
 	breakpoints,
@@ -31,7 +32,6 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/Layout/GalleryLayout.tsx
+++ b/apps-rendering/src/components/Layout/GalleryLayout.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
@@ -31,9 +32,10 @@ const wrapperStyles = css`
 
 type Props = {
 	item: Item;
+	edition: Edition;
 };
 
-const GalleryLayout: FC<Props> = ({ item, children }) => {
+const GalleryLayout: FC<Props> = ({ item, children, edition }) => {
 	const format = getFormat(item);
 
 	return (
@@ -48,7 +50,7 @@ const GalleryLayout: FC<Props> = ({ item, children }) => {
 						<Series item={item} />
 						<Headline item={item} />
 						<Standfirst item={item} />
-						<Metadata item={item} />
+						<Metadata item={item} edition={edition} />
 						<GalleryCaption
 							mainMedia={item.mainMedia}
 							format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/GalleryLayout.tsx
+++ b/apps-rendering/src/components/Layout/GalleryLayout.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import {
 	background,
 	fill,

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import {
 	background,
 	fill,
@@ -74,9 +75,10 @@ const linesStyles = (format: ArticleFormat): SerializedStyles => css`
 
 type Props = {
 	item: Item;
+	edition: Edition;
 };
 
-const ImmersiveLayout: FC<Props> = ({ item, children }) => {
+const ImmersiveLayout: FC<Props> = ({ item, children, edition }) => {
 	const format = getFormat(item);
 
 	return (
@@ -97,7 +99,7 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => {
 					<div css={mainContentStyles(format)}>
 						<LeftCentreBorder rows={[1, 5]} />
 						<StraightLines cssOverrides={linesStyles(format)} />
-						<Metadata item={item} />
+						<Metadata item={item} edition={edition} />
 						<div css={bodyStyles}>{children}</div>
 						<Tags item={item} />
 					</div>

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import {
 	background,
 	breakpoints,
@@ -28,7 +29,6 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -28,6 +28,7 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 
@@ -54,9 +55,10 @@ const BorderStyles = css`
 interface Props {
 	item: Item;
 	children: ReactNode[];
+	edition: Edition;
 }
 
-const LabsLayout: FC<Props> = ({ item, children }) => {
+const LabsLayout: FC<Props> = ({ item, children, edition }) => {
 	return (
 		<main css={[Styles, DarkStyles]}>
 			<article css={BorderStyles}>
@@ -74,7 +76,7 @@ const LabsLayout: FC<Props> = ({ item, children }) => {
 					</div>
 					<DottedLines count={1} cssOverrides={lineStyles} />
 					<section css={articleWidthStyles}>
-						<Metadata item={item} />
+						<Metadata item={item} edition={edition} />
 						{pipe(
 							item.logo,
 							map((props) => <Logo logo={props} />),

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -200,7 +200,7 @@ Analysis.story = { name: 'Analysis' };
 export const LiveBlog = (): ReactElement => (
 	<Live
 		item={{ ...live, display: ArticleDisplay.Standard }}
-		edition={Edition.UK}
+		edition={Edition.US}
 	/>
 );
 LiveBlog.story = { name: 'LiveBlog ' };
@@ -208,7 +208,7 @@ LiveBlog.story = { name: 'LiveBlog ' };
 export const DeadBlog = (): ReactElement => (
 	<Live
 		item={{ ...deadBlog, display: ArticleDisplay.Standard }}
-		edition={Edition.UK}
+		edition={Edition.AU}
 	/>
 );
 DeadBlog.story = { name: 'DeadBlog ' };

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -43,7 +43,7 @@ const formatFromItem = (
 
 export const Article = (): React.ReactNode => {
 	return (
-		<Standard item={article}>
+		<Standard item={article} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(article, some(ArticleDisplay.Standard)),
 				partition(article.body).oks,
@@ -55,7 +55,7 @@ Article.story = { name: 'Article' };
 
 export const Review = (): React.ReactNode => {
 	return (
-		<Standard item={review}>
+		<Standard item={review} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(review, some(ArticleDisplay.Standard)),
 				partition(review.body).oks,
@@ -67,7 +67,7 @@ Review.story = { name: 'Review' };
 
 export const MatchReport = (): React.ReactNode => {
 	return (
-		<Standard item={matchReport}>
+		<Standard item={matchReport} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(matchReport, some(ArticleDisplay.Standard)),
 				partition(matchReport.body).oks,
@@ -79,7 +79,7 @@ MatchReport.story = { name: 'Match Report' };
 
 export const PrintShop = (): React.ReactNode => {
 	return (
-		<Standard item={printShop}>
+		<Standard item={printShop} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(printShop, some(ArticleDisplay.Standard)),
 				partition(printShop.body).oks,
@@ -91,7 +91,7 @@ PrintShop.story = { name: 'PrintShop' };
 
 export const PhotoEssay = (): React.ReactNode => {
 	return (
-		<Standard item={photoEssay}>
+		<Standard item={photoEssay} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(photoEssay, some(ArticleDisplay.Standard)),
 				partition(photoEssay.body).oks,
@@ -103,7 +103,7 @@ PhotoEssay.story = { name: 'Photo Essay' };
 
 export const Feature = (): React.ReactNode => {
 	return (
-		<Standard item={feature}>
+		<Standard item={feature} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(feature, some(ArticleDisplay.Standard)),
 				partition(feature.body).oks,
@@ -115,7 +115,7 @@ Feature.story = { name: 'Feature' };
 
 export const Interview = (): React.ReactNode => {
 	return (
-		<Standard item={interview}>
+		<Standard item={interview} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(interview, some(ArticleDisplay.Standard)),
 				partition(interview.body).oks,
@@ -127,7 +127,7 @@ Interview.story = { name: 'Interview' };
 
 export const Quiz = (): React.ReactNode => {
 	return (
-		<Standard item={quiz}>
+		<Standard item={quiz} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(quiz, some(ArticleDisplay.Standard)),
 				partition(quiz.body).oks,
@@ -139,7 +139,7 @@ Quiz.story = { name: 'Quiz' };
 
 export const Recipe = (): React.ReactNode => {
 	return (
-		<Standard item={recipe}>
+		<Standard item={recipe} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(recipe, some(ArticleDisplay.Standard)),
 				partition(recipe.body).oks,
@@ -151,7 +151,7 @@ Recipe.story = { name: 'Recipe' };
 
 export const CommentItem = (): React.ReactNode => {
 	return (
-		<Comment item={comment}>
+		<Comment item={comment} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(comment, some(ArticleDisplay.Standard)),
 				partition(comment.body).oks,
@@ -163,7 +163,7 @@ CommentItem.story = { name: 'Comment' };
 
 export const Letter = (): React.ReactNode => {
 	return (
-		<Comment item={letter}>
+		<Comment item={letter} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(letter, some(ArticleDisplay.Standard)),
 				partition(letter.body).oks,
@@ -175,7 +175,7 @@ Letter.story = { name: 'Letter' };
 
 export const Editorial = (): React.ReactNode => {
 	return (
-		<Comment item={editorial}>
+		<Comment item={editorial} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(editorial, some(ArticleDisplay.Standard)),
 				partition(editorial.body).oks,
@@ -187,7 +187,7 @@ Editorial.story = { name: 'Editorial' };
 
 export const Analysis = (): React.ReactNode => {
 	return (
-		<Standard item={analysis}>
+		<Standard item={analysis} edition={Edition.UK}>
 			{renderAll(
 				formatFromItem(analysis, some(ArticleDisplay.Standard)),
 				partition(analysis.body).oks,

--- a/apps-rendering/src/components/Layout/MediaLayout.tsx
+++ b/apps-rendering/src/components/Layout/MediaLayout.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { background, breakpoints, from } from '@guardian/source-foundations';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
@@ -15,7 +16,6 @@ import { getFormat } from 'item';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 import { articleWidthStyles, onwardStyles } from 'styles';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/Layout/MediaLayout.tsx
+++ b/apps-rendering/src/components/Layout/MediaLayout.tsx
@@ -15,6 +15,7 @@ import { getFormat } from 'item';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 import { articleWidthStyles, onwardStyles } from 'styles';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 
@@ -35,9 +36,10 @@ const BorderStyles = css`
 interface Props {
 	item: Item;
 	children: ReactNode[];
+	edition: Edition;
 }
 
-const MediaLayout: FC<Props> = ({ item, children }) => {
+const MediaLayout: FC<Props> = ({ item, children, edition }) => {
 	const format = getFormat(item);
 	return (
 		<main css={[Styles]}>
@@ -59,6 +61,7 @@ const MediaLayout: FC<Props> = ({ item, children }) => {
 							publicationDate={item.publishDate}
 							className={articleWidthStyles}
 							item={item}
+							edition={edition}
 						/>
 					</section>
 				</header>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -42,6 +42,7 @@ import {
 	onwardStyles,
 } from 'styles';
 import { themeToPillarString } from 'themeStyles';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 
@@ -79,9 +80,10 @@ const decideLines = (
 interface Props {
 	item: StandardItem | ReviewItem | MatchReportItem;
 	children: ReactNode[];
+	edition: Edition;
 }
 
-const StandardLayout: FC<Props> = ({ item, children }) => {
+const StandardLayout: FC<Props> = ({ item, children, edition }) => {
 	// client side code won't render an Epic if there's an element with this id
 	const epicContainer = item.shouldHideReaderRevenue ? null : (
 		<div css={articleWidthStyles}>
@@ -133,7 +135,7 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 					</div>
 					{decideLines(item, lineStyles)}
 					<section css={articleWidthStyles}>
-						<Metadata item={item} />
+						<Metadata item={item} edition={edition} />
 						<Logo item={item} />
 					</section>
 				</header>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import {
 	background,
@@ -42,7 +43,6 @@ import {
 	onwardStyles,
 } from 'styles';
 import { themeToPillarString } from 'themeStyles';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -61,7 +61,11 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 	const render = renderWithAds(shouldHideAds);
 
 	if (item.theme === ArticleSpecial.Labs) {
-		return <LabsLayout item={item}>{render(item, body)}</LabsLayout>;
+		return (
+			<LabsLayout item={item} edition={edition}>
+				{render(item, body)}
+			</LabsLayout>
+		);
 	}
 
 	if (

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -122,7 +122,9 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 		}
 
 		return (
-			<StandardLayout item={item}>{render(item, body)}</StandardLayout>
+			<StandardLayout item={item} edition={edition}>
+				{render(item, body)}
+			</StandardLayout>
 		);
 	}
 

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -84,7 +84,11 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 	}
 
 	if (item.design === ArticleDesign.Gallery) {
-		return <GalleryLayout item={item}>{render(item, body)}</GalleryLayout>;
+		return (
+			<GalleryLayout item={item} edition={edition}>
+				{render(item, body)}
+			</GalleryLayout>
+		);
 	}
 
 	if (

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -115,7 +115,7 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 	) {
 		if (item.display === ArticleDisplay.Immersive) {
 			return (
-				<ImmersiveLayout item={item}>
+				<ImmersiveLayout item={item} edition={edition}>
 					{render(item, body)}
 				</ImmersiveLayout>
 			);

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -80,7 +80,11 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 		item.design === ArticleDesign.Letter ||
 		item.design === ArticleDesign.Editorial
 	) {
-		return <CommentLayout item={item}>{render(item, body)}</CommentLayout>;
+		return (
+			<CommentLayout item={item} edition={edition}>
+				{render(item, body)}
+			</CommentLayout>
+		);
 	}
 
 	if (item.design === ArticleDesign.Gallery) {

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -92,7 +92,7 @@ const Layout: FC<Props> = ({ item, shouldHideAds, edition }) => {
 		item.design === ArticleDesign.Video
 	) {
 		return (
-			<MediaLayout item={item}>
+			<MediaLayout item={item} edition={edition}>
 				{render(
 					item,
 					body.filter((elem) => elem.kind === ElementKind.Image),

--- a/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
@@ -31,6 +32,7 @@ type Props = {
 	contributors: Contributor[];
 	commentCount: Option<number>;
 	commentable: boolean;
+	edition?: Edition;
 };
 
 const GalleryMetadata: FC<Props> = ({
@@ -39,10 +41,11 @@ const GalleryMetadata: FC<Props> = ({
 	contributors,
 	commentCount,
 	commentable,
+	edition,
 }) => (
 	<div css={styles}>
 		<div css={textStyles}>
-			<Dateline date={publishDate} format={format} />
+			<Dateline date={publishDate} format={format} edition={edition} />
 			<Follow format={format} contributors={contributors} />
 		</div>
 		<CommentCount

--- a/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
@@ -32,7 +32,7 @@ type Props = {
 	contributors: Contributor[];
 	commentCount: Option<number>;
 	commentable: boolean;
-	edition?: Edition;
+	edition: Edition;
 };
 
 const GalleryMetadata: FC<Props> = ({

--- a/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';

--- a/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
@@ -34,7 +34,7 @@ type Props = {
 	contributors: Contributor[];
 	commentCount: Option<number>;
 	commentable: boolean;
-	edition?: Edition;
+	edition: Edition;
 };
 
 const ImmersiveMetadata: FC<Props> = ({

--- a/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
@@ -33,6 +34,7 @@ type Props = {
 	contributors: Contributor[];
 	commentCount: Option<number>;
 	commentable: boolean;
+	edition?: Edition;
 };
 
 const ImmersiveMetadata: FC<Props> = ({
@@ -41,10 +43,11 @@ const ImmersiveMetadata: FC<Props> = ({
 	contributors,
 	commentCount,
 	commentable,
+	edition,
 }) => (
 	<div css={styles}>
 		<div css={textStyles}>
-			<Dateline date={publishDate} format={format} />
+			<Dateline date={publishDate} format={format} edition={edition} />
 			<Follow format={format} contributors={contributors} />
 		</div>
 		<CommentCount

--- a/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/ImmersiveMetadata.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';

--- a/apps-rendering/src/components/Metadata/Metadata.stories.tsx
+++ b/apps-rendering/src/components/Metadata/Metadata.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { from, neutral } from '@guardian/source-foundations';
 import { deadBlog, live } from 'fixtures/live';
 import type { FC } from 'react';
@@ -26,13 +27,13 @@ const deadContainerStyles = css`
 
 const LiveblogMetadata: FC = () => (
 	<div css={liveContainerStyles}>
-		<Metadata item={{ ...live }} />
+		<Metadata item={{ ...live }} edition={Edition.UK} />
 	</div>
 );
 
 const DeadBlogMetadata: FC = () => (
 	<div css={deadContainerStyles}>
-		<Metadata item={{ ...deadBlog }} />
+		<Metadata item={{ ...deadBlog }} edition={Edition.UK} />
 	</div>
 );
 

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -35,7 +35,7 @@ import ImmersiveMetadata from './ImmersiveMetadata';
 
 interface Props {
 	item: Item;
-	edition?: Edition;
+	edition: Edition;
 }
 
 const styles = css`

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -206,12 +206,12 @@ const BlogLines: FC<Item> = (item: Item) => (
 	</>
 );
 
-const MetadataWithByline: FC<Props> = ({ item }: Props) => (
+const MetadataWithByline: FC<Props> = ({ item, edition }: Props) => (
 	<div css={css(styles, withBylineStyles)}>
 		<Avatar {...item} />
 		<div css={css(textStyles, withBylineTextStyles)}>
 			<Byline {...item} />
-			<Dateline date={item.publishDate} format={item} />
+			<Dateline date={item.publishDate} format={item} edition={edition} />
 			<Follow format={getFormat(item)} contributors={item.contributors} />
 		</div>
 		<CommentCount count={item.commentCount} {...item} />

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -301,6 +301,7 @@ const Metadata: FC<Props> = (props: Props) => {
 				commentCount={props.item.commentCount}
 				contributors={props.item.contributors}
 				commentable={props.item.commentable}
+				edition={props.edition}
 			/>
 		);
 	} else if (

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -289,6 +289,7 @@ const Metadata: FC<Props> = (props: Props) => {
 				commentCount={props.item.commentCount}
 				contributors={props.item.contributors}
 				commentable={props.item.commentable}
+				edition={props.edition}
 			/>
 		);
 	}

--- a/apps-rendering/src/components/Metadata/index.tsx
+++ b/apps-rendering/src/components/Metadata/index.tsx
@@ -218,10 +218,10 @@ const MetadataWithByline: FC<Props> = ({ item, edition }: Props) => (
 	</div>
 );
 
-const ShortMetadata: FC<Props> = ({ item }: Props) => (
+const ShortMetadata: FC<Props> = ({ item, edition }: Props) => (
 	<div css={styles}>
 		<div css={textStyles}>
-			<Dateline date={item.publishDate} format={item} />
+			<Dateline date={item.publishDate} format={item} edition={edition} />
 			<Follow format={getFormat(item)} contributors={item.contributors} />
 		</div>
 		<CommentCount count={item.commentCount} {...item} />

--- a/apps-rendering/src/components/media/byline.tsx
+++ b/apps-rendering/src/components/media/byline.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
@@ -11,7 +12,6 @@ import type { Item } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { renderText } from '../../renderer';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/media/byline.tsx
+++ b/apps-rendering/src/components/media/byline.tsx
@@ -11,6 +11,7 @@ import type { Item } from 'item';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
 import { renderText } from '../../renderer';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 // ----- Styles ----- //
 
@@ -42,9 +43,10 @@ interface Props {
 	publicationDate: Option<Date>;
 	className: SerializedStyles;
 	item: Item;
+	edition?: Edition;
 }
 
-const Byline: FC<Props> = ({ publicationDate, className, item }) => {
+const Byline: FC<Props> = ({ publicationDate, className, item, edition }) => {
 	const byline = pipe(
 		item.bylineHtml,
 		map((html) => <address>{renderText(html, getFormat(item))}</address>),
@@ -56,7 +58,11 @@ const Byline: FC<Props> = ({ publicationDate, className, item }) => {
 			<div>
 				<div className="author">
 					{byline}
-					<Dateline date={publicationDate} format={item} />
+					<Dateline
+						date={publicationDate}
+						format={item}
+						edition={edition}
+					/>
 				</div>
 			</div>
 		</div>

--- a/apps-rendering/src/components/media/byline.tsx
+++ b/apps-rendering/src/components/media/byline.tsx
@@ -43,7 +43,7 @@ interface Props {
 	publicationDate: Option<Date>;
 	className: SerializedStyles;
 	item: Item;
-	edition?: Edition;
+	edition: Edition;
 }
 
 const Byline: FC<Props> = ({ publicationDate, className, item, edition }) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This is a companion to #5688 to make the changes easier to review

- Passes `edition` to all layouts using a `Dateline` component
- Makes the `edition` prop required

