### PR TITLE
AR TOC - parse H2 as HeadingTwo that includes id  

### DIFF
--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -1,41 +1,9 @@
 import { getAdPlaceholderInserter } from './ads';
-import { ReactNode } from 'react';
-import { renderAll } from 'renderer';
-import { JSDOM } from 'jsdom';
-import {
-	ArticlePillar,
-	ArticleFormat,
-	ArticleDesign,
-	ArticleDisplay,
-} from '@guardian/libs';
-import { compose } from 'lib';
-import { BodyElement, flattenTextElement } from 'bodyElement';
 import AdSlot from 'adSlot';
+import { mockFormat, renderParagraphs, renderTextElement } from 'testsHelper';
 
 const shouldHideAdverts = false;
 const insertAdPlaceholders = getAdPlaceholderInserter(shouldHideAdverts);
-const mockFormat: ArticleFormat = {
-	theme: ArticlePillar.News,
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-};
-
-const textElement = (nodes: string[]): BodyElement[] => {
-	const frag = JSDOM.fragment(nodes.join(''));
-	return flattenTextElement(frag);
-};
-
-const generateParas = (paras: number): BodyElement[] => {
-	const frag = JSDOM.fragment(Array(paras).fill('<p>foo</p>').join(''));
-	return flattenTextElement(frag);
-};
-
-const render = (elements: BodyElement[]): ReactNode[] =>
-	renderAll(mockFormat, elements);
-
-const renderParagraphs = compose(render, generateParas);
-
-const renderTextElement = compose(render, textElement);
 
 describe('Adds the correct number of ad placeholders', () => {
 	test('Adds no placeholders for 2 paragraphs', () => {

--- a/apps-rendering/src/ads.test.ts
+++ b/apps-rendering/src/ads.test.ts
@@ -9,7 +9,7 @@ import {
 	ArticleDisplay,
 } from '@guardian/libs';
 import { compose } from 'lib';
-import { ElementKind, BodyElement } from 'bodyElement';
+import { BodyElement, flattenTextElement } from 'bodyElement';
 import AdSlot from 'adSlot';
 
 const shouldHideAdverts = false;
@@ -20,16 +20,18 @@ const mockFormat: ArticleFormat = {
 	display: ArticleDisplay.Standard,
 };
 
-const textElement = (nodes: string[]): BodyElement => ({
-	kind: ElementKind.Text,
-	doc: JSDOM.fragment(nodes.join('')),
-});
+const textElement = (nodes: string[]): BodyElement[] => {
+	const frag = JSDOM.fragment(nodes.join(''));
+	return flattenTextElement(frag);
+};
 
-const generateParas = (paras: number): BodyElement =>
-	textElement(Array(paras).fill('<p>foo</p>'));
+const generateParas = (paras: number): BodyElement[] => {
+	const frag = JSDOM.fragment(Array(paras).fill('<p>foo</p>').join(''));
+	return flattenTextElement(frag);
+};
 
-const render = (element: BodyElement): ReactNode[] =>
-	renderAll(mockFormat, [element]);
+const render = (elements: BodyElement[]): ReactNode[] =>
+	renderAll(mockFormat, elements);
 
 const renderParagraphs = compose(render, generateParas);
 

--- a/apps-rendering/src/bodyElement.test.ts
+++ b/apps-rendering/src/bodyElement.test.ts
@@ -1,0 +1,32 @@
+import { ElementKind, flattenTextElement } from 'bodyElement';
+import { JSDOM } from 'jsdom';
+
+describe('flattenTextElement', () => {
+	test('it returns HeadingTwo body element with text content', () => {
+		const node = JSDOM.fragment(`<h2>some text</h2>`);
+		const result = flattenTextElement(node);
+
+		expect(result.length).toEqual(1);
+		expect(result[0].kind).toEqual(ElementKind.HeadingTwo);
+		result[0].kind === ElementKind.HeadingTwo &&
+			expect(result[0].doc.textContent).toEqual('some text');
+	});
+
+	test('it returns Text body element and HeadingTwo body element with correct id', () => {
+		const nestedHtml = ['<p>paragraph 1</p>', '<h2>first heading 2</h2>'];
+		const node = JSDOM.fragment(nestedHtml.join(''));
+
+		const result = flattenTextElement(node);
+
+		expect(result.length).toEqual(2);
+		expect(result[0].kind).toEqual(ElementKind.Text);
+		expect(result[1].kind).toEqual(ElementKind.HeadingTwo);
+		expect(
+			result[1].kind === ElementKind.HeadingTwo && result[1].id.isSome(),
+		).toEqual(true);
+
+		result[1].kind === ElementKind.HeadingTwo &&
+			result[1].id.isSome() &&
+			expect(result[1].id.value).toEqual('first-heading-2');
+	});
+});

--- a/apps-rendering/src/bodyElement.test.ts
+++ b/apps-rendering/src/bodyElement.test.ts
@@ -3,7 +3,7 @@ import { JSDOM } from 'jsdom';
 
 describe('flattenTextElement', () => {
 	test('it returns HeadingTwo body element with text content', () => {
-		const node = JSDOM.fragment(`<h2>some text</h2>`);
+		const node = JSDOM.fragment('<h2>some text</h2>');
 		const result = flattenTextElement(node);
 
 		expect(result.length).toEqual(1);

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -37,7 +37,13 @@ type Text = {
 type HeadingTwo = {
 	kind: ElementKind.HeadingTwo;
 	doc: Node;
-	toc: Optional<{ id: string; text: string }>;
+	id: Optional<string>;
+};
+
+type HeadingThree = {
+	kind: ElementKind.HeadingThree;
+	doc: Node;
+	id: Optional<string>;
 };
 
 type Image = ImageData & {
@@ -225,12 +231,12 @@ const flattenTextElement = (doc: Node): BodyElement[] => {
 				return {
 					kind: ElementKind.HeadingTwo,
 					doc: node,
-					toc: Optional.fromNullable(node.textContent).flatMap(
+					id: Optional.fromNullable(node.textContent).flatMap(
 						(text) => {
 							const slug = slugify(text);
 							return slug === ''
 								? Optional.none()
-								: Optional.some({ id: slug, text });
+								: Optional.some(slug);
 						},
 					),
 				};
@@ -448,6 +454,7 @@ export {
 	ElementKind,
 	BodyElement,
 	HeadingTwo,
+	HeadingThree,
 	Body,
 	Image,
 	Text,

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -137,6 +137,7 @@ interface NewsletterSignUp {
 type BodyElement =
 	| Text
 	| HeadingTwo
+	| HeadingThree
 	| Image
 	| {
 			kind: ElementKind.Pullquote;

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -6,7 +6,7 @@ import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { ArticleTheme } from '@guardian/libs';
-import { Option, Result } from '@guardian/types';
+import type { Option, Result } from '@guardian/types';
 import {
 	err,
 	fromNullable,
@@ -23,9 +23,9 @@ import type { Embed } from 'embed';
 import type { Image as ImageData } from 'image';
 import { parseImage } from 'image';
 import { compose, pipe } from 'lib';
+import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import type { KnowledgeQuizAtom, PersonalityQuizAtom } from 'quizAtom';
-import { Optional } from 'optional';
 
 // ----- Types ----- //
 
@@ -217,7 +217,7 @@ const slugify = (text: string): string => {
 		.replace(/--+/g, '-'); // Replace multiple "-" with single "-"
 };
 
-export const flattenTextElement = (doc: Node): BodyElement[] => {
+const flattenTextElement = (doc: Node): BodyElement[] => {
 	const childNodes = Array.from(doc.childNodes);
 	return childNodes.map((node) => {
 		switch (node.nodeName) {
@@ -461,4 +461,5 @@ export {
 	AudioAtom,
 	parseElements,
 	NewsletterSignUp,
+	flattenTextElement,
 };

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -217,7 +217,7 @@ const slugify = (text: string): string => {
 		.replace(/--+/g, '-'); // Replace multiple "-" with single "-"
 };
 
-const flattenTextElement = (doc: Node): BodyElement[] => {
+export const flattenTextElement = (doc: Node): BodyElement[] => {
 	const childNodes = Array.from(doc.childNodes);
 	return childNodes.map((node) => {
 		switch (node.nodeName) {

--- a/apps-rendering/src/bodyElementKind.ts
+++ b/apps-rendering/src/bodyElementKind.ts
@@ -23,6 +23,7 @@ const enum ElementKind {
 	PersonalityQuizAtom,
 	NewsletterSignUp,
 	HeadingTwo,
+	HeadingThree,
 }
 
 // ----- Exports ----- //

--- a/apps-rendering/src/bodyElementKind.ts
+++ b/apps-rendering/src/bodyElementKind.ts
@@ -2,6 +2,7 @@
 
 const enum ElementKind {
 	Text,
+	HeadingTwo,
 	Image,
 	Pullquote,
 	Interactive,

--- a/apps-rendering/src/bodyElementKind.ts
+++ b/apps-rendering/src/bodyElementKind.ts
@@ -2,7 +2,6 @@
 
 const enum ElementKind {
 	Text,
-	HeadingTwo,
 	Image,
 	Pullquote,
 	Interactive,
@@ -23,6 +22,7 @@ const enum ElementKind {
 	KnowledgeQuizAtom,
 	PersonalityQuizAtom,
 	NewsletterSignUp,
+	HeadingTwo,
 }
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, jsx as styledH } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -71,6 +71,20 @@ const HeadingTextElement: React.FC<HeadingTextElementProps> = ({
 			);
 		case 'EM':
 			return <em key={key}>{children}</em>;
+		case 'SUB': {
+			const styles = css`
+				font-size: smaller;
+				vertical-align: sub;
+			`;
+			return styledH('sub', { css: styles, key }, children);
+		}
+		case 'SUP': {
+			const styles = css`
+				font-size: smaller;
+				vertical-align: super;
+			`;
+			return styledH('sup', { css: styles, key }, children);
+		}
 		default:
 			return null;
 	}

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -7,8 +7,8 @@ import { withDefault } from '@guardian/types';
 import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
 import Anchor from 'components/Anchor';
 import HorizontalRule from 'components/HorizontalRule';
-import { getHref } from 'renderer';
 import { identity } from 'lib';
+import { getHref } from 'renderer';
 
 interface HeadingTwoProps {
 	format: ArticleFormat;

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -6,11 +6,12 @@ import Anchor from 'components/Anchor';
 import HorizontalRule from 'components/HorizontalRule';
 import { ReactNode } from 'react';
 import { getHref } from 'renderer';
+import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
 
 interface Props {
 	format: ArticleFormat;
 	isEditions: boolean;
-	element: Node;
+	heading: HeadingTwoType;
 }
 
 const styles = (format: ArticleFormat): SerializedStyles => {
@@ -58,16 +59,23 @@ const headingTextElement =
 		}
 	};
 
-const HeadingTwo: React.FC<Props> = ({ format, isEditions, element }) => {
-	const text = element.textContent ?? '';
-	const children = Array.from(element.childNodes).map(
+const HeadingTwo: React.FC<Props> = ({ format, isEditions, heading }) => {
+	const text = heading.doc.textContent ?? '';
+	const children = Array.from(heading.doc.childNodes).map(
 		headingTextElement(format, isEditions),
 	);
 
 	return text.includes('* * *') ? (
 		<HorizontalRule />
 	) : (
-		<h2 css={styles(format)}>{children}</h2>
+		<h2
+			id={heading.toc
+				.map<string | undefined>((t) => t.id)
+				.withDefault(undefined)}
+			css={styles(format)}
+		>
+			{children}
+		</h2>
 	);
 };
 

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,4 +1,4 @@
-import { css, jsx as styledH } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -31,7 +31,7 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 
 	return css`
 		${font}
-		margin: ${remSpace[4]} 0 4px 0;
+		margin: ${remSpace[4]} 0 ${remSpace[1]} 0;
 
 		& + p {
 			margin-top: 0;
@@ -72,24 +72,41 @@ const HeadingTextElement: React.FC<HeadingTextElementProps> = ({
 		case 'EM':
 			return <em key={key}>{children}</em>;
 		case 'SUB': {
-			const styles = css`
-				font-size: smaller;
-				vertical-align: sub;
-			`;
-			return styledH('sub', { css: styles, key }, children);
+			return (
+				<sub
+					css={css`
+						font-size: smaller;
+						vertical-align: sub;
+					`}
+					key={key}
+				>
+					{children}
+				</sub>
+			);
 		}
 		case 'SUP': {
-			const styles = css`
-				font-size: smaller;
-				vertical-align: super;
-			`;
-			return styledH('sup', { css: styles, key }, children);
+			return (
+				<sup
+					css={css`
+						font-size: smaller;
+						vertical-align: super;
+					`}
+					key={key}
+				>
+					{children}
+				</sup>
+			);
 		}
 		case 'STRONG':
-			return styledH(
-				'strong',
-				{ css: { fontWeight: 'bold' }, key },
-				children,
+			return (
+				<strong
+					css={css`
+						font-weight: bold;
+					`}
+					key={key}
+				>
+					{children}
+				</strong>
 			);
 		default:
 			return null;

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -85,6 +85,12 @@ const HeadingTextElement: React.FC<HeadingTextElementProps> = ({
 			`;
 			return styledH('sup', { css: styles, key }, children);
 		}
+		case 'STRONG':
+			return styledH(
+				'strong',
+				{ css: { fontWeight: 'bold' }, key },
+				children,
+			);
 		default:
 			return null;
 	}

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -8,6 +8,7 @@ import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
 import Anchor from 'components/Anchor';
 import HorizontalRule from 'components/HorizontalRule';
 import { getHref } from 'renderer';
+import { identity } from 'lib';
 
 interface HeadingTwoProps {
 	format: ArticleFormat;
@@ -94,8 +95,8 @@ const HeadingTwo: React.FC<HeadingTwoProps> = ({
 		<HorizontalRule />
 	) : (
 		<h2
-			id={heading.toc
-				.map<string | undefined>((t) => t.id)
+			id={heading.id
+				.map<string | undefined>(identity)
 				.withDefault(undefined)}
 			css={styles(format)}
 		>

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,17 +1,25 @@
-import { css, SerializedStyles } from '@emotion/react';
-import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import { headline, remSpace, textSans } from '@guardian/source-foundations';
 import { withDefault } from '@guardian/types';
+import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
 import Anchor from 'components/Anchor';
 import HorizontalRule from 'components/HorizontalRule';
-import { ReactNode } from 'react';
 import { getHref } from 'renderer';
-import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
 
-interface Props {
+interface HeadingTwoProps {
 	format: ArticleFormat;
 	isEditions: boolean;
 	heading: HeadingTwoType;
+}
+
+interface HeadingTextElementProps {
+	format: ArticleFormat;
+	isEditions: boolean;
+	node: Node;
+	key: number;
 }
 
 const styles = (format: ArticleFormat): SerializedStyles => {
@@ -30,40 +38,57 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 	`;
 };
 
-const headingTextElement =
-	(format: ArticleFormat, isEditions = false) =>
-	(node: Node, key: number): ReactNode => {
-		const text = node.textContent ?? '';
-		const children = Array.from(node.childNodes).map(
-			headingTextElement(format, isEditions),
-		);
+const HeadingTextElement: React.FC<HeadingTextElementProps> = ({
+	format,
+	isEditions,
+	node,
+	key,
+}) => {
+	const text = node.textContent ?? '';
+	const children = Array.from(node.childNodes).map((item, i) => (
+		<HeadingTextElement
+			format={format}
+			isEditions={isEditions}
+			node={item}
+			key={i}
+		/>
+	));
 
-		switch (node.nodeName) {
-			case '#text':
-				return text;
-			case 'A':
-				return (
-					<Anchor
-						href={withDefault('')(getHref(node))}
-						format={format}
-						isEditions={isEditions}
-						key={key}
-					>
-						{children}
-					</Anchor>
-				);
-			case 'EM':
-				return <em key={key}>{children}</em>;
-			default:
-				return null;
-		}
-	};
+	switch (node.nodeName) {
+		case '#text':
+			return <>{text}</>;
+		case 'A':
+			return (
+				<Anchor
+					href={withDefault('')(getHref(node))}
+					format={format}
+					isEditions={isEditions}
+					key={key}
+				>
+					{children}
+				</Anchor>
+			);
+		case 'EM':
+			return <em key={key}>{children}</em>;
+		default:
+			return null;
+	}
+};
 
-const HeadingTwo: React.FC<Props> = ({ format, isEditions, heading }) => {
+const HeadingTwo: React.FC<HeadingTwoProps> = ({
+	format,
+	isEditions,
+	heading,
+}) => {
 	const text = heading.doc.textContent ?? '';
-	const children = Array.from(heading.doc.childNodes).map(
-		headingTextElement(format, isEditions),
-	);
+	const children = Array.from(heading.doc.childNodes).map((item, i) => (
+		<HeadingTextElement
+			format={format}
+			isEditions={isEditions}
+			node={item}
+			key={i}
+		/>
+	));
 
 	return text.includes('* * *') ? (
 		<HorizontalRule />

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,0 +1,74 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import { headline, remSpace, textSans } from '@guardian/source-foundations';
+import { withDefault } from '@guardian/types';
+import Anchor from 'components/Anchor';
+import HorizontalRule from 'components/HorizontalRule';
+import { ReactNode } from 'react';
+import { getHref } from 'renderer';
+
+interface Props {
+	format: ArticleFormat;
+	isEditions: boolean;
+	element: Node;
+}
+
+const styles = (format: ArticleFormat): SerializedStyles => {
+	const font =
+		format.theme === ArticleSpecial.Labs
+			? textSans.large({ fontWeight: 'bold' })
+			: headline.xxsmall({ fontWeight: 'bold' });
+
+	return css`
+		${font}
+		margin: ${remSpace[4]} 0 4px 0;
+
+		& + p {
+			margin-top: 0;
+		}
+	`;
+};
+
+const headingTextElement =
+	(format: ArticleFormat, isEditions = false) =>
+	(node: Node, key: number): ReactNode => {
+		const text = node.textContent ?? '';
+		const children = Array.from(node.childNodes).map(
+			headingTextElement(format, isEditions),
+		);
+
+		switch (node.nodeName) {
+			case '#text':
+				return text;
+			case 'A':
+				return (
+					<Anchor
+						href={withDefault('')(getHref(node))}
+						format={format}
+						isEditions={isEditions}
+						key={key}
+					>
+						{children}
+					</Anchor>
+				);
+			case 'EM':
+				return <em key={key}>{children}</em>;
+			default:
+				return null;
+		}
+	};
+
+const HeadingTwo: React.FC<Props> = ({ format, isEditions, element }) => {
+	const text = element.textContent ?? '';
+	const children = Array.from(element.childNodes).map(
+		headingTextElement(format, isEditions),
+	);
+
+	return text.includes('* * *') ? (
+		<HorizontalRule />
+	) : (
+		<h2 css={styles(format)}>{children}</h2>
+	);
+};
+
+export default HeadingTwo;

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -72,7 +72,7 @@ const captionDocFragment: Option<DocumentFragment> = pipe(
 	toOption,
 );
 
-const docFixture = (): DocumentFragment => {
+const docFixture = (): Node => {
 	const doc = new DocumentFragment();
 
 	const el = document.createElement('p');
@@ -82,7 +82,7 @@ const docFixture = (): DocumentFragment => {
 
 	doc.appendChild(el);
 
-	return doc;
+	return doc.firstChild!;
 };
 
 const srcset =

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -82,6 +82,7 @@ const docFixture = (): Node => {
 
 	doc.appendChild(el);
 
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- this value is not `null`
 	return doc.firstChild!;
 };
 

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -573,7 +573,7 @@ describe('Paragraph tags rendered correctly', () => {
 			'<ul><li><strong><p>Standfirst link</p></strong></li></ul>',
 		);
 		const nodes = renderText(fragment, mockFormat);
-		const html = getHtml(nodes.flat()[0]);
+		const html = getHtml(nodes);
 		expect(html).not.toContain('<strong><p>Standfirst link</p></strong>');
 	});
 });
@@ -628,7 +628,11 @@ describe('Shows drop caps', () => {
 
 	test('Shows drop cap for eligible paragraphs including Unicode Latin-1 characters', () => {
 		const unicodeLatin = `Česká ${paragraph}`;
-		const showDropCap = shouldShowDropCap(unicodeLatin, format, !isEditions);
+		const showDropCap = shouldShowDropCap(
+			unicodeLatin,
+			format,
+			!isEditions,
+		);
 		expect(showDropCap).toBe(true);
 	});
 
@@ -657,17 +661,29 @@ describe('Shows drop caps', () => {
 	test('Does not show drop cap if the paragraph is shorter than 200 characters', () => {
 		const shortParagraph =
 			'The pen might not be mightier than the sword, but maybe the printing press was heavier than the siege weapon. Just a few words can change everything.';
-		const showDropCap = shouldShowDropCap(shortParagraph, format, !isEditions);
+		const showDropCap = shouldShowDropCap(
+			shortParagraph,
+			format,
+			!isEditions,
+		);
 		expect(showDropCap).toBe(false);
 	});
 
 	test('Does not show drop cap if the article is not an allowed design (e.g. standard design)', () => {
-		const showDropCap = shouldShowDropCap(paragraph, mockFormat, !isEditions);
+		const showDropCap = shouldShowDropCap(
+			paragraph,
+			mockFormat,
+			!isEditions,
+		);
 		expect(showDropCap).toBe(false);
 	});
 
 	test('Does not show drop cap if the article is an Editions article', () => {
-		const showDropCap = shouldShowDropCap(paragraph, mockFormat, isEditions);
+		const showDropCap = shouldShowDropCap(
+			paragraph,
+			mockFormat,
+			isEditions,
+		);
 		expect(showDropCap).toBe(false);
 	});
 });

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -81,6 +81,7 @@ import {
 	themeToPillar,
 	themeToPillarString,
 } from 'themeStyles';
+import HeadingTwo from 'components/HeadingTwo';
 
 // ----- Renderer ----- //
 
@@ -137,22 +138,6 @@ const transform = (
 		return h(HorizontalRule, null, null);
 	}
 	return text;
-};
-
-const HeadingTwoStyles = (format: ArticleFormat): SerializedStyles => {
-	const font =
-		format.theme === ArticleSpecial.Labs
-			? textSans.large({ fontWeight: 'bold' })
-			: headline.xxsmall({ fontWeight: 'bold' });
-
-	return css`
-		${font}
-		margin: ${remSpace[4]} 0 4px 0;
-
-		& + p {
-			margin-top: 0;
-		}
-	`;
 };
 
 const TweetStyles = css`
@@ -253,50 +238,6 @@ const shouldShowDropCap = (
 	return (
 		allowsDropCaps(format) && text.length >= 200 && dropCapRegex.test(text)
 	);
-};
-
-const headingTextElement =
-	(format: ArticleFormat, isEditions = false) =>
-	(node: Node, key: number): ReactNode => {
-		const text = node.textContent ?? '';
-		const children = Array.from(node.childNodes).map(
-			headingTextElement(format, isEditions),
-		);
-
-		switch (node.nodeName) {
-			case '#text':
-				return text;
-			case 'A':
-				return h(
-					Anchor,
-					{
-						href: withDefault('')(getHref(node)),
-						format,
-						key,
-						isEditions,
-					},
-					children,
-				);
-			case 'EM':
-				return h('em', { key }, children);
-			default:
-				return null;
-		}
-	};
-
-const headingTwoElement = (
-	format: ArticleFormat,
-	isEditions: boolean,
-	node: Node,
-): ReactNode => {
-	const text = node.textContent ?? '';
-	const children = Array.from(node.childNodes).map(
-		headingTextElement(format, isEditions),
-	);
-
-	return text.includes('* * *')
-		? h(HorizontalRule, null, null)
-		: styledH('h2', { css: HeadingTwoStyles(format) }, children);
 };
 
 const textElement =
@@ -666,7 +607,11 @@ const render =
 			case ElementKind.Text:
 				return textRenderer(format, excludeStyles, element);
 			case ElementKind.HeadingTwo:
-				return headingTwoElement(format, false, element.doc);
+				return h(HeadingTwo, {
+					format,
+					isEditions: false,
+					element: element.doc,
+				});
 			case ElementKind.Image:
 				return imageRenderer(format, element, key);
 
@@ -748,7 +693,11 @@ const renderEditions =
 				return textRenderer(format, excludeStyles, element, true);
 
 			case ElementKind.HeadingTwo:
-				return headingTwoElement(format, true, element.doc);
+				return h(HeadingTwo, {
+					format,
+					isEditions: true,
+					element: element.doc,
+				});
 
 			case ElementKind.Image:
 				return format.design === ArticleDesign.Gallery ||

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -52,6 +52,7 @@ import GalleryImage from 'components/editions/galleryImage';
 import EditionsPullquote from 'components/editions/pullquote';
 import Video from 'components/editions/video';
 import EmbedComponentWrapper from 'components/EmbedWrapper';
+import HeadingTwo from 'components/HeadingTwo';
 import HorizontalRule from 'components/HorizontalRule';
 import Interactive from 'components/Interactive';
 import InteractiveAtom, {
@@ -74,7 +75,6 @@ import {
 	themeToPillar,
 	themeToPillarString,
 } from 'themeStyles';
-import HeadingTwo from 'components/HeadingTwo';
 
 // ----- Renderer ----- //
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -330,14 +330,6 @@ const textElement =
 					},
 					children,
 				);
-			case 'H2':
-				return text.includes('* * *')
-					? h(HorizontalRule, null, null)
-					: styledH(
-							'h2',
-							{ css: HeadingTwoStyles(format), key },
-							children,
-					  );
 			case 'BLOCKQUOTE':
 				return isEditions
 					? h('blockquote', { key }, children)

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -1,6 +1,5 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from '@emotion/react';
 import { css, jsx as styledH } from '@emotion/react';
 import {
 	AudioAtom,
@@ -16,13 +15,7 @@ import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { Breakpoint } from '@guardian/source-foundations';
-import {
-	headline,
-	neutral,
-	remSpace,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { neutral, remSpace, until } from '@guardian/source-foundations';
 import {
 	andThen,
 	fromNullable,
@@ -610,7 +603,7 @@ const render =
 				return h(HeadingTwo, {
 					format,
 					isEditions: false,
-					element: element.doc,
+					heading: element,
 				});
 			case ElementKind.Image:
 				return imageRenderer(format, element, key);
@@ -696,7 +689,7 @@ const renderEditions =
 				return h(HeadingTwo, {
 					format,
 					isEditions: true,
-					element: element.doc,
+					heading: element,
 				});
 
 			case ElementKind.Image:

--- a/apps-rendering/src/testsHelper.ts
+++ b/apps-rendering/src/testsHelper.ts
@@ -1,0 +1,52 @@
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { BodyElement } from 'bodyElement';
+import { flattenTextElement } from 'bodyElement';
+import { JSDOM } from 'jsdom';
+import { compose } from 'lib';
+import type { ReactNode } from 'react';
+import { renderAll, renderAllWithoutStyles, renderEditionsAll } from 'renderer';
+
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+};
+
+const generateParas = (paras: number): BodyElement[] => {
+	const frag = JSDOM.fragment(Array(paras).fill('<p>foo</p>').join(''));
+	return flattenTextElement(frag);
+};
+
+const textElements = (nodes: string[]): BodyElement[] => {
+	const frag = JSDOM.fragment(nodes.join(''));
+	return flattenTextElement(frag);
+};
+
+const renderElement = (element: BodyElement): ReactNode[] =>
+	renderAll(mockFormat, [element]);
+
+const renderElements = (elements: BodyElement[]): ReactNode[] =>
+	renderAll(mockFormat, elements);
+
+const renderWithoutStyles = (elements: BodyElement[]): ReactNode[] =>
+	renderAllWithoutStyles(mockFormat, elements);
+
+const renderEditions = (element: BodyElement): ReactNode[] =>
+	renderEditionsAll(mockFormat, [element]);
+
+const renderParagraphs = compose(renderElements, generateParas);
+
+const renderTextElement = compose(renderElements, textElements);
+
+export {
+	mockFormat,
+	generateParas,
+	textElements,
+	renderElement,
+	renderElements,
+	renderWithoutStyles,
+	renderEditions,
+	renderParagraphs,
+	renderTextElement,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
This PR was done through several mobbing sessions with the following people involved: 
@JamieB-gu  , @marjisound , @abeddow91 & @georgeblahblah 
## What does this change?
This PR does the following:
- At the parsing CAPI elements stage, it flattens the capi text elements so that the nested elements will be parsed as individual `BodyElement` (in the past the capi text element and its nested elements, were being parsed as 1 `BodyElement`)
- Parse `h2` elements as `BodyElement` with `HeadingTwo` kind (in the past, this would be parsed as `BodyElement` with `Text` kind)
- Adds `toc` field for BodyElement of kind `HeadingTwo` that includes the heading text and heading id 
- Adds a switch branch for `HeadingTwo` kind at the **render stage** 
- Adds `HeadingTwo` component for rendering the `h2` elements
- Updates some of the rendering helper functions in ads.test and renderer.test files 
- Update story mock data `docFixture` to return Node instead of DocumentFragment because we have now changed the renderText function in renderer and it now expects Node. 

## Why?
These changes will be enabler for adding the table of content in Analysis and Explainer articles. More details can be found here https://docs.google.com/document/d/1MqSldxfgR86kOJaXTFNaBs5LzPzSa7jC4D4YwqqMFwg/edit#

## Screenshots

| Before (with no id)      | After (with id)      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/186178434-1fdf7937-ccd4-4f3a-bb02-860954fdbaed.png) | ![image](https://user-images.githubusercontent.com/15894063/186178671-6a8109c3-6160-457c-92bd-3110bd6a512e.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
