### PR TITLE
A smaller and less square treat image

### DIFF
--- a/dotcom-rendering/src/model/enhanceTreats.ts
+++ b/dotcom-rendering/src/model/enhanceTreats.ts
@@ -42,7 +42,7 @@ const PLATFORM_TREATS: TreatType[] = [
 		containerTitle: 'Culture',
 		editionId: 'UK',
 		imageUrl:
-			'https://interactive.guim.co.uk/thrashers/culture-nugget/hashed/thrasher_img_55.1c0762e5.png',
+			'https://uploads.guim.co.uk/2022/08/19/culture-nugget-august.png',
 		altText: "What's on Netflix and Amazon this month",
 		pageId: 'uk',
 	},

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -55,7 +55,7 @@ const ImageTreat = ({
 	backgroundColour: string;
 }) => (
 	<li>
-		<img src={imageUrl} alt={altText} width="130px" height="130px" />
+		<img src={imageUrl} alt={altText} width="130px" height="auto" />
 		{links.map((link, index) => (
 			<a
 				href={link.linkTo}


### PR DESCRIPTION
## What?
This fixes the image used in the culture treat to be smaller and correctly sized


| Before      | After      |
|-------------|------------|
| <img width="303" alt="Screenshot 2022-08-19 at 13 13 57" src="https://user-images.githubusercontent.com/1336821/185616152-a8a9d66f-9a90-41b4-b040-6f1095725fe0.png">| <img width="303" alt="Screenshot 2022-08-19 at 13 11 42" src="https://user-images.githubusercontent.com/1336821/185616081-eafe4257-69fc-490f-abe7-8804b3971679.png"> |
