### PR TITLE
Add byline to letter when present

### DIFF
--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -82,7 +82,11 @@ const addressStyles = css`
 
 // ----- Byline Component Styles ----- //
 
-const styles = (iconColor: string, hasAvatar: boolean): SerializedStyles => {
+const styles = (
+	iconColor: string,
+	hasAvatar: boolean,
+	shareIcon: boolean,
+): SerializedStyles => {
 	return css`
 		position: relative;
 		display: flex;
@@ -104,12 +108,12 @@ const styles = (iconColor: string, hasAvatar: boolean): SerializedStyles => {
 		}
 		min-height: ${remSpace[12]};
 
-		${!hasAvatar && `padding-bottom: ${remSpace[4]};`}
+		${!hasAvatar && shareIcon && `padding-bottom: ${remSpace[4]};`}
 		margin: 0;
 
 		${from.tablet} {
 			min-height: ${remSpace[9]};
-			${!hasAvatar && `padding-bottom: ${remSpace[9]};`}
+			${!hasAvatar && shareIcon && `padding-bottom: ${remSpace[9]};`}
 		}
 	`;
 };
@@ -180,34 +184,36 @@ const getBylineStyles = (
 	format: ArticleFormat,
 	iconColor: string,
 	hasAvatar: boolean,
+	shareIcon: boolean,
 ): SerializedStyles => {
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {
-		return css(styles(iconColor, hasAvatar), immersiveStyles);
+		return css(styles(iconColor, hasAvatar, shareIcon), immersiveStyles);
 	}
 	if (format.design === ArticleDesign.Interview) {
-		return css(styles(iconColor, hasAvatar), interviewStyles);
+		return css(styles(iconColor, hasAvatar, shareIcon), interviewStyles);
 	}
 	if (format.design === ArticleDesign.Comment) {
-		return css(styles(iconColor, hasAvatar));
+		return css(styles(iconColor, hasAvatar, shareIcon));
 	}
 	if (format.display === ArticleDisplay.Showcase) {
-		return css(styles(iconColor, hasAvatar), showcaseStyles);
+		return css(styles(iconColor, hasAvatar, shareIcon), showcaseStyles);
 	}
 	if (
 		format.design === ArticleDesign.Gallery ||
 		format.design === ArticleDesign.Audio ||
 		format.design === ArticleDesign.Video
 	) {
-		return css(styles(iconColor, hasAvatar), galleryStyles);
+		return css(styles(iconColor, hasAvatar, shareIcon), galleryStyles);
 	}
-	return styles(iconColor, hasAvatar);
+	return styles(iconColor, hasAvatar, shareIcon);
 };
 
 // ----- Component ----- //
 
 interface Props {
 	item: Item;
+	shareIcon?: boolean;
 }
 
 const renderText = (
@@ -255,15 +261,17 @@ const ignoreTextColour = (format: ArticleFormat): boolean =>
 	format.design === ArticleDesign.Video ||
 	format.display === ArticleDisplay.Immersive;
 
-const Byline: FC<Props> = ({ item }) => {
+const Byline: FC<Props> = ({ item, shareIcon = true }) => {
 	const format = getFormat(item);
 	const { kicker: kickerColor } = getThemeStyles(format.theme);
 
 	const iconColor = ignoreIconColour(format) ? neutral[100] : kickerColor;
-	const showShareIcon = hasShareIcon(format);
+	const showShareIcon = hasShareIcon(format) && shareIcon;
 
 	return maybeRender(item.bylineHtml, (byline) => (
-		<div css={getBylineStyles(format, iconColor, hasAvatar(item))}>
+		<div
+			css={getBylineStyles(format, iconColor, hasAvatar(item), shareIcon)}
+		>
 			<address css={addressStyles}>{renderText(byline, format)}</address>
 			{showShareIcon && <ShareIcon />}
 			{hasAvatar(item) && (

--- a/apps-rendering/src/components/editions/header/index.tsx
+++ b/apps-rendering/src/components/editions/header/index.tsx
@@ -236,11 +236,7 @@ const LetterHeader: FC<HeaderProps> = ({ item }) => (
 		<Series item={item} />
 		<Headline item={item} />
 		{maybeRender(item.bylineHtml, (byline) => {
-			if (
-				Array.from(byline.childNodes)
-					.map((node) => node.textContent)
-					.findIndex((e) => e === 'Letters') > -1
-			) {
+			if (byline.textContent === 'Letters') {
 				return null;
 			}
 

--- a/apps-rendering/src/components/editions/header/index.tsx
+++ b/apps-rendering/src/components/editions/header/index.tsx
@@ -24,6 +24,7 @@ import {
 	wideContentWidth,
 	wideImmersiveWidth,
 } from '../styles';
+import { maybeRender } from 'lib';
 
 const wide = wideContentWidth + 12;
 const tablet = tabletContentWidth + 12;
@@ -234,6 +235,17 @@ const LetterHeader: FC<HeaderProps> = ({ item }) => (
 		<HeaderMedia item={item} />
 		<Series item={item} />
 		<Headline item={item} />
+		{maybeRender(item.bylineHtml, (byline) => {
+			if (
+				Array.from(byline.childNodes)
+					.map((node) => node.textContent)
+					.findIndex((e) => e === 'Letters') > -1
+			) {
+				return null;
+			}
+
+			return <Byline item={item} shareIcon={false} />;
+		})}
 		<Lines />
 		<Standfirst item={item} shareIcon />
 	</header>

--- a/apps-rendering/src/components/editions/header/index.tsx
+++ b/apps-rendering/src/components/editions/header/index.tsx
@@ -12,6 +12,7 @@ import Series from 'components/editions/series';
 import Standfirst from 'components/editions/standfirst';
 import type { Item } from 'item';
 import { isPicture } from 'item';
+import { maybeRender } from 'lib';
 import type { FC, ReactElement } from 'react';
 import {
 	articleMarginStyles,
@@ -24,7 +25,6 @@ import {
 	wideContentWidth,
 	wideImmersiveWidth,
 } from '../styles';
-import { maybeRender } from 'lib';
 
 const wide = wideContentWidth + 12;
 const tablet = tabletContentWidth + 12;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add conditional byline to letters in Editions

## Why?
See [#5629](https://github.com/guardian/dotcom-rendering/issues/5629)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="628" alt="image" src="https://user-images.githubusercontent.com/99400613/185650261-206e3760-681f-4a1f-a8e5-cbf91f007305.png"> | <img width="615" alt="image" src="https://user-images.githubusercontent.com/99400613/185650059-bd822cfe-65c6-4ce4-b96f-0d659c0c615b.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
