### PR TITLE
Add useParticipations display rule for Sign In Gate

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -9,6 +9,7 @@ import {
 	useParticipations,
 } from './displayRule';
 import { CurrentSignInGateABTest } from './types';
+import { Participations } from '@guardian/ab-core';
 
 describe('SignInGate - displayRule methods', () => {
 	describe('isNPageOrHigherPageView', () => {
@@ -124,7 +125,9 @@ describe('SignInGate - displayRule methods', () => {
 			localStorage.clear();
 		});
 		const getParticipationsFromLocalStorage = () =>
-			storage.local.get('gu.ab.participations');
+			(storage.local.get('gu.ab.participations') as
+				| Participations
+				| undefined) || {};
 
 		const currentTest: CurrentSignInGateABTest = {
 			id: 'test-id',
@@ -139,21 +142,22 @@ describe('SignInGate - displayRule methods', () => {
 			jest.spyOn(Date, 'now').mockReturnValue(before);
 
 			expect(await useParticipations(cutoff, currentTest)).toBe(true);
-			expect(
-				getParticipationsFromLocalStorage()[currentTest.id],
-			).toBeDefined();
+			expect(getParticipationsFromLocalStorage()).toBeDefined();
 		});
 		test('useParticipations returns correctly after the cutoff if not in participation', async () => {
 			jest.spyOn(Date, 'now').mockReturnValue(after);
 
 			expect(await useParticipations(cutoff, currentTest)).toBe(false);
-			expect(getParticipationsFromLocalStorage()).toBeNull();
+			expect(
+				getParticipationsFromLocalStorage()[currentTest.id],
+			).not.toBeDefined();
 		});
 		test('useParticipations returns correctly after the cutoff if in participation', async () => {
 			jest.spyOn(Date, 'now').mockReturnValue(after);
 			storage.local.set('gu.ab.participations', {
 				[currentTest.id]: { variant: `${currentTest.variant}` },
 			});
+
 			expect(await useParticipations(cutoff, currentTest)).toBe(true);
 		});
 	});

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -1,6 +1,7 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
 import { onConsent } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { getLocale } from '@guardian/libs';
 import {
 	getParticipationsFromLocalStorage,
 	setParticipationsInLocalStorage,

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -91,7 +91,7 @@ export const useParticipations = (
 	currentTest: CurrentSignInGateABTest,
 ): Promise<boolean> => {
 	const now = Date.now(); // UTC
-	const { id, name, variant } = currentTest;
+	const { id, variant } = currentTest;
 
 	// BEFORE cutoff date all users will be bucketed and potentially shown the gate if they satisfy all subsequent conditions
 	if (now < cutOff) {
@@ -105,7 +105,7 @@ export const useParticipations = (
 	// AFTER cutoff date, browsers without local storage test paticipatieon
 	const participations = getParticipationsFromLocalStorage();
 	// if the test particpation exists, show the test gate
-	return !!participations[id] // TODO rely on id and variant, not just id ??
+	return !!participations[id] && participations[id]?.variant === variant
 		? Promise.resolve(true)
 		: Promise.resolve(false);
 };

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -103,10 +103,10 @@ export const useParticipations = (
 		return Promise.resolve(true); //  we only want to bucket until the cutoff
 	}
 
-	// AFTER cutoff date, browsers without local storage test paticipatieon
+	// AFTER cutoff date, browsers without local storage test participation will not be shown the gate
 	const participations = getParticipationsFromLocalStorage();
-	// if the test particpation exists, show the test gate
-	return !!participations[id] && participations[id]?.variant === variant
+	// if the test participation exists, show the test gate
+	return participations[id]?.variant === variant
 		? Promise.resolve(true)
 		: Promise.resolve(false);
 };

--- a/dotcom-rendering/src/web/experiments/ab-localstorage.ts
+++ b/dotcom-rendering/src/web/experiments/ab-localstorage.ts
@@ -1,0 +1,25 @@
+import type { Participations } from '@guardian/ab-core';
+import { storage } from '@guardian/libs';
+
+const participationsKey = 'gu.ab.participations';
+
+// -------
+// Reading
+// -------
+export const getParticipationsFromLocalStorage = (): Participations =>
+	(storage.local.get(participationsKey) as Participations | undefined) ?? {};
+
+// -------
+// Writing
+// -------
+
+// Wipes all localStorage participations
+export const clearParticipations = (): void => {
+	storage.local.remove(participationsKey);
+};
+
+export const setParticipationsInLocalStorage = (
+	participations: Participations,
+): void => {
+	storage.local.set(participationsKey, participations);
+};


### PR DESCRIPTION
This PR adds a new display rule, which will run to determine whether or not to show the sign in gate. 

**`useParticipations`** - this display rule will either set an AB test participation in local storage or check local storage for participation when determining whether to display the gate. 

**Why do we need `useParticipations`?** 

We would like to be able to run long-running tests over several weeks, but only accumulate browsers in the test bucket for part of that time. This will allow us to AB test behaviour over time.  We cannot use the `mvt_id` cookie alone, as this is set by Fastly and we crucially do not know when it was set on a given browser. The solution implemented repurposes the existing `gu.ab.participations` local storage key to flag browsers bucketed into a test within a pre-defined "cutoff" window. 

_Caveats_ - this solution does not require a new cookie with timestamp. This solution also means all users in the `mvt_id` test bucket range encountering the test after the cutoff window will _never_ see the sign in gate until the test is is turned off.  


TODO
- Investigate if there a way to default back to the standard sign in gate if a test "canShow" function returns false? 