### PR TITLE
a11y : Add id for skip to main content for full page interactive layout

### DIFF
--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -328,23 +328,25 @@ export const FullPageInteractiveLayout = ({
 				backgroundColour={palette.background.article}
 				element="main"
 			>
-				<article>
-					<Renderer
-						format={format}
-						elements={
-							CAPIArticle.blocks[0]
-								? CAPIArticle.blocks[0].elements
-								: []
-						}
-						host={host}
-						pageId={CAPIArticle.pageId}
-						webTitle={CAPIArticle.webTitle}
-						ajaxUrl={CAPIArticle.config.ajaxUrl}
-						switches={CAPIArticle.config.switches}
-						isAdFreeUser={CAPIArticle.isAdFreeUser}
-						isSensitive={CAPIArticle.config.isSensitive}
-					/>
-				</article>
+				<div id="maincontent" tabIndex={-1}>
+					<article>
+						<Renderer
+							format={format}
+							elements={
+								CAPIArticle.blocks[0]
+									? CAPIArticle.blocks[0].elements
+									: []
+							}
+							host={host}
+							pageId={CAPIArticle.pageId}
+							webTitle={CAPIArticle.webTitle}
+							ajaxUrl={CAPIArticle.config.ajaxUrl}
+							switches={CAPIArticle.config.switches}
+							isAdFreeUser={CAPIArticle.isAdFreeUser}
+							isSensitive={CAPIArticle.config.isSensitive}
+						/>
+					</article>
+				</div>
 			</Section>
 
 			{NAV.subNavSections && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds the ID to skip to main content for full page interactive layouts.

This resolves https://github.com/guardian/dotcom-rendering/issues/5038

## Why?

This was highlighted by the DAC review: https://drive.google.com/file/d/1EiqM0vMziEvdG_N8ne0GtIg-MsDydvqy/view

