### PR TITLE
Rename `OnwardsSource` type

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -361,8 +361,8 @@
                     "url": {
                         "type": "string"
                     },
-                    "onwardsType": {
-                        "$ref": "#/definitions/OnwardsType"
+                    "onwardsSource": {
+                        "$ref": "#/definitions/OnwardsSource"
                     },
                     "format": {
                         "type": "object",
@@ -390,7 +390,7 @@
                 "required": [
                     "format",
                     "heading",
-                    "onwardsType",
+                    "onwardsSource",
                     "trails"
                 ]
             }
@@ -4283,16 +4283,16 @@
                 "sponsorName"
             ]
         },
-        "OnwardsType": {
+        "OnwardsSource": {
             "enum": [
                 "curated-content",
-                "default-onwards",
                 "more-galleries",
                 "more-media-in-section",
                 "more-on-this-story",
                 "related-content",
                 "related-stories",
-                "series"
+                "series",
+                "unknown-source"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -3,7 +3,7 @@ import type { CommercialProperties } from './commercial';
 import type { ConfigType } from './config';
 import type { EditionId } from './edition';
 import type { FooterType } from './footer';
-import type { CAPIOnwardsType } from './onwards';
+import type { CAPIOnwards } from './onwards';
 import type { CAPITrailType } from './trails';
 
 /**
@@ -72,7 +72,7 @@ export interface CAPIArticleType {
 		trails: CAPITrailType[];
 		heading: string;
 	};
-	onwards?: CAPIOnwardsType[];
+	onwards?: CAPIOnwards[];
 	beaconURL: string;
 	isCommentable: boolean;
 	commercialProperties: CommercialProperties;

--- a/dotcom-rendering/src/types/onwards.ts
+++ b/dotcom-rendering/src/types/onwards.ts
@@ -3,17 +3,17 @@ import type { CAPITrailType } from './trails';
 /**
  * Onwards
  */
-export type CAPIOnwardsType = {
+export type CAPIOnwards = {
 	heading: string;
 	trails: CAPITrailType[];
 	description?: string;
 	url?: string;
-	onwardsType: OnwardsType;
+	onwardsSource: OnwardsSource;
 	format: CAPIFormat;
 	isCuratedContent?: boolean;
 };
 
-export type OnwardsType =
+export type OnwardsSource =
 	| 'series'
 	| 'more-on-this-story'
 	| 'related-stories'
@@ -21,4 +21,4 @@ export type OnwardsType =
 	| 'more-media-in-section'
 	| 'more-galleries'
 	| 'curated-content'
-	| 'default-onwards'; // We should never see this in the analytics data!
+	| 'unknown-source'; // We should never see this in the analytics data!

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -12,7 +12,7 @@ import {
 import libDebounce from 'lodash.debounce';
 import { useEffect, useRef, useState } from 'react';
 import type { Branding } from '../../types/branding';
-import type { OnwardsType } from '../../types/onwards';
+import type { OnwardsSource } from '../../types/onwards';
 import type { Palette } from '../../types/palette';
 import type { TrailType } from '../../types/trails';
 import { decidePalette } from '../lib/decidePalette';
@@ -29,7 +29,7 @@ type Props = {
 	trails: TrailType[];
 	description?: string;
 	url?: string;
-	onwardsType: OnwardsType;
+	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
 };
 
@@ -428,7 +428,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 	</div>
 );
 
-export const Carousel = ({ heading, trails, onwardsType, format }: Props) => {
+export const Carousel = ({ heading, trails, onwardsSource, format }: Props) => {
 	const palette = decidePalette(format);
 	const carouselRef = useRef<HTMLUListElement>(null);
 
@@ -437,7 +437,7 @@ export const Carousel = ({ heading, trails, onwardsType, format }: Props) => {
 
 	const arrowName = 'carousel-small-arrow';
 
-	const isCuratedContent = onwardsType === 'curated-content';
+	const isCuratedContent = onwardsSource === 'curated-content';
 
 	const notPresentation = (el: HTMLElement): boolean =>
 		el.getAttribute('role') !== 'presentation';
@@ -583,7 +583,7 @@ export const Carousel = ({ heading, trails, onwardsType, format }: Props) => {
 			</div>
 			<div
 				css={[containerStyles, containerMargins]}
-				data-component={onwardsType}
+				data-component={onwardsSource}
 				data-link={formatAttrString(heading)}
 			>
 				<Hide when="above" breakpoint="leftCol">

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -186,7 +186,7 @@ export const Headlines = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails}
-				onwardsType="more-on-this-story"
+				onwardsSource="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -198,7 +198,7 @@ export const Headlines = () => (
 			<Carousel
 				heading="Sport"
 				trails={trails}
-				onwardsType="curated-content"
+				onwardsSource="curated-content"
 				format={{
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,
@@ -217,7 +217,7 @@ export const SingleItemCarousel = () => (
 			<Carousel
 				heading="More on this story"
 				trails={trails.slice(1, 2)}
-				onwardsType="more-on-this-story"
+				onwardsSource="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -236,7 +236,7 @@ export const Immersive = () => (
 			<Carousel
 				heading="More on this story"
 				trails={immersiveTrails}
-				onwardsType="more-on-this-story"
+				onwardsSource="more-on-this-story"
 				format={{
 					theme: ArticlePillar.News,
 					design: ArticleDesign.Standard,
@@ -248,7 +248,7 @@ export const Immersive = () => (
 			<Carousel
 				heading="Sport"
 				trails={immersiveTrails}
-				onwardsType="curated-content"
+				onwardsSource="curated-content"
 				format={{
 					theme: ArticlePillar.Sport,
 					design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/web/components/DecideOnwards.tsx
+++ b/dotcom-rendering/src/web/components/DecideOnwards.tsx
@@ -1,4 +1,4 @@
-import type { CAPIOnwardsType } from '../../types/onwards';
+import type { CAPIOnwards } from '../../types/onwards';
 import { decideTrail } from '../lib/decideTrail';
 import { Carousel } from './Carousel.importable';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
@@ -9,23 +9,23 @@ export const DecideOnwards = ({
 	onwards,
 	format,
 }: {
-	onwards: CAPIOnwardsType[];
+	onwards: CAPIOnwards[];
 	format: ArticleFormat;
 }) => (
 	<>
-		{onwards.map(({ heading, trails, onwardsType, url }) => {
+		{onwards.map(({ heading, trails, onwardsSource, url }) => {
 			if (trails.length > 0) {
 				return (
 					<Section
 						fullWidth={true}
-						key={onwardsType}
+						key={onwardsSource}
 						showTopBorder={false}
 					>
 						<Island deferUntil="visible">
 							<Carousel
 								heading={heading}
 								trails={trails.map(decideTrail)}
-								onwardsType={onwardsType}
+								onwardsSource={onwardsSource}
 								format={format}
 							/>
 						</Island>
@@ -37,7 +37,7 @@ export const DecideOnwards = ({
 				return (
 					<Section
 						fullWidth={true}
-						key={onwardsType}
+						key={onwardsSource}
 						showTopBorder={false}
 					>
 						<Island
@@ -48,7 +48,7 @@ export const DecideOnwards = ({
 							<FetchOnwardsData
 								url={url}
 								limit={8}
-								onwardsType={onwardsType}
+								onwardsSource={onwardsSource}
 								format={format}
 							/>
 						</Island>

--- a/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchOnwardsData.importable.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useEffect } from 'react';
-import type { OnwardsType } from '../../types/onwards';
+import type { OnwardsSource } from '../../types/onwards';
 import type { CAPITrailType, TrailType } from '../../types/trails';
 import { decideTrail } from '../lib/decideTrail';
 import { revealStyles } from '../lib/revealStyles';
@@ -11,7 +11,7 @@ import { Placeholder } from './Placeholder';
 type Props = {
 	url: string;
 	limit: number; // Limit the number of items shown (the api often returns more)
-	onwardsType: OnwardsType;
+	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
 };
 
@@ -29,7 +29,7 @@ const minHeight = css`
 export const FetchOnwardsData = ({
 	url,
 	limit,
-	onwardsType,
+	onwardsSource,
 	format,
 }: Props) => {
 	const { data, loading, error } = useApi<OnwardsResponse>(url);
@@ -78,7 +78,7 @@ export const FetchOnwardsData = ({
 						heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
 						trails={buildTrails(data.trails, limit)}
 						description={data.description}
-						onwardsType={onwardsType}
+						onwardsSource={onwardsSource}
 						format={format}
 					/>
 				</div>

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
 import { joinUrl } from '../../lib/joinUrl';
 import type { EditionId } from '../../types/edition';
-import type { OnwardsType } from '../../types/onwards';
+import type { OnwardsSource } from '../../types/onwards';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Section } from './Section';
 
@@ -202,7 +202,7 @@ export const OnwardsUpper = ({
 	);
 
 	let url;
-	let onwardsType: OnwardsType = 'default-onwards';
+	let onwardsSource: OnwardsSource = 'unknown-source';
 
 	if (!showRelatedContent) {
 		// Then don't show related content
@@ -225,7 +225,7 @@ export const OnwardsUpper = ({
 			'series',
 			`${seriesTag.id}.json?dcr&shortUrl=${shortUrlId}`,
 		]);
-		onwardsType = 'series';
+		onwardsSource = 'series';
 	} else if (!hasRelated) {
 		// There is no related content to show
 	} else if (tagToFilterBy) {
@@ -255,13 +255,13 @@ export const OnwardsUpper = ({
 		}
 
 		url = joinUrl([ajaxUrl, popularInTagUrl]);
-		onwardsType = 'related-content';
+		onwardsSource = 'related-content';
 	} else {
 		// Default to generic related endpoint
 		const relatedUrl = `/related/${pageId}.json?dcr=true`;
 
 		url = joinUrl([ajaxUrl, relatedUrl]);
-		onwardsType = 'related-stories';
+		onwardsSource = 'related-stories';
 	}
 
 	const curatedDataUrl = showRelatedContent
@@ -275,7 +275,7 @@ export const OnwardsUpper = ({
 					<FetchOnwardsData
 						url={url}
 						limit={8}
-						onwardsType={onwardsType}
+						onwardsSource={onwardsSource}
 						format={format}
 					/>
 				</Section>
@@ -285,7 +285,7 @@ export const OnwardsUpper = ({
 					<FetchOnwardsData
 						url={curatedDataUrl}
 						limit={20}
-						onwardsType="curated-content"
+						onwardsSource="curated-content"
 						format={format}
 					/>
 				</Section>

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -730,7 +730,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -532,7 +532,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -641,7 +641,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1186,7 +1186,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											trails={CAPIArticle.storyPackage.trails.map(
 												decideTrail,
 											)}
-											onwardsType="more-on-this-story"
+											onwardsSource="more-on-this-story"
 											format={format}
 										/>
 									</Island>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -481,7 +481,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -683,7 +683,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -816,7 +816,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										trails={CAPIArticle.storyPackage.trails.map(
 											decideTrail,
 										)}
-										onwardsType="more-on-this-story"
+										onwardsSource="more-on-this-story"
 										format={format}
 									/>
 								</Island>

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -7,7 +7,7 @@ import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
 import type { CAPIArticleType } from '../../types/frontend';
-import type { CAPIOnwardsType } from '../../types/onwards';
+import type { CAPIOnwards } from '../../types/onwards';
 import { articleToHtml } from './articleToHtml';
 import { blocksToHtml } from './blocksToHtml';
 import { frontToHtml } from './frontToHtml';
@@ -179,17 +179,18 @@ export const renderKeyEvents = (
 };
 
 export const renderOnwards = (
-	{ body }: { body: CAPIOnwardsType },
+	{ body }: { body: CAPIOnwards },
 	res: express.Response,
 ): void => {
 	try {
-		const { heading, description, url, onwardsType, trails, format } = body;
+		const { heading, description, url, onwardsSource, trails, format } =
+			body;
 
 		const html = onwardsToHtml({
 			heading,
 			description,
 			url,
-			onwardsType,
+			onwardsSource,
 			trails,
 			format,
 		});

--- a/dotcom-rendering/src/web/server/onwardsToHtml.tsx
+++ b/dotcom-rendering/src/web/server/onwardsToHtml.tsx
@@ -1,5 +1,5 @@
 import { renderToString } from 'react-dom/server';
-import type { CAPIOnwardsType } from '../../types/onwards';
+import type { CAPIOnwards } from '../../types/onwards';
 import type { CAPITrailType, TrailType } from '../../types/trails';
 import { Carousel } from '../components/Carousel.importable';
 import { decideFormat } from '../lib/decideFormat';
@@ -22,16 +22,16 @@ export const onwardsToHtml = ({
 	heading,
 	// description,
 	// url,
-	onwardsType,
+	onwardsSource,
 	trails,
 	format: CAPIFormat,
-}: CAPIOnwardsType): string => {
+}: CAPIOnwards): string => {
 	const format = decideFormat(CAPIFormat);
 
 	const html = renderToString(
 		<Carousel
 			heading={heading}
-			onwardsType={onwardsType}
+			onwardsSource={onwardsSource}
 			trails={buildTrails(trails, 8)}
 			format={format}
 		/>,


### PR DESCRIPTION
## What does this change?

Rename types to be more explicit:

- `OnwardsType` &rarr; `OnwardsSource`
- `CAPIOnwardsType` &rarr; `CAPIOnwards` 
- 'default-onwards' &rarr; 'unknown-source'

## Why?

Together with @jamesgorrie, we think it helps to think about these data types better. See also #5794.
