### PR TITLE
Add global h3 styles

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -1,13 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import {
-	between,
-	body,
-	headline,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { between, body, headline, space } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -1,7 +1,13 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { between, body, headline, space } from '@guardian/source-foundations';
+import {
+	between,
+	body,
+	headline,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';
@@ -58,13 +64,22 @@ const globalOlStyles = () => css`
 `;
 
 const globalH3Styles = (display: ArticleDisplay) => {
-	if (display !== ArticleDisplay.NumberedList) return null;
-	return css`
-		h3 {
-			${headline.xsmall({ fontWeight: 'bold' })};
-			margin-bottom: ${space[2]}px;
-		}
-	`;
+	switch (display) {
+		case ArticleDisplay.NumberedList:
+			return css`
+				h3 {
+					${headline.xsmall({ fontWeight: 'bold' })};
+					margin-bottom: ${space[2]}px;
+				}
+			`;
+		default:
+			return css`
+				h3 {
+					${body.medium({ fontWeight: 'bold' })};
+					margin-bottom: ${space[4]}px;
+				}
+			`;
+	}
 };
 
 const globalStrongStyles = css`

--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -219,6 +219,11 @@ export const TextBlockComponent = ({
 						prefix: '<ul>',
 						suffix: '</ul>',
 					},
+					{
+						unwrappedElement: 'h3',
+						prefix: '<h3>',
+						suffix: '</h3>',
+					},
 				],
 				html,
 			});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Provides global h3 styles to all h3 elements, not just those in a numbered list. 

## Why?
Composer doesn't provide h3 tags, it provides "faux" h3 tags (`<p><strong>`). DCR previously converted these faux tags to h3 tags for numbered lists only. We have recently hoisted this logic to enhance all h3s. As such, we need to add additional styles. 

Whilst undertaking this work, we also noticed that these h3 tags were being wrapped in a span due to React injecting them via dangerouslySetHtml. We have updated the unwrapping logic to stop h3 tags from being wrapped in a unnecessary span. 

Paired with @oliverlloyd 
