### PR TITLE
Add Explainer standfirst

### DIFF
--- a/apps-rendering/src/components/Standfirst/ExplainerStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ExplainerStandfirst.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import { headline } from '@guardian/source-foundations';
+import type { Item } from 'item';
+import { getFormat } from 'item';
+import type { FC } from 'react';
+import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
+
+const styles = css`
+	${headline.xxxsmall({ fontWeight: 'light' })}
+`;
+
+interface Props {
+	item: Item;
+}
+
+const ExplainerStandfirst: FC<Props> = ({ item }) => (
+	<DefaultStandfirst
+		item={item}
+		css={css(defaultStyles(getFormat(item)), styles)}
+	/>
+);
+
+export default ExplainerStandfirst;

--- a/apps-rendering/src/components/Standfirst/index.tsx
+++ b/apps-rendering/src/components/Standfirst/index.tsx
@@ -5,6 +5,7 @@ import type { Item } from 'item';
 import { getFormat } from 'item';
 import AnalysisStandfirst from './AnalysisStandfirst';
 import DeadBlogStandfirst from './DeadBlogStandfirst';
+import ExplainerStandfirst from './ExplainerStandfirst';
 import GalleryStandfirst from './GalleryStandfirst';
 import ImmersiveLabsStandfirst from './ImmersiveLabsStandfirst';
 import ImmersiveStandfirst from './ImmersiveStandfirst';
@@ -63,6 +64,8 @@ const Standfirst: React.FC<Props> = ({ item }) => {
 			return <InterviewStandfirst item={item} />;
 		case ArticleDesign.Analysis:
 			return <AnalysisStandfirst item={item} />;
+		case ArticleDesign.Explainer:
+			return <ExplainerStandfirst item={item} />;
 		default:
 			return (
 				<DefaultStandfirst

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -186,6 +186,22 @@ export const Analysis = () => {
 };
 Analysis.story = { name: 'Analysis' };
 
+export const Explainer = () => {
+	return (
+		<Section fullWidth={true}>
+			<Standfirst
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Explainer,
+					theme: ArticlePillar.News,
+				}}
+				standfirst="This is how Explainer standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
+			/>
+		</Section>
+	);
+};
+Explainer.story = { name: 'Explainer' };
+
 export const Gallery = () => {
 	return (
 		<Section fullWidth={true}>

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -151,6 +151,7 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Review:
 				case ArticleDesign.NewsletterSignup:
+				case ArticleDesign.Explainer:
 					return css`
 						${headline.xxsmall({
 							fontWeight: 'light',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the explainer standfirst to AR and DCR in line with new editorial designs. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/186140184-47bb06f0-8794-4bb5-9035-89766fe9d22f.png
[after]: https://user-images.githubusercontent.com/20416599/186140172-2ebd1be0-a428-4910-a7c4-fb3100ec9457.png

| Before      | After      |
|-------------|------------|
| ![before-ar][] | ![after-ar][] |

[before-ar]: https://user-images.githubusercontent.com/20416599/186143133-8dfe0b24-157d-48fa-989a-df9f8b0a53e0.png
[after-ar]: https://user-images.githubusercontent.com/20416599/186141772-299e1b4d-0032-4999-aee2-1216a2a41664.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
