### PR TITLE
fix: coerce switches to boolean

### DIFF
--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -125,9 +125,9 @@ export const Blocks: React.FunctionComponent<{
 		contentType,
 		commercialProperties,
 		switches: {
-			ampPrebid: switches.ampPrebid,
-			permutive: switches.permutive,
-			ampAmazon: switches.ampAmazon,
+			ampPrebid: !!switches.ampPrebid,
+			permutive: !!switches.permutive,
+			ampAmazon: !!switches.ampAmazon,
 		},
 	};
 

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -126,9 +126,9 @@ export const Body: React.FC<{
 		contentType: data.contentType,
 		commercialProperties: data.commercialProperties,
 		switches: {
-			ampPrebid: config.switches.ampPrebid,
-			permutive: config.switches.permutive,
-			ampAmazon: config.switches.ampAmazon,
+			ampPrebid: !!config.switches.ampPrebid,
+			permutive: !!config.switches.permutive,
+			ampAmazon: !!config.switches.ampAmazon,
 		},
 	};
 

--- a/dotcom-rendering/src/web/components/Article.tsx
+++ b/dotcom-rendering/src/web/components/Article.tsx
@@ -62,7 +62,7 @@ export const Article = ({ CAPIArticle, NAV, format }: Props) => {
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">
 				<CommercialMetrics
-					enabled={CAPIArticle.config.switches.commercialMetrics}
+					enabled={!!CAPIArticle.config.switches.commercialMetrics}
 				/>
 			</Island>
 			<Island clientOnly={true} deferUntil="idle">

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -344,7 +344,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								}
 								urls={CAPIArticle.nav.readerRevenueLinks.header}
 								remoteHeader={
-									CAPIArticle.config.switches.remoteHeader
+									!!CAPIArticle.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
@@ -544,7 +544,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									shortUrlId={CAPIArticle.config.shortUrlId}
 									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -783,7 +783,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPIArticle.config.switches
+								!!CAPIArticle.config.switches
 									.enableDiscussionSwitch
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -872,10 +872,10 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -88,7 +88,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							}
 							discussionApiUrl={front.config.discussionApiUrl}
 							urls={front.nav.readerRevenueLinks.header}
-							remoteHeader={front.config.switches.remoteHeader}
+							remoteHeader={!!front.config.switches.remoteHeader}
 							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
 							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
 						/>

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -221,7 +221,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							urls={CAPIArticle.nav.readerRevenueLinks.header}
 							remoteHeader={
-								CAPIArticle.config.switches.remoteHeader
+								!!CAPIArticle.config.switches.remoteHeader
 							}
 							contributionsServiceUrl={
 								CAPIArticle.contributionsServiceUrl
@@ -406,10 +406,10 @@ export const FullPageInteractiveLayout = ({
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -363,7 +363,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									shortUrlId={CAPIArticle.config.shortUrlId}
 									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -585,7 +585,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPIArticle.config.switches
+								!!CAPIArticle.config.switches
 									.enableDiscussionSwitch
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -670,10 +670,10 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -435,7 +435,7 @@ export const InteractiveImmersiveLayout = ({
 									shortUrlId={CAPIArticle.config.shortUrlId}
 									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -530,10 +530,10 @@ export const InteractiveImmersiveLayout = ({
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -281,7 +281,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								}
 								urls={CAPIArticle.nav.readerRevenueLinks.header}
 								remoteHeader={
-									CAPIArticle.config.switches.remoteHeader
+									!!CAPIArticle.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
@@ -488,7 +488,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										}
 										ajaxUrl={CAPIArticle.config.ajaxUrl}
 										showShareCount={
-											CAPIArticle.config.switches
+											!!CAPIArticle.config.switches
 												.serverShareCounts
 										}
 									/>
@@ -695,7 +695,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPIArticle.config.switches
+								!!CAPIArticle.config.switches
 									.enableDiscussionSwitch
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -791,10 +791,10 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Layout.stories.tsx
@@ -83,7 +83,7 @@ export const HydratedLayoutWrapper = ({
 	designName: string;
 	theme: string;
 }) => {
-	const fixture = Fixtures[designName] || Fixtures.Standard;
+	const fixture = Fixtures[designName] ?? Standard;
 
 	const serverCAPI = {
 		...fixture,
@@ -114,7 +114,7 @@ export const Liveblog = () => {
 	return (
 		<HydratedLayout
 			ServerCAPI={{
-				...Fixtures.LiveBlog,
+				...Live,
 				keyEvents: [],
 			}}
 		/>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -286,11 +286,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const showKeyEventsCarousel = CAPIArticle.config.switches.keyEventsCarousel;
 
-	const isInFilteringBeta =
+	const isInFilteringBeta = !!(
 		CAPIArticle.config.switches.automaticFilters &&
-		CAPIArticle.availableTopics;
+		CAPIArticle.availableTopics
+	);
 
-	const showTopicFilterBank = CAPIArticle.config.switches.automaticFilters;
+	const showTopicFilterBank = !!CAPIArticle.config.switches.automaticFilters;
 
 	const showToggle = !showTopicFilterBank || !CAPIArticle.availableTopics;
 
@@ -338,7 +339,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							urls={CAPIArticle.nav.readerRevenueLinks.header}
 							remoteHeader={
-								CAPIArticle.config.switches.remoteHeader
+								!!CAPIArticle.config.switches.remoteHeader
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={CAPIArticle.config.idApiUrl}
@@ -575,7 +576,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										}
 										ajaxUrl={CAPIArticle.config.ajaxUrl}
 										showShareCount={
-											CAPIArticle.config.switches
+											!!CAPIArticle.config.switches
 												.serverShareCounts
 										}
 									/>
@@ -647,7 +648,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									}
 									format={format}
 									enhanceTweetsSwitch={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.enhanceTweets
 									}
 									onFirstPage={pagination.currentPage === 1}
@@ -747,7 +748,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											}
 											ajaxUrl={CAPIArticle.config.ajaxUrl}
 											showShareCount={
-												CAPIArticle.config.switches
+												!!CAPIArticle.config.switches
 													.serverShareCounts
 											}
 										/>
@@ -1246,7 +1247,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									CAPIArticle.config.discussionApiClientHeader
 								}
 								enableDiscussionSwitch={
-									CAPIArticle.config.switches
+									!!CAPIArticle.config.switches
 										.enableDiscussionSwitch
 								}
 								isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -1344,10 +1345,10 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -251,7 +251,9 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 						}
 						discussionApiUrl={CAPIArticle.config.discussionApiUrl}
 						urls={CAPIArticle.nav.readerRevenueLinks.header}
-						remoteHeader={CAPIArticle.config.switches.remoteHeader}
+						remoteHeader={
+							!!CAPIArticle.config.switches.remoteHeader
+						}
 						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPIArticle.config.idApiUrl}
 					/>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -287,7 +287,8 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											.header
 									}
 									remoteHeader={
-										CAPIArticle.config.switches.remoteHeader
+										!!CAPIArticle.config.switches
+											.remoteHeader
 									}
 									contributionsServiceUrl={
 										contributionsServiceUrl
@@ -504,7 +505,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									shortUrlId={CAPIArticle.config.shortUrlId}
 									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -736,7 +737,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPIArticle.config.switches
+								!!CAPIArticle.config.switches
 									.enableDiscussionSwitch
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -826,10 +827,10 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -383,7 +383,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								}
 								urls={CAPIArticle.nav.readerRevenueLinks.header}
 								remoteHeader={
-									CAPIArticle.config.switches.remoteHeader
+									!!CAPIArticle.config.switches.remoteHeader
 								}
 								contributionsServiceUrl={
 									contributionsServiceUrl
@@ -619,7 +619,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									shortUrlId={CAPIArticle.config.shortUrlId}
 									ajaxUrl={CAPIArticle.config.ajaxUrl}
 									showShareCount={
-										CAPIArticle.config.switches
+										!!CAPIArticle.config.switches
 											.serverShareCounts
 									}
 								/>
@@ -870,7 +870,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.config.discussionApiClientHeader
 							}
 							enableDiscussionSwitch={
-								CAPIArticle.config.switches
+								!!CAPIArticle.config.switches
 									.enableDiscussionSwitch
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
@@ -967,10 +967,10 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							CAPIArticle.shouldHideReaderRevenue
 						}
 						remoteBannerSwitch={
-							CAPIArticle.config.switches.remoteBanner
+							!!CAPIArticle.config.switches.remoteBanner
 						}
 						puzzleBannerSwitch={
-							CAPIArticle.config.switches.puzzlesBanner
+							!!CAPIArticle.config.switches.puzzlesBanner
 						}
 						tags={CAPIArticle.tags}
 					/>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -154,7 +154,7 @@ export const renderElement = ({
 						duration={element.duration}
 						pillar={format.theme}
 						contentIsNotSensitive={!isSensitive}
-						aCastisEnabled={switches.acast}
+						aCastisEnabled={!!switches.acast}
 						readerCanBeShownAds={!isAdFreeUser}
 					/>
 				</Island>,
@@ -440,7 +440,7 @@ export const renderElement = ({
 				true,
 				<VideoAtom
 					assets={element.assets}
-					poster={element.posterImage && element.posterImage[0].url}
+					poster={element.posterImage?.[0]?.url}
 				/>,
 			];
 		case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
@@ -757,7 +757,7 @@ export const renderElement = ({
 						mediaTitle={element.mediaTitle}
 						altText={element.altText}
 						origin={host}
-						stickyVideos={isBlog && switches.stickyVideos}
+						stickyVideos={!!(isBlog && switches.stickyVideos)}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Cooerce switches to booleans. Undefined switches will be explicitely `false`.

## Why?

Relying on the falsiness of these switches is not as explicit.

These will throw errors when we have `noUncheckedIndexedAccess`.

#5777 