### PR TITLE
Dblatcher/signup placement tweak

### DIFF
--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -51,29 +51,30 @@ const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 3;
 //    | TextTextTextTextTextText  | +------+
 //    | TextTextTextText          |
 
-const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT_TO_TAKE_ACCOUNT_OF_WHEN_SORTING = 4;
-// The maximum distance is set so that the sort function does not always place
-// the SignUp as high as possible to be above a (fairly distant) floating element
-// resulting in the block being higher than is ideal.
-
-//	 0 TEXT
-//	 1 TEXT
-//	 2 TEXT
-//    [too high] <--  Without this rule the SignUp
-//	 3 RICHLINK     | tends to go too high so it's
-//	 4 TEXT         | above the floating element
-//	 5 TEXT         |
-//	 6 TEXT         |
-//	 7 TEXT         |
-//     [target] ----+ Staying here would probably be
-//	 8 TEXT           fine as there are four paragraphs
-//	 9 TEXT           between this spot and the richlink
-//	10 TEXT
-//	11 TEXT
-//	12 TEXT
-//	13 TEXT
-//	14 TEXT
-
+/**
+ * The maximum distance is set so that the sort function does not always place
+ * the SignUp as high as possible to be above a (fairly distant) floating element
+ * resulting in the block being higher than is ideal.
+ * @example
+ *	 0 TEXT
+ *	 1 TEXT
+ *	 2 TEXT
+ *    [too high] <--  Without this rule the SignUp
+ *	 3 RICHLINK     | tends to go too high so it's
+ *	 4 TEXT         | above the floating element
+ *	 5 TEXT         |
+ *	 6 TEXT         |
+ *	 7 TEXT         |
+ *     [target] ----+ Staying here would probably be
+ *	 8 TEXT           fine as there are four paragraphs
+ *	 9 TEXT           between this spot and the richlink
+ *	10 TEXT
+ *	11 TEXT
+ *	12 TEXT
+ *	13 TEXT
+ *	14 TEXT
+ */
+const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 
 const checkIfAfterText = (index: number, elements: CAPIElement[]): boolean =>

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -8,7 +8,7 @@ type PlaceInArticle = {
 };
 
 const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 3;
-// These values are an approximation - the aim is to avoid a blank space between
+// This value is an approximation - the aim is to avoid a blank space between
 // the element before the SignUp and the end of the floating element.
 // The SignUp block css uses 'clear:left' so a left floating element won't interfer
 // with its layout.
@@ -75,6 +75,11 @@ const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 3;
  *	14 TEXT
  */
 const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
+
+/**
+ * The maximum distance from the center of the article that the
+ * signup can be placed.
+ */
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 
 const checkIfAfterText = (index: number, elements: CAPIElement[]): boolean =>
@@ -98,7 +103,7 @@ const getDistanceAfterFloating = (
 	// it would be more logical to return Infinity here,
 	// but having an outsized finite value simplifies the sort function
 	// (Infinity - Infinity == NaN)
-	const outsizedValue = elements.length * 10;
+	const outsizedValue = elements.length + 1;
 
 	// if there are no floating elements before the position, return the outsizedValue
 	if (!lastFloatingElementBeforePlace) {
@@ -107,10 +112,7 @@ const getDistanceAfterFloating = (
 
 	// if the last floating element is more than the maximum distance before the postions, return the outsizedValue
 	const distance = index - elements.indexOf(lastFloatingElementBeforePlace);
-	if (
-		distance >
-		MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT_TO_TAKE_ACCOUNT_OF_WHEN_SORTING
-	) {
+	if (distance > MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT) {
 		return outsizedValue;
 	}
 

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -64,13 +64,15 @@ const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT_TO_TAKE_ACCOUNT_OF_WHEN_SORTING = 
 //	 4 TEXT         | above the floating element
 //	 5 TEXT         |
 //	 6 TEXT         |
-//     [target] ----+
-//	 7 TEXT
-//	 8 TEXT
-//	 9 TEXT
+//	 7 TEXT         |
+//     [target] ----+ Staying here would probably be
+//	 8 TEXT           fine as there are four paragraphs
+//	 9 TEXT           between this spot and the richlink
 //	10 TEXT
 //	11 TEXT
 //	12 TEXT
+//	13 TEXT
+//	14 TEXT
 
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 
@@ -120,8 +122,9 @@ const placeIsSuitable = (place: PlaceInArticle): boolean =>
 	place.distanceFromTarget <= MAXIMUM_DISTANCE_FROM_MIDDLE;
 
 /**
- * Sort the places, putting those furtherest from a previous floating elment
- * first, then by distance from the target
+ * Sort the suitable places in descending order of preference by:
+ *  - preferring places not close after a floating element, then
+ *  - preferrring places further down
  */
 const sortPlaces = (placeA: PlaceInArticle, placeB: PlaceInArticle): number => {
 	const floatingComparison =
@@ -129,7 +132,7 @@ const sortPlaces = (placeA: PlaceInArticle, placeB: PlaceInArticle): number => {
 	if (floatingComparison !== 0) {
 		return floatingComparison;
 	}
-	return placeA.distanceFromTarget - placeB.distanceFromTarget;
+	return placeB.position - placeA.position;
 };
 
 /**

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -7,14 +7,14 @@ type PlaceInArticle = {
 	distanceAfterFloating: number;
 };
 
-const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
-// This value is an approximation - the aim is to avoid a blank space between
+const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 3;
+// These values are an approximation - the aim is to avoid a blank space between
 // the element before the SignUp and the end of the floating element.
 // The SignUp block css uses 'clear:left' so a left floating element won't interfer
 // with its layout.
 // However, the actual heights of the elements when rendered is not taken into
-// account. 4 paragraphs should be enough, but if the floating element was
-// taller than all 4 paragraphs combined, there would be a gap, as illustrated below.
+// account. 3 paragraphs should be enough, but if the floating element was
+// taller than all 3 paragraphs combined, there would be a gap, as illustrated below.
 // This is why sortPlaces prioritises  distanceAfterFloating over distanceFromTarget.
 
 //    | TextTextTextTextTextText
@@ -27,7 +27,6 @@ const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
 //  |float|
 //  |float| TextTextTextTextText
 //  |float|
-//  |float| TextTextTextText
 //  |float|
 //  |float|
 //  |float|
@@ -52,6 +51,27 @@ const MINIMUM_DISTANCE_AFTER_FLOATING_ELEMENT = 4;
 //    | TextTextTextTextTextText  | +------+
 //    | TextTextTextText          |
 
+const MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT_TO_TAKE_ACCOUNT_OF_WHEN_SORTING = 4;
+// The maximum distance is set so that the sort function does not always place
+// the SignUp as high as possible to be above a (fairly distant) floating element
+// resulting in the block being higher than is ideal.
+
+//	 0 TEXT
+//	 1 TEXT
+//	 2 TEXT
+//    [too high] <--  Without this rule the SignUp
+//	 3 RICHLINK     | tends to go too high so it's
+//	 4 TEXT         | above the floating element
+//	 5 TEXT         |
+//	 6 TEXT         |
+//     [target] ----+
+//	 7 TEXT
+//	 8 TEXT
+//	 9 TEXT
+//	10 TEXT
+//	11 TEXT
+//	12 TEXT
+
 const MAXIMUM_DISTANCE_FROM_MIDDLE = 4;
 
 const checkIfAfterText = (index: number, elements: CAPIElement[]): boolean =>
@@ -72,14 +92,26 @@ const getDistanceAfterFloating = (
 				['supporting', 'thumbnail', 'richLink'].includes(element.role),
 		);
 
+	// it would be more logical to return Infinity here,
+	// but having an outsized finite value simplifies the sort function
+	// (Infinity - Infinity == NaN)
+	const outsizedValue = elements.length * 10;
+
+	// if there are no floating elements before the position, return the outsizedValue
 	if (!lastFloatingElementBeforePlace) {
-		// it would be more logical to return Infinity here,
-		// but having an outsized finite value simplifies the sort function
-		// (Infinity - Infinity == NaN)
-		return elements.length * 10;
+		return outsizedValue;
 	}
 
-	return index - elements.indexOf(lastFloatingElementBeforePlace);
+	// if the last floating element is more than the maximum distance before the postions, return the outsizedValue
+	const distance = index - elements.indexOf(lastFloatingElementBeforePlace);
+	if (
+		distance >
+		MAXIMUM_DISTANCE_AFTER_FLOATING_ELEMENT_TO_TAKE_ACCOUNT_OF_WHEN_SORTING
+	) {
+		return outsizedValue;
+	}
+
+	return distance;
 };
 
 const placeIsSuitable = (place: PlaceInArticle): boolean =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates the Signup block placement logic:
 - The maximum distance from the center is now 3 places - was 4
 - When sorting the possible positions, previous floating elements more than 4 paragraph above the possible insert position are not taken into account
 - when sorting the possible places, prefer places that are further down (but still within 3 places of the center) - before, they were sorted to prefer places closer to the center

## Why?
Editorial noted that on some article the signup block was appearing sooner than they would want it. This was caused by the sorting logic preferring places that were not after a floating element. If a slot before/above the floating element was in range, it would always take that that slot, leading to a tendency to 'go high' on articles with a floating element around the middle of the articles.

Previous floating elements do still need to be taken into account for the reasons outlined [here](https://github.com/guardian/dotcom-rendering/pull/5410#discussion_r930899305), but if the floating element is more than 4 paragraph above, there *should* be no extra spacing (or very little if the floating element is very tall and/or all four paragraphs are very short)


## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="436" alt="BBC- current" src="https://user-images.githubusercontent.com/30567854/186143093-b637159a-e800-4fdf-b5fc-35e664a917f2.png"> | <img width="436" alt="bbc-second-change" src="https://user-images.githubusercontent.com/30567854/186143174-3bd0f6b6-0bb9-4193-92c6-2b726df94e0e.png"> |
| <img width="436" alt="minions-current" src="https://user-images.githubusercontent.com/30567854/186143322-89bd2d43-7bdd-4cfd-adf3-ae40793d8393.png">| <img width="436" alt="minions-second-change" src="https://user-images.githubusercontent.com/30567854/186143377-e5195753-916a-46a1-b9a8-f0c7ed373ac2.png"> |






[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
