### PR TITLE
feat: add type-guards for filtering arrays

### DIFF
--- a/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.stories.tsx
@@ -3,28 +3,31 @@ import { NumberedList } from '../../../fixtures/generated/articles/NumberedList'
 import { enhanceInteractiveContentsElements } from '../../model/enhance-interactive-contents-elements';
 import { InteractiveContentsBlockComponent } from './InteractiveContentsBlockComponent';
 
-// @ts-expect-error: we know that NumberedList fixture has an interactive content block
-const interactiveContentsBlock: InteractiveContentsBlockElement =
-	enhanceInteractiveContentsElements(NumberedList.blocks)[0].elements.find(
-		(block) =>
-			block._type ===
-			'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
-	);
+const interactiveContentsBlock = enhanceInteractiveContentsElements(
+	NumberedList.blocks,
+)[0]?.elements.find(
+	(block): block is InteractiveContentsBlockElement =>
+		block._type ===
+		'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+);
 
 export default {
 	component: InteractiveContentsBlockComponent,
 	title: 'Components/InteractiveContentsBlockElement',
 };
 
-export const Default = () => (
-	<div
-		css={css`
-			margin: 20px;
-		`}
-	>
-		<InteractiveContentsBlockComponent
-			subheadingLinks={interactiveContentsBlock.subheadingLinks}
-			endDocumentElementId={interactiveContentsBlock.endDocumentElementId}
-		/>
-	</div>
-);
+export const Default = () =>
+	interactiveContentsBlock ? (
+		<div
+			css={css`
+				margin: 20px;
+			`}
+		>
+			<InteractiveContentsBlockComponent
+				subheadingLinks={interactiveContentsBlock.subheadingLinks}
+				endDocumentElementId={
+					interactiveContentsBlock.endDocumentElementId
+				}
+			/>
+		</div>
+	) : null;

--- a/dotcom-rendering/src/web/lib/notification.ts
+++ b/dotcom-rendering/src/web/lib/notification.ts
@@ -6,20 +6,20 @@ export interface Notification {
 	message: string;
 }
 
+const hasTargetAndMessage = (
+	card: BrazeCard,
+): card is BrazeCard & { extras: Notification } =>
+	Boolean(card.extras.message) && Boolean(card.extras.target);
+
 export const mapBrazeCardsToNotifications = (
 	cards: BrazeCard[],
 ): Notification[] => {
-	return cards
-		.filter(
-			(card: BrazeCard) =>
-				Boolean(card.extras.message) && Boolean(card.extras.target),
-		)
-		.map((card) => {
-			return {
-				target: card.extras.target,
-				message: card.extras.message,
-			};
-		});
+	return cards.filter(hasTargetAndMessage).map((card) => {
+		return {
+			target: card.extras.target,
+			message: card.extras.message,
+		};
+	});
 };
 
 const groupNotificationsByTarget = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use type-guards when filtering arrays to get narrower types on the filtered items.

## Why?

These will throw errors when we have `noUncheckedIndexedAccess`.

#5777 