### PR TITLE
Introduce Tuple helpers

### DIFF
--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -3,7 +3,10 @@ import { PhotoEssay } from '../../fixtures/generated/articles/PhotoEssay';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import { nonEmpty } from '../web/lib/tuple';
 import { enhanceImages } from './enhance-images';
+
+if (!nonEmpty(images)) throw new Error('Empty images list');
 
 const image = {
 	...images[0],
@@ -76,7 +79,7 @@ describe('Enhance Images', () => {
 					elements: [
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,
@@ -622,7 +625,7 @@ describe('Enhance Images', () => {
 					elements: [
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,
@@ -640,7 +643,7 @@ describe('Enhance Images', () => {
 						},
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,
@@ -672,6 +675,10 @@ describe('Enhance Images', () => {
 				elementId: 'mockId',
 				html: '<p>Just some normal text</p>',
 			};
+
+			if (!(images[0] && images[1] && images[2] && images[3])) {
+				throw new Error('Not enough images');
+			}
 
 			const input: Block[] = [
 				{
@@ -725,7 +732,7 @@ describe('Enhance Images', () => {
 					elements: [
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,
@@ -895,7 +902,7 @@ describe('Enhance Images', () => {
 					elements: [
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,
@@ -957,7 +964,7 @@ describe('Enhance Images', () => {
 						},
 						{
 							_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement',
-							elementId: images[0].elementId,
+							elementId: image.elementId,
 							images: [
 								{
 									...image,

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
+import type { ServerSideTests } from '../../types/config';
 import type { Palette } from '../../types/palette';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';

--- a/dotcom-rendering/src/web/components/CricketScoreboard.tsx
+++ b/dotcom-rendering/src/web/components/CricketScoreboard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { between, space, textSans, until } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
+import { isTuple } from '../lib/tuple';
 
 const ALL_OUT_WICKETS = 10;
 
@@ -106,14 +107,17 @@ export const CricketInnings = ({
 
 	// There can be up to 2 innings per team in a cricket match
 	switch (teamInnings.length) {
-		case 1:
+		case 1: {
+			if (!isTuple(teamInnings, 1)) throw new Error('Not two innings');
 			return (
 				<p>
 					{cricketScore({ innings: teamInnings[0] })} (
 					{teamInnings[0].overs} overs)
 				</p>
 			);
-		case 2:
+		}
+		case 2: {
+			if (!isTuple(teamInnings, 2)) throw new Error('Not two innings');
 			return (
 				<p>
 					{cricketScore({ innings: teamInnings[0], short: true })}
@@ -122,6 +126,7 @@ export const CricketInnings = ({
 					{teamInnings[1].overs} overs)
 				</p>
 			);
+		}
 		default:
 			return <p>Yet to bat</p>;
 	}

--- a/dotcom-rendering/src/web/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
+import { isTuple } from '../lib/tuple';
 import { Dropdown } from './Dropdown';
 
 const links = [
@@ -54,6 +55,10 @@ describe('Dropdown', () => {
 				dataLinkName="linkname"
 			/>,
 		);
+
+		if (!isTuple(links, 4)) {
+			throw new Error('missing links');
+		}
 
 		expect(getByText(links[0].title)).toBeInTheDocument();
 		expect(getByText(links[1].title)).toBeInTheDocument();

--- a/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
@@ -1,7 +1,11 @@
 import { breakpoints } from '@guardian/source-foundations';
-import { trails } from '../../../fixtures/manual/trails';
+import { trails as mockTrails } from '../../../fixtures/manual/trails';
+import { isTuple } from '../lib/tuple';
 import { DynamicFast } from './DynamicFast';
 import { Section } from './Section';
+
+const trails = mockTrails.slice(0, 12);
+if (!isTuple(trails, 12)) throw new Error('Invalid number of trails');
 
 export default {
 	component: DynamicFast,

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { nonEmpty } from '../lib/tuple';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -80,7 +81,7 @@ const Card75_Card25 = ({
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
-	if (cards.length < 2) return null;
+	if (!(cards[0] && cards[1])) return null;
 
 	return (
 		<UL direction="row">
@@ -378,6 +379,7 @@ const Card75_ColumnOfCards25 = ({
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => {
+	if (!nonEmpty(cards)) throw new Error('Empty trails');
 	const [primary, ...remaining] = cards;
 	return (
 		<UL direction="row">
@@ -509,7 +511,7 @@ export const DynamicPackage = ({
 			secondSlice = cards.slice(0, 1);
 			break;
 		default:
-			if (cards[0].isBoosted) {
+			if (cards[0]?.isBoosted) {
 				layout = 'threeOrFourStandardsBoosted';
 				firstSlice = snaps;
 				secondSlice = cards.slice(0, 1);

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -1,5 +1,6 @@
 import { breakpoints } from '@guardian/source-foundations';
 import { trails } from '../../../fixtures/manual/trails';
+import { isTuple } from '../lib/tuple';
 import { DynamicSlowMPU } from './DynamicSlowMPU';
 import { Section } from './Section';
 
@@ -23,6 +24,7 @@ export default {
 };
 
 const bigs = trails.slice(0, 3);
+if (!isTuple(bigs, 3)) throw new Error('Invalid number of bigs');
 const standards = trails.slice(3);
 
 export const NoBigs = () => (

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -2,6 +2,7 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { isTuple } from '../lib/tuple';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -25,7 +26,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 	showAge,
 	index,
 }: {
-	cards: TrailType[];
+	cards: [TrailType, TrailType, TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
@@ -92,7 +93,7 @@ const ColumnOfThree50_Ad50 = ({
 	showAge,
 	index,
 }: {
-	cards: TrailType[];
+	cards: [TrailType, TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
@@ -147,7 +148,7 @@ const Card75_Card25 = ({
 	containerPalette,
 	showAge,
 }: {
-	cards: TrailType[];
+	cards: [TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -188,7 +189,7 @@ const Card50_Card50 = ({
 	containerPalette,
 	showAge,
 }: {
-	cards: TrailType[];
+	cards: [TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -229,7 +230,7 @@ const Card50_Card25_Card25 = ({
 	containerPalette,
 	showAge,
 }: {
-	cards: TrailType[];
+	cards: [TrailType, TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -256,7 +257,7 @@ const Card50_Card25_Card25 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={
-					cards[1]?.supportingContent &&
+					cards[1].supportingContent &&
 					cards[1].supportingContent.length > 0
 						? undefined
 						: cards[1].trailText
@@ -277,7 +278,7 @@ const Card50_Card25_Card25 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={
-					cards[2]?.supportingContent &&
+					cards[2].supportingContent &&
 					cards[2].supportingContent.length > 0
 						? undefined
 						: cards[2].trailText
@@ -315,7 +316,7 @@ export const DynamicSlowMPU = ({
 	let standardCards: TrailType[] = [];
 	switch (groupedTrails.big.length) {
 		case 0: {
-			standardCards = groupedTrails.standard;
+			standardCards = groupedTrails.standard.slice(0, 4);
 			layout = 'noBigs';
 			break;
 		}
@@ -324,14 +325,14 @@ export const DynamicSlowMPU = ({
 			// there is always at least two
 			const promoted = groupedTrails.standard.slice(0, 1);
 			bigCards = [...groupedTrails.big, ...promoted];
-			standardCards = groupedTrails.standard.slice(1);
+			standardCards = groupedTrails.standard.slice(1, 4);
 			layout = 'twoBigs';
 			break;
 		}
 		case 2: {
 			bigCards = groupedTrails.big;
-			standardCards = groupedTrails.standard;
-			if (groupedTrails.big[0].isBoosted) {
+			standardCards = groupedTrails.standard.slice(0, 3);
+			if (groupedTrails.big[0]?.isBoosted) {
 				layout = 'twoBigsBoosted';
 			} else {
 				layout = 'twoBigs';
@@ -340,7 +341,7 @@ export const DynamicSlowMPU = ({
 		}
 		case 3: {
 			bigCards = groupedTrails.big;
-			standardCards = groupedTrails.standard;
+			standardCards = groupedTrails.standard.slice(0, 3);
 			layout = 'threeBigs';
 			break;
 		}
@@ -348,7 +349,7 @@ export const DynamicSlowMPU = ({
 			// If there are more than three big cards, these extra bigs are demoted to
 			// standard.
 			const demoted = groupedTrails.big.slice(3);
-			standardCards = [...demoted, ...groupedTrails.standard];
+			standardCards = [...demoted, ...groupedTrails.standard].slice(0, 3);
 			bigCards = groupedTrails.big.slice(0, 3);
 			layout = 'threeBigs';
 		}
@@ -356,6 +357,11 @@ export const DynamicSlowMPU = ({
 
 	switch (layout) {
 		case 'noBigs': {
+			if (!isTuple(standardCards, 4)) {
+				throw new Error(
+					`Invalid number of cards: ${bigCards.length} big & ${standardCards.length} standard`,
+				);
+			}
 			return (
 				<Card33_ColumnOfThree33_Ad33
 					cards={standardCards}
@@ -366,6 +372,11 @@ export const DynamicSlowMPU = ({
 			);
 		}
 		case 'twoBigs': {
+			if (!(isTuple(bigCards, 2) && isTuple(standardCards, 3))) {
+				throw new Error(
+					`Invalid number of cards: ${bigCards.length} big & ${standardCards.length} standard`,
+				);
+			}
 			return (
 				<>
 					<Card50_Card50
@@ -383,6 +394,11 @@ export const DynamicSlowMPU = ({
 			);
 		}
 		case 'twoBigsBoosted': {
+			if (!(isTuple(bigCards, 2) && isTuple(standardCards, 3))) {
+				throw new Error(
+					`Invalid number of cards: ${bigCards.length} big & ${standardCards.length} standard`,
+				);
+			}
 			return (
 				<>
 					<Card75_Card25
@@ -400,6 +416,11 @@ export const DynamicSlowMPU = ({
 			);
 		}
 		case 'threeBigs': {
+			if (!(isTuple(bigCards, 3) && isTuple(standardCards, 3))) {
+				throw new Error(
+					`Invalid number of cards: ${bigCards.length} big & ${standardCards.length} standard`,
+				);
+			}
 			return (
 				<>
 					<Card50_Card25_Card25

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
@@ -1,5 +1,6 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { nonEmpty } from '../lib/tuple';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -15,6 +16,8 @@ export const FixedMediumSlowVII = ({
 	containerPalette,
 	showAge,
 }: Props) => {
+	if (!nonEmpty(trails)) throw new Error('Empty trails');
+
 	const primary = trails[0];
 	const firstSlice = trails.slice(1, 3);
 	const secondSlice = trails.slice(3, 7);

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -2,6 +2,7 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { isTuple } from '../lib/tuple';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -26,7 +27,7 @@ const Card100 = ({
 	containerPalette,
 	showAge,
 }: {
-	trails: TrailType[];
+	trails: [TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -57,7 +58,7 @@ const Card50_Card50 = ({
 	containerPalette,
 	showAge,
 }: {
-	trails: TrailType[];
+	trails: [TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -98,7 +99,7 @@ const Card33_Card33_Card33 = ({
 	containerPalette,
 	showAge,
 }: {
-	trails: TrailType[];
+	trails: [TrailType, TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
@@ -154,7 +155,7 @@ const Card66_Ad33 = ({
 	showAge,
 	index,
 }: {
-	trails: TrailType[];
+	trails: [TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
@@ -190,7 +191,7 @@ const Card33_Card33_Ad33 = ({
 	showAge,
 	index,
 }: {
-	trails: TrailType[];
+	trails: [TrailType, TrailType];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	index: number;
@@ -202,7 +203,7 @@ const Card33_Card33_Ad33 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={
-					trails[0]?.supportingContent &&
+					trails[0].supportingContent &&
 					trails[0].supportingContent.length > 0
 						? undefined
 						: trails[0].trailText
@@ -225,7 +226,7 @@ const Card33_Card33_Ad33 = ({
 				containerPalette={containerPalette}
 				showAge={showAge}
 				trailText={
-					trails[1]?.supportingContent &&
+					trails[1].supportingContent &&
 					trails[1].supportingContent.length > 0
 						? undefined
 						: trails[1].trailText
@@ -288,27 +289,33 @@ export const FixedMediumSlowXIIMPU = ({
 			return null;
 		}
 		case 1: {
+			const single = trails.slice(0, 1);
+			if (!isTuple(single, 1)) throw new Error('Not a 1-tuple');
 			return (
 				<Card100
-					trails={trails}
+					trails={single}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>
 			);
 		}
 		case 2: {
+			const double = trails.slice(0, 2);
+			if (!isTuple(double, 2)) throw new Error('Not a 2-tuple');
 			return (
 				<Card50_Card50
-					trails={trails}
+					trails={double}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>
 			);
 		}
 		case 3: {
+			const triple = trails.slice(0, 3);
+			if (!isTuple(triple, 3)) throw new Error('Not a 3-tuple');
 			return (
 				<Card33_Card33_Card33
-					trails={trails}
+					trails={triple}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>
@@ -317,6 +324,9 @@ export const FixedMediumSlowXIIMPU = ({
 		case 4: {
 			const topThree = trails.slice(0, 3);
 			const remainingCards = trails.slice(3);
+			if (!(isTuple(topThree, 3) && isTuple(remainingCards, 1))) {
+				throw new Error('Invalid number of cards');
+			}
 			return (
 				<>
 					<Card33_Card33_Card33
@@ -336,7 +346,10 @@ export const FixedMediumSlowXIIMPU = ({
 		}
 		case 5: {
 			const topThree = trails.slice(0, 3);
-			const remainingCards = trails.slice(3);
+			const remainingCards = trails.slice(3, 5);
+			if (!(isTuple(topThree, 3) && isTuple(remainingCards, 2))) {
+				throw new Error('Invalid number of cards');
+			}
 			return (
 				<>
 					<Card33_Card33_Card33
@@ -362,6 +375,10 @@ export const FixedMediumSlowXIIMPU = ({
 			const topThree = trails.slice(0, 3);
 			const remainingCards = trails.slice(3, 9);
 			const lengthIsEven = remainingCards.length % 2 === 0;
+
+			if (!isTuple(topThree, 3)) {
+				throw new Error('Invalid number of topThree');
+			}
 			return (
 				<>
 					<Card33_Card33_Card33

--- a/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.stories.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { breakpoints, from } from '@guardian/source-foundations';
-import { liveBlock } from '../../../fixtures/manual/liveBlock';
 import { images } from '../../../fixtures/generated/images';
+import { liveBlock } from '../../../fixtures/manual/liveBlock';
+import { nonEmpty } from '../lib/tuple';
 import { LiveBlock } from './LiveBlock';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
@@ -252,6 +253,7 @@ export const RichLink = () => {
 RichLink.story = { name: 'with a rich link being forced inline' };
 
 export const FirstImage = () => {
+	if (!nonEmpty(images)) return null;
 	const block: Block = {
 		...liveBlock,
 		elements: [
@@ -288,6 +290,7 @@ export const FirstImage = () => {
 FirstImage.story = { name: 'with an image as the first element' };
 
 export const ImageRoles = () => {
+	if (!nonEmpty(images)) return null;
 	const block: Block = {
 		...liveBlock,
 		elements: [
@@ -350,6 +353,7 @@ export const ImageRoles = () => {
 ImageRoles.story = { name: 'with images at different roles' };
 
 export const Thumbnail = () => {
+	if (!nonEmpty(images)) return null;
 	const block: Block = {
 		...liveBlock,
 		elements: [
@@ -401,6 +405,7 @@ export const Thumbnail = () => {
 Thumbnail.story = { name: 'with a thumbnail image surrounded by text' };
 
 export const ImageAndTitle = () => {
+	if (!nonEmpty(images)) return null;
 	const block: Block = {
 		...liveBlock,
 		title: 'Afternoon summary',

--- a/dotcom-rendering/src/web/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/web/components/Liveness.importable.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { initHydration } from '../browser/islands/initHydration';
 import { updateTimeElement } from '../browser/relativeTime/updateTimeElements';
+import { nonEmpty } from '../lib/tuple';
 import { useApi } from '../lib/useApi';
 import { Toast } from './Toast';
 
@@ -119,7 +120,7 @@ function getKey(
 			'filterKeyEvents',
 			filterKeyEvents ? 'true' : 'false',
 		);
-		if (selectedTopics && selectedTopics.length > 0)
+		if (selectedTopics && nonEmpty(selectedTopics))
 			url.searchParams.set(
 				'topics',
 				`${selectedTopics[0].type}:${selectedTopics[0].value}`,
@@ -229,6 +230,8 @@ export const Liveness = ({
 		if (!topOfBlog) return () => {};
 
 		const observer = new window.IntersectionObserver(([entry]) => {
+			if (!entry) return;
+
 			setTopOfBlogVisible(entry.isIntersecting);
 
 			if (entry.isIntersecting && onFirstPage) {

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
+import { isTuple } from '../lib/tuple';
 import { Caption } from './Caption';
 import { GridItem } from './GridItem';
 import { ImageComponent } from './ImageComponent';
@@ -96,7 +97,8 @@ export const MultiImageBlockComponent = ({
 	const imageCount = images.length;
 
 	switch (imageCount) {
-		case 1:
+		case 1: {
+			if (!isTuple(images, 1)) throw new Error();
 			return (
 				<div
 					css={css`
@@ -123,7 +125,9 @@ export const MultiImageBlockComponent = ({
 					)}
 				</div>
 			);
-		case 2:
+		}
+		case 2: {
+			if (!isTuple(images, 2)) throw new Error();
 			return (
 				<div
 					css={css`
@@ -163,7 +167,9 @@ export const MultiImageBlockComponent = ({
 					)}
 				</div>
 			);
-		case 3:
+		}
+		case 3: {
+			if (!isTuple(images, 3)) throw new Error();
 			return (
 				<div
 					css={css`
@@ -211,7 +217,9 @@ export const MultiImageBlockComponent = ({
 					)}
 				</div>
 			);
-		case 4:
+		}
+		case 4: {
+			if (!isTuple(images, 4)) throw new Error();
 			return (
 				<div
 					css={css`
@@ -266,6 +274,7 @@ export const MultiImageBlockComponent = ({
 					)}
 				</div>
 			);
+		}
 		default:
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/web/components/Palettes.stories.tsx
@@ -1,4 +1,6 @@
-import { trails } from '../../../fixtures/manual/trails';
+import { trails as mockTrails } from '../../../fixtures/manual/trails';
+import type { DCRGroupedTrails } from '../../types/front';
+import { isTuple } from '../lib/tuple';
 import { DynamicFast } from './DynamicFast';
 import { Section } from './Section';
 
@@ -6,7 +8,13 @@ export default {
 	title: 'Layouts/Palettes',
 };
 
-const groupedTrails = {
+const trails = mockTrails.slice(0, 10);
+
+if (!isTuple(trails, 10)) {
+	throw new Error('Invalid number of trails');
+}
+
+const groupedTrails: DCRGroupedTrails = {
 	snap: [],
 	huge: [],
 	veryBig: [{ isBoosted: true, ...trails[0] }, trails[1]],

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import React from 'react';
+import { nonEmpty } from '../lib/tuple';
 
 /**
  * Working on this file? Checkout out 027-pictures.md & 029-signing-image-urls.md for background information & context
@@ -198,7 +199,7 @@ const generateSignedUrl = ({
 
 	// Construct and sign the url
 	const url = new URL(master);
-	const service = url.hostname.split('.')[0];
+	const [service = 'unknown'] = url.hostname.split('.');
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
 		// Why 45 and 85?
@@ -258,6 +259,8 @@ export const Picture = ({
 				}),
 			};
 		});
+
+	if (!nonEmpty(sources)) return null;
 
 	return (
 		<picture css={block}>

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -12,6 +12,7 @@ import {
 import ArrowInCircle from '../../static/icons/arrow-in-circle.svg';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
+import { nonEmpty } from '../lib/tuple';
 import { Avatar } from './Avatar';
 import { Hide } from './Hide';
 import { QuoteIcon } from './QuoteIcon';
@@ -191,7 +192,8 @@ const readMoreText: (contentType: string) => string = (contentType) => {
 
 const getMainContributor: (tags: TagType[]) => string = (tags) => {
 	const contributorTags = tags.filter((t) => t.type === 'Contributor');
-	return contributorTags.length > 0 ? contributorTags[0].title : '';
+	if (!nonEmpty(contributorTags)) return '';
+	return contributorTags[0].title;
 };
 
 const imageStyles = css`

--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -10,6 +10,7 @@ import {
 import { Link } from '@guardian/source-react-components';
 import type { TreatType } from '../../types/front';
 import { decidePalette } from '../lib/decidePalette';
+import { nonEmpty } from '../lib/tuple';
 import { SvgCrossword } from './SvgCrossword';
 
 const TextTreat = ({
@@ -102,7 +103,8 @@ export const Treats = ({
 	treats: TreatType[];
 	borderColour?: string;
 }) => {
-	if (treats.length === 0) return null;
+	if (!nonEmpty(treats)) return null;
+
 	return (
 		<ul
 			css={css`
@@ -112,6 +114,7 @@ export const Treats = ({
 		>
 			{treats.map((treat) => {
 				if (
+					nonEmpty(treat.links) &&
 					treat.links[0].linkTo === '/crosswords' &&
 					treat.links[0].text
 				) {

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -21,6 +21,7 @@ import { Snap } from '../components/Snap';
 import { SubNav } from '../components/SubNav.importable';
 import { DecideContainer } from '../lib/DecideContainer';
 import { decidePalette } from '../lib/decidePalette';
+import { nonEmpty } from '../lib/tuple';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -152,7 +153,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						collection.backfill,
 					);
 					// There are some containers that have zero trails. We don't want to render these
-					if (trails.length === 0) return null;
+					if (!nonEmpty(trails)) return null;
 
 					const ophanName = ophanComponentId(collection.displayName);
 					const ophanComponentLink = `container-${index} | ${ophanName}`;

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
+import type { ServerSideTests } from '../../types/config';
 import {
 	adCollapseStyles,
 	labelStyles as adLabelStyles,

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -7,6 +7,7 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
+import type { ServerSideTests } from '../../types/config';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '../components/CalloutBlockComponent.importable';

--- a/dotcom-rendering/src/web/lib/tuple.test.ts
+++ b/dotcom-rendering/src/web/lib/tuple.test.ts
@@ -1,0 +1,51 @@
+import { isTuple, nonEmpty } from './tuple';
+
+describe('Tuple helpers', () => {
+	describe('nonEmpty', () => {
+		test('Works with a non-empty array', () => {
+			expect(nonEmpty([0])).toBe(true);
+		});
+
+		test('Fails with an empty array', () => {
+			expect(nonEmpty([])).toBe(false);
+		});
+
+		test('Does not narrow the second item', () => {
+			const arr = [0, 1];
+			expect(nonEmpty(arr)).toBe(true);
+			if (nonEmpty(arr)) {
+				const [, second] = arr;
+				// @TODO @ts-expect-error
+				expect(second === 1).toBe(true);
+			}
+		});
+	});
+	describe('isTuple', () => {
+		test.each([
+			[0, []],
+			[1, [0]],
+			[3, [0, 1, 2]],
+			[12, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]],
+		] as const)('Works with %s', (count, tuple) => {
+			expect(isTuple(tuple, count)).toBe(true);
+		});
+
+		test.each([
+			[0, [0]],
+			[1, [0, 1]],
+			[9, []],
+		] as const)('Fails with %s', (count, tuple) => {
+			expect(isTuple(tuple, count)).toBe(false);
+		});
+
+		test('Does not narrow with values longer than 12 with', () => {
+			const bakersDozen = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+			expect(isTuple(bakersDozen, 13)).toBe(true);
+
+			const [, , , , , , , , , , , , egg] = bakersDozen;
+
+			// @TODO @ts-expect-error
+			expect(egg === 12).toBe(true);
+		});
+	});
+});

--- a/dotcom-rendering/src/web/lib/tuple.ts
+++ b/dotcom-rendering/src/web/lib/tuple.ts
@@ -1,0 +1,46 @@
+/**
+ * Type-guard that check whether an array contains at least a single item.
+ *
+ * If `true`, the type is narrowed from T[] to the [T, ...T[]] tuple,
+ * which safely allows accessing the first item.
+ */
+export const nonEmpty = <T>(arr: T[]): arr is [T, ...T[]] => arr.length >= 1;
+
+/** A tuple of up to 12 items. Larger tuples will not be narrowed */
+type Tuple<T, N extends number> = N extends 12
+	? [T, T, T, T, T, T, T, T, T, T, T, T]
+	: N extends 11
+	? [T, T, T, T, T, T, T, T, T, T, T]
+	: N extends 10
+	? [T, T, T, T, T, T, T, T, T, T]
+	: N extends 9
+	? [T, T, T, T, T, T, T, T, T]
+	: N extends 8
+	? [T, T, T, T, T, T, T, T]
+	: N extends 7
+	? [T, T, T, T, T, T, T]
+	: N extends 6
+	? [T, T, T, T, T, T]
+	: N extends 5
+	? [T, T, T, T, T]
+	: N extends 4
+	? [T, T, T, T]
+	: N extends 3
+	? [T, T, T]
+	: N extends 2
+	? [T, T]
+	: N extends 1
+	? [T]
+	: N extends 0
+	? []
+	: T[];
+
+/**
+ * Type-guard for whether an array is a tuple of exact length.
+ *
+ * Only tuples of 12 elements or less will be narrowed.
+ */
+export const isTuple = <T, N extends number>(
+	arr: Array<T> | ReadonlyArray<T>,
+	count: N,
+): arr is Tuple<T, N> => arr.length === count;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

> **Note**
> A tuple is an array of fixed length. Most people are familiar with the words “couple“ and “triple“. 
> Read more on [Wikipedia: Tuple](https://en.wikipedia.org/wiki/Tuple)

Introduce two tuple helpers which help narrowing types: `nonEmpty` and `isTuple`.

By checking an array is `nonEmpty`, you can ensure that there is at least a single element.
By checking that an array `isTuple(…, n)`, you can ensure that there is precisely `n` elements in it.

## Why?

These will throw errors when we have `noUncheckedIndexedAccess` in #5777.

When we try to access an element in an array, [the TypeScript compiler will not warn us by default that the element might be `undefined`](https://www.typescriptlang.org/play?#code/MYewdgzgLgBANgUylBAnCMC8MDaAiAQzwBoY8AjEs4PAXQG4AoR0SWAMwIDcQBXVAJYoAMkhSos8MWgg4AjACYGzAPQqYACTQIYUAJ4AHBBGCCDsKAAsBYANYZOPfkISjkaGAIwEY0QWABzUnJeC2sMLxgAd1RwAIA6FnAIEER4uBAAgAo8ADFuBAB+Kkc+QRFpVFJ9IxB2GFLnCvdUAEp6IA). There are two very common cases in our codebase, and these helpers cover them: checking that an array has a least one item, and checking that an array has a precise length.

These patterns are used a lot in the Fronts cards, forcing precise number of cards where we expect them, instead of failing softly like we do now. 