### PR TITLE
Create explainer type

### DIFF
--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -21,6 +21,7 @@ import type {
 	Analysis,
 	Comment,
 	Editorial,
+	Explainer,
 	Feature,
 	Interview,
 	Item,
@@ -474,6 +475,11 @@ const quiz: Quiz = {
 	theme: ArticlePillar.Sport,
 };
 
+const explainer: Explainer = {
+	design: ArticleDesign.Explainer,
+	...fields,
+};
+
 // ----- Exports ----- //
 
 export {
@@ -496,4 +502,5 @@ export {
 	recipe,
 	quiz,
 	pinnedBlock,
+	explainer,
 };

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -158,6 +158,11 @@ interface Analysis extends Fields {
 	design: ArticleDesign.Analysis;
 	body: Body;
 }
+
+interface Explainer extends Fields {
+	design: ArticleDesign.Explainer;
+	body: Body;
+}
 // Catch-all for other Designs for now. As coverage of Designs increases,
 // this will likely be split out into each ArticleDesign type.
 interface Standard extends Fields {
@@ -187,7 +192,8 @@ type Item =
 	| Editorial
 	| Correction
 	| Interview
-	| Analysis;
+	| Analysis
+	| Explainer;
 
 // ----- Convenience Types ----- //
 
@@ -541,6 +547,7 @@ export {
 	PhotoEssay,
 	Feature,
 	PrintShop,
+	Explainer,
 	fromCapi,
 	fromCapiLiveBlog,
 	getFormat,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds an explainer type and fixture to apps rendering

## Why?
We have a new design type called Explainer.
