### PR TITLE
Ar explainer headline bold

### DIFF
--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -10,6 +10,13 @@ import { from, headline, remSpace } from '@guardian/source-foundations';
 import type { Item } from 'item';
 import { articleWidthStyles, darkModeCss } from 'styles';
 
+const boldFontStyles: SerializedStyles = css`
+	${headline.small({ fontWeight: 'bold' })}
+	${from.tablet} {
+		${headline.medium({ fontWeight: 'bold' })}
+	}
+`;
+
 export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 	const baseStyles = css`
 		${headline.small()}
@@ -32,6 +39,14 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 				padding-bottom: ${remSpace[1]};
 			`;
 		case ArticleDesign.Analysis:
+			return css`
+				${baseStyles}
+				${articleWidthStyles}
+				background-color: ${background.headline(format)};
+				${darkModeCss`
+					background-color: ${background.headlineDark(format)};
+				`}
+			`;
 		case ArticleDesign.Explainer:
 			return css`
 				${baseStyles}
@@ -40,6 +55,7 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 				${darkModeCss`
 					background-color: ${background.headlineDark(format)};
 				`}
+				${boldFontStyles}
 			`;
 		default:
 			return css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Make Explainer headline bold in AR

## Why?
Requested by editorial design team https://docs.google.com/document/d/1MqSldxfgR86kOJaXTFNaBs5LzPzSa7jC4D4YwqqMFwg/edit#

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/186193737-9c64519c-6899-464b-a6b3-ad66262407e3.png) | ![image](https://user-images.githubusercontent.com/15894063/186193620-49237389-0f79-4458-ac1f-651cee41cf56.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
