### PR TITLE
Revert "Subnav: until desktop add search bar and style reader revenue links"

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -195,15 +195,14 @@ const columnStyle = css`
 export const Column = ({
 	column,
 	index,
-	isLastColumn,
 }: {
 	column: PillarType;
 	index: number;
-	isLastColumn: boolean;
 }) => {
 	// As the elements are dynamic we need to specify the IDs here
 	const columnInputId = `${column.title}-checkbox-input`;
 	const collapseColumnInputId = `${column.title}-button`;
+
 	return (
 		<li css={[columnStyle, pillarDivider]} role="none">
 			{/*
@@ -290,9 +289,7 @@ export const Column = ({
 					</li>
 				))}
 			</ul>
-			{isLastColumn && (
-				<div css={[hideWhenChecked(columnInputId), lineStyle]}></div>
-			)}
+			<div css={[hideWhenChecked(columnInputId), lineStyle]}></div>
 		</li>
 	);
 };

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -7,16 +7,8 @@ import {
 	brandText,
 	from,
 	headline,
-	neutral,
 	textSans,
 } from '@guardian/source-foundations';
-import {
-	Button,
-	Label,
-	SvgArrowRightStraight,
-	SvgMagnifyingGlass,
-	TextInput,
-} from '@guardian/source-react-components';
 import type { NavType } from '../../../../model/extract-nav';
 import { Column } from './Column';
 import { MoreColumn } from './MoreColumn';
@@ -124,104 +116,6 @@ const brandExtensionLink = css`
 	}
 `;
 
-const lineStyle = css`
-	background-color: ${brand[600]};
-	content: '';
-	display: block;
-	height: 1px;
-	left: 50px;
-	width: 100%;
-	right: 0;
-	margin-left: 50px;
-`;
-
-const searchBar = css`
-	${from.desktop} {
-		display: none;
-	}
-	box-sizing: border-box;
-	display: block;
-	margin-left: 13px;
-	max-width: 23.75rem;
-	position: relative;
-	margin-bottom: 24px;
-	margin-right: 41px;
-	padding-bottom: 15px;
-`;
-
-const searchInput = css`
-	${textSans.large()}
-	background-color: rgba(255,255,255, .1);
-	border: 0;
-	border-radius: 1000px;
-	box-sizing: border-box;
-	color: ${neutral[100]};
-	height: 36px;
-	padding-left: 38px;
-	vertical-align: middle;
-	width: 100%;
-
-	&::placeholder {
-		color: ${neutral[100]};
-	}
-
-	&:focus {
-		outline: none;
-		padding-right: 40px;
-
-		&::placeholder {
-			opacity: 0;
-		}
-	}
-
-	&:focus ~ button {
-		opacity: 1;
-		outline: none;
-		pointer-events: all;
-	}
-`;
-
-const searchGlass = css`
-	position: absolute;
-	left: 7px;
-	top: 6px;
-	fill: ${neutral[100]};
-`;
-
-const searchSubmit = css`
-	background: transparent;
-	border: 0;
-	bottom: 0;
-	cursor: pointer;
-	display: block;
-	opacity: 0;
-	pointer-events: none;
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 50px;
-	fill: ${neutral[100]};
-
-	&:focus,
-	&:active {
-		opacity: 1;
-		outline: none;
-		pointer-events: all;
-	}
-
-	&:before {
-		height: 12px;
-		top: 11px;
-		width: 12px;
-	}
-
-	&:after {
-		border-right: 0;
-		top: 17px;
-		width: 20px;
-	}
-`;
-
 export const Columns: React.FC<{
 	format: ArticleFormat;
 	nav: NavType;
@@ -236,49 +130,8 @@ export const Columns: React.FC<{
 				column={column}
 				key={column.title.toLowerCase()}
 				index={i}
-				isLastColumn={i !== nav.pillars.length - 1}
 			/>
 		))}
-		<li>
-			<form css={searchBar} action="https://www.google.co.uk/search">
-				<TextInput
-					hideLabel={true}
-					label="Search input"
-					cssOverrides={searchInput}
-					name="q"
-					placeholder="Search"
-					data-link-name="nav2 : search"
-				/>
-
-				<Label hideLabel={true} text="google-search">
-					<div css={searchGlass}>
-						<SvgMagnifyingGlass
-							isAnnouncedByScreenReader={true}
-							size="medium"
-						/>
-					</div>
-				</Label>
-				<Button
-					icon={
-						<SvgArrowRightStraight
-							isAnnouncedByScreenReader={true}
-							size="medium"
-						/>
-					}
-					aria-label="Search with google"
-					cssOverrides={searchSubmit}
-					data-link-name="nav2 : search : submit"
-					type="submit"
-				></Button>
-				<input
-					type="hidden"
-					name="as_sitesearch"
-					value="www.theguardian.com"
-				/>
-			</form>
-			<div css={lineStyle}></div>
-		</li>
-
 		<ReaderRevenueLinks readerRevenueLinks={nav.readerRevenueLinks} />
 		<MoreColumn
 			column={nav.otherLinks}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -4,7 +4,6 @@ import {
 	brandText,
 	from,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import type { LinkType } from '../../../../model/extract-nav';
 
@@ -29,12 +28,6 @@ const columnLinkTitle = css`
 	position: relative;
 	text-align: left;
 	width: 100%;
-
-	${until.desktop} {
-		color: ${brandAlt[400]};
-		font-size: 20px;
-		font-weight: 700;
-	}
 
 	${from.tablet} {
 		padding-left: 60px;


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#5764 because we're seeing Cypress failures on `main`