### PR TITLE
Remove custom padding for Explainer headline

### DIFF
--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -39,6 +39,7 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 				padding-bottom: ${remSpace[1]};
 			`;
 		case ArticleDesign.Analysis:
+<<<<<<< Updated upstream
 			return css`
 				${baseStyles}
 				${articleWidthStyles}
@@ -48,6 +49,8 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 				`}
 			`;
 		case ArticleDesign.Explainer:
+=======
+>>>>>>> Stashed changes
 			return css`
 				${baseStyles}
 				${articleWidthStyles}

--- a/apps-rendering/src/components/HeadlineTag/index.tsx
+++ b/apps-rendering/src/components/HeadlineTag/index.tsx
@@ -19,6 +19,7 @@ const headlineTagStyles = (format: ArticleFormat): SerializedStyles => css`
 	display: inline-block;
 	box-decoration-break: clone;
 	padding: 0 0.375rem 0.125rem;
+	margin-bottom: 0.25rem;
 	${from.tablet} {
 		${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'loose' })}
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes the custom headline padding for explainer as this is only wanted for Analysis

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png
