### PR TITLE
refactor: use Object.entries()

### DIFF
--- a/dotcom-rendering/src/lib/sharing-urls.ts
+++ b/dotcom-rendering/src/lib/sharing-urls.ts
@@ -4,12 +4,12 @@ const appendParamsToBaseUrl: (
 		[key: string]: string;
 	},
 ) => string = (baseUrl, params) =>
-	Object.keys(params).reduce((shareUrl: string, param: string, i: number) => {
+	Object.entries(params).reduce((shareUrl, [param, value], i) => {
 		const separator = i > 0 ? '&' : '?';
 
 		return `${shareUrl}${separator}${encodeURIComponent(
 			param,
-		)}=${encodeURIComponent(params[param])}`;
+		)}=${encodeURIComponent(value)}`;
 	}, baseUrl);
 
 export const getSharingUrls = (

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -81,9 +81,9 @@ export const abTestPayload = (tests: {
 	[key: string]: string;
 }): OphanABPayload => {
 	const records: { [key: string]: OphanABEvent } = {};
-	Object.keys(tests).forEach((testName) => {
+	Object.entries(tests).forEach(([testName, variantName]) => {
 		records[`ab${testName}`] = {
-			variantName: tests[testName],
+			variantName,
 			complete: false,
 		};
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When we want both keys and values, make this explicit.

## Why?

This also prevents possibly `undefined` values if/when `noUncheckedIndexedAccess` is turned on.