### PR TITLE
Ar table of content v2

### DIFF
--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -13,6 +13,7 @@ import {
 	some,
 	withDefault,
 } from '@guardian/types';
+import { Optional } from 'optional';
 
 // ----- Functions ----- //
 
@@ -65,6 +66,11 @@ const index =
 	(i: number) =>
 	<A>(arr: A[]): Option<A> =>
 		fromNullable(arr[i]);
+
+const indexOptional =
+	(i: number) =>
+	<A>(arr: A[]): Optional<A> =>
+		Optional.fromNullable(arr[i]);
 
 const resultFromNullable =
 	<E>(e: E) =>
@@ -151,6 +157,7 @@ export {
 	maybeRender,
 	handleErrors,
 	index,
+	indexOptional,
 	resultFromNullable,
 	optionMap3,
 	parseIntOpt,

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -1,0 +1,44 @@
+import { HeadingThree, HeadingTwo } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import { JSDOM } from 'jsdom';
+import { Optional } from 'optional';
+import { fromBodyElements } from 'outline';
+
+const makeHeadingTwo = (text: string, id: string): HeadingTwo => {
+	return {
+		kind: ElementKind.HeadingTwo,
+		id: Optional.some(id),
+		doc: JSDOM.fragment(`<h2>${text}</h2>`).firstChild!,
+	};
+};
+
+const makeHeadingThree = (text: string, id: string): HeadingThree => {
+	return {
+		kind: ElementKind.HeadingThree,
+		id: Optional.some(id),
+		doc: JSDOM.fragment(`<h3>${text}</h3>`).firstChild!,
+	};
+};
+
+describe('outline', () => {
+	test('it creates an outline', () => {
+		const output = fromBodyElements([
+			makeHeadingTwo('Interesting topic 1', 'interesting-topic-1'),
+			makeHeadingTwo('Interesting topic 2', 'interesting-topic-2'),
+			makeHeadingThree('Subtopic 1', 'subtopic-1'),
+			makeHeadingThree('Subtopic 2', 'subtopic-2'),
+			makeHeadingTwo('Interesting topic 3', 'interesting-topic-3'),
+			makeHeadingThree('Subtopic 3', 'subtopic-3'),
+		]);
+
+		expect(output.length).toEqual(3);
+		expect(output[0].id).toEqual('interesting-topic-1');
+		expect(output[0].subheadings.length).toEqual(0);
+
+		expect(output[1].id).toEqual('interesting-topic-2');
+		expect(output[1].subheadings.length).toEqual(2);
+		expect(output[1].subheadings[0].id).toEqual('subtopic-1');
+		expect(output[1].subheadings[1].id).toEqual('subtopic-2');
+		console.log(output);
+	});
+});

--- a/apps-rendering/src/outline.ts
+++ b/apps-rendering/src/outline.ts
@@ -1,0 +1,57 @@
+import { BodyElement } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import { indexOptional } from 'lib';
+import { Optional } from 'optional';
+
+type Fields = {
+	id: string;
+	doc: Node;
+};
+
+type Outline = Array<
+	Fields & {
+		subheadings: Array<Fields>;
+	}
+>;
+
+const fromBodyElements = (elements: BodyElement[]): Outline => {
+	return elements.reduce(
+		(outline: Outline, element: BodyElement): Outline => {
+			switch (element.kind) {
+				case ElementKind.HeadingTwo:
+					return element.id
+						.map((id) => [
+							...outline,
+							{
+								id,
+								doc: element.doc,
+								subheadings: [],
+							},
+						])
+						.withDefault(outline);
+
+				case ElementKind.HeadingThree:
+					const last = indexOptional(outline.length - 1)(outline);
+					return Optional.map2(last, element.id, (l, id) => [
+						...outline.slice(0, outline.length - 1),
+						{
+							...l,
+							subheadings: [
+								...l.subheadings,
+								{
+									id,
+									doc: element.doc,
+								},
+							],
+						},
+					]).withDefault(outline);
+				default:
+					return outline;
+			}
+		},
+		[],
+	);
+};
+
+export type { Outline };
+export { fromBodyElements };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
