### PR TITLE
AR TOC - Outline module

### DIFF
--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -27,6 +27,7 @@ import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type {
 	Item,
+	Explainer as ExplainerItem,
 	MatchReport as MatchReportItem,
 	Review as ReviewItem,
 	Standard as StandardItem,
@@ -71,7 +72,7 @@ const decideLines = (
 };
 
 interface Props {
-	item: StandardItem | ReviewItem | MatchReportItem;
+	item: StandardItem | ReviewItem | MatchReportItem | ExplainerItem;
 	children: ReactNode[];
 }
 

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -26,8 +26,8 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type {
-	Item,
 	Explainer as ExplainerItem,
+	Item,
 	MatchReport as MatchReportItem,
 	Review as ReviewItem,
 	Standard as StandardItem,

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -389,6 +389,7 @@ const articleWithStandfirstLink: Item = {
 const analysis: Analysis = {
 	design: ArticleDesign.Analysis,
 	...fields,
+	outline: [],
 };
 
 const feature: Feature = {
@@ -482,6 +483,7 @@ const quiz: Quiz = {
 const explainer: Explainer = {
 	design: ArticleDesign.Explainer,
 	...fields,
+	outline: [],
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -43,11 +43,12 @@ import type { LiveBlock } from 'liveBlock';
 import { parseMany as parseLiveBlocks } from 'liveBlock';
 import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
+import type { Outline } from 'outline';
+import { fromBodyElements } from 'outline';
 import type { LiveBlogPagedBlocks } from 'pagination';
 import { getPagedBlocks } from 'pagination';
 import type { Context } from 'parserContext';
 import { themeFromString } from 'themeStyles';
-import { fromBodyElements, Outline } from 'outline';
 
 // ----- Item Type ----- //
 

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -13,6 +13,7 @@ import {
 	some,
 	withDefault,
 } from '@guardian/types';
+import { Optional } from 'optional';
 
 // ----- Functions ----- //
 
@@ -65,6 +66,11 @@ const index =
 	(i: number) =>
 	<A>(arr: A[]): Option<A> =>
 		fromNullable(arr[i]);
+
+const indexOptional =
+	(i: number) =>
+	<A>(arr: A[]): Optional<A> =>
+		Optional.fromNullable(arr[i]);
 
 const resultFromNullable =
 	<E>(e: E) =>
@@ -151,6 +157,7 @@ export {
 	maybeRender,
 	handleErrors,
 	index,
+	indexOptional,
 	resultFromNullable,
 	optionMap3,
 	parseIntOpt,

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -1,0 +1,44 @@
+import { HeadingThree, HeadingTwo } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import { JSDOM } from 'jsdom';
+import { Optional } from 'optional';
+import { fromBodyElements } from 'outline';
+
+const makeHeadingTwo = (text: string, id: string): HeadingTwo => {
+	return {
+		kind: ElementKind.HeadingTwo,
+		id: Optional.some(id),
+		doc: JSDOM.fragment(`<h2>${text}</h2>`).firstChild!,
+	};
+};
+
+const makeHeadingThree = (text: string, id: string): HeadingThree => {
+	return {
+		kind: ElementKind.HeadingThree,
+		id: Optional.some(id),
+		doc: JSDOM.fragment(`<h3>${text}</h3>`).firstChild!,
+	};
+};
+
+describe('outline', () => {
+	test('it creates an outline', () => {
+		const output = fromBodyElements([
+			makeHeadingTwo('Interesting topic 1', 'interesting-topic-1'),
+			makeHeadingTwo('Interesting topic 2', 'interesting-topic-2'),
+			makeHeadingThree('Subtopic 1', 'subtopic-1'),
+			makeHeadingThree('Subtopic 2', 'subtopic-2'),
+			makeHeadingTwo('Interesting topic 3', 'interesting-topic-3'),
+			makeHeadingThree('Subtopic 3', 'subtopic-3'),
+		]);
+
+		expect(output.length).toEqual(3);
+		expect(output[0].id).toEqual('interesting-topic-1');
+		expect(output[0].subheadings.length).toEqual(0);
+
+		expect(output[1].id).toEqual('interesting-topic-2');
+		expect(output[1].subheadings.length).toEqual(2);
+		expect(output[1].subheadings[0].id).toEqual('subtopic-1');
+		expect(output[1].subheadings[1].id).toEqual('subtopic-2');
+		console.log(output);
+	});
+});

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -27,17 +27,17 @@ const makeParagraph = (text: string): BodyElement => {
 	};
 };
 
-const makeLiveEventElement = (): BodyElement => ({
+const liveEventElement: BodyElement = {
 	kind: ElementKind.LiveEvent,
 	linkText: 'this links to a live event',
 	url: 'https://theguardian.com',
-});
+};
 
-const makeRichLinkElement = (): BodyElement => ({
+const richLinkElement: BodyElement = {
 	kind: ElementKind.RichLink,
 	url: 'https://theguardian.com',
 	linkText: 'this links to a related article',
-});
+};
 
 describe('outline', () => {
 	test('it creates an empty outline given an empty list of body elements', () => {
@@ -71,10 +71,10 @@ describe('outline', () => {
 			makeParagraph('paragraph 1'),
 			makeHeadingThree('Subtopic 1', 'subtopic-1'),
 			makeParagraph('paragraph 1'),
-			makeLiveEventElement(),
+			liveEventElement,
 			makeHeadingThree('Subtopic 2', 'subtopic-2'),
 			makeHeadingTwo('Interesting topic 2', 'interesting-topic-2'),
-			makeRichLinkElement(),
+			richLinkElement,
 			makeHeadingThree('Subtopic 3', 'subtopic-3'),
 		]);
 
@@ -83,7 +83,7 @@ describe('outline', () => {
 		expect(output[0].subheadings.length).toEqual(2);
 		expect(output[0].subheadings[0].id).toEqual('subtopic-1');
 		expect(output[0].subheadings[1].id).toEqual('subtopic-2');
-		expect(output[0].subheadings.length).toEqual(2);
+		expect(output[1].subheadings.length).toEqual(1);
 		expect(output[1].id).toEqual('interesting-topic-2');
 		expect(output[1].subheadings.length).toEqual(1);
 		expect(output[1].subheadings[0].id).toEqual('subtopic-3');

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -40,6 +40,11 @@ const makeRichLinkElement = (): BodyElement => ({
 });
 
 describe('outline', () => {
+	test('it creates an empty outline given an empty list of body elements', () => {
+		const output = fromBodyElements([]);
+
+		expect(output.length).toEqual(0);
+	});
 	test('it creates an outline given a list of H2 and H3 body elements', () => {
 		const output = fromBodyElements([
 			makeHeadingTwo('Interesting topic 1', 'interesting-topic-1'),

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -85,7 +85,6 @@ describe('outline', () => {
 		expect(output[0].subheadings[1].id).toEqual('subtopic-2');
 		expect(output[1].subheadings.length).toEqual(1);
 		expect(output[1].id).toEqual('interesting-topic-2');
-		expect(output[1].subheadings.length).toEqual(1);
 		expect(output[1].subheadings[0].id).toEqual('subtopic-3');
 	});
 });

--- a/apps-rendering/src/outline.test.ts
+++ b/apps-rendering/src/outline.test.ts
@@ -1,4 +1,4 @@
-import { HeadingThree, HeadingTwo } from 'bodyElement';
+import { BodyElement, HeadingThree, HeadingTwo } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
 import { JSDOM } from 'jsdom';
 import { Optional } from 'optional';
@@ -20,8 +20,27 @@ const makeHeadingThree = (text: string, id: string): HeadingThree => {
 	};
 };
 
+const makeParagraph = (text: string): BodyElement => {
+	return {
+		kind: ElementKind.Text,
+		doc: JSDOM.fragment(`<p>${text}</p>`).firstChild!,
+	};
+};
+
+const makeLiveEventElement = (): BodyElement => ({
+	kind: ElementKind.LiveEvent,
+	linkText: 'this links to a live event',
+	url: 'https://theguardian.com',
+});
+
+const makeRichLinkElement = (): BodyElement => ({
+	kind: ElementKind.RichLink,
+	url: 'https://theguardian.com',
+	linkText: 'this links to a related article',
+});
+
 describe('outline', () => {
-	test('it creates an outline', () => {
+	test('it creates an outline given a list of H2 and H3 body elements', () => {
 		const output = fromBodyElements([
 			makeHeadingTwo('Interesting topic 1', 'interesting-topic-1'),
 			makeHeadingTwo('Interesting topic 2', 'interesting-topic-2'),
@@ -39,6 +58,29 @@ describe('outline', () => {
 		expect(output[1].subheadings.length).toEqual(2);
 		expect(output[1].subheadings[0].id).toEqual('subtopic-1');
 		expect(output[1].subheadings[1].id).toEqual('subtopic-2');
-		console.log(output);
+	});
+
+	test('it creates an outline given a list of mixed body elements', () => {
+		const output = fromBodyElements([
+			makeHeadingTwo('Interesting topic 1', 'interesting-topic-1'),
+			makeParagraph('paragraph 1'),
+			makeHeadingThree('Subtopic 1', 'subtopic-1'),
+			makeParagraph('paragraph 1'),
+			makeLiveEventElement(),
+			makeHeadingThree('Subtopic 2', 'subtopic-2'),
+			makeHeadingTwo('Interesting topic 2', 'interesting-topic-2'),
+			makeRichLinkElement(),
+			makeHeadingThree('Subtopic 3', 'subtopic-3'),
+		]);
+
+		expect(output.length).toEqual(2);
+		expect(output[0].id).toEqual('interesting-topic-1');
+		expect(output[0].subheadings.length).toEqual(2);
+		expect(output[0].subheadings[0].id).toEqual('subtopic-1');
+		expect(output[0].subheadings[1].id).toEqual('subtopic-2');
+		expect(output[0].subheadings.length).toEqual(2);
+		expect(output[1].id).toEqual('interesting-topic-2');
+		expect(output[1].subheadings.length).toEqual(1);
+		expect(output[1].subheadings[0].id).toEqual('subtopic-3');
 	});
 });

--- a/apps-rendering/src/outline.ts
+++ b/apps-rendering/src/outline.ts
@@ -1,0 +1,57 @@
+import { BodyElement } from 'bodyElement';
+import { ElementKind } from 'bodyElementKind';
+import { indexOptional } from 'lib';
+import { Optional } from 'optional';
+
+type Fields = {
+	id: string;
+	doc: Node;
+};
+
+type Outline = Array<
+	Fields & {
+		subheadings: Array<Fields>;
+	}
+>;
+
+const fromBodyElements = (elements: BodyElement[]): Outline => {
+	return elements.reduce(
+		(outline: Outline, element: BodyElement): Outline => {
+			switch (element.kind) {
+				case ElementKind.HeadingTwo:
+					return element.id
+						.map((id) => [
+							...outline,
+							{
+								id,
+								doc: element.doc,
+								subheadings: [],
+							},
+						])
+						.withDefault(outline);
+
+				case ElementKind.HeadingThree:
+					const last = indexOptional(outline.length - 1)(outline);
+					return Optional.map2(last, element.id, (l, id) => [
+						...outline.slice(0, outline.length - 1),
+						{
+							...l,
+							subheadings: [
+								...l.subheadings,
+								{
+									id,
+									doc: element.doc,
+								},
+							],
+						},
+					]).withDefault(outline);
+				default:
+					return outline;
+			}
+		},
+		[],
+	);
+};
+
+export type { Outline };
+export { fromBodyElements };

--- a/apps-rendering/src/outline.ts
+++ b/apps-rendering/src/outline.ts
@@ -1,4 +1,4 @@
-import { BodyElement } from 'bodyElement';
+import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
 import { indexOptional } from 'lib';
 import { Optional } from 'optional';
@@ -10,7 +10,7 @@ type Fields = {
 
 type Outline = Array<
 	Fields & {
-		subheadings: Array<Fields>;
+		subheadings: Fields[];
 	}
 >;
 
@@ -28,7 +28,7 @@ const fromBodyElements = (elements: BodyElement[]): Outline =>
 						},
 					])
 					.withDefault(outline);
-			case ElementKind.HeadingThree:
+			case ElementKind.HeadingThree: {
 				const currentH2 = indexOptional(outline.length - 1)(outline);
 				return Optional.map2(currentH2, element.id, (h2, id) => [
 					...outline.slice(0, outline.length - 1),
@@ -43,6 +43,7 @@ const fromBodyElements = (elements: BodyElement[]): Outline =>
 						],
 					},
 				]).withDefault(outline);
+			}
 			default:
 				return outline;
 		}

--- a/apps-rendering/src/outline.ts
+++ b/apps-rendering/src/outline.ts
@@ -14,44 +14,39 @@ type Outline = Array<
 	}
 >;
 
-const fromBodyElements = (elements: BodyElement[]): Outline => {
-	return elements.reduce(
-		(outline: Outline, element: BodyElement): Outline => {
-			switch (element.kind) {
-				case ElementKind.HeadingTwo:
-					return element.id
-						.map((id) => [
-							...outline,
+const fromBodyElements = (elements: BodyElement[]): Outline =>
+	elements.reduce((outline: Outline, element: BodyElement): Outline => {
+		switch (element.kind) {
+			case ElementKind.HeadingTwo:
+				return element.id
+					.map((id) => [
+						...outline,
+						{
+							id,
+							doc: element.doc,
+							subheadings: [],
+						},
+					])
+					.withDefault(outline);
+			case ElementKind.HeadingThree:
+				const currentH2 = indexOptional(outline.length - 1)(outline);
+				return Optional.map2(currentH2, element.id, (h2, id) => [
+					...outline.slice(0, outline.length - 1),
+					{
+						...h2,
+						subheadings: [
+							...h2.subheadings,
 							{
 								id,
 								doc: element.doc,
-								subheadings: [],
 							},
-						])
-						.withDefault(outline);
-
-				case ElementKind.HeadingThree:
-					const last = indexOptional(outline.length - 1)(outline);
-					return Optional.map2(last, element.id, (l, id) => [
-						...outline.slice(0, outline.length - 1),
-						{
-							...l,
-							subheadings: [
-								...l.subheadings,
-								{
-									id,
-									doc: element.doc,
-								},
-							],
-						},
-					]).withDefault(outline);
-				default:
-					return outline;
-			}
-		},
-		[],
-	);
-};
+						],
+					},
+				]).withDefault(outline);
+			default:
+				return outline;
+		}
+	}, []);
 
 export type { Outline };
 export { fromBodyElements };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
This PR was done through a few mobbing sessions with the following people involved:
@JamieB-gu  , @georgeblahblah & @marjisound 
## What does this change?
- This PR creates a new type `Outline` which will be used for the table of content component (in future PR).  
- It also adds a new function `fromBodyElements` which extracts outline from the list of body elements. 
- The outline field is added to the Explainer & Analysis Item models. 

In future PR, when the component is created, the outline field can be used in the layout to render the table of content. 

Note:
This PR is currently going into `ar-table-of-content` branch, because it's dependant on the changes on that branch. After https://github.com/guardian/dotcom-rendering/pull/5767 is merged, the target would be changed to `main`

## Why?
Enabler for having table of content on Explainer/Analysis articles, and even for more stuff in the future. 

The table of content in Explainer articles has been requested by the Editorial Design team. More details can be found here https://docs.google.com/document/d/1MqSldxfgR86kOJaXTFNaBs5LzPzSa7jC4D4YwqqMFwg/edit#

<!--
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
