### PR TITLE
Refactor Object.keys => Object.entries

### DIFF
--- a/apps-rendering/src/components/EmbedWrapper/index.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/index.tsx
@@ -434,12 +434,15 @@ const EmbedComponentInClickToView: FC<EmbedComponentInClickToViewProps> = ({
 const withDatasetKeyFormat = (
 	dataSet: Record<string, string>,
 ): Record<string, string> => {
-	return Object.keys(dataSet).reduce((accumulatedObject, currentKey) => {
-		const newKey =
-			'data-' +
-			currentKey.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-		return { ...accumulatedObject, [newKey]: dataSet[currentKey] };
-	}, {});
+	return Object.entries(dataSet).reduce(
+		(accumulatedObject, [currentKey, currentValue]) => {
+			const newKey =
+				'data-' +
+				currentKey.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+			return { ...accumulatedObject, [newKey]: currentValue };
+		},
+		{},
+	);
 };
 
 const EmbedComponentWrapper: FC<Props> = ({ embed, editions }: Props) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses `Object.entries` instead of `Object.keys`, prompted by #5830 
- This function uses both the keys & values

Tested on CODE