### PR TITLE
refactor: remove `any` type from article-section

### DIFF
--- a/dotcom-rendering/src/model/article-sections.ts
+++ b/dotcom-rendering/src/model/article-sections.ts
@@ -1,4 +1,4 @@
-export const sections: SectionNielsenAPI[] = [
+export const sections = [
 	{
 		name: 'Guardian',
 		apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
@@ -87,9 +87,9 @@ export const sections: SectionNielsenAPI[] = [
 		name: 'TvRadio',
 		apiID: '3277F0D0-9389-4A32-A4D6-516B49D87E45',
 	},
-];
+] as const;
 
-const subsections: { [key: string]: any } = {
+const subsections: { [key: string]: SectionNielsenAPI | undefined } = {
 	books: sections[1],
 	'childrens-books-site': sections[1],
 	business: sections[2],


### PR DESCRIPTION
## What does this change?

Use the `as const` assertion on our list of sections, and type the subsections object with `SectionNielsenAPI`.

## Why?

Stricter type-safety than `any`. Better Intellisense.

## Screenshots

![image](https://user-images.githubusercontent.com/76776/186433300-46a123fc-312c-4c53-9f3f-dac34c2e4a99.png)
