### PR TITLE
Remove images from rich links

### DIFF
--- a/apps-rendering/src/components/RichLink/index.tsx
+++ b/apps-rendering/src/components/RichLink/index.tsx
@@ -90,11 +90,6 @@ const richLinkStyles = (format: ArticleFormat): SerializedStyles => {
 			${richLinkPillarStyles(formatFromTheme(ArticlePillar.Lifestyle))}
 		}
 
-		img {
-			width: calc(100% + ${remSpace[6]});
-			margin: -${remSpace[3]} 0 0 -${remSpace[3]};
-		}
-
 		button {
 			background: none;
 			border: none;
@@ -204,7 +199,6 @@ const RichLink = (props: {
 		'aside',
 		{ ...attributes },
 		styledH('a', { href: url }, [
-			h('div', { className: 'js-image', key: `${url}-div` }, null),
 			h('h1', { key: `${url}-h1` }, linkText),
 			h('button', { key: `${url}-button` }, [
 				h(SvgArrowRightStraight, { key: `${url}-svg` }),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the images from RichLinks

## Why?
For parity with DCR

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="731" alt="image" src="https://user-images.githubusercontent.com/99400613/186476761-63c0abbc-c9cf-4b74-ab1a-4ead6f45471a.png"> | <img width="714" alt="image" src="https://user-images.githubusercontent.com/99400613/186476677-3f3f26de-519b-4664-a4bd-7275ff27aa9f.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
