### PR TITLE
fix: safe `performance.getEntriesByType`

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -48,6 +48,8 @@ export const doHydration = (
 			return { clientOnly, timeTaken };
 		})
 		.then(({ clientOnly, timeTaken }) => {
+			if (!('getEntriesByType' in window.performance)) return;
+
 			// Log performance info
 			const { duration: download = -1 } =
 				window.performance


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Some browsers do not support `window.performance.getEntriesByType`, so we check for its existence before measuring the time taken.

## Why?

This is the top reported `TypeError` in Sentry.

Fixes CLIENT-SIDE-PROD-CSXR
Fixes CLIENT-SIDE-PROD-CTRH

This method was Introduced in #5298.
Related to the fix in #5299