### PR TITLE
Add top margin to blog series

### DIFF
--- a/apps-rendering/src/components/Series/index.tsx
+++ b/apps-rendering/src/components/Series/index.tsx
@@ -133,7 +133,9 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 		format.design === ArticleDesign.DeadBlog
 	) {
 		return css`
-			margin-top: ${remSpace[1]};
+			${from.desktop} {
+				margin-top: ${remSpace[1]};
+			}
 		`;
 	}
 

--- a/apps-rendering/src/components/Series/index.tsx
+++ b/apps-rendering/src/components/Series/index.tsx
@@ -132,7 +132,9 @@ const getStyles = (format: ArticleFormat): SerializedStyles => {
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog
 	) {
-		return css();
+		return css`
+			margin-top: ${remSpace[1]};
+		`;
 	}
 
 	return standardStyles;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a margin to the top of the series component on blogs

## Why?
The ascenders of the series and headline were out of alignment

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="888" alt="image" src="https://user-images.githubusercontent.com/99400613/186638958-baa88772-b0fd-4f0f-b9af-cb558c461528.png"> | <img width="899" alt="image" src="https://user-images.githubusercontent.com/99400613/186638891-ec90e00f-ed70-40e4-a8ca-f207290051e6.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
