### PR TITLE
Fix the hover colour for standfirst links

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1217,14 +1217,7 @@ const textRichLink = (format: ArticleFormat): string => {
 };
 
 const hoverStandfirstLink = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.DeadBlog)
-		return pillarPalette[format.theme].main;
-	if (format.design === ArticleDesign.LiveBlog) {
-		return WHITE;
-	}
-	if (format.theme === ArticleSpecial.SpecialReport)
-		return specialReport[400];
-	return border.secondary;
+	return textStandfirstLink(format);
 };
 
 const borderRichLink: (format: ArticleFormat) => string = (format) => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We now always use the text colour to style the underline when hovering links in the standfirst

## Why?
To simplify this code and fix an issue where we were not highlighting the hover properly


| Before      | After      |
|-------------|------------|
| ![2022-08-25 11 36 31](https://user-images.githubusercontent.com/1336821/186643307-bcfb11d7-7ad5-4a1a-b4fe-e83daa67acb1.gif) | ![2022-08-25 11 34 11](https://user-images.githubusercontent.com/1336821/186643199-20b663c5-df08-4746-86a5-dbf651ebb2be.gif) |