### PR TITLE
Don't always stack the byline on Analysis pieces

### DIFF
--- a/dotcom-rendering/src/web/components/BylineLink.tsx
+++ b/dotcom-rendering/src/web/components/BylineLink.tsx
@@ -1,5 +1,9 @@
 import { ArticleDesign } from '@guardian/libs';
-import { getBylineComponentsFromTokens, isContributor } from '../../lib/byline';
+import {
+	getBylineComponentsFromTokens,
+	getSoleContributor,
+	isContributor,
+} from '../../lib/byline';
 
 type Props = {
 	byline: string;
@@ -88,12 +92,13 @@ function removeComma(bylinePart: string) {
 
 export const BylineLink = ({ byline, tags, format }: Props) => {
 	const tokens = bylineAsTokens(byline, tags);
-
+	const hasSingleContributor = !!getSoleContributor(tags, byline);
 	const bylineComponents = getBylineComponentsFromTokens(tokens, tags);
+
 	const renderedTokens = bylineComponents.map((bylineComponent) => {
 		if (typeof bylineComponent === 'string') {
 			const displayString =
-				format.design === ArticleDesign.Analysis
+				format.design === ArticleDesign.Analysis && hasSingleContributor
 					? removeComma(bylineComponent)
 					: bylineComponent;
 			return displayString ? <span>{displayString}</span> : null;

--- a/dotcom-rendering/src/web/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineByline.tsx
@@ -76,16 +76,20 @@ const opinionStyles = (palette: Palette, format: ArticleFormat) => css`
 	}
 `;
 
-const analysisStyles = (palette: Palette) => css`
+const analysisStyles = (palette: Palette, hasSingleContributor: boolean) => css`
 	${headline.medium({
 		fontWeight: 'light',
 	})}
 	line-height: 38px;
-	display: flex;
-	flex-direction: column;
 	font-style: italic;
 	color: ${palette.text.headlineByline};
 	background: ${palette.background.headlineByline};
+
+	${hasSingleContributor &&
+	css`
+		display: flex;
+		flex-direction: column;
+	`}
 
 	${until.tablet} {
 		${headline.small({
@@ -203,7 +207,12 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				case ArticleDesign.Analysis:
 					return (
 						<div css={opinionWrapperStyles}>
-							<div css={analysisStyles(palette)}>
+							<div
+								css={analysisStyles(
+									palette,
+									hasSingleContributor,
+								)}
+							>
 								<BylineLink
 									byline={byline}
 									tags={tags}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes a bug where the byline looked wrong when an Analysis piece had multiple contributors stacked on top of each other

| Before      | After      |
|-------------|------------|
| <img width="643" alt="Screenshot 2022-08-25 at 11 59 57" src="https://user-images.githubusercontent.com/1336821/186647530-157e2559-51f9-4e91-8a5e-e8a07a19b719.png"> | <img width="643" alt="Screenshot 2022-08-25 at 11 56 14" src="https://user-images.githubusercontent.com/1336821/186647473-7bccd7b9-ce13-43b9-b96e-c54e9e01cfa2.png"> |