### PR TITLE
Add isMobile Sign In Gate display rule

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -171,17 +171,19 @@ describe('SignInGate - displayRule methods', () => {
 			'get',
 		);
 
-		// FIXME sometimes this navigator property does not exist in testing env
-		!window.navigator.maxTouchPoints &&
+		// Sometimes this navigator property does not exist in testing env
+		if (!window.navigator.maxTouchPoints) {
 			Object.defineProperty(window.navigator, 'maxTouchPoints', {
 				configurable: true,
 				get: () => '',
 			});
+		}
 		const maxTouchPointGetter = jest.spyOn(
 			window.navigator,
 			'maxTouchPoints',
 			'get',
 		);
+
 		test('is mobile device', () => {
 			maxTouchPointGetter.mockReturnValue(1);
 			expect(isMobile()).toBe(true);

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.test.ts
@@ -1,6 +1,7 @@
 import { incrementDailyArticleCount } from '../../lib/dailyArticleCount';
 import {
 	isIOS9,
+	isMobile,
 	isNPageOrHigherPageView,
 	isValidContentType,
 	isValidSection,
@@ -159,6 +160,45 @@ describe('SignInGate - displayRule methods', () => {
 					},
 				]),
 			).toBe(false);
+		});
+	});
+
+	describe('isMobile', () => {
+		// spy on user agent to mock return value
+		const userAgentGetter = jest.spyOn(
+			window.navigator,
+			'userAgent',
+			'get',
+		);
+
+		// FIXME sometimes this navigator property does not exist in testing env
+		!window.navigator.maxTouchPoints &&
+			Object.defineProperty(window.navigator, 'maxTouchPoints', {
+				configurable: true,
+				get: () => '',
+			});
+		const maxTouchPointGetter = jest.spyOn(
+			window.navigator,
+			'maxTouchPoints',
+			'get',
+		);
+		test('is mobile device', () => {
+			maxTouchPointGetter.mockReturnValue(1);
+			expect(isMobile()).toBe(true);
+		});
+		test('is not mobile device', () => {
+			maxTouchPointGetter.mockReturnValue(0);
+			expect(isMobile()).toBe(false);
+		});
+		test('is mobile device if touchpoint info missing', () => {
+			userAgentGetter.mockReturnValueOnce(
+				'Mozilla/5.0 (iPhone; CPU OS 10_3 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+			);
+			expect(isMobile()).toBe(true);
+		});
+		test('is not mobile device if touchpoint info missing', () => {
+			userAgentGetter.mockReturnValueOnce('');
+			expect(isMobile()).toBe(false);
 		});
 	});
 });

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -33,7 +33,7 @@ export const isIOS9 = (): boolean => {
 // determine if the browser is a mobile device if it supports touch points, with user agent fallback
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
 export const isMobile = (): boolean => {
-	if (!!navigator.maxTouchPoints) {
+	if (navigator.maxTouchPoints) {
 		return navigator.maxTouchPoints > 0;
 	} else {
 		const ua = navigator.userAgent;

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -30,6 +30,20 @@ export const isIOS9 = (): boolean => {
 	return appleDevice && os;
 };
 
+// determine if the browser is a mobile device if it supports touch points, with user agent fallback
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+export const isMobile = (): boolean => {
+	if (!!navigator.maxTouchPoints) {
+		return navigator.maxTouchPoints > 0;
+	} else {
+		const ua = navigator.userAgent;
+		return (
+			/\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(ua) ||
+			/\b(Android|Windows Phone|iPad|iPod)\b/i.test(ua)
+		);
+	}
+};
+
 // hide the sign in gate on article types that are not supported
 export const isValidContentType = (contentType: string): boolean => {
 	// It's safer to definitively *include* types as we


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR adds a new display rule to check device type, which determines whether or not to show the sign in gate.

'isMobile' - checks if a browsing device is a mobile device or not, based on the [latest Mozilla guidance](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent) to use maxTouchpoints

## Why?

This is required to implement an upcoming Sign In Gate AB test

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
