### PR TITLE
use Option<Newsletter> instead of optional Newsletter

### DIFF
--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -369,6 +369,7 @@ const fields = {
 	footballContent: none,
 	logo: none,
 	webUrl: '',
+	promotedNewsletter: none,
 };
 
 const article: Standard = {

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -257,6 +257,7 @@ const fields = {
 	footballContent: none,
 	logo: none,
 	webUrl: '',
+	promotedNewsletter: none,
 };
 
 const pinnedBlock: LiveBlock = {

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -66,7 +66,7 @@ interface Fields extends ArticleFormat {
 	relatedContent: Option<ResizedRelatedContent>;
 	logo: Option<Logo>;
 	webUrl: string;
-	promotedNewsletter?: Newsletter;
+	promotedNewsletter: Option<Newsletter>;
 }
 
 interface MatchReport extends Fields {
@@ -309,7 +309,7 @@ const itemFields = (
 		),
 		logo: paidContentLogo(content.tags),
 		webUrl: content.webUrl,
-		promotedNewsletter: request.promotedNewsletter,
+		promotedNewsletter: fromNullable(request.promotedNewsletter),
 	};
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
use `Option<Newsletter>` instead of `Newsletter | undefined` at the type for `fields.promotedNewsletter`

## Why?
Consistency with the rest of the AR structure. 
https://github.com/guardian/dotcom-rendering/pull/5808#discussion_r954108482

