### PR TITLE
refactor(types): extract Switches to config

### DIFF
--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -3,6 +3,7 @@ import { neutral, text, textSans } from '@guardian/source-foundations';
 import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../lib/pillars';
 import type { CommercialProperties } from '../../types/commercial';
+import type { Switches } from '../../types/config';
 import type { EditionId } from '../../types/edition';
 import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';

--- a/dotcom-rendering/src/amp/components/ContentABTest.tsx
+++ b/dotcom-rendering/src/amp/components/ContentABTest.tsx
@@ -1,5 +1,6 @@
 import sha256 from 'crypto-js/sha256';
 import React from 'react';
+import type { Switches } from '../../types/config';
 
 const AB_TEST_GROUPS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const;
 

--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -683,10 +683,6 @@ interface TimelineEvent {
 	toUnixDate?: number;
 }
 
-interface Switches {
-	[key: string]: boolean;
-}
-
 type RatingSizeType = 'large' | 'medium' | 'small';
 
 // -------------------------------------

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3893,10 +3893,7 @@
                     "type": "string"
                 },
                 "switches": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "boolean"
-                    }
+                    "$ref": "#/definitions/Switches"
                 },
                 "abTests": {
                     "description": "This type is not support by JSON-schema, it evaluates as `object`",
@@ -4069,6 +4066,12 @@
                 "stage",
                 "switches"
             ]
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
         },
         "CAPITrailType": {
             "type": "object",

--- a/dotcom-rendering/src/model/enhance-switches.ts
+++ b/dotcom-rendering/src/model/enhance-switches.ts
@@ -1,4 +1,6 @@
-export type ABTestSwitches = { [key: `ab${string}`]: boolean };
+import type { Switches } from '../types/config';
+
+export type ABTestSwitches = { [key: `ab${string}`]: boolean | undefined };
 
 /**
  * Switches that start with "ab" are used for AB tests.

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -1,5 +1,5 @@
 import { extract as extractGA } from '../model/extract-ga';
-import type { ConfigType, ServerSideTests } from '../types/config';
+import type { ConfigType, ServerSideTests, Switches } from '../types/config';
 import type { EditionId } from '../types/edition';
 import type { DCRFrontType } from '../types/front';
 import type { CAPIArticleType } from '../types/frontend';
@@ -28,7 +28,7 @@ export interface WindowGuardianConfig {
 	libs: {
 		googletag: string;
 	};
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	tests: ServerSideTests;
 	ophan: {
 		pageViewId: string;
@@ -59,7 +59,7 @@ interface WindowGuardianFrontConfig {
 	libs: {
 		googletag: string;
 	};
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	tests: ServerSideTests;
 	ophan: {
 		pageViewId: string;

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -20,6 +20,10 @@ export type ServerSideTests = {
 
 export type ServerSideTestNames = `${string}Control` | `${string}Variant`;
 
+export interface Switches {
+	[key: string]: boolean | undefined;
+}
+
 /**
  * the config model will contain useful app/site
  * level data. Although currently derived from the config model
@@ -31,7 +35,7 @@ export interface ConfigType extends CommercialConfigType {
 	sentryPublicApiKey: string;
 	sentryHost: string;
 	dcrSentryDsn: string;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	abTests: ServerSideTests;
 	dfpAccountId: string;
 	commercialBundleUrl: string;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -1,5 +1,5 @@
 import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
-import type { ServerSideTests } from './config';
+import type { ServerSideTests, Switches } from './config';
 import type { EditionId } from './edition';
 import type { FooterType } from './footer';
 import type { TrailType } from './trails';

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
-import type { ServerSideTests } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import type { Palette } from '../../types/palette';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';
@@ -19,7 +19,7 @@ type Props = {
 	webTitle: string;
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	section: string;
 	shouldHideReaderRevenue: boolean;
 	tags: TagType[];

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 // eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import type { Switches } from '../../types/config';
 import { RenderArticleElement } from '../lib/renderElement';
 import { LastUpdated } from './LastUpdated';
 import { ShareIcons } from './ShareIcons';
@@ -15,7 +16,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	isLiveUpdate?: boolean;
 	isPinnedPost: boolean;
 	pinnedPostId?: string;

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
+import type { Switches } from '../../types/config';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
 
@@ -78,7 +79,7 @@ export const MainMedia: React.FC<{
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 }> = ({
 	elements,
 	format,

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -1,6 +1,7 @@
 import { AB } from '@guardian/ab-core';
 import type { CoreAPIConfig } from '@guardian/ab-core/dist/types';
 import { getCookie, log } from '@guardian/libs';
+import type { ABTestSwitches } from '../../model/enhance-switches';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';
 import { tests } from '../experiments/ab-tests';
 import { getCypressSwitches } from '../experiments/cypress-switches';
@@ -8,7 +9,7 @@ import { getForcedParticipationsFromUrl } from '../lib/getAbUrlHash';
 import { setABTests } from '../lib/useAB';
 
 type Props = {
-	abTestSwitches: CoreAPIConfig['abTestSwitches'];
+	abTestSwitches: ABTestSwitches;
 	forcedTestVariants?: CoreAPIConfig['forcedTestVariants'];
 	isDev: boolean;
 	pageIsSensitive: CoreAPIConfig['pageIsSensitive'];

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -12,6 +12,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import type { NavType } from '../../model/extract-nav';
+import type { Switches } from '../../types/config';
 import type { CAPIArticleType } from '../../types/frontend';
 import {
 	adCollapseStyles,
@@ -49,7 +50,7 @@ const Renderer: React.FC<{
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 }> = ({
 	format,
 	elements,

--- a/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -10,6 +10,7 @@ import {
 } from '@guardian/source-foundations';
 import React from 'react';
 import type { NavType } from '../../model/extract-nav';
+import type { Switches } from '../../types/config';
 import type { CAPIArticleType } from '../../types/frontend';
 import type { Palette } from '../../types/palette';
 import {
@@ -157,7 +158,7 @@ const Renderer: React.FC<{
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 }> = ({
 	format,
 	elements,

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
-import type { ServerSideTests } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import {
 	adCollapseStyles,
 	labelStyles as adLabelStyles,

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -1,4 +1,5 @@
 import { Hide } from '@guardian/source-react-components';
+import type { Switches } from '../../types/config';
 import { EnhancePinnedPost } from '../components/EnhancePinnedPost.importable';
 import { FilterKeyEventsToggle } from '../components/FilterKeyEventsToggle.importable';
 import { Island } from '../components/Island';
@@ -19,7 +20,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	isLiveUpdate?: boolean;
 	section: string;
 	shouldHideReaderRevenue: boolean;

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -7,7 +7,7 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
-import type { ServerSideTests } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '../components/CalloutBlockComponent.importable';
@@ -79,7 +79,7 @@ type Props = {
 	ajaxUrl: string;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	switches: { [key: string]: boolean };
+	switches: Switches;
 	isPinnedPost?: boolean;
 	abTests?: ServerSideTests;
 };

--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -2,6 +2,7 @@
 // if the SignInGateSelector determines a gate should be rendered.
 
 import React from 'react';
+import type { Switches } from '../../types/config';
 import { Island } from '../components/Island';
 import { SignInGateSelector } from '../components/SignInGateSelector.importable';
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extract the `Switches` type to `types/config.ts` and import it explicitely.
Add the possibility that values are `undefined`, which is more explicit.

## Why?

Follow-up on #5804, which was pre-emptively coercing these switches to `boolean`. The TS compiler would now raise these as errors.