### PR TITLE
Varying webpack bundles for tests - Sentry tag

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -51,6 +51,11 @@ Sentry.init({
 	},
 });
 
+Sentry.setTag(
+	'dcr.bundle',
+	window.guardian.config.page.abTests.jsBundleVariant,
+);
+
 export const reportError = (error: Error, feature?: string): void => {
 	Sentry.withScope(() => {
 		if (feature) {


### PR DESCRIPTION
## What does this change?

Add a Sentry tag based on the bundle variant

## Why?

So we can trace errors back to the bundle type

