### PR TITLE
Use `makeWindowGuardian` everywhere

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3880,6 +3880,9 @@
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
             "type": "object",
             "properties": {
+                "dcrCouldRender": {
+                    "type": "boolean"
+                },
                 "ajaxUrl": {
                     "type": "string"
                 },
@@ -3925,7 +3928,7 @@
                     "type": "string"
                 },
                 "stage": {
-                    "type": "string"
+                    "$ref": "#/definitions/StageType"
                 },
                 "frontendAssetsFullURL": {
                     "type": "string"
@@ -3940,7 +3943,7 @@
                     "type": "number"
                 },
                 "edition": {
-                    "type": "string"
+                    "$ref": "#/definitions/EditionId"
                 },
                 "section": {
                     "type": "string"
@@ -4072,6 +4075,14 @@
             "additionalProperties": {
                 "type": "boolean"
             }
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
         },
         "CAPITrailType": {
             "type": "object",

--- a/dotcom-rendering/src/model/extract-ga.test.ts
+++ b/dotcom-rendering/src/model/extract-ga.test.ts
@@ -1,5 +1,5 @@
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
-import { extract } from './extract-ga';
+import { extractGA } from './extract-ga';
 
 const pillar: LegacyPillar = 'news';
 const base = {
@@ -36,6 +36,6 @@ const CAPIArticle = {
 
 describe('Google Analytics extracts and formats CAPIArticle response correctly', () => {
 	it('GA Extract returns correctly formatted GA response', () => {
-		expect(extract(CAPIArticle)).toEqual(base);
+		expect(extractGA(CAPIArticle)).toEqual(base);
 	});
 });

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -49,7 +49,7 @@ const formatStringForGa = (string: string): string =>
 	string.toLowerCase().split(' ').join('');
 
 // we should not bring down the website if a trackable field is missing!
-export const extract = ({
+export const extractGA = ({
 	webTitle,
 	format,
 	sectionName,

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -1,5 +1,6 @@
 // All GA fields should  fall back to default values -
 
+import type { EditionId } from '../../src/types/edition';
 import type { CAPIArticleType } from '../types/frontend';
 
 const filterTags = (
@@ -48,18 +49,36 @@ const formatStringForGa = (string: string): string =>
 	string.toLowerCase().split(' ').join('');
 
 // we should not bring down the website if a trackable field is missing!
-export const extract = (data: CAPIArticleType): GADataType => ({
-	webTitle: data.webTitle,
-	pillar: convertToLegacyPillar(data.format.theme),
-	section: data.sectionName || '',
-	contentType: formatStringForGa(data.contentType),
-	commissioningDesks: formatStringForGa(getCommissioningDesk(data.tags)),
-	contentId: data.pageId,
-	authorIds: filterTags(data.tags, 'Contributor'),
-	keywordIds: filterTags(data.tags, 'Keyword'),
-	toneIds: filterTags(data.tags, 'Tone'),
-	seriesId: filterTags(data.tags, 'Series'),
+export const extract = ({
+	webTitle,
+	format,
+	sectionName,
+	contentType,
+	tags,
+	pageId,
+	editionId,
+	beaconURL,
+}: {
+	webTitle: string;
+	format: CAPIFormat;
+	sectionName?: string;
+	contentType: string;
+	tags: TagType[];
+	pageId: string;
+	editionId: EditionId;
+	beaconURL: string;
+}): GADataType => ({
+	webTitle: webTitle,
+	pillar: convertToLegacyPillar(format.theme),
+	section: sectionName || '',
+	contentType: formatStringForGa(contentType),
+	commissioningDesks: formatStringForGa(getCommissioningDesk(tags)),
+	contentId: pageId,
+	authorIds: filterTags(tags, 'Contributor'),
+	keywordIds: filterTags(tags, 'Keyword'),
+	toneIds: filterTags(tags, 'Tone'),
+	seriesId: filterTags(tags, 'Series'),
 	isHosted: 'false', // TODO - This is missing from the Frontend Data model
-	edition: data.editionId.toLowerCase(),
-	beaconUrl: data.beaconURL,
+	edition: editionId.toLowerCase(),
+	beaconUrl: beaconURL,
 });

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -296,7 +296,6 @@
                 "avatarApiUrl",
                 "avatarImagesUrl",
                 "beaconUrl",
-                "brazeApiKey",
                 "buildNumber",
                 "calloutsUrl",
                 "commercialBundleUrl",

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -137,10 +137,6 @@ export const makeWindowGuardian = (
 export const makeFrontWindowGuardian = (
 	front: DCRFrontType,
 ): {
-	// The 'config' attribute is derived from CAPIArticle and contains
-	// all the data that, for legacy reasons, for instance compatibility
-	// with the frontend commercial stack, or other scripts, we want to find
-	// at window.guardian.config
 	config: WindowGuardianFrontConfig;
 	polyfilled: boolean;
 	adBlockers: any;

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -55,6 +55,7 @@ interface WindowGuardianFrontConfig {
 		showRelatedContent: boolean;
 		ajaxUrl: string;
 		shouldHideReaderRevenue: boolean;
+		googleRecaptchaSiteKey?: string;
 	};
 	libs: {
 		googletag: string;
@@ -66,43 +67,6 @@ interface WindowGuardianFrontConfig {
 		browserId: string;
 	};
 }
-
-const makeWindowGuardianConfig = (
-	CAPIArticle: CAPIArticleType,
-): WindowGuardianConfig => {
-	const { config } = CAPIArticle;
-	return {
-		// This indicates to the client side code that we are running a dotcom-rendering rendered page.
-		isDotcomRendering: true,
-		isDev: process.env.NODE_ENV !== 'production',
-		stage: config.stage,
-		frontendAssetsFullURL: config.frontendAssetsFullURL,
-		page: Object.assign(config, {
-			dcrCouldRender: true,
-			contentType: CAPIArticle.contentType,
-			edition: CAPIArticle.editionId,
-			revisionNumber: config.revisionNumber,
-			dcrSentryDsn:
-				'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-			sentryPublicApiKey: config.sentryPublicApiKey,
-			sentryHost: config.sentryHost,
-			keywordIds: config.keywordIds,
-			dfpAccountId: config.dfpAccountId,
-			adUnit: config.adUnit,
-			showRelatedContent: true,
-			ajaxUrl: config.ajaxUrl,
-		}),
-		libs: {
-			googletag: config.googletagUrl,
-		},
-		switches: config.switches,
-		tests: config.abTests,
-		ophan: {
-			pageViewId: '',
-			browserId: '',
-		},
-	} as WindowGuardianConfig;
-};
 
 export const makeWindowGuardian = (
 	CAPIArticle: CAPIArticleType,
@@ -121,8 +85,41 @@ export const makeWindowGuardian = (
 	};
 	GAData: GADataType;
 } => {
+	const { config, editionId } = CAPIArticle;
 	return {
-		config: makeWindowGuardianConfig(CAPIArticle),
+		config: {
+			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
+			isDotcomRendering: true,
+			isDev: process.env.NODE_ENV !== 'production',
+			stage: config.stage,
+			frontendAssetsFullURL: config.frontendAssetsFullURL,
+			page: Object.assign(config, {
+				dcrCouldRender: true,
+				contentType: CAPIArticle.contentType,
+				edition: editionId,
+				revisionNumber: config.revisionNumber,
+				dcrSentryDsn:
+					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+				sentryPublicApiKey: config.sentryPublicApiKey,
+				sentryHost: config.sentryHost,
+				keywordIds: config.keywordIds,
+				dfpAccountId: config.dfpAccountId,
+				adUnit: config.adUnit,
+				showRelatedContent: true,
+				ajaxUrl: config.ajaxUrl,
+				shouldHideReaderRevenue:
+					config.shouldHideReaderRevenue ?? false,
+			}),
+			libs: {
+				googletag: config.googletagUrl,
+			},
+			switches: config.switches,
+			tests: config.abTests,
+			ophan: {
+				pageViewId: '',
+				browserId: '',
+			},
+		},
 		polyfilled: false,
 		adBlockers: {
 			active: undefined,
@@ -134,44 +131,6 @@ export const makeWindowGuardian = (
 			},
 		},
 		GAData: extractGA(CAPIArticle),
-	};
-};
-
-const makeFrontWindowGuardianConfig = ({
-	config,
-	editionId,
-}: DCRFrontType): WindowGuardianFrontConfig => {
-	return {
-		// This indicates to the client side code that we are running a dotcom-rendering rendered page.
-		isDotcomRendering: true,
-		isDev: process.env.NODE_ENV !== 'production',
-		stage: config.stage,
-		frontendAssetsFullURL: config.frontendAssetsFullURL,
-		page: {
-			dcrCouldRender: true,
-			contentType: 'TODO: Do we need this?',
-			edition: editionId,
-			revisionNumber: config.revisionNumber,
-			dcrSentryDsn:
-				'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-			sentryPublicApiKey: config.sentryPublicApiKey,
-			sentryHost: config.sentryHost,
-			keywordIds: config.keywordIds,
-			dfpAccountId: config.dfpAccountId,
-			adUnit: config.adUnit,
-			showRelatedContent: true,
-			ajaxUrl: config.ajaxUrl,
-			shouldHideReaderRevenue: false, // TODO Pass this in
-		},
-		libs: {
-			googletag: config.googletagUrl,
-		},
-		switches: config.switches,
-		tests: config.abTests,
-		ophan: {
-			pageViewId: '',
-			browserId: '',
-		},
 	};
 };
 
@@ -191,8 +150,40 @@ export const makeFrontWindowGuardian = (
 		};
 	};
 } => {
+	const { config, editionId } = front;
 	return {
-		config: makeFrontWindowGuardianConfig(front),
+		config: {
+			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
+			isDotcomRendering: true,
+			isDev: process.env.NODE_ENV !== 'production',
+			stage: config.stage,
+			frontendAssetsFullURL: config.frontendAssetsFullURL,
+			page: {
+				dcrCouldRender: true,
+				contentType: 'TODO: Do we need this?',
+				edition: editionId,
+				revisionNumber: config.revisionNumber,
+				dcrSentryDsn:
+					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+				sentryPublicApiKey: config.sentryPublicApiKey,
+				sentryHost: config.sentryHost,
+				keywordIds: config.keywordIds,
+				dfpAccountId: config.dfpAccountId,
+				adUnit: config.adUnit,
+				showRelatedContent: true,
+				ajaxUrl: config.ajaxUrl,
+				shouldHideReaderRevenue: false, // TODO Pass this in
+			},
+			libs: {
+				googletag: config.googletagUrl,
+			},
+			switches: config.switches,
+			tests: config.abTests,
+			ophan: {
+				pageViewId: '',
+				browserId: '',
+			},
+		},
 		polyfilled: false,
 		adBlockers: {
 			active: undefined,

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -1,8 +1,5 @@
-import { extractGA } from '../model/extract-ga';
 import type { ConfigType, ServerSideTests, Switches } from '../types/config';
 import type { EditionId } from '../types/edition';
-import type { DCRFrontType } from '../types/front';
-import type { CAPIArticleType } from '../types/frontend';
 
 export interface WindowGuardianConfig {
 	isDotcomRendering: boolean;
@@ -24,7 +21,9 @@ export interface WindowGuardianConfig {
 		ajaxUrl: string;
 		shouldHideReaderRevenue: boolean;
 		googleRecaptchaSiteKey?: string;
-	} & ConfigType;
+		brazeApiKey?: string;
+		isPaidContent: boolean;
+	};
 	libs: {
 		googletag: string;
 	};
@@ -36,45 +35,65 @@ export interface WindowGuardianConfig {
 	};
 }
 
-interface WindowGuardianFrontConfig {
-	isDotcomRendering: boolean;
-	isDev: boolean;
+/**
+ * This function constructs the data object that gets written to the global
+ * window.guardian property
+ */
+export const makeWindowGuardian = ({
+	editionId,
+	stage,
+	frontendAssetsFullURL,
+	revisionNumber,
+	sentryPublicApiKey,
+	sentryHost,
+	keywordIds,
+	dfpAccountId,
+	adUnit,
+	ajaxUrl,
+	googletagUrl,
+	switches,
+	abTests,
+	brazeApiKey,
+	isPaidContent,
+	contentType,
+	shouldHideReaderRevenue,
+	unknownConfig = {},
+	GAData,
+}: {
+	editionId: EditionId;
 	stage: StageType;
 	frontendAssetsFullURL: string;
-	page: {
-		dcrCouldRender: boolean;
-		contentType: string;
-		edition: EditionId;
-		revisionNumber: string;
-		dcrSentryDsn: string;
-		sentryHost: string;
-		sentryPublicApiKey: string;
-		keywordIds: string;
-		dfpAccountId: string;
-		adUnit: string;
-		showRelatedContent: boolean;
-		ajaxUrl: string;
-		shouldHideReaderRevenue: boolean;
-		googleRecaptchaSiteKey?: string;
-	};
-	libs: {
-		googletag: string;
-	};
+	revisionNumber: string;
+	sentryPublicApiKey: string;
+	sentryHost: string;
+	keywordIds: string;
+	dfpAccountId: string;
+	adUnit: string;
+	ajaxUrl: string;
+	googletagUrl: string;
 	switches: Switches;
-	tests: ServerSideTests;
-	ophan: {
-		pageViewId: string;
-		browserId: string;
-	};
-}
-
-export const makeWindowGuardian = (
-	CAPIArticle: CAPIArticleType,
-): {
-	// The 'config' attribute is derived from CAPIArticle and contains
-	// all the data that, for legacy reasons, for instance compatibility
-	// with the frontend commercial stack, or other scripts, we want to find
-	// at window.guardian.config
+	abTests: ServerSideTests;
+	brazeApiKey?: string;
+	isPaidContent: boolean;
+	contentType?: string;
+	shouldHideReaderRevenue?: boolean;
+	/**
+	 * In the case of articles we don't know the exact values that need to exist
+	 * on the window.guardian.config.page property so rather than filter them we
+	 * allow the entire object to be passed through here and we then extend it
+	 * using Object.assigns
+	 *
+	 * This is obviously rubbish but has to be weighed against the risk of the
+	 * commercial code failing because it depended on a property we removed
+	 */
+	unknownConfig?: ConfigType | object;
+	GAData?: GADataType;
+}): {
+	/**
+	 * The 'config' attribute is derived from the data passed to DCR and contains
+	 * all the properties that we (and other code running on the site) want to
+	 * find at window.guardian.config
+	 */
 	config: WindowGuardianConfig;
 	polyfilled: boolean;
 	adBlockers: any;
@@ -83,38 +102,38 @@ export const makeWindowGuardian = (
 			reportError: (error: Error, feature: string) => void;
 		};
 	};
-	GAData: GADataType;
+	GAData?: GADataType;
 } => {
-	const { config, editionId } = CAPIArticle;
 	return {
 		config: {
 			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
 			isDotcomRendering: true,
 			isDev: process.env.NODE_ENV !== 'production',
-			stage: config.stage,
-			frontendAssetsFullURL: config.frontendAssetsFullURL,
-			page: Object.assign(config, {
+			stage: stage,
+			frontendAssetsFullURL: frontendAssetsFullURL,
+			page: Object.assign(unknownConfig, {
 				dcrCouldRender: true,
-				contentType: CAPIArticle.contentType,
+				contentType: contentType ?? '',
 				edition: editionId,
-				revisionNumber: config.revisionNumber,
+				revisionNumber: revisionNumber,
 				dcrSentryDsn:
 					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-				sentryPublicApiKey: config.sentryPublicApiKey,
-				sentryHost: config.sentryHost,
-				keywordIds: config.keywordIds,
-				dfpAccountId: config.dfpAccountId,
-				adUnit: config.adUnit,
+				sentryPublicApiKey: sentryPublicApiKey,
+				sentryHost: sentryHost,
+				keywordIds: keywordIds,
+				dfpAccountId: dfpAccountId,
+				adUnit: adUnit,
 				showRelatedContent: true,
-				ajaxUrl: config.ajaxUrl,
-				shouldHideReaderRevenue:
-					config.shouldHideReaderRevenue ?? false,
+				ajaxUrl: ajaxUrl,
+				shouldHideReaderRevenue: !!shouldHideReaderRevenue,
+				brazeApiKey,
+				isPaidContent,
 			}),
 			libs: {
-				googletag: config.googletagUrl,
+				googletag: googletagUrl,
 			},
-			switches: config.switches,
-			tests: config.abTests,
+			switches: switches,
+			tests: abTests,
 			ophan: {
 				pageViewId: '',
 				browserId: '',
@@ -130,65 +149,6 @@ export const makeWindowGuardian = (
 				reportError: () => null,
 			},
 		},
-		GAData: extractGA(CAPIArticle),
-	};
-};
-
-export const makeFrontWindowGuardian = (
-	front: DCRFrontType,
-): {
-	config: WindowGuardianFrontConfig;
-	polyfilled: boolean;
-	adBlockers: any;
-	modules: {
-		sentry: {
-			reportError: (error: Error, feature: string) => void;
-		};
-	};
-} => {
-	const { config, editionId } = front;
-	return {
-		config: {
-			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
-			isDotcomRendering: true,
-			isDev: process.env.NODE_ENV !== 'production',
-			stage: config.stage,
-			frontendAssetsFullURL: config.frontendAssetsFullURL,
-			page: {
-				dcrCouldRender: true,
-				contentType: 'TODO: Do we need this?',
-				edition: editionId,
-				revisionNumber: config.revisionNumber,
-				dcrSentryDsn:
-					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-				sentryPublicApiKey: config.sentryPublicApiKey,
-				sentryHost: config.sentryHost,
-				keywordIds: config.keywordIds,
-				dfpAccountId: config.dfpAccountId,
-				adUnit: config.adUnit,
-				showRelatedContent: true,
-				ajaxUrl: config.ajaxUrl,
-				shouldHideReaderRevenue: false, // TODO Pass this in
-			},
-			libs: {
-				googletag: config.googletagUrl,
-			},
-			switches: config.switches,
-			tests: config.abTests,
-			ophan: {
-				pageViewId: '',
-				browserId: '',
-			},
-		},
-		polyfilled: false,
-		adBlockers: {
-			active: undefined,
-			onDetect: [],
-		},
-		modules: {
-			sentry: {
-				reportError: () => null,
-			},
-		},
+		GAData,
 	};
 };

--- a/dotcom-rendering/src/model/window-guardian.ts
+++ b/dotcom-rendering/src/model/window-guardian.ts
@@ -1,4 +1,4 @@
-import { extract as extractGA } from '../model/extract-ga';
+import { extractGA } from '../model/extract-ga';
 import type { ConfigType, ServerSideTests, Switches } from '../types/config';
 import type { EditionId } from '../types/edition';
 import type { DCRFrontType } from '../types/front';

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -43,7 +43,7 @@ export interface ConfigType extends CommercialConfigType {
 	shortUrlId: string;
 	isDev?: boolean;
 	googletagUrl: string;
-	stage: string;
+	stage: StageType;
 	frontendAssetsFullURL: string;
 	adUnit: string;
 	isSensitive: boolean;

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -1,3 +1,5 @@
+import type { EditionId } from './edition';
+
 export interface CommercialConfigType {
 	isPaidContent?: boolean;
 	pageId: string;
@@ -31,6 +33,7 @@ export interface Switches {
  * this data could eventually be defined in dotcom-rendering
  */
 export interface ConfigType extends CommercialConfigType {
+	dcrCouldRender?: boolean;
 	ajaxUrl: string;
 	sentryPublicApiKey: string;
 	sentryHost: string;
@@ -48,7 +51,7 @@ export interface ConfigType extends CommercialConfigType {
 	adUnit: string;
 	isSensitive: boolean;
 	videoDuration?: number;
-	edition: string;
+	edition: EditionId;
 	section: string;
 
 	sharedAdTargeting: { [key: string]: any };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -345,7 +345,7 @@ type FEFrontConfigType = {
 	beaconUrl: string;
 	userAttributesApiUrl: string;
 	host: string;
-	brazeApiKey: string;
+	brazeApiKey?: string;
 	calloutsUrl: string;
 	requiresMembershipAccess: boolean;
 	onwardWebSocket: string;

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -48,7 +48,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 			);
 
 		const isDev =
-			window.guardian.config.page.isDev ||
+			window.guardian.config.isDev ||
 			window.location.hostname.includes(
 				process.env.HOSTNAME || 'localhost',
 			);

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -5,6 +5,7 @@ import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import { ASSET_ORIGIN, getScriptArrayFromFile } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
+import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
 import type { CAPIArticleType } from '../../types/frontend';
@@ -172,7 +173,36 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	 * is placed in a script tag on the page
 	 */
 	const windowGuardian = escapeData(
-		JSON.stringify(makeWindowGuardian(CAPIArticle)),
+		JSON.stringify(
+			makeWindowGuardian({
+				editionId: CAPIArticle.editionId,
+				stage: CAPIArticle.config.stage,
+				frontendAssetsFullURL: CAPIArticle.config.frontendAssetsFullURL,
+				revisionNumber: CAPIArticle.config.revisionNumber,
+				sentryPublicApiKey: CAPIArticle.config.sentryPublicApiKey,
+				sentryHost: CAPIArticle.config.sentryHost,
+				keywordIds: CAPIArticle.config.keywordIds,
+				dfpAccountId: CAPIArticle.config.dfpAccountId,
+				adUnit: CAPIArticle.config.adUnit,
+				ajaxUrl: CAPIArticle.config.ajaxUrl,
+				googletagUrl: CAPIArticle.config.googletagUrl,
+				switches: CAPIArticle.config.switches,
+				abTests: CAPIArticle.config.abTests,
+				brazeApiKey: CAPIArticle.config.brazeApiKey,
+				isPaidContent: CAPIArticle.pageType.isPaidContent,
+				GAData: extractGA({
+					webTitle: CAPIArticle.webTitle,
+					format: CAPIArticle.format,
+					sectionName: CAPIArticle.sectionName,
+					contentType: CAPIArticle.contentType,
+					tags: CAPIArticle.tags,
+					pageId: CAPIArticle.pageId,
+					editionId: CAPIArticle.editionId,
+					beaconURL: CAPIArticle.beaconURL,
+				}),
+				unknownConfig: CAPIArticle.config,
+			}),
+		),
 	);
 
 	const hasAmpInteractiveTag = CAPIArticle.tags.some(

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -5,7 +5,7 @@ import { renderToString } from 'react-dom/server';
 import { getScriptArrayFromFile } from '../../lib/assets';
 import { escapeData } from '../../lib/escapeData';
 import { extractNAV } from '../../model/extract-nav';
-import { makeFrontWindowGuardian } from '../../model/window-guardian';
+import { makeWindowGuardian } from '../../model/window-guardian';
 import type { DCRFrontType } from '../../types/front';
 import { FrontPage } from '../components/FrontPage';
 import { getHttp3Url } from '../lib/getHttp3Url';
@@ -125,7 +125,25 @@ export const frontToHtml = ({ front }: Props): string => {
 	 * is placed in a script tag on the page
 	 */
 	const windowGuardian = escapeData(
-		JSON.stringify(makeFrontWindowGuardian(front)),
+		JSON.stringify(
+			makeWindowGuardian({
+				editionId: front.editionId,
+				stage: front.config.stage,
+				frontendAssetsFullURL: front.config.frontendAssetsFullURL,
+				revisionNumber: front.config.revisionNumber,
+				sentryPublicApiKey: front.config.sentryPublicApiKey,
+				sentryHost: front.config.sentryHost,
+				keywordIds: front.config.keywordIds,
+				dfpAccountId: front.config.dfpAccountId,
+				adUnit: front.config.adUnit,
+				ajaxUrl: front.config.ajaxUrl,
+				googletagUrl: front.config.googletagUrl,
+				switches: front.config.switches,
+				abTests: front.config.abTests,
+				brazeApiKey: front.config.brazeApiKey,
+				isPaidContent: front.config.isPaidContent,
+			}),
+		),
 	);
 
 	const keywords = front.config.keywords ?? '';


### PR DESCRIPTION
## What?
This PR merges `makeFrontWindowGuardian` with `makeWindowGuardian`

## Why?
We want to be able to serve more than two different types of page with DCR but without loosing too much common functionality in terms of how we construct the page. We previously merged `articleTemplate` and `frontTemplate` for the same reasons.