### PR TITLE
Prioritise `Display` vs. `role` when chosing image sizes

### DIFF
--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -45,8 +45,22 @@ const decideImageWidths = ({
 	format: ArticleFormat;
 }): ImageWidthType[] => {
 	if (isMainMedia) {
-		switch (role) {
-			case 'showcase':
+		switch (format.display) {
+			case ArticleDisplay.Immersive: {
+				// If display is Immersive then main media should *always*
+				// use these larger image sources
+				return [
+					{ breakpoint: breakpoints.mobile, width: 480 },
+					{ breakpoint: breakpoints.mobileLandscape, width: 660 },
+					{ breakpoint: breakpoints.phablet, width: 740 },
+					{ breakpoint: breakpoints.tablet, width: 980 },
+					{ breakpoint: breakpoints.desktop, width: 1140 },
+					{ breakpoint: breakpoints.leftCol, width: 1300 },
+					{ breakpoint: breakpoints.wide, width: 1900 },
+				];
+			}
+			case ArticleDisplay.Showcase:
+			case ArticleDisplay.NumberedList: {
 				if (format.design === ArticleDesign.Feature) {
 					// The main image on feature articles gets larger sources when showcase
 					// e.g.: http://www.theguardian.com/politics/2015/may/02/nicola-sturgeon-im-the-boss-now
@@ -69,20 +83,7 @@ const decideImageWidths = ({
 						{ breakpoint: breakpoints.wide, width: 1020 },
 					];
 				}
-			case 'immersive':
-				return [
-					{ breakpoint: breakpoints.mobile, width: 480 },
-					{ breakpoint: breakpoints.mobileLandscape, width: 660 },
-					{ breakpoint: breakpoints.phablet, width: 740 },
-					{ breakpoint: breakpoints.tablet, width: 980 },
-					{ breakpoint: breakpoints.desktop, width: 1140 },
-					{ breakpoint: breakpoints.leftCol, width: 1300 },
-					{ breakpoint: breakpoints.wide, width: 1900 },
-				];
-			case 'supporting':
-			case 'thumbnail':
-			case 'halfWidth':
-			case 'inline':
+			}
 			default:
 				return [
 					{ breakpoint: breakpoints.mobile, width: 465 },


### PR DESCRIPTION
## What does this change?
This PR fixes #5878 by ensuring we prefer the use of `format.display` when deciding which image sizes rather than `image.role`

## Why?
Because there was an issue before where an immersive article could still have its main media given a role of `showcase`.

In Composer, the main media can have two possible weightings, `default` and `showcase`. If you choose `showcase` then this has the effect of making the main media larger and repositioning some elements on the page. DCR defines this as `Display.Showcase`. However, if you continue to edit the article in Composer to add the `displayHint` of `immersive` then this has the effect of 'overriding' the showcase role and the article becomes `Display.Immersive`. This strange behaviour by the tool was not anticipated by DCR and so we were still choosing the image sizes assuming showcase but the main media was being rendered full width immersive.

Article.Display is always correct so we now favour this over `role`