### PR TITLE
fix(language): prefer “allow” to “whitelist”

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -119,6 +119,8 @@ module.exports = {
 			{ packageDir: ['..', '.'] },
 		],
 
+		'id-denylist': ['error', 'whitelist', 'whiteList', 'WHITELIST'],
+
 		...rulesToReview,
 		...rulesToEnforce,
 		...rulesToOverrideGuardianConfig,

--- a/dotcom-rendering/src/amp/components/Onward.tsx
+++ b/dotcom-rendering/src/amp/components/Onward.tsx
@@ -13,7 +13,7 @@ const innerContainerStyles = css`
 `;
 
 const sectionHasMostViewed = (sectionID: string): boolean => {
-	const whitelist = new Set([
+	const allowed = new Set([
 		'commentisfree',
 		'sport',
 		'football',
@@ -40,7 +40,7 @@ const sectionHasMostViewed = (sectionID: string): boolean => {
 		'global-development',
 	]);
 
-	return whitelist.has(sectionID);
+	return allowed.has(sectionID);
 };
 
 export const Onward: React.FC<{

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/browser';
+import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
 
-// Only send errors matching these regexes
-const whitelistUrls = [
+const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,
 	new RegExp(`/$(process.env.HOSTNAME || 'localhost')/`),
 	/assets\.guim\.co\.uk/,
@@ -35,7 +35,7 @@ const {
 
 Sentry.init({
 	ignoreErrors,
-	whitelistUrls,
+	allowUrls,
 	dsn: dcrSentryDsn,
 	environment: stage || 'DEV',
 	integrations: [new CaptureConsole({ levels: ['error'] })],

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -16,7 +16,7 @@ type PillarForContainer =
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
 // If you change this list then you should also update ^
 // order matters here (first match wins)
-export const WHITELISTED_TAGS = [
+export const ALLOWED_TAGS = [
 	// sport tags
 	'sport/cricket',
 	'sport/rugby-union',
@@ -51,7 +51,7 @@ const firstPopularTag = (
 	pageTags: string | string[],
 	isPaidContent: boolean,
 ) => {
-	// This function looks for the first tag in pageTags, that also exists in our whitelist
+	// This function looks for the first tag in pageTags, that also exists in our allowlist
 	if (!pageTags) {
 		// If there are no page tags we will never find a match so
 		return false;
@@ -65,12 +65,12 @@ const firstPopularTag = (
 		tags = pageTags;
 	}
 
-	const firstTagInWhitelist =
-		tags.find((tag: string) => WHITELISTED_TAGS.includes(tag)) || false;
+	const firstTagInAllowedList =
+		tags.find((tag: string) => ALLOWED_TAGS.includes(tag)) || false;
 
 	// For paid content we just return the first tag, otherwise we
-	// filter for the first tag in the whitelist
-	return isPaidContent ? tags[0] : firstTagInWhitelist;
+	// filter for the first tag in the allowlist
+	return isPaidContent ? tags[0] : firstTagInAllowedList;
 };
 
 const onwardsWrapper = css`


### PR DESCRIPTION
## What does this change?

Removes uses of relying on a “white” v “black” dichotomy to mean “allow“ v “forbidden”.

Adds ESLint rule to try and prevent this from happening again.

## Why?

It’s noted as a specific exampled from [our inclusive communication guidelines](https://github.com/guardian/our-engineering-culture/blob/main/inclusive-communication.md#some-examples).