### PR TITLE
fix: allow thrasher-tracker URLs

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,4 +1,4 @@
-name: Scheduled daily jobs
+name: ⏰ Scheduled daily jobs
 on:
   schedule:
     # Every work day of the week at 08:08

--- a/scripts/ci-deno.sh
+++ b/scripts/ci-deno.sh
@@ -8,6 +8,6 @@ deno run \
 
 deno run \
 	--no-check=remote \
-	--allow-net=www.theguardian.com,api.github.com \
+	--allow-net \
 	--allow-env="GITHUB_TOKEN" \
-	scripts/deno//thrasher-tracker.ts
+	scripts/deno/thrasher-tracker.ts

--- a/scripts/deno/thrasher-tracker.ts
+++ b/scripts/deno/thrasher-tracker.ts
@@ -1,9 +1,11 @@
 import { array, object, string } from 'https://deno.land/x/zod@v3.17.3/mod.ts';
 import { fetchJSON } from './json.ts';
-import prettyBytes from 'https://esm.sh/pretty-bytes';
+import prettyBytes from 'https://esm.sh/pretty-bytes@6.0.0';
 import { octokit } from './github.ts';
 
 // -- Constants -- //
+
+const gu = 'https://www.theguardian.com/';
 
 const fronts = ['uk', 'us', 'international', 'au'] as const;
 
@@ -69,7 +71,7 @@ const getThrasherResources = (urls: URL[]) => {
 };
 
 const getFrontThrashers = async (path: string) => {
-	const url = new URL(`https://theguardian.com/${path}.json?dcr`);
+	const url = new URL(`${path}.json?dcr`, gu);
 	const {
 		pressedPage: { collections },
 	} = await fetchJSON(url, { parser: frontSchema.parse });
@@ -146,14 +148,14 @@ const getTable = (data: Awaited<ReturnType<typeof getFrontThrashers>>) => {
 
 const lines = ['# Largest thrashers on network fronts'];
 
-for (const id of fronts) {
+for (const front of fronts) {
 	lines.push(
 		'',
 		'',
-		`## [${id.toUpperCase()} Front](https://www.theguardian.com/${id}) `,
+		`## [${front.toUpperCase()} Front](${new URL(front, gu).toString()}) `,
 		'',
 	);
-	const data = await getFrontThrashers(id);
+	const data = await getFrontThrashers(front);
 
 	lines.push(...getTable(data));
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix scripts/deno/thrasher-tracker.ts URLs

## Why?

The action is failing on `main` :( It’s an unfortunate quirk of Github that if you create a new action, you cannot run it until it’s merged in, so we could not test this as part of #5857 .

- Failure: https://github.com/guardian/dotcom-rendering/actions/runs/2954611157
- Success: https://github.com/guardian/dotcom-rendering/actions/runs/2955299417