### PR TITLE
Add support for `fixed/video` container

### DIFF
--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -30,7 +30,7 @@ type Props = {
 	description?: string;
 	url?: string;
 	onwardsSource: OnwardsSource;
-	format: ArticleFormat;
+	format?: ArticleFormat;
 };
 
 // Carousel icons - need replicating from source for centring
@@ -158,12 +158,12 @@ const dotStyle = css`
 	}
 `;
 
-const dotActiveStyle = (palette: Palette) => css`
-	background-color: ${palette.background.carouselDot};
+const dotActiveStyle = (palette?: Palette) => css`
+	background-color: ${palette?.background.carouselDot ?? neutral[0]};
 
 	&:hover,
 	&:focus {
-		background-color: ${palette.background.carouselDotFocus};
+		background-color: ${palette?.background.carouselDotFocus ?? neutral[0]};
 	}
 `;
 
@@ -197,8 +197,8 @@ const buttonContainerStyle = css`
 		display: none;
 	}
 `;
-const prevButtonContainerStyle = (format: ArticleFormat) => {
-	switch (format.design) {
+const prevButtonContainerStyle = (format?: ArticleFormat) => {
+	switch (format?.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog: {
 			return css`
@@ -310,8 +310,10 @@ const headerStyles = css`
 	margin-left: 0;
 `;
 
-const titleStyle = (palette: Palette, isCuratedContent?: boolean) => css`
-	color: ${isCuratedContent ? palette.text.carouselTitle : text.primary};
+const titleStyle = (palette?: Palette, isCuratedContent?: boolean) => css`
+	color: ${isCuratedContent && palette
+		? palette.text.carouselTitle
+		: text.primary};
 `;
 
 const Title = ({
@@ -320,7 +322,7 @@ const Title = ({
 	isCuratedContent,
 }: {
 	title: string;
-	palette: Palette;
+	palette?: Palette;
 	isCuratedContent?: boolean;
 }) => (
 	<h2 css={headerStyles}>
@@ -387,7 +389,7 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 type HeaderAndNavProps = {
 	heading: string;
 	trails: TrailType[];
-	palette: Palette;
+	palette?: Palette;
 	index: number;
 	isCuratedContent?: boolean;
 	goToIndex: (newIndex: number) => void;
@@ -429,7 +431,7 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 );
 
 export const Carousel = ({ heading, trails, onwardsSource, format }: Props) => {
-	const palette = decidePalette(format);
+	const palette = format && decidePalette(format);
 	const carouselRef = useRef<HTMLUListElement>(null);
 
 	const [index, setIndex] = useState(0);
@@ -545,8 +547,8 @@ export const Carousel = ({ heading, trails, onwardsSource, format }: Props) => {
 			<LeftColumn
 				borderType="partial"
 				size={
-					format.design === ArticleDesign.LiveBlog ||
-					format.design === ArticleDesign.DeadBlog
+					format?.design === ArticleDesign.LiveBlog ||
+					format?.design === ArticleDesign.DeadBlog
 						? 'wide'
 						: 'compact'
 				}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -178,12 +178,25 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					if (collection.collectionType === 'fixed/video') {
 						return (
 							<Section
+								key={collection.id}
 								fullWidth={true}
 								padBottom={true}
 								showSideBorders={true}
+								showTopBorder={index > 0}
+								padContent={false}
+								centralBorder="partial"
+								url={collection.href}
 								ophanComponentLink={ophanComponentLink}
 								ophanComponentName={ophanName}
 								containerName={collection.collectionType}
+								containerPalette={collection.containerPalette}
+								toggleable={true}
+								sectionId={collection.id}
+								showDateHeader={
+									collection.config.showDateHeader
+								}
+								editionId={front.editionId}
+								treats={collection.treats}
 							>
 								<Island deferUntil="visible">
 									<Carousel

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -10,6 +10,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import type { NavType } from '../../model/extract-nav';
 import type { DCRFrontType } from '../../types/front';
 import { AdSlot } from '../components/AdSlot';
+import { Carousel } from '../components/Carousel.importable';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -170,6 +171,27 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								containerName={collection.collectionType}
 							>
 								<Snap snapData={trails[0].snapData} />
+							</Section>
+						);
+					}
+
+					if (collection.collectionType === 'fixed/video') {
+						return (
+							<Section
+								fullWidth={true}
+								padBottom={true}
+								showSideBorders={true}
+								ophanComponentLink={ophanComponentLink}
+								ophanComponentName={ophanName}
+								containerName={collection.collectionType}
+							>
+								<Island deferUntil="visible">
+									<Carousel
+										heading={collection.displayName}
+										trails={trails}
+										onwardsSource="unknown-source"
+									/>
+								</Island>
 							</Section>
 						);
 					}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds support for the `fixed/video` container using the `Carousel` component.

This closes #5149 

This is a stopgap. The existing video container is very different to `Carousel`, it allows videos to be played insitue and clicking partially off-screen cards triggers a scroll, none of the 'cards' are links. In this PR, we simply add classic Cards for each video article.

## Why?
Because taking this approach took me exactly 19 minutes to implement. If I were to create a new carousel to match the one that currently shows on front pages I would have to invest considerably more time. We may well still implement this different behaviour but having a stopgap is perhaps useful in terms of making a DCR AB test happen.

<img width="1431" alt="Screenshot 2022-08-30 at 14 51 40" src="https://user-images.githubusercontent.com/1336821/187456002-a56cb951-637d-4227-a53d-1eeef109b792.png">
