### PR TITLE
Adds test run for new AB test long-running trial implementation using localStorage participations

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/sign-in-gate.cy.js
@@ -59,7 +59,7 @@ describe('Sign In Gate Tests', function () {
 		beforeEach(function () {
 			disableCMP();
 			// sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
-			setMvtCookie('500');
+			setMvtCookie('500000');
 
 			// set article count to be min number to view gate
 			setArticleCount(3);

--- a/dotcom-rendering/src/web/components/SignInGate/signInGate.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/signInGate.ts
@@ -3,7 +3,12 @@ import type { ABTest } from '@guardian/ab-core';
 // Sign in Gate A/B Tests
 import { signInGateMainControl } from '../../experiments/tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from '../../experiments/tests/sign-in-gate-main-variant';
-import { signInGateMandatoryLongTestRun } from '../../experiments/tests/sign-in-gate-mandatory-long-testrun';
+import {
+	signInGateMandatoryLongTestRunUk,
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
+} from '../../experiments/tests/sign-in-gate-mandatory-long-testrun';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainControl } from './gates/main-control';
@@ -21,17 +26,26 @@ export const componentName = 'sign-in-gate';
 export const signInGateTests: ReadonlyArray<ABTest> = [
 	signInGateMainVariant,
 	signInGateMainControl,
-	signInGateMandatoryLongTestRun,
+	signInGateMandatoryLongTestRunUk,
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
 ];
 
 export const signInGateTestVariantToGateMapping: SignInGateTestMap = {
 	'main-control-4': gateMainControl,
 	'main-variant-4': gateMainVariant,
-	'mandatory-long-testrun': gateMainVariant, // showing main gate for test run
+	'mandatory-long-testrun-uk': gateMainVariant, // showing main gate for test run
+	'mandatory-long-testrun-na': gateMainVariant, // showing main gate for test run
+	'mandatory-long-testrun-aunz': gateMainVariant, // showing main gate for test run
+	'mandatory-long-testrun-eu': gateMainVariant, // showing main gate for test run
 };
 
 export const signInGateTestIdToComponentId: { [key: string]: string } = {
 	SignInGateMainVariant: 'main_variant_4',
 	SignInGateMainControl: 'main_control_4',
-	signInGateMandatoryLongTestRun: 'mandatory_long_testrun',
+	SignInGateMandatoryLongTestRunUk: 'mandatory_long_testrun_uk',
+	SignInGateMandatoryLongTestRunAunz: 'mandatory_long_testrun_aunz',
+	SignInGateMandatoryLongTestRunEu: 'mandatory_long_testrun_eu',
+	SignInGateMandatoryLongTestRunNa: 'mandatory_long_testrun_na',
 };

--- a/dotcom-rendering/src/web/components/SignInGate/signInGate.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/signInGate.ts
@@ -3,6 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 // Sign in Gate A/B Tests
 import { signInGateMainControl } from '../../experiments/tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from '../../experiments/tests/sign-in-gate-main-variant';
+import { signInGateMandatoryLongTestRun } from '../../experiments/tests/sign-in-gate-mandatory-long-testrun';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainControl } from './gates/main-control';
@@ -20,14 +21,17 @@ export const componentName = 'sign-in-gate';
 export const signInGateTests: ReadonlyArray<ABTest> = [
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateMandatoryLongTestRun,
 ];
 
 export const signInGateTestVariantToGateMapping: SignInGateTestMap = {
 	'main-control-4': gateMainControl,
 	'main-variant-4': gateMainVariant,
+	'mandatory-long-testrun': gateMainVariant, // showing main gate for test run
 };
 
 export const signInGateTestIdToComponentId: { [key: string]: string } = {
 	SignInGateMainVariant: 'main_variant_4',
 	SignInGateMainControl: 'main_control_4',
+	signInGateMandatoryLongTestRun: 'mandatory_long_testrun',
 };

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -8,6 +8,7 @@ import {
 } from './tests/newsletter-merch-unit-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { signInGateMandatoryLongTestRun } from './tests/sign-in-gate-mandatory-long-testrun';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseVariants,
 	consentlessAds,
 	integrateIMA,
+	signInGateMandatoryLongTestRun,
 ];

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -8,7 +8,12 @@ import {
 } from './tests/newsletter-merch-unit-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
-import { signInGateMandatoryLongTestRun } from './tests/sign-in-gate-mandatory-long-testrun';
+import {
+	signInGateMandatoryLongTestRunUk,
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
+} from './tests/sign-in-gate-mandatory-long-testrun';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -20,5 +25,8 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseVariants,
 	consentlessAds,
 	integrateIMA,
-	signInGateMandatoryLongTestRun,
+	signInGateMandatoryLongTestRunUk,
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
 ];

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
@@ -7,7 +7,7 @@ describe('canRun using participations', () => {
 		localStorage.clear();
 	});
 	const getParticipationsFromLocalStorage = () =>
-		storage.local.get('gu.ab.participations') as Participations | undefined;
+		storage.local.get('gu.ab.participations');
 
 	const abTestId = 'test-id';
 	const variantId = 'variant-id';
@@ -18,15 +18,14 @@ describe('canRun using participations', () => {
 		'test-id': { variant: 'variant-id' },
 	};
 
-	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true', async () => {
+	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true', () => {
 		expect(setOrUseParticipations(true, abTestId, variantId)).toBe(true);
-
 		expect(getParticipationsFromLocalStorage()).toStrictEqual(
 			currentTestParticipation,
 		);
 	});
 
-	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true, even if other participatio is present', async () => {
+	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true, even if other participatio is present', () => {
 		storage.local.set('gu.ab.participations', otherParticipation);
 
 		expect(setOrUseParticipations(true, abTestId, variantId)).toBe(true);
@@ -36,12 +35,12 @@ describe('canRun using participations', () => {
 		});
 	});
 
-	test('canRun using participations returns correctly if setParticipationsFlag is false and no localstorage participation is set,', async () => {
+	test('canRun using participations returns correctly if setParticipationsFlag is false and no localstorage participation is set', () => {
 		expect(setOrUseParticipations(false, abTestId, variantId)).toBe(false);
 		expect(getParticipationsFromLocalStorage()).toBeNull();
 	});
 
-	test('canRun using participations returns correctly if setParticipationsFlag is false and correct localstorgae participation is present,', async () => {
+	test('canRun using participations returns correctly if setParticipationsFlag is false and correct localstorage participation is present', () => {
 		storage.local.set('gu.ab.participations', currentTestParticipation);
 
 		expect(setOrUseParticipations(false, abTestId, variantId)).toBe(true);
@@ -50,7 +49,7 @@ describe('canRun using participations', () => {
 		);
 	});
 
-	test('canRun using participations returns correctly if setParticipationsFlag is false and multiple localstorgae participations present,', async () => {
+	test('canRun using participations returns correctly if setParticipationsFlag is false and multiple localstorage participations present', () => {
 		storage.local.set('gu.ab.participations', {
 			...otherParticipation,
 			...currentTestParticipation,

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
@@ -1,0 +1,65 @@
+import { storage } from '@guardian/libs';
+import { Participations } from '@guardian/ab-core';
+import { setOrUseParticipations } from './ab-exclusions';
+
+describe('canRun using participations', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+	const getParticipationsFromLocalStorage = () =>
+		storage.local.get('gu.ab.participations') as Participations | undefined;
+
+	const abTestId = 'test-id';
+	const variantId = 'variant-id';
+	const otherParticipation: Participations = {
+		'other-id': { variant: 'other-id' },
+	};
+	const currentTestParticipation: Participations = {
+		'test-id': { variant: 'variant-id' },
+	};
+
+	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true', async () => {
+		expect(setOrUseParticipations(true, abTestId, variantId)).toBe(true);
+
+		expect(getParticipationsFromLocalStorage()).toStrictEqual(
+			currentTestParticipation,
+		);
+	});
+
+	test('canRun using participations sets participation key and returns true if setParticipationsFlag is true, even if other participatio is present', async () => {
+		storage.local.set('gu.ab.participations', otherParticipation);
+
+		expect(setOrUseParticipations(true, abTestId, variantId)).toBe(true);
+		expect(getParticipationsFromLocalStorage()).toStrictEqual({
+			...otherParticipation,
+			...currentTestParticipation,
+		});
+	});
+
+	test('canRun using participations returns correctly if setParticipationsFlag is false and no localstorage participation is set,', async () => {
+		expect(setOrUseParticipations(false, abTestId, variantId)).toBe(false);
+		expect(getParticipationsFromLocalStorage()).toBeNull();
+	});
+
+	test('canRun using participations returns correctly if setParticipationsFlag is false and correct localstorgae participation is present,', async () => {
+		storage.local.set('gu.ab.participations', currentTestParticipation);
+
+		expect(setOrUseParticipations(false, abTestId, variantId)).toBe(true);
+		expect(getParticipationsFromLocalStorage()).toStrictEqual(
+			currentTestParticipation,
+		);
+	});
+
+	test('canRun using participations returns correctly if setParticipationsFlag is false and multiple localstorgae participations present,', async () => {
+		storage.local.set('gu.ab.participations', {
+			...otherParticipation,
+			...currentTestParticipation,
+		});
+
+		expect(setOrUseParticipations(false, abTestId, variantId)).toBe(true);
+		expect(getParticipationsFromLocalStorage()).toStrictEqual({
+			...otherParticipation,
+			...currentTestParticipation,
+		});
+	});
+});

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
@@ -12,7 +12,8 @@ import {
  * After the cut off date users without the local storage participation key won't see the gate at all.
  *
  * Caveats - There will be natural churn of users to account for. Users can manually delete localStorage at any time.
- * Some browsers also automatically delete local storage specifically on Webkit browsers (Safari/iOS) since iOS and iPadOS 13.4, Safari 13.1 on macOS
+ * Some browsers also automatically delete local storage after some time.
+ * Notably: ITP in Safari since iOS and iPadOS 13.4, Safari 13.1 on macOS @see https://webkit.org/tracking-prevention/#intelligent-tracking-prevention-itp
  *
  */
 export const setParticipations = (

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
@@ -32,9 +32,7 @@ export const setOrUseParticipations = (
 
 	if (setParticipationsFlag) {
 		// check if participation already exists
-		if (participations[abTestId]?.variant === variantId) {
-			return true;
-		}
+		if (participations[abTestId]?.variant === variantId) return true;
 
 		// else set add participation to local storage
 		setParticipations({

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
@@ -1,0 +1,51 @@
+import { Participations } from '@guardian/ab-core';
+import {
+	getParticipationsFromLocalStorage,
+	setParticipationsInLocalStorage,
+} from './ab-localstorage';
+
+/**
+ * Occasionally we may want to track long-running behavior of browsers in a certain test,
+ * without adding new browsers to the test bucket. We cannot rely on the GU_mvt_id bucketing alone to do this.
+ * You can use this method to show the gate based on local storage participation key ("gu.ab.participations") instead.
+ *
+ * After the cut off date users without the local storage participation key won't see the gate at all.
+ *
+ * Caveats - There will be natural churn of users to account for. Users can manually delete localStorage at any time.
+ * Some browsers also automatically delete local storage specifically on Webkit browsers (Safari/iOS) since iOS and iPadOS 13.4, Safari 13.1 on macOS
+ *
+ */
+export const setParticipations = (
+	currentTestParticipation: Participations,
+): void => {
+	// sets participation under local storage key: 'gu.ab.participations'
+	setParticipationsInLocalStorage(currentTestParticipation);
+};
+
+// Put this LAST in any row of canRun boolean functions so we don't set the flag unless all other criteria are true
+export const setOrUseParticipations = (
+	setParticipationsFlag: boolean, // If setParticipationsFlag is true, will set flag and run test, else will run based on flag
+	abTestId: string,
+	variantId: string, // IMPORTANT: Can only be used for single variant AB Tests!
+): boolean => {
+	const participations = getParticipationsFromLocalStorage();
+
+	if (setParticipationsFlag) {
+		// check if participation already exists
+		if (participations[abTestId]?.variant === variantId) {
+			return true;
+		}
+
+		// else set add participation to local storage
+		setParticipations({
+			...participations,
+			[abTestId]: {
+				variant: variantId,
+			},
+		});
+		return true; // test will be run
+	} else {
+		// if the test participation exists in localstorage, run the test
+		return participations[abTestId]?.variant === variantId;
+	}
+};

--- a/dotcom-rendering/src/web/experiments/lib/ab-localstorage.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-localstorage.test.ts
@@ -1,0 +1,37 @@
+import { isParticipations } from './ab-localstorage';
+
+describe('isParticipations validation', () => {
+	test('Localstorage Participation data is validated correctly,', () => {
+		const goodDatum: unknown = {
+			foobar: { variant: 'foobar' },
+		};
+		const goodData: unknown = {
+			foobar: { variant: 'foobar' },
+			barfoo: { variant: 'barfoo' },
+		};
+
+		expect(isParticipations(goodDatum)).toBe(true);
+		expect(isParticipations(goodData)).toBe(true);
+		expect(
+			isParticipations({
+				foobar: { foobar: 'foobar' },
+			}),
+		).toBe(false);
+		expect(
+			isParticipations({
+				foobar: { variant: 1 },
+			}),
+		).toBe(false);
+		expect(
+			isParticipations({
+				foobar: 'abc',
+			}),
+		).toBe(false);
+		expect(
+			isParticipations({
+				2: { foobar: 'foobar' },
+			}),
+		).toBe(false);
+		expect(isParticipations('anything')).toBe(false);
+	});
+});

--- a/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
@@ -1,0 +1,30 @@
+import type { Participations } from '@guardian/ab-core';
+import { storage } from '@guardian/libs';
+
+/**
+ * These utils have been lifted from the equivalent Frontend file
+ * https://github.com/guardian/frontend/blob/18f5d8aa4a4191f4efb58b37dc39685860369e04/static/src/javascripts/projects/common/modules/experiments/ab-local-storage.ts
+ */
+
+const participationsKey = 'gu.ab.participations';
+
+// -------
+// Reading
+// -------
+export const getParticipationsFromLocalStorage = (): Participations =>
+	(storage.local.get(participationsKey) as Participations | undefined) ?? {};
+
+// -------
+// Writing
+// -------
+
+// Wipes all localStorage participations
+export const clearParticipations = (): void => {
+	storage.local.remove(participationsKey);
+};
+
+export const setParticipationsInLocalStorage = (
+	participations: Participations,
+): void => {
+	storage.local.set(participationsKey, participations);
+};

--- a/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
@@ -1,5 +1,5 @@
 import type { Participations } from '@guardian/ab-core';
-import { storage } from '@guardian/libs';
+import { isObject, isString, storage } from '@guardian/libs';
 
 /**
  * These utils have been lifted from the equivalent Frontend file
@@ -8,11 +8,25 @@ import { storage } from '@guardian/libs';
 
 const participationsKey = 'gu.ab.participations';
 
+export const isParticipations = (
+	participations: unknown,
+): participations is Participations => {
+	if (!isObject(participations)) return false;
+	return Object.values(participations).some((participation) => {
+		if (!isObject(participation)) return false;
+		if (!isString(participation.variant)) return false;
+		return true;
+	});
+};
+
 // -------
 // Reading
 // -------
-export const getParticipationsFromLocalStorage = (): Participations =>
-	(storage.local.get(participationsKey) as Participations | undefined) ?? {};
+
+export const getParticipationsFromLocalStorage = (): Participations => {
+	const participations = storage.local.get(participationsKey);
+	return isParticipations(participations) ? participations : {};
+};
 
 // -------
 // Writing

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,8 +7,8 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
-	audienceOffset: 0.0,
+	audience: 0.8999,
+	audienceOffset: 0.0001,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,8 +7,8 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.8999,
-	audienceOffset: 0.0001,
+	audience: 0.89,
+	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
@@ -1,0 +1,36 @@
+import type { ABTest } from '@guardian/ab-core';
+import { setOrUseParticipations } from '../lib/ab-exclusions';
+
+// Flag to determine whether the canRun function 'setOrUseParticipations' will set a participation (true)
+// or use localstorage participation key to decide canRun result (false)
+const setParticipationsFlag = true;
+
+export const signInGateMandatoryLongTestRun: ABTest = {
+	id: 'SignInGateMandatoryLongTestRun',
+	start: '2022-08-01',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Show mandatory sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0001, // todo
+	audienceOffset: 0.0, // todo
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestVariant',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () =>
+		setOrUseParticipations(
+			setParticipationsFlag,
+			'SignInGateMandatoryLongTestRun', // test id
+			'mandatory-long-testrun', // variant id - can only be used for single variant test
+		),
+	variants: [
+		{
+			id: 'mandatory-long-testrun',
+			test: (): void => {},
+		},
+	],
+};

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
@@ -1,35 +1,184 @@
 import type { ABTest } from '@guardian/ab-core';
+import { getCountryCodeSync } from '../../lib/getCountryCode';
 import { setOrUseParticipations } from '../lib/ab-exclusions';
 
 // Flag to determine whether the canRun function 'setOrUseParticipations' will set a participation (true)
 // or use localstorage participation key to decide canRun result (false)
 const setParticipationsFlag = true;
 
-export const signInGateMandatoryLongTestRun: ABTest = {
-	id: 'SignInGateMandatoryLongTestRun',
-	start: '2022-08-01',
+export const signInGateMandatoryLongTestRunUk: ABTest = {
+	id: 'SignInGateMandatoryLongTestRunUk',
+	start: '2022-09-20',
 	expiry: '2022-10-01',
 	author: 'vlbee',
 	description:
-		'Show mandatory sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.0001, // todo
-	audienceOffset: 0.0, // todo
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0025,
+	audienceOffset: 0.89,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-	dataLinkNames: 'SignInGateMandatoryLongTestVariant',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunUk',
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
 	canRun: () =>
+		['GB'].includes(getCountryCodeSync() ?? '') &&
 		setOrUseParticipations(
 			setParticipationsFlag,
-			'SignInGateMandatoryLongTestRun', // test id
-			'mandatory-long-testrun', // variant id - can only be used for single variant test
+			'SignInGateMandatoryLongTestRunUk', // test id
+			'mandatory-long-testrun-uk', // variant id - can only be used for single variant test
 		),
 	variants: [
 		{
-			id: 'mandatory-long-testrun',
+			id: 'mandatory-long-testrun-uk',
+			test: (): void => {},
+		},
+	],
+};
+
+export const signInGateMandatoryLongTestRunNa: ABTest = {
+	id: 'SignInGateMandatoryLongTestRunNa',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0025,
+	audienceOffset: 0.8925,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunNa',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () =>
+		['US', 'CA'].includes(getCountryCodeSync() ?? '') &&
+		setOrUseParticipations(
+			setParticipationsFlag,
+			'SignInGateMandatoryLongTestRunNa', // test id
+			'mandatory-long-testrun-na', // variant id - can only be used for single variant test
+		),
+	variants: [
+		{
+			id: 'mandatory-long-testrun-na',
+			test: (): void => {},
+		},
+	],
+};
+
+export const signInGateMandatoryLongTestRunAunz: ABTest = {
+	id: 'SignInGateMandatoryLongTestRunAunz',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0025,
+	audienceOffset: 0.895,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunAunz',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () =>
+		['AU', 'NZ'].includes(getCountryCodeSync() ?? '') &&
+		setOrUseParticipations(
+			setParticipationsFlag,
+			'SignInGateMandatoryLongTestRunAunz', // test id
+			'mandatory-long-testrun-aunz', // variant id - can only be used for single variant test
+		),
+	variants: [
+		{
+			id: 'mandatory-long-testrun-aunz',
+			test: (): void => {},
+		},
+	],
+};
+
+const EuropeList = [
+	'AX',
+	'AL',
+	'AD',
+	'AT',
+	'BE',
+	'BG',
+	'BA',
+	'BY',
+	'CH',
+	'CZ',
+	'DE',
+	'DK',
+	'ES',
+	'EE',
+	'FI',
+	'FR',
+	'FO',
+	'GG',
+	'GI',
+	'GR',
+	'HR',
+	'HU',
+	'IM',
+	'IE',
+	'IS',
+	'IT',
+	'JE',
+	'LI',
+	'LT',
+	'LU',
+	'LV',
+	'MC',
+	'MD',
+	'MK',
+	'MT',
+	'ME',
+	'NL',
+	'NO',
+	'PL',
+	'PT',
+	'RO',
+	'RU',
+	'SJ',
+	'SM',
+	'RS',
+	'SK',
+	'SI',
+	'SE',
+	'UA',
+	'VA',
+	'XK',
+];
+
+export const signInGateMandatoryLongTestRunEu: ABTest = {
+	id: 'SignInGateMandatoryLongTestRunEu',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0025,
+	audienceOffset: 0.8975,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunEu',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () =>
+		[...EuropeList].includes(getCountryCodeSync() ?? '') &&
+		setOrUseParticipations(
+			setParticipationsFlag,
+			'SignInGateMandatoryLongTestRunEu', // test id
+			'mandatory-long-testrun-eu', // variant id - can only be used for single variant test
+		),
+	variants: [
+		{
+			id: 'mandatory-long-testrun-eu',
 			test: (): void => {},
 		},
 	],

--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
@@ -14,7 +14,7 @@ export const signInGateMandatoryLongTestRunUk: ABTest = {
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
 	audience: 0.0025,
-	audienceOffset: 0.89,
+	audienceOffset: 0.89, // 890001 - 892500
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -22,17 +22,18 @@ export const signInGateMandatoryLongTestRunUk: ABTest = {
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
-	canRun: () =>
-		['GB'].includes(getCountryCodeSync() ?? '') &&
-		setOrUseParticipations(
-			setParticipationsFlag,
-			'SignInGateMandatoryLongTestRunUk', // test id
-			'mandatory-long-testrun-uk', // variant id - can only be used for single variant test
-		),
+	canRun: () => true,
 	variants: [
 		{
 			id: 'mandatory-long-testrun-uk',
 			test: (): void => {},
+			canRun: () =>
+				['GB'].includes(getCountryCodeSync() ?? '') &&
+				setOrUseParticipations(
+					setParticipationsFlag,
+					'SignInGateMandatoryLongTestRunUk', // test id
+					'mandatory-long-testrun-uk', // variant id - can only be used for single variant test
+				),
 		},
 	],
 };
@@ -45,7 +46,7 @@ export const signInGateMandatoryLongTestRunNa: ABTest = {
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
 	audience: 0.0025,
-	audienceOffset: 0.8925,
+	audienceOffset: 0.8925, // 892501 - 895000
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -53,17 +54,18 @@ export const signInGateMandatoryLongTestRunNa: ABTest = {
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
-	canRun: () =>
-		['US', 'CA'].includes(getCountryCodeSync() ?? '') &&
-		setOrUseParticipations(
-			setParticipationsFlag,
-			'SignInGateMandatoryLongTestRunNa', // test id
-			'mandatory-long-testrun-na', // variant id - can only be used for single variant test
-		),
+	canRun: () => true,
 	variants: [
 		{
 			id: 'mandatory-long-testrun-na',
 			test: (): void => {},
+			canRun: () =>
+				['US', 'CA'].includes(getCountryCodeSync() ?? '') &&
+				setOrUseParticipations(
+					setParticipationsFlag,
+					'SignInGateMandatoryLongTestRunNa', // test id
+					'mandatory-long-testrun-na', // variant id - can only be used for single variant test
+				),
 		},
 	],
 };
@@ -76,7 +78,7 @@ export const signInGateMandatoryLongTestRunAunz: ABTest = {
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
 	audience: 0.0025,
-	audienceOffset: 0.895,
+	audienceOffset: 0.895, // 895001 - 897500
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -84,17 +86,18 @@ export const signInGateMandatoryLongTestRunAunz: ABTest = {
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
-	canRun: () =>
-		['AU', 'NZ'].includes(getCountryCodeSync() ?? '') &&
-		setOrUseParticipations(
-			setParticipationsFlag,
-			'SignInGateMandatoryLongTestRunAunz', // test id
-			'mandatory-long-testrun-aunz', // variant id - can only be used for single variant test
-		),
+	canRun: () => true,
 	variants: [
 		{
 			id: 'mandatory-long-testrun-aunz',
 			test: (): void => {},
+			canRun: () =>
+				['AU', 'NZ'].includes(getCountryCodeSync() ?? '') &&
+				setOrUseParticipations(
+					setParticipationsFlag,
+					'SignInGateMandatoryLongTestRunAunz', // test id
+					'mandatory-long-testrun-aunz', // variant id - can only be used for single variant test
+				),
 		},
 	],
 };
@@ -161,7 +164,7 @@ export const signInGateMandatoryLongTestRunEu: ABTest = {
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
 	audience: 0.0025,
-	audienceOffset: 0.8975,
+	audienceOffset: 0.8975, // 897501 - 900000
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -169,17 +172,18 @@ export const signInGateMandatoryLongTestRunEu: ABTest = {
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
-	canRun: () =>
-		[...EuropeList].includes(getCountryCodeSync() ?? '') &&
-		setOrUseParticipations(
-			setParticipationsFlag,
-			'SignInGateMandatoryLongTestRunEu', // test id
-			'mandatory-long-testrun-eu', // variant id - can only be used for single variant test
-		),
+	canRun: () => true,
 	variants: [
 		{
 			id: 'mandatory-long-testrun-eu',
 			test: (): void => {},
+			canRun: () =>
+				[...EuropeList].includes(getCountryCodeSync() ?? '') &&
+				setOrUseParticipations(
+					setParticipationsFlag,
+					'SignInGateMandatoryLongTestRunEu', // test id
+					'mandatory-long-testrun-eu', // variant id - can only be used for single variant test
+				),
 		},
 	],
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds new AB testing utility called `setOrUseParticipations` that can be used as a test definition's `canRun` function. This function will set a localStorage ab testing key, or use the presence of that key to determine if a test can run, based on a switch flag.
   - Caveats: to simplify implementation and avoid scope creep, this function assumes only one variant per test. 
   
- Add AB tests definitions for a test run of the Sign In Gate long running mandatory test that will use this localstorage key. 
   - Test run includes 4 regions, 1% each. 
   - Dependant PR - https://github.com/guardian/frontend/pull/25437
   - Notes - during the bucketing stage, a single browser can be bucketed into two test participations if they move regions during that time (eg. travel from the US to UK). The test will only run for their current region. This can be avoided by staggering test offsets but not really neccessary for a test run. 

## Why?

- We need to run a test on browser behaviour over time, but need a way to limit new browsers being added to the test bucket during that time. This PR adds an implementation of for a two-stage  (bucketing and testing) AB test. 
- We need to have a test run of the two-stage bucketing implemented here. 

## Testing 

### Local

**`setParticipationsFlag = true`**
| mvt in range | geo location matches test | participation is set correctly | ophan fires with correct test registration | tested? |
| ------------ | ------------------------- | -------------------- | ------------------------------------------ | ---- |
| y            | y                         | y                    | y                                          | ✔ |
| y            | n                         | n                    | n                                          |  ✔|
| n            | y                         | n                    | n                                          |  ✔ |
| n            | n                         | n                    | n                                          | ✔ |

**`setParticipationsFlag = false`**
| mvt in range | geo location matches test | correct participation present | ophan fires with correct test registration |        |
| ------------ | ------------------------- | ----------------------------- | ------------------------------------------ | ------ |
| y            | y                         | y                             | y                                          | ✔️ |
| y            | y                         | y - multiple                  | y                                          | ✔️     |
| y            | n                         | y - multiple                  | n                                          | ✔️     |
| n            | y                         | y - multiple                  | n                                          | ✔️     |
| n            | n                         | y - multiple                  | n                                          | ✔️     |
| y            | y                         | n                             | n                                          | ✔️     |
| y            | n                         | n                             | n                                          | ✔️     |
| n            | y                         | n                             | n                                          | ✔️     |
| n            | n                         | n                             | n                                          | ✔️     |

### Code


