### PR TITLE
feat(bundle): use @guardian/browserslist-config

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,6 +63,7 @@
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.6.0",
     "@guardian/braze-components": "^7.4.0",
+    "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.11.1",
     "@guardian/discussion-rendering": "^10.2.1",

--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -7,7 +7,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = false;
+const BUILD_VARIANT = true;
 
 module.exports = {
 	BUILD_VARIANT,

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -57,9 +57,8 @@ const getLoaders = (bundle) => {
 								'@babel/preset-env',
 								{
 									bugfixes: true,
-									targets: {
-										esmodules: true,
-									},
+									targets:
+										'extends @guardian/browserslist-config',
 								},
 							],
 						],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,6 +2818,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
+"@guardian/browserslist-config@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-2.0.3.tgz#1c8b832ab564b257f8146ca1b3183b7683026ec9"
+  integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
+
 "@guardian/commercial-core@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.3.0.tgz#f04bc56d4eedef9feb2a4c844142a7b11082d9bd"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Run an experiment for the variant bundle, using [the guardian’s browserlist config](https://github.com/guardian/csnx/tree/main/libs/%40guardian/browserslist-config) as a target.

Note that we are [currently rolling out out the `DCRJSBundleVariant` to 1%](https://github.com/guardian/frontend/blob/6709656637a612120b06892f264273ca9ea9473a/common/app/experiments/Experiments.scala#L19-L26).

## Why?

We want to check the impact on performance of using this target in DCR.

We will compare:
- Core Web Vitals for readers in the control and variant. We expect the variant to perform as good or better than the control. 
- Attention time is not significantly worse.
- Any difference in errors reported by Sentry for the `dcr.bundle` tag.