### PR TITLE
refactor(gap): use css flex gap property

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -1,50 +1,38 @@
 import { css } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source-foundations';
 import { verticalDivider } from '../../../lib/verticalDivider';
 import { verticalDividerWithBottomOffset } from '../../../lib/verticalDividerWithBottomOffset';
+
+/**
+ * This value needs to match the one set
+ * in the `verticalDividerWithBottomOffset`
+ */
+const GAP_SIZE = `${space[3]}px`;
 
 const liStyles = css`
 	/* This position relative is needed to contain the vertical divider */
 	position: relative;
 
 	display: flex;
+	row-gap: ${GAP_SIZE};
 `;
 
-const sidePaddingStyles = (
-	padSidesOnMobile: boolean,
-	paddingSize: string,
-) => css`
+const sidePaddingStyles = (padSidesOnMobile: boolean) => css`
 	/* Set spacing on the li element */
 	${padSidesOnMobile && until.tablet} {
-		padding-left: ${paddingSize};
-		padding-right: ${paddingSize};
+		padding-left: 10px;
+		padding-right: 10px;
 	}
 
 	${from.tablet} {
-		padding-left: ${paddingSize};
-		padding-right: ${paddingSize};
+		padding-left: 10px;
+		padding-right: 10px;
 	}
 `;
 
 const snapAlignStartStyles = css`
 	/* Snap start of card */
 	scroll-snap-align: start;
-`;
-
-const paddingBottomStyles = (paddingSize: string) => css`
-	padding-bottom: ${paddingSize};
-`;
-
-const mobilePaddingBottomStyles = (paddingSize: string) => css`
-	${until.tablet} {
-		padding-bottom: ${paddingSize};
-	}
-`;
-
-const marginTopStyles = css`
-	${until.tablet} {
-		margin-top: 12px;
-	}
 `;
 
 const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
@@ -69,28 +57,30 @@ const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
 	return sizeStyle;
 };
 
-function decideDivider(
+const decideDivider = (
 	offsetBottomPaddingOnDivider: boolean,
 	paddingSize: string,
-) {
-	return offsetBottomPaddingOnDivider
+) =>
+	offsetBottomPaddingOnDivider
 		? verticalDividerWithBottomOffset(paddingSize)
 		: verticalDivider;
-}
 
 type Props = {
 	children: React.ReactNode;
-	percentage?: CardPercentageType; // Used to give a particular LI more or less weight / space
-	stretch?: boolean; // When true, the card stretches based on content
-	showDivider?: boolean; // If this LI wraps a card in a row this should be true
-	padSides?: boolean; // If this LI directly wraps a card this should be true
-	padSidesOnMobile?: boolean; // Should be true if spacing between cards is desired on mobile devices
-	padBottom?: boolean;
-	padBottomOnMobile?: boolean; // Should be true if spacing below is desired on mobile devices
-	showTopMarginWhenStacked?: boolean;
-	snapAlignStart?: boolean; // True when snapping card when scrolling e.g. in carousel
-	// Prevent the divider from spanning the LI's bottom padding. To be used when you know that the
-	// LI will have bottom padding, but won't have another card in the same container directly below it.
+	/** Used to give a particular LI more or less weight / space */
+	percentage?: CardPercentageType;
+	/** When true, the card stretches based on content */
+	stretch?: boolean;
+	/** If this LI wraps a card in a row this should be true */
+	showDivider?: boolean;
+	/** If this LI directly wraps a card this should be true */
+	padSides?: boolean;
+	/** Should be true if spacing between cards is desired on mobile devices */
+	padSidesOnMobile?: boolean;
+	/** True when snapping card when scrolling e.g. in carousel */
+	snapAlignStart?: boolean;
+	/** Prevent the divider from spanning the LI's bottom padding. To be used when you know that the
+	LI will have bottom padding, but won't have another card in the same container directly below it. */
 	offsetBottomPaddingOnDivider?: boolean;
 };
 
@@ -101,18 +91,11 @@ export const LI = ({
 	showDivider,
 	padSides = false,
 	padSidesOnMobile = false,
-	padBottom,
-	padBottomOnMobile,
-	showTopMarginWhenStacked,
 	snapAlignStart = false,
 	offsetBottomPaddingOnDivider = false,
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
-	// paddingSize is set here because the offset value used for the
-	// verticalDividerWithBottomOffset needs to match the value used for
-	// paddingBottom
-	const paddingSize = '10px';
 
 	return (
 		<li
@@ -120,11 +103,8 @@ export const LI = ({
 				liStyles,
 				sizeStyles,
 				showDivider &&
-					decideDivider(offsetBottomPaddingOnDivider, paddingSize),
-				padSides && sidePaddingStyles(padSidesOnMobile, paddingSize),
-				padBottom && paddingBottomStyles(paddingSize),
-				padBottomOnMobile && mobilePaddingBottomStyles(paddingSize),
-				showTopMarginWhenStacked && marginTopStyles,
+					decideDivider(offsetBottomPaddingOnDivider, GAP_SIZE),
+				padSides && sidePaddingStyles(padSidesOnMobile),
 				snapAlignStart && snapAlignStartStyles,
 			]}
 		>

--- a/dotcom-rendering/src/web/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/UL.tsx
@@ -1,21 +1,18 @@
 import { css } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source-foundations';
 import { verticalDivider } from '../../../lib/verticalDivider';
 
 type Direction = 'row' | 'column' | 'row-reverse';
 
-const ulStyles = (direction?: Direction) => css`
+const ulStyles = (direction: Direction) => css`
 	position: relative;
 	display: flex;
 	flex-direction: ${direction};
+	row-gap: 12px;
 	${until.tablet} {
 		flex-direction: column;
 		width: 100%;
 	}
-`;
-
-const marginBottomStyles = css`
-	margin-bottom: 10px;
 `;
 
 const wrapStyles = css`
@@ -24,12 +21,20 @@ const wrapStyles = css`
 	}
 `;
 
+const marginBottomStyles = css`
+	margin-bottom: ${space[3]}px;
+`;
+
 type Props = {
 	children: React.ReactNode;
-	direction?: Direction; // Passed to flex-direction
-	showDivider?: boolean; // If this UL is a column and not the left most column
-	padBottom?: boolean; // If this UL is a row, add spacing below
-	wrapCards?: boolean; // Used to keep cards aligned in adjacent columns
+	/** Passed to flex-direction */
+	direction?: Direction;
+	/** If this UL is a column and not the left most column */
+	showDivider?: boolean;
+	/** If this UL is a row, add spacing below */
+	padBottom?: boolean;
+	/** Used to keep cards aligned in adjacent columns */
+	wrapCards?: boolean;
 };
 
 export const UL = ({

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -3,6 +3,7 @@ import { until } from '@guardian/source-foundations';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
+import { verticalDivider } from '../lib/verticalDivider';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -66,7 +67,6 @@ const Primaries = ({
 								index === boostedIndex ? '75%' : '25%'
 							}
 							showDivider={index > 0}
-							showTopMarginWhenStacked={index > 0}
 						>
 							<FrontCard
 								trail={card}
@@ -111,7 +111,6 @@ const Primaries = ({
 						padSides={true}
 						percentage={primaries.length === 1 ? '100%' : '50%'}
 						showDivider={index > 0}
-						showTopMarginWhenStacked={index > 0}
 					>
 						<FrontCard
 							trail={card}
@@ -162,6 +161,7 @@ const FirstBigBoostedPlusBig = ({
 		flex-direction: column;
 		flex-basis: 50%;
 		flex-grow: 1;
+		row-gap: 12px;
 		${until.tablet} {
 			flex-basis: 100%;
 		}
@@ -179,15 +179,11 @@ const FirstBigBoostedPlusBig = ({
 				display: flex;
 				flex-basis: 100%;
 				flex-wrap: wrap;
+				row-gap: 10px;
 			`}
 		>
-			<ul css={manualUlStyles}>
-				<LI
-					showDivider={true}
-					padSides={true}
-					padBottom={standardsCol1.length > 0}
-					padBottomOnMobile={standardsCol1.length > 0}
-				>
+			<ul css={[manualUlStyles, verticalDivider]}>
+				<LI showDivider={true} padSides={true}>
 					<FrontCard
 						trail={big}
 						starRating={big.starRating}
@@ -200,19 +196,9 @@ const FirstBigBoostedPlusBig = ({
 						imagePositionOnMobile="left"
 					/>
 				</LI>
-				{standardsCol1.map((card, cardIndex) => {
+				{standardsCol1.map((card) => {
 					return (
-						<LI
-							key={card.url}
-							showDivider={true}
-							padSides={true}
-							padBottom={cardIndex < standardsCol1.length - 1}
-							padBottomOnMobile={
-								// If there are cards in the second col, we always want padding
-								standardsCol2.length > 0 ||
-								cardIndex < standardsCol1.length - 1
-							}
-						>
+						<LI key={card.url} padSides={true}>
 							<FrontCard
 								trail={card}
 								starRating={card.starRating}
@@ -225,18 +211,10 @@ const FirstBigBoostedPlusBig = ({
 					);
 				})}
 			</ul>
-			<ul css={manualUlStyles}>
-				{standardsCol2.map((card, cardIndex) => {
+			<ul css={[manualUlStyles, verticalDivider]}>
+				{standardsCol2.map((card) => {
 					return (
-						<LI
-							key={card.url}
-							showDivider={true}
-							padSides={true}
-							padBottom={cardIndex < standardsCol2.length - 1}
-							padBottomOnMobile={
-								cardIndex < standardsCol2.length - 1
-							}
-						>
+						<LI key={card.url} padSides={true}>
 							<FrontCard
 								trail={card}
 								starRating={card.starRating}
@@ -455,8 +433,6 @@ export const DynamicFast = ({
 								key={card.url}
 								percentage={`50%`}
 								padSides={true}
-								padBottom={false}
-								showTopMarginWhenStacked={cardIndex > 0}
 								showDivider={cardIndex > 0}
 							>
 								<FrontCard
@@ -480,8 +456,6 @@ export const DynamicFast = ({
 							key={card.url}
 							percentage={`25%`}
 							padSides={true}
-							padBottom={false}
-							showTopMarginWhenStacked={cardIndex > 0}
 							showDivider={cardIndex > 0}
 						>
 							<FrontCard
@@ -497,10 +471,7 @@ export const DynamicFast = ({
 					);
 				})}
 				{standardsDisplayConfig.columns > 0 && (
-					<LI
-						percentage={standardsDisplayConfig.containerWidth}
-						showTopMarginWhenStacked={true}
-					>
+					<LI percentage={standardsDisplayConfig.containerWidth}>
 						<UL direction="row" wrapCards={true}>
 							{/* If the first big is boosted & we have a second big,
 							it should be at the start of the standards but have an image  */}
@@ -526,14 +497,11 @@ export const DynamicFast = ({
 											stretch={true}
 											showDivider={true}
 											padSides={true}
-											padBottom={shouldPadWrappableRows(
+											offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 												cardIndex,
 												standards.length,
 												standardsDisplayConfig.columns,
 											)}
-											padBottomOnMobile={
-												cardIndex < standards.length - 1
-											}
 										>
 											<FrontCard
 												trail={card}

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention -- because underscores work here*/
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -22,8 +23,8 @@ const Snap100 = ({
 }) => {
 	if (!snaps[0]) return null;
 	return (
-		<UL>
-			<LI padSides={true} padBottom={true}>
+		<UL padBottom={true}>
+			<LI padSides={true}>
 				<FrontCard
 					trail={snaps[0]}
 					containerPalette={containerPalette}
@@ -52,8 +53,8 @@ const Card100 = ({
 }) => {
 	if (!cards[0]) return null;
 	return (
-		<UL>
-			<LI padSides={true} padBottom={true}>
+		<UL padBottom={true}>
+			<LI padSides={true}>
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
@@ -84,7 +85,7 @@ const Card75_Card25 = ({
 
 	return (
 		<UL direction="row">
-			<LI padSides={true} padBottomOnMobile={true} percentage="75%">
+			<LI padSides={true} percentage="75%">
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
@@ -98,7 +99,7 @@ const Card75_Card25 = ({
 					trailText={cards[0].trailText}
 				/>
 			</LI>
-			<LI padSides={true} padBottomOnMobile={false} percentage="25%">
+			<LI padSides={true} percentage="25%" showDivider={true}>
 				<FrontCard
 					trail={cards[1]}
 					containerPalette={containerPalette}
@@ -125,15 +126,9 @@ const Card25_Card25_Card25_Card25 = ({
 }) => {
 	return (
 		<UL direction="row" padBottom={padBottom}>
-			{cards.map((card, cardIndex) => {
+			{cards.map((card) => {
 				return (
-					<LI
-						key={card.url}
-						padSides={true}
-						padBottom={false}
-						padBottomOnMobile={cardIndex < cards.length - 1}
-						showDivider={true}
-					>
+					<LI key={card.url} padSides={true} showDivider={true}>
 						<FrontCard
 							trail={card}
 							containerPalette={containerPalette}
@@ -163,14 +158,11 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 
 	return (
 		<UL direction="row">
-			{bigs.map((card, cardIndex) => {
+			{bigs.map((card) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
-						showTopMarginWhenStacked={false}
-						padBottom={false}
-						padBottomOnMobile={cardIndex < bigs.length - 1}
 						showDivider={true}
 						percentage="25%"
 					>
@@ -184,26 +176,14 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			<LI
-				showDivider={true}
-				showTopMarginWhenStacked={true}
-				percentage="25%"
-			>
+			<LI showDivider={true} percentage="25%">
 				<UL direction="row" wrapCards={true}>
-					{remaining.map((card, cardIndex) => {
+					{remaining.map((card) => {
 						return (
 							<LI
 								percentage="100%"
 								key={card.url}
 								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={
-									// No bottom margin on the last card
-									cardIndex < 1
-								}
-								padBottomOnMobile={
-									cardIndex < remaining.length - 1
-								}
 							>
 								<FrontCard
 									trail={card}
@@ -236,14 +216,11 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 
 	return (
 		<UL direction="row">
-			{bigs.map((card, cardIndex) => {
+			{bigs.map((card) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
-						showTopMarginWhenStacked={false}
-						padBottom={false}
-						padBottomOnMobile={cardIndex < bigs.length - 1}
 						percentage="25%"
 						showDivider={true}
 					>
@@ -257,11 +234,7 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			<LI
-				showDivider={true}
-				showTopMarginWhenStacked={true}
-				percentage="50%"
-			>
+			<LI showDivider={true} percentage="50%">
 				<UL direction="row" wrapCards={true}>
 					{remaining.map((card, cardIndex) => {
 						return (
@@ -269,14 +242,12 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 								percentage="50%"
 								key={card.url}
 								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={
-									// No bottom margin on the last card
-									cardIndex < 2
-								}
-								padBottomOnMobile={
-									cardIndex < remaining.length - 1
-								}
+								showDivider={true}
+								offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+									cardIndex,
+									remaining.length,
+									2,
+								)}
 							>
 								<FrontCard
 									trail={card}
@@ -309,17 +280,9 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 
 	return (
 		<UL direction="row">
-			{bigs.map((card, cardIndex) => {
+			{bigs.map((card) => {
 				return (
-					<LI
-						key={card.url}
-						padSides={true}
-						showTopMarginWhenStacked={false}
-						padBottom={false}
-						padBottomOnMobile={cardIndex < bigs.length - 1}
-						percentage="25%"
-						showDivider={true}
-					>
+					<LI key={card.url} padSides={true} percentage="25%">
 						<FrontCard
 							trail={card}
 							containerPalette={containerPalette}
@@ -330,11 +293,7 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			<LI
-				showDivider={true}
-				showTopMarginWhenStacked={true}
-				percentage="75%"
-			>
+			<LI showDivider={true} percentage="75%">
 				<UL direction="row" wrapCards={true}>
 					{remaining.map((card, cardIndex) => {
 						return (
@@ -342,15 +301,12 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 								percentage="33.333%"
 								key={card.url}
 								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={
-									// No bottom margin on the last card
-									cardIndex < 3
-								}
 								showDivider={true}
-								padBottomOnMobile={
-									cardIndex < remaining.length - 1
-								}
+								offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+									cardIndex,
+									remaining.length,
+									3,
+								)}
 							>
 								<FrontCard
 									trail={card}
@@ -380,7 +336,7 @@ const Card75_ColumnOfCards25 = ({
 }) => {
 	const [primary, ...remaining] = cards;
 	return (
-		<UL direction="row">
+		<UL direction="row" padBottom={true}>
 			<LI padSides={true} percentage="75%">
 				<FrontCard
 					trail={primary}
@@ -395,24 +351,11 @@ const Card75_ColumnOfCards25 = ({
 					isDynamo={true}
 				/>
 			</LI>
-			<LI
-				showDivider={true}
-				showTopMarginWhenStacked={true}
-				percentage="25%"
-			>
+			<LI showDivider={true} percentage="25%">
 				<UL direction="column">
 					{remaining.map((card, cardIndex) => {
 						return (
-							<LI
-								key={card.url}
-								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={
-									// No bottom margin on the last card
-									cardIndex < remaining.length - 1
-								}
-								padBottomOnMobile={false}
-							>
+							<LI key={card.url} padSides={true}>
 								<FrontCard
 									trail={card}
 									containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -28,8 +28,8 @@ const Card100PictureTop = ({
 }) => {
 	if (!cards[0]) return null;
 	return (
-		<UL>
-			<LI percentage="100%" padSides={true} padBottom={true}>
+		<UL padBottom={true}>
+			<LI percentage="100%" padSides={true}>
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
@@ -56,8 +56,8 @@ const Card100PictureRight = ({
 }) => {
 	if (!cards[0]) return null;
 	return (
-		<UL>
-			<LI percentage="100%" padSides={true} padBottom={true}>
+		<UL padBottom={true}>
+			<LI percentage="100%" padSides={true}>
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
@@ -89,12 +89,7 @@ const ColumnOfCards50_Card50 = ({
 
 	return (
 		<UL direction="row-reverse">
-			<LI
-				percentage="50%"
-				padSides={true}
-				showDivider={true}
-				padBottomOnMobile={true}
-			>
+			<LI percentage="50%" padSides={true} showDivider={true}>
 				<FrontCard
 					trail={big}
 					containerPalette={containerPalette}
@@ -107,17 +102,12 @@ const ColumnOfCards50_Card50 = ({
 			</LI>
 			<LI percentage="50%">
 				<UL direction="row" wrapCards={true}>
-					{remaining.map((card, cardIndex) => {
+					{remaining.map((card) => {
 						return (
 							<LI
 								percentage="100%"
 								key={card.url}
 								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={cardIndex < remaining.length - 1}
-								padBottomOnMobile={
-									cardIndex < remaining.length - 1
-								}
 							>
 								<FrontCard
 									trail={card}
@@ -152,12 +142,7 @@ const ColumnOfCards50_Card25_Card25 = ({
 		<UL direction="row-reverse">
 			{bigs.map((big) => {
 				return (
-					<LI
-						percentage="25%"
-						padSides={true}
-						padBottomOnMobile={true}
-						showDivider={true}
-					>
+					<LI percentage="25%" padSides={true} showDivider={true}>
 						<FrontCard
 							trail={big}
 							containerPalette={containerPalette}
@@ -177,17 +162,12 @@ const ColumnOfCards50_Card25_Card25 = ({
 			})}
 			<LI percentage="50%">
 				<UL direction="row" wrapCards={true}>
-					{remaining.map((card, cardIndex) => {
+					{remaining.map((card) => {
 						return (
 							<LI
 								percentage="100%"
 								key={card.url}
 								padSides={true}
-								showTopMarginWhenStacked={false}
-								padBottom={cardIndex < remaining.length - 1}
-								padBottomOnMobile={
-									cardIndex < remaining.length - 1
-								}
 							>
 								<FrontCard
 									trail={card}
@@ -223,7 +203,7 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 						percentage="50%"
 						padSides={true}
 						showDivider={index % 2 === 1}
-						padBottom={shouldPadWrappableRows(
+						offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 							index,
 							cards.length,
 							2,

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -39,13 +39,9 @@ const Card33_ColumnOfThree33_Ad33 = ({
 				showAge={showAge}
 			/>
 		</LI>
-		<LI
-			percentage="33.333%"
-			showDivider={true}
-			showTopMarginWhenStacked={true}
-		>
+		<LI percentage="33.333%" showDivider={true}>
 			<UL direction="column">
-				<LI padSides={true} padBottom={true}>
+				<LI padSides={true}>
 					<FrontCard
 						trail={cards[1]}
 						containerPalette={containerPalette}
@@ -54,7 +50,7 @@ const Card33_ColumnOfThree33_Ad33 = ({
 						headlineSize="small"
 					/>
 				</LI>
-				<LI padSides={true} padBottom={true}>
+				<LI padSides={true}>
 					<FrontCard
 						trail={cards[2]}
 						containerPalette={containerPalette}
@@ -101,7 +97,7 @@ const ColumnOfThree50_Ad50 = ({
 	<UL direction="row">
 		<LI percentage="50%">
 			<UL direction="column">
-				<LI padSides={true} padBottom={true}>
+				<LI padSides={true}>
 					<FrontCard
 						trail={cards[0]}
 						containerPalette={containerPalette}
@@ -110,7 +106,7 @@ const ColumnOfThree50_Ad50 = ({
 						headlineSize="small"
 					/>
 				</LI>
-				<LI padSides={true} padBottom={true}>
+				<LI padSides={true}>
 					<FrontCard
 						trail={cards[1]}
 						containerPalette={containerPalette}
@@ -164,12 +160,7 @@ const Card50_Card25_Card25 = ({
 				supportingContent={cards[0].supportingContent}
 			/>
 		</LI>
-		<LI
-			percentage="25%"
-			padSides={true}
-			showDivider={true}
-			showTopMarginWhenStacked={true}
-		>
+		<LI percentage="25%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={cards[1]}
 				containerPalette={containerPalette}
@@ -185,12 +176,7 @@ const Card50_Card25_Card25 = ({
 				}
 			/>
 		</LI>
-		<LI
-			percentage="25%"
-			padSides={true}
-			showDivider={true}
-			showTopMarginWhenStacked={true}
-		>
+		<LI percentage="25%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={cards[2]}
 				containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
+++ b/dotcom-rendering/src/web/components/ExtraCardsContainer.tsx
@@ -44,18 +44,16 @@ export const ExtraCardsContainer = ({
 	const percentage = '25%';
 	return (
 		<>
-			<UL direction="row" padBottom={true} wrapCards={true}>
+			<UL direction="row" wrapCards={true}>
 				{trails.map((trail, index) => (
 					<LI
 						padSides={true}
 						percentage={percentage}
-						padBottom={true}
 						showDivider={!isFirstInRow(index)}
 						key={trail.url}
-						offsetBottomPaddingOnDivider={hasNoCardBelowIt(
-							index,
-							trails.length,
-						)}
+						offsetBottomPaddingOnDivider={
+							!hasNoCardBelowIt(index, trails.length)
+						}
 					>
 						<Card
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -23,7 +23,7 @@ export const FixedLargeSlowXIV = ({
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
-				<LI padSides={true} percentage="75%" padBottomOnMobile={true}>
+				<LI padSides={true} percentage="75%">
 					<FrontCard
 						trail={primary}
 						starRating={primary.starRating}
@@ -51,9 +51,8 @@ export const FixedLargeSlowXIV = ({
 						<LI
 							padSides={true}
 							percentage="25%"
-							showDivider={cardIndex !== 0}
+							showDivider={cardIndex > 0}
 							key={card.url}
-							padBottomOnMobile={cardIndex != 3}
 						>
 							<FrontCard
 								trail={card}
@@ -66,7 +65,7 @@ export const FixedLargeSlowXIV = ({
 					);
 				})}
 			</UL>
-			<UL direction="row" padBottom={true} wrapCards={true}>
+			<UL direction="row" wrapCards={true}>
 				{thirdSlice.map((card, cardIndex) => {
 					return (
 						<LI
@@ -77,8 +76,7 @@ export const FixedLargeSlowXIV = ({
 								cardIndex !== 4 &&
 								cardIndex !== 8
 							}
-							padBottom={cardIndex < 4}
-							padBottomOnMobile={
+							offsetBottomPaddingOnDivider={
 								cardIndex !== thirdSlice.length - 1
 							}
 							key={card.url}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -27,7 +27,6 @@ export const FixedMediumSlowVI = ({
 							key={trail.url}
 							padSides={true}
 							showDivider={index > 0}
-							padBottomOnMobile={index === 0 ? true : false}
 							percentage={index === 0 ? '75%' : '25%'}
 						>
 							<FrontCard
@@ -55,7 +54,6 @@ export const FixedMediumSlowVI = ({
 							key={trail.url}
 							padSides={true}
 							showDivider={index > 0}
-							padBottomOnMobile={true}
 						>
 							<FrontCard
 								trail={trail}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
@@ -26,7 +26,6 @@ export const FixedMediumSlowVII = ({
 					key={primary.url}
 					padSides={true}
 					showDivider={false}
-					padBottomOnMobile={true}
 					percentage="50%"
 				>
 					<FrontCard
@@ -40,13 +39,12 @@ export const FixedMediumSlowVII = ({
 						supportingContent={primary.supportingContent}
 					/>
 				</LI>
-				{firstSlice.map((trail, index) => {
+				{firstSlice.map((trail) => {
 					return (
 						<LI
 							key={trail.url}
 							padSides={true}
 							showDivider={true}
-							padBottomOnMobile={index !== 1}
 							percentage="25%"
 						>
 							<FrontCard
@@ -74,14 +72,13 @@ export const FixedMediumSlowVII = ({
 					);
 				})}
 			</UL>
-			<UL direction="row" padBottom={true}>
+			<UL direction="row">
 				{secondSlice.map((trail, index) => {
 					return (
 						<LI
 							key={trail.url}
 							padSides={true}
 							showDivider={index > 0}
-							padBottomOnMobile={true}
 						>
 							<FrontCard
 								trail={trail}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -61,7 +61,7 @@ const Card50_Card50 = ({
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 }) => (
-	<UL direction="row" padBottom={true}>
+	<UL direction="row">
 		<LI percentage="50%" padSides={true}>
 			<FrontCard
 				trail={trails[0]}
@@ -71,12 +71,7 @@ const Card50_Card50 = ({
 				imagePositionOnMobile="top"
 			/>
 		</LI>
-		<LI
-			percentage="50%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="50%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={trails[1]}
 				containerPalette={containerPalette}
@@ -97,12 +92,14 @@ const Card33_Card33_Card33 = ({
 	trails,
 	containerPalette,
 	showAge,
+	padBottom,
 }: {
 	trails: TrailType[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
+	padBottom?: boolean;
 }) => (
-	<UL direction="row" padBottom={true}>
+	<UL direction="row" padBottom={padBottom}>
 		<LI percentage="33.333%" padSides={true}>
 			<FrontCard
 				trail={trails[0]}
@@ -112,12 +109,7 @@ const Card33_Card33_Card33 = ({
 				imagePositionOnMobile="top"
 			/>
 		</LI>
-		<LI
-			percentage="33.333%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="33.333%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={trails[1]}
 				containerPalette={containerPalette}
@@ -126,12 +118,7 @@ const Card33_Card33_Card33 = ({
 				imagePositionOnMobile="left"
 			/>
 		</LI>
-		<LI
-			percentage="33.333%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="33.333%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={trails[2]}
 				containerPalette={containerPalette}
@@ -159,7 +146,7 @@ const Card66_Ad33 = ({
 	showAge?: boolean;
 	index: number;
 }) => (
-	<UL direction="row" padBottom={true}>
+	<UL direction="row">
 		<LI percentage="66.666%" padSides={true}>
 			<FrontCard
 				trail={trails[0]}
@@ -195,7 +182,7 @@ const Card33_Card33_Ad33 = ({
 	showAge?: boolean;
 	index: number;
 }) => (
-	<UL direction="row" padBottom={true}>
+	<UL direction="row">
 		<LI percentage="33.333%" padSides={true}>
 			<FrontCard
 				trail={trails[0]}
@@ -214,12 +201,7 @@ const Card33_Card33_Ad33 = ({
 				}
 			/>
 		</LI>
-		<LI
-			percentage="33.333%"
-			padSides={true}
-			showDivider={true}
-			showTopMarginWhenStacked={true}
-		>
+		<LI percentage="33.333%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={trails[1]}
 				containerPalette={containerPalette}
@@ -244,23 +226,6 @@ const Card33_Card33_Ad33 = ({
 		</LI>
 	</UL>
 );
-
-/**
- * If the count of cards is odd there is just a single card on
- * the bottom row with nothing under it which does not need
- * padding
- */
-function shouldPadWhenOdd(i: number, noOfCards: number) {
-	return i !== noOfCards - 1;
-}
-
-/**
- * If the count of cards is even the last two sit on the bottom
- * row with nothing underneath so we don't want to pad them
- */
-function shouldPadWhenEven(i: number, noOfCards: number) {
-	return i !== noOfCards - 1 && i !== noOfCards - 2;
-}
 
 /**
  *
@@ -323,6 +288,7 @@ export const FixedMediumSlowXIIMPU = ({
 						trails={topThree}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						padBottom={true}
 					/>
 
 					<Card66_Ad33
@@ -343,6 +309,7 @@ export const FixedMediumSlowXIIMPU = ({
 						trails={topThree}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						padBottom={true}
 					/>
 
 					<Card33_Card33_Ad33
@@ -368,12 +335,13 @@ export const FixedMediumSlowXIIMPU = ({
 						trails={topThree}
 						containerPalette={containerPalette}
 						showAge={showAge}
+						padBottom={remainingCards.length >= 2}
 					/>
 					<UL direction="row">
 						<LI percentage="66.666%">
 							{/*
 							 *	This pattern of using wrapCards on the UL + percentage=50 and stretch=true
-							 * on the LI creates a dynanic list of cards over two columns. Crucially,
+							 * on the LI creates a dynamic list of cards over two columns. Crucially,
 							 * cards align horizontally in rows. If the number of trails is odd the last
 							 * card stretches full width.
 							 *
@@ -387,17 +355,6 @@ export const FixedMediumSlowXIIMPU = ({
 								{remainingCards.map((trail, trailIndex) => (
 									<LI
 										padSides={true}
-										padBottom={
-											lengthIsEven
-												? shouldPadWhenEven(
-														trailIndex,
-														remainingCards.length,
-												  )
-												: shouldPadWhenOdd(
-														trailIndex,
-														remainingCards.length,
-												  )
-										}
 										offsetBottomPaddingOnDivider={
 											lengthIsEven
 												? false
@@ -409,11 +366,6 @@ export const FixedMediumSlowXIIMPU = ({
 										showDivider={trailIndex % 2 !== 0}
 										percentage="50%"
 										stretch={true}
-										showTopMarginWhenStacked={
-											lengthIsEven &&
-											remainingCards.length ===
-												trailIndex + 1
-										}
 									>
 										<FrontCard
 											trail={trail}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.tsx
@@ -24,7 +24,6 @@ export const FixedSmallSlowIII = ({
 					<LI
 						padSides={true}
 						showDivider={index > 0}
-						padBottomOnMobile={true}
 						percentage={index === 0 ? '50%' : '25%'}
 						key={trail.url}
 					>

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.tsx
@@ -21,12 +21,7 @@ export const FixedSmallSlowIV = ({
 		<UL direction="row">
 			{slicedTrails.map((trail, index) => {
 				return (
-					<LI
-						key={trail.url}
-						padSides={true}
-						showDivider={index > 0}
-						padBottomOnMobile={true}
-					>
+					<LI key={trail.url} padSides={true} showDivider={index > 0}>
 						<FrontCard
 							trail={trail}
 							starRating={trail.starRating}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -21,21 +21,16 @@ export const FixedSmallSlowVMPU = ({
 }: Props) => {
 	return (
 		<UL direction="row">
-			<LI percentage="33.333%" padSides={true} padBottomOnMobile={true}>
+			<LI percentage="33.333%" padSides={true}>
 				<FrontCard
 					trail={trails[0]}
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>
 			</LI>
-			<LI
-				percentage="33.333%"
-				padSides={true}
-				showDivider={true}
-				padBottomOnMobile={true}
-			>
+			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<UL direction="column">
-					<LI padBottom={true}>
+					<LI>
 						<FrontCard
 							trail={trails[1]}
 							containerPalette={containerPalette}
@@ -44,7 +39,7 @@ export const FixedSmallSlowVMPU = ({
 							headlineSize="small"
 						/>
 					</LI>
-					<LI padBottom={true}>
+					<LI>
 						<FrontCard
 							trail={trails[2]}
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
@@ -26,7 +26,6 @@ export const FixedSmallSlowVThird = ({
 						key={trail.url}
 						padSides={true}
 						showDivider={index > 0}
-						padBottomOnMobile={true}
 						percentage="25%"
 					>
 						<FrontCard
@@ -41,14 +40,9 @@ export const FixedSmallSlowVThird = ({
 			})}
 			<LI showDivider={true} percentage="50%">
 				<UL direction="column">
-					{secondaries.map((trail, index) => {
+					{secondaries.map((trail) => {
 						return (
-							<LI
-								key={trail.url}
-								padBottom={index != 2}
-								padSides={true}
-								padBottomOnMobile={true}
-							>
+							<LI key={trail.url} padSides={true}>
 								<FrontCard
 									trail={trail}
 									containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -37,12 +37,7 @@ export const Card50_Card50 = ({
 				imagePositionOnMobile="top"
 			/>
 		</LI>
-		<LI
-			percentage="50%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="50%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={cards[1]}
 				containerPalette={containerPalette}
@@ -80,12 +75,7 @@ export const Card75_Card25 = ({
 				imagePositionOnMobile="top"
 			/>
 		</LI>
-		<LI
-			percentage="25%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="25%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={cards[1]}
 				containerPalette={containerPalette}
@@ -117,12 +107,7 @@ export const Card25_Card75 = ({
 				showAge={showAge}
 			/>
 		</LI>
-		<LI
-			percentage="75%"
-			padSides={true}
-			showTopMarginWhenStacked={true}
-			showDivider={true}
-		>
+		<LI percentage="75%" padSides={true} showDivider={true}>
 			<FrontCard
 				trail={cards[0]}
 				containerPalette={containerPalette}

--- a/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
+++ b/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
@@ -1,4 +1,5 @@
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { border, from } from '@guardian/source-foundations';
 
 export function verticalDividerWithBottomOffset(
@@ -16,7 +17,7 @@ export function verticalDividerWithBottomOffset(
 				width: 1px;
 				/* 100% is a reasonable fallback for browsers which don't support calc() */
 				height: 100%;
-				height: calc(100% - ${bottomPaddingSize});
+				height: calc(100% + ${bottomPaddingSize});
 				border-left: 1px solid ${border.secondary};
 			}
 		}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use flex’s [gap](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) property instead of padding top and bottoms with margins.

Some bottom margins are kept for the `<UL>` component.

## Why?

It’s more semantic, it removes code and it looks nearly identical. There’s a 2px difference for vertical spacing, as we are now using Source’s `space[3]`. This achieved better design consistency, at 12px, up from 10px.

We can get rid of much of the complex decision-making around `padBottom` or `padBottomOnMobile` in `<LI>`s.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/188116319-46b3399e-215a-4629-8baa-c35c0135fb2d.png
[after]: https://user-images.githubusercontent.com/76776/188657913-2c2f494e-13d9-4efc-b2f5-ece194a95726.png

## Known issues

Some older browsers may not support this property. Tested with Chrome 83, this does not look _too_ bad, as we still have horizontal which visually indicate a break between cards:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/76776/188189197-76109874-c5bc-4ee0-baf5-608e3c72bd2a.png">