### PR TITLE
Sensitive shady pie

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -20,6 +20,7 @@ type InlineProps = {
 	index: number;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
+	shouldHideAds?: boolean;
 };
 
 type NonInlineProps = {
@@ -28,6 +29,7 @@ type NonInlineProps = {
 	index?: never;
 	shouldHideReaderRevenue?: boolean;
 	isPaidContent?: boolean;
+	shouldHideAds?: boolean;
 };
 
 /**
@@ -227,6 +229,7 @@ export const AdSlot = ({
 	shouldHideReaderRevenue = false,
 	isPaidContent = false,
 	index,
+	shouldHideAds = false,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -261,6 +264,7 @@ export const AdSlot = ({
 								}
 								isPaidContent={isPaidContent}
 								adStyles={adStyles}
+								shouldHideAds={shouldHideAds}
 							/>
 						</Island>
 					);

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -25,10 +25,12 @@ export const TopRightAdSlot = ({
 	adStyles,
 	shouldHideReaderRevenue,
 	isPaidContent,
+	shouldHideAds,
 }: {
 	adStyles: SerializedStyles[];
 	shouldHideReaderRevenue: boolean;
 	isPaidContent: boolean;
+	shouldHideAds: boolean;
 }) => {
 	const adBlockerDetected = useAdBlockInUse();
 	const isSignedIn =
@@ -39,7 +41,8 @@ export const TopRightAdSlot = ({
 		!isSignedIn &&
 		!shouldHideReaderRevenue &&
 		!isPaidContent &&
-		!isServer
+		!isServer &&
+		!shouldHideAds
 	) {
 		// Show a fixed image asking people to subscribe
 		return <ShadyPie />;

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -677,6 +677,9 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPaidContent={
 											CAPIArticle.pageType.isPaidContent
 										}
+										shouldHideAds={
+											CAPIArticle.shouldHideAds
+										}
 									/>
 									{!isPaidContent ? (
 										<Island

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -492,6 +492,9 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														CAPIArticle.pageType
 															.isPaidContent
 													}
+													shouldHideAds={
+														CAPIArticle.shouldHideAds
+													}
 												/>
 											</div>
 										)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1153,6 +1153,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 												CAPIArticle.pageType
 													.isPaidContent
 											}
+											shouldHideAds={
+												CAPIArticle.shouldHideAds
+											}
 										/>
 									</RightColumn>
 								</div>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -631,6 +631,9 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPaidContent={
 											CAPIArticle.pageType.isPaidContent
 										}
+										shouldHideAds={
+											CAPIArticle.shouldHideAds
+										}
 									/>
 									{!isPaidContent ? (
 										<Island

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -761,6 +761,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPaidContent={
 											CAPIArticle.pageType.isPaidContent
 										}
+										shouldHideAds={
+											CAPIArticle.shouldHideAds
+										}
 									/>
 									{!isPaidContent ? (
 										<Island


### PR DESCRIPTION
## What does this change?
The shady pie component (promotes a digital subscription when an ad blocker is being used) was still showing on some articles marked as sensitive. This update only returns a shady pie component if the content is suitable for showing ads.

## Why?
On certain types of articles we probably shouldn't be showing any kind of promotional material.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="300" alt="Screenshot 2022-08-31 at 15 54 41" src="https://user-images.githubusercontent.com/108270776/187715965-a841f411-cad2-4225-9c87-6eaab9165b19.png"> | <img width="280" alt="Screenshot 2022-08-31 at 15 54 50" src="https://user-images.githubusercontent.com/108270776/187716001-12023a38-cf53-4534-b8bf-0003e2cb7951.png"> |
