### PR TITLE
Change AR To `t4g.small`

### DIFF
--- a/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
+++ b/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
@@ -165,7 +165,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIMobileappsrendering",
         },
-        "InstanceType": "t4g.micro",
+        "InstanceType": "t4g.small",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
@@ -1186,7 +1186,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMIMobileappsrendering",
         },
-        "InstanceType": "t4g.micro",
+        "InstanceType": "t4g.small",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -84,7 +84,7 @@ export class MobileAppsRendering extends GuStack {
 			},
 			instanceType: InstanceType.of(
 				InstanceClass.T4G,
-				InstanceSize.MICRO,
+				InstanceSize.SMALL,
 			),
 			certificateProps: {
 				CODE: {


### PR DESCRIPTION
## Why?

We'd like to try running AR on EC2's `t4g.small` instances for a few days, which is a step up from our current `t4g.micro` instances.

A more detailed explanation why can be found in #5913.

Information on the different EC2 instance types can be found here: https://aws.amazon.com/ec2/instance-types/

## Changes

- Change EC2 instance type to `t4g.small`
