### PR TITLE
remove table of content for explainer

### DIFF
--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -23,7 +23,6 @@ import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
-import TableOfContents from 'components/TableOfContents';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type {
@@ -135,16 +134,6 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 						<Metadata item={item} />
 						<Logo item={item} />
 					</section>
-
-					{item.design === ArticleDesign.Explainer &&
-						item.outline.length > 0 && (
-							<section css={articleWidthStyles}>
-								<TableOfContents
-									format={getFormat(item)}
-									outline={item.outline}
-								/>
-							</section>
-						)}
 				</header>
 				<Body className={[articleWidthStyles]} format={item}>
 					{children}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The editorials asked to roll back the table of content in the Explainer articles, since they need to consider if they want table of content for all Explainer articles or only for a sub category of explainers e.g. Q and A articles. Also they are considering if it needs to be switchable (onn/off) by the users

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
