### PR TITLE
`WitnessBlockComponent` may not have a caption

### DIFF
--- a/dotcom-rendering/src/lib/content.d.ts
+++ b/dotcom-rendering/src/lib/content.d.ts
@@ -509,7 +509,7 @@ interface WitnessTypeDataImage extends WitnessTypeDataBase {
 	_type: 'model.dotcomrendering.pageElements.WitnessTypeDataImage';
 	type: 'image';
 	alt: string;
-	caption: string;
+	caption?: string;
 	mediaId: string;
 	photographer: string;
 }

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3306,7 +3306,6 @@
                 "authorName",
                 "authorUsername",
                 "authorWitnessProfileUrl",
-                "caption",
                 "dateCreated",
                 "mediaId",
                 "originalUrl",

--- a/dotcom-rendering/src/web/components/WitnessBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/WitnessBlockComponent.tsx
@@ -126,7 +126,7 @@ const WitnessWrapper = ({
 
 type ImageProps = {
 	assets: WitnessAssetType[];
-	caption: string;
+	caption?: string;
 	title: string;
 	authorName: string;
 	dateCreated: string;
@@ -170,14 +170,16 @@ export const WitnessImageBlockComponent = ({
 						itemProp="name"
 						dangerouslySetInnerHTML={{ __html: title }}
 					/>
-					<div itemProp="description">
-						<p
-							css={css`
-								${body.medium()}
-							`}
-							dangerouslySetInnerHTML={{ __html: caption }}
-						/>
-					</div>
+					{!!caption && (
+						<div itemProp="description">
+							<p
+								css={css`
+									${body.medium()}
+								`}
+								dangerouslySetInnerHTML={{ __html: caption }}
+							/>
+						</div>
+					)}
 				</figcaption>
 			</>
 		</WitnessWrapper>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Mark the caption field as optional.

## Why?

Prevent some older articles with _guardian**witness**_ elements from failing validation.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/188111380-adac6083-4f76-4e27-97d3-132fcc0e859c.png
[after]: https://user-images.githubusercontent.com/76776/188111275-c3a0d8e1-23dc-47f9-a8f5-eb77c2423e15.png