### PR TITLE
Hide epic if sign-in gate is visible

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -169,7 +169,11 @@ export const SlotBodyEnd = ({
 	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCount]);
 
 	if (SelectedEpic) {
-		return <SelectedEpic />;
+		return (
+			<div id="slot-body-end">
+				<SelectedEpic />
+			</div>
+		);
 	}
 
 	return null;


### PR DESCRIPTION
This stopped working during the migration to islands - https://github.com/guardian/dotcom-rendering/commit/968d35a99f05f9c00fee63d772ba2890ae4973c9

Original fix: https://github.com/guardian/dotcom-rendering/pull/1990