### PR TITLE
Add explainer to supported article designs

### DIFF
--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -170,6 +170,7 @@ const getSectionStyles = (item: ArticleFormat): SerializedStyles[] => {
 
 const Layout: FC<Props> = ({ item }) => {
 	if (
+		item.design === ArticleDesign.Explainer ||
 		item.design === ArticleDesign.Analysis ||
 		item.design === ArticleDesign.Standard ||
 		item.design === ArticleDesign.Comment ||


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `Explainer` to the article designs supported by Editions

## Why?
Explainer is a new article type that wasn't previously considered

### Note
This is a very simple _Occam's Razor_ fix, there may well be differences with the Explainer type that I haven't considered and will cause issues so discussion is welcome. Just put this up on the off chance that this is all that needs to be done to save the editions publishing team the work of recreating all these articles to get them to display.

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
