### PR TITLE
Migrate `Result`

### DIFF
--- a/apps-rendering/src/atoms.test.ts
+++ b/apps-rendering/src/atoms.test.ts
@@ -24,11 +24,12 @@ import { QAndAItem } from '@guardian/content-atom-model/qanda/qAndAItem';
 import { QuizAtom } from '@guardian/content-atom-model/quiz/quizAtom';
 import { TimelineAtom } from '@guardian/content-atom-model/timeline/timelineAtom';
 import { TimelineItem } from '@guardian/content-atom-model/timeline/timelineItem';
-import { err, fromNullable, ok, some } from '@guardian/types';
+import { fromNullable, some } from '@guardian/types';
 import { ElementKind } from 'bodyElement';
 import { atomScript } from 'components/InteractiveAtom';
 import Int64 from 'node-int64';
 import { DocParser } from 'parserContext';
+import { Result } from 'result';
 import { formatOptionalDate, parseAtom } from './atoms';
 
 describe('formatOptionalDate', () => {
@@ -71,7 +72,7 @@ describe('parseAtom', () => {
 	it('returns an error if the atom has no data', () => {
 		blockElement.contentAtomTypeData = undefined;
 		expect(parseAtom(blockElement, {}, docParser)).toEqual(
-			err('The atom has no data'),
+			Result.err('The atom has no data'),
 		);
 	});
 
@@ -82,7 +83,7 @@ describe('parseAtom', () => {
 			atomType: unsupportedAtomType,
 		};
 		expect(parseAtom(blockElement, {}, docParser)).toEqual(
-			err(`Atom type not supported: ${unsupportedAtomType}`),
+			Result.err(`Atom type not supported: ${unsupportedAtomType}`),
 		);
 	});
 
@@ -117,13 +118,13 @@ describe('parseAtom', () => {
 			atoms.interactives = [];
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if there's not atom content`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No content for atom: ${atomId}`),
+				Result.err(`No content for atom: ${atomId}`),
 			);
 		});
 
@@ -148,7 +149,7 @@ describe('parseAtom', () => {
 			atomsWithData.interactives = [interactiveWithData];
 
 			expect(parseAtom(blockElement, atomsWithData, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.InteractiveAtom,
 					html,
 					css,
@@ -198,20 +199,20 @@ describe('parseAtom', () => {
 		it(`returns an error if no guide atom id matches`, () => {
 			guide.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no guide title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or body for atom: ${atomId}`),
+				Result.err(`No title or body for atom: ${atomId}`),
 			);
 		});
 
 		it(`returns GuideAtom result type given the correct guide`, () => {
 			guide.title = 'guide title';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.GuideAtom,
 					html: 'guide body',
 					title: guide.title,
@@ -228,7 +229,7 @@ describe('parseAtom', () => {
 			};
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.GuideAtom,
 					html: 'guide body',
 					title: guide.title,
@@ -279,20 +280,20 @@ describe('parseAtom', () => {
 		it(`returns an error if no guide atom id matches`, () => {
 			qanda.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no guide title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or body for atom: ${atomId}`),
+				Result.err(`No title or body for atom: ${atomId}`),
 			);
 		});
 
 		it(`returns GuideAtom result type given the correct guide`, () => {
 			qanda.title = 'qanda title';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.QandaAtom,
 					html: 'qanda body',
 					title: qanda.title,
@@ -309,7 +310,7 @@ describe('parseAtom', () => {
 			};
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.QandaAtom,
 					html: 'qanda body',
 					id: atomId,
@@ -360,20 +361,20 @@ describe('parseAtom', () => {
 		it(`returns an error if no profile atom id matches`, () => {
 			profile.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no profile title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or body for atom: ${atomId}`),
+				Result.err(`No title or body for atom: ${atomId}`),
 			);
 		});
 
 		it(`returns ProfileAtom result type given the correct profile`, () => {
 			profile.title = 'profile title';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.ProfileAtom,
 					html: 'profile body',
 					title: profile.title,
@@ -390,7 +391,7 @@ describe('parseAtom', () => {
 			};
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.ProfileAtom,
 					html: 'profile body',
 					id: atomId,
@@ -433,13 +434,13 @@ describe('parseAtom', () => {
 		it(`returns an error if no chart atom id matches`, () => {
 			chart.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no chart title or defaultHtml`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or defaultHtml for atom: ${atomId}`),
+				Result.err(`No title or defaultHtml for atom: ${atomId}`),
 			);
 		});
 
@@ -448,7 +449,7 @@ describe('parseAtom', () => {
 			chart.defaultHtml = 'some default html';
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.ChartAtom,
 					title: 'chart title',
 					id: atomId,
@@ -475,7 +476,7 @@ describe('parseAtom', () => {
 			docParser = jest.fn(() => frag);
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.ChartAtom,
 					title: 'chart title',
 					id: atomId,
@@ -527,13 +528,13 @@ describe('parseAtom', () => {
 		it(`returns an error if no timeline atom id matches`, () => {
 			timeline.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no timeline title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title for atom: ${atomId}`),
+				Result.err(`No title for atom: ${atomId}`),
 			);
 		});
 
@@ -542,7 +543,7 @@ describe('parseAtom', () => {
 			timelineItem.body = 'timeline item body';
 			timelineItem.date = new Int64('123456789abcdef0');
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`Invalid date in timeline atom`),
+				Result.err(`Invalid date in timeline atom`),
 			);
 		});
 
@@ -553,7 +554,7 @@ describe('parseAtom', () => {
 			timelineItem.toDate = new Int64(1614157023336);
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.TimelineAtom,
 					title: 'timeline title',
 					id: atomId,
@@ -608,13 +609,13 @@ describe('parseAtom', () => {
 		it(`returns an error if no explainer atom id matches`, () => {
 			explainer.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error if no explainer title or body`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title or body for atom: ${atomId}`),
+				Result.err(`No title or body for atom: ${atomId}`),
 			);
 		});
 
@@ -623,7 +624,7 @@ describe('parseAtom', () => {
 			explainerAtom.body = 'explainer body';
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.ExplainerAtom,
 					html: 'explainer body',
 					title: 'explainer title',
@@ -679,21 +680,21 @@ describe('parseAtom', () => {
 		it(`returns an error if no media atom id matches`, () => {
 			media.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error given no poster url`, () => {
 			mediaAtom.posterUrl = '';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No posterUrl for atom: ${atomId}`),
+				Result.err(`No posterUrl for atom: ${atomId}`),
 			);
 		});
 
 		it(`returns an error given no video id`, () => {
 			mediaAtom.activeVersion = new Int64(42);
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No videoId for atom: ${atomId}`),
+				Result.err(`No videoId for atom: ${atomId}`),
 			);
 		});
 
@@ -705,7 +706,7 @@ describe('parseAtom', () => {
 			docParser = jest.fn(() => frag);
 
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.MediaAtom,
 					posterUrl: 'poster-url',
 					caption: some(frag),
@@ -756,20 +757,20 @@ describe('parseAtom', () => {
 		it(`returns an error if no audio atom id matches`, () => {
 			audio.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error given no audio title`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No title for audio atom with id: ${atomId}`),
+				Result.err(`No title for audio atom with id: ${atomId}`),
 			);
 		});
 
 		it(`parses audio atom correctly`, () => {
 			audio.title = 'audio title';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.AudioAtom,
 					id: 'atom-id',
 					kicker: 'audio-kickcer',
@@ -835,20 +836,20 @@ describe('parseAtom', () => {
 		it(`returns an error if no quiz atom id matches`, () => {
 			quiz.data.kind = 'interactive';
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No atom matched this id: ${atomId}`),
+				Result.err(`No atom matched this id: ${atomId}`),
 			);
 		});
 
 		it(`returns an error of quiz atom has no content`, () => {
 			quizAtom.content.questions = [];
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				err(`No content for atom: ${atomId}`),
+				Result.err(`No content for atom: ${atomId}`),
 			);
 		});
 
 		it(`parses knowledge quiz atom correctly`, () => {
 			expect(parseAtom(blockElement, atoms, docParser)).toEqual(
-				ok({
+				Result.ok({
 					kind: ElementKind.KnowledgeQuizAtom,
 					id: atomId,
 					questions: [

--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -1,8 +1,8 @@
 import type { TimelineEvent } from '@guardian/atoms-rendering/dist/types/types';
 import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
-import { err, fromNullable, ok } from '@guardian/types';
-import type { Result } from '@guardian/types';
+import { fromNullable } from '@guardian/types';
+import { Result } from 'result';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
 import { atomScript } from 'components/InteractiveAtom';
@@ -23,7 +23,7 @@ function parseAtom(
 	docParser: DocParser,
 ): Result<string, BodyElement> {
 	if (element.contentAtomTypeData === undefined) {
-		return err('The atom has no data');
+		return Result.err('The atom has no data');
 	}
 
 	const id = element.contentAtomTypeData.atomId;
@@ -35,16 +35,16 @@ function parseAtom(
 			);
 
 			if (atom?.data.kind !== 'interactive') {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { html, css, mainJS: js } = atom.data.interactive;
 
 			if (!html && !css && !js) {
-				return err(`No content for atom: ${id}`);
+				return Result.err(`No content for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.InteractiveAtom,
 				html,
 				css,
@@ -56,7 +56,7 @@ function parseAtom(
 			const atom = atoms.guides?.find((guide) => guide.id === id);
 
 			if (atom?.data.kind !== 'guide' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title } = atom;
@@ -65,10 +65,10 @@ function parseAtom(
 			const { body } = atom.data.guide.items[0];
 
 			if (!title || !body) {
-				return err(`No title or body for atom: ${id}`);
+				return Result.err(`No title or body for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.GuideAtom,
 				html: body,
 				title,
@@ -82,7 +82,7 @@ function parseAtom(
 			const atom = atoms.qandas?.find((qanda) => qanda.id === id);
 
 			if (atom?.data.kind !== 'qanda' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title } = atom;
@@ -91,10 +91,10 @@ function parseAtom(
 			const credit = atom.data.qanda.eventImage?.master?.credit;
 
 			if (!title || !body) {
-				return err(`No title or body for atom: ${id}`);
+				return Result.err(`No title or body for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.QandaAtom,
 				html: body,
 				title,
@@ -108,7 +108,7 @@ function parseAtom(
 			const atom = atoms.profiles?.find((profile) => profile.id === id);
 
 			if (atom?.data.kind !== 'profile' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title } = atom;
@@ -117,10 +117,10 @@ function parseAtom(
 			const credit = atom.data.profile.headshot?.master?.credit;
 
 			if (!title || !body) {
-				return err(`No title or body for atom: ${id}`);
+				return Result.err(`No title or body for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.ProfileAtom,
 				html: body,
 				title,
@@ -134,13 +134,13 @@ function parseAtom(
 			const atom = atoms.charts?.find((chart) => chart.id === id);
 
 			if (atom?.data.kind !== 'chart' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title, defaultHtml } = atom;
 
 			if (!title || !defaultHtml) {
-				return err(`No title or defaultHtml for atom: ${id}`);
+				return Result.err(`No title or defaultHtml for atom: ${id}`);
 			}
 
 			const doc = docParser(defaultHtml);
@@ -156,7 +156,7 @@ function parseAtom(
 				(script) => script.innerHTML,
 			);
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.ChartAtom,
 				title,
 				id,
@@ -172,7 +172,7 @@ function parseAtom(
 			);
 
 			if (atom?.data.kind !== 'timeline' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title } = atom;
@@ -190,14 +190,14 @@ function parseAtom(
 			const description = atom.data.timeline.description;
 
 			if (!title) {
-				return err(`No title for atom: ${id}`);
+				return Result.err(`No title for atom: ${id}`);
 			}
 
 			if (events.some((event) => event.date === '')) {
-				return err('Invalid date in timeline atom');
+				return Result.err('Invalid date in timeline atom');
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.TimelineAtom,
 				title,
 				id,
@@ -212,16 +212,16 @@ function parseAtom(
 			);
 
 			if (atom?.data.kind !== 'explainer' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { title, body } = atom.data.explainer;
 
 			if (!title || !body) {
-				return err(`No title or body for atom: ${id}`);
+				return Result.err(`No title or body for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.ExplainerAtom,
 				html: body,
 				title,
@@ -233,7 +233,7 @@ function parseAtom(
 			const atom = atoms.media?.find((media) => media.id === id);
 
 			if (atom?.data.kind !== 'media') {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { posterUrl, duration, assets, activeVersion, title } =
@@ -244,14 +244,14 @@ function parseAtom(
 			)?.id;
 			const caption = docParser(title);
 			if (!posterUrl) {
-				return err(`No posterUrl for atom: ${id}`);
+				return Result.err(`No posterUrl for atom: ${id}`);
 			}
 
 			if (!videoId) {
-				return err(`No videoId for atom: ${id}`);
+				return Result.err(`No videoId for atom: ${id}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.MediaAtom,
 				id,
 				posterUrl,
@@ -266,16 +266,16 @@ function parseAtom(
 			const atom = atoms.audios?.find((audio) => audio.id === id);
 
 			if (atom?.data.kind !== 'audio') {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 			const { id: audioId, title } = atom;
 			const { kicker, trackUrl } = atom.data.audio;
 
 			if (!title) {
-				return err(`No title for audio atom with id: ${audioId}`);
+				return Result.err(`No title for audio atom with id: ${audioId}`);
 			}
 
-			return ok({
+			return Result.ok({
 				kind: ElementKind.AudioAtom,
 				id: audioId,
 				trackUrl,
@@ -287,13 +287,13 @@ function parseAtom(
 		case 'quiz': {
 			const atom = atoms.quizzes?.find((quiz) => quiz.id === id);
 			if (atom?.data.kind !== 'quiz' || !id) {
-				return err(`No atom matched this id: ${id}`);
+				return Result.err(`No atom matched this id: ${id}`);
 			}
 
 			const { content } = atom.data.quiz;
 
 			if (content.questions.length === 0) {
-				return err(`No content for atom: ${id}`);
+				return Result.err(`No content for atom: ${id}`);
 			}
 
 			const questions = content.questions.map((question) => {
@@ -312,7 +312,7 @@ function parseAtom(
 			});
 
 			if (atom.data.quiz.quizType === 'knowledge') {
-				return ok({
+				return Result.ok({
 					kind: ElementKind.KnowledgeQuizAtom,
 					id,
 					questions,
@@ -327,7 +327,7 @@ function parseAtom(
 			}
 
 			if (atom.data.quiz.quizType === 'personality') {
-				return ok({
+				return Result.ok({
 					kind: ElementKind.PersonalityQuizAtom,
 					id,
 					questions,
@@ -336,13 +336,13 @@ function parseAtom(
 				});
 			}
 
-			return err(
+			return Result.err(
 				`Atom quizType '${atom.data.quiz.quizType}' is not supported.`,
 			);
 		}
 
 		default: {
-			return err(
+			return Result.err(
 				`Atom type not supported: ${element.contentAtomTypeData.atomType}`,
 			);
 		}

--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -2,13 +2,13 @@ import type { TimelineEvent } from '@guardian/atoms-rendering/dist/types/types';
 import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { fromNullable } from '@guardian/types';
-import { Result } from 'result';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
 import { atomScript } from 'components/InteractiveAtom';
 import { isValidDate } from 'date';
 import type Int64 from 'node-int64';
 import type { DocParser } from 'parserContext';
+import { Result } from 'result';
 
 function formatOptionalDate(date: Int64 | undefined): string | undefined {
 	if (date === undefined) return undefined;
@@ -272,7 +272,9 @@ function parseAtom(
 			const { kicker, trackUrl } = atom.data.audio;
 
 			if (!title) {
-				return Result.err(`No title for audio atom with id: ${audioId}`);
+				return Result.err(
+					`No title for audio atom with id: ${audioId}`,
+				);
 			}
 
 			return Result.ok({

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -256,7 +256,7 @@ const parse =
 
 				const doc = context.docParser(html);
 
-				return flattenTextElement(doc).map(Result.ok);
+				return flattenTextElement(doc).map((elem) => Result.ok(elem));
 			}
 
 			case ElementType.IMAGE:

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -8,11 +8,7 @@ import type { BlockElement } from '@guardian/content-api-models/v1/blockElement'
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { ArticleTheme } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import {
-	fromNullable,
-	map,
-	withDefault,
-} from '@guardian/types';
+import { fromNullable, map, withDefault } from '@guardian/types';
 import { parseAtom } from 'atoms';
 import { ElementKind } from 'bodyElementKind';
 import { formatDate } from 'date';
@@ -23,8 +19,8 @@ import { parseImage } from 'image';
 import { compose, pipe } from 'lib';
 import { Optional } from 'optional';
 import type { Context } from 'parserContext';
-import { Result } from 'result';
 import type { KnowledgeQuizAtom, PersonalityQuizAtom } from 'quizAtom';
+import { Result } from 'result';
 
 // ----- Types ----- //
 
@@ -203,10 +199,11 @@ const tweetContent = (
 
 const toEmbedElement = (
 	parsed: Result<string, Embed>,
-): Result<string, BodyElement> => parsed.map((embed) => ({
-	kind: ElementKind.Embed,
-	embed,
-}));
+): Result<string, BodyElement> =>
+	parsed.map((embed) => ({
+		kind: ElementKind.Embed,
+		embed,
+	}));
 
 const slugify = (text: string): string => {
 	return text
@@ -295,7 +292,9 @@ const parse =
 				const { iframeUrl, alt } = element.interactiveTypeData ?? {};
 
 				if (!iframeUrl) {
-					return Result.err('No iframeUrl field on interactiveTypeData');
+					return Result.err(
+						'No iframeUrl field on interactiveTypeData',
+					);
 				}
 
 				return Result.ok({
@@ -311,7 +310,9 @@ const parse =
 				if (!url) {
 					return Result.err('No "url" field on richLinkTypeData');
 				} else if (!linkText) {
-					return Result.err('No "linkText" field on richLinkTypeData');
+					return Result.err(
+						'No "linkText" field on richLinkTypeData',
+					);
 				}
 
 				return Result.ok({ kind: ElementKind.RichLink, url, linkText });
@@ -326,10 +327,12 @@ const parse =
 					return Result.err('No "html" field on tweetTypeData');
 				}
 
-				return tweetContent(id, context.docParser(h)).map((content) => ({
+				return tweetContent(id, context.docParser(h)).map(
+					(content) => ({
 						kind: ElementKind.Tweet,
 						content,
-					}));
+					}),
+				);
 			}
 
 			case ElementType.EMBED: {

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -7,13 +7,10 @@ import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { ArticleTheme } from '@guardian/libs';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import {
-	err,
 	fromNullable,
 	map,
-	ok,
-	resultMap,
 	withDefault,
 } from '@guardian/types';
 import { parseAtom } from 'atoms';
@@ -26,6 +23,7 @@ import { parseImage } from 'image';
 import { compose, pipe } from 'lib';
 import { Optional } from 'optional';
 import type { Context } from 'parserContext';
+import { Result } from 'result';
 import type { KnowledgeQuizAtom, PersonalityQuizAtom } from 'quizAtom';
 
 // ----- Types ----- //
@@ -195,17 +193,17 @@ const tweetContent = (
 	const blockquote = doc.querySelector('blockquote');
 
 	if (blockquote !== null) {
-		return ok(blockquote.childNodes);
+		return Result.ok(blockquote.childNodes);
 	}
 
-	return err(
+	return Result.err(
 		`There was no blockquote element in the tweet with id: ${tweetId}`,
 	);
 };
 
-const toEmbedElement: (
+const toEmbedElement = (
 	parsed: Result<string, Embed>,
-) => Result<string, BodyElement> = resultMap((embed) => ({
+): Result<string, BodyElement> => parsed.map((embed) => ({
 	kind: ElementKind.Embed,
 	embed,
 }));
@@ -256,25 +254,25 @@ const parse =
 				const html = element.textTypeData?.html;
 
 				if (!html) {
-					return err('No html field on textTypeData');
+					return Result.err('No html field on textTypeData');
 				}
 
 				const doc = context.docParser(html);
 
-				return flattenTextElement(doc).map(ok);
+				return flattenTextElement(doc).map(Result.ok);
 			}
 
 			case ElementType.IMAGE:
 				return pipe(
 					parseImage(context)(element),
 					map<ImageData, Result<string, Image>>((image) =>
-						ok({
+						Result.ok({
 							kind: ElementKind.Image,
 							...image,
 						}),
 					),
 					withDefault<Result<string, Image>>(
-						err("I couldn't find a master asset"),
+						Result.err("I couldn't find a master asset"),
 					),
 				);
 
@@ -283,10 +281,10 @@ const parse =
 					element.pullquoteTypeData ?? {};
 
 				if (!quote) {
-					return err('No quote field on pullquoteTypeData');
+					return Result.err('No quote field on pullquoteTypeData');
 				}
 
-				return ok({
+				return Result.ok({
 					kind: ElementKind.Pullquote,
 					quote,
 					attribution: fromNullable(attribution),
@@ -297,10 +295,10 @@ const parse =
 				const { iframeUrl, alt } = element.interactiveTypeData ?? {};
 
 				if (!iframeUrl) {
-					return err('No iframeUrl field on interactiveTypeData');
+					return Result.err('No iframeUrl field on interactiveTypeData');
 				}
 
-				return ok({
+				return Result.ok({
 					kind: ElementKind.Interactive,
 					url: iframeUrl,
 					alt: fromNullable(alt),
@@ -311,37 +309,34 @@ const parse =
 				const { url, linkText } = element.richLinkTypeData ?? {};
 
 				if (!url) {
-					return err('No "url" field on richLinkTypeData');
+					return Result.err('No "url" field on richLinkTypeData');
 				} else if (!linkText) {
-					return err('No "linkText" field on richLinkTypeData');
+					return Result.err('No "linkText" field on richLinkTypeData');
 				}
 
-				return ok({ kind: ElementKind.RichLink, url, linkText });
+				return Result.ok({ kind: ElementKind.RichLink, url, linkText });
 			}
 
 			case ElementType.TWEET: {
 				const { id, html: h } = element.tweetTypeData ?? {};
 
 				if (!id) {
-					return err('No "id" field on tweetTypeData');
+					return Result.err('No "id" field on tweetTypeData');
 				} else if (!h) {
-					return err('No "html" field on tweetTypeData');
+					return Result.err('No "html" field on tweetTypeData');
 				}
 
-				return pipe(
-					tweetContent(id, context.docParser(h)),
-					resultMap((content) => ({
+				return tweetContent(id, context.docParser(h)).map((content) => ({
 						kind: ElementKind.Tweet,
 						content,
-					})),
-				);
+					}));
 			}
 
 			case ElementType.EMBED: {
 				const { html: embedHtml } = element.embedTypeData ?? {};
 
 				if (!embedHtml) {
-					return err('No html field on embedTypeData');
+					return Result.err('No html field on embedTypeData');
 				}
 
 				const id = context
@@ -351,7 +346,7 @@ const parse =
 
 				if (id) {
 					if (!campaigns) {
-						return err('No campaign data for this callout');
+						return Result.err('No campaign data for this callout');
 					}
 
 					const campaign = campaigns.find(
@@ -359,13 +354,13 @@ const parse =
 					);
 
 					if (!campaign) {
-						return err('No matching campaign');
+						return Result.err('No matching campaign');
 					}
 
 					const description = context.docParser(
 						campaign.fields.description ?? '',
 					);
-					return ok({
+					return Result.ok({
 						kind: ElementKind.Callout,
 						id,
 						campaign,
@@ -389,7 +384,7 @@ const parse =
 				} = element.membershipTypeData ?? {};
 
 				if (!linkText || !url) {
-					return err(
+					return Result.err(
 						'No linkText or originalUrl field on membershipTypeData',
 					);
 				}
@@ -399,7 +394,7 @@ const parse =
 						? formatDate(new Date(start.iso8601))
 						: undefined;
 
-				return ok({
+				return Result.ok({
 					kind: ElementKind.LiveEvent,
 					linkText,
 					url,
@@ -423,14 +418,14 @@ const parse =
 
 			case ElementType.CONTENTATOM: {
 				if (!atoms) {
-					return err('No atom data returned by capi');
+					return Result.err('No atom data returned by capi');
 				}
 
 				return parseAtom(element, atoms, context.docParser);
 			}
 
 			default:
-				return err(
+				return Result.err(
 					`I'm afraid I don't understand the element I was given: ${element.type}`,
 				);
 		}
@@ -440,7 +435,7 @@ const parseElements =
 	(context: Context, atoms?: Atoms, campaigns?: Campaign[]) =>
 	(elements: Elements): Array<Result<string, BodyElement>> => {
 		if (!elements) {
-			return [err('No body elements available')];
+			return [Result.err('No body elements available')];
 		}
 		return elements.flatMap(parse(context, atoms, campaigns));
 	};

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -7,7 +7,6 @@ import { AudioAtom } from '@guardian/atoms-rendering';
 import type { ICommentResponse as CommentResponse } from '@guardian/bridget';
 import { Topic } from '@guardian/bridget/Topic';
 import { App } from '@guardian/discussion-rendering/build/App';
-import { either } from '@guardian/types';
 import {
 	ads,
 	getAdSlots,
@@ -434,7 +433,7 @@ function hydrateClickToView(): void {
 	document
 		.querySelectorAll('.js-click-to-view-container')
 		.forEach((container) =>
-			either(
+			createEmbedComponentFromProps(container).either(
 				(error: string) => {
 					logger.error(
 						`Failed to create Embed for hydration: ${error}`,
@@ -443,7 +442,7 @@ function hydrateClickToView(): void {
 				(embedComponent: ReactElement) => {
 					ReactDOM.hydrate(embedComponent, container);
 				},
-			)(createEmbedComponentFromProps(container)),
+			),
 		);
 }
 

--- a/apps-rendering/src/client/atoms.tsx
+++ b/apps-rendering/src/client/atoms.tsx
@@ -71,12 +71,14 @@ const parseQuizProps = (
 		resultFromNullable(
 			'The quiz atom did not have an accompanying element containing props',
 		),
-	).flatMap((p) =>
-		Result.fromUnsafe(
-			(): unknown => JSON.parse(p.replace(/&quot;/g, '"')),
-			'The props for the quiz atom are not valid JSON',
-		),
-	).flatMap(parse(quizPropsParser));
+	)
+		.flatMap((p) =>
+			Result.fromUnsafe(
+				(): unknown => JSON.parse(p.replace(/&quot;/g, '"')),
+				'The props for the quiz atom are not valid JSON',
+			),
+		)
+		.flatMap(parse(quizPropsParser));
 
 const hydrateQuizzes = (): void =>
 	Array.from(document.querySelectorAll('.js-quiz')).forEach((atomElement) => {
@@ -104,7 +106,7 @@ const hydrateQuizzes = (): void =>
 
 			ReactDOM.hydrate(atom, atomElement);
 		}
-		
+
 		if (parsedProps.isErr()) {
 			console.error(parsedProps.error);
 		}

--- a/apps-rendering/src/client/liveblog.ts
+++ b/apps-rendering/src/client/liveblog.ts
@@ -1,4 +1,3 @@
-import { ResultKind } from '@guardian/types';
 import { formatLocalTimeDateTz } from 'date';
 import { dateParser, parse } from 'parser';
 import { logger } from '../logger';
@@ -9,12 +8,12 @@ function lastUpdatedDates(): void {
 			const isoDateTimeString = element.getAttribute('datetime');
 			const date = parse(dateParser)(isoDateTimeString);
 
-			if (date.kind === ResultKind.Ok) {
+			if (date.isOk()) {
 				element.textContent = `Updated: ${formatLocalTimeDateTz(
 					date.value,
 				)}`;
-			} else {
-				logger.warn(`Unable to parse and format date: ${date.err}`);
+			} else if (date.isErr()) {
+				logger.warn(`Unable to parse and format date: ${date.error}`);
 			}
 		},
 	);

--- a/apps-rendering/src/client/parser.ts
+++ b/apps-rendering/src/client/parser.ts
@@ -1,8 +1,7 @@
 // ----- Imports ----- //
 
-import type { Result } from '@guardian/types';
-import { err, ok } from '@guardian/types';
 import { errorToString } from 'lib';
+import { Result } from 'result';
 
 // ----- Functions ----- //
 
@@ -15,10 +14,10 @@ const parse =
 				.childNodes;
 
 			Array.from(docNodes).forEach((node) => frag.appendChild(node));
-			return ok(frag);
+			return Result.ok(frag);
 		} catch (e) {
 			const errString = errorToString(e, 'unknown reason');
-			return err(
+			return Result.err(
 				`I wasn't able to parse the string into a DocumentFragment because: ${errString}`,
 			);
 		}

--- a/apps-rendering/src/components/Byline/Byline.stories.tsx
+++ b/apps-rendering/src/components/Byline/Byline.stories.tsx
@@ -10,11 +10,9 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
-import { pipe } from 'lib';
 import type { FC } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Byline from './';
@@ -32,11 +30,9 @@ const byline = (): string => text('Byline', 'Jane Smith');
 const job = (): string => text('Job Title', 'Editor of things');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-	pipe(
+	parseByline(
 		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
-		parseByline,
-		toOption,
-	);
+	).toOption();
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.test.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.test.tsx
@@ -4,7 +4,7 @@
 
 import { matchers } from '@emotion/jest';
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
-import { none, ok, some } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import type {
 	EmailSignup,
 	Embed,
@@ -16,6 +16,7 @@ import type {
 import { EmbedKind } from 'embed';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
+import { Result } from 'result';
 import type { SourceDetails } from './';
 import EmbedComponentWrapper, {
 	createEmbedComponentFromProps,
@@ -63,7 +64,7 @@ describe('EmbedComponentWrapper.embedComponentFromWrapperProps', () => {
 			const embedComponentFromWrapperProps =
 				createEmbedComponentFromProps(container.firstElementChild);
 			expect(embedComponentFromWrapperProps).toStrictEqual(
-				ok(expectedWrapperContents),
+				Result.ok(expectedWrapperContents),
 			);
 		} else {
 			fail('EmbedComponentWrapper was not rendered');

--- a/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.test.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.test.tsx
@@ -4,7 +4,7 @@
 
 import { matchers } from '@emotion/jest';
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
-import { none, some } from '@guardian/types';
+import { none, ok, some } from '@guardian/types';
 import type {
 	EmailSignup,
 	Embed,
@@ -63,7 +63,7 @@ describe('EmbedComponentWrapper.embedComponentFromWrapperProps', () => {
 			const embedComponentFromWrapperProps =
 				createEmbedComponentFromProps(container.firstElementChild);
 			expect(embedComponentFromWrapperProps).toStrictEqual(
-				some(expectedWrapperContents),
+				ok(expectedWrapperContents),
 			);
 		} else {
 			fail('EmbedComponentWrapper was not rendered');

--- a/apps-rendering/src/components/EmbedWrapper/index.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/index.tsx
@@ -2,13 +2,7 @@
 
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
 import type { Option } from '@guardian/types';
-import {
-	fromNullable,
-	map,
-	none,
-	some,
-	withDefault,
-} from '@guardian/types';
+import { fromNullable, map, none, some, withDefault } from '@guardian/types';
 import ClickToView from 'components/ClickToView';
 import EmbedComponent from 'components/Embed';
 import { EmbedKind } from 'embed';
@@ -157,8 +151,8 @@ const divElementPropsToEmbedComponentProps = (
 		container: Record<string, string | undefined>,
 		parameterName: string,
 	): Result<string, number> =>
-		requiredStringParam(container, parameterName)
-			.flatMap((value: string) => {
+		requiredStringParam(container, parameterName).flatMap(
+			(value: string) => {
 				const parsedValue = Number.parseInt(value);
 
 				if (Number.isNaN(parsedValue)) {
@@ -166,14 +160,15 @@ const divElementPropsToEmbedComponentProps = (
 				}
 
 				return Result.ok(parsedValue);
-			});
+			},
+		);
 
 	const requiredBooleanParam = (
 		container: Record<string, string | undefined>,
 		parameterName: string,
 	): Result<string, boolean> =>
-		requiredStringParam(container, parameterName)
-			.flatMap((value: string) => {
+		requiredStringParam(container, parameterName).flatMap(
+			(value: string) => {
 				if (value === 'true') {
 					return Result.ok(true);
 				}
@@ -182,7 +177,8 @@ const divElementPropsToEmbedComponentProps = (
 				}
 
 				return Result.err(`${value} is not a valid boolean value`);
-			});
+			},
+		);
 
 	const getDataAttributesFromElement = (
 		container: Element,
@@ -190,7 +186,9 @@ const divElementPropsToEmbedComponentProps = (
 		if (container instanceof HTMLElement) {
 			return Result.ok({ ...container.dataset });
 		} else {
-			return Result.err('Embed wrapper Element does not have a dataset field');
+			return Result.err(
+				'Embed wrapper Element does not have a dataset field',
+			);
 		}
 	};
 
@@ -225,8 +223,8 @@ const divElementPropsToEmbedComponentProps = (
 	const dataAttributesToEmbed = (
 		elementProps: Record<string, string | undefined>,
 	): Result<string, Embed> =>
-		parseEmbedKind(elementProps['kind'])
-			.flatMap((embedKind: EmbedKind): Result<string, Embed> => {
+		parseEmbedKind(elementProps['kind']).flatMap(
+			(embedKind: EmbedKind): Result<string, Embed> => {
 				switch (embedKind) {
 					case EmbedKind.Spotify:
 						return resultMap3(
@@ -265,8 +263,8 @@ const divElementPropsToEmbedComponentProps = (
 							requiredNumberParam(elementProps, 'width'),
 						)(requiredNumberParam(elementProps, 'height'));
 					case EmbedKind.Instagram: {
-						return requiredStringParam(elementProps, 'id')
-							.map((id: string): Instagram => ({
+						return requiredStringParam(elementProps, 'id').map(
+							(id: string): Instagram => ({
 								kind: EmbedKind.Instagram,
 								id,
 								caption: fromNullable(elementProps['caption']),
@@ -277,22 +275,24 @@ const divElementPropsToEmbedComponentProps = (
 						);
 					}
 					case EmbedKind.Generic: {
-						return parseGenericFields(elementProps)
-							.map((genericFields: GenericFields): Generic => ({
+						return parseGenericFields(elementProps).map(
+							(genericFields: GenericFields): Generic => ({
 								kind: EmbedKind.Generic,
 								...genericFields,
-							}));
+							}),
+						);
 					}
 					case EmbedKind.TikTok: {
-						return parseGenericFields(elementProps)
-							.map((genericFields: GenericFields): TikTok => ({
+						return parseGenericFields(elementProps).map(
+							(genericFields: GenericFields): TikTok => ({
 								kind: EmbedKind.TikTok,
 								...genericFields,
-							}));
+							}),
+						);
 					}
 					case EmbedKind.EmailSignup: {
-						return requiredStringParam(elementProps, 'src')
-							.map((src: string): EmailSignup => ({
+						return requiredStringParam(elementProps, 'src').map(
+							(src: string): EmailSignup => ({
 								kind: EmbedKind.EmailSignup,
 								src,
 								alt: fromNullable(elementProps['alt']),
@@ -308,26 +308,28 @@ const divElementPropsToEmbedComponentProps = (
 						);
 					}
 				}
-			});
+			},
+		);
 
-	return getDataAttributesFromElement(container)
-		.flatMap((dataAttributes) =>
-			resultMap2((editions: boolean, embed: Embed) => {
-				const sourceDetails = getSourceDetailsForEmbed(embed);
-				return { editions, embed, sourceDetails };
-			})(requiredBooleanParam(dataAttributes, 'editions'))(
-				dataAttributesToEmbed(dataAttributes),
-			));
+	return getDataAttributesFromElement(container).flatMap((dataAttributes) =>
+		resultMap2((editions: boolean, embed: Embed) => {
+			const sourceDetails = getSourceDetailsForEmbed(embed);
+			return { editions, embed, sourceDetails };
+		})(requiredBooleanParam(dataAttributes, 'editions'))(
+			dataAttributesToEmbed(dataAttributes),
+		),
+	);
 };
 
 const createEmbedComponentFromProps = (
 	container: Element,
-): Result<string, ReactElement> => 
-	divElementPropsToEmbedComponentProps(container)
-		.flatMap((embedComponentProps: EmbedComponentInClickToViewProps) =>
+): Result<string, ReactElement> =>
+	divElementPropsToEmbedComponentProps(container).flatMap(
+		(embedComponentProps: EmbedComponentInClickToViewProps) =>
 			resultFromNullable(
 				`I can't construct a Component for embed of type ${embedComponentProps.embed.kind}`,
-			)(h(EmbedComponentInClickToView, embedComponentProps)));
+			)(h(EmbedComponentInClickToView, embedComponentProps)),
+	);
 
 type SourceDetails = { source: Option<string>; sourceDomain: Option<string> };
 

--- a/apps-rendering/src/components/EmbedWrapper/index.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/index.tsx
@@ -1,15 +1,11 @@
 // ----- Imports ----- //
 
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import {
-	err,
 	fromNullable,
 	map,
 	none,
-	ok,
-	resultAndThen,
-	resultMap,
 	some,
 	withDefault,
 } from '@guardian/types';
@@ -29,6 +25,7 @@ import type {
 import { pipe, resultFromNullable, resultMap2, resultMap3 } from 'lib';
 import { createElement as h } from 'react';
 import type { FC, ReactElement } from 'react';
+import { Result } from 'result';
 
 // ----- Component ----- //
 
@@ -159,47 +156,41 @@ const divElementPropsToEmbedComponentProps = (
 	const requiredNumberParam = (
 		container: Record<string, string | undefined>,
 		parameterName: string,
-	): Result<string, number> => {
-		return pipe(
-			requiredStringParam(container, parameterName),
-			resultAndThen((value: string) => {
+	): Result<string, number> =>
+		requiredStringParam(container, parameterName)
+			.flatMap((value: string) => {
 				const parsedValue = Number.parseInt(value);
 
 				if (Number.isNaN(parsedValue)) {
-					return err(`${value} is not a integer`);
+					return Result.err(`${value} is not a integer`);
 				}
 
-				return ok(parsedValue);
-			}),
-		);
-	};
+				return Result.ok(parsedValue);
+			});
 
 	const requiredBooleanParam = (
 		container: Record<string, string | undefined>,
 		parameterName: string,
-	): Result<string, boolean> => {
-		return pipe(
-			requiredStringParam(container, parameterName),
-			resultAndThen((value: string) => {
+	): Result<string, boolean> =>
+		requiredStringParam(container, parameterName)
+			.flatMap((value: string) => {
 				if (value === 'true') {
-					return ok(true);
+					return Result.ok(true);
 				}
 				if (value === 'false') {
-					return ok(false);
+					return Result.ok(false);
 				}
 
-				return err(`${value} is not a valid boolean value`);
-			}),
-		);
-	};
+				return Result.err(`${value} is not a valid boolean value`);
+			});
 
 	const getDataAttributesFromElement = (
 		container: Element,
 	): Result<string, Record<string, string | undefined>> => {
 		if (container instanceof HTMLElement) {
-			return ok({ ...container.dataset });
+			return Result.ok({ ...container.dataset });
 		} else {
-			return err('Embed wrapper Element does not have a dataset field');
+			return Result.err('Embed wrapper Element does not have a dataset field');
 		}
 	};
 
@@ -207,10 +198,10 @@ const divElementPropsToEmbedComponentProps = (
 		kindValue: string | undefined,
 	): Result<string, EmbedKind> => {
 		if (kindValue && kindValue in EmbedKind) {
-			return ok(kindValue as EmbedKind);
+			return Result.ok(kindValue as EmbedKind);
 		}
 
-		return err(`'${kindValue ?? 'undefined'}' is not an EmbedKind`);
+		return Result.err(`'${kindValue ?? 'undefined'}' is not an EmbedKind`);
 	};
 
 	type ElementProps = Record<string, string | undefined>;
@@ -233,10 +224,9 @@ const divElementPropsToEmbedComponentProps = (
 		);
 	const dataAttributesToEmbed = (
 		elementProps: Record<string, string | undefined>,
-	): Result<string, Embed> => {
-		return pipe(
-			parseEmbedKind(elementProps['kind']),
-			resultAndThen((embedKind: EmbedKind): Result<string, Embed> => {
+	): Result<string, Embed> =>
+		parseEmbedKind(elementProps['kind'])
+			.flatMap((embedKind: EmbedKind): Result<string, Embed> => {
 				switch (embedKind) {
 					case EmbedKind.Spotify:
 						return resultMap3(
@@ -275,8 +265,8 @@ const divElementPropsToEmbedComponentProps = (
 							requiredNumberParam(elementProps, 'width'),
 						)(requiredNumberParam(elementProps, 'height'));
 					case EmbedKind.Instagram: {
-						return resultMap<string, Instagram>(
-							(id: string): Instagram => ({
+						return requiredStringParam(elementProps, 'id')
+							.map((id: string): Instagram => ({
 								kind: EmbedKind.Instagram,
 								id,
 								caption: fromNullable(elementProps['caption']),
@@ -284,35 +274,25 @@ const divElementPropsToEmbedComponentProps = (
 									elementProps['tracking'],
 								),
 							}),
-						)(requiredStringParam(elementProps, 'id'));
+						);
 					}
 					case EmbedKind.Generic: {
-						return pipe(
-							elementProps,
-							parseGenericFields,
-							resultMap(
-								(genericFields: GenericFields): Generic => ({
-									kind: EmbedKind.Generic,
-									...genericFields,
-								}),
-							),
-						);
+						return parseGenericFields(elementProps)
+							.map((genericFields: GenericFields): Generic => ({
+								kind: EmbedKind.Generic,
+								...genericFields,
+							}));
 					}
 					case EmbedKind.TikTok: {
-						return pipe(
-							elementProps,
-							parseGenericFields,
-							resultMap(
-								(genericFields: GenericFields): TikTok => ({
-									kind: EmbedKind.TikTok,
-									...genericFields,
-								}),
-							),
-						);
+						return parseGenericFields(elementProps)
+							.map((genericFields: GenericFields): TikTok => ({
+								kind: EmbedKind.TikTok,
+								...genericFields,
+							}));
 					}
 					case EmbedKind.EmailSignup: {
-						return resultMap<string, EmailSignup>(
-							(src: string): EmailSignup => ({
+						return requiredStringParam(elementProps, 'src')
+							.map((src: string): EmailSignup => ({
 								kind: EmbedKind.EmailSignup,
 								src,
 								alt: fromNullable(elementProps['alt']),
@@ -325,37 +305,29 @@ const divElementPropsToEmbedComponentProps = (
 									elementProps['sourceDomain'],
 								),
 							}),
-						)(requiredStringParam(elementProps, 'src'));
+						);
 					}
 				}
-			}),
-		);
-	};
+			});
 
-	return pipe(
-		getDataAttributesFromElement(container),
-		resultAndThen((dataAttributes) => {
-			return resultMap2((editions: boolean, embed: Embed) => {
+	return getDataAttributesFromElement(container)
+		.flatMap((dataAttributes) =>
+			resultMap2((editions: boolean, embed: Embed) => {
 				const sourceDetails = getSourceDetailsForEmbed(embed);
 				return { editions, embed, sourceDetails };
 			})(requiredBooleanParam(dataAttributes, 'editions'))(
 				dataAttributesToEmbed(dataAttributes),
-			);
-		}),
-	);
+			));
 };
 
 const createEmbedComponentFromProps = (
 	container: Element,
-): Result<string, ReactElement> => {
-	return resultAndThen(
-		(embedComponentProps: EmbedComponentInClickToViewProps) => {
-			return resultFromNullable(
+): Result<string, ReactElement> => 
+	divElementPropsToEmbedComponentProps(container)
+		.flatMap((embedComponentProps: EmbedComponentInClickToViewProps) =>
+			resultFromNullable(
 				`I can't construct a Component for embed of type ${embedComponentProps.embed.kind}`,
-			)(h(EmbedComponentInClickToView, embedComponentProps));
-		},
-	)(divElementPropsToEmbedComponentProps(container));
-};
+			)(h(EmbedComponentInClickToView, embedComponentProps)));
 
 type SourceDetails = { source: Option<string>; sourceDomain: Option<string> };
 

--- a/apps-rendering/src/components/HeadlineByline/HeadlineByline.stories.tsx
+++ b/apps-rendering/src/components/HeadlineByline/HeadlineByline.stories.tsx
@@ -1,9 +1,7 @@
 // ----- Imports ----- //
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import { toOption } from '@guardian/types';
 import { parse } from 'client/parser';
-import { pipe } from 'lib';
 import type { FC } from 'react';
 import HeadlineByline from './';
 
@@ -13,11 +11,9 @@ const parser = new DOMParser();
 const parseByline = parse(parser);
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-	pipe(
+	parseByline(
 		`<a href="https://www.theguardian.com/profile/leah-harper">Leah Harper</a>`,
-		parseByline,
-		toOption,
-	);
+	).toOption();
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -4,7 +4,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
-import { partition, some, withDefault } from '@guardian/types';
+import { some, withDefault } from '@guardian/types';
 import AnalysisLayout from 'components/Layout/AnalysisLayout';
 import Comment from 'components/Layout/CommentLayout';
 import Standard from 'components/Layout/StandardLayout';
@@ -28,6 +28,7 @@ import { deadBlog, live } from 'fixtures/live';
 import type { Item } from 'item';
 import type { ReactElement } from 'react';
 import { renderAll } from 'renderer';
+import { Result } from 'result';
 import Live from './LiveLayout';
 
 // ----- Functions ----- //
@@ -48,7 +49,7 @@ export const Article = (): React.ReactNode => {
 		<Standard item={article}>
 			{renderAll(
 				formatFromItem(article, some(ArticleDisplay.Standard)),
-				partition(article.body).oks,
+				Result.partition(article.body).oks,
 			)}
 		</Standard>
 	);
@@ -60,7 +61,7 @@ export const Review = (): React.ReactNode => {
 		<Standard item={review}>
 			{renderAll(
 				formatFromItem(review, some(ArticleDisplay.Standard)),
-				partition(review.body).oks,
+				Result.partition(review.body).oks,
 			)}
 		</Standard>
 	);
@@ -72,7 +73,7 @@ export const MatchReport = (): React.ReactNode => {
 		<Standard item={matchReport}>
 			{renderAll(
 				formatFromItem(matchReport, some(ArticleDisplay.Standard)),
-				partition(matchReport.body).oks,
+				Result.partition(matchReport.body).oks,
 			)}
 		</Standard>
 	);
@@ -84,7 +85,7 @@ export const PrintShop = (): React.ReactNode => {
 		<Standard item={printShop}>
 			{renderAll(
 				formatFromItem(printShop, some(ArticleDisplay.Standard)),
-				partition(printShop.body).oks,
+				Result.partition(printShop.body).oks,
 			)}
 		</Standard>
 	);
@@ -96,7 +97,7 @@ export const PhotoEssay = (): React.ReactNode => {
 		<Standard item={photoEssay}>
 			{renderAll(
 				formatFromItem(photoEssay, some(ArticleDisplay.Standard)),
-				partition(photoEssay.body).oks,
+				Result.partition(photoEssay.body).oks,
 			)}
 		</Standard>
 	);
@@ -108,7 +109,7 @@ export const Feature = (): React.ReactNode => {
 		<Standard item={feature}>
 			{renderAll(
 				formatFromItem(feature, some(ArticleDisplay.Standard)),
-				partition(feature.body).oks,
+				Result.partition(feature.body).oks,
 			)}
 		</Standard>
 	);
@@ -120,7 +121,7 @@ export const Interview = (): React.ReactNode => {
 		<Standard item={interview}>
 			{renderAll(
 				formatFromItem(interview, some(ArticleDisplay.Standard)),
-				partition(interview.body).oks,
+				Result.partition(interview.body).oks,
 			)}
 		</Standard>
 	);
@@ -132,7 +133,7 @@ export const Quiz = (): React.ReactNode => {
 		<Standard item={quiz}>
 			{renderAll(
 				formatFromItem(quiz, some(ArticleDisplay.Standard)),
-				partition(quiz.body).oks,
+				Result.partition(quiz.body).oks,
 			)}
 		</Standard>
 	);
@@ -144,7 +145,7 @@ export const Recipe = (): React.ReactNode => {
 		<Standard item={recipe}>
 			{renderAll(
 				formatFromItem(recipe, some(ArticleDisplay.Standard)),
-				partition(recipe.body).oks,
+				Result.partition(recipe.body).oks,
 			)}
 		</Standard>
 	);
@@ -156,7 +157,7 @@ export const CommentItem = (): React.ReactNode => {
 		<Comment item={comment}>
 			{renderAll(
 				formatFromItem(comment, some(ArticleDisplay.Standard)),
-				partition(comment.body).oks,
+				Result.partition(comment.body).oks,
 			)}
 		</Comment>
 	);
@@ -168,7 +169,7 @@ export const Letter = (): React.ReactNode => {
 		<Comment item={letter}>
 			{renderAll(
 				formatFromItem(letter, some(ArticleDisplay.Standard)),
-				partition(letter.body).oks,
+				Result.partition(letter.body).oks,
 			)}
 		</Comment>
 	);
@@ -180,7 +181,7 @@ export const Editorial = (): React.ReactNode => {
 		<Comment item={editorial}>
 			{renderAll(
 				formatFromItem(editorial, some(ArticleDisplay.Standard)),
-				partition(editorial.body).oks,
+				Result.partition(editorial.body).oks,
 			)}
 		</Comment>
 	);
@@ -192,7 +193,7 @@ export const Analysis = (): React.ReactNode => {
 		<AnalysisLayout item={analysis}>
 			{renderAll(
 				formatFromItem(analysis, some(ArticleDisplay.Standard)),
-				partition(analysis.body).oks,
+				Result.partition(analysis.body).oks,
 			)}
 		</AnalysisLayout>
 	);
@@ -204,7 +205,7 @@ export const Explainer = (): React.ReactNode => {
 		<Standard item={explainer}>
 			{renderAll(
 				formatFromItem(explainer, some(ArticleDisplay.Standard)),
-				partition(explainer.body).oks,
+				Result.partition(explainer.body).oks,
 			)}
 		</Standard>
 	);

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -17,9 +17,9 @@ import StandardLayout from 'components/Layout/StandardLayout';
 import type { Item } from 'item';
 import type { FC, ReactNode } from 'react';
 import { renderAll, renderAllWithoutStyles } from 'renderer';
+import { Result } from 'result';
 import AnalysisLayout from './AnalysisLayout';
 import ImmersiveLayout from './ImmersiveLayout';
-import { Result } from 'result';
 
 // ----- Functions ----- //
 

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/source-foundations';
-import { partition } from '@guardian/types';
 import { getAdPlaceholderInserter } from 'ads';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -20,6 +19,7 @@ import type { FC, ReactNode } from 'react';
 import { renderAll, renderAllWithoutStyles } from 'renderer';
 import AnalysisLayout from './AnalysisLayout';
 import ImmersiveLayout from './ImmersiveLayout';
+import { Result } from 'result';
 
 // ----- Functions ----- //
 
@@ -56,7 +56,7 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 		return <LiveLayout item={item} />;
 	}
 
-	const body = partition(item.body).oks;
+	const body = Result.partition(item.body).oks;
 	const render = renderWithAds(shouldHideAds);
 
 	if (item.theme === ArticleSpecial.Labs) {

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -3,7 +3,7 @@ import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { map, partition, withDefault } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import { LastUpdated } from 'components/LastUpdated';
 import type { Contributor } from 'contributor';
 import { datetimeFormat, timestampFormat } from 'datetime';
@@ -11,6 +11,7 @@ import { pipe } from 'lib';
 import type { LiveBlock as LiveBlockType } from 'liveBlock';
 import type { FC } from 'react';
 import { renderAll } from 'renderer';
+import { Result } from 'result';
 
 // ----- Functions ----- //
 
@@ -57,7 +58,7 @@ const LiveBlock: FC<LiveBlockProps> = ({
 			supportsDarkMode={true}
 			contributors={block.contributors.map(contributorToBlockContributor)}
 		>
-			{renderAll(format, partition(block.body).oks)}
+			{renderAll(format, Result.partition(block.body).oks)}
 
 			<footer
 				css={css`

--- a/apps-rendering/src/components/editions/byline/byline.stories.tsx
+++ b/apps-rendering/src/components/editions/byline/byline.stories.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { none, some, toOption } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
@@ -15,7 +15,6 @@ import {
 	review,
 } from 'fixtures/item';
 import type { Image } from 'image';
-import { pipe } from 'lib';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Byline from './index';
@@ -58,11 +57,9 @@ const byline = (): string => text('Byline', 'Jane Smith');
 const job = (): string => text('Job Title', 'Editor of things');
 
 const mockBylineHtml = (): Option<DocumentFragment> =>
-	pipe(
+	parseByline(
 		`<a href="${profileLink()}">${byline()}</a> ${job()}`,
-		parseByline,
-		toOption,
-	);
+	).toOption();
 
 const isImmersive = (): { display: ArticleDisplay } => {
 	return {

--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -11,11 +11,11 @@ import {
 	neutral,
 	remSpace,
 } from '@guardian/source-foundations';
-import { partition } from '@guardian/types';
 import type { Item } from 'item';
 import { isPicture } from 'item';
 import type { FC } from 'react';
 import { renderEditionsAll } from 'renderer';
+import { Result } from 'result';
 import Header from '../header';
 import {
 	articleMarginStyles,
@@ -214,7 +214,10 @@ const Layout: FC<Props> = ({ item }) => {
 							className={'body-content'}
 							css={bodyStyles(item)}
 						>
-							{renderEditionsAll(item, partition(item.body).oks)}
+							{renderEditionsAll(
+								item,
+								Result.partition(item.body).oks,
+							)}
 						</section>
 					</div>
 				</article>

--- a/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
@@ -1,12 +1,10 @@
 // ----- Imports ----- //
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
-import { toOption } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { analysis, article, comment, media } from 'fixtures/item';
-import { pipe } from 'lib';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from '.';
@@ -16,11 +14,9 @@ import Standfirst from '.';
 const parser = new DOMParser();
 const parseStandfirst = parse(parser);
 
-const standfirst: Option<DocumentFragment> = pipe(
+const standfirst: Option<DocumentFragment> = parseStandfirst(
 	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
-	parseStandfirst,
-	toOption,
-);
+).toOption();
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/embed.ts
+++ b/apps-rendering/src/embed.ts
@@ -2,11 +2,7 @@
 
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
-import {
-	andThen,
-	fromNullable,
-	withDefault,
-} from '@guardian/types';
+import { andThen, fromNullable, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { parseIntOpt, pipe, resultFromNullable } from 'lib';
 import type { DocParser } from 'parserContext';
@@ -154,11 +150,13 @@ const parseIframe =
 			),
 		).flatMap(iframeAttributes);
 
-const genericHeight = (parser: DocParser) => (html: string): number =>
-	parseIframe(parser)(html).either(
-		(_) => 300,
-		(attrs) => attrs.height,
-	);
+const genericHeight =
+	(parser: DocParser) =>
+	(html: string): number =>
+		parseIframe(parser)(html).either(
+			(_) => 300,
+			(attrs) => attrs.height,
+		);
 
 const isGuardianDomain = (href: string): boolean => {
 	try {
@@ -322,14 +320,16 @@ const parseGenericInstagram =
 	(element: BlockElement): Result<string, Instagram> =>
 		extractGenericHtml(element)
 			.flatMap(extractInstagramId(parser))
-			.map((id: string): Instagram => ({
-				kind: EmbedKind.Instagram,
-				id,
-				caption: fromNullable(element.embedTypeData?.alt),
-				tracking:
-					element.tracking?.tracks ??
-					EmbedTracksType.DOES_NOT_TRACK,
-			}));
+			.map(
+				(id: string): Instagram => ({
+					kind: EmbedKind.Instagram,
+					id,
+					caption: fromNullable(element.embedTypeData?.alt),
+					tracking:
+						element.tracking?.tracks ??
+						EmbedTracksType.DOES_NOT_TRACK,
+				}),
+			);
 
 const emailFromIframe =
 	(element: BlockElement) =>
@@ -378,8 +378,8 @@ const parseGeneric =
 			return emailSignup;
 		}
 
-		return extractGenericHtml(element)
-			.map((html: string): Generic | TikTok => ({
+		return extractGenericHtml(element).map(
+			(html: string): Generic | TikTok => ({
 				kind: parseGenericEmbedKind(parser)(element)(html),
 				alt: fromNullable(element.embedTypeData?.alt),
 				html,
@@ -390,7 +390,8 @@ const parseGeneric =
 				// If there's no tracking information the embed does not track
 				tracking:
 					element.tracking?.tracks ?? EmbedTracksType.DOES_NOT_TRACK,
-			}));
+			}),
+		);
 	};
 
 // ----- Exports ----- //

--- a/apps-rendering/src/fixtures/galleryBody.ts
+++ b/apps-rendering/src/fixtures/galleryBody.ts
@@ -1,4 +1,5 @@
 import type { Body } from 'bodyElement';
+import { Result } from 'result';
 
 const captionFragment = (headline: string, body: string): DocumentFragment => {
 	const frag = new DocumentFragment();
@@ -11,126 +12,114 @@ const captionFragment = (headline: string, body: string): DocumentFragment => {
 };
 
 export const galleryBody: Body = [
-	{
-		kind: 0,
-		value: {
-			kind: 1,
-			src: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3',
-			srcset: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=45&fit=bounds&s=253ff45edb114b0605b7bce66b7f78f3 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=45&fit=bounds&s=3be9e2a7e7f1b2ac4efab144d6c07a28 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=45&fit=bounds&s=14c3c8f7d54a8d8794664492efc68641 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=45&fit=bounds&s=2745788813a433224e06421647d60b2c 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=45&fit=bounds&s=dcdc2c3d03aee717124c58914a5c39de 2000w',
-			alt: {
-				kind: 0,
-				value: 'Washington, DC, US Subcommittee chair Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol, during a House Judiciary subcommittee on Crime, Terrorism, and Homeland Security hearing',
-			},
-			width: 5699,
-			height: 3799,
-			caption: {
-				kind: 0,
-				value: captionFragment(
-					'Washington DC, US',
-					'Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing',
-				),
-			},
-			credit: { kind: 0, value: 'Photograph: Al Drago/Getty Images' },
-			nativeCaption: {
-				kind: 0,
-				value: '<strong>Washington DC, US</strong> <br><br>Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing',
-			},
-			role: 0,
+	Result.ok({
+		kind: 1,
+		src: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3',
+		srcset: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w',
+		dpr2Srcset:
+			'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=45&fit=bounds&s=253ff45edb114b0605b7bce66b7f78f3 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=45&fit=bounds&s=3be9e2a7e7f1b2ac4efab144d6c07a28 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=45&fit=bounds&s=14c3c8f7d54a8d8794664492efc68641 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=45&fit=bounds&s=2745788813a433224e06421647d60b2c 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=45&fit=bounds&s=dcdc2c3d03aee717124c58914a5c39de 2000w',
+		alt: {
+			kind: 0,
+			value: 'Washington, DC, US Subcommittee chair Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol, during a House Judiciary subcommittee on Crime, Terrorism, and Homeland Security hearing',
 		},
-	},
-	{
-		kind: 0,
-		value: {
-			kind: 1,
-			src: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063',
-			srcset: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=45&fit=bounds&s=20c42477022d7ce2b2ac2d0b5cb688de 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=45&fit=bounds&s=dff09e82b640f93f268212b3a0de5b4e 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=45&fit=bounds&s=a4e0cdc7de19d34a17c874c3a81a1ebe 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=45&fit=bounds&s=478eaedffbc1085109b5b4e29f2200b9 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=45&fit=bounds&s=e8e63bb3ec8ead5b6607b25fea2cd528 2000w',
-			alt: {
-				kind: 0,
-				value: 'Prayagraj, India A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers, during Magh Mela festival',
-			},
-			width: 5472,
-			height: 3648,
-			caption: {
-				kind: 0,
-				value: captionFragment(
-					'Prayagraj, India',
-					'A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers',
-				),
-			},
-			credit: { kind: 0, value: 'Photograph: Rajesh Kumar Singh/AP' },
-			nativeCaption: {
-				kind: 0,
-				value: '<strong>Prayagraj, India</strong> <br><br>A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers',
-			},
-			role: 0,
+		width: 5699,
+		height: 3799,
+		caption: {
+			kind: 0,
+			value: captionFragment(
+				'Washington DC, US',
+				'Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing',
+			),
 		},
-	},
-	{
-		kind: 0,
-		value: {
-			kind: 1,
-			src: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c',
-			srcset: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=45&fit=bounds&s=b6beebe9a75fe6d5ce9475c0d13e429c 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=45&fit=bounds&s=1516f1b11f5a186d13bc2e7dc56eecde 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=45&fit=bounds&s=665b8f94e20042d415967c7a382cd561 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=45&fit=bounds&s=7bb7869708fa9d17b025aa334ba3a564 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=45&fit=bounds&s=3c40f4ca2a68a4393201f94f025eb68a 2000w',
-			alt: {
-				kind: 0,
-				value: 'Hua Hin, Thailand A bird flies over the abandoned sculpture of a Buddhist monk in Cha-am outside Hua Hin, south of Bangkok',
-			},
-			width: 4482,
-			height: 2988,
-			caption: {
-				kind: 0,
-				value: captionFragment(
-					'Hua Hin, Thailand',
-					'A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok',
-				),
-			},
-			credit: {
-				kind: 0,
-				value: 'Photograph: Mladen Antonov/AFP/Getty Images',
-			},
-			nativeCaption: {
-				kind: 0,
-				value: '<strong>Hua Hin, Thailand <br><br></strong>A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok',
-			},
-			role: 0,
+		credit: { kind: 0, value: 'Photograph: Al Drago/Getty Images' },
+		nativeCaption: {
+			kind: 0,
+			value: '<strong>Washington DC, US</strong> <br><br>Sheila Jackson Lee shows a photograph from the 6 January attack on the US Capitol during a House judiciary subcommittee hearing',
 		},
-	},
-	{
-		kind: 0,
-		value: {
-			kind: 1,
-			src: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867',
-			srcset: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=45&fit=bounds&s=0f3c3dbd3fc24dc38b6a25593933d036 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=45&fit=bounds&s=3eb9e25c8e38ec8ae5e9b0a7e10c6c67 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=45&fit=bounds&s=317b489ad130fde80b1ea52214b0341a 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=45&fit=bounds&s=e0770f452eb0745fa25c47b78cdff4b4 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=45&fit=bounds&s=798fd1d9b81dc6b3fa425022e6201e64 2000w',
-			alt: {
-				kind: 0,
-				value: 'Mulhouse, France A polar bear cub makes its first steps outside, in an enclosure at the Zoological and Botanical park in eastern France. The cub was born in November 2020',
-			},
-			width: 3600,
-			height: 2400,
-			caption: {
-				kind: 0,
-				value: captionFragment(
-					'Mulhouse, France',
-					'A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park',
-				),
-			},
-			credit: {
-				kind: 0,
-				value: 'Photograph: Sébastien Bozon/AFP/Getty Images',
-			},
-			nativeCaption: {
-				kind: 0,
-				value: '<strong>Mulhouse, France</strong> <br><br>A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park',
-			},
-			role: 0,
+		role: 0,
+	}),
+	Result.ok({
+		kind: 1,
+		src: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063',
+		srcset: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w',
+		dpr2Srcset:
+			'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=45&fit=bounds&s=20c42477022d7ce2b2ac2d0b5cb688de 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=45&fit=bounds&s=dff09e82b640f93f268212b3a0de5b4e 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=45&fit=bounds&s=a4e0cdc7de19d34a17c874c3a81a1ebe 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=45&fit=bounds&s=478eaedffbc1085109b5b4e29f2200b9 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=45&fit=bounds&s=e8e63bb3ec8ead5b6607b25fea2cd528 2000w',
+		alt: {
+			kind: 0,
+			value: 'Prayagraj, India A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers, during Magh Mela festival',
 		},
-	},
+		width: 5472,
+		height: 3648,
+		caption: {
+			kind: 0,
+			value: captionFragment(
+				'Prayagraj, India',
+				'A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers',
+			),
+		},
+		credit: { kind: 0, value: 'Photograph: Rajesh Kumar Singh/AP' },
+		nativeCaption: {
+			kind: 0,
+			value: '<strong>Prayagraj, India</strong> <br><br>A Hindu holy man lies in front of an image of the goddess of learning at Sangam, the sacred confluence of the Ganga, Yamuna and Saraswati rivers',
+		},
+		role: 0,
+	}),
+	Result.ok({
+		kind: 1,
+		src: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c',
+		srcset: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w',
+		dpr2Srcset:
+			'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=45&fit=bounds&s=b6beebe9a75fe6d5ce9475c0d13e429c 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=45&fit=bounds&s=1516f1b11f5a186d13bc2e7dc56eecde 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=45&fit=bounds&s=665b8f94e20042d415967c7a382cd561 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=45&fit=bounds&s=7bb7869708fa9d17b025aa334ba3a564 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=45&fit=bounds&s=3c40f4ca2a68a4393201f94f025eb68a 2000w',
+		alt: {
+			kind: 0,
+			value: 'Hua Hin, Thailand A bird flies over the abandoned sculpture of a Buddhist monk in Cha-am outside Hua Hin, south of Bangkok',
+		},
+		width: 4482,
+		height: 2988,
+		caption: {
+			kind: 0,
+			value: captionFragment(
+				'Hua Hin, Thailand',
+				'A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok',
+			),
+		},
+		credit: {
+			kind: 0,
+			value: 'Photograph: Mladen Antonov/AFP/Getty Images',
+		},
+		nativeCaption: {
+			kind: 0,
+			value: '<strong>Hua Hin, Thailand <br><br></strong>A bird flies over the abandoned sculpture of a Buddhist monk south of Bangkok',
+		},
+		role: 0,
+	}),
+	Result.ok({
+		kind: 1,
+		src: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867',
+		srcset: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w',
+		dpr2Srcset:
+			'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=45&fit=bounds&s=0f3c3dbd3fc24dc38b6a25593933d036 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=45&fit=bounds&s=3eb9e25c8e38ec8ae5e9b0a7e10c6c67 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=45&fit=bounds&s=317b489ad130fde80b1ea52214b0341a 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=45&fit=bounds&s=e0770f452eb0745fa25c47b78cdff4b4 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=45&fit=bounds&s=798fd1d9b81dc6b3fa425022e6201e64 2000w',
+		alt: {
+			kind: 0,
+			value: 'Mulhouse, France A polar bear cub makes its first steps outside, in an enclosure at the Zoological and Botanical park in eastern France. The cub was born in November 2020',
+		},
+		width: 3600,
+		height: 2400,
+		caption: {
+			kind: 0,
+			value: captionFragment(
+				'Mulhouse, France',
+				'A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park',
+			),
+		},
+		credit: {
+			kind: 0,
+			value: 'Photograph: Sébastien Bozon/AFP/Getty Images',
+		},
+		nativeCaption: {
+			kind: 0,
+			value: '<strong>Mulhouse, France</strong> <br><br>A polar bear cub takes its first steps outside in an enclosure at the zoological and botanical park',
+		},
+		role: 0,
+	}),
 ];

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -57,18 +57,19 @@ const parseHtml = (html: string): Option<DocumentFragment> =>
 const headline =
 	'Reclaimed lakes and giant airports: how Mexico City might have looked';
 
-const standfirst =
-	parseHtml('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>');
+const standfirst = parseHtml(
+	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
+);
 
+const standfirstWithLink = parseHtml(
+	'<p>Boris Johnson’s spokesperson says ‘it’s deeply regrettable that this took place at a time of national mourning’</p><ul><li><a href="https://www.theguardian.com/world/series/coronavirus-live/latest">Coronavirus – latest updates</a></li><li><a href="https://www.theguardian.com/world/coronavirus-outbreak">See all our coronavirus coverage</a></li></ul>',
+);
 
-const standfirstWithLink =
-	parseHtml('<p>Boris Johnson’s spokesperson says ‘it’s deeply regrettable that this took place at a time of national mourning’</p><ul><li><a href="https://www.theguardian.com/world/series/coronavirus-live/latest">Coronavirus – latest updates</a></li><li><a href="https://www.theguardian.com/world/coronavirus-outbreak">See all our coronavirus coverage</a></li></ul>');
+const bylineHtml = parseHtml(
+	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
+);
 
-const bylineHtml =
-	parseHtml('<a href="https://theguardian.com">Jane Smith</a> Editor of things');
-
-const captionDocFragment =
-	parseHtml('<em>Jane Smith</em> Editor of things');
+const captionDocFragment = parseHtml('<em>Jane Smith</em> Editor of things');
 
 const docFixture = (): Node => {
 	const doc = new DocumentFragment();

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -10,7 +10,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { none, OptionKind, partition, some } from '@guardian/types';
+import { none, OptionKind, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -399,7 +399,7 @@ const articleWithStandfirstLink: Item = {
 };
 
 const outlineFromItem = (body: Body): Outline => {
-	const elements = partition(body).oks;
+	const elements = Result.partition(body).oks;
 	return fromBodyElements(elements);
 };
 const analysis: Analysis = {

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -10,14 +10,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import {
-	none,
-	OptionKind,
-	partition,
-	ResultKind,
-	some,
-	toOption,
-} from '@guardian/types';
+import { none, OptionKind, partition, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
@@ -42,46 +35,40 @@ import type {
 	Review,
 	Standard,
 } from 'item';
-import { pipe } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
 import type { Outline } from 'outline';
 import { fromBodyElements } from 'outline';
+import { Result } from 'result';
 import { galleryBody } from './galleryBody';
 import { relatedContent } from './relatedContent';
 
 // ----- Fixture ----- //
 
 const parser = new DOMParser();
-const parseHtml = parse(parser);
+const parseHtml = (html: string): Option<DocumentFragment> =>
+	parse(parser)(html).either<Option<DocumentFragment>>(
+		(_err) => none,
+		(doc) => some(doc),
+	);
 
 const headline =
 	'Reclaimed lakes and giant airports: how Mexico City might have looked';
 
-const standfirst: Option<DocumentFragment> = pipe(
-	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
-	parseHtml,
-	toOption,
-);
+const standfirst =
+	parseHtml('<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>');
 
-const standfirstWithLink: Option<DocumentFragment> = pipe(
-	'<p>Boris Johnson’s spokesperson says ‘it’s deeply regrettable that this took place at a time of national mourning’</p><ul><li><a href="https://www.theguardian.com/world/series/coronavirus-live/latest">Coronavirus – latest updates</a></li><li><a href="https://www.theguardian.com/world/coronavirus-outbreak">See all our coronavirus coverage</a></li></ul>',
-	parseHtml,
-	toOption,
-);
-const bylineHtml: Option<DocumentFragment> = pipe(
-	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
-	parseHtml,
-	toOption,
-);
 
-const captionDocFragment: Option<DocumentFragment> = pipe(
-	'<em>Jane Smith</em> Editor of things',
-	parseHtml,
-	toOption,
-);
+const standfirstWithLink =
+	parseHtml('<p>Boris Johnson’s spokesperson says ‘it’s deeply regrettable that this took place at a time of national mourning’</p><ul><li><a href="https://www.theguardian.com/world/series/coronavirus-live/latest">Coronavirus – latest updates</a></li><li><a href="https://www.theguardian.com/world/coronavirus-outbreak">See all our coronavirus coverage</a></li></ul>');
+
+const bylineHtml =
+	parseHtml('<a href="https://theguardian.com">Jane Smith</a> Editor of things');
+
+const captionDocFragment =
+	parseHtml('<em>Jane Smith</em> Editor of things');
 
 const docFixture = (): Node => {
 	const doc = new DocumentFragment();
@@ -183,124 +170,85 @@ const mainMedia: Option<MainMedia> = {
 const doc = docFixture();
 
 const body: Body = [
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.HeadingTwo,
+		id: Optional.some('who-qualifies-for-student-loan-forgiveness'),
+		doc: h2ElementWithSub(),
+	}),
+	Result.ok({
+		kind: ElementKind.Image,
+		src: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d',
+		srcset: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w',
+		dpr2Srcset:
+			'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w',
+		alt: {
+			kind: OptionKind.Some,
+			value: 'Jane Giddins outside her home in Newton St Loe',
 		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.HeadingTwo,
-			id: Optional.some('who-qualifies-for-student-loan-forgiveness'),
-			doc: h2ElementWithSub(),
+		width: 2000,
+		height: 2500,
+		caption: none,
+		credit: {
+			kind: OptionKind.Some,
+			value: 'Photograph: Sam Frost/The Guardian',
 		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Image,
-			src: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d',
-			srcset: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w',
-			dpr2Srcset:
-				'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=45&fit=bounds&s=498eae817a853dc03b77fc3fb3508d67 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=45&fit=bounds&s=005b16c339d71fe13ef0946afbc6923d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=45&fit=bounds&s=d49f1edee81d825f0d5402b45f228314 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=45&fit=bounds&s=ed564fd8a52304188fdc419a0838ed0f 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=45&fit=bounds&s=53c0fa1df2ec23b439c488d3801778e3 2000w',
-			alt: {
-				kind: OptionKind.Some,
-				value: 'Jane Giddins outside her home in Newton St Loe',
-			},
-			width: 2000,
-			height: 2500,
-			caption: none,
-			credit: {
-				kind: OptionKind.Some,
-				value: 'Photograph: Sam Frost/The Guardian',
-			},
-			nativeCaption: {
-				kind: OptionKind.Some,
-				value: 'Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles.',
-			},
-			role: ArticleElementRole.Standard,
+		nativeCaption: {
+			kind: OptionKind.Some,
+			value: 'Jane Giddins outside her home in Newton St Loe, Somerset. She is denied the legal right to buy the freehold because of an exemption granted to Prince Charles.',
 		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.HeadingTwo,
-			id: Optional.some('how-the-student-debt-crisis-started'),
-			doc: elementFixture('h2', 'How the student debt crisis started?'),
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.GuideAtom,
-			html: "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
-			title: "What is Queen's consent?",
-			id: '575888ee-9973-4256-9a96-bad4b9c65d81',
-			image: undefined,
-			credit: undefined,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.HeadingTwo,
-			id: Optional.some('what-student-debt-looks-like-today'),
-			doc: elementFixture('h2', 'What student debt looks like today?'),
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Pullquote,
-			quote: 'Why should the crown be allowed to carry on with a feudal system just because they want to?',
-			attribution: { kind: 0, value: 'Jane Giddins' },
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
-	{
-		kind: ResultKind.Ok,
-		value: {
-			kind: ElementKind.Text,
-			doc,
-		},
-	},
+		role: ArticleElementRole.Standard,
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.HeadingTwo,
+		id: Optional.some('how-the-student-debt-crisis-started'),
+		doc: elementFixture('h2', 'How the student debt crisis started?'),
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.GuideAtom,
+		html: "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
+		title: "What is Queen's consent?",
+		id: '575888ee-9973-4256-9a96-bad4b9c65d81',
+		image: undefined,
+		credit: undefined,
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.HeadingTwo,
+		id: Optional.some('what-student-debt-looks-like-today'),
+		doc: elementFixture('h2', 'What student debt looks like today?'),
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.Pullquote,
+		quote: 'Why should the crown be allowed to carry on with a feudal system just because they want to?',
+		attribution: { kind: 0, value: 'Jane Giddins' },
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
+	Result.ok({
+		kind: ElementKind.Text,
+		doc,
+	}),
 ];
 
 const pinnedBlock: LiveBlock = {
@@ -310,13 +258,10 @@ const pinnedBlock: LiveBlock = {
 	firstPublished: new Date('2021-11-02T10:20:20Z'),
 	lastModified: new Date('2021-11-02T11:13:13Z'),
 	body: [
-		{
-			kind: ResultKind.Ok,
-			value: {
-				kind: ElementKind.Text,
-				doc,
-			},
-		},
+		Result.ok({
+			kind: ElementKind.Text,
+			doc,
+		}),
 	],
 	contributors: [],
 	isPinned: true,

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -7,11 +7,10 @@ import {
 	ArticleElementRole,
 	ArticlePillar,
 } from '@guardian/libs';
-import { none, OptionKind, some, toOption } from '@guardian/types';
+import { none, OptionKind, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { parse } from 'client/parser';
 import type { DeadBlog, LiveBlog } from 'item';
-import { pipe } from 'lib';
 import type { LiveBlock } from 'liveBlock';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
@@ -23,22 +22,17 @@ const parseHtml = parse(parser);
 const headline =
 	'Covid live: Brazil health minister who shook hands with maskless Boris Johnson at UN tests positive';
 
-const standfirst: Option<DocumentFragment> = pipe(
+const standfirst: Option<DocumentFragment> = parseHtml(
 	'<p><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ae7e58f08b228c9498279#block-614ae7e58f08b228c9498279">Marcelo Quiroga tests positive</a> at UN general assembly in New York; <a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ad64b8f087b5c6fb4a8dc#block-614ad64b8f087b5c6fb4a8dc">Australia tourism minister says</a> on track to reopen borders ‘by Christmas’</p>\n<ul>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/2021/sep/22/calculated-risk-ardern-gambles-as-new-zealand-covid-restrictions-eased">Ardern gambles as New Zealand Covid restrictions eased</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/australia-news/2021/sep/22/riot-police-on-melbourne-streets-to-prevent-third-day-of-protests">Riot police on Melbourne streets to prevent third day of protests</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/global-development/2021/sep/21/argentina-to-lift-almost-all-covid-restrictions-as-cases-and-deaths-fall">Argentina to lift almost all Covid restrictions as cases and deaths fall</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/education/2021/sep/21/more-than-100000-pupils-off-school-in-england-last-week-amid-covid-surge">‘High alert’ warning as more than 100,000 pupils in England miss school</a></li>\n</ul>',
-	parseHtml,
-	toOption,
-);
+).toOption();
 
-const bylineHtml: Option<DocumentFragment> = pipe(
+const bylineHtml: Option<DocumentFragment> = parseHtml(
 	'<a href="https://theguardian.com">Tom Ambrose</a> (now); <a href="https://theguardian.com">Miranda Bryant</a> and <a href="https://theguardian.com">Helen Sullivan</a> (earlier)',
-	parseHtml,
-	toOption,
-);
-const captionDocFragment: Option<DocumentFragment> = pipe(
+).toOption();
+
+const captionDocFragment: Option<DocumentFragment> = parseHtml(
 	'<em>Jane Smith</em> Editor of things',
-	parseHtml,
-	toOption,
-);
+).toOption();
 
 const mainMedia: Option<MainMedia> = {
 	kind: OptionKind.Some,

--- a/apps-rendering/src/image/srcsets.ts
+++ b/apps-rendering/src/image/srcsets.ts
@@ -35,27 +35,26 @@ const sign = (salt: string, path: string): string =>
 		.digest('hex');
 
 function src(salt: string, input: string, width: number, dpr: Dpr): string {
-	return Result.fromUnsafe(() => new URL(input), 'invalid url')
-		.either(
-			(_err) => input,
-			(url) => {
-				const service = getSubdomain(url.hostname);
+	return Result.fromUnsafe(() => new URL(input), 'invalid url').either(
+		(_err) => input,
+		(url) => {
+			const service = getSubdomain(url.hostname);
 
-				const params = new URLSearchParams({
-					width: width.toString(),
-					quality:
-						dpr === Dpr.Two
-							? lowerQuality.toString()
-							: defaultQuality.toString(),
-					fit: 'bounds',
-				});
+			const params = new URLSearchParams({
+				width: width.toString(),
+				quality:
+					dpr === Dpr.Two
+						? lowerQuality.toString()
+						: defaultQuality.toString(),
+				fit: 'bounds',
+			});
 
-				const path = `${url.pathname}?${params.toString()}`;
-				const sig = sign(salt, path);
+			const path = `${url.pathname}?${params.toString()}`;
+			const sig = sign(salt, path);
 
-				return `${imageResizer}/${service}${path}&s=${sig}`;
-			}
-		);
+			return `${imageResizer}/${service}${path}&s=${sig}`;
+		},
+	);
 }
 
 const srcsetWithWidths =

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -18,7 +18,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { fromNullable, map, none, partition } from '@guardian/types';
+import { fromNullable, map, none } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
@@ -48,6 +48,7 @@ import { fromBodyElements } from 'outline';
 import type { LiveBlogPagedBlocks } from 'pagination';
 import { getPagedBlocks } from 'pagination';
 import type { Context } from 'parserContext';
+import { Result } from 'result';
 import { themeFromString } from 'themeStyles';
 
 // ----- Item Type ----- //
@@ -323,7 +324,7 @@ const itemFields = (
 };
 
 const outlineFromItem = (item: ItemFieldsWithBody): Outline => {
-	const elements = partition(item.body).oks;
+	const elements = Result.partition(item.body).oks;
 	return fromBodyElements(elements);
 };
 

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -86,7 +86,9 @@ const resultMap3 =
 	<E>(resultA: Result<E, A>) =>
 	(resultB: Result<E, B>) =>
 	(resultC: Result<E, C>): Result<E, D> =>
-		resultA.flatMap(a => resultB.flatMap(b => resultC.map(c => f(a, b, c))));
+		resultA.flatMap((a) =>
+			resultB.flatMap((b) => resultC.map((c) => f(a, b, c))),
+		);
 
 const optionMap3 =
 	<A, B, C, D>(f: (a: A, b: B, c: C) => D) =>
@@ -108,7 +110,7 @@ const resultMap2 =
 	<A, B, C>(f: (a: A, b: B) => C) =>
 	<E>(resultA: Result<E, A>) =>
 	(resultB: Result<E, B>): Result<E, C> =>
-		resultA.flatMap(a => resultB.map(b => f(a, b)));
+		resultA.flatMap((a) => resultB.map((b) => f(a, b)));
 
 const fold =
 	<A, B>(f: (value: A) => B, ifNone: B) =>

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -1,19 +1,17 @@
 // ----- Imports ----- //
 
 import { maybeRender, pipe } from '@guardian/common-rendering/src/lib';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import {
-	err,
 	fromNullable,
 	map,
 	none,
-	ok,
 	OptionKind,
-	ResultKind,
 	some,
 	withDefault,
 } from '@guardian/types';
 import { Optional } from 'optional';
+import { Result } from 'result';
 
 // ----- Functions ----- //
 
@@ -75,7 +73,7 @@ const indexOptional =
 const resultFromNullable =
 	<E>(e: E) =>
 	<A>(a: A | null | undefined): Result<E, A> =>
-		a === null || a === undefined ? err(e) : ok(a);
+		a === null || a === undefined ? Result.err(e) : Result.ok(a);
 
 const parseIntOpt = (int: string): Option<number> => {
 	const parsed = parseInt(int);
@@ -87,21 +85,8 @@ const resultMap3 =
 	<A, B, C, D>(f: (a: A, b: B, c: C) => D) =>
 	<E>(resultA: Result<E, A>) =>
 	(resultB: Result<E, B>) =>
-	(resultC: Result<E, C>): Result<E, D> => {
-		if (resultA.kind === ResultKind.Err) {
-			return resultA;
-		}
-
-		if (resultB.kind === ResultKind.Err) {
-			return resultB;
-		}
-
-		if (resultC.kind === ResultKind.Err) {
-			return resultC;
-		}
-
-		return ok(f(resultA.value, resultB.value, resultC.value));
-	};
+	(resultC: Result<E, C>): Result<E, D> =>
+		resultA.flatMap(a => resultB.flatMap(b => resultC.map(c => f(a, b, c))));
 
 const optionMap3 =
 	<A, B, C, D>(f: (a: A, b: B, c: C) => D) =>
@@ -117,22 +102,13 @@ const optionMap3 =
 	};
 
 const resultToNullable = <E, A>(result: Result<E, A>): A | undefined =>
-	result.kind === ResultKind.Ok ? result.value : undefined;
+	result.isOk() ? result.value : undefined;
 
 const resultMap2 =
 	<A, B, C>(f: (a: A, b: B) => C) =>
 	<E>(resultA: Result<E, A>) =>
-	(resultB: Result<E, B>): Result<E, C> => {
-		if (resultA.kind === ResultKind.Err) {
-			return resultA;
-		}
-
-		if (resultB.kind === ResultKind.Err) {
-			return resultB;
-		}
-
-		return ok(f(resultA.value, resultB.value));
-	};
+	(resultB: Result<E, B>): Result<E, C> =>
+		resultA.flatMap(a => resultB.map(b => f(a, b)));
 
 const fold =
 	<A, B>(f: (value: A) => B, ifNone: B) =>

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -2,14 +2,14 @@
 
 import type { Block } from '@guardian/content-api-models/v1/block';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import type { Result } from '@guardian/types';
-import { err, ok, OptionKind, partition } from '@guardian/types';
+import { OptionKind } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
 import type { Contributor } from 'contributor';
 import { tagToContributor } from 'contributor';
 import type { Context } from 'parserContext';
+import { Result } from 'result';
 
 // ----- Types ----- //
 
@@ -45,18 +45,18 @@ const parse =
 		const lastModifiedDate = maybeCapiDate(block.lastModifiedDate);
 
 		if (firstPublishedDate.kind === OptionKind.None) {
-			return err(
+			return Result.err(
 				"Could not parse live block: 'firstPublishedDate' was invalid",
 			);
 		}
 
 		if (lastModifiedDate.kind === OptionKind.None) {
-			return err(
+			return Result.err(
 				"Could not parse live block: 'lastModifiedDate' was invalid",
 			);
 		}
 
-		return ok({
+		return Result.ok({
 			id: block.id,
 			isKeyEvent: block.attributes.keyEvent ?? false,
 			title: block.title ?? '',
@@ -74,7 +74,7 @@ const parse =
 const parseMany =
 	(context: Context) =>
 	(blocks: Block[], tags: Tag[]): LiveBlock[] =>
-		partition(blocks.map(parse(context, tags))).oks;
+		Result.partition(blocks.map(parse(context, tags))).oks;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/parser.test.ts
+++ b/apps-rendering/src/parser.test.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { err, none, ok, ResultKind } from '@guardian/types';
+import { Optional } from 'optional';
+import { Result } from 'result';
 import {
 	maybe,
 	dateParser,
@@ -22,7 +23,7 @@ describe('parser', () => {
 			const fooParser = succeed('foo');
 
 			const result = parse(fooParser)(42);
-			expect(result).toStrictEqual(ok('foo'));
+			expect(result).toStrictEqual(Result.ok('foo'));
 		});
 	});
 
@@ -31,7 +32,7 @@ describe('parser', () => {
 			const fooParser = parseFail('Uh oh!');
 			const result = parse(fooParser)(42);
 
-			expect(result).toStrictEqual(err('Uh oh!'));
+			expect(result).toStrictEqual(Result.err('Uh oh!'));
 		});
 	});
 
@@ -42,14 +43,14 @@ describe('parser', () => {
 			const parser = fieldParser('foo', numberParser);
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 
 		it('runs the parser over a given input and provides a failed `err` result', () => {
 			const parser = fieldParser('bar', numberParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 	});
 
@@ -58,21 +59,21 @@ describe('parser', () => {
 			const input: unknown = 'foo';
 
 			const result = parse(stringParser)(input);
-			expect(result).toStrictEqual(ok('foo'));
+			expect(result).toStrictEqual(Result.ok('foo'));
 		});
 
 		it('produces a failed parsing result if the input is not a string', () => {
 			const inputOne: unknown = 42;
 			const resultOne = parse(stringParser)(inputOne);
-			expect(resultOne.kind).toBe(ResultKind.Err);
+			expect(resultOne.isErr()).toBe(true);
 
 			const inputTwo: unknown = ['foo', 'bar'];
 			const resultTwo = parse(stringParser)(inputTwo);
-			expect(resultTwo.kind).toBe(ResultKind.Err);
+			expect(resultTwo.isErr()).toBe(true);
 
 			const inputThree: unknown = { foo: 'bar' };
 			const resultThree = parse(stringParser)(inputThree);
-			expect(resultThree.kind).toBe(ResultKind.Err);
+			expect(resultThree.isErr()).toBe(true);
 		});
 	});
 
@@ -81,21 +82,21 @@ describe('parser', () => {
 			const input: unknown = 42;
 
 			const result = parse(numberParser)(input);
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 
 		it('produces a failed parsing result if the input is not a number', () => {
 			const inputOne: unknown = 'foo';
 			const resultOne = parse(numberParser)(inputOne);
-			expect(resultOne.kind).toBe(ResultKind.Err);
+			expect(resultOne.isErr()).toBe(true);
 
 			const inputTwo: unknown = ['foo', 'bar'];
 			const resultTwo = parse(numberParser)(inputTwo);
-			expect(resultTwo.kind).toBe(ResultKind.Err);
+			expect(resultTwo.isErr()).toBe(true);
 
 			const inputThree: unknown = { foo: 'bar' };
 			const resultThree = parse(numberParser)(inputThree);
-			expect(resultThree.kind).toBe(ResultKind.Err);
+			expect(resultThree.isErr()).toBe(true);
 		});
 	});
 
@@ -103,39 +104,39 @@ describe('parser', () => {
 		it('produces a successful parsing result if the input can make a valid Date', () => {
 			const inputOne: unknown = 42;
 			const resultOne = parse(dateParser)(inputOne);
-			expect(resultOne).toStrictEqual(ok(new Date(42)));
+			expect(resultOne).toStrictEqual(Result.ok(new Date(42)));
 
 			const inputTwo: unknown = '1970-01-01T00:00:00.042Z';
 			const resultTwo = parse(dateParser)(inputTwo);
 			expect(resultTwo).toStrictEqual(
-				ok(new Date('1970-01-01T00:00:00.042Z')),
+				Result.ok(new Date('1970-01-01T00:00:00.042Z')),
 			);
 
 			const inputThree: unknown = new Date(42);
 			const resultThree = parse(dateParser)(inputThree);
-			expect(resultThree).toStrictEqual(ok(new Date(42)));
+			expect(resultThree).toStrictEqual(Result.ok(new Date(42)));
 		});
 
 		it("produces a failed parsing result if the input can't make a valid Date", () => {
 			const inputOne: unknown = 'foo';
 			const resultOne = parse(dateParser)(inputOne);
-			expect(resultOne.kind).toBe(ResultKind.Err);
+			expect(resultOne.isErr()).toBe(true);
 
 			const inputTwo: unknown = NaN;
 			const resultTwo = parse(dateParser)(inputTwo);
-			expect(resultTwo.kind).toBe(ResultKind.Err);
+			expect(resultTwo.isErr()).toBe(true);
 
 			const inputThree: unknown = ['foo', 'bar'];
 			const resultThree = parse(dateParser)(inputThree);
-			expect(resultThree.kind).toBe(ResultKind.Err);
+			expect(resultThree.isErr()).toBe(true);
 
 			const inputFour: unknown = { foo: 'bar' };
 			const resultFour = parse(dateParser)(inputFour);
-			expect(resultFour.kind).toBe(ResultKind.Err);
+			expect(resultFour.isErr()).toBe(true);
 
 			const inputFive: unknown = new Date(NaN);
 			const resultFive = parse(dateParser)(inputFive);
-			expect(resultFive.kind).toBe(ResultKind.Err);
+			expect(resultFive.isErr()).toBe(true);
 		});
 	});
 
@@ -146,7 +147,7 @@ describe('parser', () => {
 			const parser = maybe(fieldParser('bar', numberParser));
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(ok(none));
+			expect(result).toStrictEqual(Result.ok(Optional.none()));
 		});
 
 		it("produces a failed parse result when it doesn't wrap the parser that fails", () => {
@@ -155,7 +156,7 @@ describe('parser', () => {
 			const parser = fieldParser('bar', maybe(numberParser));
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 	});
 
@@ -166,21 +167,21 @@ describe('parser', () => {
 			const parser = fieldParser('foo', numberParser);
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 
 		it("provides a failed parse result if the field doesn't exist", () => {
 			const parser = fieldParser('bar', numberParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 
 		it("provides a failed parse result if the value doesn't parse", () => {
 			const parser = fieldParser('foo', stringParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 	});
 
@@ -191,21 +192,21 @@ describe('parser', () => {
 			const parser = indexParser(1, numberParser);
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 
 		it("provides a failed parse result if the index doesn't exist", () => {
 			const parser = indexParser(7, numberParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 
 		it("provides a failed parse result if the value doesn't parse", () => {
 			const parser = indexParser(1, stringParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 	});
 
@@ -216,21 +217,21 @@ describe('parser', () => {
 			const parser = locationParser(['foo', 'bar'], numberParser);
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 
 		it('provides a failed parse result if the location does not exist', () => {
 			const parser = locationParser(['foo', 'baz'], numberParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 
 		it('provides a failed parse result if the location is empty and the value is nested', () => {
 			const parser = locationParser([], numberParser);
 			const result = parse(parser)(json);
 
-			expect(result.kind).toBe(ResultKind.Err);
+			expect(result.isErr()).toBe(true);
 		});
 
 		it('provides a successful parse result if the location is empty and the value is not nested', () => {
@@ -238,7 +239,7 @@ describe('parser', () => {
 			const parser = locationParser([], numberParser);
 			const result = parse(parser)(jsonB);
 
-			expect(result).toStrictEqual(ok(42));
+			expect(result).toStrictEqual(Result.ok(42));
 		});
 	});
 });

--- a/apps-rendering/src/parser.test.ts
+++ b/apps-rendering/src/parser.test.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Optional } from 'optional';
+import { none } from '@guardian/types';
 import { Result } from 'result';
 import {
 	maybe,
@@ -147,7 +147,7 @@ describe('parser', () => {
 			const parser = maybe(fieldParser('bar', numberParser));
 			const result = parse(parser)(json);
 
-			expect(result).toStrictEqual(Result.ok(Optional.none()));
+			expect(result).toStrictEqual(Result.ok(none));
 		});
 
 		it("produces a failed parse result when it doesn't wrap the parser that fails", () => {

--- a/apps-rendering/src/parser.ts
+++ b/apps-rendering/src/parser.ts
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import type { Option } from '@guardian/types';
-import { none, some } from '@guardian/types';
 import { Result } from 'result';
 
 // ----- Types ----- //
@@ -131,11 +130,7 @@ const dateParser: Parser<Date> = parser((a) => {
  * const resultB = parse(parserB)(json); // Err<string>, with 'missing field' err
  */
 const maybe = <A>(pa: Parser<A>): Parser<Option<A>> =>
-	parser((a) => {
-		const result = pa.run(a);
-
-		return Result.ok(result.isOk() ? some(result.value) : none);
-	});
+	parser((a) => Result.ok(pa.run(a).toOption()));
 
 // ----- Data Structure Parsers ----- //
 

--- a/apps-rendering/src/parser.ts
+++ b/apps-rendering/src/parser.ts
@@ -1,14 +1,7 @@
 // ----- Imports ----- //
 
-import type { Option, Result } from '@guardian/types';
-import {
-	err,
-	ok,
-	resultAndThen,
-	ResultKind,
-	resultMap,
-	toOption,
-} from '@guardian/types';
+import { Optional } from 'optional';
+import { Result } from 'result';
 
 // ----- Types ----- //
 
@@ -33,7 +26,7 @@ const parser = <A>(f: (a: unknown) => Result<string, A>): Parser<A> => ({
  *
  * const result = parse(fooParser)(42); // Ok<string>, with value 'foo'
  */
-const succeed = <A>(a: A): Parser<A> => parser((_) => ok(a));
+const succeed = <A>(a: A): Parser<A> => parser((_) => Result.ok(a));
 
 /**
  * Ignores whatever the input is and instead provides a failed parsing
@@ -46,7 +39,7 @@ const succeed = <A>(a: A): Parser<A> => parser((_) => ok(a));
  *
  * const result = parse(fooParser)(42); // Err<string>, with value 'Uh oh!'
  */
-const fail = <A>(e: string): Parser<A> => parser((_) => err(e));
+const fail = <A>(e: string): Parser<A> => parser((_) => Result.err(e));
 
 const isObject = (a: unknown): a is Record<string, unknown> =>
 	typeof a === 'object' && a !== null;
@@ -81,8 +74,8 @@ const parse =
  */
 const stringParser: Parser<string> = parser((a) =>
 	typeof a === 'string'
-		? ok(a)
-		: err(`Unable to parse ${String(a)} as a string`),
+		? Result.ok(a)
+		: Result.err(`Unable to parse ${String(a)} as a string`),
 );
 
 /**
@@ -90,8 +83,8 @@ const stringParser: Parser<string> = parser((a) =>
  */
 const numberParser: Parser<number> = parser((a) =>
 	typeof a === 'number' && !isNaN(a)
-		? ok(a)
-		: err(`Unable to parse ${String(a)} as a number`),
+		? Result.ok(a)
+		: Result.err(`Unable to parse ${String(a)} as a number`),
 );
 
 /**
@@ -99,8 +92,8 @@ const numberParser: Parser<number> = parser((a) =>
  */
 const booleanParser: Parser<boolean> = parser((a) =>
 	typeof a === 'boolean'
-		? ok(a)
-		: err(`Unable to parse ${String(a)} as a boolean`),
+		? Result.ok(a)
+		: Result.err(`Unable to parse ${String(a)} as a boolean`),
 );
 
 /**
@@ -111,13 +104,13 @@ const dateParser: Parser<Date> = parser((a) => {
 		const d = new Date(a);
 
 		if (d.toString() === 'Invalid Date') {
-			return err(`${String(a)} isn't a valid Date`);
+			return Result.err(`${String(a)} isn't a valid Date`);
 		}
 
-		return ok(d);
+		return Result.ok(d);
 	}
 
-	return err(`Can't transform ${String(a)} into a date`);
+	return Result.err(`Can't transform ${String(a)} into a date`);
 });
 
 /**
@@ -136,8 +129,8 @@ const dateParser: Parser<Date> = parser((a) => {
  * const parserB = fieldParser('bar', maybe(numberParser)); // Parser<Option<number>>
  * const resultB = parse(parserB)(json); // Err<string>, with 'missing field' err
  */
-const maybe = <A>(pa: Parser<A>): Parser<Option<A>> =>
-	parser((a) => ok(toOption(pa.run(a))));
+const maybe = <A>(pa: Parser<A>): Parser<Optional<A>> =>
+	parser((a) => Result.ok(pa.run(a).toOptional()));
 
 // ----- Data Structure Parsers ----- //
 
@@ -160,13 +153,13 @@ const maybe = <A>(pa: Parser<A>): Parser<Option<A>> =>
 const fieldParser = <A>(field: string, pa: Parser<A>): Parser<A> =>
 	parser((a) => {
 		if (!isObject(a)) {
-			return err(
+			return Result.err(
 				`Can't lookup field '${field}' on something that isn't an object`,
 			);
 		}
 
 		if (!(field in a)) {
-			return err(`Field ${field} doesn't exist in ${String(a)}`);
+			return Result.err(`Field ${field} doesn't exist in ${String(a)}`);
 		}
 
 		return pa.run(a[field]);
@@ -191,7 +184,7 @@ const fieldParser = <A>(field: string, pa: Parser<A>): Parser<A> =>
 const indexParser = <A>(index: number, pa: Parser<A>): Parser<A> =>
 	parser((a) => {
 		if (!Array.isArray(a)) {
-			return err(
+			return Result.err(
 				`Can't lookup index ${index} on something that isn't an Array`,
 			);
 		}
@@ -199,7 +192,7 @@ const indexParser = <A>(index: number, pa: Parser<A>): Parser<A> =>
 		const value: unknown = a[index];
 
 		if (value === undefined) {
-			return err(`Nothing found at index ${index}`);
+			return Result.err(`Nothing found at index ${index}`);
 		}
 
 		return pa.run(value);
@@ -244,20 +237,15 @@ const arrayParser = <A>(pa: Parser<A>): Parser<A[]> =>
 	parser((a) => {
 		const f = (acc: A[], remainder: unknown[]): Result<string, A[]> => {
 			if (remainder.length === 0) {
-				return ok(acc);
+				return Result.ok(acc);
 			}
 
 			const [item, ...tail] = remainder;
 			const parsed = pa.run(item);
 
-			if (parsed.kind === ResultKind.Ok) {
-				return f([...acc, parsed.value], tail);
-			}
-
-			return err(
-				`Could not parse array item ${String(item)} because ${
-					parsed.err
-				}`,
+			return parsed.either(
+				(err) => Result.err(`Could not parse array item ${String(item)} because ${err}`),
+				(a) => f([...acc, a], tail),
 			);
 		};
 
@@ -265,7 +253,7 @@ const arrayParser = <A>(pa: Parser<A>): Parser<A[]> =>
 			return f([], a);
 		}
 
-		return err(`Could not parse ${String(a)} as an array`);
+		return Result.err(`Could not parse ${String(a)} as an array`);
 	});
 
 // ----- Combinator Functions ----- //
@@ -290,7 +278,7 @@ const arrayParser = <A>(pa: Parser<A>): Parser<A[]> =>
 const map =
 	<A, B>(f: (a: A) => B) =>
 	(pa: Parser<A>): Parser<B> =>
-		parser((a) => resultMap(f)(pa.run(a)));
+		parser((a) => pa.run(a).map(f));
 
 /**
  * Similar to `map`. Will apply the given function `f` to the results of two
@@ -321,21 +309,13 @@ const map =
 const map2 =
 	<A, B, C>(f: (a: A, b: B) => C) =>
 	(pa: Parser<A>, pb: Parser<B>): Parser<C> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			return ok(f(resultA.value, resultB.value));
-		});
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).map(resB =>
+					f(resA, resB),
+				),
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -344,27 +324,15 @@ const map2 =
 const map3 =
 	<A, B, C, D>(f: (a: A, b: B, c: C) => D) =>
 	(pa: Parser<A>, pb: Parser<B>, pc: Parser<C>): Parser<D> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			return ok(f(resultA.value, resultB.value, resultC.value));
-		});
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).map(resC =>
+						f(resA, resB, resC),
+					),
+				),
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -373,35 +341,17 @@ const map3 =
 const map4 =
 	<A, B, C, D, E>(f: (a: A, b: B, c: C, d: D) => E) =>
 	(pa: Parser<A>, pb: Parser<B>, pc: Parser<C>, pd: Parser<D>): Parser<E> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			const resultD = pd.run(a);
-
-			if (resultD.kind === ResultKind.Err) {
-				return resultD;
-			}
-
-			return ok(
-				f(resultA.value, resultB.value, resultC.value, resultD.value),
-			);
-		});
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).flatMap(resC =>
+						pd.run(a).map(resD =>
+							f(resA, resB, resC, resD),
+						),
+					),
+				),
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -416,47 +366,19 @@ const map5 =
 		pd: Parser<D>,
 		pe: Parser<E>,
 	): Parser<F> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			const resultD = pd.run(a);
-
-			if (resultD.kind === ResultKind.Err) {
-				return resultD;
-			}
-
-			const resultE = pe.run(a);
-
-			if (resultE.kind === ResultKind.Err) {
-				return resultE;
-			}
-
-			return ok(
-				f(
-					resultA.value,
-					resultB.value,
-					resultC.value,
-					resultD.value,
-					resultE.value,
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).flatMap(resC =>
+						pd.run(a).flatMap(resD =>
+							pe.run(a).map(resE =>
+								f(resA, resB, resC, resD, resE),
+							),
+						),
+					),
 				),
-			);
-		});
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -472,54 +394,21 @@ const map6 =
 		pe: Parser<E>,
 		pf: Parser<F>,
 	): Parser<G> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			const resultD = pd.run(a);
-
-			if (resultD.kind === ResultKind.Err) {
-				return resultD;
-			}
-
-			const resultE = pe.run(a);
-
-			if (resultE.kind === ResultKind.Err) {
-				return resultE;
-			}
-
-			const resultF = pf.run(a);
-
-			if (resultF.kind === ResultKind.Err) {
-				return resultF;
-			}
-
-			return ok(
-				f(
-					resultA.value,
-					resultB.value,
-					resultC.value,
-					resultD.value,
-					resultE.value,
-					resultF.value,
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).flatMap(resC =>
+						pd.run(a).flatMap(resD =>
+							pe.run(a).flatMap(resE =>
+								pf.run(a).map(resF =>
+									f(resA, resB, resC, resD, resE, resF),
+								),
+							),
+						),
+					),
 				),
-			);
-		});
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -538,61 +427,31 @@ const map7 =
 		pf: Parser<F>,
 		pg: Parser<G>,
 	): Parser<H> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			const resultD = pd.run(a);
-
-			if (resultD.kind === ResultKind.Err) {
-				return resultD;
-			}
-
-			const resultE = pe.run(a);
-
-			if (resultE.kind === ResultKind.Err) {
-				return resultE;
-			}
-
-			const resultF = pf.run(a);
-
-			if (resultF.kind === ResultKind.Err) {
-				return resultF;
-			}
-
-			const resultG = pg.run(a);
-
-			if (resultG.kind === ResultKind.Err) {
-				return resultG;
-			}
-
-			return ok(
-				f(
-					resultA.value,
-					resultB.value,
-					resultC.value,
-					resultD.value,
-					resultE.value,
-					resultF.value,
-					resultG.value,
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).flatMap(resC =>
+						pd.run(a).flatMap(resD =>
+							pe.run(a).flatMap(resE =>
+								pf.run(a).flatMap(resF =>
+									pg.run(a).map(resG =>
+										f(
+											resA,
+											resB,
+											resC,
+											resD,
+											resE,
+											resF,
+											resG,
+										),
+									),
+								),
+							),
+						),
+					),
 				),
-			);
-		});
+			),
+		);
 
 /**
  * Similar to `map2`, but for more parsers. See the docs for that function for
@@ -612,68 +471,34 @@ const map8 =
 		pg: Parser<G>,
 		ph: Parser<H>,
 	): Parser<I> =>
-		parser((a) => {
-			const resultA = pa.run(a);
-
-			if (resultA.kind === ResultKind.Err) {
-				return resultA;
-			}
-
-			const resultB = pb.run(a);
-
-			if (resultB.kind === ResultKind.Err) {
-				return resultB;
-			}
-
-			const resultC = pc.run(a);
-
-			if (resultC.kind === ResultKind.Err) {
-				return resultC;
-			}
-
-			const resultD = pd.run(a);
-
-			if (resultD.kind === ResultKind.Err) {
-				return resultD;
-			}
-
-			const resultE = pe.run(a);
-
-			if (resultE.kind === ResultKind.Err) {
-				return resultE;
-			}
-
-			const resultF = pf.run(a);
-
-			if (resultF.kind === ResultKind.Err) {
-				return resultF;
-			}
-
-			const resultG = pg.run(a);
-
-			if (resultG.kind === ResultKind.Err) {
-				return resultG;
-			}
-
-			const resultH = ph.run(a);
-
-			if (resultH.kind === ResultKind.Err) {
-				return resultH;
-			}
-
-			return ok(
-				f(
-					resultA.value,
-					resultB.value,
-					resultC.value,
-					resultD.value,
-					resultE.value,
-					resultF.value,
-					resultG.value,
-					resultH.value,
+		parser((a) =>
+			pa.run(a).flatMap(resA =>
+				pb.run(a).flatMap(resB =>
+					pc.run(a).flatMap(resC =>
+						pd.run(a).flatMap(resD =>
+							pe.run(a).flatMap(resE =>
+								pf.run(a).flatMap(resF =>
+									pg.run(a).flatMap(resG =>
+										ph.run(a).map(resH =>
+											f(
+												resA,
+												resB,
+												resC,
+												resD,
+												resE,
+												resF,
+												resG,
+												resH,
+											),
+										),
+									),
+								),
+							),
+						),
+					),
 				),
-			);
-		});
+			),
+		);
 
 /**
  * Like `map` but applies a function that *also* returns an `Parser`. Then
@@ -711,7 +536,7 @@ const andThen =
 	<A, B>(f: (a: A) => Parser<B>) =>
 	(pa: Parser<A>): Parser<B> =>
 		parser((a) =>
-			resultAndThen<string, A, B>((x) => f(x).run(a))(pa.run(a)),
+			pa.run(a).flatMap((x) => f(x).run(a)),
 		);
 
 /**
@@ -753,21 +578,21 @@ const oneOf = <A>(parsers: Array<Parser<A>>): Parser<A> =>
 			errs: string[],
 		): Result<string, A> => {
 			if (remainingParsers.length === 0) {
-				return err(errs.join(' '));
+				return Result.err(errs.join(' '));
 			}
 
 			const [head, ...tail] = remainingParsers;
 			const result = head.run(a);
 
-			if (result.kind === ResultKind.Ok) {
-				return result;
+			if (result.isErr()) {
+				return f(tail, [...errs, result.error]);
 			}
 
-			return f(tail, [...errs, result.err]);
+			return result;
 		};
 
 		if (parsers.length === 0) {
-			return err("The list of parsers passed to 'oneOf' was empty");
+			return Result.err("The list of parsers passed to 'oneOf' was empty");
 		}
 
 		return f(parsers, []);

--- a/apps-rendering/src/parser.ts
+++ b/apps-rendering/src/parser.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { Optional } from 'optional';
+import type { Optional } from 'optional';
 import { Result } from 'result';
 
 // ----- Types ----- //
@@ -244,7 +244,12 @@ const arrayParser = <A>(pa: Parser<A>): Parser<A[]> =>
 			const parsed = pa.run(item);
 
 			return parsed.either(
-				(err) => Result.err(`Could not parse array item ${String(item)} because ${err}`),
+				(err) =>
+					Result.err(
+						`Could not parse array item ${String(
+							item,
+						)} because ${err}`,
+					),
 				(a) => f([...acc, a], tail),
 			);
 		};
@@ -310,11 +315,7 @@ const map2 =
 	<A, B, C>(f: (a: A, b: B) => C) =>
 	(pa: Parser<A>, pb: Parser<B>): Parser<C> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).map(resB =>
-					f(resA, resB),
-				),
-			),
+			pa.run(a).flatMap((resA) => pb.run(a).map((resB) => f(resA, resB))),
 		);
 
 /**
@@ -325,13 +326,15 @@ const map3 =
 	<A, B, C, D>(f: (a: A, b: B, c: C) => D) =>
 	(pa: Parser<A>, pb: Parser<B>, pc: Parser<C>): Parser<D> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).map(resC =>
-						f(resA, resB, resC),
-					),
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc.run(a).map((resC) => f(resA, resB, resC)),
+						),
 				),
-			),
 		);
 
 /**
@@ -342,15 +345,23 @@ const map4 =
 	<A, B, C, D, E>(f: (a: A, b: B, c: C, d: D) => E) =>
 	(pa: Parser<A>, pb: Parser<B>, pc: Parser<C>, pd: Parser<D>): Parser<E> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).flatMap(resC =>
-						pd.run(a).map(resD =>
-							f(resA, resB, resC, resD),
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc
+								.run(a)
+								.flatMap((resC) =>
+									pd
+										.run(a)
+										.map((resD) =>
+											f(resA, resB, resC, resD),
+										),
+								),
 						),
-					),
 				),
-			),
 		);
 
 /**
@@ -367,17 +378,33 @@ const map5 =
 		pe: Parser<E>,
 	): Parser<F> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).flatMap(resC =>
-						pd.run(a).flatMap(resD =>
-							pe.run(a).map(resE =>
-								f(resA, resB, resC, resD, resE),
-							),
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc
+								.run(a)
+								.flatMap((resC) =>
+									pd
+										.run(a)
+										.flatMap((resD) =>
+											pe
+												.run(a)
+												.map((resE) =>
+													f(
+														resA,
+														resB,
+														resC,
+														resD,
+														resE,
+													),
+												),
+										),
+								),
 						),
-					),
 				),
-			),
 		);
 
 /**
@@ -395,19 +422,38 @@ const map6 =
 		pf: Parser<F>,
 	): Parser<G> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).flatMap(resC =>
-						pd.run(a).flatMap(resD =>
-							pe.run(a).flatMap(resE =>
-								pf.run(a).map(resF =>
-									f(resA, resB, resC, resD, resE, resF),
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc
+								.run(a)
+								.flatMap((resC) =>
+									pd
+										.run(a)
+										.flatMap((resD) =>
+											pe
+												.run(a)
+												.flatMap((resE) =>
+													pf
+														.run(a)
+														.map((resF) =>
+															f(
+																resA,
+																resB,
+																resC,
+																resD,
+																resE,
+																resF,
+															),
+														),
+												),
+										),
 								),
-							),
 						),
-					),
 				),
-			),
 		);
 
 /**
@@ -428,29 +474,43 @@ const map7 =
 		pg: Parser<G>,
 	): Parser<H> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).flatMap(resC =>
-						pd.run(a).flatMap(resD =>
-							pe.run(a).flatMap(resE =>
-								pf.run(a).flatMap(resF =>
-									pg.run(a).map(resG =>
-										f(
-											resA,
-											resB,
-											resC,
-											resD,
-											resE,
-											resF,
-											resG,
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc
+								.run(a)
+								.flatMap((resC) =>
+									pd
+										.run(a)
+										.flatMap((resD) =>
+											pe
+												.run(a)
+												.flatMap((resE) =>
+													pf
+														.run(a)
+														.flatMap((resF) =>
+															pg
+																.run(a)
+																.map((resG) =>
+																	f(
+																		resA,
+																		resB,
+																		resC,
+																		resD,
+																		resE,
+																		resF,
+																		resG,
+																	),
+																),
+														),
+												),
 										),
-									),
 								),
-							),
 						),
-					),
 				),
-			),
 		);
 
 /**
@@ -472,32 +532,54 @@ const map8 =
 		ph: Parser<H>,
 	): Parser<I> =>
 		parser((a) =>
-			pa.run(a).flatMap(resA =>
-				pb.run(a).flatMap(resB =>
-					pc.run(a).flatMap(resC =>
-						pd.run(a).flatMap(resD =>
-							pe.run(a).flatMap(resE =>
-								pf.run(a).flatMap(resF =>
-									pg.run(a).flatMap(resG =>
-										ph.run(a).map(resH =>
-											f(
-												resA,
-												resB,
-												resC,
-												resD,
-												resE,
-												resF,
-												resG,
-												resH,
-											),
+			pa
+				.run(a)
+				.flatMap((resA) =>
+					pb
+						.run(a)
+						.flatMap((resB) =>
+							pc
+								.run(a)
+								.flatMap((resC) =>
+									pd
+										.run(a)
+										.flatMap((resD) =>
+											pe
+												.run(a)
+												.flatMap((resE) =>
+													pf
+														.run(a)
+														.flatMap((resF) =>
+															pg
+																.run(a)
+																.flatMap(
+																	(resG) =>
+																		ph
+																			.run(
+																				a,
+																			)
+																			.map(
+																				(
+																					resH,
+																				) =>
+																					f(
+																						resA,
+																						resB,
+																						resC,
+																						resD,
+																						resE,
+																						resF,
+																						resG,
+																						resH,
+																					),
+																			),
+																),
+														),
+												),
 										),
-									),
 								),
-							),
 						),
-					),
 				),
-			),
 		);
 
 /**
@@ -535,9 +617,7 @@ const map8 =
 const andThen =
 	<A, B>(f: (a: A) => Parser<B>) =>
 	(pa: Parser<A>): Parser<B> =>
-		parser((a) =>
-			pa.run(a).flatMap((x) => f(x).run(a)),
-		);
+		parser((a) => pa.run(a).flatMap((x) => f(x).run(a)));
 
 /**
  * Handles situations where there are multiple valid ways that the input data
@@ -592,7 +672,9 @@ const oneOf = <A>(parsers: Array<Parser<A>>): Parser<A> =>
 		};
 
 		if (parsers.length === 0) {
-			return Result.err("The list of parsers passed to 'oneOf' was empty");
+			return Result.err(
+				"The list of parsers passed to 'oneOf' was empty",
+			);
 		}
 
 		return f(parsers, []);

--- a/apps-rendering/src/parser.ts
+++ b/apps-rendering/src/parser.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import type { Optional } from 'optional';
+import type { Option } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import { Result } from 'result';
 
 // ----- Types ----- //
@@ -129,8 +130,12 @@ const dateParser: Parser<Date> = parser((a) => {
  * const parserB = fieldParser('bar', maybe(numberParser)); // Parser<Option<number>>
  * const resultB = parse(parserB)(json); // Err<string>, with 'missing field' err
  */
-const maybe = <A>(pa: Parser<A>): Parser<Optional<A>> =>
-	parser((a) => Result.ok(pa.run(a).toOptional()));
+const maybe = <A>(pa: Parser<A>): Parser<Option<A>> =>
+	parser((a) => {
+		const result = pa.run(a);
+
+		return Result.ok(result.isOk() ? some(result.value) : none);
+	});
 
 // ----- Data Structure Parsers ----- //
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -19,14 +19,12 @@ import { neutral, remSpace, until } from '@guardian/source-foundations';
 import {
 	andThen,
 	fromNullable,
-	fromUnsafe,
 	map,
 	none,
 	some,
-	toOption,
 	withDefault,
 } from '@guardian/types';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { ElementKind } from 'bodyElement';
 import type {
 	AudioAtom as AudioAtomElement,
@@ -69,6 +67,7 @@ import RichLink from 'components/RichLink';
 import { isElement, pipe } from 'lib';
 import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
+import { Result } from 'result';
 import { backgroundColor, darkModeCss } from 'styles';
 import {
 	themeFromString,
@@ -86,14 +85,9 @@ const transformHref = (href: string): string => {
 		return `https://www.theguardian.com/${href}`;
 	}
 
-	const url: Result<string, URL> = fromUnsafe(
-		() => new URL(href),
-		'invalid url',
-	);
-
-	return pipe(
-		toOption(url),
-		map((url) => {
+	return Result.fromUnsafe(() => new URL(href), 'invalid url')
+		.toOptional()
+		.map(url => {
 			const path = url.pathname.split('/');
 			const isLatest =
 				url.hostname === 'www.theguardian.com' &&
@@ -104,9 +98,8 @@ const transformHref = (href: string): string => {
 			}
 
 			return href;
-		}),
-		withDefault(href),
-	);
+		})
+		.withDefault(href);
 };
 
 const getHref = (node: Node): Option<string> =>

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -87,7 +87,7 @@ const transformHref = (href: string): string => {
 
 	return Result.fromUnsafe(() => new URL(href), 'invalid url')
 		.toOptional()
-		.map(url => {
+		.map((url) => {
 			const path = url.pathname.split('/');
 			const isLatest =
 				url.hostname === 'www.theguardian.com' &&

--- a/apps-rendering/src/result.ts
+++ b/apps-rendering/src/result.ts
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
 
+import type { Option } from '@guardian/types';
+import { none, some } from '@guardian/types';
 import { Optional } from 'optional';
 
 // ----- Classes ----- //
@@ -67,6 +69,12 @@ abstract class Result<E, A> {
 	 * @returns {Optional<A>} An {@linkcode Optional}
 	 */
 	abstract toOptional(): Optional<A>;
+
+	/**
+	 * Temporary method to convert to the old `Option` type. Same functionality
+	 * as {@linkcode toOptional} but with `Option`.
+	 */
+	abstract toOption(): Option<A>;
 
 	/**
 	 * Checks if a {@linkcode Result} is an `Ok`. Can be used in type guards to
@@ -209,6 +217,10 @@ class Ok<E, A> extends Result<E, A> {
 		return Optional.some(this.value);
 	}
 
+	toOption(): Option<A> {
+		return some(this.value);
+	}
+
 	isOk(): this is Ok<E, A> {
 		return true;
 	}
@@ -245,6 +257,10 @@ class Err<E, A> extends Result<E, A> {
 
 	toOptional(): Optional<A> {
 		return Optional.none();
+	}
+
+	toOption(): Option<A> {
+		return none;
 	}
 
 	isOk(): this is Ok<E, A> {

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -2,13 +2,13 @@
 
 import { createHash } from 'crypto';
 import { ArticleDesign } from '@guardian/libs';
-import { map, partition, withDefault } from '@guardian/types';
-import type { Result } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import type { BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElement';
 import type { ThirdPartyEmbeds } from 'capi';
 import type { Item } from 'item';
 import { compose, pipe } from 'lib';
+import { Result } from 'result';
 
 // ----- Types ----- //
 
@@ -55,7 +55,7 @@ const getElements = (item: Item): Array<Result<string, BodyElement>> =>
 		: item.body;
 
 const getValidElements = (item: Item): BodyElement[] =>
-	partition(getElements(item)).oks;
+	Result.partition(getElements(item)).oks;
 
 const interactiveAssets = compose(extractInteractiveAssets, getValidElements);
 

--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -4,15 +4,13 @@ import type { Scorer } from '@guardian/apps-rendering-api-models/scorer';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 import {
-	err,
 	fromNullable,
 	map2,
 	none,
 	map as optMap,
-	resultAndThen,
 	some,
 } from '@guardian/types';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import { padStart } from 'date';
 import { fold, pipe } from 'lib';
 import fetch from 'node-fetch';
@@ -30,6 +28,7 @@ import {
 	stringParser,
 	succeed,
 } from 'parser';
+import { Result } from 'result';
 
 type Teams = [string, string];
 
@@ -139,10 +138,9 @@ const parseFootballResponse = async (
 		return pipe(
 			await response.json(),
 			parse(footballErrorParser),
-			resultAndThen<string, string, FootballContent>(err),
-		);
+		).flatMap<FootballContent>(Result.err);
 	} else {
-		return err('Problem accessing PA API');
+		return Result.err('Problem accessing PA API');
 	}
 };
 
@@ -194,7 +192,7 @@ const getFootballContent = async (
 		);
 
 		return footballContent;
-	}, Promise.resolve(err('Could not get selectorId')))(selectorId);
+	}, Promise.resolve(Result.err('Could not get selectorId')))(selectorId);
 };
 
 export { getFootballContent };

--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -3,13 +3,7 @@ import type { FootballTeam } from '@guardian/apps-rendering-api-models/footballT
 import type { Scorer } from '@guardian/apps-rendering-api-models/scorer';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import {
-	fromNullable,
-	map2,
-	none,
-	map as optMap,
-	some,
-} from '@guardian/types';
+import { fromNullable, map2, none, map as optMap, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { padStart } from 'date';
 import { fold, pipe } from 'lib';

--- a/apps-rendering/src/server/footballContent.ts
+++ b/apps-rendering/src/server/footballContent.ts
@@ -129,10 +129,9 @@ const parseFootballResponse = async (
 		const parser = footballContentParserFor(selectorId);
 		return pipe(await response.json(), parse(parser));
 	} else if (response.status === 400) {
-		return pipe(
-			await response.json(),
-			parse(footballErrorParser),
-		).flatMap<FootballContent>(Result.err);
+		return pipe(await response.json(), parse(footballErrorParser)).flatMap(
+			(error) => Result.err(error),
+		);
 	} else {
 		return Result.err('Problem accessing PA API');
 	}

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -8,14 +8,11 @@ import type { RenderingRequest } from '@guardian/apps-rendering-api-models/rende
 import type { Content } from '@guardian/content-api-models/v1/content';
 import type { ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
-import type { Option, Result } from '@guardian/types';
+import type { Option } from '@guardian/types';
 import {
-	either,
-	err,
 	fromNullable,
 	map,
 	none,
-	ok,
 	OptionKind,
 	some,
 	withDefault,
@@ -45,6 +42,7 @@ import {
 import { render as renderEditions } from 'server/editionsPage';
 import { render } from 'server/page';
 import { getConfigValue } from 'server/ssmConfig';
+import { Result } from 'result';
 import { App, Stack, Stage } from './appIdentity';
 import { getMappedAssetLocation } from './assets';
 import { getFootballContent } from './footballContent';
@@ -106,20 +104,20 @@ const parseCapiResponse =
 					logger.error(
 						`CAPI returned a 200 for ${articleId}, but didn't give me any content`,
 					);
-					return err(500);
+					return Result.err(500);
 				}
 
 				if (response.relatedContent === undefined) {
 					logger.error(
 						`Unable to fetch related content for ${articleId}`,
 					);
-					return err(500);
+					return Result.err(500);
 				}
 
 				const relatedContent = parseRelatedContent(
 					response.relatedContent,
 				);
-				return ok([response.content, relatedContent]);
+				return Result.ok([response.content, relatedContent]);
 			}
 
 			case 404:
@@ -127,7 +125,7 @@ const parseCapiResponse =
 					`CAPI says that it doesn't recognise this resource: ${articleId}`,
 				);
 
-				return err(404);
+				return Result.err(404);
 
 			default: {
 				const response = await errorDecoder(buffer);
@@ -135,7 +133,7 @@ const parseCapiResponse =
 				logger.error(
 					`I received a ${status} code from CAPI with the message: ${response.message} for resource ${capiResponse.url}`,
 				);
-				return err(500);
+				return Result.err(500);
 			}
 		}
 	};
@@ -145,7 +143,7 @@ const askCapiFor = (articleId: string): CapiReturn =>
 		if (key === undefined) {
 			logger.error('Could not get CAPI key');
 
-			return err(500);
+			return Result.err(500);
 		}
 
 		return capiRequest(articleId)(key).then(parseCapiResponse(articleId));
@@ -336,7 +334,7 @@ async function serveArticleGet(
 		const capiContent = await askCapiFor(articleId);
 		const edition = editionFromString(req.params.edition);
 
-		await either(
+		await capiContent.either(
 			(errorStatus: number) => {
 				res.sendStatus(errorStatus);
 				return Promise.resolve();
@@ -372,7 +370,7 @@ async function serveArticleGet(
 					);
 				}
 			},
-		)(capiContent);
+		);
 	} catch (e) {
 		logger.error(`This error occurred`, e);
 		res.sendStatus(500);

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -33,6 +33,7 @@ import { MainMediaKind } from 'mainMedia';
 import type { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import { parseRelatedContent } from 'relatedContent';
+import { Result } from 'result';
 import {
 	capiContentDecoder,
 	capiDecoder,
@@ -42,7 +43,6 @@ import {
 import { render as renderEditions } from 'server/editionsPage';
 import { render } from 'server/page';
 import { getConfigValue } from 'server/ssmConfig';
-import { Result } from 'result';
 import { App, Stack, Stage } from './appIdentity';
 import { getMappedAssetLocation } from './assets';
 import { getFootballContent } from './footballContent';


### PR DESCRIPTION
## Why?

This PR migrates AR over to use the new, class-based `Result` data type added in #5609. See that PR for more details about why we're making this change.

Draft for now while I fix the failing build and do some testing.

## Changes

- Fixed a bug in the tests where a value was incorrectly being checked against a `Some` rather than an `Ok`
- Migrated `ok` and `err` to `Result.ok` and `Result.err`
- Migrated old `Result` functions to new methods
- Migrated discriminated union checks to `isOk` and `isErr` methods
- Fixed bug in video embed test in `item.test.ts`
- Rewrote `resultMap2` and `resultMap3` to use `flatMap` and `map`
- Rewrote parser map functions to use `flatMap` and `map`
- Added temporary `toOption` method until we're ready to migrate to `Optional`
