### PR TITLE
Stop adding AMP link if it is unsupported

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -207,16 +207,23 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 		),
 	);
 
-	const hasAmpInteractiveTag = CAPIArticle.tags.some(
-		(tag) => tag.id === 'tracking/platformfunctional/ampinteractive',
-	);
+	const getAmpLink = (tags: TagType[]) => {
+		// We don’t support AMP for Immersive articles in frontend
+		// https://github.com/guardian/frontend/blob/149c8d3be273edf784465a780ee332bd58e2a9b3/common/app/model/content.scala#L95
+		if (CAPIArticle.format.display === 'ImmersiveDisplay') return undefined;
+		if (CAPIArticle.format.design === 'InteractiveDesign') {
+			const hasAmpInteractiveTag = tags.some(
+				(tag) =>
+					tag.id === 'tracking/platformfunctional/ampinteractive',
+			);
+			if (!hasAmpInteractiveTag) return undefined;
+		}
+
+		return `https://amp.theguardian.com/${CAPIArticle.pageId}`;
+	};
 
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
-	const ampLink =
-		CAPIArticle.format.design !== 'InteractiveDesign' ||
-		hasAmpInteractiveTag
-			? `https://amp.theguardian.com/${CAPIArticle.pageId}`
-			: undefined;
+	const ampLink = getAmpLink(CAPIArticle.tags);
 
 	const { openGraphData } = CAPIArticle;
 	const { twitterData } = CAPIArticle;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove the `ampLink` from the page template if an article is Immersive.

## Why?

It’s unsupported in frontend. We are sending the wrong information about what we support.

- https://github.com/guardian/frontend/pull/11397 (the PR is light on details…)
- https://github.com/guardian/frontend/pull/25451
- #5931