### PR TITLE
Add tweaks from review

### DIFF
--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -77,10 +77,13 @@ const captionStyles = (format: ArticleFormat): SerializedStyles => css`
 	& {
 		color: ${text.gallery(format)};
 	}
-	> span {
+
+	span {
 		${textSans.xsmall({ lineHeight: 'regular' })}
 	}
-	> h2 {
+
+	h2,
+	h2 > span {
 		${headline.xxxsmall()}
 	}
 

--- a/apps-rendering/src/components/Dateline/index.tsx
+++ b/apps-rendering/src/components/Dateline/index.tsx
@@ -62,7 +62,7 @@ const getStyles = (
 const getDatelineStyles = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
-			return getStyles(neutral[100], neutral[100]);
+			return getStyles(neutral[86], neutral[86]);
 		case ArticleDesign.LiveBlog:
 			return getStyles(neutral[100], neutral[20]);
 		case ArticleDesign.DeadBlog:

--- a/apps-rendering/src/components/Headline/GalleryHeadline.tsx
+++ b/apps-rendering/src/components/Headline/GalleryHeadline.tsx
@@ -16,7 +16,7 @@ import { darkModeCss } from 'styles';
 const styles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'bold' })}
 	background-color: ${background.headline(format)};
-	color: ${text.gallery(format)};
+	color: ${text.headline(format)};
 	padding: 0 ${remSpace[5]} ${remSpace[9]} 0;
 	${grid.column.centre}
 	grid-row: 3 / 5;
@@ -32,7 +32,7 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 
 	${darkModeCss`
 		background-color: ${background.headlineDark(format)};
-		color: ${text.galleryDark(format)};
+		color: ${text.headlineDark(format)};
 	`}
 `;
 

--- a/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
@@ -21,14 +21,15 @@ import { darkModeCss } from 'styles';
 // ----- Component ----- //
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
-	${textSans.xxsmall()}
+	${textSans.xsmall()}
 	background-color: ${background.articleContent(format)};
-
 	${grid.column.centre}
-	padding-top: ${remSpace[9]};
+	padding-bottom: ${remSpace[9]};
 
 	${from.leftCol} {
 		${grid.column.left}
+		padding-top: ${remSpace[9]};
+		padding-bottom: 0;
 		grid-row: 4;
 		padding-top: ${remSpace[1]};
 	}

--- a/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
-
-import { css, SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
+++ b/apps-rendering/src/components/Metadata/GalleryMetadata.tsx
@@ -1,9 +1,10 @@
 // ----- Imports ----- //
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import { neutral, remSpace } from '@guardian/source-foundations';
+import { remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import CommentCount from 'components/CommentCount';
 import Dateline from 'components/Dateline';
@@ -14,9 +15,9 @@ import type { FC } from 'react';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	display: flex;
-	color: ${neutral[100]};
+	color: ${text.gallery(format)};
 	${grid.column.centre}
 	grid-row: 7/8;
 	padding: 0 ${remSpace[5]} ${remSpace[9]} 0;
@@ -43,7 +44,7 @@ const GalleryMetadata: FC<Props> = ({
 	commentable,
 	edition,
 }) => (
-	<div css={styles}>
+	<div css={styles(format)}>
 		<div css={textStyles}>
 			<Dateline date={publishDate} format={format} edition={edition} />
 			<Follow format={format} contributors={contributors} />

--- a/apps-rendering/src/components/Series/GallerySeries.tsx
+++ b/apps-rendering/src/components/Series/GallerySeries.tsx
@@ -28,8 +28,8 @@ const styles = css`
 `;
 
 const linkStyles = (format: ArticleFormat): SerializedStyles => css`
-	background-color: ${text.seriesTitle(format)};
-	color: ${background.series(format)};
+	color: ${text.seriesTitle(format)};
+	background-color: ${background.series(format)};
 	${headline.xxxsmall({ fontWeight: 'bold' })}
 	line-height: 2;
 	text-decoration: none;

--- a/apps-rendering/src/components/Series/GallerySeries.tsx
+++ b/apps-rendering/src/components/Series/GallerySeries.tsx
@@ -28,8 +28,8 @@ const styles = css`
 `;
 
 const linkStyles = (format: ArticleFormat): SerializedStyles => css`
-	color: ${text.seriesTitle(format)};
-	background-color: ${background.series(format)};
+	background-color: ${text.seriesTitle(format)};
+	color: ${background.series(format)};
 	${headline.xxxsmall({ fontWeight: 'bold' })}
 	line-height: 2;
 	text-decoration: none;

--- a/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
@@ -4,7 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import { body, from, remSpace } from '@guardian/source-foundations';
+import { from, headline, remSpace } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
@@ -15,7 +15,7 @@ import { darkModeCss } from 'styles';
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
 	${grid.span('centre-column-start', 3)}
-	${body.medium({ fontWeight: 'bold', lineHeight: 'tight' })}
+	${headline.xxxsmall({ fontWeight: 'bold' })}
 	color: ${text.standfirst(format)};
 	grid-row: 5/6;
 	padding-bottom: ${remSpace[2]};

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -317,7 +317,9 @@ const borderFromFormat = (format: ArticleFormat): string => {
 		text-decoration: none;
 	`;
 
-	return isBlog(format) ? styles : 'none';
+	return isBlog(format) || format.design === ArticleDesign.Gallery
+		? styles
+		: 'none';
 };
 
 const standfirstTextElement =

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -516,7 +516,10 @@ const supportBannerDark = (_format: ArticleFormat): Colour => {
 };
 
 const series = (format: ArticleFormat): Colour => {
-	if (format.display === ArticleDisplay.Immersive) {
+	if (
+		format.display === ArticleDisplay.Immersive ||
+		format.design === ArticleDesign.Gallery
+	) {
 		switch (format.theme) {
 			case ArticlePillar.Sport:
 				return sport[400];

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -110,6 +110,10 @@ const relatedCardDark = (_format: ArticleFormat): Colour => {
 };
 
 const standfirstLink = (format: ArticleFormat): Colour => {
+	if (format.design === ArticleDesign.Gallery) {
+		return neutral[46];
+	}
+
 	switch (format.theme) {
 		case ArticlePillar.News:
 			return news[600];

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -626,7 +626,6 @@ const standfirst = ({ design }: ArticleFormat): Colour => {
 		case ArticleDesign.LiveBlog:
 			return neutral[100];
 		case ArticleDesign.Gallery:
-			return neutral[100];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			return neutral[86];
@@ -669,6 +668,7 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 					return specialReport[300];
 			}
 		case ArticleDesign.Gallery:
+			return neutral[100];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			switch (format.theme) {
@@ -1043,7 +1043,7 @@ const signUpFormButtonDark = (_format: ArticleFormat): string => {
 };
 
 const gallery = (_format: ArticleFormat): string => {
-	return neutral[100];
+	return neutral[86];
 };
 
 const galleryDark = (_format: ArticleFormat): string => {

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -668,7 +668,7 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 					return specialReport[300];
 			}
 		case ArticleDesign.Gallery:
-			return neutral[100];
+			return neutral[86];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			switch (format.theme) {
@@ -812,6 +812,8 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 	}
 
 	switch (format.design) {
+		case ArticleDesign.Gallery:
+			return neutral[100];
 		case ArticleDesign.DeadBlog:
 			switch (format.theme) {
 				case ArticlePillar.News:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Implements tweaks suggested in [#5932](https://github.com/guardian/dotcom-rendering/issues/5932)

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
