### PR TITLE
Always show tab titles

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooter.test.tsx
@@ -87,7 +87,7 @@ describe('MostViewedFooterData', () => {
 		expect(getByTestId(secondHeading)).toHaveStyle(HIDDEN);
 	});
 
-	it('should not show the tab menu when there is only one group of tabs', async () => {
+	it('should still show the tab menu when there is only one group of tabs', async () => {
 		useApi.mockReturnValue({ data: responseWithOneTab });
 
 		const { queryByText } = render(
@@ -104,7 +104,7 @@ describe('MostViewedFooterData', () => {
 
 		expect(
 			queryByText(responseWithOneTab.tabs[0].heading),
-		).not.toBeInTheDocument();
+		).toBeInTheDocument();
 	});
 
 	it("should display the text 'Live' for live blogs", () => {

--- a/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
@@ -57,7 +57,7 @@ const unselectedStyles = css`
 	}
 `;
 
-const tabButton = css`
+const buttonStyles = (isSelected: boolean) => css`
 	${headline.xxxsmall()};
 	color: ${neutral[7]};
 	margin: 0;
@@ -73,7 +73,7 @@ const tabButton = css`
 	width: 100%;
 
 	&:hover {
-		cursor: pointer;
+		cursor: ${isSelected ? 'default' : 'pointer'};
 	}
 `;
 
@@ -130,7 +130,7 @@ export const MostViewedFooterGrid = ({
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
 	return (
 		<>
-			{Array.isArray(data) && data.length > 1 && (
+			{Array.isArray(data) && (
 				<ul css={tabsContainer} role="tablist">
 					{data.map((tab: TrailTabType, i: number) => {
 						if (!tab.heading) return null;
@@ -157,7 +157,7 @@ export const MostViewedFooterGrid = ({
 								data-chromatic="ignore"
 							>
 								<button
-									css={tabButton}
+									css={buttonStyles(isSelected)}
 									onClick={() => setSelectedTabIndex(i)}
 								>
 									<span

--- a/dotcom-rendering/src/web/components/MostViewedFooterLayout.stories.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterLayout.stories.tsx
@@ -46,8 +46,7 @@ export const withOneTabs = () => {
 					<MostViewedFooter
 						tabs={[
 							{
-								heading:
-									'The heading does not show when there is one tab',
+								heading: 'in the UK',
 								trails: trails.slice(0, 10),
 							},
 						]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The PR fixes #5910 by removing the restriction that prevented the tab header from being displayed if there was only one tab. It also changes the css such that the mouse pointer is no longer shown when hovering over the active tab

## Why?
Because if no tab header shows then the reader is not given any context for what the list of trails being shown relate to. We hard code the container title to be `Most viewed` but sometimes this is most viewed globally but it might just be 'in sport' or 'in culture'. By showing the tab header we give that context.


| Before      | After      |
|-------------|------------|
| <img width="1004" alt="Screenshot 2022-09-05 at 17 20 19" src="https://user-images.githubusercontent.com/1336821/188488590-63f8e4e0-6bee-4c68-9ba4-befa1cac637e.png"> | <img width="1004" alt="Screenshot 2022-09-05 at 17 18 41" src="https://user-images.githubusercontent.com/1336821/188488593-56762af3-9fe9-4d6b-aa96-10dd65b79340.png"> |
