### PR TITLE
Stop Rendering Dinkus Paragraphs

### DIFF
--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -242,7 +242,12 @@ const textElement =
 		);
 		switch (node.nodeName) {
 			case 'P': {
+				if (text === '* * *') {
+					return children;
+				}
+
 				const showDropCap = shouldShowDropCap(text, format, isEditions);
+
 				return h(
 					Paragraph,
 					{ key, format, showDropCap, isEditions },


### PR DESCRIPTION
## Why?

Don't render paragraphs when they contain a dinkus. It results in `<p><hr></p>`, which is invalid and the browser converts to `<p></p><hr><p></p>`. Both variants break the dropcap CSS.

## Changes

- Don't render paragraph tags when they contain a dinkus
