### PR TITLE
feat: support AMP immersives

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -208,9 +208,6 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	);
 
 	const getAmpLink = (tags: TagType[]) => {
-		// We don’t support AMP for Immersive articles in frontend
-		// https://github.com/guardian/frontend/blob/149c8d3be273edf784465a780ee332bd58e2a9b3/common/app/model/content.scala#L95
-		if (CAPIArticle.format.display === 'ImmersiveDisplay') return undefined;
 		if (CAPIArticle.format.design === 'InteractiveDesign') {
 			const hasAmpInteractiveTag = tags.some(
 				(tag) =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Implementation of https://github.com/guardian/frontend/pull/25455

## Why?

I have tested the last 200 articles from CAPI with a `displayHint` of `immersive`, and 199 of them could be rendered without any issue by DCR.


--- 

Script to assert the ability of DCR to render articles, while you have DCR running on port 3030:

```ts
deno run --allow-net https://gist.githubusercontent.com/mxdvl/ace928d0ea34302031d825a970782cda/raw/amp-immersives.ts
```

<img width="453" alt="image" src="https://user-images.githubusercontent.com/76776/188580550-de487e65-b17b-4ec3-8af5-e096d8082608.png">