### PR TITLE
fix: Always show Click to View warning on liveblogs

### DIFF
--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -72,6 +72,11 @@ const RoleStory = ({
 						source="A Thirdparty Provider"
 						sourceDomain="thirdparty.com"
 						onAccept={() => {}}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						{children}
 					</ClickToView>
@@ -502,6 +507,11 @@ export const EmbedBlockComponentStory = () => {
 						source={facebookEmbed.source}
 						sourceDomain={facebookEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -528,6 +538,11 @@ export const EmbedBlockComponentStory = () => {
 						source={vimeoEmbedEmbed.source}
 						sourceDomain={vimeoEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -554,6 +569,11 @@ export const EmbedBlockComponentStory = () => {
 						source={youtubeEmbedEmbed.source}
 						sourceDomain={youtubeEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -580,6 +600,11 @@ export const EmbedBlockComponentStory = () => {
 						source={spotifyEmbedEmbed.source}
 						sourceDomain={spotifyEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -606,6 +631,11 @@ export const EmbedBlockComponentStory = () => {
 						source={bandcampEmbedEmbed.source}
 						sourceDomain={bandcampEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -632,6 +662,11 @@ export const EmbedBlockComponentStory = () => {
 						source={ourworldindataEmbedEmbed.source}
 						sourceDomain={ourworldindataEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -658,6 +693,11 @@ export const EmbedBlockComponentStory = () => {
 						source={bbcEmbedEmbed.source}
 						sourceDomain={bbcEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>The end.</p>,
@@ -709,6 +749,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						source={instagramEmbedEmbed.source}
 						sourceDomain={instagramEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -735,6 +780,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						source={formStackEmbed.source}
 						sourceDomain={formStackEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -762,6 +812,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						source={scribdEmbedEmbed.source}
 						sourceDomain={scribdEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -789,6 +844,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						source={scribdEmbedEmbed.source}
 						sourceDomain={scribdEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>
@@ -816,6 +876,11 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						source={scribdEmbedEmbed.source}
 						sourceDomain={scribdEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>The end.</p>,
@@ -864,6 +929,11 @@ export const VimeoBlockComponentStory = () => {
 						source={vimeoVideoEmbed.source}
 						sourceDomain={vimeoVideoEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<VimeoBlockComponent
 							format={{
@@ -927,6 +997,11 @@ export const DocumentBlockComponentStory = () => {
 						source={scribdDocumentEmbed.source}
 						sourceDomain={scribdDocumentEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<DocumentBlockComponent
 							embedUrl={scribdDocumentEmbed.embedUrl}
@@ -935,6 +1010,11 @@ export const DocumentBlockComponentStory = () => {
 							title={scribdDocumentEmbed.title}
 							isTracking={false}
 							isMainMedia={false}
+							format={{
+								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: ArticlePillar.News,
+							}}
 						/>
 					</ClickToView>
 				</Figure>
@@ -984,6 +1064,11 @@ export const SoundCloudBlockComponentStory = () => {
 						source={soundcloudAudioEmbed.source}
 						sourceDomain={soundcloudAudioEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<SoundcloudBlockComponent
 							element={soundcloudAudioEmbed}
@@ -1011,6 +1096,11 @@ export const SoundCloudBlockComponentStory = () => {
 						source={soundcloudEmbedEmbed.source}
 						sourceDomain={soundcloudEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<SoundcloudBlockComponent
 							element={soundcloudEmbedEmbed}
@@ -1063,6 +1153,11 @@ export const SpotifyBlockComponentStory = () => {
 						source={spotifyAudioEmbed.source}
 						sourceDomain={spotifyAudioEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<SpotifyBlockComponent
 							embedUrl={spotifyAudioEmbed.embedUrl}
@@ -1129,6 +1224,11 @@ export const TweetBlockComponentStory = () => {
 						source={twitterTweetEmbed.source}
 						sourceDomain={twitterTweetEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<TweetBlockComponent element={twitterTweetEmbed} />
 					</ClickToView>
@@ -1178,6 +1278,11 @@ export const InstagramBlockComponentStory = () => {
 						element={instagramInstramEmbed}
 						index={1}
 						isMainMedia={false}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					/>
 				</Figure>
 				<p css={paragraphStyle}>The end.</p>,
@@ -1224,6 +1329,11 @@ export const MapBlockComponentStory = () => {
 						source={mapEmbedEmbed.source}
 						sourceDomain={mapEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<MapEmbedBlockComponent
 							embedUrl={mapEmbedEmbed.embedUrl}
@@ -1287,11 +1397,21 @@ export const VineBlockComponentStory = () => {
 						source={vineEmbedEmbed.source}
 						sourceDomain={vineEmbedEmbed.sourceDomain}
 						role="inline"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: ArticlePillar.News,
+						}}
 					>
 						<VineBlockComponent
 							element={vineEmbedEmbed}
 							role="inline"
 							isTracking={false}
+							format={{
+								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: ArticlePillar.News,
+							}}
 						/>
 					</ClickToView>
 				</Figure>

--- a/dotcom-rendering/src/web/components/ClickToView.test.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.test.tsx
@@ -1,16 +1,21 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { render } from '@testing-library/react';
 import { ClickToView } from './ClickToView';
 
 describe('ClickToView', () => {
 	it('It should render the third party content if it is not tracking', () => {
-		const thirdPartyContent = <div data-testid="third-party-content" />;
 		const { getByTestId } = render(
 			<ClickToView
 				isTracking={false}
 				source="A Third Party"
 				sourceDomain="athirdparty.com"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			>
-				{thirdPartyContent}
+				<div data-testid="third-party-content" />
 			</ClickToView>,
 		);
 
@@ -23,6 +28,11 @@ describe('ClickToView', () => {
 				isTracking={true}
 				source="A Third Party"
 				sourceDomain="athirdparty.com"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			>
 				<div id="third-party-content" />
 			</ClickToView>,
@@ -38,7 +48,15 @@ describe('ClickToView', () => {
 	});
 	it('It should render a generic overlay if a source is not present', () => {
 		const { getByText } = render(
-			<ClickToView isTracking={true} sourceDomain="athirdparty.com">
+			<ClickToView
+				isTracking={true}
+				sourceDomain="athirdparty.com"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
+			>
 				<div id="third-party-content" />
 			</ClickToView>,
 		);
@@ -52,5 +70,22 @@ describe('ClickToView', () => {
 				{ exact: false },
 			),
 		).toBeInTheDocument();
+	});
+	it('It should render a overlay if its a liveblog', () => {
+		const { queryByTestId } = render(
+			<ClickToView
+				isTracking={true}
+				sourceDomain="athirdparty.com"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: ArticlePillar.News,
+				}}
+			>
+				<div data-testid="third-party-content" />
+			</ClickToView>,
+		);
+
+		expect(queryByTestId('third-party-content')).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/web/components/ClickToView.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.tsx
@@ -101,6 +101,9 @@ const shouldDisplayOverlay = ({
 	if (isMainMedia) {
 		return false;
 	}
+
+	// See https://github.com/guardian/frontend/issues/25454
+	// This dependency on format can be removed once CAPI is properly setting the tracking field correctly.
 	if (
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog

--- a/dotcom-rendering/src/web/components/ClickToView.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import {
 	background,
 	border,
@@ -16,6 +17,7 @@ type Props = {
 	isMainMedia?: boolean;
 	source?: string;
 	sourceDomain?: string;
+	format: ArticleFormat;
 };
 
 const roleTextSize = (role: RoleType) => {
@@ -89,15 +91,23 @@ const shouldDisplayOverlay = ({
 	isTracking,
 	isOverlayClicked,
 	isMainMedia,
+	format,
 }: {
 	isTracking: boolean;
 	isOverlayClicked: boolean;
 	isMainMedia?: boolean;
+	format: ArticleFormat;
 }) => {
-	if (isMainMedia || !isTracking) {
+	if (isMainMedia) {
 		return false;
 	}
-	if (isOverlayClicked) {
+	if (
+		format.design === ArticleDesign.LiveBlog ||
+		format.design === ArticleDesign.DeadBlog
+	) {
+		return true;
+	}
+	if (!isTracking || isOverlayClicked) {
 		return false;
 	}
 	return true;
@@ -111,6 +121,7 @@ export const ClickToView = ({
 	isMainMedia,
 	source,
 	sourceDomain = 'unknown',
+	format,
 }: Props) => {
 	const [isOverlayClicked, setIsOverlayClicked] = useState<boolean>(false);
 
@@ -128,6 +139,7 @@ export const ClickToView = ({
 			isTracking,
 			isOverlayClicked,
 			isMainMedia,
+			format,
 		})
 	) {
 		return (

--- a/dotcom-rendering/src/web/components/ClickToView.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.tsx
@@ -98,10 +98,9 @@ const shouldDisplayOverlay = ({
 	isMainMedia?: boolean;
 	format: ArticleFormat;
 }) => {
-	if (isMainMedia) {
+	if (isMainMedia || isOverlayClicked) {
 		return false;
 	}
-
 	// See https://github.com/guardian/frontend/issues/25454
 	// This dependency on format can be removed once CAPI is properly setting the tracking field correctly.
 	if (
@@ -110,7 +109,7 @@ const shouldDisplayOverlay = ({
 	) {
 		return true;
 	}
-	if (!isTracking || isOverlayClicked) {
+	if (!isTracking) {
 		return false;
 	}
 	return true;

--- a/dotcom-rendering/src/web/components/DocumentBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/DocumentBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleFormat } from '@guardian/libs';
 import { LinkButton } from '@guardian/source-react-components';
 import { ClickToView } from './ClickToView';
 
@@ -35,6 +36,7 @@ type Props = {
 	sourceDomain?: string;
 	title?: string;
 	width: number;
+	format: ArticleFormat;
 };
 
 export const DocumentBlockComponent = ({
@@ -47,6 +49,7 @@ export const DocumentBlockComponent = ({
 	sourceDomain,
 	title,
 	width,
+	format,
 }: Props) => {
 	return (
 		<ClickToView
@@ -55,6 +58,7 @@ export const DocumentBlockComponent = ({
 			isMainMedia={isMainMedia}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			<div css={widthOverride}>
 				<iframe

--- a/dotcom-rendering/src/web/components/DocumentBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/DocumentBlockComponent.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { DocumentBlockComponent } from './DocumentBlockComponent.importable';
 
 export default {
@@ -28,6 +29,11 @@ export const documentEmbed = () => {
 				title=""
 				isTracking={false}
 				isMainMedia={false}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			/>
 			<p>DocumentCloud Document</p>
 			<DocumentBlockComponent
@@ -38,6 +44,11 @@ export const documentEmbed = () => {
 				source="DocumentCloud"
 				isTracking={false}
 				isMainMedia={false}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			/>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleFormat } from '@guardian/libs';
 import { from, space, text, textSans } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import { ClickToView } from './ClickToView';
@@ -11,6 +12,7 @@ type Props = {
 	isMainMedia?: boolean;
 	source?: string;
 	sourceDomain?: string;
+	format: ArticleFormat;
 };
 
 const emailCaptionStyle = css`
@@ -46,6 +48,7 @@ export const EmbedBlockComponent = ({
 	isMainMedia,
 	source,
 	sourceDomain,
+	format,
 }: Props) => {
 	// TODO: Email embeds are being turned into atoms, so we can remove this hack when that happens
 	const isEmailEmbed = html.includes('email/form');
@@ -56,6 +59,7 @@ export const EmbedBlockComponent = ({
 			isMainMedia={isMainMedia}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			<div data-cy="embed-block" css={embedContainerStyles(isEmailEmbed)}>
 				{!!(isEmailEmbed && caption) && (

--- a/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleFormat } from '@guardian/libs';
 import { updateIframeHeight } from '../browser/updateIframeHeight';
 import { ClickToView } from './ClickToView';
 
@@ -15,7 +16,8 @@ export const InstagramBlockComponent: React.FC<{
 	element: InstagramBlockElement;
 	index: number;
 	isMainMedia: boolean;
-}> = ({ element, index, isMainMedia }) => {
+	format: ArticleFormat;
+}> = ({ element, index, isMainMedia, format }) => {
 	return (
 		<ClickToView
 			role={element.role}
@@ -26,6 +28,7 @@ export const InstagramBlockComponent: React.FC<{
 			onAccept={() =>
 				updateIframeHeight(`iframe[name="instagram-embed-${index}"]`)
 			}
+			format={format}
 		>
 			<iframe
 				css={fullWidthStyles}

--- a/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
@@ -56,6 +56,7 @@ export const MapEmbedBlockComponent = ({
 			isMainMedia={isMainMedia}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			<div css={embedContainer}>
 				<MaintainAspectRatio height={height} width={width}>

--- a/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
@@ -52,6 +52,7 @@ export const SpotifyBlockComponent = ({
 			isMainMedia={isMainMedia}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			<div css={embedContainer} data-cy="spotify-embed">
 				<iframe

--- a/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleFormat } from '@guardian/libs';
 import { updateIframeHeight } from '../browser/updateIframeHeight';
 import { ClickToView } from './ClickToView';
 
@@ -12,6 +13,7 @@ type Props = {
 	source?: string;
 	sourceDomain?: string;
 	isPinnedPost?: boolean;
+	format: ArticleFormat;
 };
 
 const fullWidthStyles = css`
@@ -28,6 +30,7 @@ export const UnsafeEmbedBlockComponent = ({
 	source,
 	sourceDomain,
 	isPinnedPost,
+	format,
 }: Props) => {
 	// This allows for when a block is duplicated on a live blog inside a pinned post
 	const uniqueIndex = isPinnedPost ? `${index}-pinned` : index;
@@ -41,6 +44,7 @@ export const UnsafeEmbedBlockComponent = ({
 			onAccept={() =>
 				updateIframeHeight(`iframe[name="unsafe-embed-${uniqueIndex}"]`)
 			}
+			format={format}
 		>
 			<iframe
 				css={fullWidthStyles}

--- a/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { useEffect } from 'react';
 import { embedIframe } from '../browser/embedIframe/embedIframe';
 import { UnsafeEmbedBlockComponent } from './UnsafeEmbedBlockComponent.importable';
@@ -30,6 +31,11 @@ export const DefaultStory = () => {
 				source=""
 				sourceDomain=""
 				role="inline"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticlePillar.News,
+				}}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
@@ -54,6 +54,7 @@ export const VideoFacebookBlockComponent = ({
 			isMainMedia={isMainMedia}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			<div css={embedContainer}>
 				<MaintainAspectRatio height={height} width={width}>

--- a/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleFormat } from '@guardian/libs';
 import { textSans } from '@guardian/source-foundations';
 import { ClickToView } from './ClickToView';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
@@ -16,6 +17,7 @@ type Props = {
 	isTracking: boolean;
 	source?: string;
 	sourceDomain?: string;
+	format: ArticleFormat;
 };
 
 export const VineBlockComponent = ({
@@ -24,6 +26,7 @@ export const VineBlockComponent = ({
 	isTracking,
 	source,
 	sourceDomain,
+	format,
 }: Props) => {
 	return (
 		<ClickToView
@@ -31,6 +34,7 @@ export const VineBlockComponent = ({
 			isTracking={isTracking}
 			source={source}
 			sourceDomain={sourceDomain}
+			format={format}
 		>
 			{!!(element.url && element.width && element.height) && (
 				<div>

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -249,6 +249,7 @@ export const renderElement = ({
 						sourceDomain={element.sourceDomain}
 						title={element.title}
 						width={element.width}
+						format={format}
 					/>
 				</Island>,
 			];
@@ -278,6 +279,7 @@ export const renderElement = ({
 							source={element.source}
 							sourceDomain={element.sourceDomain}
 							isPinnedPost={isPinnedPost}
+							format={format}
 						/>
 					</Island>,
 				];
@@ -294,6 +296,7 @@ export const renderElement = ({
 						isMainMedia={isMainMedia}
 						source={element.source}
 						sourceDomain={element.sourceDomain}
+						format={format}
 					/>
 				</Island>,
 			];
@@ -360,6 +363,7 @@ export const renderElement = ({
 						element={element}
 						index={index}
 						isMainMedia={isMainMedia}
+						format={format}
 					/>
 				</Island>,
 			];
@@ -695,6 +699,7 @@ export const renderElement = ({
 						isTracking={element.isThirdPartyTracking}
 						source={element.source}
 						sourceDomain={element.sourceDomain}
+						format={format}
 					/>
 				</Island>,
 			];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Always enable the Click to View wrapper on Liveblog embeds.

## Why?

Currently CAPI isn't setting the `tracking` field on Embeds correctly if you use the Query parameter that liveblogs use, this is potentially a pretty big privacy issue for our users. I go a bit more into detail in this issue: https://github.com/guardian/frontend/issues/25454

Unfortunately this PR is probably going to add Click to View wrappers to some embeds that don't actually track, but without copying CAPI's list of trusted embed sources its not really possible to decide that in DCR.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/188616616-b32505b9-82c5-460c-88d2-25489cdcea30.png
[after]: https://user-images.githubusercontent.com/21217225/188616511-7c9d61e5-568d-4796-ada2-93848b70d498.png
