### PR TITLE
Don't try to parse shortUrl as a URL

### DIFF
--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -639,8 +639,7 @@ export const Carousel = ({ heading, trails, onwardsSource, format }: Props) => {
 						// Don't try to render cards that have no publication date. This property is technically optional
 						// but we rarely if ever expect it not to exist
 						if (!webPublicationDate) return null;
-						const discussionId =
-							shortUrl && new URL(shortUrl).pathname;
+						const discussionId = shortUrl;
 
 						return (
 							<CarouselCard


### PR DESCRIPTION
**Update**: closing this as it was based on faulty assumptions.

The `shortUrlPath` in a `PressedCard` gets used as the `shortUrl` in a `FaciaCard`, in Frontend. (https://github.com/guardian/frontend/blob/3bcce394d0f105bcd3b47aafc944c41674d85bd7/common/app/layout/FaciaCard.scala#L68)

Because the `shortUrlPath` is not a valid URL, it was throwing an error in a DCR method which expected `shortUrl` to be a URL. However, the specific code which was sending the `FaciaCard` version of the `shortUrl` to DCR is not in production. It  feels like there is a potential bug in the area here, but I'm not aware of any current bug in the production code.


---
`shortUrl` is not a valid URL, so it cannot be parsed as such. It seems
to arrive at the carousel component already in the format required for a
`discussionId`.

Co-authored by: Ashleigh Carr <ashcorr20@gmail.com>
Co-authored by: Ioanna Kokkini <ioannakok@users.noreply.github.com>

@oliverlloyd this seemed to be causing a bug -- does this seem like a sensible fix to you?