### PR TITLE
Remove Husky From AR

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -12523,11 +12523,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
-    "husky": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.2.0.tgz",
-      "integrity": "sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg=="
-    },
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -81,7 +81,6 @@
     "eslint-plugin-react": "^7.30.1",
     "express": "^4.18.1",
     "html-webpack-plugin": "^5.5.0",
-    "husky": "^5.2.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "jsdom": "^16.7.0",


### PR DESCRIPTION
## Why?

It's already a dependency in the project root, and its config also lives in the project root. We don't need it separately in AR too.

It doesn't appear to be a dependency of the DCR sub-project either.

## Changes

- Remove husky as an AR dependency
