### PR TITLE
Set colour to gallery's neutral[86] for follow link

### DIFF
--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -419,6 +419,10 @@ const headlineTag = (_format: ArticleFormat): Colour => neutral[100];
 const headlineTagDark = (_format: ArticleFormat): Colour => neutral[10];
 
 const follow = (format: ArticleFormat): Colour => {
+	if (format.design === ArticleDesign.Gallery) {
+		return neutral[86];
+	}
+
 	switch (format.theme) {
 		case ArticlePillar.News:
 			switch (format.design) {
@@ -447,6 +451,8 @@ const followDark = (format: ArticleFormat): Colour => {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
 			return neutral[100];
+		case ArticleDesign.Gallery:
+			return neutral[86];
 		default:
 			switch (format.theme) {
 				case ArticlePillar.News:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the colour of the follow link in the gallery metadata component
## Why?
Using theme colours on the dark background does not meet a11y standards
## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/99400613/188707361-917638b6-c4e7-43f0-8185-fb61c86a887a.png) | <img width="157" alt="image" src="https://user-images.githubusercontent.com/99400613/188707408-57dc8b96-e4a5-4652-a79f-b6050125ad23.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
