### PR TITLE
Gallery Image Sizes

### DIFF
--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -6,9 +6,11 @@ import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, textSans } from '@guardian/source-foundations';
 import Img from 'components/ImgAlt';
 import { grid } from 'grid/grid';
+import type { Image } from 'image/image';
+import type { Sizes } from 'image/sizes';
 import type { FC } from 'react';
 import { darkModeCss } from 'styles';
-import { getDefaultImgStyles, getDefaultSizes } from './BodyImage.defaults';
+import { getDefaultImgStyles } from './BodyImage.defaults';
 import type { BodyImageProps } from './BodyImage.defaults';
 
 const figureStyles = css`
@@ -108,6 +110,19 @@ const captionStyles = (format: ArticleFormat): SerializedStyles => css`
 	`}
 `;
 
+const imgSizes = (image: Image): Sizes => {
+	const ratio = image.width / image.height;
+
+	return {
+		mediaQueries: [
+			{ breakpoint: 'wide', size: `min(1020px, 100vh * ${ratio})` },
+			{ breakpoint: 'leftCol', size: `min(940px, 100vh * ${ratio})` },
+			{ breakpoint: 'phablet', size: `min(620px, 100vh * ${ratio})` },
+		],
+		default: `min(100vw, 100vh * ${ratio})`,
+	};
+};
+
 const GalleryBodyImage: FC<BodyImageProps> = ({
 	image,
 	format,
@@ -119,7 +134,7 @@ const GalleryBodyImage: FC<BodyImageProps> = ({
 		<div css={imageWrapperStyles(format)}>
 			<Img
 				image={image}
-				sizes={getDefaultSizes(image.role)}
+				sizes={imgSizes(image)}
 				className={getDefaultImgStyles(image.role, supportsDarkMode)}
 				format={format}
 				supportsDarkMode={supportsDarkMode}


### PR DESCRIPTION
## Why?

We use image `<source>`s along with the `sizes` attribute to provide hints to the browser about what images it should load. The advantage of this is that it can make requests for images before the CSS has been parsed and applied, which reduces image load time. The downside is that you have to specify image sizes in your HTML, alongside where you specify it in your CSS (i.e. in two places). In essence, you have to figure out what the consequence of your CSS will be, and capture that in your `<source>` tags.

The images in the body of galleries are sized differently to images in most other articles. This means we can't use the default sizes created for standard articles, and must instead create a set specific to the gallery designs. This PR makes that change.

## Changes

- Specify sizes for gallery body images
