### PR TITLE
fix: Use two columns on mobile, the same as we do for blogs

### DIFF
--- a/dotcom-rendering/src/web/components/MatchStats.tsx
+++ b/dotcom-rendering/src/web/components/MatchStats.tsx
@@ -121,16 +121,15 @@ const StatsGrid = ({
 							}
 
 							${until.phablet} {
-								grid-template-columns: 100%;
+								grid-template-columns: 50% 50%;
 								grid-template-areas:
-									'title'
-									'possession'
-									'attempts'
-									'corners'
-									'fouls'
-									'subtitle'
-									'home'
-									'away';
+									'title			title'
+									'possession		possession'
+									'attempts		attempts'
+									'corners		corners'
+									'fouls			fouls'
+									'subtitle		subtitle'
+									'home			away';
 							}
 						}
 					`}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes https://github.com/guardian/dotcom-rendering/issues/4784 by changing the grid layout we use for non blog articles on mobile from a single column (100%) to a two column view (50% 50%).

## Why?
Because @rcrphillips asked us to 😸  (Sorry this took so long Rob!)

| Before      | After      |
|-------------|------------|
| <img width="398" alt="Screenshot 2022-09-07 at 15 23 26" src="https://user-images.githubusercontent.com/1336821/188903655-ddc25d63-9998-4c48-a8e5-08a5052a5df3.png"> | <img width="398" alt="Screenshot 2022-09-07 at 15 22 11" src="https://user-images.githubusercontent.com/1336821/188903693-fcad5396-9276-433f-8115-0dbca6ffc4c8.png"> |
