### PR TITLE
Hide merch slots on labs articles

### DIFF
--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -224,6 +224,8 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(CAPIArticle);
 
+	const isLabs = format.theme === ArticleSpecial.Labs;
+
 	return (
 		<>
 			<ImmersiveHeader
@@ -327,7 +329,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 						<GridItem area="lines">
 							{format.design === ArticleDesign.PhotoEssay &&
-							format.theme !== ArticleSpecial.Labs ? (
+							!isLabs ? (
 								<></>
 							) : (
 								<div css={maxWidth}>
@@ -504,21 +506,21 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 					</ImmersiveGrid>
 				</Section>
-
-				<Section
-					fullWidth={true}
-					padSides={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot
-						position="merchandising-high"
-						display={format.display}
-					/>
-				</Section>
-
+				{!isLabs && (
+					<Section
+						fullWidth={true}
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising-high"
+							display={format.display}
+						/>
+					</Section>
+				)}
 				{CAPIArticle.onwards ? (
 					<DecideOnwards
 						onwards={CAPIArticle.onwards}
@@ -571,7 +573,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</Island>
 					</>
 				)}
-
 				{!isPaidContent && showComments && (
 					<Section
 						fullWidth={true}
@@ -597,7 +598,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						/>
 					</Section>
 				)}
-
 				{!isPaidContent && (
 					<Section
 						title="Most viewed"
@@ -619,17 +619,21 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</MostViewedFooterLayout>
 					</Section>
 				)}
-
-				<Section
-					fullWidth={true}
-					padSides={false}
-					showTopBorder={false}
-					showSideBorders={false}
-					backgroundColour={neutral[93]}
-					element="aside"
-				>
-					<AdSlot position="merchandising" display={format.display} />
-				</Section>
+				{!isLabs && (
+					<Section
+						fullWidth={true}
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={neutral[93]}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising"
+							display={format.display}
+						/>
+					</Section>
+				)}
 			</main>
 
 			{NAV.subNavSections && (

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -245,9 +245,11 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	 */
 	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
 
+	const isLabs = format.theme === ArticleSpecial.Labs;
+
 	return (
 		<>
-			{format.theme !== ArticleSpecial.Labs ? (
+			{!isLabs ? (
 				<>
 					<div>
 						{renderAds && (
@@ -657,7 +659,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</ShowcaseGrid>
 				</Section>
 
-				{renderAds && (
+				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
 						padSides={false}
@@ -774,7 +776,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{renderAds && (
+				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
 						padSides={false}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -345,6 +345,8 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	 */
 	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
 
+	const isLabs = format.theme === ArticleSpecial.Labs;
+
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -362,7 +364,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</Section>
 						</Stuck>
 					)}
-					{format.theme !== ArticleSpecial.Labs && (
+					{!isLabs && (
 						<Section
 							fullWidth={true}
 							showTopBorder={false}
@@ -411,42 +413,37 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							editionId={CAPIArticle.editionId}
 						/>
 					</Section>
-					{NAV.subNavSections &&
-						format.theme !== ArticleSpecial.Labs && (
-							<>
-								<Section
-									fullWidth={true}
-									backgroundColour={
-										palette.background.article
-									}
-									padSides={false}
-									element="aside"
-								>
-									<Island deferUntil="idle">
-										<SubNav
-											subNavSections={NAV.subNavSections}
-											currentNavLink={NAV.currentNavLink}
-											format={format}
-										/>
-									</Island>
-								</Section>
-								<Section
-									fullWidth={true}
-									backgroundColour={
-										palette.background.article
-									}
-									padSides={false}
-									showTopBorder={false}
-								>
-									<StraightLines
-										count={4}
-										cssOverrides={css`
-											display: block;
-										`}
+					{NAV.subNavSections && !isLabs && (
+						<>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								element="aside"
+							>
+								<Island deferUntil="idle">
+									<SubNav
+										subNavSections={NAV.subNavSections}
+										currentNavLink={NAV.currentNavLink}
+										format={format}
 									/>
-								</Section>
-							</>
-						)}
+								</Island>
+							</Section>
+							<Section
+								fullWidth={true}
+								backgroundColour={palette.background.article}
+								padSides={false}
+								showTopBorder={false}
+							>
+								<StraightLines
+									count={4}
+									cssOverrides={css`
+										display: block;
+									`}
+								/>
+							</Section>
+						</>
+					)}
 				</>
 			</div>
 
@@ -786,7 +783,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</StandardGrid>
 				</Section>
 
-				{renderAds && (
+				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"
@@ -906,7 +903,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 					</Section>
 				)}
 
-				{renderAds && (
+				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
 						data-print-layout="hide"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides merch slots on article pages if they're labs articles.

## Why?
Now that we're reserving space for merch slots to reduce CLS (PRs https://github.com/guardian/dotcom-rendering/pull/5561 and https://github.com/guardian/frontend/pull/25321), if they are not filled like on Labs articles there are large empty spaces left.

We know merch slots will never be shown on Labs articles so we can hide them server side.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1731150/189130594-413e8deb-325f-49e5-9a12-ee4f9c3b36af.png
[after]: https://user-images.githubusercontent.com/1731150/189130629-3507cbb7-0343-42ac-bcea-77c69890046d.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
