### PR TITLE
chore (deps): bump @guardian/consent-management-platform from 10.7.1 to 10.11.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
     "@guardian/atoms-rendering": "^23.4.0",
     "@guardian/braze-components": "^7.3.0",
     "@guardian/commercial-core": "^4.3.0",
-    "@guardian/consent-management-platform": "10.7.1",
+    "@guardian/consent-management-platform": "10.11.1",
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/libs": "^7.1.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,12 +2801,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.3.0.tgz#f04bc56d4eedef9feb2a4c844142a7b11082d9bd"
   integrity sha512-T7aE9kqc0JCNaASh7iHof6+MMOTnoEwinYiIjbJSjMoNRfuMSKIfLpWjZfZ8w58uvOygIx6MJDFTRdyT5J5Fvw==
 
-"@guardian/consent-management-platform@10.7.1":
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.7.1.tgz#ed672e1a7cc0e177d820dc7b2ebbfd26531a2d86"
-  integrity sha512-9wN4Bu0VMfpDg0p1/PjO/hAuPN7pJrBm24YXLWmAnfvHci0Wr+WMSF5ZOwhbMA01jl5IP3Hr1TKpFbkg3NhGdg==
+"@guardian/consent-management-platform@10.11.1":
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.11.1.tgz#fa01a9262963ac07df9476e591d14601efbc4588"
+  integrity sha512-7dKcKZ3L/Y/hG9MB6i1invZmTVL6EepIv1ioGCW7uR9MVhWcuIGR1MJqKWMIzQgtZ2p0CXtSzKQOvbRtfX5fxQ==
   dependencies:
-    "@guardian/libs" "1.6.1 - 3.3.0"
+    "@guardian/libs" "^7.1.4"
 
 "@guardian/discussion-rendering@^10.1.1":
   version "10.1.1"
@@ -2846,15 +2846,15 @@
     "@typescript-eslint/eslint-plugin" "5.9.1"
     "@typescript-eslint/parser" "5.9.1"
 
-"@guardian/libs@1.6.1 - 3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
-  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
-
 "@guardian/libs@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.0.tgz#1c80905e29df158d09f4681ec13f37fdbcbbe5f2"
   integrity sha512-GTFY5sFyKov2HZFdWEKhnWB1IjBFiFhtzJdG2BlFcRBeRo/8DlBvOMjURY+hnoIdgEo1f3A+hHUBdqLsRP5Uig==
+
+"@guardian/libs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
 
 "@guardian/prettier@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps the CMP to 10.7.1 to incorporate changes from: 

- bump @guardian.lib to 7.1.4
- https://github.com/guardian/consent-management-platform/commit/a54aa2d07c7288abf75a68d5b03c3f565b6b3bd9 

## Why?

- To ensure dependencies up to date.
- feat: Setup Gpc signal test for ccpa

[Frontend PR](https://github.com/guardian/frontend/pull/25447) (dependabot)
