### PR TITLE
fix: add class .js-native-video to MainMediaVideo wrapper for client script

### DIFF
--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -188,7 +188,7 @@ function slideshow(): void {
 }
 
 function getVideoSlots(): VideoSlot[] {
-	const videoSlots = document.querySelectorAll('.native-video');
+	const videoSlots = document.querySelectorAll('.js-native-video');
 
 	if (videoSlots.length === 0) {
 		return [];

--- a/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
@@ -61,6 +61,7 @@ interface Props {
 
 const MainMediaVideo: FC<Props> = ({ video, format }) => (
 	<div
+		className="js-native-video"
 		css={styles(format)}
 		data-posterUrl={video.posterUrl}
 		data-videoId={video.videoId}

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -561,7 +561,7 @@ const mediaAtomRenderer = (
 		'data-posterUrl': posterUrl,
 		'data-videoId': videoId,
 		'data-duration': duration,
-		className: 'native-video',
+		className: 'js-native-video',
 		css: styles,
 	};
 	const figcaption = h(FigCaption, {


### PR DESCRIPTION
## What does this change?

- Adds `.js-native-video` class to the `MainMediaVideo`
- Renames `.native-video` on media atom renderer to `.js-native-video`

## Why?

The client side script [`nativeCommunication.ts`](https://github.com/guardian/dotcom-rendering/blob/main/apps-rendering/src/client/nativeCommunication.ts) looks for elements with a specific class name to pass video information via Bridget to the apps. For `MainMediaVideo`, this class was missing and so the elements were not found.