### PR TITLE
fix(caption): display camera icon if caption or credit exists

### DIFF
--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -21,6 +21,7 @@ import {
 	fromNullable,
 	map,
 	none,
+	OptionKind,
 	some,
 	withDefault,
 } from '@guardian/types';
@@ -402,12 +403,18 @@ const imageRenderer = (
 	key: number,
 ): ReactNode => {
 	const { caption, credit, nativeCaption } = element;
+
+	const cap =
+		caption.kind === OptionKind.Some || credit.kind === OptionKind.Some
+			? some([
+					h(Caption, { format, caption }),
+					h(Credit, { credit, format, key }),
+			  ])
+			: none;
+
 	return h(BodyImage, {
-		caption: some([
-			h(Caption, { format, caption }),
-			h(Credit, { credit, format, key }),
-		]),
-		format: format,
+		caption: cap,
+		format,
 		key,
 		supportsDarkMode: true,
 		lightbox: some({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- if neither the image `caption` or `credit` have a value, sets the `caption` prop of `BodyImage` to `none`. Previously, this was always wrapped in a `some`, which meant the caption icon would display even if there was no value

## Why?

Fixes #5973 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screen Shot 2022-09-12 at 10 49 20](https://user-images.githubusercontent.com/705427/189624464-bdab5be9-d928-4466-bf6b-03b28b88bc35.png) | ![Screen Shot 2022-09-12 at 10 37 17](https://user-images.githubusercontent.com/705427/189624234-61300618-5b42-466f-9c44-18f8f2bc993c.png) |

