### PR TITLE
Revert "chore: double the min/max ASG sizes"

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -8,8 +8,8 @@ new MobileAppsRendering(app, 'MobileAppsRendering', {
 	stack: 'mobile',
 	cloudFormationStackName,
 	recordPrefix: 'mobile-rendering',
-	asgMinSize: { CODE: 1, PROD: 6 },
-	asgMaxSize: { CODE: 2, PROD: 24 },
+	asgMinSize: { CODE: 1, PROD: 3 },
+	asgMaxSize: { CODE: 2, PROD: 12 },
 });
 
 new MobileAppsRendering(app, 'MobileAppsRenderingPreview', {


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#5969

Fixes #5980 