### PR TITLE
Revert "Scale up servers from 9 > 18"

### DIFF
--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -79,8 +79,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 18
-      MaxCapacity: 72
+      MinCapacity: 9
+      MaxCapacity: 36
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#5971
No need to be scaled up anymore.