### PR TITLE
fix(riff-raff): repository is dotcom-rendering, not apps-rendering

### DIFF
--- a/apps-rendering/artifact.json
+++ b/apps-rendering/artifact.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Mobile::mobile-apps-rendering",
-  "vcsURL": "https://github.com/guardian/apps-rendering",
+  "vcsURL": "https://github.com/guardian/dotcom-rendering",
   "actions": [
     {
       "action": "mobile-apps-rendering",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Fixes the repository URL in the Riff Raff configuration, from `apps-rendering` to `dotcom-rendering`

## Why?

Fixes navigation to the deployed commit from Riff Raff

