### PR TITLE
refactor(cdk): use GuAsgCapacity type

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -9,9 +9,9 @@ new MobileAppsRendering(app, 'MobileAppsRendering-CODE', {
 	stack: 'mobile',
 	stage: 'CODE',
 	recordPrefix: 'mobile-rendering',
-	asgSize: {
-		min: 1,
-		max: 2,
+	asgCapacity: {
+		minimumInstances: 1,
+		maximumInstances: 2,
 	},
 	appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 	hostedZoneId: 'Z6PRU8YR6TQDK',
@@ -23,9 +23,9 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 	stack: 'mobile',
 	stage: 'PROD',
 	recordPrefix: 'mobile-rendering',
-	asgSize: {
-		min: 3,
-		max: 12,
+	asgCapacity: {
+		minimumInstances: 3,
+		maximumInstances: 12,
 	},
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',
@@ -37,9 +37,9 @@ new MobileAppsRendering(app, 'MobileAppsRenderingPreview-CODE', {
 	stack: 'mobile-preview',
 	stage: 'CODE',
 	recordPrefix: 'mobile-preview-rendering',
-	asgSize: {
-		min: 1,
-		max: 2,
+	asgCapacity: {
+		minimumInstances: 1,
+		maximumInstances: 2,
 	},
 	appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 	hostedZoneId: 'Z6PRU8YR6TQDK',
@@ -51,9 +51,9 @@ new MobileAppsRendering(app, 'MobileAppsRenderingPreview-PROD', {
 	stack: 'mobile-preview',
 	stage: 'PROD',
 	recordPrefix: 'mobile-preview-rendering',
-	asgSize: {
-		min: 1,
-		max: 2,
+	asgCapacity: {
+		minimumInstances: 1,
+		maximumInstances: 2,
 	},
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.test.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.test.ts
@@ -9,9 +9,9 @@ describe('The MobileAppsRendering stack', () => {
 			stack: 'mobile',
 			stage: 'TEST',
 			recordPrefix: 'mobile-rendering',
-			asgSize: {
-				min: 1,
-				max: 2,
+			asgCapacity: {
+				minimumInstances: 1,
+				maximumInstances: 2,
 			},
 			appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 			hostedZoneId: 'TEST-HOSTED-ZONE-ID',
@@ -32,9 +32,9 @@ describe('The MobileAppsRenderingPreview stack', () => {
 				stack: 'mobile-preview',
 				stage: 'TEST',
 				recordPrefix: 'mobile-preview-rendering',
-				asgSize: {
-					min: 1,
-					max: 2,
+				asgCapacity: {
+					minimumInstances: 1,
+					maximumInstances: 2,
 				},
 				appsRenderingDomain: 'mobile-aws.code.dev-guardianapis.com',
 				hostedZoneId: 'TEST-HOSTED-ZONE-ID',

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -3,6 +3,7 @@ import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
+import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
 import type { App, CfnElement } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import {
@@ -18,14 +19,9 @@ import {
 	RecordType,
 } from 'aws-cdk-lib/aws-route53';
 
-interface AsgSize {
-	min: number;
-	max: number;
-}
-
 interface AppsStackProps extends GuStackProps {
 	recordPrefix: string;
-	asgSize: AsgSize;
+	asgCapacity: GuAsgCapacity;
 	appsRenderingDomain: string;
 	hostedZoneId: string;
 	targetCpuUtilisation: number;
@@ -100,8 +96,8 @@ export ASSETS_MANIFEST="/opt/${appName}/manifest.json"
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${this.region} mobile-log-aggregation-${this.stage} '/var/log/${appName}/*'
 /usr/local/node/pm2 logrotate -u ${appName}`,
 			scaling: {
-				minimumInstances: props.asgSize.min,
-				maximumInstances: props.asgSize.max,
+				minimumInstances: props.asgCapacity.minimumInstances,
+				maximumInstances: props.asgCapacity.maximumInstances,
 			},
 		});
 

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -95,10 +95,7 @@ export ASSETS_MANIFEST="/opt/${appName}/manifest.json"
 /usr/local/node/pm2 start --name ${appName} --uid ${appName} --gid mapi /opt/${appName}/server.js
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${this.region} mobile-log-aggregation-${this.stage} '/var/log/${appName}/*'
 /usr/local/node/pm2 logrotate -u ${appName}`,
-			scaling: {
-				minimumInstances: props.asgCapacity.minimumInstances,
-				maximumInstances: props.asgCapacity.maximumInstances,
-			},
+			scaling: props.asgCapacity,
 		});
 
 		const asg = appsRenderingApp.autoScalingGroup;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses the `GuAsgCapacity` type to model the AutoScaling Group sizes. This replaces a custom type

## Why?

- It doesn't make sense to duplicate the type
