### PR TITLE
fix: Labs header overlapping right advert

### DIFF
--- a/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
+++ b/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
@@ -14,13 +14,11 @@ import {
 import LabsLogo from '../../static/logos/the-guardian-labs.svg';
 import { Dropdown } from './Dropdown';
 
-export const LABS_HEADER_HEIGHT = 55;
-
 const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			position: relative;
-			height: ${LABS_HEADER_HEIGHT}px;
+			height: 55px;
 			display: flex;
 			justify-content: space-between;
 		`}

--- a/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
+++ b/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
@@ -14,11 +14,13 @@ import {
 import LabsLogo from '../../static/logos/the-guardian-labs.svg';
 import { Dropdown } from './Dropdown';
 
+export const LABS_HEADER_HEIGHT = 55;
+
 const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			position: relative;
-			height: 55px;
+			height: ${LABS_HEADER_HEIGHT}px;
 			display: flex;
 			justify-content: space-between;
 		`}

--- a/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
+++ b/dotcom-rendering/src/web/components/LabsHeader.importable.tsx
@@ -12,13 +12,14 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source-react-components';
 import LabsLogo from '../../static/logos/the-guardian-labs.svg';
+import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { Dropdown } from './Dropdown';
 
 const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
 			position: relative;
-			height: 55px;
+			height: ${LABS_HEADER_HEIGHT}px;
 			display: flex;
 			justify-content: space-between;
 		`}

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -1,12 +1,12 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { getCookie } from '@guardian/libs';
+import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { ShadyPie } from './ShadyPie';
 
 const isServer = typeof window === 'undefined';
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
-const LABS_HEADER_HEIGHT = 55;
 
 /**
  * TopRightAdSlot decides if we should render the ShadyPie or not

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -2,6 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { getCookie } from '@guardian/libs';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
+import { LABS_HEADER_HEIGHT } from './LabsHeader.importable';
 import { ShadyPie } from './ShadyPie';
 
 const isServer = typeof window === 'undefined';
@@ -67,7 +68,8 @@ export const TopRightAdSlot = ({
 				css={[
 					css`
 						position: sticky;
-						top: 0;
+						/* Possibly account for the sticky Labs header and 6px of padding */
+						top: ${isPaidContent ? LABS_HEADER_HEIGHT + 6 : 0}px;
 					`,
 					adStyles,
 				]}

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -2,11 +2,11 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { getCookie } from '@guardian/libs';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
-import { LABS_HEADER_HEIGHT } from './LabsHeader.importable';
 import { ShadyPie } from './ShadyPie';
 
 const isServer = typeof window === 'undefined';
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
+const LABS_HEADER_HEIGHT = 55;
 
 /**
  * TopRightAdSlot decides if we should render the ShadyPie or not

--- a/dotcom-rendering/src/web/lib/labs-constants.ts
+++ b/dotcom-rendering/src/web/lib/labs-constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Height of the Guardian Labs header
+ *
+ * Note this constant is stored separately so that it can be imported
+ * into two distinct islands without polluting their bundles with extra
+ * unecessary code.
+ */
+export const LABS_HEADER_HEIGHT = 55;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This is a fix to prevent the Labs header from overlapping the right advert, once a user starts scrolling and the header becomes sticky. This is achieved by applying an offset of `55px` (the height of the Labs header) plus a padding of `6px` (to match the padding of the advert when it's not scrolling) to the `top` of the advert.

## Why?

Prevent the Labs header from overlapping the top of an advert.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/8000415/189696495-887405ac-9c8d-4565-8940-9cddc4ff918f.png
[after]: https://user-images.githubusercontent.com/8000415/189696290-9e9a2135-7c34-4302-937c-37a0c0f49724.png