### PR TITLE
Fix `<li>` padding when adjacent to floating images

### DIFF
--- a/dotcom-rendering/src/web/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TextBlockComponent.tsx
@@ -150,6 +150,7 @@ export const TextBlockComponent = ({
 				li {
 					margin-bottom: 6px;
 					padding-left: 20px;
+					display: flow-root;
 
 					p {
 						display: inline;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #5987 by adding `display: flow-root;` to the `li` element, causing a new [block formatting content](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context#exclude_external_floats) to be created such that the `padding-left` value is applied appropriately.

The entertaining article used for testing: https://www.theguardian.com/australia-news/2022/sep/13/interspecies-innovation-arms-race-cockatoos-and-humans-at-war-over-wheelie-bin-raids

### Can i use `display: flow-root;`?
Yes, [support for this property](https://caniuse.com/flow-root) is good and any degradation is graceful.

| Before      | After      |
|-------------|------------|
| <img width="655" alt="Screenshot 2022-09-13 at 09 09 50" src="https://user-images.githubusercontent.com/1336821/189854435-c99423f5-019c-45ba-890d-c28fda45d0b4.png"> | <img width="655" alt="Screenshot 2022-09-13 at 09 09 36" src="https://user-images.githubusercontent.com/1336821/189854481-08c7d392-cd7f-4aeb-91b6-615af07a3d09.png"> |
