### PR TITLE
Remove `aria-label` from navigation links

### DIFF
--- a/dotcom-rendering/src/web/components/Pillars.tsx
+++ b/dotcom-rendering/src/web/components/Pillars.tsx
@@ -274,7 +274,6 @@ export const Pillars: React.FC<{
 							showDivider && pillarDivider,
 						]}
 						id={isTopNav && i === 0 ? 'navigation' : undefined}
-						aria-label={i === 0 ? 'Navigation' : undefined}
 						href={p.url}
 						data-link-name={`${dataLinkName} : primary : ${p.title}`}
 					>

--- a/scripts/deno/iframe-titles.ts
+++ b/scripts/deno/iframe-titles.ts
@@ -167,7 +167,7 @@ const issue_number = 5510;
 
 if (!octokit) {
 	console.log(body);
-	Deno.exit(0);
+	Deno.exit();
 }
 
 try {
@@ -185,8 +185,9 @@ try {
 } catch (error) {
 	// do_something
 	console.warn(`Failed to update issue #${issue_number}`);
+	console.error(error);
 
 	console.log(body);
 }
 
-Deno.exit(0);
+Deno.exit();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove aria-label from navigation links, as they are already described by their content.

## Why?

Implemented in #3210

Fixes #5054

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/189883959-8301c56d-bed0-40f1-9dda-17b4600adbe2.png
[after]: https://user-images.githubusercontent.com/76776/189883632-84988bc4-1cb0-4694-97d2-3e6b41801b28.png