### PR TITLE
Remove tabindex from skip to maincontent links

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -187,7 +187,6 @@ export const ArticleBody = ({
 	}
 	return (
 		<div
-			tabIndex={0}
 			id="maincontent"
 			css={[
 				isInteractive ? null : bodyPadding,

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -329,7 +329,7 @@ export const FullPageInteractiveLayout = ({
 				backgroundColour={palette.background.article}
 				element="main"
 			>
-				<article id="maincontent" tabIndex={-1}>
+				<article id="maincontent">
 					<Renderer
 						format={format}
 						elements={


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This removes tabindex from maincontent links.
## Why?
The tabindex was not providing any benefit.

It is not generally used and not mentioned on webaim:
https://webaim.org/techniques/skipnav/

A tab index of -1 was suggested by DAC however this may have been due to tabindexes already being present on some links.






