### PR TITLE
Upgrade Permutive SDK

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -526,30 +526,31 @@ declare module 'dynamic-import-polyfill' {
 
 declare namespace JSX {
 	interface IntrinsicElements {
-		'amp-state': any;
-		'amp-form': any;
-		'amp-experiment': any;
-		'amp-sidebar': any;
 		'amp-accordion': any;
-		'amp-img': any;
-		'amp-twitter': any;
-		'amp-list': any;
-		'amp-vimeo': any;
-		'amp-facebook': any;
-		'amp-video': any;
-		'amp-instagram': any;
-		'amp-soundcloud': any;
-		'amp-iframe': any;
-		'amp-analytics': any;
-		'amp-pixel': any;
 		'amp-ad': any;
-		'amp-sticky-ad': any;
-		'amp-youtube': any;
-		'amp-geo': any;
-		'amp-consent': any;
-		'amp-live-list': any;
+		'amp-analytics': any;
 		'amp-audio': any;
+		'amp-consent': any;
 		'amp-embed': any;
+		'amp-experiment': any;
+		'amp-facebook': any;
+		'amp-form': any;
+		'amp-geo': any;
+		'amp-iframe': any;
+		'amp-img': any;
+		'amp-instagram': any;
+		'amp-list': any;
+		'amp-live-list': any;
+		'amp-pixel': any;
+		'amp-script': any;
+		'amp-sidebar': any;
+		'amp-soundcloud': any;
+		'amp-state': any;
+		'amp-sticky-ad': any;
+		'amp-twitter': any;
+		'amp-video': any;
+		'amp-vimeo': any;
+		'amp-youtube': any;
 	}
 }
 

--- a/dotcom-rendering/src/amp/components/Analytics.tsx
+++ b/dotcom-rendering/src/amp/components/Analytics.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { PermutivePayload } from '../lib/permutive';
 
 export interface AnalyticsModel {
 	gaTracker: string;
@@ -11,11 +10,6 @@ export interface AnalyticsModel {
 	id: string;
 	neilsenAPIID: string;
 	domain: string;
-	permutive: {
-		namespace: string;
-		apiKey: string;
-		payload: PermutivePayload;
-	};
 	ipsosSectionName: string;
 }
 
@@ -32,7 +26,6 @@ export const Analytics: React.FC<{
 		id,
 		neilsenAPIID,
 		domain,
-		permutive,
 		ipsosSectionName,
 	},
 }) => {
@@ -85,17 +78,6 @@ export const Analytics: React.FC<{
                         "section": "${section}",
                         "segC": "Guardian - Google AMP"
                     }
-                }
-            </script>
-        </amp-analytics>`,
-		`<amp-analytics data-block-on-consent type="permutive">
-            <script type="application/json">
-                {
-                    "vars": {
-                        "namespace": "${permutive.namespace}",
-                        "key": "${permutive.apiKey}"
-                    },
-                    "extraUrlParams": ${JSON.stringify(permutive.payload)}
                 }
             </script>
         </amp-analytics>`,

--- a/dotcom-rendering/src/amp/components/Permutive.tsx
+++ b/dotcom-rendering/src/amp/components/Permutive.tsx
@@ -7,5 +7,70 @@ export interface PermutiveModel {
 }
 
 export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
-	return null;
+	const permutiveConfig = `
+		<script type="application/json">
+			{
+				"apiKey": "${apiKey}",
+				"projectId": "${projectId}",
+				"environment": "production"
+			}
+		</script>`;
+
+	const permutiveAmpScript = `
+		<script type="application/json">
+			{
+				"extraUrlParams": ${JSON.stringify(payload)}
+			}
+		</script>`;
+
+	const permutiveCachedTargetingScript = `
+		exportFunction('ct', () => {let c = JSON.parse(localStorage.getItem('_pdfps'));let i = localStorage.getItem('permutive-id');return {targeting:{permutive: c ? c : [], puid: i}, ppid: i};})
+	`;
+
+	const pampScript = `
+		fetch('https://cdn.permutive.app/queries/${projectId}-amp.json').then(r => r.json()).then(d => AMP.setState({permutiveConfig: {ampJson: d}}));
+	`;
+
+	return (
+		<>
+			<amp-state
+				id="permutiveConfig"
+				dangerouslySetInnerHTML={{ __html: permutiveConfig }}
+			/>
+			<amp-analytics
+				type="permutive-ampscript"
+				dangerouslySetInnerHTML={{ __html: permutiveAmpScript }}
+			/>
+			<amp-script
+				id="permutiveCachedTargeting"
+				sandboxed=""
+				script="permutiveCachedTargetingScript"
+			></amp-script>
+			<script
+				id="permutiveCachedTargetingScript"
+				type="text/plain"
+				// @ts-expect-error -- Do as Permutive instructs
+				target="amp-script"
+				dangerouslySetInnerHTML={{
+					__html: permutiveCachedTargetingScript,
+				}}
+			></script>
+			<amp-script sandboxed="" script="pamp-json"></amp-script>
+			<script
+				id="pamp-json"
+				type="text/plain"
+				// @ts-expect-error -- Do as Permutive instructs
+				target="amp-script"
+				dangerouslySetInnerHTML={{
+					__html: pampScript,
+				}}
+			></script>
+			<amp-script
+				data-block-on-consent={true}
+				id="permutiveSdk"
+				sandboxed=""
+				src={`https://cdn.permutive.app/ampsdk/${projectId}-ampscript.js`}
+			></amp-script>
+		</>
+	);
 };

--- a/dotcom-rendering/src/amp/components/Permutive.tsx
+++ b/dotcom-rendering/src/amp/components/Permutive.tsx
@@ -6,6 +6,9 @@ export interface PermutiveModel {
 	payload: PermutivePayload;
 }
 
+/**
+ * Responsible for ensuring the necessary scripts are placed on articles in order to run the Permutive SDK
+ */
 export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 	const permutiveConfig = `
 		<script type="application/json">
@@ -43,6 +46,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 			/>
 			<amp-script
 				id="permutiveCachedTargeting"
+				// Empty string required to pass AMP validation
 				sandboxed=""
 				script="permutiveCachedTargetingScript"
 			></amp-script>
@@ -55,7 +59,11 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 					__html: permutiveCachedTargetingScript,
 				}}
 			></script>
-			<amp-script sandboxed="" script="pamp-json"></amp-script>
+			<amp-script
+				// Empty string required to pass AMP validation
+				sandboxed=""
+				script="pamp-json"
+			></amp-script>
 			<script
 				id="pamp-json"
 				type="text/plain"
@@ -68,6 +76,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 			<amp-script
 				data-block-on-consent={true}
 				id="permutiveSdk"
+				// Empty string required to pass AMP validation
 				sandboxed=""
 				src={`https://cdn.permutive.app/ampsdk/${projectId}-ampscript.js`}
 			></amp-script>

--- a/dotcom-rendering/src/amp/components/Permutive.tsx
+++ b/dotcom-rendering/src/amp/components/Permutive.tsx
@@ -1,0 +1,11 @@
+import type { PermutivePayload } from '../lib/permutive';
+
+export interface PermutiveModel {
+	apiKey: string;
+	projectId: string;
+	payload: PermutivePayload;
+}
+
+export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
+	return null;
+};

--- a/dotcom-rendering/src/amp/components/Permutive.tsx
+++ b/dotcom-rendering/src/amp/components/Permutive.tsx
@@ -37,14 +37,17 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 	return (
 		<>
 			<amp-state
+				data-block-on-consent=""
 				id="permutiveConfig"
 				dangerouslySetInnerHTML={{ __html: permutiveConfig }}
 			/>
 			<amp-analytics
+				data-block-on-consent=""
 				type="permutive-ampscript"
 				dangerouslySetInnerHTML={{ __html: permutiveAmpScript }}
 			/>
 			<amp-script
+				data-block-on-consent=""
 				id="permutiveCachedTargeting"
 				// Empty string required to pass AMP validation
 				sandboxed=""
@@ -60,6 +63,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 				}}
 			></script>
 			<amp-script
+				data-block-on-consent=""
 				// Empty string required to pass AMP validation
 				sandboxed=""
 				script="pamp-json"
@@ -74,7 +78,7 @@ export const Permutive = ({ apiKey, projectId, payload }: PermutiveModel) => {
 				}}
 			></script>
 			<amp-script
-				data-block-on-consent={true}
+				data-block-on-consent=""
 				id="permutiveSdk"
 				// Empty string required to pass AMP validation
 				sandboxed=""

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -3,8 +3,7 @@ import { ContentABTestProvider } from './ContentABTest';
 import { RegionalAd } from './RegionalAd';
 
 describe('RegionalAd', () => {
-	const permutiveURL =
-		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+	const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
 
 	const ukRelevantYieldURL =
 		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -80,7 +80,7 @@ export const getRTCParameters = (adType: AdType): RTCParameters => ({
 	...getPubAndProfileIds(adType),
 });
 
-const permutiveURL = 'https://guardian.amp.permutive.com/rtc?type=doubleclick';
+const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
 
 const amazonConfig = {
 	aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },

--- a/dotcom-rendering/src/amp/pages/Article.tsx
+++ b/dotcom-rendering/src/amp/pages/Article.tsx
@@ -14,6 +14,8 @@ import { ContentABTestProvider } from '../components/ContentABTest';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Onward } from '../components/Onward';
+import type { PermutiveModel } from '../components/Permutive';
+import { Permutive } from '../components/Permutive';
 import { Sidebar } from '../components/Sidebar';
 import { filterForTagsOfType } from '../lib/tag-utils';
 import type { AmpExperiments } from '../server/ampExperimentCache';
@@ -49,12 +51,25 @@ export const Article: React.FC<{
 	articleData: ArticleModel;
 	config: ConfigType;
 	analytics: AnalyticsModel;
-}> = ({ nav, articleData, config, analytics, experimentsData }) => {
+	permutive: PermutiveModel;
+}> = ({
+	nav,
+	articleData,
+	config,
+	analytics,
+	experimentsData,
+	permutive: { projectId, apiKey, payload },
+}) => {
 	return (
 		<ContentABTestProvider
 			switches={config.switches}
 			pageId={config.pageId}
 		>
+			<Permutive
+				projectId={projectId}
+				apiKey={apiKey}
+				payload={payload}
+			/>
 			<Analytics key="analytics" analytics={analytics} />
 			<AnalyticsIframe url={config.ampIframeUrl} />
 			<AdConsent />

--- a/dotcom-rendering/src/amp/server/document.test.tsx
+++ b/dotcom-rendering/src/amp/server/document.test.tsx
@@ -2,6 +2,7 @@ import validator from 'amphtml-validator';
 import { Standard as ExampleArticle } from '../../../fixtures/generated/articles/Standard';
 import { extractNAV } from '../../model/extract-nav';
 import type { AnalyticsModel } from '../components/Analytics';
+import type { PermutiveModel } from '../components/Permutive';
 import { Article } from '../pages/Article';
 import { document } from './document';
 
@@ -45,14 +46,15 @@ test('produces valid AMP doc', async () => {
 		id: ExampleArticle.pageId,
 		neilsenAPIID: 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXX',
 		domain: 'amp.theguardian.com',
-		permutive: {
-			namespace: 'guardian',
-			apiKey: '42-2020',
-			payload: {
-				'properties.content.title': 'article title',
-			},
-		},
 		ipsosSectionName: 'section',
+	};
+
+	const permutive: PermutiveModel = {
+		projectId: 'example',
+		apiKey: '42-2020',
+		payload: {
+			'properties.content.title': 'article title',
+		},
 	};
 
 	const body = (
@@ -62,6 +64,7 @@ test('produces valid AMP doc', async () => {
 			articleData={{ ...ExampleArticle, shouldHideReaderRevenue: false }}
 			config={config}
 			analytics={analytics}
+			permutive={permutive}
 		/>
 	);
 

--- a/dotcom-rendering/src/amp/server/document.tsx
+++ b/dotcom-rendering/src/amp/server/document.tsx
@@ -82,6 +82,7 @@ export const document = ({
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
 	<script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
+	<script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
 
     <!-- AMP element which is specific to the live blog -->
     <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>

--- a/dotcom-rendering/src/amp/server/index.tsx
+++ b/dotcom-rendering/src/amp/server/index.tsx
@@ -5,6 +5,7 @@ import { findBySubsection } from '../../model/article-sections';
 import { extractNAV } from '../../model/extract-nav';
 import { validateAsCAPIType } from '../../model/validate';
 import type { AnalyticsModel } from '../components/Analytics';
+import type { PermutiveModel } from '../components/Permutive';
 import { generatePermutivePayload } from '../lib/permutive';
 import { extractScripts } from '../lib/scripts';
 import { Article } from '../pages/Article';
@@ -22,8 +23,14 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 			...extractScripts(elements, CAPIArticle.mainMediaElements),
 		];
 
-		const sectionName = CAPIArticle.sectionName || '';
+		const sectionName = CAPIArticle.sectionName ?? '';
 		const neilsenAPIID = findBySubsection(sectionName).apiID;
+
+		const permutive: PermutiveModel = {
+			projectId: 'd6691a17-6fdb-4d26-85d6-b3dd27f55f08',
+			apiKey: '359ba275-5edd-4756-84f8-21a24369ce0b',
+			payload: generatePermutivePayload(config),
+		};
 
 		const analytics: AnalyticsModel = {
 			gaTracker: 'UA-78705427-1',
@@ -35,12 +42,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 			id: CAPIArticle.pageId,
 			neilsenAPIID,
 			domain: 'amp.theguardian.com',
-			permutive: {
-				namespace: 'guardian',
-				apiKey: '359ba275-5edd-4756-84f8-21a24369ce0b',
-				payload: generatePermutivePayload(config),
-			},
-			ipsosSectionName: config.ipsosTag || 'guardian',
+			ipsosSectionName: config.ipsosTag ?? 'guardian',
 		};
 
 		const metadata = {
@@ -59,6 +61,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 					articleData={CAPIArticle}
 					nav={extractNAV(CAPIArticle.nav)}
 					analytics={analytics}
+					permutive={permutive}
 					config={config}
 				/>
 			),


### PR DESCRIPTION
## What does this change?

Upgrade [Permutive](https://permutive.com/) to use V2 of their AMP SDK.

This broadly follows the instructions laid out in a private version of [this upgrade guide](https://support.permutive.com/hc/en-us/articles/4795090202140-AMP-v2-Deployment-Verification).

The main changes here include:
1. Moving all of the Permutive-related logic into a separate `<Permutive />` component. This has benefits for organisation, but also is necessary to match the upgrade guide's desire to have everything directly in the document `<body>`.
2. Updating the props required to configure the Permutive SDK.
3. Transfer all of the boilerplate scripts from the guide (see above) to the new Permutive component.

Most of this PR represents updating the boilerplate required to get Permutive working. We maintain the same payload we were sending previously, and the values used to configure the SDK are changed slightly (we use a `projectId` rather than a namespace).

## Why?

In order to hopefully realise the benefits laid out here:

> "AMP functionality previously prevented targeting without third-party cookies via any platform or mechanism - but our new AMP SDK has been built to work without third-party cookies. You can unlock increased scale, improve audience 
 addressability, monetise more of your users across key browsers and leverage insights on your AMP audience."
