### PR TITLE
feat: enforce recommended a11y jsx

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -74,6 +74,7 @@ module.exports = {
 		'airbnb-typescript',
 		'prettier',
 		'plugin:@guardian/source-react-components/recommended',
+		'plugin:jsx-a11y/recommended',
 	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -102,6 +103,20 @@ module.exports = {
 		'react/no-danger': 'off', // We use `dangerouslySetInnerHTML` in several components
 		'react/prop-types': [0],
 		'jsx-expressions/strict-logical-expressions': 'error',
+		'jsx-a11y/aria-role': [
+			'error',
+			{
+				/**
+				 * As we use the `role` prop for editorial weighting,
+				 * we do not want to check developer-created components’
+				 * use of the `role` attribute.
+				 *
+				 * @see RoleType
+				 * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md#rule-details
+				 */
+				ignoreNonDOM: true,
+			},
+		],
 
 		'array-callback-return': 'error',
 		'global-require': 'error',
@@ -113,7 +128,7 @@ module.exports = {
 		'no-underscore-dangle': ['warn', { allow: ['_type'] }],
 		'no-useless-escape': 'error',
 
-		"object-shorthand": ["error", "always"],
+		'object-shorthand': ['error', 'always'],
 
 		'import/no-extraneous-dependencies': [
 			'error',

--- a/dotcom-rendering/src/amp/components/Epic.tsx
+++ b/dotcom-rendering/src/amp/components/Epic.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid -- It’s AMP! */
 import { css } from '@emotion/react';
 import {
 	body,

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -140,54 +140,50 @@ export const ArticleBody = ({
 		format.design === ArticleDesign.DeadBlog
 	) {
 		return (
-			<>
-				<div
-					tabIndex={0}
-					id="liveblog-body"
-					// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
-					className="js-liveblog-body"
-					css={[
-						globalStrongStyles,
-						globalH2Styles(format.display),
-						globalH3Styles(format.display),
-						globalLinkStyles(palette),
-						// revealStyles is used to animate the reveal of new blocks
-						(format.design === ArticleDesign.DeadBlog ||
-							format.design === ArticleDesign.LiveBlog) &&
-							revealStyles,
-					]}
-				>
-					<LiveBlogRenderer
-						format={format}
-						blocks={blocks}
-						pinnedPost={pinnedPost}
-						adTargeting={adTargeting}
-						host={host}
-						pageId={pageId}
-						webTitle={webTitle}
-						ajaxUrl={ajaxUrl}
-						switches={switches}
-						isAdFreeUser={isAdFreeUser}
-						isSensitive={isSensitive}
-						isLiveUpdate={false}
-						section={section}
-						shouldHideReaderRevenue={shouldHideReaderRevenue}
-						tags={tags}
-						isPaidContent={isPaidContent}
-						contributionsServiceUrl={contributionsServiceUrl}
-						onFirstPage={onFirstPage}
-						keyEvents={keyEvents}
-						filterKeyEvents={filterKeyEvents}
-						availableTopics={availableTopics}
-						selectedTopics={selectedTopics}
-					/>
-				</div>
-			</>
+			<div
+				id="liveblog-body"
+				// This classname is used by Spacefinder as the container in which it'll attempt to insert inline ads
+				className="js-liveblog-body"
+				css={[
+					globalStrongStyles,
+					globalH2Styles(format.display),
+					globalH3Styles(format.display),
+					globalLinkStyles(palette),
+					// revealStyles is used to animate the reveal of new blocks
+					(format.design === ArticleDesign.DeadBlog ||
+						format.design === ArticleDesign.LiveBlog) &&
+						revealStyles,
+				]}
+			>
+				<LiveBlogRenderer
+					format={format}
+					blocks={blocks}
+					pinnedPost={pinnedPost}
+					adTargeting={adTargeting}
+					host={host}
+					pageId={pageId}
+					webTitle={webTitle}
+					ajaxUrl={ajaxUrl}
+					switches={switches}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					isLiveUpdate={false}
+					section={section}
+					shouldHideReaderRevenue={shouldHideReaderRevenue}
+					tags={tags}
+					isPaidContent={isPaidContent}
+					contributionsServiceUrl={contributionsServiceUrl}
+					onFirstPage={onFirstPage}
+					keyEvents={keyEvents}
+					filterKeyEvents={filterKeyEvents}
+					availableTopics={availableTopics}
+					selectedTopics={selectedTopics}
+				/>
+			</div>
 		);
 	}
 	return (
 		<div
-			tabIndex={0}
 			id="maincontent"
 			css={[
 				isInteractive ? null : bodyPadding,

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -30,6 +30,7 @@ export const CardLink = ({
 	dataLinkName = 'article',
 }: Props) => {
 	return (
+		// eslint-disable-next-line jsx-a11y/anchor-has-content -- we have an aria-label attribute describing the content
 		<a
 			href={linkTo}
 			css={fauxLinkStyles}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -65,13 +65,19 @@ const collapseColumnButton = css`
 		color: ${brandAlt[400]};
 	}
 `;
-
-export const CollapseColumnButton: React.FC<{
+type Props = {
 	title: string;
 	columnInputId: string;
 	collapseColumnInputId: string;
 	ariaControls: string;
-}> = ({ title, columnInputId, collapseColumnInputId, ariaControls }) => (
+};
+
+export const CollapseColumnButton = ({
+	title,
+	columnInputId,
+	collapseColumnInputId,
+	ariaControls,
+}: Props) => (
 	<label
 		id={collapseColumnInputId}
 		className="selectableMenuItem"
@@ -85,6 +91,7 @@ export const CollapseColumnButton: React.FC<{
 		aria-haspopup="true"
 		aria-controls={ariaControls}
 		tabIndex={-1}
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle
 		role="menuitem"
 		data-cy={`column-collapse-${title}`}
 		data-link-name={`nav2 : column-toggle-${title}: show`}

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -78,6 +78,7 @@ export const ShowMoreMenu = ({ display }: { display: ArticleDisplay }) => (
 			htmlFor={navInputCheckboxId}
 			data-link-name="nav2 : veggie-burger: show"
 			tabIndex={0}
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle
 			role="button"
 			data-cy="nav-show-more-button"
 		>

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -101,9 +101,11 @@ const veggieBurgerStyles = (display: ArticleDisplay) => css`
 	}
 `;
 
-export const VeggieBurgerMenu: React.FC<{
+type Props = {
 	display: ArticleDisplay;
-}> = ({ display }) => {
+};
+
+export const VeggieBurgerMenu = ({ display }: Props) => {
 	return (
 		<label
 			id={veggieBurgerId}
@@ -113,6 +115,7 @@ export const VeggieBurgerMenu: React.FC<{
 			htmlFor={navInputCheckboxId}
 			data-link-name="nav2 : veggie-burger: show"
 			tabIndex={0}
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle
 			role="button"
 			data-cy="veggie-burger"
 		>

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -329,6 +329,8 @@ export const SecureSignupIframe = ({
 	return (
 		<>
 			<iframe
+				// @TODO check with @dblatcher if there is a better title
+				title={`Sign up to ${newsletterId}`}
 				ref={iframeRef}
 				css={css`
 					width: 100%;

--- a/dotcom-rendering/src/web/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/SubNav.importable.tsx
@@ -178,11 +178,13 @@ export const SubNav = ({ subNavSections, currentNavLink, format }: Props) => {
 			data-cy="sub-nav"
 			data-component="sub-nav"
 		>
+			{/* eslint-disable jsx-a11y/no-redundant-roles -- A11y fix for Safari {@see https://github.com/guardian/dotcom-rendering/pull/5041} */}
 			<ul
 				ref={ulRef}
 				css={[expandSubNav ? expandedStyles : collapsedStyles]}
 				role="list"
 			>
+				{/* eslint-enable jsx-a11y/no-redundant-roles */}
 				{subNavSections.parent && (
 					<li
 						key={subNavSections.parent.url}


### PR DESCRIPTION
## What does this change?

Enforce recommended Accessibility JSX ESLint rules.

Make an exception for the `aria-role` rule on custom components, because the attribute has a specific editorial meaning: how should an image display, aka _weighting_. We do not want to see errors when using a prop with this name outside of actual html tags.

```ts
// aka weighting. RoleType affects how an image is placed. It is called weighting
// in Composer but role in CAPI. We respect CAPI so we maintain this nomenclature
// in DCR
type RoleType =
	| 'immersive'
	| 'supporting'
	| 'showcase'
	| 'inline'
	| 'thumbnail'
	| 'halfWidth';
```

## Why?

The plugin was introduced in #114, but disabled at some point since.