### PR TITLE
Add maincontent id to ShowcaseLayout

### DIFF
--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -412,7 +412,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 				</>
 			)}
 
-			<main data-layout="ShowcaseLayout">
+			<main data-layout="ShowcaseLayout" id="maincontent">
 				<Section
 					fullWidth={true}
 					showTopBorder={false}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This adds a maincontent id to ShowcaseLayout

This resolves https://github.com/guardian/dotcom-rendering/issues/5046

## Why?

This was highlighted by the DAC review: https://drive.google.com/file/d/1-0ios16ru__yYGveB1pNrQg7nj4wDivb/view

