### PR TITLE
fix: more meaningful sign-up iframe title

### DIFF
--- a/dotcom-rendering/src/web/components/EmailSignup.tsx
+++ b/dotcom-rendering/src/web/components/EmailSignup.tsx
@@ -96,6 +96,7 @@ export const EmailSignup = ({
 			</div>
 			<p css={descriptionStyles}>{description}</p>
 			<SecureSignup
+				name={name}
 				newsletterId={identityName}
 				successDescription={successDescription}
 				hidePrivacyMessage={hidePrivacyMessage}

--- a/dotcom-rendering/src/web/components/SecureSignup.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignup.tsx
@@ -9,6 +9,7 @@ import { SecureSignupIframe } from './SecureSignupIframe.importable';
 
 export type Props = {
 	newsletterId: string;
+	name: string;
 	successDescription: string;
 	/** Override this with caution: you _must_ ensure this wording exists nearby if not included in this component */
 	hidePrivacyMessage?: boolean;
@@ -61,6 +62,7 @@ export const SecureSignup = ({
 	newsletterId,
 	successDescription,
 	hidePrivacyMessage = false,
+	name,
 }: Props) => {
 	const { html, styles } = generateForm(newsletterId);
 
@@ -72,6 +74,7 @@ export const SecureSignup = ({
 				placeholderHeight={65}
 			>
 				<SecureSignupIframe
+					name={name}
 					html={html}
 					styles={styles}
 					newsletterId={newsletterId}

--- a/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
+++ b/dotcom-rendering/src/web/components/SecureSignupIframe.importable.tsx
@@ -28,6 +28,7 @@ const isServer = typeof window === 'undefined';
 // https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
 
 type Props = {
+	name: string;
 	styles: string;
 	html: string;
 	newsletterId: string;
@@ -171,6 +172,7 @@ const sendTracking = (
 };
 
 export const SecureSignupIframe = ({
+	name,
 	styles,
 	html,
 	newsletterId,
@@ -329,8 +331,7 @@ export const SecureSignupIframe = ({
 	return (
 		<>
 			<iframe
-				// @TODO check with @dblatcher if there is a better title
-				title={`Sign up to ${newsletterId}`}
+				title={`Sign up to ${name}`}
 				ref={iframeRef}
 				css={css`
 					width: 100%;

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -400,6 +400,7 @@ export const NewsletterSignupLayout: React.FC<Props> = ({
 							)}
 
 							<SecureSignup
+								name="One Two Three Four"
 								newsletterId="1234"
 								successDescription="nice"
 								hidePrivacyMessage={true}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add a meaningful title to the Signup iframe.

## Why?

It is currently a machine-readable ID, rather than a human-readable name.

Follow-up on #5997, following @dblatcher’s recommendation to pass down the `name`.