### PR TITLE
Adds isInRegion ABTest canRun function util for Mandatory Sign in Gate test

### DIFF
--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
@@ -1,6 +1,26 @@
 import { storage } from '@guardian/libs';
 import { Participations } from '@guardian/ab-core';
-import { setOrUseParticipations } from './ab-exclusions';
+import { setOrUseParticipations, isInRegion } from './ab-exclusions';
+import * as lib from '../../lib/getCountryCode';
+
+describe('canRun using isInRegion', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	test('isInRegion exclusion returns false if geolocation is not available', () => {
+		jest.spyOn(lib, 'getCountryCodeSync').mockReturnValue(null);
+		expect(isInRegion(['US', 'CA'])).toBe(false);
+	});
+	test('isInRegion exclusion returns true if geolocation is in region', () => {
+		jest.spyOn(lib, 'getCountryCodeSync').mockReturnValue('CA');
+		expect(isInRegion(['US', 'CA'])).toBe(true);
+	});
+	test('isInRegion exclusion returns false if geolocation is not in region', () => {
+		jest.spyOn(lib, 'getCountryCodeSync').mockReturnValue('GB');
+		expect(isInRegion(['US', 'CA'])).toBe(false);
+	});
+});
 
 describe('canRun using participations', () => {
 	beforeEach(() => {

--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.ts
@@ -1,4 +1,5 @@
 import { Participations } from '@guardian/ab-core';
+import { getCountryCodeSync } from '../../lib/getCountryCode';
 import {
 	getParticipationsFromLocalStorage,
 	setParticipationsInLocalStorage,
@@ -8,8 +9,6 @@ import {
  * Occasionally we may want to track long-running behavior of browsers in a certain test,
  * without adding new browsers to the test bucket. We cannot rely on the GU_mvt_id bucketing alone to do this.
  * You can use this method to show the gate based on local storage participation key ("gu.ab.participations") instead.
- *
- * After the cut off date users without the local storage participation key won't see the gate at all.
  *
  * Caveats - There will be natural churn of users to account for. Users can manually delete localStorage at any time.
  * Some browsers also automatically delete local storage specifically on Webkit browsers (Safari/iOS) since iOS and iPadOS 13.4, Safari 13.1 on macOS
@@ -47,3 +46,64 @@ export const setOrUseParticipations = (
 		return participations[abTestId]?.variant === variantId;
 	}
 };
+
+/**
+ * Regional Exclusions
+ */
+export const isInRegion = (region: string[]): boolean => {
+	const countryCode = getCountryCodeSync();
+	return !!countryCode && region.includes(countryCode);
+};
+export const EuropeList = [
+	'AX',
+	'AL',
+	'AD',
+	'AT',
+	'BE',
+	'BG',
+	'BA',
+	'BY',
+	'CH',
+	'CZ',
+	'DE',
+	'DK',
+	'ES',
+	'EE',
+	'FI',
+	'FR',
+	'FO',
+	'GG',
+	'GI',
+	'GR',
+	'HR',
+	'HU',
+	'IM',
+	'IE',
+	'IS',
+	'IT',
+	'JE',
+	'LI',
+	'LT',
+	'LU',
+	'LV',
+	'MC',
+	'MD',
+	'MK',
+	'MT',
+	'ME',
+	'NL',
+	'NO',
+	'PL',
+	'PT',
+	'RO',
+	'RU',
+	'SJ',
+	'SM',
+	'RS',
+	'SK',
+	'SI',
+	'SE',
+	'UA',
+	'VA',
+	'XK',
+];


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a small utility called `isInRegion' to the abtest-exclusions file plus tests.
- Adds the list of countries comprising 'Europe' as includes too many countries


## Why?

This function will be used along with `setOrUseParticipations` in the `canRun` function of the AB Test defininitions of the mandatory sign in gate test. If the canRun function returns false, the test is not run and ophan tracking when the test framework initialises sends empty query parameters (eg. `&abTestRegister={}`)

Notes: AB test framework is syncronous but the `getCountryCode` utility is async as it falls back on to an API request, so I have used `getCountryCodeSync` which only checks for the cookie value.  I don't see this having significant impact on numbers in the test bucket but we can check in the test run. 

### Example usage

```
canRun: () =>
		isInRegion(['US', 'CA']) &&
		setOrUseParticipations(
			setParticipationsFlag,
			'SignInGateMandatoryLongTestRun', // test id
			'mandatory-long-testrun', // variant id - can only be used for single variant test
		),
```

ROW example:
```
canRun: () =>
		!isInRegion(['GB', 'US', 'CA', 'AU', 'NZ', ...EuropeList ]) &&
		setOrUseParticipations(
			setParticipationsFlag,
			'SignInGateMandatoryLongTestRun', // test id
			'mandatory-long-testrun', // variant id - can only be used for single variant test
		),
```

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
