### PR TITLE
Catch more multiple contributors

### DIFF
--- a/dotcom-rendering/src/lib/byline.test.ts
+++ b/dotcom-rendering/src/lib/byline.test.ts
@@ -229,6 +229,40 @@ describe('Byline utilities', () => {
 
 				expect(soleContributor).toBe(undefined);
 			});
+
+			it('Paul MacInnes, Nesrine Malik, Julie Bindel, Peter Preston', () => {
+				// https://www.theguardian.com/commentisfree/2011/dec/30/person-of-2011-writers-verdict
+
+				const soleContributor = getSoleContributor(
+					[
+						{
+							id: 'profile/paulmacinnes',
+							type: 'Contributor',
+							title: 'Paul MacInnes',
+							twitterHandle: 'PaulMac',
+						},
+						{
+							id: 'profile/peterpreston',
+							type: 'Contributor',
+							title: 'Peter Preston',
+						},
+						{
+							id: 'profile/nesrinemalik',
+							type: 'Contributor',
+							title: 'Nesrine Malik',
+						},
+						{
+							id: 'profile/juliebindel',
+							type: 'Contributor',
+							title: 'Julie Bindel',
+							twitterHandle: 'bindelj',
+						},
+					],
+					'Paul MacInnes, Nesrine Malik, Julie Bindel, Peter Preston',
+				);
+
+				expect(soleContributor).toBe(undefined);
+			});
 		});
 	});
 });

--- a/dotcom-rendering/src/lib/byline.ts
+++ b/dotcom-rendering/src/lib/byline.ts
@@ -25,11 +25,14 @@ export const getSoleContributor = (
 	if (!byline) return undefined;
 	if (byline.includes(' and ')) return undefined;
 
-	const soleContributor = tags
+	const [firstContributor, otherContributor] = tags
 		.filter(isContributor)
-		.find(({ title }) => byline.includes(title));
+		.filter(({ title }) => byline.includes(title));
 
-	return soleContributor;
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- we don’t have unchecked indexed access
+	if (otherContributor) return undefined;
+
+	return firstContributor;
 };
 
 export const getContributorTagsForToken = (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Update the algorithm to check whether an article has a single contributor.

If there is more than single contributor

## Why?

Sometimes, the byline does not have the word “and”. Such as in [Your person of 2011: writers' verdict](https://www.theguardian.com/commentisfree/2011/dec/30/person-of-2011-writers-verdict).

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/190427072-08e4e212-43d7-43c0-9ba1-6f1274b5488d.png
[after]: https://user-images.githubusercontent.com/76776/190427184-36c80580-95dd-472f-be49-b781414f709d.png