### PR TITLE
feat: Don't disable Turbosnap when package.json changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,3 +23,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
           onlyChanged: true
+          untraced: '**/(package**.json|yarn.lock)'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,4 +52,3 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
-          onlyChanged: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,26 +1,55 @@
 name: Chromatic 👓
+
 on:
   push:
+    branches: [main]
     paths-ignore:
       - "dotcom-rendering/docs/**"
+  pull_request:
+    paths-ignore:
+        - "dotcom-rendering/docs/**"
+
 jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout - On Pull Request
+        uses: actions/checkout@v3
+        if:  ${{ github.event_name == 'pull_request'}}
         with:
           fetch-depth: 0
+          # By default the pull_request event will run on a ephermeral merge commit which simulates a merge between the pull request
+          # and the target branch. This can cause issues with Chromatic https://www.chromatic.com/docs/turbosnap#github-pullrequest-triggers
+          # Hopefully by checking out the HEAD commit of a PR instead of the merge commit we can avoid some of those issues.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout - On Push Event
+        uses: actions/checkout@v3
+        if:  ${{ github.event_name == 'push'}}
+        with:
+          fetch-depth: 0
+
       - uses: guardian/actions-setup-node@main
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, common, dotcom)
       - uses: bahmutov/npm-install@v1
 
-      - uses: chromaui/action@v1
+      - name: Chromatic - Non Dependency PR / main
+        uses: chromaui/action@v1
+        if: ${{ github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
           onlyChanged: true
           untraced: '**/(package**.json|yarn.lock)'
+
+      - name: Chromatic - Dependency PR
+        uses: chromaui/action@v1
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          autoAcceptChanges: main
+          onlyChanged: true


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
(Sorry about the long blurb of HIGHLY confusing Chromatic details)

## What does this change?

Changes our Chromatic action to keep Turbosnap enabled even if it detects a change to the `package.json`, except on Dependency PR's. 

## August Figures

Total Snapshots Taken: 910,000
Total Snapshots Skipped: 950,000
Overall Snapshots Taken/Skipped: 1,860,000

 - **100,000 Snapshots generated by dependabot PR's where Turbosnap is disabled.**
   - Not much we can do about those, it's useful to have visual regression testing on dependency changes. Chromatic have mentioned that they're working on making Turbosnap a bit more intelligent so that it can understand the impacts of a `package.json` change.
 - **150,000 Snapshots generated on the Main branch with Turbosnap disabled.**
    - Not useful at all, changes on main get auto accepted, even if Chromatic did find an issue caused by a dependency change it wouldn't be flagged for review.
   - Most of the time this happens when Chromatic runs on a merge commit in main. It's hard to describe exactly whats going on here but hopefully this chart helps:
   
      Feature Branch created from main->Dependabot PR merged into main->Feature Branch merged into main->Turbosnap disabled on merge commit between main and feature branch due to the dependency changes in main
      
      From the Turbosnap docs:
      > When you have a merge commit, Chromatic considers any file that has changed since either ancestor’s commit to decide if a story needs to be re-snapshotted. In other words, the union of the git changes.
    

  - **350,000 Snapshots generated by non main Branches with Turbosnap disabled**
    - It was really hard to pinpoint exactly whats causing Turbosnap to be disabled for these builds, but I think I've narrowed it mostly down to 2 things:
      1. Merging `main` into a branch, main might have dependency changes which disable Turbosnap.
      2. Squashed commits. I found this one really tricky to investigate and I'm still not sure if I've wrapped my head around it or not. Here's the general gist of what I understood.
      
         When PR gets squashed into a single commit(Before merging - I'm not talking about a squash merge) Turbosnap loses some critical data about the commit history used for working out changed files. It resolves this by finding the commit which the branch was created from and then copies build information from the last Chromatic build that ran on that commit. Since we don't commit directly to main our branches are always branching off a merge commit (Most recent commit on main will always be a merge commit), this means that the build that Chromatic copies data from is always a Merge commit build and seems to come with a lot of the other issues mentioned with Merge commits earlier.

## Other things worth trying

As of chromatic 6.6.* Turbosnap supports using the `Rebase` option when merging a PR. Since this type of merge doesn't create a merge commit I wonder if we could improve Turbosnap perfomance by enforcing this merge strategy on PR's.

## Why?

Less snapshots = Less false positives & smaller bills💰💰💰