### PR TITLE
refactor(themeStyles): use editorialPalette

### DIFF
--- a/apps-rendering/src/components/editions/byline/index.tsx
+++ b/apps-rendering/src/components/editions/byline/index.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type {
@@ -20,7 +21,6 @@ import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC, ReactNode } from 'react';
-import { getThemeStyles } from 'themeStyles';
 import EditionsAvatar from '../avatar';
 import ShareIcon from '../shareIcon';
 import {
@@ -143,7 +143,7 @@ const standardTextStyles = (
 `;
 
 const bylinePrimaryStyles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	const kickerColor = text.editionsKicker(format);
 	const color = ignoreTextColour(format) ? neutral[100] : kickerColor;
 
 	if (
@@ -263,7 +263,7 @@ const ignoreTextColour = (format: ArticleFormat): boolean =>
 
 const Byline: FC<Props> = ({ item, shareIcon = true }) => {
 	const format = getFormat(item);
-	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	const kickerColor = text.editionsKicker(format);
 
 	const iconColor = ignoreIconColour(format) ? neutral[100] : kickerColor;
 	const showShareIcon = hasShareIcon(format) && shareIcon;

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -1,5 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,
@@ -14,7 +15,6 @@ import Img from 'components/ImgAlt';
 import type { Sizes } from 'image/sizes';
 import { maybeRender, pipe } from 'lib';
 import type { FC } from 'react';
-import { getThemeStyles } from 'themeStyles';
 
 const width = '100%';
 
@@ -178,7 +178,7 @@ const CaptionDescription: FC<{ description: string[] }> = ({ description }) => {
 };
 
 const GalleryImageCaption: FC<CaptionProps> = ({ details, format }) => {
-	const { kicker } = getThemeStyles(format.theme);
+	const kicker = text.editionsKicker(format);
 
 	const styles = css`
 		${from.tablet} {

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -2,6 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import {
+	background,
+	fill,
+} from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { brandAltBackground, from } from '@guardian/source-foundations';
@@ -18,7 +22,6 @@ import { isPicture as checkIfPicture, getFormat } from 'item';
 import { maybeRender } from 'lib';
 import { MainMediaKind } from 'mainMedia';
 import type { FC } from 'react';
-import { getThemeStyles } from 'themeStyles';
 import FootballScores from '../footballScores';
 import { wideImageWidth } from '../styles';
 import Video from '../video';
@@ -166,8 +169,8 @@ interface Props {
 const HeaderMedia: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 	const isPicture = checkIfPicture(item.tags);
-	const { cameraIcon: iconColor, cameraIconBackground: iconBackgroundColor } =
-		getThemeStyles(format.theme);
+	const iconColour = fill.editionsCameraIcon(format);
+	const iconBackgroundColour = background.editionsCameraIcon(format);
 	const matchScores = 'football' in item ? item.football : none;
 
 	return maybeRender(item.mainMedia, (media) => {
@@ -212,8 +215,8 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						caption={caption}
 						credit={credit}
 						styles={getCaptionStyles(format)}
-						iconColor={iconColor}
-						iconBackgroundColor={iconBackgroundColor}
+						iconColor={iconColour}
+						iconBackgroundColor={iconBackgroundColour}
 						isFullWidthImage={isFullWidthImage(format)}
 					/>
 					<StarRating item={item} />

--- a/apps-rendering/src/components/editions/headline/index.tsx
+++ b/apps-rendering/src/components/editions/headline/index.tsx
@@ -20,7 +20,6 @@ import { getFormat } from 'item';
 import { index } from 'lib';
 import { MainMediaKind } from 'mainMedia';
 import type { FC } from 'react';
-import { getThemeStyles } from 'themeStyles';
 import Series from '../series';
 import {
 	articleWidthStyles,
@@ -152,7 +151,7 @@ const getSharedStyles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 const getQuoteStyles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker } = getThemeStyles(format.theme);
+	const kicker = text.editionsKicker(format);
 
 	return css`
 		margin: 0;
@@ -265,7 +264,7 @@ interface Props {
 
 const Headline: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
-	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	const kickerColor = text.editionsKicker(format);
 	const contributor = index(0)(item.contributors);
 
 	const hasImage =

--- a/apps-rendering/src/components/editions/pullquote/index.tsx
+++ b/apps-rendering/src/components/editions/pullquote/index.tsx
@@ -1,5 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline } from '@guardian/source-foundations';
 import { SvgQuote } from '@guardian/source-react-components';
@@ -7,13 +8,12 @@ import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import { pipe } from 'lib';
 import type { FC, ReactNode } from 'react';
-import { getThemeStyles } from 'themeStyles';
 
 export const pullquoteWidth = '10.875rem';
 const pullquoteTailSize = '1.5rem';
 
 const styles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker } = getThemeStyles(format.theme);
+	const kicker = text.editionsKicker(format);
 	return css`
 		width: ${pullquoteWidth};
 		position: relative;
@@ -60,7 +60,7 @@ const styles = (format: ArticleFormat): SerializedStyles => {
 };
 
 const quoteStyles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker } = getThemeStyles(format.theme);
+	const kicker = text.editionsKicker(format);
 
 	return css`
 		margin: 0;

--- a/apps-rendering/src/components/editions/series/index.tsx
+++ b/apps-rendering/src/components/editions/series/index.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import {
 	from,
@@ -13,7 +14,6 @@ import type { Item } from 'item';
 import { getFormat } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
-import { getThemeStyles } from 'themeStyles';
 import { kickerPicker } from '../kickerPicker';
 
 // ----- Component ----- //
@@ -46,7 +46,7 @@ interface Props {
 
 const getStyles = (item: Item): SerializedStyles => {
 	const format = getFormat(item);
-	const { kicker } = getThemeStyles(format.theme);
+	const kicker = text.editionsKicker(format);
 	if (
 		item.design === ArticleDesign.Interview ||
 		item.display === ArticleDisplay.Immersive

--- a/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
+++ b/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
@@ -2,11 +2,13 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticlePillar } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
+import { article } from 'fixtures/item';
 import type { ReactElement } from 'react';
+// import { selectPillar } from 'storybookHelpers';
 import { selectPillar } from 'storybookHelpers';
-import { getThemeStyles } from 'themeStyles';
 import ShareIcon from '.';
 
 // ----- Setup ----- //
@@ -33,8 +35,11 @@ const styles = (kickerColor: string): SerializedStyles => {
 // ----- Stories ----- //
 
 const Default = (): ReactElement => {
-	const theme = selectPillar(ArticlePillar.News);
-	const { kicker } = getThemeStyles(theme);
+	const item = {
+		...article,
+		theme: selectPillar(ArticlePillar.News),
+	};
+	const kicker = text.editionsKicker(item);
 
 	return (
 		<div css={styles(kicker)}>

--- a/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
+++ b/apps-rendering/src/components/editions/shareIcon/shareIcon.stories.tsx
@@ -7,7 +7,6 @@ import { ArticlePillar } from '@guardian/libs';
 import { withKnobs } from '@storybook/addon-knobs';
 import { article } from 'fixtures/item';
 import type { ReactElement } from 'react';
-// import { selectPillar } from 'storybookHelpers';
 import { selectPillar } from 'storybookHelpers';
 import ShareIcon from '.';
 

--- a/apps-rendering/src/components/editions/standfirst/index.tsx
+++ b/apps-rendering/src/components/editions/standfirst/index.tsx
@@ -2,6 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text as textPalette } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { FontWeight, LineHeight } from '@guardian/source-foundations';
@@ -17,7 +18,6 @@ import type { Item } from 'item';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
-import { getThemeStyles } from 'themeStyles';
 import ShareIcon from '../shareIcon';
 import { articleWidthStyles, sidePadding } from '../styles';
 
@@ -90,7 +90,7 @@ const textContainerStyles = css`
 `;
 
 const getStyles = (format: ArticleFormat): SerializedStyles => {
-	const { kicker: kickerColor } = getThemeStyles(format.theme);
+	const kickerColor = textPalette.editionsKicker(format);
 
 	// ArticleDisplay.Immersive needs to come before ArticleDesign.Interview
 	if (format.display === ArticleDisplay.Immersive) {

--- a/apps-rendering/src/themeStyles.ts
+++ b/apps-rendering/src/themeStyles.ts
@@ -5,116 +5,8 @@
 
 import type { ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
-import {
-	culture,
-	lifestyle,
-	news,
-	opinion,
-	specialReport,
-	sport,
-} from '@guardian/source-foundations';
 
 // ----- Types ----- //
-
-/**
- * @deprecated Use the `editorialPalette` module from `common-rendering` instead
- */
-interface ThemeStyles {
-	kicker: string;
-	inverted: string;
-	liveblogKicker: string;
-	liveblogBackground: string;
-	liveblogDarkBackground: string;
-	link: string;
-	cameraIcon: string;
-	cameraIconBackground: string;
-}
-
-type ThemeColours = {
-	[theme in ArticleTheme]: ThemeStyles;
-};
-
-/**
- * @deprecated Use the `editorialPalette` module from `common-rendering` instead
- */
-export const themeColours: ThemeColours = {
-	[ArticlePillar.News]: {
-		kicker: news[400],
-		inverted: news[500],
-		liveblogKicker: news[600],
-		liveblogBackground: news[200],
-		liveblogDarkBackground: news[100],
-		link: news[300],
-		cameraIcon: news[800],
-		cameraIconBackground: news[400],
-	},
-	[ArticlePillar.Opinion]: {
-		kicker: opinion[400],
-		inverted: opinion[500],
-		liveblogKicker: opinion[600],
-		liveblogBackground: opinion[200],
-		liveblogDarkBackground: opinion[100],
-		link: opinion[300],
-		cameraIcon: opinion[800],
-		cameraIconBackground: opinion[400],
-	},
-	[ArticlePillar.Sport]: {
-		kicker: sport[400],
-		inverted: sport[500],
-		liveblogKicker: sport[600],
-		liveblogBackground: sport[200],
-		liveblogDarkBackground: sport[100],
-		link: sport[300],
-		cameraIcon: sport[800],
-		cameraIconBackground: sport[400],
-	},
-	[ArticlePillar.Culture]: {
-		kicker: culture[400],
-		inverted: culture[500],
-		liveblogKicker: culture[600],
-		liveblogBackground: culture[200],
-		liveblogDarkBackground: culture[100],
-		link: culture[300],
-		cameraIcon: culture[800],
-		cameraIconBackground: culture[400],
-	},
-	[ArticlePillar.Lifestyle]: {
-		kicker: lifestyle[400],
-		inverted: lifestyle[500],
-		liveblogKicker: lifestyle[500],
-		liveblogBackground: lifestyle[200],
-		liveblogDarkBackground: lifestyle[100],
-		link: lifestyle[300],
-		cameraIcon: lifestyle[800],
-		cameraIconBackground: lifestyle[400],
-	},
-	[ArticleSpecial.SpecialReport]: {
-		kicker: specialReport[400],
-		inverted: specialReport[500],
-		liveblogKicker: specialReport[500],
-		liveblogBackground: specialReport[200],
-		liveblogDarkBackground: specialReport[100],
-		link: specialReport[300],
-		cameraIcon: specialReport[800],
-		cameraIconBackground: specialReport[400],
-	},
-	[ArticleSpecial.Labs]: {
-		kicker: specialReport[400],
-		inverted: specialReport[500],
-		liveblogKicker: specialReport[500],
-		liveblogBackground: specialReport[200],
-		liveblogDarkBackground: specialReport[100],
-		link: specialReport[300],
-		cameraIcon: specialReport[800],
-		cameraIconBackground: specialReport[400],
-	},
-};
-
-/**
- * @deprecated Use the `editorialPalette` module from `common-rendering` instead
- */
-const getThemeStyles = (theme: ArticleTheme): ThemeStyles =>
-	themeColours[theme];
 
 function themeFromString(theme: string | undefined): ArticlePillar {
 	switch (theme) {
@@ -176,10 +68,4 @@ const stringToPillar = (pillar: string): ArticlePillar => {
 
 // ----- Exports ----- //
 
-export {
-	getThemeStyles,
-	themeFromString,
-	themeToPillarString,
-	themeToPillar,
-	stringToPillar,
-};
+export { themeFromString, themeToPillarString, themeToPillar, stringToPillar };

--- a/apps-rendering/src/themeStyles.ts
+++ b/apps-rendering/src/themeStyles.ts
@@ -177,7 +177,6 @@ const stringToPillar = (pillar: string): ArticlePillar => {
 // ----- Exports ----- //
 
 export {
-	ThemeStyles,
 	getThemeStyles,
 	themeFromString,
 	themeToPillarString,

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -639,6 +639,26 @@ const articleContent = (format: ArticleFormat): string => {
 
 const signUpFormDark = (_format: ArticleFormat): Colour => neutral[10];
 
+const editionsCameraIcon = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
+		case ArticleSpecial.Labs:
+			return specialReport[400];
+		case ArticlePillar.News:
+		default:
+			return news[400];
+	}
+};
+
 // ----- API ----- //
 
 const background = {
@@ -685,6 +705,7 @@ const background = {
 	pinnedPost,
 	articleContent,
 	signUpFormDark,
+	editionsCameraIcon,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -23,6 +23,26 @@ import { Colour } from '.';
 const cameraCaptionIcon = (): Colour => neutral[46];
 const cameraCaptionIconDark = (): Colour => neutral[60];
 
+const editionsCameraIcon = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.Opinion:
+			return opinion[800];
+		case ArticlePillar.Sport:
+			return sport[800];
+		case ArticlePillar.Culture:
+			return culture[800];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[800];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[800];
+		case ArticleSpecial.Labs:
+			return specialReport[800];
+		case ArticlePillar.News:
+		default:
+			return news[800];
+	}
+};
+
 const commentCount = (format: ArticleFormat): Colour => {
 	if (format.design === ArticleDesign.LiveBlog) {
 		return neutral[86];
@@ -221,6 +241,7 @@ const signUpFormButtonDark = (_format: ArticleFormat): Colour => neutral[86];
 const fill = {
 	cameraCaptionIcon,
 	cameraCaptionIconDark,
+	editionsCameraIcon,
 	commentCount,
 	commentCountDark,
 	commentCountWide,

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -812,6 +812,24 @@ const kicker = (format: ArticleFormat): Colour => {
 	}
 };
 
+const editionsKicker = (format: ArticleFormat): Colour => {
+	switch (format.theme) {
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.Labs:
+			return specialReport[400];
+		default:
+			return news[400];
+	}
+};
+
 const seriesTitle = (format: ArticleFormat): Colour => {
 	if (format.display === ArticleDisplay.Immersive) {
 		return neutral[100];
@@ -1102,6 +1120,7 @@ const text = {
 	keyEventsInline,
 	keyEventsLeftColumn,
 	kicker,
+	editionsKicker,
 	linkDark,
 	mediaArticleBody,
 	mediaArticleBodyLinkDark,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Refactors usages of `themeStyles` to `editorialPalette`
- Deletes unused `themeStyles` exports

## Why?

- the `themeStyles` module is deprecated in favour of `editorialPalette`