### PR TITLE
chore(deps): bump apps-rendering-api-models

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2762,9 +2762,9 @@
       }
     },
     "@guardian/apps-rendering-api-models": {
-      "version": "1.1.1-SNAPSHOT-1",
-      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-1.1.1-SNAPSHOT-1.tgz",
-      "integrity": "sha512-EyLEv2fER1392tmGyis171I3YmCd7Sutg5yJWSo3567by7IIzKE3YS8nE2P7oCFJn4J1qLpRjeLWsnPo8nNksg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-1.1.1.tgz",
+      "integrity": "sha512-WR051+HS28SJUPd0iI7trkTFTh5hSt7sPoLuB6hzF4RHvwNKSxmPexstR35W53uiQ6UO4vUYjrCBjI/OhACcPg==",
       "requires": {
         "@guardian/content-api-models": "^17.3.0",
         "@guardian/content-atom-model": "^3.4.0",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "^7.15.6",
     "@creditkarma/thrift-server-core": "^0.16.1",
     "@emotion/jest": "^11.10.0",
-    "@guardian/apps-rendering-api-models": "^1.1.1-SNAPSHOT-1",
+    "@guardian/apps-rendering-api-models": "^1.1.1",
     "@guardian/atoms-rendering": "^22.0.0",
     "@guardian/bridget": "^1.11.0",
     "@guardian/cdk": "^47.3.3",


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Bumps `@guardian/apps-rendering-api-models@1.1.1`

