### PR TITLE
Fix vertical dividers on Fronts 

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -472,7 +472,11 @@ export const DynamicFast = ({
 				})}
 				{standardsDisplayConfig.columns > 0 && (
 					<LI percentage={standardsDisplayConfig.containerWidth}>
-						<UL direction="row" wrapCards={true}>
+						<UL
+							direction="row"
+							wrapCards={true}
+							showDivider={bigs.length > 0}
+						>
 							{/* If the first big is boosted & we have a second big,
 							it should be at the start of the standards but have an image  */}
 							{firstBigBoostedPlusBig ? (
@@ -488,6 +492,7 @@ export const DynamicFast = ({
 							) : (
 								// Regular standards layout
 								standards.map((card, cardIndex) => {
+									const { columns } = standardsDisplayConfig;
 									return (
 										<LI
 											key={card.url}
@@ -495,12 +500,14 @@ export const DynamicFast = ({
 												standardsDisplayConfig.cardWidth
 											}
 											stretch={true}
-											showDivider={true}
+											showDivider={
+												cardIndex % columns !== 0
+											}
 											padSides={true}
 											offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 												cardIndex,
 												standards.length,
-												standardsDisplayConfig.columns,
+												columns,
 											)}
 										>
 											<FrontCard

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { until } from '@guardian/source-foundations';
+import { space, until } from '@guardian/source-foundations';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
@@ -161,7 +161,7 @@ const FirstBigBoostedPlusBig = ({
 		flex-direction: column;
 		flex-basis: 50%;
 		flex-grow: 1;
-		row-gap: 12px;
+		row-gap: ${space[3]}px;
 		${until.tablet} {
 			flex-basis: 100%;
 		}
@@ -179,7 +179,7 @@ const FirstBigBoostedPlusBig = ({
 				display: flex;
 				flex-basis: 100%;
 				flex-wrap: wrap;
-				row-gap: 10px;
+				row-gap: ${space[3]}px;
 			`}
 		>
 			<ul css={[manualUlStyles, verticalDivider]}>

--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -491,14 +491,13 @@ export const DynamicFast = ({
 								/>
 							) : (
 								// Regular standards layout
-								standards.map((card, cardIndex) => {
-									const { columns } = standardsDisplayConfig;
+								standards.map((card, cardIndex, { length }) => {
+									const { columns, cardWidth } =
+										standardsDisplayConfig;
 									return (
 										<LI
 											key={card.url}
-											percentage={
-												standardsDisplayConfig.cardWidth
-											}
+											percentage={cardWidth}
 											stretch={true}
 											showDivider={
 												cardIndex % columns !== 0
@@ -506,7 +505,7 @@ export const DynamicFast = ({
 											padSides={true}
 											offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 												cardIndex,
-												standards.length,
+												length - (length % columns),
 												columns,
 											)}
 										>

--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -126,9 +126,13 @@ const Card25_Card25_Card25_Card25 = ({
 }) => {
 	return (
 		<UL direction="row" padBottom={padBottom}>
-			{cards.map((card) => {
+			{cards.map((card, cardIndex) => {
 				return (
-					<LI key={card.url} padSides={true} showDivider={true}>
+					<LI
+						key={card.url}
+						padSides={true}
+						showDivider={cardIndex > 0}
+					>
 						<FrontCard
 							trail={card}
 							containerPalette={containerPalette}
@@ -158,12 +162,12 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 
 	return (
 		<UL direction="row">
-			{bigs.map((card) => {
+			{bigs.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
-						showDivider={true}
+						showDivider={cardIndex > 0}
 						percentage="25%"
 					>
 						<FrontCard
@@ -176,7 +180,7 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 					</LI>
 				);
 			})}
-			<LI showDivider={true} percentage="25%">
+			<LI showDivider={bigs.length > 0} percentage="25%">
 				<UL direction="row" wrapCards={true}>
 					{remaining.map((card) => {
 						return (
@@ -216,13 +220,13 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 
 	return (
 		<UL direction="row">
-			{bigs.map((card) => {
+			{bigs.map((card, cardIndex) => {
 				return (
 					<LI
 						key={card.url}
 						padSides={true}
 						percentage="25%"
-						showDivider={true}
+						showDivider={cardIndex > 0}
 					>
 						<FrontCard
 							trail={card}

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -357,7 +357,7 @@ export const DynamicSlow = ({
 					/>
 				);
 			default:
-				return <></>;
+				return null;
 		}
 	};
 

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -197,7 +197,8 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 }) => {
 	return (
 		<UL direction="row" wrapCards={true}>
-			{cards.map((card, index) => {
+			{cards.map((card, index, { length }) => {
+				const columns = 2;
 				return (
 					<LI
 						percentage="50%"
@@ -205,8 +206,8 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 						showDivider={index % 2 === 1}
 						offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 							index,
-							cards.length,
-							2,
+							length - (length % columns),
+							columns,
 						)}
 					>
 						<FrontCard

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -67,16 +67,17 @@ export const FixedLargeSlowXIV = ({
 				})}
 			</UL>
 			<UL direction="row" wrapCards={true}>
-				{thirdSlice.map((card, cardIndex) => {
+				{thirdSlice.map((card, cardIndex, { length }) => {
+					const columns = 4;
 					return (
 						<LI
 							padSides={true}
 							percentage="25%"
-							showDivider={cardIndex % 4 !== 0}
+							showDivider={cardIndex % columns !== 0}
 							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
 								cardIndex,
-								thirdSlice.length,
-								4,
+								length,
+								columns,
 							)}
 							key={card.url}
 						>

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -1,5 +1,6 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -71,14 +72,12 @@ export const FixedLargeSlowXIV = ({
 						<LI
 							padSides={true}
 							percentage="25%"
-							showDivider={
-								cardIndex !== 0 &&
-								cardIndex !== 4 &&
-								cardIndex !== 8
-							}
-							offsetBottomPaddingOnDivider={
-								cardIndex !== thirdSlice.length - 1
-							}
+							showDivider={cardIndex % 4 !== 0}
+							offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+								cardIndex,
+								thirdSlice.length,
+								4,
+							)}
 							key={card.url}
 						>
 							<FrontCard

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -2,6 +2,7 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -228,17 +229,6 @@ const Card33_Card33_Ad33 = ({
 );
 
 /**
- *
- * When there is an odd number of cards the last card spans
- * both columns so we don't want to push the divider for the
- * previous two cards above it down. If we did it would
- * touch
- */
-function shouldOffsetWhenOdd(i: number, noOfCards: number) {
-	return i === noOfCards - 2 || i === noOfCards - 3;
-}
-
-/**
  * FixedMediumSlowXIIMPU
  *
  */
@@ -328,7 +318,6 @@ export const FixedMediumSlowXIIMPU = ({
 		default: {
 			const topThree = trails.slice(0, 3);
 			const remainingCards = trails.slice(3, 9);
-			const lengthIsEven = remainingCards.length % 2 === 0;
 			return (
 				<>
 					<Card33_Card33_Card33
@@ -355,14 +344,11 @@ export const FixedMediumSlowXIIMPU = ({
 								{remainingCards.map((trail, trailIndex) => (
 									<LI
 										padSides={true}
-										offsetBottomPaddingOnDivider={
-											lengthIsEven
-												? false
-												: shouldOffsetWhenOdd(
-														trailIndex,
-														remainingCards.length,
-												  )
-										}
+										offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+											trailIndex,
+											remainingCards.length,
+											2,
+										)}
 										showDivider={trailIndex % 2 !== 0}
 										percentage="50%"
 										stretch={true}

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.tsx
@@ -341,27 +341,31 @@ export const FixedMediumSlowXIIMPU = ({
 							 * |_______________________|
 							 */}
 							<UL direction="row" wrapCards={true}>
-								{remainingCards.map((trail, trailIndex) => (
-									<LI
-										padSides={true}
-										offsetBottomPaddingOnDivider={shouldPadWrappableRows(
-											trailIndex,
-											remainingCards.length,
-											2,
-										)}
-										showDivider={trailIndex % 2 !== 0}
-										percentage="50%"
-										stretch={true}
-									>
-										<FrontCard
-											trail={trail}
-											containerPalette={containerPalette}
-											showAge={showAge}
-											imageUrl={undefined}
-											headlineSize="small"
-										/>
-									</LI>
-								))}
+								{remainingCards.map(
+									(trail, trailIndex, { length }) => (
+										<LI
+											padSides={true}
+											offsetBottomPaddingOnDivider={shouldPadWrappableRows(
+												trailIndex,
+												length - (length % 2),
+												2,
+											)}
+											showDivider={trailIndex % 2 !== 0}
+											percentage="50%"
+											stretch={true}
+										>
+											<FrontCard
+												trail={trail}
+												containerPalette={
+													containerPalette
+												}
+												showAge={showAge}
+												imageUrl={undefined}
+												headlineSize="small"
+											/>
+										</LI>
+									),
+								)}
 							</UL>
 						</LI>
 						<LI percentage="33.333%" showDivider={true}>

--- a/dotcom-rendering/src/web/lib/dynamicSlices.test.ts
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.test.ts
@@ -1,0 +1,113 @@
+import { shouldPadWrappableRows } from './dynamicSlices';
+
+describe('shouldPadWrappableRows', () => {
+	describe('Three columns', () => {
+		const columns = 3;
+		describe('Five cards', () => {
+			const cards = 5;
+			// true:  0 1 2
+			// false: 3 4
+			it.each([
+				[0, true],
+				[1, true],
+				[2, true],
+				[3, false],
+				[4, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+
+		describe('Six cards', () => {
+			const cards = 6;
+			// true:  0 1 2
+			// false: 3 4 5
+			it.each([
+				[0, true],
+				[1, true],
+				[2, true],
+				[3, false],
+				[4, false],
+				[5, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+
+		describe('Seven cards', () => {
+			const cards = 7;
+			// true:  0 1 2
+			// true:  3 4 5
+			// false: 6
+			it.each([
+				[0, true],
+				[1, true],
+				[2, true],
+				[3, true],
+				[4, true],
+				[5, true],
+				[6, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+	});
+
+	describe('Two columns', () => {
+		const columns = 2;
+		describe('Three cards', () => {
+			const cards = 3;
+			// true:  0 1
+			// false: 2
+			it.each([
+				[0, true],
+				[1, true],
+				[2, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+
+		describe('Four cards', () => {
+			const cards = 4;
+			// true:  0 1
+			// false: 2 3
+			it.each([
+				[0, true],
+				[1, true],
+				[2, false],
+				[3, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+
+		describe('Five cards', () => {
+			const cards = 5;
+			// true:  0 1
+			// true:  2 3
+			// false: 4
+			it.each([
+				[0, true],
+				[1, true],
+				[2, true],
+				[3, true],
+				[4, false],
+			])('card number %s should return %s', (index, expected) => {
+				expect(shouldPadWrappableRows(index, cards, columns)).toBe(
+					expected,
+				);
+			});
+		});
+	});
+});

--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -122,23 +122,31 @@ export const Card25_Card75 = ({
 );
 
 /**
- * Abstraction to decide whether to show padding on wrapped rows of cards, e.g
+ * Abstraction to decide whether to show padding on wrapped rows of cards.
  *
- * ```
- * Card - Card - Card ↵
- * Card - Card
- * ```
+ * For three columns, We have different results with 5 or 9 cards
  *
- * In the above example we want padding on all but the bottom two cards,
- * but in another example
- *
+ * @example - All but last 2
  * ```
- * Card - Card - Card ↵
- * Card - Card - Card ↵
- * Card - Card - Card
+ * ┌───┐ ┌───┐ ┌───┐
+ * │Pad│ │Pad│ │Pad│
+ * └───┘ └───┘ └───┘
+ * ┌───┐ ┌───┐
+ * │No!│ │No!│
+ * └───┘ └───┘
  * ```
- *
- * We want padding on all but the last 3.
+ * - All but last 3
+ * ```
+ * ┌───┐ ┌───┐ ┌───┐
+ * │Pad│ │Pad│ │Pad│
+ * └───┘ └───┘ └───┘
+ * ┌───┐ ┌───┐ ┌───┐
+ * │Pad│ │Pad│ │Pad│
+ * └───┘ └───┘ └───┘
+ * ┌───┐ ┌───┐ ┌───┐
+ * │No!│ │No!│ │No!│
+ * └───┘ └───┘ └───┘
+ * ```
  *
  * @param index - Index of the current card
  * @param totalCards - Total number of cards being shown

--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -124,15 +124,19 @@ export const Card25_Card75 = ({
 /**
  * Abstraction to decide whether to show padding on wrapped rows of cards, e.g
  *
+ * ```
  * Card - Card - Card ↵
  * Card - Card
+ * ```
  *
  * In the above example we want padding on all but the bottom two cards,
  * but in another example
  *
+ * ```
  * Card - Card - Card ↵
  * Card - Card - Card ↵
  * Card - Card - Card
+ * ```
  *
  * We want padding on all but the last 3.
  *


### PR DESCRIPTION
## What does this change?

Fixes visual glitches on our containers.

There were a few instances of vertical spacing still at 10px.

In a few instances, our vertical dividers were reaching incorrectly into empty space, or added to the left of a container. Several of these instances have been caught and fixed using Chromatic as the source of truth.

## Why?

Separation of concern from #5904 

## Screenshots

Notice the vertical divider on the left side and its clearing the gap on the right side:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before-2][] | ![after-2][] |

[before]: https://user-images.githubusercontent.com/76776/191321590-42204e17-4696-42c0-95ba-61c96eb96e88.png
[after]: https://user-images.githubusercontent.com/76776/191321179-b2aad499-53b1-4648-b12c-e8d34c91daad.png

[before-2]: https://user-images.githubusercontent.com/76776/191327705-2bdf2333-e481-4d0f-b6e6-63bf2a2a9df7.png
[after-2]: https://user-images.githubusercontent.com/76776/191457773-e0dc08b0-4173-4922-bb9a-ec888845f4c1.png


