### PR TITLE
Bump @guardian/braze-components to v7.4.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.6.0",
-    "@guardian/braze-components": "^7.3.0",
+    "@guardian/braze-components": "^7.4.0",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.11.1",
     "@guardian/discussion-rendering": "^10.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,10 +2791,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
-  integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
+"@guardian/braze-components@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
+  integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
 "@guardian/commercial-core@^4.3.0":
   version "4.3.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bump `@guardian/braze-components` to v7.4.0.

## Why?

The 7.4.0 release contains support for multiple section filters for a message.

