### PR TITLE
Update the API AR models version and release to 1.1.1

### DIFF
--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1-SNAPSHOT"
+version in ThisBuild := "1.1.1"

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.1"
+ThisBuild / version := "1.1.2-SNAPSHOT"

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1"
+ThisBuild / version := "1.1.1"

--- a/apps-rendering/api-models/scala/version.sbt
+++ b/apps-rendering/api-models/scala/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.2-SNAPSHOT"
+ThisBuild / version := "1.1.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This updates the apps rendering API models version to be 1.1.1 and allows a version release of the thrift model

## Why?
There are some dependency updates in the API