### PR TITLE
Cypress runs headless Chrome locally and mutes audio

### DIFF
--- a/dotcom-rendering/cypress.config.js
+++ b/dotcom-rendering/cypress.config.js
@@ -27,6 +27,13 @@ module.exports = defineConfig({
   },
   e2e: {
     setupNodeEvents(on, config) {
+	  on('before:browser:launch', (browser = {}, launchOptions) => {
+	    // mute audio in Chrome when running headless
+	    if (browser.family === 'chromium' && browser.isHeadless) {
+	      launchOptions.args.push('--mute-audio');
+	    }
+		return launchOptions;
+      });
       return plugins(on, config)
     },
     baseUrl: 'http://localhost:9000/',

--- a/dotcom-rendering/cypress.config.js
+++ b/dotcom-rendering/cypress.config.js
@@ -4,38 +4,38 @@ import plugins from './cypress/plugins';
 // https://docs.cypress.io/guides/references/configuration
 
 module.exports = defineConfig({
-  viewportWidth: 1500,
-  viewportHeight: 860,
-  video: false,
-  chromeWebSecurity: false,
-  blockHosts: [
-    '*ophan.theguardian.com',
-    'pixel.adsafeprotected.com',
-    '*permutive.com',
-    '*adnxs.com',
-    '*adsystem.com',
-    '*casalemedia.com',
-    '*pubmatic.com',
-    '*360yield.com',
-    '*omnitagjs.com',
-    '*the-ozone-project.com',
-    '*openx.net',
-  ],
-  retries: {
-    "runMode": 2,
-    "openMode": 0
-  },
-  e2e: {
-    setupNodeEvents(on, config) {
-	  on('before:browser:launch', (browser = {}, launchOptions) => {
-	    // mute audio in Chrome when running headless
-	    if (browser.family === 'chromium' && browser.isHeadless) {
-	      launchOptions.args.push('--mute-audio');
-	    }
-		return launchOptions;
-      });
-      return plugins(on, config)
-    },
-    baseUrl: 'http://localhost:9000/',
-  },
-})
+	viewportWidth: 1500,
+	viewportHeight: 860,
+	video: false,
+	chromeWebSecurity: false,
+	blockHosts: [
+		'*ophan.theguardian.com',
+		'pixel.adsafeprotected.com',
+		'*permutive.com',
+		'*adnxs.com',
+		'*adsystem.com',
+		'*casalemedia.com',
+		'*pubmatic.com',
+		'*360yield.com',
+		'*omnitagjs.com',
+		'*the-ozone-project.com',
+		'*openx.net',
+	],
+	retries: {
+		runMode: 2,
+		openMode: 0,
+	},
+	e2e: {
+		setupNodeEvents(on, config) {
+			on('before:browser:launch', (browser = {}, launchOptions) => {
+				// mute audio in Chrome when running headless
+				if (browser.family === 'chromium' && browser.isHeadless) {
+					launchOptions.args.push('--mute-audio');
+				}
+				return launchOptions;
+			});
+			return plugins(on, config);
+		},
+		baseUrl: 'http://localhost:9000/',
+	},
+});

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -96,7 +96,7 @@ dev-legacy: clear clean-dist install gen-dotenv
 cypress: export NODE_ENV=production
 cypress: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")
-	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress run --spec "cypress/e2e/**/*"'
+	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress run --browser chrome --spec "cypress/e2e/**/*"'
 
 ampValidation: export NODE_ENV=production
 ampValidation: clean-dist install build

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -28,7 +28,7 @@
     "cypress:run": "cypress run",
     "cypress:open:e2e": "cypress open --e2e --browser chrome",
     "cypress:run:e2e": "cypress run --browser chrome --spec 'cypress/e2e/**/*'",
-    "cypress:run:percy": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'",
+    "cypress:run:percy": "percy exec -- cypress run --browser chrome --config specPattern='cypress/snapshot/**/*'",
     "unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
     "makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./scripts/webpack/webpack.config.js"
   },

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -26,7 +26,7 @@
     "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "cypress:open:e2e": "cypress open --e2e --browser=chrome",
+    "cypress:open:e2e": "cypress open --e2e --browser chrome",
     "cypress:run:e2e": "cypress run --spec 'cypress/e2e/**/*'",
     "cypress:run:percy": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'",
     "unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -27,7 +27,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "cypress:open:e2e": "cypress open --e2e --browser chrome",
-    "cypress:run:e2e": "cypress run --spec 'cypress/e2e/**/*'",
+    "cypress:run:e2e": "cypress run --browser chrome --spec 'cypress/e2e/**/*'",
     "cypress:run:percy": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'",
     "unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
     "makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./scripts/webpack/webpack.config.js"

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -25,7 +25,7 @@
     "createtoc": "doctoc $npm_package_tocList --github --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
     "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run",
+    "cypress:run": "cypress run --browser chrome",
     "cypress:open:e2e": "cypress open --e2e --browser chrome",
     "cypress:run:e2e": "cypress run --browser chrome --spec 'cypress/e2e/**/*'",
     "cypress:run:percy": "percy exec -- cypress run --browser chrome --config specPattern='cypress/snapshot/**/*'",


### PR DESCRIPTION
## What does this change?

- Updates all local Cypress tasks (make and Yarn) to force headless Chrome rather than the default Electron browser.
- Mute audio when running headless 🙉 

## Why?

- aligns with CI script which already forces Chrome
- Chrome allows much more control of its behaviour via command line arguments (controlling audio for example :)
- anecdotally it's approx 30% faster than Electron when running tests locally

