### PR TITLE
feat(AMP): handle newsletter sign up page embed problems

### DIFF
--- a/dotcom-rendering/src/amp/pages/Article.tsx
+++ b/dotcom-rendering/src/amp/pages/Article.tsx
@@ -34,16 +34,12 @@ const Body: React.FunctionComponent<{
 }> = ({ data, config }) => {
 	const { format } = data;
 
-	switch (format.design) {
-		case 'LiveBlogDesign':
-		case 'DeadBlogDesign':
-			return <BodyLiveblog data={data} config={config} />;
-
-		case 'NewsletterSignupDesign':
-			// Insert change here
-			return <BodyArticle data={data} config={config} />;
+	if (
+		format.design === 'LiveBlogDesign' ||
+		format.design === 'DeadBlogDesign'
+	) {
+		return <BodyLiveblog data={data} config={config} />;
 	}
-
 	return <BodyArticle data={data} config={config} />;
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

**For newsletter sign up pages only**, replaces the article body with placeholder text prompting the user to visit the webURL instead of trying to sign up on the AMP page, since AMP pages do not render embeds.

_This text is currently added manually in composer by editorial team in AUS. It would be great for them to not have to do this._

## Why?

The newsletters team have not created or designed a special format (yet..) for the newsletter sign up pages in AMP. 
This ensures that users visiting the page in AMP have an obvious workaround to sign up to a newsletter.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/43961396/191557170-c34b3305-9fec-433e-9abd-da6369fcfffe.png
[after]: https://user-images.githubusercontent.com/43961396/191556755-28f986ff-2880-4ced-9e06-8c48944b285e.png
[before2]: https://user-images.githubusercontent.com/43961396/191703359-0450caef-8087-4bce-b924-604c44076658.png
[after2]: https://user-images.githubusercontent.com/43961396/191703275-4433b639-fd06-4ea6-9294-bf177de0dc05.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
