### PR TITLE
Add `canonical` link to `pageTemplate`

### DIFF
--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -275,5 +275,6 @@ window.twttr = (function(d, s, id) {
 				: undefined,
 		recipeMarkup,
 		offerHttp3,
+		canonicalURL: url,
 	});
 };

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -21,6 +21,7 @@ export const pageTemplate = ({
 	twitterData,
 	initTwitter,
 	recipeMarkup,
+	canonicalURL,
 }: {
 	css: string;
 	html: string;
@@ -38,6 +39,7 @@ export const pageTemplate = ({
 	twitterData?: { [key: string]: string };
 	initTwitter?: string;
 	recipeMarkup?: string;
+	canonicalURL?: string;
 }): string => {
 	const favicon =
 		process.env.NODE_ENV === 'production'
@@ -184,6 +186,11 @@ https://workforus.theguardian.com/careers/product-engineering/
 			    ${weAreHiringMessage}
                 <title>${title}</title>
                 <meta name="description" content="${he.encode(description)}" />
+				${
+					canonicalURL !== undefined
+						? '<link rel="canonical" href="${canonicalURL}" />'
+						: '<!-- no canonical URL -->'
+				}
                 <meta charset="utf-8">
 
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">


### PR DESCRIPTION
## What does this change?
Adds the `<link rel="canonical" href="{url}" />` to article pages.

## Why?

While digging into [Google search console](https://search.google.com/search-console) there are some reasons why pages aren't being indexed. The second most frequent reason, and the only one that seems to be growing steadily over time was "[Duplicate page without canonical tag](https://support.google.com/webmasters/answer/7440203#duplicate_page_without_canonical_tag)". This lead me to [this solution](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?visit_id=637994434325810631-1629966483&rd=1) - which is what is implemented here.

Here's a sample of the URLs it's suggesting aren't being indexed:
1. https://www.theguardian.com/business/2021/feb/14/uk-airlines-warn-of-job-losses-as-they-lose-business-to-brexit?CMP=Share_iOSApp_Other
2. https://www.theguardian.com/technology/2016/aug/01/amazon-noise-cancelling-headphones-know-your-name?utm_content=buffer42bd9&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer
3. https://www.theguardian.com/books/live/2017/feb/10/neil-gaiman-webchat-norse-mythology?page=with:block-58a2f6a8e4b09b65848eb7a1

Here's the growing graph (numbers and links omitted for privacy):
<img width="824" alt="Screenshot 2022-09-22 at 12 36 49" src="https://user-images.githubusercontent.com/31692/191755863-aedd0c3e-c05e-400d-80a3-5cc26a29065c.png">

This makes sense that we should be setting a canonical, as the canonical for `1.` should be `https://www.theguardian.com/business/2021/feb/14/uk-airlines-warn-of-job-losses-as-they-lose-business-to-brexit`.

We should probably make this non-optional and add it to fronts, but thought I would start with this.


## Screenshots

URL: http://localhost:3030/Article?url=https://www.theguardian.com/business/2021/feb/14/uk-airlines-warn-of-job-losses-as-they-lose-business-to-brexit?CMP=Share_iOSApp_Other

### before
<img width="1050" alt="Screenshot 2022-09-22 at 14 08 32" src="https://user-images.githubusercontent.com/31692/191755674-59e9b53b-1ff5-4eb4-a2aa-53f6e3d4a9e5.png">

### after
<img width="1022" alt="Screenshot 2022-09-22 at 14 08 17" src="https://user-images.githubusercontent.com/31692/191755632-d0f841fe-b048-47ca-94b2-8960ee411342.png">

