### PR TITLE
Snapshot using fewer breakpoints

### DIFF
--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -240,7 +240,11 @@ export default {
 		layout: 'fullscreen',
 		chromatic: {
 			diffThreshold: 0.4,
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -240,12 +240,7 @@ export default {
 		layout: 'fullscreen',
 		chromatic: {
 			diffThreshold: 0.4,
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/DynamicFast',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/DynamicFast',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -17,7 +17,11 @@ export default {
 	title: 'Components/DynamicPackage',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -17,16 +17,7 @@ export default {
 	title: 'Components/DynamicPackage',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
@@ -18,7 +18,11 @@ export default {
 	title: 'Components/DynamicSlow',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.stories.tsx
@@ -18,16 +18,7 @@ export default {
 	title: 'Components/DynamicSlow',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/DynamicSlowMPU',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/DynamicSlowMPU',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FilterButton.stories.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.stories.tsx
@@ -25,7 +25,11 @@ export default {
 	parameters: {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FilterButton.stories.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.stories.tsx
@@ -25,15 +25,7 @@ export default {
 	parameters: {
 		// Set the viewports in Chromatic at a component level.
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedLargeSlowXIV',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedLargeSlowXIV',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedMediumSlowVI',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedMediumSlowVI',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedMediumSlowVII',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.stories.tsx
@@ -1,6 +1,5 @@
 import { breakpoints } from '@guardian/source-foundations';
 import { trails } from '../../../fixtures/manual/trails';
-
 import { FixedMediumSlowVII } from './FixedMediumSlowVII';
 import { Section } from './Section';
 
@@ -9,16 +8,7 @@ export default {
 	title: 'Components/FixedMediumSlowVII',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedMediumSlowXIIMPU',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedMediumSlowXIIMPU',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedSmallSlowI',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowI.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedSmallSlowI',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedSmallSlowIII',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIII.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedSmallSlowIII',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedSmallSlowIV',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowIV.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedSmallSlowIV',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedSmallSlowVMPU',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedSmallSlowVMPU',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
@@ -8,7 +8,11 @@ export default {
 	title: 'Components/FixedSmallSlowVThird',
 	parameters: {
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.stories.tsx
@@ -8,16 +8,7 @@ export default {
 	title: 'Components/FixedSmallSlowVThird',
 	parameters: {
 		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.mobileLandscape,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.leftCol,
-				breakpoints.wide,
-			],
+			viewports: [breakpoints.mobile, breakpoints.wide],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/web/components/PinnedPost.stories.tsx
@@ -35,7 +35,11 @@ export default {
 			values: [{ name: 'grey', value: 'lightgrey' }],
 		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.wide],
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/web/components/Section.stories.tsx
+++ b/dotcom-rendering/src/web/components/Section.stories.tsx
@@ -276,10 +276,6 @@ MultipleStory.story = {
 		chromatic: {
 			viewports: [
 				breakpoints.mobile,
-				breakpoints.mobileMedium,
-				breakpoints.phablet,
-				breakpoints.tablet,
-				breakpoints.desktop,
 				breakpoints.leftCol,
 				breakpoints.wide,
 			],


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This reduces the number of breakpoints we use to take Chromatic snapshots.

## Why?
This will make it easier to review diffs and speed up our test suite.

## Why not?
The argument against this change is that we reduce the level of test coverage. It's true that by not running regression tests at all breakpoints we risk a problem slipping through, but in my experience we very rarely see visual bugs are breakpoints other than desktop or mobile so I think this is a fair tradeoff.

| Before      | After      |
|-------------|------------|
| <img width="270" alt="Screenshot 2022-09-22 at 16 56 07" src="https://user-images.githubusercontent.com/1336821/191795126-daa7177a-3196-45db-9b76-82d54b5fa89d.png">  | <img width="270" alt="Screenshot 2022-09-22 at 16 55 50" src="https://user-images.githubusercontent.com/1336821/191795153-f3c26af3-98f6-406b-9142-4d03774942ca.png"> |