### PR TITLE
use template strings

### DIFF
--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -188,7 +188,7 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <meta name="description" content="${he.encode(description)}" />
 				${
 					canonicalURL !== undefined
-						? '<link rel="canonical" href="${canonicalURL}" />'
+						? `<link rel="canonical" href="${canonicalURL}" />`
 						: '<!-- no canonical URL -->'
 				}
                 <meta charset="utf-8">


### PR DESCRIPTION
## What does this change?
Fixes a bug from https://github.com/guardian/dotcom-rendering/pull/6040 by using template strings.
Currently we have `<link rel="canonical" href="${canonicalURL}" />` on the site.
