### PR TITLE
Switch off setParticipationsFlag for SignInGate mandatory long test run

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
@@ -4,7 +4,7 @@ import { setOrUseParticipations } from '../lib/ab-exclusions';
 
 // Flag to determine whether the canRun function 'setOrUseParticipations' will set a participation (true)
 // or use localstorage participation key to decide canRun result (false)
-const setParticipationsFlag = true;
+const setParticipationsFlag = false;
 
 export const signInGateMandatoryLongTestRunUk: ABTest = {
 	id: 'SignInGateMandatoryLongTestRunUk',


### PR DESCRIPTION
Switches off the flag so we go from bucketing to just running the test. 

Original PR #5891 