### PR TITLE
Add AdSlot component to deadblogs

### DIFF
--- a/apps-rendering/src/components/LiveBlocks/index.tsx
+++ b/apps-rendering/src/components/LiveBlocks/index.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
-import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import type { Option } from '@guardian/types';
 import { map, OptionKind, withDefault } from '@guardian/types';
 import AdSlot from 'adSlot';

--- a/apps-rendering/src/components/LiveBlocks/index.tsx
+++ b/apps-rendering/src/components/LiveBlocks/index.tsx
@@ -31,11 +31,13 @@ const LiveBlocks: FC<LiveBlocksProps> = ({
 	const showPinnedPost =
 		pageNumber === 1 && pinnedPost.kind === OptionKind.Some;
 
+	const firstAdIndex = 1;
+
 	const showAd = (index: number): boolean =>
 		// This can be removed when LiveBlogs are deployed
 		format.design === ArticleDesign.DeadBlog &&
 		// Add an AdSlot at 2nd and every other 5 blocks
-		(index === 1 || (index - 1) % 5 === 0);
+		(index === firstAdIndex || (index - firstAdIndex) % 5 === 0);
 
 	return (
 		<>

--- a/apps-rendering/src/components/LiveBlocks/index.tsx
+++ b/apps-rendering/src/components/LiveBlocks/index.tsx
@@ -1,9 +1,10 @@
 // ----- Imports ----- //
 
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
-import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import type { Option } from '@guardian/types';
 import { map, OptionKind, withDefault } from '@guardian/types';
+import AdSlot from 'adSlot';
 import LiveBlock from 'components/LiveBlock';
 import PinnedPost from 'components/PinnedPost';
 import { pipe } from 'lib';
@@ -29,6 +30,12 @@ const LiveBlocks: FC<LiveBlocksProps> = ({
 	const showPinnedPost =
 		pageNumber === 1 && pinnedPost.kind === OptionKind.Some;
 
+	const showAd = (index: number): boolean =>
+		// This can be removed when LiveBlogs are deployed
+		format.design === ArticleDesign.DeadBlog &&
+		// Add an AdSlot at 2nd and every other 5 blocks
+		(index === 1 || (index - 1) % 5 === 0);
+
 	return (
 		<>
 			{/* Accordion? */}
@@ -39,21 +46,30 @@ const LiveBlocks: FC<LiveBlocksProps> = ({
 					edition={edition}
 				/>
 			)}
-			{blocks.map((block) => (
-				<LiveBlock
-					key={block.id}
-					block={block}
-					format={format}
-					// This is false because it's only true when it's
-					// used for the actual pinned post on top of the page
-					isPinnedPost={false}
-					isOriginalPinnedPost={pipe(
-						pinnedPost,
-						map((pinned) => block.id === pinned.id),
-						withDefault<boolean>(false),
-					)}
-					edition={edition}
-				/>
+			{blocks.map((block, index) => (
+				<>
+					<LiveBlock
+						key={block.id}
+						block={block}
+						format={format}
+						// This is false because it's only true when it's
+						// used for the actual pinned post on top of the page
+						isPinnedPost={false}
+						isOriginalPinnedPost={pipe(
+							pinnedPost,
+							map((pinned) => block.id === pinned.id),
+							withDefault<boolean>(false),
+						)}
+						edition={edition}
+					/>
+					{showAd(index) ? (
+						<AdSlot
+							className="ad-placeholder hidden"
+							format={format}
+							paragraph={index}
+						/>
+					) : null}
+				</>
 			))}
 		</>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds ads to deadblogs at certain intervals between blocks

## Screenshots
 ![image](https://user-images.githubusercontent.com/99400613/191973518-bfd1f2e5-db3f-4f4c-91fa-ed851be4e5b3.png) ![image](https://user-images.githubusercontent.com/99400613/191973480-056d4adc-54c4-46a6-9746-07f5e2d342d7.png)

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
