### PR TITLE
Unsalted pictures 🖼️🙅🧂

### DIFF
--- a/dotcom-rendering/docs/architecture/029-signing-image-urls.md
+++ b/dotcom-rendering/docs/architecture/029-signing-image-urls.md
@@ -1,3 +1,6 @@
+> **Warning**
+> We no longer sign picture URLs
+
 # DCR now signs image urls
 
 **Refactor Picture.tsx now that DCR can sign image urls itself**

--- a/dotcom-rendering/scripts/secrets.js
+++ b/dotcom-rendering/scripts/secrets.js
@@ -1,8 +1,5 @@
 const secrets = [
-	{
-		key: 'IMAGE_SALT',
-		missingMessage: 'Images will fallback to a placeholder image',
-	},
+	// No current secrets
 ];
 
 module.exports = secrets;

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
@@ -177,40 +176,22 @@ const generateSignedUrl = ({
 	imageWidth: number;
 	resolution: 'low' | 'high';
 }): string => {
-	const sign = (salt: string, path: string): string => {
-		return createHash('md5')
-			.update(salt + path)
-			.digest('hex');
-	};
-
-	const salt = process.env.IMAGE_SALT;
-	if (!salt && process.env.NODE_ENV === 'production' && !process.env.CI) {
-		// If no IMAGE_SALT env variable is set in production then something has
-		// gone wrong and we want to know about it
-		throw new Error(
-			'No IMAGE_SALT value found when constructing picture source',
-		);
-	} else if (!salt) {
-		// If no IMAGE_SALT is set outside of production it likely means the
-		// developer has yet to set the env file. In this case we continue
-		// using a default image
-		return 'https://i.guim.co.uk/img/media/52f8e9183bbc03c48fcdf4ed9a4e12b3a19a9927/0_0_5000_3000/master/5000.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=196c7f25bf2fddcb45512d3ff25e20c0';
-	}
-
-	// Construct and sign the url
 	const url = new URL(master);
-	const service = url.hostname.split('.')[0];
+	const [service] = url.hostname.split('.');
+
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
 		// Why 45 and 85?
 		// See: https://github.com/guardian/fastly-image-service/blob/21312b81955d57338b3efd7a0c21b3987f13e7ed/fastly-io_guim_co_uk/src/main/resources/varnish/main.vcl
-		quality: resolution === 'high' ? '45' : '85',
-		fit: 'max',
+		...(resolution === 'high'
+			? { quality: '45', dpr: '2' }
+			: { quality: '85', dpr: '1' }),
+		s: 'none',
 	});
-	if (resolution === 'high') params.set('dpr', '2');
-	const path = `${url.pathname}?${params.toString()}`;
-	const sig = sign(salt, path);
-	return `https://i.guim.co.uk/img/${service}${path}&s=${sig}`;
+
+	return `https://i.guim.co.uk/img/${service}${
+		url.pathname
+	}?${params.toString()}`;
 };
 
 const descendingByBreakpoint = (a: ImageWidthType, b: ImageWidthType) => {

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -162,12 +162,13 @@ const decideImageWidths = ({
 };
 
 /**
- * Generates a url for calling the Fastly Image Optimiser
+ * Generates a URL for calling the Fastly Image Optimiser.
  *
- * @see {@link https://developer.fastly.com/reference/io/}
+ * @see https://developer.fastly.com/reference/io/
+ * @see https://github.com/guardian/fastly-image-service/blob/main/fastly-io_guim_co_uk/src/main/resources/varnish/main.vcl
  *
  */
-const generateSignedUrl = ({
+const generateImageURL = ({
 	master,
 	imageWidth,
 	resolution,
@@ -182,7 +183,9 @@ const generateSignedUrl = ({
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
 		// Why 45 and 85?
-		// See: https://github.com/guardian/fastly-image-service/blob/21312b81955d57338b3efd7a0c21b3987f13e7ed/fastly-io_guim_co_uk/src/main/resources/varnish/main.vcl
+		// This numbers have been picked in 2018 as the right
+		// balance between image fidelity and file size
+		// https://github.com/guardian/fastly-image-service/pull/35
 		...(resolution === 'high'
 			? { quality: '45', dpr: '2' }
 			: { quality: '85', dpr: '1' }),
@@ -228,12 +231,12 @@ export const Picture = ({
 			return {
 				breakpoint,
 				width: imageWidth,
-				hiResUrl: generateSignedUrl({
+				hiResUrl: generateImageURL({
 					master,
 					imageWidth,
 					resolution: 'high',
 				}),
-				lowResUrl: generateSignedUrl({
+				lowResUrl: generateImageURL({
 					master,
 					imageWidth,
 					resolution: 'low',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Stop signing `Picture` URLs.

## Why?

We now [support `s=none` in our VCL](https://github.com/guardian/fastly-image-service/pull/62).

Resolves #6036

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/192263153-edd693f8-fc23-4e6f-9eee-aa675b2be42b.png
[after]: https://user-images.githubusercontent.com/76776/192263121-2ff89f33-492f-4dae-95a1-9b20a15c8577.png