### PR TITLE
Actually serve smallest image on fallback

### DIFF
--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -283,7 +283,7 @@ export const Picture = ({
 						calculate width. The value of 167vh relates to an assumed image ratio of 5:3
 						which is equal to 167 (viewport height) : 100 (viewport width)
 
-						If either of these media queires match then the browser will choose an image from the
+						If either of these media queries match then the browser will choose an image from the
 						list of sources in srcset based on the viewport list. If the media query doesn't match
 						it continues checking using the standard sources underneath
 					*/}

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -265,6 +265,9 @@ export const Picture = ({
 	 * The assumption here is readers on devices that do not support srcset
 	 * are likely to be on poor network connections so we're going
 	 * to fallback to the smallest image.
+	 *
+	 * Sources are ordered in `descendingByBreakpoint` order,
+	 * so the last one is the smallest.
 	 */
 	const [fallbackSource] = sources.slice(-1);
 

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -260,6 +260,14 @@ export const Picture = ({
 			};
 		});
 
+	const ratio = parseInt(height, 10) / parseInt(width, 10);
+	/**
+	 * The assumption here is readers on devices that do not support srcset
+	 * are likely to be on poor network connections so we're going
+	 * to fallback to the smallest image.
+	 */
+	const [fallbackSource] = sources.slice(-1);
+
 	return (
 		<picture css={block}>
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
@@ -319,11 +327,9 @@ export const Picture = ({
 
 			<img
 				alt={alt}
-				// The assumption here is readers on devices that do not support srcset are likely to be on poor
-				// network connections so we're going to fallback to the smallest image
-				src={sources[0].lowResUrl}
-				height={height}
-				width={width}
+				src={fallbackSource.lowResUrl}
+				width={fallbackSource.width}
+				height={fallbackSource.width * ratio}
 				loading={
 					isLazy && !Picture.disableLazyLoading ? 'lazy' : undefined
 				}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Actually pick the smallest image for fallback.
Set the `width` and `height` explicitely for the `img` tag based on that image’s dimensions by calculating its ratio.

## Why?

We are sorting the sources by width in a descending order. This means browsers without sources support get the largest source.

## Screenshots

| Before      | After      |
|-------------|------------|
| 21 kB | 6 kB |
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/192315759-4b93df40-f7b4-415a-b153-96e1e6e59e83.png
[after]: https://user-images.githubusercontent.com/76776/192315597-b112fc38-b51c-420a-9c52-5b5341abafd8.png

