### PR TITLE
Fix inline merch slot positioning

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -139,6 +139,31 @@ const adStyles = css`
 			margin-right: -398px;
 		}
 	}
+
+	.ad-slot-container--im {
+		float: left;
+		background-color: transparent;
+
+		.ad-slot {
+			width: 130px;
+
+			${from.mobileLandscape} {
+				width: 220px;
+			}
+			&:not(.ad-slot--rendered) {
+				width: 0;
+				height: 0;
+			}
+
+			&.ad-slot--rendered {
+				margin: 5px 10px 6px 0;
+				${from.mobileLandscape} {
+					margin-bottom: 12px;
+					margin-right: 20px;
+				}
+			}
+		}
+	}
 `;
 
 export const ArticleContainer = ({ children, format }: Props) => {

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import { from } from '@guardian/source-foundations';
 import type { ServerSideTests, Switches } from '../../types/config';
 import {
 	adCollapseStyles,
@@ -24,27 +23,6 @@ const commercialPosition = css`
 const adStylesDynamic = css`
 	${adLabelStyles}
 	${adCollapseStyles}
-
-	.ad-slot--im {
-		float: left;
-		width: 130px;
-		${from.mobileLandscape} {
-			width: 220px;
-		}
-
-		&:not(.ad-slot--rendered) {
-			width: 0;
-			height: 0;
-		}
-
-		&.ad-slot--rendered {
-			margin: 5px 10px 6px 0;
-			${from.mobileLandscape} {
-				margin-bottom: 12px;
-				margin-right: 20px;
-			}
-		}
-	}
 `;
 
 export const ArticleRenderer: React.FC<{


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Move some of the `im` slot styling to it's container
- Move styling to `ArticleContainer.tsx` with the rest of the container styles.

## Why?
Merch slots should be floated left and not be the full-width of the article, this been broken since we added containers to inline slots in https://github.com/guardian/frontend/pull/25236.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/1731150/192323535-5660222f-9c43-408a-82c0-c759be941d03.png
[after]: https://user-images.githubusercontent.com/1731150/192323563-bbeb9e3d-e292-45ad-903c-e3b04352eed2.png
[before2]: https://user-images.githubusercontent.com/1731150/192323788-ad406924-dc04-4ac5-b2b4-97a2b2a84c2f.png
[after2]: https://user-images.githubusercontent.com/1731150/192323812-db30c899-ee7e-43ef-a473-cab7d65ec937.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
