### PR TITLE
Add support for Fixed/Medium/FastXII container

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.stories.tsx
@@ -1,0 +1,29 @@
+import { trails } from '../../../fixtures/manual/trails';
+import { breakpoints } from '@guardian/source-foundations';
+import { Section } from './Section';
+import { FixedMediumFastXII } from './FixedMediumFastXII';
+
+export default {
+	component: FixedMediumFastXII,
+	title: 'Components/FixedMediumFastXII',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<Section
+		title="FixedMediumFastXII"
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedMediumFastXII trails={trails} showAge={true} />
+	</Section>
+);
+Default.story = { name: 'FixedMediumFastXII' };

--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
@@ -1,0 +1,67 @@
+import type { DCRContainerPalette } from '../../types/front';
+import type { TrailType } from '../../types/trails';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { FrontCard } from './FrontCard';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+};
+
+export const FixedMediumFastXII = ({
+	trails,
+	containerPalette,
+	showAge,
+}: Props) => {
+	const firstSlice = trails.slice(0, 4);
+	const secondSlice = trails.slice(4, 8);
+	const thirdSlice = trails.slice(8, 12);
+
+	return (
+		<>
+			<UL direction="row" padBottom={true}>
+				{firstSlice.map((trail) => {
+					return (
+						<LI key={trail.url} padSides={true} percentage="25%">
+							<FrontCard
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			<UL direction="row" padBottom={true}>
+				{secondSlice.map((trail) => {
+					return (
+						<LI key={trail.url} padSides={true} percentage="25%">
+							<FrontCard
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								imageUrl={undefined}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+			<UL direction="row" padBottom={true}>
+				{thirdSlice.map((trail) => {
+					return (
+						<LI key={trail.url} padSides={true} percentage="25%">
+							<FrontCard
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								imageUrl={undefined}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -17,6 +17,7 @@ import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
 import { FixedSmallSlowVMPU } from '../components/FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
+import { FixedMediumFastXII } from '../components/FixedMediumFastXII';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -141,6 +142,14 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 					index={index}
+				/>
+			);
+		case 'fixed/medium/fast-XII':
+			return (
+				<FixedMediumFastXII
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
 				/>
 			);
 		default:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #5144 

## What does this change?
Adds support for `Fixed/Medium/FastXII` container type.

## Screenshots

|        | frontend | DCR |
|--------|----------|-----|
| Before | ![image](https://user-images.githubusercontent.com/19683595/192340779-81441928-0d3a-4ede-b683-2064af68e6bb.png) | ![image](https://user-images.githubusercontent.com/19683595/192341066-3ad7be7b-991d-4c8f-8b1e-3ba87b21b6ca.png) |
| After  | ![image](https://user-images.githubusercontent.com/19683595/192340810-1a3e23b7-9386-43c2-a3f1-c160bd9ed1b3.png) | ![image](https://user-images.githubusercontent.com/19683595/192340891-56c22ff0-69d1-406a-a277-caf72f9236f9.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
