### PR TITLE
Prevent hiding headlines in network fronts and 1st container in non-network fronts

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -372,6 +372,9 @@
         },
         "isAdFreeUser": {
             "type": "boolean"
+        },
+        "isNetworkFront": {
+            "type": "boolean"
         }
     },
     "required": [
@@ -381,6 +384,7 @@
         "editionLongForm",
         "guardianBaseURL",
         "isAdFreeUser",
+        "isNetworkFront",
         "nav",
         "pageFooter",
         "pageId",
@@ -2580,9 +2584,6 @@
                             "uneditable"
                         ]
                     }
-                },
-                "isNetworkFront": {
-                    "type": "boolean"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -17,6 +17,7 @@ export interface FEFrontType {
 	commercialProperties: Record<string, unknown>;
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
+	isNetworkFront: boolean;
 }
 
 export interface DCRFrontType {
@@ -27,6 +28,7 @@ export interface DCRFrontType {
 	config: FEFrontConfigType;
 	pageFooter: FooterType;
 	isAdFreeUser: boolean;
+	isNetworkFront: boolean;
 }
 
 interface FEPressedPageType {
@@ -34,7 +36,6 @@ interface FEPressedPageType {
 	seoData: FESeoDataType;
 	frontProperties: FEFrontPropertiesType;
 	collections: FECollectionType[];
-	isNetworkFront?: boolean;
 }
 
 interface DCRPressedPageType {
@@ -42,7 +43,6 @@ interface DCRPressedPageType {
 	seoData: FESeoDataType;
 	frontProperties: FEFrontPropertiesType;
 	collections: DCRCollectionType[];
-	isNetworkFront?: boolean;
 }
 
 type FEContainerType =

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import type { NavType } from '../../model/extract-nav';
-import type { DCRFrontType } from '../../types/front';
+import type { DCRCollectionType, DCRFrontType } from '../../types/front';
 import { AdSlot } from '../components/AdSlot';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
@@ -54,6 +54,14 @@ const shouldInsertMerchHigh = (
 	}
 
 	return index === desiredPosition;
+};
+
+const isToggleable = (index: number, collection: DCRCollectionType) => {
+	return (
+		index != 0 &&
+		collection.collectionType != 'nav/list' &&
+		collection.collectionType != 'nav/media-list'
+	);
 };
 
 export const FrontLayout = ({ front, NAV }: Props) => {
@@ -251,7 +259,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								ophanComponentName={ophanName}
 								containerName={collection.collectionType}
 								containerPalette={collection.containerPalette}
-								toggleable={true}
+								toggleable={isToggleable(index, collection)}
 								sectionId={collection.id}
 								showDateHeader={
 									collection.config.showDateHeader

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -56,12 +56,24 @@ const shouldInsertMerchHigh = (
 	return index === desiredPosition;
 };
 
-const isToggleable = (index: number, collection: DCRCollectionType) => {
+const isNavList = (collection: DCRCollectionType) => {
 	return (
-		index != 0 &&
-		collection.collectionType != 'nav/list' &&
-		collection.collectionType != 'nav/media-list'
+		collection.collectionType == 'nav/list' ||
+		collection.collectionType == 'nav/media-list'
 	);
+};
+
+const isToggleable = (
+	index: number,
+	collection: DCRCollectionType,
+	isNetworkFront: boolean,
+) => {
+	if (isNetworkFront) {
+		return (
+			collection.displayName.toLowerCase() != 'headlines' &&
+			!isNavList(collection)
+		);
+	} else return index != 0 && !isNavList(collection);
 };
 
 export const FrontLayout = ({ front, NAV }: Props) => {
@@ -259,7 +271,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								ophanComponentName={ophanName}
 								containerName={collection.collectionType}
 								containerPalette={collection.containerPalette}
-								toggleable={isToggleable(index, collection)}
+								toggleable={isToggleable(
+									index,
+									collection,
+									front.isNetworkFront,
+								)}
 								sectionId={collection.id}
 								showDateHeader={
 									collection.config.showDateHeader
@@ -282,7 +298,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							</Section>
 							{shouldInsertMerchHigh(
 								index,
-								front.pressedPage.isNetworkFront,
+								front.isNetworkFront,
 								front.pressedPage.collections.length,
 								front.pressedPage.frontProperties.isPaidContent,
 							) && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes https://github.com/guardian/dotcom-rendering/issues/5562

## What does this change?
* Brings `isNetworkFront` one level up in JSON schema and makes it required field
* Prevents hiding "Headlines" in network fronts
* Prevents hiding the 1st container of a non-network pressed front
* Prevents hiding `nav/list` and nav/media-list`

## Why?
To achieve parity with frontend 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/192516237-97dd8b8e-9c03-4960-a74e-2f082270201b.png) | ![image](https://user-images.githubusercontent.com/19683595/192515990-e4585599-a3df-4652-b061-1b56a83aea7a.png) |
| ![image](https://user-images.githubusercontent.com/19683595/192516337-63cc5823-355d-407c-861b-ebb52b122692.png) | ![image](https://user-images.githubusercontent.com/19683595/192516114-8da2b487-02a4-4949-a26c-bf25dfce0157.png) |
| ![image](https://user-images.githubusercontent.com/19683595/193889954-c93a7728-9d4a-4a2b-843a-bacb035b2559.png) | ![image](https://user-images.githubusercontent.com/19683595/193890029-095040d8-a9b3-4109-bb73-9cc137956e0b.png) |
| ![image](https://user-images.githubusercontent.com/19683595/193888776-e5d3307b-a5b6-4c0b-a67c-5e43f80aa22b.png) | ![image](https://user-images.githubusercontent.com/19683595/193888550-be856231-7546-487a-9ccf-fba3ba356073.png) |
| ![image](https://user-images.githubusercontent.com/19683595/193888968-f2eb3378-de80-441e-a8ff-a11ba757f136.png) | ![image](https://user-images.githubusercontent.com/19683595/193888623-a7857d78-7e74-46e9-b658-d51021760661.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
