### PR TITLE
WIP: Create dcr-deployment.yml workflow

### DIFF
--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
+  cache_path: ./
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -19,7 +20,7 @@ jobs:
         run: yarn --frozen-lockfile
       - uses: actions/cache@v3
         with:
-          path: dotcom-rendering
+          path: ${{env.cache_path}}
           key: ${{env.cache_name}}
   lint:
     name: Lint
@@ -28,7 +29,7 @@ jobs:
     steps:
       - uses: actions/cache@v3
         with:
-          path: dotcom-rendering
+          path: ${{env.cache_path}}
           key: ${{env.cache_name}}
       - name: Lint
         run: make lint
@@ -45,7 +46,7 @@ jobs:
     steps:
       - uses: actions/cache@v3
         with:
-          path: dotcom-rendering
+          path: ${{env.cache_path}}
           key: ${{env.cache_name}}
       - name: Generate production build
         run: make build

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
+      - run: whereis node
+      - run: ls -la /usr/local/bin/node
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -20,11 +20,13 @@ jobs:
       - name: Yarn install
         run: yarn --frozen-lockfile
       # Save the output for use in further jobs
+      - name: Tar files
+        run: tar -czvf setup-project.tar.gz .
       - name: Upload setup project
         uses: actions/upload-artifact@v3
         with:
           name: setup-project-output
-          path: ./
+          path: setup-project.tar.gz
   lint:
     name: lint
     needs: [setup]
@@ -35,6 +37,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: setup-project-output
+      - name: Extract project
+        run: tar -xzvf setup-project.tar.gz
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -56,6 +60,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: setup-project-output
+      - name: Extract project
+        run: tar -xzvf setup-project.tar.gz
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -65,11 +71,13 @@ jobs:
       - name: Validate Build
         run: make buildCheck
         working-directory: dotcom-rendering
+      - name: Tar files
+        run: tar -czvf built-project.tar.gz .
       - name: Upload built project
         uses: actions/upload-artifact@v3
         with:
           name: built-project-output
-          path: ./
+          path: build-project.tar.gz
   deploy:
     needs: [build, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -5,9 +5,9 @@ on:
       - 'apps-rendering/**'
 
 env:
-  cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
-  cache_path: ./
+  # We set NODE_ENV=production globally, this ensures we have consistent yarn installs between jobs
   NODE_ENV: production
+  built_project_filename: built-project.tar.gz
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -72,14 +72,42 @@ jobs:
         run: make buildCheck
         working-directory: dotcom-rendering
       - name: Tar files
-        run: touch built-project.tar.gz && tar --exclude=built-project.tar.gz -czf built-project.tar.gz .
+        run: touch ${{env.built_project_filename}} && tar --exclude=${{env.built_project_filename}} -czf ${{env.built_project_filename}} .
       - name: Upload built project
         uses: actions/upload-artifact@v3
         with:
           name: built-project-output
-          path: built-project.tar.gz
+          path: ${{env.built_project_filename}}
+  cypress:
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6]
+    steps:
+      # Setup Environment
+      - name: Download built project
+        uses: actions/download-artifact@v3
+        with:
+          name: built-project-output
+      - name: Extract project
+        run: tar -xzf ${{env.built_project_filename}}
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        with:
+          start: make start-ci
+          working-directory: dotcom-rendering
+          wait-on: 'http://localhost:9000'
+          wait-on-timeout: 30
+          browser: chrome
+          spec: cypress/e2e/parallel-${{ matrix.group }}/*.js
+
   deploy:
-    needs: [build, lint]
+    needs: [build, lint, cypress]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -37,7 +37,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
       - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -66,7 +66,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
       - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -93,7 +93,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
       - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -115,7 +115,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
       - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -139,7 +139,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
       - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -164,7 +164,7 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.build_cache_name}}
       - if: steps.build-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
@@ -262,3 +262,21 @@ jobs:
     steps:
       - name: Deploy
         run: echo "Coming soon..."
+  clear-cache:
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear cache
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.actions.deleteActionsCacheByKey({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              key: "${{setup_cache_name}}"
+            })
+            await github.rest.actions.deleteActionsCacheByKey({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              key: "${{built_cache_name}}"
+            })

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -214,6 +214,12 @@ jobs:
   lighthouse:
     needs: [build]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
+          - 'http://localhost:9000/Front?url=https://www.theguardian.com/uk'
     steps:
       # Setup Environment
       - uses: actions/cache@v3
@@ -233,6 +239,7 @@ jobs:
         working-directory: dotcom-rendering
         env:
           LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+          LHCI_URL: ${{ matrix.group }}
         run: |
           npm install -g puppeteer-core@2.1.0 @lhci/cli@0.8.2
           lhci autorun
@@ -243,8 +250,9 @@ jobs:
           deno-version: v1.21.0
 
       - name: Surface Lighthouse Results
-        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH" --allow-read scripts/deno/surface-lighthouse-results.ts
+        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH","LHCI_URL" --allow-read scripts/deno/surface-lighthouse-results.ts
         env:
+          LHCI_URL: ${{ matrix.group }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
     needs:

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn --frozen-lockfile
       # Save the output for use in further jobs
       - name: Tar files
-        run: tar -czf setup-project.tar.gz .
+        run: touch setup-project.tar.gz && tar --exclude=setup-project.tar.gz -czf setup-project.tar.gz .
       - name: Upload setup project
         uses: actions/upload-artifact@v3
         with:
@@ -72,12 +72,12 @@ jobs:
         run: make buildCheck
         working-directory: dotcom-rendering
       - name: Tar files
-        run: tar -czf built-project.tar.gz .
+        run: touch built-project.tar.gz && tar --exclude=built-project.tar.gz -czf built-project.tar.gz .
       - name: Upload built project
         uses: actions/upload-artifact@v3
         with:
           name: built-project-output
-          path: build-project.tar.gz
+          path: built-project.tar.gz
   deploy:
     needs: [build, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -1,0 +1,48 @@
+name: DCR Deployment
+on:
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+      - uses: guardian/actions-setup-node@v2
+        with:
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: yarn
+  lint:
+    name: Lint
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint
+        run: make lint
+        working-directory: dotcom-rendering
+      - name: Stylelint
+        run: make stylelint
+        working-directory: dotcom-rendering
+      - name: Prettier check
+        run: yarn prettier:check
+        working-directory: dotcom-rendering
+  build:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
+
+      - name: Validate Build
+        run: make buildCheck
+        working-directory: dotcom-rendering
+  deploy:
+    needs: [build, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy
+        run: echo "Coming soon...

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -6,9 +6,7 @@ on:
 
 env:
   cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
-  cache_path: |
-    ./
-    /usr/local/bin/node
+  cache_path: ./
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -30,12 +28,14 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
-      - run: whereis node
-      - run: ls -la /usr/local/bin/node
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering
@@ -49,6 +49,10 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -27,7 +27,6 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
   lint:
-    name: lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +54,6 @@ jobs:
         run: yarn prettier:check
         working-directory: dotcom-rendering
   typescript:
-    name: lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +75,7 @@ jobs:
         run: yarn tsc
         working-directory: dotcom-rendering
   development-checks:
-    name: lint
+    name: stories & schema check
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
@@ -102,7 +100,6 @@ jobs:
         run: make check-stories
         working-directory: dotcom-rendering
   jest:
-    name: lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -3,6 +3,9 @@ on:
   push:
     paths-ignore:
       - 'apps-rendering/**'
+
+env:
+  CACHE_NAME: setup-output
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -12,14 +15,21 @@ jobs:
         uses: guardian/actions-setup-node@v2
         with:
           cache: 'yarn'
-
       - name: Yarn install
         run: yarn --frozen-lockfile
+      - uses: actions/cache@v3
+        with:
+          path: dotcom-rendering
+          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
   lint:
     name: Lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v3
+        with:
+          path: dotcom-rendering
+          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering
@@ -33,6 +43,10 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v3
+        with:
+          path: dotcom-rendering
+          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
       - name: Generate production build
         run: make build
         working-directory: dotcom-rendering

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -5,7 +5,7 @@ on:
       - 'apps-rendering/**'
 
 env:
-  CACHE_NAME: setup-output
+  cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: dotcom-rendering
-          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
+          key: ${{env.cache_name}}
   lint:
     name: Lint
     needs: [setup]
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: dotcom-rendering
-          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
+          key: ${{env.cache_name}}
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: dotcom-rendering
-          key: ${{GITHUB_RUN_ID}}-${{GITHUB_RUN_NUMBER}}-${{CACHE_NAME}}
+          key: ${{env.cache_name}}
       - name: Generate production build
         run: make build
         working-directory: dotcom-rendering

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Node
-      - uses: guardian/actions-setup-node@v2
+        uses: guardian/actions-setup-node@v2
         with:
           cache: 'yarn'
 

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -23,26 +23,6 @@ jobs:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
       - run: whereis node
-  lint:
-    name: Lint
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/cache@v3
-        with:
-          path: ${{env.cache_path}}
-          key: ${{env.cache_name}}
-      - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
-      - name: Lint
-        run: make lint
-        working-directory: dotcom-rendering
-      - name: Stylelint
-        run: make stylelint
-        working-directory: dotcom-rendering
-      - name: Prettier check
-        run: yarn prettier:check
-        working-directory: dotcom-rendering
   build:
     needs: [setup]
     runs-on: ubuntu-latest
@@ -59,6 +39,28 @@ jobs:
 
       - name: Validate Build
         run: make buildCheck
+        working-directory: dotcom-rendering
+  lint:
+    name: Lint
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.cache_name}}
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Lint
+        run: make lint
+        working-directory: dotcom-rendering
+      - name: Stylelint
+        run: make stylelint
+        working-directory: dotcom-rendering
+      - name: Prettier check
+        run: yarn prettier:check
         working-directory: dotcom-rendering
   deploy:
     needs: [build, lint]

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -26,6 +26,35 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
+  build:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: setup-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
+      - name: Validate Build
+        run: make buildCheck
+        working-directory: dotcom-rendering
+      # Cache the build output for further steps
+      - uses: actions/cache@v3
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.build_cache_name}}
   lint:
     needs: [setup]
     runs-on: ubuntu-latest
@@ -118,37 +147,8 @@ jobs:
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
       - name: Run Jest
-        run: CI=true yarn test
+        run: CI=true yarn test:ci
         working-directory: dotcom-rendering
-  build:
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      # Setup Environment
-      - uses: actions/cache@v3
-        id: setup-cache
-        with:
-          path: ${{env.cache_path}}
-          key: ${{env.setup_cache_name}}
-      - if: steps.setup-cache.outputs.cache-hit != 'true'
-        uses: actions/github-script@v3
-        with:
-          script: |
-            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
-      - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
-      # Job Steps
-      - name: Generate production build
-        run: make build
-        working-directory: dotcom-rendering
-      - name: Validate Build
-        run: make buildCheck
-        working-directory: dotcom-rendering
-      # Cache the build output for further steps
-      - uses: actions/cache@v3
-        with:
-          path: ${{env.cache_path}}
-          key: ${{env.build_cache_name}}
   cypress:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -28,14 +28,12 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
-      - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
-        with:
-          cache: 'yarn'
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering
@@ -49,14 +47,12 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
-      - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
-        with:
-          cache: 'yarn'
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
       - name: Generate production build
         run: make build
         working-directory: dotcom-rendering

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn --frozen-lockfile
       # Save the output for use in further jobs
       - name: Tar files
-        run: tar -czvf setup-project.tar.gz .
+        run: tar -czf setup-project.tar.gz .
       - name: Upload setup project
         uses: actions/upload-artifact@v3
         with:
@@ -38,7 +38,7 @@ jobs:
         with:
           name: setup-project-output
       - name: Extract project
-        run: tar -xzvf setup-project.tar.gz
+        run: tar -xzf setup-project.tar.gz
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -61,7 +61,7 @@ jobs:
         with:
           name: setup-project-output
       - name: Extract project
-        run: tar -xzvf setup-project.tar.gz
+        run: tar -xzf setup-project.tar.gz
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -72,7 +72,7 @@ jobs:
         run: make buildCheck
         working-directory: dotcom-rendering
       - name: Tar files
-        run: tar -czvf built-project.tar.gz .
+        run: tar -czf built-project.tar.gz .
       - name: Upload built project
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'yarn'
       - name: Yarn install
         run: yarn --frozen-lockfile
-      # Cache the output for use in further jobs
+      # Cache the setup output for use in further jobs
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
@@ -33,10 +33,11 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/cache@v3
+        id: setup-cache
         with:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v3
         with:
           script: |
@@ -59,10 +60,11 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/cache@v3
+        id: setup-cache
         with:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v3
         with:
           script: |
@@ -76,7 +78,7 @@ jobs:
       - name: Validate Build
         run: make buildCheck
         working-directory: dotcom-rendering
-      # Cache the output for further steps
+      # Cache the build output for further steps
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
@@ -91,10 +93,11 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/cache@v3
+        id: build-cache
         with:
           path: ${{env.cache_path}}
           key: ${{env.build_cache_name}}
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.build-cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v3
         with:
           script: |

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -54,6 +54,75 @@ jobs:
       - name: Prettier check
         run: yarn prettier:check
         working-directory: dotcom-rendering
+  typescript:
+    name: lint
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: setup-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Check typescript
+        run: yarn tsc
+        working-directory: dotcom-rendering
+  development-checks:
+    name: lint
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: setup-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Run check-schema script
+        run: make check-schema
+        working-directory: dotcom-rendering
+      - name: Run check-stories script
+        run: make check-stories
+        working-directory: dotcom-rendering
+  jest:
+    name: lint
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: setup-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
+      - if: steps.setup-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Run Jest
+        run: CI=true yarn test
+        working-directory: dotcom-rendering
   build:
     needs: [setup]
     runs-on: ubuntu-latest
@@ -114,9 +183,84 @@ jobs:
           wait-on-timeout: 30
           browser: chrome
           spec: cypress/e2e/parallel-${{ matrix.group }}/*.js
+  percy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: build-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.build_cache_name}}
+      - if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Install cypress
+        uses: cypress-io/github-action@v4
+        with:
+          runTests: false
+          start: make start-ci
+          working-directory: dotcom-rendering
+          wait-on: 'http://localhost:9000'
+          wait-on-timeout: 30
+      - name: Percy Test
+        working-directory: dotcom-rendering
+        run: yarn cypress:run:percy
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  lighthouse:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - uses: actions/cache@v3
+        id: build-cache
+        with:
+          path: ${{env.cache_path}}
+          key: ${{env.build_cache_name}}
+      - if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Install and run Lighthouse CI
+        working-directory: dotcom-rendering
+        env:
+          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+        run: |
+          npm install -g puppeteer-core@2.1.0 @lhci/cli@0.8.2
+          lhci autorun
 
+      - name: Setup deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: v1.21.0
+
+      - name: Surface Lighthouse Results
+        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH" --allow-read scripts/deno/surface-lighthouse-results.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    needs: [build, lint, cypress]
+    needs:
+      [
+        build,
+        lint,
+        typescript,
+        development-checks,
+        jest,
+        cypress,
+        percy,
+        lighthouse,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -36,8 +36,11 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
-      - name: Extract project
-        run: tar -xzf setup-project.tar.gz
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -59,6 +62,11 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.setup_cache_name}}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -86,6 +94,11 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.build_cache_name}}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing cache - Please re-run the full dcr-deployment action!')
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -262,8 +262,9 @@ jobs:
     steps:
       - name: Deploy
         run: echo "Coming soon..."
-  clear-cache:
-    needs: [deploy]
+  cleanup-setup-cache:
+    # IMPORTANT: 'needs' should include any job using on 'env.setup_cache_name' in actions/cache
+    needs: [build, lint, typescript, development-checks, jest]
     runs-on: ubuntu-latest
     steps:
       - name: Clear cache
@@ -275,6 +276,14 @@ jobs:
               repo: context.repo.repo,
               key: "${{env.setup_cache_name}}"
             })
+  cleanup-build-cache:
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear cache
+        uses: actions/github-script@v6
+        with:
+          script: |
             await github.rest.actions.deleteActionsCacheByKey({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Node
-        uses: guardian/actions-setup-node@v2
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
       - name: Yarn install
@@ -22,6 +22,7 @@ jobs:
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
+      - run: whereis node
   lint:
     name: Lint
     needs: [setup]

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -6,7 +6,9 @@ on:
 
 env:
   cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
-  cache_path: ./
+  cache_path: |
+    ./
+    /usr/local/bin/node
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -19,39 +19,22 @@ jobs:
           cache: 'yarn'
       - name: Yarn install
         run: yarn --frozen-lockfile
-      # Cache the output for use in further jobs
-      - uses: actions/cache@v3
+      # Save the output for use in further jobs
+      - name: Upload setup project
+        uses: actions/upload-artifact@v3
         with:
-          path: ${{env.cache_path}}
-          key: ${{env.cache_name}}
-  build:
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      # Setup Environment
-      - uses: actions/cache@v3
-        with:
-          path: ${{env.cache_path}}
-          key: ${{env.cache_name}}
-      - name: Install Node
-        uses: guardian/actions-setup-node@v2.4.1
-      # Job Steps
-      - name: Generate production build
-        run: make build
-        working-directory: dotcom-rendering
-      - name: Validate Build
-        run: make buildCheck
-        working-directory: dotcom-rendering
+          name: setup-project-output
+          path: ./
   lint:
-    name: Lint
+    name: lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
       # Setup Environment
-      - uses: actions/cache@v3
+      - name: Download setup project
+        uses: actions/download-artifact@v3
         with:
-          path: ${{env.cache_path}}
-          key: ${{env.cache_name}}
+          name: setup-project-output
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -64,6 +47,29 @@ jobs:
       - name: Prettier check
         run: yarn prettier:check
         working-directory: dotcom-rendering
+  build:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      # Setup Environment
+      - name: Download setup project
+        uses: actions/download-artifact@v3
+        with:
+          name: setup-project-output
+      - name: Install Node
+        uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
+      - name: Validate Build
+        run: make buildCheck
+        working-directory: dotcom-rendering
+      - name: Upload built project
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-project-output
+          path: ./
   deploy:
     needs: [build, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -7,7 +7,9 @@ on:
 env:
   # We set NODE_ENV=production globally, this ensures we have consistent yarn installs between jobs
   NODE_ENV: production
-  built_project_filename: built-project.tar.gz
+  setup_cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
+  build_cache_name: ${{github.run_id}}-${{github.run_number}}-build-output
+  cache_path: ./
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -19,24 +21,21 @@ jobs:
           cache: 'yarn'
       - name: Yarn install
         run: yarn --frozen-lockfile
-      # Save the output for use in further jobs
-      - name: Tar files
-        run: touch setup-project.tar.gz && tar --exclude=setup-project.tar.gz -czf setup-project.tar.gz .
-      - name: Upload setup project
-        uses: actions/upload-artifact@v3
+      # Cache the output for use in further jobs
+      - uses: actions/cache@v3
         with:
-          name: setup-project-output
-          path: setup-project.tar.gz
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
   lint:
     name: lint
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
       # Setup Environment
-      - name: Download setup project
-        uses: actions/download-artifact@v3
+      - uses: actions/cache@v3
         with:
-          name: setup-project-output
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
       - name: Extract project
         run: tar -xzf setup-project.tar.gz
       - name: Install Node
@@ -56,12 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup Environment
-      - name: Download setup project
-        uses: actions/download-artifact@v3
+      - uses: actions/cache@v3
         with:
-          name: setup-project-output
-      - name: Extract project
-        run: tar -xzf setup-project.tar.gz
+          path: ${{env.cache_path}}
+          key: ${{env.setup_cache_name}}
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps
@@ -71,13 +68,11 @@ jobs:
       - name: Validate Build
         run: make buildCheck
         working-directory: dotcom-rendering
-      - name: Tar files
-        run: touch ${{env.built_project_filename}} && tar --exclude=${{env.built_project_filename}} -czf ${{env.built_project_filename}} .
-      - name: Upload built project
-        uses: actions/upload-artifact@v3
+      # Cache the output for further steps
+      - uses: actions/cache@v3
         with:
-          name: built-project-output
-          path: ${{env.built_project_filename}}
+          path: ${{env.cache_path}}
+          key: ${{env.build_cache_name}}
   cypress:
     needs: [build]
     runs-on: ubuntu-latest
@@ -87,12 +82,10 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
     steps:
       # Setup Environment
-      - name: Download built project
-        uses: actions/download-artifact@v3
+      - uses: actions/cache@v3
         with:
-          name: built-project-output
-      - name: Extract project
-        run: tar -xzf ${{env.built_project_filename}}
+          path: ${{env.cache_path}}
+          key: ${{env.build_cache_name}}
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
       # Job Steps

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -14,7 +14,7 @@ jobs:
           cache: 'yarn'
 
       - name: Yarn install
-        run: yarn
+        run: yarn --frozen-lockfile
   lint:
     name: Lint
     needs: [setup]

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -7,6 +7,7 @@ on:
 env:
   cache_name: ${{github.run_id}}-${{github.run_number}}-setup-output
   cache_path: ./
+  NODE_ENV: production
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -18,25 +19,26 @@ jobs:
           cache: 'yarn'
       - name: Yarn install
         run: yarn --frozen-lockfile
+      # Cache the output for use in further jobs
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
-      - run: whereis node
   build:
     needs: [setup]
     runs-on: ubuntu-latest
     steps:
+      # Setup Environment
       - uses: actions/cache@v3
         with:
           path: ${{env.cache_path}}
           key: ${{env.cache_name}}
       - name: Install Node
         uses: guardian/actions-setup-node@v2.4.1
+      # Job Steps
       - name: Generate production build
         run: make build
         working-directory: dotcom-rendering
-
       - name: Validate Build
         run: make buildCheck
         working-directory: dotcom-rendering
@@ -67,4 +69,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy
-        run: echo "Coming soon...
+        run: echo "Coming soon..."

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -278,5 +278,5 @@ jobs:
             await github.rest.actions.deleteActionsCacheByKey({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              key: "${{env.built_cache_name}}"
+              key: "${{env.build_cache_name}}"
             })

--- a/.github/workflows/dcr-deployment.yml
+++ b/.github/workflows/dcr-deployment.yml
@@ -273,10 +273,10 @@ jobs:
             await github.rest.actions.deleteActionsCacheByKey({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              key: "${{setup_cache_name}}"
+              key: "${{env.setup_cache_name}}"
             })
             await github.rest.actions.deleteActionsCacheByKey({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              key: "${{built_cache_name}}"
+              key: "${{env.built_cache_name}}"
             })

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -1,28 +1,26 @@
 {
-	"name": "@guardian/common-rendering",
-	"version": "1.0.0",
-	"license": "Apache-2.0",
-	"scripts": {
-		"test": "jest"
-	},
-	"dependencies": {
-		"@emotion/react": "^11.4.1",
-		"@guardian/libs": "^7.1.0",
-		"@guardian/types": "^9.0.1",
-		"react": "^17.0.2"
-	},
-	"devDependencies": {
-		"@emotion/jest": "^11.3.0",
-		"@types/jest": "^27.4.0",
-		"@types/react-test-renderer": "^17.0.1",
-		"jest": "^26.6.3",
-		"react-test-renderer": "^17.0.1",
-		"ts-jest": "^26.5.3"
-	},
-	"jest": {
-		"preset": "ts-jest/presets/js-with-ts",
-		"transformIgnorePatterns": [
-			"node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
-		]
-	}
+  "name": "@guardian/common-rendering",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.4.1",
+    "@guardian/libs": "^7.1.0",
+    "@guardian/types": "^9.0.1",
+    "react": "^17.0.2",
+    "@emotion/jest": "^11.3.0",
+    "@types/jest": "^27.4.0",
+    "@types/react-test-renderer": "^17.0.1",
+    "jest": "^26.6.3",
+    "react-test-renderer": "^17.0.1",
+    "ts-jest": "^26.5.3"
+  },
+  "jest": {
+    "preset": "ts-jest/presets/js-with-ts",
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
+    ]
+  }
 }

--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -1,10 +1,7 @@
 module.exports = {
 	ci: {
 		collect: {
-			url: [
-				'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads',
-				'http://localhost:9000/Front?url=https://www.theguardian.com/uk',
-			],
+			url: [process.env.LHCI_URL],
 			startServerCommand:
 				'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
 			numberOfRuns: '10',

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -168,7 +168,7 @@ clean-deps:
 
 install: check-env
 	$(call log, "refreshing dependencies")
-	@yarn --silent
+	@yarn
 
 reinstall: clear clean-deps install
 	$(call log, "dependencies have been reinstalled ♻️")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -168,7 +168,7 @@ clean-deps:
 
 install: check-env
 	$(call log, "refreshing dependencies")
-	@yarn
+	@yarn --silent
 
 reinstall: clear clean-deps install
 	$(call log, "dependencies have been reinstalled ♻️")

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -30,13 +30,15 @@ deploy:
 
 # prod #########################################
 
+build: export NODE_ENV=production
 build: clean-dist install
 	$(call log, "building production bundles")
-	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js --progress
+	@webpack --config ./scripts/webpack/webpack.config.js --progress
 
+build-ci: export NODE_ENV=production
 build-ci: clean-dist install
 	$(call log, "building production bundles")
-	@NODE_ENV=production SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
+	@SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
 
 start-ci: export NODE_ENV=production
 start-ci: install gen-dotenv-ci

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -30,15 +30,13 @@ deploy:
 
 # prod #########################################
 
-build: export NODE_ENV=production
 build: clean-dist install
 	$(call log, "building production bundles")
-	@webpack --config ./scripts/webpack/webpack.config.js --progress
+	@NODE_ENV=production webpack --config ./scripts/webpack/webpack.config.js --progress
 
-build-ci: export NODE_ENV=production
 build-ci: clean-dist install
 	$(call log, "building production bundles")
-	@SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
+	@NODE_ENV=production SKIP_LEGACY=true webpack --config ./scripts/webpack/webpack.config.js
 
 start-ci: export NODE_ENV=production
 start-ci: install gen-dotenv-ci

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -21,7 +21,7 @@
     "tsc": "tsc",
     "test": "jest --maxWorkers=50%",
     "test:watch": "jest --watch --maxWorkers=25%",
-    "test:ci": "jest --runInBand",
+    "test:ci": "DISABLE_LOGGING_AND_METRICS=true jest",
     "createtoc": "doctoc $npm_package_tocList --github --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
     "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
     "cypress:open": "cypress open",

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -67,7 +67,7 @@ const results: AssertionResult[] = JSON.parse(
 /* -- Definitions -- */
 
 /** The string to search for when looking for a comment */
-const IDENTIFIER_COMMENT = `<-- url: ${process.env.LHCI_URL} -->`;
+const IDENTIFIER_COMMENT = `<-- url: ${Deno.env.get('LHCI_URL')} -->`;
 const GIHUB_PARAMS = {
 	owner: 'guardian',
 	repo: 'dotcom-rendering',
@@ -108,7 +108,7 @@ const generateAuditTable = (
 			)} | ${expected} | ${formatNumber(expected, actual)} |`,
 	);
 
-	const [, testUrlClean] = process.env.LHCI_URL.split('?url=');
+	const [, testUrlClean] = Deno.env.get('LHCI_URL').split('?url=');
 
 	const table = [
 		`> tested url \`${testUrlClean}\``,
@@ -126,7 +126,7 @@ const createLighthouseResultsMd = (): string => {
 	const failedAuditCount = results.filter((result) => !result.passed).length;
 	const reportUrl = results[0].url;
 
-	const [endpoint] = process.env.LHCI_URL.split('?url=');
+	const [endpoint] = Deno.env.get('LHCI_URL').split('?url=');
 
 	return [
 		IDENTIFIER_COMMENT,


### PR DESCRIPTION
Co-Authored-By: James Gorrie <jamesgorrie@users.noreply.github.com>

# Creating one, uninfied, workflow for deployment of DCR

TODO - more info here

## Why not `actions/artifact`?

The `actions/artifact` package allows jobs to upload 'artifacts', which can then be fetched in other jobs.

Should we be using artifact or cache? Github provides some [guidance](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#comparing-artifacts-and-dependency-caching)

> - Use caching when you want to reuse files that don't change often between jobs or workflow runs, such as build dependencies from a package management system.
> - Use artifacts when you want to save files produced by a job to view after a workflow run has ended, such as built binaries or build logs.

While neither fits perfectly, testing both was essential to understanding which would work best for our requirement of sharing the ready-to-go-project & built project between jobs.

To use actions/artifacts, we had to first compress the contents of the project into a tar/zip format &upload it with the artifacts action. We would then do the same in reverse in our next job, downloading then extracting the contents.

The problem became time, the tar process itself would take over a minute, and it would take 1+ minutes to archive / extract the tar files, 2+ minutes to upload the archive, and over a minute to download it.

This shift meant that actions were taking considerably longer to complete than they are now, defeating the purpose of such a system!

It's unclear exactly why, but the actions/cache system allows for much much faster uploads & downloads, with no archiving required, making it a much faster solution.

artifacts:
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/9575458/193289149-53fb0143-6065-4896-9204-9e2f1ed4d853.png">
cache (taken slightly later, but compare 'setup' & 'build' times:
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/9575458/193289359-16d43568-0e36-4762-9eff-227f4f3408ab.png">

## `actions/cache` limits

> A repository can have up to 10GB of caches. Once the 10GB limit is reached, older caches will be evicted based on when the cache was last accessed. Caches that are not accessed within the last week will also be evicted.

This could pose a problem for us, Each build requires 2 caches (1 setup project, 1 built project) - which total ~600MB of cached content. 

This means in theory our cache would have room for 16 pushes before they are cleared, not including the pre-existing dependency caches we already have.

If any job is run and the cache is missing (for example you're re-running an older, failed job) - The user will be given an error informing them they must re-run the entire `dcr-deployment.yml` workflow, which will re-create the required caches.

We have a few avenues to try and avoid this stage being reached; as outlined below:
- [x] (compete) For successful workflows, use the API to clear the caches that were created (complete)
- [ ] (todo) Delete caches of failed workflows when new pushes are made to a head branch
- [ ] (todo) For unsuccessful workflows, delete the cache after X amount of time (suggestion: do on a cron job overnight) - This will have the side-effect that if you're re-running a job a day after it first ran, you'd need to re-run the entire DCR deployment job, not just the one which failed.

Data shows we have up to 27 unique commits that have failures per-day (Thanks @bryophyta :
![image](https://user-images.githubusercontent.com/9575458/193635114-7b989b0d-3a4a-4ea3-a920-53775d5bc0a2.png)
