### PR TITLE
feat: helper to merge Dependabot branches

### DIFF
--- a/scripts/deno/dependabot.ts
+++ b/scripts/deno/dependabot.ts
@@ -1,0 +1,41 @@
+/**
+ * A regex to filter matching branches
+ */
+const REGEX = Deno.args[0];
+
+const process = Deno.run({
+	cmd: [
+		'git',
+		'branch',
+		'-r',
+		'--list',
+		'origin/dependabot/*',
+		'--no-merged',
+	],
+	stdout: 'piped',
+});
+
+const branches = new TextDecoder()
+	.decode(await process.output())
+	.split('\n')
+	.map((line) => line.trim())
+	.filter((branch) => branch.match(REGEX));
+
+console.warn('About to merge the following branches:', branches);
+
+const shouldProceed = confirm('Do you want to merge these branches?');
+if (!shouldProceed) {
+	console.info('Not merging anything');
+	Deno.exit();
+}
+
+for (const branch of branches) {
+	const process = Deno.run({
+		cmd: ['git', 'merge', branch],
+	});
+	const { code } = await process.status();
+	if (code !== 0) Deno.exit(code);
+	console.info('merged', branch.split('/').at(-1));
+}
+
+Deno.exit();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add a helper to [get dependabot branches](https://github.com/guardian/dotcom-rendering/pulls/app%2Fdependabot) and easily merge them in.

See #6076 for example usage.

## Why?

Updating PRs one by one is mandraulic.

## Screenshots

<img width="775" alt="image" src="https://user-images.githubusercontent.com/76776/192815547-746270cc-c9fc-4587-8c91-1f525dcba680.png">
