### PR TITLE
fix(video): unwrap media atom duration from `option`

### DIFF
--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -196,8 +196,8 @@ function getVideoSlots(): VideoSlot[] {
 
 	return Array.from(videoSlots).reduce((slots: VideoSlot[], elem) => {
 		const slotPosition = elem.getBoundingClientRect();
-		const videoId = elem.getAttribute('data-videoId');
-		const posterUrl = elem.getAttribute('data-posterUrl');
+		const videoId = elem.getAttribute('data-videoid');
+		const posterUrl = elem.getAttribute('data-posterurl');
 		const durationString = elem.getAttribute('data-duration');
 		const rect = getRect(slotPosition);
 		if (videoId && posterUrl) {

--- a/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaVideo/index.tsx
@@ -63,8 +63,8 @@ const MainMediaVideo: FC<Props> = ({ video, format }) => (
 	<div
 		className="js-native-video"
 		css={styles(format)}
-		data-posterUrl={video.posterUrl}
-		data-videoId={video.videoId}
+		data-posterurl={video.posterUrl}
+		data-videoid={video.videoId}
 		data-duration={video.duration}
 	></div>
 );

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -567,7 +567,7 @@ const mediaAtomRenderer = (
 	const attributes = {
 		'data-posterUrl': posterUrl,
 		'data-videoId': videoId,
-		'data-duration': duration,
+		'data-duration': withDefault<number | null>(null)(duration),
 		className: 'js-native-video',
 		css: styles,
 	};

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -565,8 +565,8 @@ const mediaAtomRenderer = (
 	};
 
 	const attributes = {
-		'data-posterUrl': posterUrl,
-		'data-videoId': videoId,
+		'data-posterurl': posterUrl,
+		'data-videoid': videoId,
 		'data-duration': withDefault<number | null>(null)(duration),
 		className: 'js-native-video',
 		css: styles,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Unwraps the media atom duration from an `option`. Defaults to `null`, which would not render the attribute. `duration` is an optional attribute.
- Removes `data-` attribute camel casing, to clear a warning from React about unknown props:

```
Warning: React does not recognize the `data-videoId` prop on a DOM element.
If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-videoid` instead. 
```

## Why?

- Fixes #6075 

