### PR TITLE
Use h2 tag for Advertisement header

### DIFF
--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -13,7 +13,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
-import type { FC, ReactElement } from 'react';
+import type { FC } from 'react';
 import { darkModeCss, wideContentWidth } from 'styles';
 
 type Props = {

--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -110,14 +110,14 @@ const adSlotStyles = css`
 	}
 `;
 
-const AdSlot: FC<Props> = ({ className, paragraph, format }): ReactElement => (
+const AdSlot: FC<Props> = ({ className, paragraph, format }) => (
 	<aside
 		css={styles(format)}
 		className={className}
 		key={`ad-after-${paragraph}-para`}
 	>
 		<div css={adLabelsStyles(format)} className="ad-labels">
-			<h1>Advertisement</h1>
+			<h2>Advertisement</h2>
 		</div>
 		<div css={adSlotStyles} className="ad-slot"></div>
 		<div css={supportBannerStyles(format)} className="support-banner">


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Uses `h2` for the Advertisement header, instead of `h1`. This improves accessibility

## Why?

- Fixes #6091 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
