### PR TITLE
Immersive Subheading Styles

### DIFF
--- a/apps-rendering/src/components/HeadingTwo/HeadingTwo.defaults.tsx
+++ b/apps-rendering/src/components/HeadingTwo/HeadingTwo.defaults.tsx
@@ -1,0 +1,151 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { headline, remSpace } from '@guardian/source-foundations';
+import { withDefault } from '@guardian/types';
+import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
+import Anchor from 'components/Anchor';
+import HorizontalRule from 'components/HorizontalRule';
+import type { Styleable } from 'lib';
+import { identity } from 'lib';
+import { getHref } from 'renderer';
+import type { FC } from 'react';
+
+// ----- Components ----- //
+
+interface DefaultProps {
+	format: ArticleFormat;
+	isEditions: boolean;
+	heading: HeadingTwoType;
+}
+
+type Props = Styleable<DefaultProps>;
+
+interface HeadingTextElementProps {
+	format: ArticleFormat;
+	isEditions: boolean;
+	node: Node;
+	key: number;
+}
+
+const defaultStyles = css`
+	${headline.xxsmall({ fontWeight: 'bold' })}
+	margin: ${remSpace[4]} 0 ${remSpace[1]} 0;
+
+	& + p {
+		margin-top: 0;
+	}
+`;
+
+const HeadingTextElement: FC<HeadingTextElementProps> = ({
+	format,
+	isEditions,
+	node,
+	key,
+}) => {
+	const text = node.textContent ?? '';
+	const children = Array.from(node.childNodes).map((item, i) => (
+		<HeadingTextElement
+			format={format}
+			isEditions={isEditions}
+			node={item}
+			key={i}
+		/>
+	));
+
+	switch (node.nodeName) {
+		case '#text':
+			return <>{text}</>;
+		case 'A':
+			return (
+				<Anchor
+					href={withDefault('')(getHref(node))}
+					format={format}
+					isEditions={isEditions}
+					key={key}
+				>
+					{children}
+				</Anchor>
+			);
+		case 'EM':
+			return <em key={key}>{children}</em>;
+		case 'SUB': {
+			return (
+				<sub
+					css={css`
+						font-size: smaller;
+						vertical-align: sub;
+					`}
+					key={key}
+				>
+					{children}
+				</sub>
+			);
+		}
+		case 'SUP': {
+			return (
+				<sup
+					css={css`
+						font-size: smaller;
+						vertical-align: super;
+					`}
+					key={key}
+				>
+					{children}
+				</sup>
+			);
+		}
+		case 'STRONG':
+			return (
+				<strong
+					css={css`
+						font-weight: bold;
+					`}
+					key={key}
+				>
+					{children}
+				</strong>
+			);
+		default:
+			return null;
+	}
+};
+
+const DefaultHeadingTwo: FC<Props> = ({
+	format,
+	isEditions,
+	heading,
+	className,
+}) => {
+	const text = heading.doc.textContent ?? '';
+	const children = Array.from(heading.doc.childNodes).map((item, i) => (
+		<HeadingTextElement
+			format={format}
+			isEditions={isEditions}
+			node={item}
+			key={i}
+		/>
+	));
+
+	return text.includes('* * *') ? (
+		<HorizontalRule />
+	) : (
+		<h2
+			id={heading.id
+				.map<string | undefined>(identity)
+				.withDefault(undefined)}
+			css={className}
+		>
+			{children}
+		</h2>
+	);
+};
+
+// ----- Exports ----- //
+
+export type { DefaultProps };
+
+export { defaultStyles };
+
+export default DefaultHeadingTwo;

--- a/apps-rendering/src/components/HeadingTwo/HeadingTwo.defaults.tsx
+++ b/apps-rendering/src/components/HeadingTwo/HeadingTwo.defaults.tsx
@@ -9,8 +9,8 @@ import Anchor from 'components/Anchor';
 import HorizontalRule from 'components/HorizontalRule';
 import type { Styleable } from 'lib';
 import { identity } from 'lib';
-import { getHref } from 'renderer';
 import type { FC } from 'react';
+import { getHref } from 'renderer';
 
 // ----- Components ----- //
 

--- a/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
@@ -3,7 +3,8 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import type { FC } from 'react';
-import DefaultHeadingTwo, { DefaultProps } from './HeadingTwo.defaults';
+import type { DefaultProps } from './HeadingTwo.defaults';
+import DefaultHeadingTwo from './HeadingTwo.defaults';
 
 // ----- Component ----- //
 
@@ -12,11 +13,8 @@ const styles = css`
 `;
 
 const ImmersiveHeadingTwo: FC<DefaultProps> = (props) => (
-	<DefaultHeadingTwo
-		{...props}
-		css={styles}
-	/>
-)
+	<DefaultHeadingTwo {...props} css={styles} />
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
@@ -1,0 +1,23 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { headline } from '@guardian/source-foundations';
+import type { FC } from 'react';
+import DefaultHeadingTwo, { DefaultProps } from './HeadingTwo.defaults';
+
+// ----- Component ----- //
+
+const styles = css`
+	${headline.medium({ fontWeight: 'light' })}
+`;
+
+const ImmersiveHeadingTwo: FC<DefaultProps> = (props) => (
+	<DefaultHeadingTwo
+		{...props}
+		css={styles}
+	/>
+)
+
+// ----- Exports ----- //
+
+export default ImmersiveHeadingTwo;

--- a/apps-rendering/src/components/HeadingTwo/LabsHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/LabsHeadingTwo.tsx
@@ -3,7 +3,8 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
 import type { FC } from 'react';
-import DefaultHeadingTwo, { DefaultProps, defaultStyles } from './HeadingTwo.defaults';
+import type { DefaultProps } from './HeadingTwo.defaults';
+import DefaultHeadingTwo, { defaultStyles } from './HeadingTwo.defaults';
 
 // ----- Component ----- //
 
@@ -12,11 +13,8 @@ const styles = css`
 `;
 
 const LabsHeadingTwo: FC<DefaultProps> = (props) => (
-	<DefaultHeadingTwo
-		{...props}
-		css={css(defaultStyles, styles)}
-	/>
-)
+	<DefaultHeadingTwo {...props} css={css(defaultStyles, styles)} />
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/HeadingTwo/LabsHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/LabsHeadingTwo.tsx
@@ -1,0 +1,23 @@
+// ----- Imports ----- //
+
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/source-foundations';
+import type { FC } from 'react';
+import DefaultHeadingTwo, { DefaultProps, defaultStyles } from './HeadingTwo.defaults';
+
+// ----- Component ----- //
+
+const styles = css`
+	${textSans.large({ fontWeight: 'bold' })}
+`;
+
+const LabsHeadingTwo: FC<DefaultProps> = (props) => (
+	<DefaultHeadingTwo
+		{...props}
+		css={css(defaultStyles, styles)}
+	/>
+)
+
+// ----- Exports ----- //
+
+export default LabsHeadingTwo;

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,42 +1,39 @@
 import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { FC } from 'react';
-import DefaultHeadingTwo, { DefaultProps, defaultStyles } from './HeadingTwo.defaults';
+import type { DefaultProps } from './HeadingTwo.defaults';
+import DefaultHeadingTwo, { defaultStyles } from './HeadingTwo.defaults';
 import ImmersiveHeadingTwo from './ImmersiveHeadingTwo';
 import LabsHeadingTwo from './LabsHeadingTwo';
 
-const HeadingTwo: FC<DefaultProps> = ({
-    format,
-	isEditions,
-	heading,
-}) => {
-    if (format.display === ArticleDisplay.Immersive) {
-        return (
-            <ImmersiveHeadingTwo
-                format={format}
-                isEditions={isEditions}
-                heading={heading}
-            />
-        );
-    }
+const HeadingTwo: FC<DefaultProps> = ({ format, isEditions, heading }) => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return (
+			<ImmersiveHeadingTwo
+				format={format}
+				isEditions={isEditions}
+				heading={heading}
+			/>
+		);
+	}
 
-    if (format.theme === ArticleSpecial.Labs) {
-        return (
-            <LabsHeadingTwo
-                format={format}
-                isEditions={isEditions}
-                heading={heading}
-            />
-        );
-    }
+	if (format.theme === ArticleSpecial.Labs) {
+		return (
+			<LabsHeadingTwo
+				format={format}
+				isEditions={isEditions}
+				heading={heading}
+			/>
+		);
+	}
 
-    return (
-        <DefaultHeadingTwo
-            format={format}
-            isEditions={isEditions}
-            heading={heading}
-            css={defaultStyles}
-        />
-    );
-}
+	return (
+		<DefaultHeadingTwo
+			format={format}
+			isEditions={isEditions}
+			heading={heading}
+			css={defaultStyles}
+		/>
+	);
+};
 
 export default HeadingTwo;

--- a/apps-rendering/src/components/HeadingTwo/index.tsx
+++ b/apps-rendering/src/components/HeadingTwo/index.tsx
@@ -1,145 +1,42 @@
-import { css } from '@emotion/react';
-import type { SerializedStyles } from '@emotion/react';
-import { ArticleSpecial } from '@guardian/libs';
-import type { ArticleFormat } from '@guardian/libs';
-import { headline, remSpace, textSans } from '@guardian/source-foundations';
-import { withDefault } from '@guardian/types';
-import type { HeadingTwo as HeadingTwoType } from 'bodyElement';
-import Anchor from 'components/Anchor';
-import HorizontalRule from 'components/HorizontalRule';
-import { identity } from 'lib';
-import { getHref } from 'renderer';
+import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import type { FC } from 'react';
+import DefaultHeadingTwo, { DefaultProps, defaultStyles } from './HeadingTwo.defaults';
+import ImmersiveHeadingTwo from './ImmersiveHeadingTwo';
+import LabsHeadingTwo from './LabsHeadingTwo';
 
-interface HeadingTwoProps {
-	format: ArticleFormat;
-	isEditions: boolean;
-	heading: HeadingTwoType;
-}
-
-interface HeadingTextElementProps {
-	format: ArticleFormat;
-	isEditions: boolean;
-	node: Node;
-	key: number;
-}
-
-const styles = (format: ArticleFormat): SerializedStyles => {
-	const font =
-		format.theme === ArticleSpecial.Labs
-			? textSans.large({ fontWeight: 'bold' })
-			: headline.xxsmall({ fontWeight: 'bold' });
-
-	return css`
-		${font}
-		margin: ${remSpace[4]} 0 ${remSpace[1]} 0;
-
-		& + p {
-			margin-top: 0;
-		}
-	`;
-};
-
-const HeadingTextElement: React.FC<HeadingTextElementProps> = ({
-	format,
-	isEditions,
-	node,
-	key,
-}) => {
-	const text = node.textContent ?? '';
-	const children = Array.from(node.childNodes).map((item, i) => (
-		<HeadingTextElement
-			format={format}
-			isEditions={isEditions}
-			node={item}
-			key={i}
-		/>
-	));
-
-	switch (node.nodeName) {
-		case '#text':
-			return <>{text}</>;
-		case 'A':
-			return (
-				<Anchor
-					href={withDefault('')(getHref(node))}
-					format={format}
-					isEditions={isEditions}
-					key={key}
-				>
-					{children}
-				</Anchor>
-			);
-		case 'EM':
-			return <em key={key}>{children}</em>;
-		case 'SUB': {
-			return (
-				<sub
-					css={css`
-						font-size: smaller;
-						vertical-align: sub;
-					`}
-					key={key}
-				>
-					{children}
-				</sub>
-			);
-		}
-		case 'SUP': {
-			return (
-				<sup
-					css={css`
-						font-size: smaller;
-						vertical-align: super;
-					`}
-					key={key}
-				>
-					{children}
-				</sup>
-			);
-		}
-		case 'STRONG':
-			return (
-				<strong
-					css={css`
-						font-weight: bold;
-					`}
-					key={key}
-				>
-					{children}
-				</strong>
-			);
-		default:
-			return null;
-	}
-};
-
-const HeadingTwo: React.FC<HeadingTwoProps> = ({
-	format,
+const HeadingTwo: FC<DefaultProps> = ({
+    format,
 	isEditions,
 	heading,
 }) => {
-	const text = heading.doc.textContent ?? '';
-	const children = Array.from(heading.doc.childNodes).map((item, i) => (
-		<HeadingTextElement
-			format={format}
-			isEditions={isEditions}
-			node={item}
-			key={i}
-		/>
-	));
+    if (format.display === ArticleDisplay.Immersive) {
+        return (
+            <ImmersiveHeadingTwo
+                format={format}
+                isEditions={isEditions}
+                heading={heading}
+            />
+        );
+    }
 
-	return text.includes('* * *') ? (
-		<HorizontalRule />
-	) : (
-		<h2
-			id={heading.id
-				.map<string | undefined>(identity)
-				.withDefault(undefined)}
-			css={styles(format)}
-		>
-			{children}
-		</h2>
-	);
-};
+    if (format.theme === ArticleSpecial.Labs) {
+        return (
+            <LabsHeadingTwo
+                format={format}
+                isEditions={isEditions}
+                heading={heading}
+            />
+        );
+    }
+
+    return (
+        <DefaultHeadingTwo
+            format={format}
+            isEditions={isEditions}
+            heading={heading}
+            css={defaultStyles}
+        />
+    );
+}
 
 export default HeadingTwo;

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -19,7 +19,7 @@ import { Result } from 'result';
 type Styleable<Props> = Props & {
 	css?: SerializedStyles;
 	className?: string;
-}
+};
 
 // ----- Functions ----- //
 

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/react';
 import { maybeRender, pipe } from '@guardian/common-rendering/src/lib';
 import type { Option } from '@guardian/types';
 import {
@@ -12,6 +13,13 @@ import {
 } from '@guardian/types';
 import { Optional } from 'optional';
 import { Result } from 'result';
+
+// ----- Types ----- //
+
+type Styleable<Props> = Props & {
+	css?: SerializedStyles;
+	className?: string;
+}
 
 // ----- Functions ----- //
 
@@ -145,3 +153,5 @@ export {
 	fold,
 	toNullable,
 };
+
+export type { Styleable };


### PR DESCRIPTION
## Why?

Changing the styles of subheadings (`h2`s) on immersives. They're now `headline.medium` (34px) and a light font weight (300). Part of the work captured in #6074.

This also includes a couple of refactors:

1. Updated the `HeadingTwo` component to use the index/defaults pattern
2. Added a `Styleable` type for use with components that take the `css` prop. This could be rolled out to other components if we think it's useful.

## Changes

- Added new `Styleable` type
- Migrated `HeadingTwo` to the index/defaults pattern
- Created a `HeadingTwo` defaults module
- Created an `ImmersiveHeadingTwo` component
- Moved labs subheadings to separate subcomponent

## Screenshots

| Before | After |
| - | - |
| ![subheading-before] | ![subheading-after] |

[subheading-before]: https://user-images.githubusercontent.com/53781962/193050958-d205832c-ed2c-4bf0-834b-6e501cfbd7f0.jpg
[subheading-after]: https://user-images.githubusercontent.com/53781962/193050975-c537033f-0c7a-4bbd-895b-ac3c2cdc6fab.jpg
