### PR TITLE
Revert "Dc subnav add editions switch"

### DIFF
--- a/dotcom-rendering/src/model/extract-nav.ts
+++ b/dotcom-rendering/src/model/extract-nav.ts
@@ -1,5 +1,4 @@
 import { ArticlePillar } from '@guardian/libs';
-import type { EditionId } from '../types/edition';
 import { findPillar } from './find-pillar';
 
 export interface BaseLinkType {
@@ -13,10 +12,6 @@ export interface LinkType extends BaseLinkType {
 	mobileOnly?: boolean;
 	pillar?: ArticleTheme;
 	more?: boolean;
-}
-
-export interface EditionLinkType extends LinkType {
-	editionId: EditionId;
 }
 
 export interface PillarType extends LinkType {

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -8,10 +8,7 @@ import {
 	until,
 	visuallyHidden,
 } from '@guardian/source-foundations';
-import type {
-	EditionLinkType,
-	PillarType,
-} from '../../../../model/extract-nav';
+import type { PillarType } from '../../../../model/extract-nav';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
 // CSS
@@ -73,7 +70,7 @@ const columnLinkTitle = css`
 	}
 `;
 
-export const mainMenuLinkStyle = css`
+const mainMenuLinkStyle = css`
 	box-sizing: border-box;
 	overflow: hidden;
 	position: relative;
@@ -83,7 +80,7 @@ export const mainMenuLinkStyle = css`
 	}
 `;
 
-export const columnLinks = css`
+const columnLinks = css`
 	${textSans.medium()};
 	box-sizing: border-box;
 	display: flex;
@@ -198,19 +195,15 @@ const columnStyle = css`
 export const Column = ({
 	column,
 	index,
-	showLineBelow,
+	isLastColumn,
 }: {
-	column: PillarType | EditionLinkType;
+	column: PillarType;
 	index: number;
-	showLineBelow: boolean;
+	isLastColumn: boolean;
 }) => {
 	// As the elements are dynamic we need to specify the IDs here
-	//Replace whitespace with hyphen https://stackoverflow.com/questions/3794919/replace-all-spaces-in-a-string-with/3795147#3795147
-	const columnInputId = `${column.title}-checkbox-input`.split(' ').join('-');
-	const collapseColumnInputId = `${column.title}-button`.split(' ').join('-');
-	const ariaControls = `${column.title.toLowerCase()}Links`
-		.split(' ')
-		.join('-');
+	const columnInputId = `${column.title}-checkbox-input`;
+	const collapseColumnInputId = `${column.title}-button`;
 
 	return (
 		<li css={[columnStyle, pillarDivider]} role="none">
@@ -260,7 +253,7 @@ export const Column = ({
 				collapseColumnInputId={collapseColumnInputId}
 				title={column.title}
 				columnInputId={columnInputId}
-				ariaControls={ariaControls}
+				ariaControls={`${column.title.toLowerCase()}Links`}
 			/>
 
 			{/* ColumnLinks */}
@@ -268,12 +261,12 @@ export const Column = ({
 				css={[
 					columnLinks,
 					index === 0 && firstColumnLinks,
-					!!column.children && pillarColumnLinks,
+					!!column.pillar && pillarColumnLinks,
 					hideWhenNotChecked(columnInputId),
 				]}
 				role="menu"
-				id={ariaControls}
-				data-cy={ariaControls}
+				id={`${column.title.toLowerCase()}Links`}
+				data-cy={`${column.title.toLowerCase()}Links`}
 			>
 				{(column.children || []).map((link) => (
 					<li
@@ -298,7 +291,7 @@ export const Column = ({
 					</li>
 				))}
 			</ul>
-			{showLineBelow && (
+			{isLastColumn && (
 				<div css={[hideWhenChecked(columnInputId), lineStyle]}></div>
 			)}
 		</li>

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -14,8 +14,7 @@ import {
 	LinkButton,
 	SvgMagnifyingGlass,
 } from '@guardian/source-react-components';
-import type { EditionLinkType, NavType } from '../../../../model/extract-nav';
-import type { EditionId } from '../../../../types/edition';
+import type { NavType } from '../../../../model/extract-nav';
 import { Column, lineStyle } from './Column';
 import { MoreColumn } from './MoreColumn';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
@@ -132,130 +131,74 @@ const searchBar = css`
 	padding-bottom: 15px;
 `;
 
-const editionList: EditionLinkType[] = [
-	{
-		url: '/preference/edition/int',
-		editionId: 'INT',
-		longTitle: 'International edition',
-		title: 'International edition',
-	},
-	{
-		url: '/preference/edition/au',
-		editionId: 'UK',
-		longTitle: 'UK edition',
-		title: 'UK edition',
-	},
-	{
-		url: '/preference/edition/us',
-		editionId: 'US',
-		longTitle: 'US edition',
-		title: 'US edition',
-	},
-	{
-		url: '/preference/edition/au',
-		editionId: 'AU',
-		longTitle: 'Australia edition',
-		title: 'AU edition',
-	},
-];
-
-const getEdition = (editionId: EditionId): EditionLinkType => {
-	return (
-		editionList.find((edition) => edition.editionId === editionId) ??
-		editionList[1]
-	);
-};
-
-const getRemainingEditions = (editionId: EditionId): EditionLinkType[] => {
-	return editionList.filter((edition) => edition.editionId !== editionId);
-};
-
 export const Columns: React.FC<{
-	editionId: EditionId;
 	format: ArticleFormat;
 	nav: NavType;
-}> = ({ format, nav, editionId }) => {
-	const activeEdition = getEdition(editionId);
-	const remainingEditions = getRemainingEditions(activeEdition.editionId);
-	return (
-		<ul
-			css={columnsStyle(format.display)}
-			role="menubar"
-			data-cy="nav-menu-columns"
-		>
-			{nav.pillars.map((column, i) => (
-				<Column
-					column={column}
-					key={column.title.toLowerCase()}
-					index={i}
-					showLineBelow={i !== nav.pillars.length - 1}
-				/>
-			))}
-
-			<li role="none">
-				<ThemeProvider theme={{ ...buttonThemeBrand }}>
-					<div css={searchBar}>
-						<LinkButton
-							href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
-							tabIndex={-1}
-							className="selectableMenuItem"
-							priority="secondary"
-							icon={
-								<SvgMagnifyingGlass
-									isAnnouncedByScreenReader={true}
-									size="medium"
-								/>
-							}
-							aria-label="Search with google"
-							data-link-name="nav2 : search : submit"
-							type="submit"
-						>
-							Search
-						</LinkButton>
-					</div>
-				</ThemeProvider>
-
-				<div css={lineStyle}></div>
-			</li>
-
-			<ReaderRevenueLinks readerRevenueLinks={nav.readerRevenueLinks} />
-			{/* This is where the edition dropdown is inserted					 */}
+}> = ({ format, nav }) => (
+	<ul
+		css={columnsStyle(format.display)}
+		role="menubar"
+		data-cy="nav-menu-columns"
+	>
+		{nav.pillars.map((column, i) => (
 			<Column
-				column={{
-					...activeEdition,
-					children: remainingEditions,
-				}}
-				index={10}
-				showLineBelow={true}
+				column={column}
+				key={column.title.toLowerCase()}
+				index={i}
+				isLastColumn={i !== nav.pillars.length - 1}
 			/>
+		))}
 
-			<MoreColumn
-				column={nav.otherLinks}
-				brandExtensions={nav.brandExtensions}
-				key="more"
-			/>
-			<li css={desktopBrandExtensionColumn} role="none">
-				<ul css={brandExtensionList} role="menu">
-					{nav.brandExtensions.map((brandExtension) => (
-						<li
-							css={brandExtensionListItem}
+		<li>
+			<ThemeProvider theme={{ ...buttonThemeBrand }}>
+				<div css={searchBar}>
+					<LinkButton
+						href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+						tabIndex={-1}
+						className="selectableMenuItem"
+						priority="secondary"
+						icon={
+							<SvgMagnifyingGlass
+								isAnnouncedByScreenReader={true}
+								size="medium"
+							/>
+						}
+						aria-label="Search with google"
+						data-link-name="nav2 : search : submit"
+						type="submit"
+					>
+						Search
+					</LinkButton>
+				</div>
+			</ThemeProvider>
+
+			<div css={lineStyle}></div>
+		</li>
+
+		<ReaderRevenueLinks readerRevenueLinks={nav.readerRevenueLinks} />
+		<MoreColumn
+			column={nav.otherLinks}
+			brandExtensions={nav.brandExtensions}
+			key="more"
+		/>
+		<li css={desktopBrandExtensionColumn} role="none">
+			<ul css={brandExtensionList} role="menu">
+				{nav.brandExtensions.map((brandExtension) => (
+					<li css={brandExtensionListItem} key={brandExtension.title}>
+						<a
+							className="selectableMenuItem"
+							css={brandExtensionLink}
+							href={brandExtension.url}
 							key={brandExtension.title}
+							role="menuitem"
+							data-link-name={`nav2 : brand extension : ${brandExtension.longTitle}`}
+							tabIndex={-1}
 						>
-							<a
-								className="selectableMenuItem"
-								css={brandExtensionLink}
-								href={brandExtension.url}
-								key={brandExtension.title}
-								role="menuitem"
-								data-link-name={`nav2 : brand extension : ${brandExtension.longTitle}`}
-								tabIndex={-1}
-							>
-								{brandExtension.longTitle}
-							</a>
-						</li>
-					))}
-				</ul>
-			</li>
-		</ul>
-	);
-};
+							{brandExtension.longTitle}
+						</a>
+					</li>
+				))}
+			</ul>
+		</li>
+	</ul>
+);

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -7,7 +7,6 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import type { NavType } from '../../../../model/extract-nav';
-import type { EditionId } from '../../../../types/edition';
 import { getZIndex } from '../../../lib/getZIndex';
 import { navInputCheckboxId } from '../config';
 import { Columns } from './Columns';
@@ -105,10 +104,9 @@ const mainMenuStyles = css`
 `;
 
 export const ExpandedMenu: React.FC<{
-	editionId: EditionId;
 	format: ArticleFormat;
 	nav: NavType;
-}> = ({ format, nav, editionId }) => {
+}> = ({ format, nav }) => {
 	return (
 		<div id="expanded-menu-root">
 			<ShowMoreMenu display={format.display} />
@@ -119,7 +117,7 @@ export const ExpandedMenu: React.FC<{
 					data-testid="expanded-menu"
 					data-cy="expanded-menu"
 				>
-					<Columns editionId={editionId} format={format} nav={nav} />
+					<Columns format={format} nav={nav} />
 				</div>
 			</div>
 		</div>

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -40,6 +40,17 @@ const columnStyle = css`
 	padding-bottom: 10px;
 	position: relative;
 
+	:after {
+		background-color: ${brand[600]};
+		top: 0;
+		content: '';
+		display: block;
+		height: 1px;
+		left: 50px;
+		position: absolute;
+		right: 0;
+	}
+
 	/* Remove the border from the top item on mobile */
 	:first-of-type:after {
 		content: none;

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -229,7 +229,7 @@ export const Nav = ({ format, nav, subscribeUrl, editionId }: Props) => {
 					dataLinkName="nav2"
 					isTopNav={true}
 				/>
-				<ExpandedMenu editionId={editionId} nav={nav} format={format} />
+				<ExpandedMenu nav={nav} format={format} />
 			</div>
 			{displayRoundel && (
 				<PositionRoundel>


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#6012

There is a visual bug on the desktop nav:
<img width="1564" alt="image" src="https://user-images.githubusercontent.com/9575458/193072518-a8a454a6-1ebb-4de6-a8fb-6c2ec502fc7b.png">
