### PR TITLE
Update SDC

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -68,7 +68,7 @@
     "@guardian/discussion-rendering": "^10.2.1",
     "@guardian/libs": "^7.1.0",
     "@guardian/shimport": "^1.0.2",
-    "@guardian/support-dotcom-components": "^1.0.4",
+    "@guardian/support-dotcom-components": "^1.0.5",
     "@guardian/tsconfig": "^0.1.4",
     "@percy/cli": "^1.4.0",
     "@percy/cypress": "^3.1.2",

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -14,7 +14,7 @@ import type { ArticleCounts } from '../../../lib/article-count';
 import { trackNonClickInteraction } from '../../browser/ga/ga';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import {
-	getLastOneOffContributionTimestamp,
+	getLastOneOffContributionDate,
 	getPurchaseInfo,
 	hasCmpConsentForBrowserId,
 	hasOptedOutOfArticleCount,
@@ -137,7 +137,7 @@ const buildPayload = async ({
 				: undefined,
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn,
-			lastOneOffContributionDate: getLastOneOffContributionTimestamp(),
+			lastOneOffContributionDate: getLastOneOffContributionDate(),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -14,6 +14,7 @@ import type { ArticleCounts } from '../../../lib/article-count';
 import { trackNonClickInteraction } from '../../browser/ga/ga';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import {
+	getLastOneOffContributionTimestamp,
 	getPurchaseInfo,
 	hasCmpConsentForBrowserId,
 	hasOptedOutOfArticleCount,
@@ -130,12 +131,13 @@ const buildPayload = async ({
 			modulesVersion: MODULES_VERSION,
 			sectionId,
 			tagIds: tags.map((tag) => tag.id),
-			contentType,
+			contentType,p
 			browserId: (await hasCmpConsentForBrowserId())
 				? browserId || undefined
 				: undefined,
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn,
+			lastOneOffContributionDate: getLastOneOffContributionTimestamp(),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -131,7 +131,7 @@ const buildPayload = async ({
 			modulesVersion: MODULES_VERSION,
 			sectionId,
 			tagIds: tags.map((tag) => tag.id),
-			contentType,p
+			contentType,
 			browserId: (await hasCmpConsentForBrowserId())
 				? browserId || undefined
 				: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,10 +2907,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.4.0.tgz#69cf404b56db3ca507702d29dae6a40eeb145cf4"
   integrity sha512-5Q4Vl8ek0UV0Y9ob5y3Smq5xHs1d3lEzLynv5qqlYqVBlhze5Ypg5IzrPcEpKtcUaCIQeI9d5FevHM9fmm18sQ==
 
-"@guardian/support-dotcom-components@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.4.tgz#1d09ce408bcfa435eb2411255688e22a2eede032"
-  integrity sha512-g23KJoJiJVIC75DZW87zyblmNMnjujCgCKntLVLblKoSxIzOBLhzkPUnJqzPtG3aztTPRbqmhLzqgzm6M56/qw==
+"@guardian/support-dotcom-components@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.5.tgz#659720c332c62b211efab9a45350c042184a5082"
+  integrity sha512-BVvGeyS5dAD9Qu7NwFUsDou9LN5o9LZH5I4BnVf2Tg7Rj/mxdnO5qPygwI0dKFEbNHql4BEhJqSBdWI9MUSPWw==
 
 "@guardian/tsconfig@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

There is a new version of the support-dotcom-components library.
This adds the `lastOneOffContributionDate` field for banner targeting.

See [SDC PR](https://github.com/guardian/support-dotcom-components/pull/757) for details.

Tested in CODE