### PR TITLE
Add `mask-image property` to make gate transparent

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -136,6 +136,7 @@ export const firstParagraphOverlay = (isComment: boolean) => css`
 		70%,
 		rgba(255, 255, 255, 0)
 	);
+	mask-image: linear-gradient(rgba(0, 0, 0, 0), transparent);
 `;
 
 // This css does 3 things


### PR DESCRIPTION
## What does this change?
Adds the `mask-image` property to `shared.tsx` file to make the gate overlay transparent.

## Why?
This is a design-related decision.

## Screenshots

### Desktop

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/55602675/193283312-f325a8dc-e6d0-4f15-ad72-bc9d0024311c.png

[after]: https://user-images.githubusercontent.com/55602675/193283425-6c68adfa-fa57-44f1-b90c-8a5e76aafc95.png

### Mobile

| Before      | After      |
|-------------|------------|
| ![before2][] | ![after2][] |

[before2]: https://user-images.githubusercontent.com/55602675/193283983-79384716-dda6-485b-a90c-cb674f6140c8.png

[after2]: https://user-images.githubusercontent.com/55602675/193284034-4aa7cb81-b089-42b7-87b5-982272dfb9fe.png

