### PR TITLE
Sign-in gate fixes

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -33,7 +33,6 @@ export const mainStandaloneComment = () => {
 				signInUrl="https://profile.theguardian.com/"
 				dismissGate={() => {}}
 				ophanComponentId="test"
-				isComment={true}
 			/>
 		</Section>
 	);
@@ -64,7 +63,6 @@ export const mainStandaloneMandatoryComment = () => {
 				dismissGate={() => {}}
 				ophanComponentId="test"
 				isMandatory={true}
-				isComment={true}
 			/>
 		</Section>
 	);

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -287,7 +287,6 @@ export const SignInGateFakeSocial = ({
 	dismissGate,
 	abTest,
 	ophanComponentId,
-	isComment,
 }: SignInGateProps) => {
 	const verticalButtonStack =
 		abTest?.variant === 'fake-social-variant-vertical';
@@ -295,7 +294,7 @@ export const SignInGateFakeSocial = ({
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-fake-social">
 			<style>{hideElementsCss}</style>
-			<div css={firstParagraphOverlay(!!isComment)} />
+			<div css={firstParagraphOverlay} />
 			<h1 css={[heading, bodyPadding]}>
 				You need to register to keep reading
 			</h1>

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -25,13 +25,12 @@ export const SignInGateMain = ({
 	dismissGate,
 	abTest,
 	ophanComponentId,
-	isComment,
 	isMandatory = false,
 }: SignInGateProps) => {
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
-			<div css={firstParagraphOverlay(!!isComment)} />
+			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>You need to register to keep reading</h1>
 			<p css={bodyBold}>
 				It’s still free to read - this is not a paywall

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/react';
 import {
-	background,
 	brand,
 	from,
 	headline,
 	line,
-	opinion,
 	space,
 	text,
 	textSans,
@@ -123,40 +121,40 @@ export const privacyLink = css`
 	cursor: pointer;
 `;
 
-export const firstParagraphOverlay = (isComment: boolean) => css`
+export const firstParagraphOverlay = css`
 	margin-top: -250px;
 	width: 100%;
 	height: 250px;
 	position: absolute;
-
-	/* "transparent" only works here because == rgba(0,0,0,0) */
-	background-image: linear-gradient(
-		0deg,
-		${isComment ? opinion[800] : background.primary},
-		70%,
-		rgba(255, 255, 255, 0)
-	);
-	mask-image: linear-gradient(rgba(0, 0, 0, 0), transparent);
 `;
 
-// This css does 3 things
-// 1. first hide all article content using display: none; (.article-body-commercial-selector > *)
-// 2. make the sign in gate (#sign-in-gate), and the first 2 paragraphs of the article visible (.article-body-commercial-selector p:nth-of-type(-n+3))
-// 3. hide any siblings after the sign in gate in case a paragraph is still visible (#sign-in-gate ~ *) because of the css in 2
-export const hideElementsCss = `
-    .article-body-commercial-selector > * {
+/**
+ * This CSS hides everything in an article, except the first two paragraphs and
+ * the sign-in gate. The order in which rules are laid out matters.
+ */
+export const hideElementsCss = [
+	// 1. hide all article content
+	`.article-body-commercial-selector > * {
         display: none;
-    }
-
-    #sign-in-gate, .article-body-commercial-selector p:nth-of-type(-n + 3) {
+    }`,
+	// 2. make the sign in gate and the first 2 paragraphs of the article visible
+	`#sign-in-gate, .article-body-commercial-selector p:nth-of-type(-n + 3) {
         display: block;
+    }`,
+	// 3. mask the first and second with a gradient overlay
+	`.article-body-commercial-selector > p:nth-of-type(1) {
+        mask-image: linear-gradient(black, rgba(0, 0, 0, 0.5));
     }
-
-    #sign-in-gate ~ * {
+	.article-body-commercial-selector > p:nth-of-type(2) {
+        mask-image: linear-gradient(rgba(0, 0, 0, 0.5), transparent);
+    }
+	`,
+	// 4. hide any siblings after the sign in gate in case a paragraph
+	// is still visible because of the CSS in 2
+	`#sign-in-gate ~ * {
         display: none;
-    }
-
-    #slot-body-end {
+    }`,
+	`#slot-body-end {
         display: none;
-    }
-`;
+    }`,
+].join('\n');

--- a/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/fake-social-variant.tsx
@@ -16,14 +16,7 @@ const SignInGateFakeSocial = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({
-		ophanComponentId,
-		dismissGate,
-		guUrl,
-		signInUrl,
-		abTest,
-		isComment,
-	}) => (
+	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateFakeSocial
@@ -32,7 +25,6 @@ export const signInGateComponent: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
-					isComment={isComment}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/main-variant.tsx
@@ -16,14 +16,7 @@ const SignInGateMain = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({
-		ophanComponentId,
-		dismissGate,
-		guUrl,
-		signInUrl,
-		abTest,
-		isComment,
-	}) => (
+	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateMain
@@ -32,7 +25,6 @@ export const signInGateComponent: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
-					isComment={isComment}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/us-mandatory-control.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/us-mandatory-control.tsx
@@ -16,14 +16,7 @@ const SignInGateMain = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({
-		ophanComponentId,
-		dismissGate,
-		guUrl,
-		signInUrl,
-		abTest,
-		isComment,
-	}) => (
+	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateMain
@@ -32,7 +25,6 @@ export const signInGateComponent: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
-					isComment={isComment}
 				/>
 			</Suspense>
 		</Lazy>

--- a/dotcom-rendering/src/web/components/SignInGate/gates/us-mandatory-variant.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gates/us-mandatory-variant.tsx
@@ -16,14 +16,7 @@ const SignInGateMain = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-	gate: ({
-		ophanComponentId,
-		dismissGate,
-		guUrl,
-		signInUrl,
-		abTest,
-		isComment,
-	}) => (
+	gate: ({ ophanComponentId, dismissGate, guUrl, signInUrl, abTest }) => (
 		<Lazy margin={300}>
 			<Suspense fallback={<></>}>
 				<SignInGateMain
@@ -32,7 +25,6 @@ export const signInGateComponent: SignInGateComponent = {
 					guUrl={guUrl}
 					signInUrl={signInUrl}
 					abTest={abTest}
-					isComment={isComment}
 					isMandatory={true}
 				/>
 			</Suspense>

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -21,7 +21,6 @@ export interface SignInGateProps {
 	guUrl: string;
 	dismissGate: () => void;
 	ophanComponentId: string;
-	isComment?: boolean;
 	abTest?: CurrentSignInGateABTest;
 	isMandatory?: boolean;
 }

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -1,4 +1,4 @@
-import { ArticleDesign, getCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { constructQuery } from '../../lib/querystring';
 import { useOnce } from '../lib/useOnce';
@@ -91,7 +91,6 @@ const generateSignInUrl = ({
 // fires a VIEW ophan component event
 // and show the gate component if it exists
 const ShowSignInGate = ({
-	format,
 	abTest,
 	setShowGate,
 	signInUrl,
@@ -121,9 +120,6 @@ const ShowSignInGate = ({
 			},
 			abTest,
 			ophanComponentId: signInGateTestIdToComponentId[abTest.id],
-			isComment:
-				format.design === ArticleDesign.Comment ||
-				format.design === ArticleDesign.Editorial,
 		});
 	}
 	// return nothing if no gate needs to be shown


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Applies the CSS introduced in #6101 to the article paragraphs themselves.

## Why?

The gradient mask was lost.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/195044068-0258b0af-e977-402f-ba9b-775c14a9b47c.png
[after]: https://user-images.githubusercontent.com/76776/195044147-4d80c7ad-a829-4a3f-bbc1-62cf226b6dd0.png