### PR TITLE
Exhaustiveness check in switch statements

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -118,6 +118,7 @@ module.exports = {
 			},
 		],
 
+		'@typescript-eslint/switch-exhaustiveness-check': 'error',
 		'array-callback-return': 'error',
 		'global-require': 'error',
 		'no-console': 'warn',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

> Require switch-case statements to be exhaustive with union type.

https://typescript-eslint.io/rules/switch-exhaustiveness-check/

## Why?

> Union type may have a lot of parts. It's easy to forget to consider all cases in switch. This rule reminds which parts are missing. If domain of the problem requires to have only a partial switch, developer may explicitly add a default clause.

Are types are currently exhaustive, but that's mainly thanks to our use of default cases. If we were to remove some of them, our TypeScript and ESLint checks would still pass, which I discovered refactoring #6066

It is worth noting that you might get a warning because “not all code paths return a value” when removing one of the cases in a switch. However, what we want in this case is absolute certainty, which we would not get without it.