### PR TITLE
Migrate Editions Page To Same Emotion Cache As Apps Page

### DIFF
--- a/apps-rendering/src/server/editionsPage.tsx
+++ b/apps-rendering/src/server/editionsPage.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
-import { cache } from '@emotion/css';
+import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
-import { extractCritical } from '@emotion/server';
+import createEmotionServer from '@emotion/server/create-instance';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
 import type { ArticleTheme } from '@guardian/libs';
@@ -48,6 +48,8 @@ enum EditionsEnv {
 // ----- Setup ----- //
 
 const docParser = JSDOM.fragment.bind(null);
+const emotionCache = createCache({ key: 'ar' });
+const emotionServer = createEmotionServer(emotionCache);
 
 // ----- Functions ----- //
 
@@ -129,10 +131,10 @@ function renderHead(
 
 const renderBody = (item: Item): EmotionCritical =>
 	compose(
-		extractCritical,
+		emotionServer.extractCritical,
 		renderToString,
 	)(
-		<CacheProvider value={cache}>
+		<CacheProvider value={emotionCache}>
 			<Layout item={item} />
 		</CacheProvider>,
 	);

--- a/apps-rendering/src/server/editionsPage.tsx
+++ b/apps-rendering/src/server/editionsPage.tsx
@@ -19,7 +19,6 @@ import type { Response } from 'express';
 import type { Item } from 'item';
 import { fromCapi } from 'item';
 import { JSDOM } from 'jsdom';
-import { compose } from 'lib';
 import type { ReactElement } from 'react';
 import { createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -130,13 +129,12 @@ function renderHead(
 }
 
 const renderBody = (item: Item): EmotionCritical =>
-	compose(
-		emotionServer.extractCritical,
-		renderToString,
-	)(
-		<CacheProvider value={emotionCache}>
-			<Layout item={item} />
-		</CacheProvider>,
+	emotionServer.extractCritical(
+		renderToString(
+			<CacheProvider value={emotionCache}>
+				<Layout item={item} />
+			</CacheProvider>,
+		),
 	);
 
 const buildHtml = (

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	"dependencies": {
 		"@babel/core": "^7.16.12",
 		"@emotion/cache": "^11.4.0",
-		"@emotion/css": "^11.1.3",
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/eslint-config": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,7 +2553,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.3.0":
+"@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
   integrity sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==
@@ -2621,17 +2621,6 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/css@^11.1.3":
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.5.0.tgz#0a80017080cb44d47994fe576b9923bfc8b0f6ad"
-  integrity sha512-mqjz/3aqR9rp40M+pvwdKYWxlQK4Nj3cnNjo3Tx6SM14dSsEn7q/4W2/I7PlgG+mb27iITHugXuBIHH/QwUBVQ==
-  dependencies:
-    "@emotion/babel-plugin" "^11.0.0"
-    "@emotion/cache" "^11.5.0"
-    "@emotion/serialize" "^1.0.0"
-    "@emotion/sheet" "^1.0.3"
-    "@emotion/utils" "^1.0.0"
-
 "@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -2694,7 +2683,7 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
-"@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2":
+"@emotion/serialize@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
   integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==


### PR DESCRIPTION
## Why?

It looks like the only use of `@emotion/css` we have is importing the cache in the Editions page. We moved over to using the `@emotion/cache` package for the main apps page in https://github.com/guardian/apps-rendering/pull/1228 :

https://github.com/guardian/dotcom-rendering/blob/7cfd402bd5ef9fe3bf0de56f10d1bce716c5a409/apps-rendering/src/server/page.tsx#L37-L38

https://github.com/guardian/dotcom-rendering/blob/7cfd402bd5ef9fe3bf0de56f10d1bce716c5a409/apps-rendering/src/server/page.tsx#L131-L138

 This PR switches to the same mechanism for the Editions page, removing the need to depend on `@emotion/css`.

## Changes

- Used the same emotion cache setup on Editions as is used for apps
- Removed `@emotion/css` as a dependency
