### PR TITLE
Add 0% ab test for Confiant SDK update

### DIFF
--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
+import { confiantSDKUpdateTest } from './tests/confiant-sdk-update';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIMA } from './tests/integrate-ima';
 import {
@@ -31,4 +32,5 @@ export const tests: ABTest[] = [
 	signInGateMandatoryLongTestRunEu,
 	signInGateMandatoryLongTestRunNa,
 	shadyPieClickThrough,
+	confiantSDKUpdateTest,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
+++ b/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const confiantSDKUpdateTest: ABTest = {
+	id: 'ConfiantSDKUpdate',
+	start: '2022-10-04',
+	expiry: '2022-10-30',
+	author: 'Jake Lee Kennedy',
+	description: 'Test the new Confiant SDK, to share with the Confiant team',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No change/improved ad load times',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: (): void => {
+				//
+			},
+		},
+	],
+};

--- a/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
+++ b/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
 export const confiantSDKUpdateTest: ABTest = {
-	id: 'ConfiantSDKUpdate',
+	id: 'ConfiantSdkUpdate',
 	start: '2022-10-04',
 	expiry: '2022-10-28',
 	author: 'Jake Lee Kennedy',

--- a/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
+++ b/dotcom-rendering/src/web/experiments/tests/confiant-sdk-update.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const confiantSDKUpdateTest: ABTest = {
 	id: 'ConfiantSDKUpdate',
 	start: '2022-10-04',
-	expiry: '2022-10-30',
+	expiry: '2022-10-28',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the new Confiant SDK, to share with the Confiant team',
 	audience: 0,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add 0% ab test for Confiant SDK update

## Why?
We need to be able to create a test of the change to send to confiant to verify that all is working correctly before deploying fully.
