### PR TITLE
fix: deadblog standfirst & metadata colours in dark mode

### DIFF
--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -80,6 +80,10 @@ const metadataWrapperStyles = (format: ArticleFormat): SerializedStyles => {
 		case ArticleDesign.DeadBlog:
 			return css`
 				background-color: ${neutral[93]};
+
+				${darkModeCss`
+					background-color: ${background.articleContentDark(format)};
+				`}
 			`;
 		default:
 			return css`

--- a/apps-rendering/src/components/LiveDateline/index.tsx
+++ b/apps-rendering/src/components/LiveDateline/index.tsx
@@ -8,6 +8,7 @@ import type { Option } from '@guardian/types';
 import { makeRelativeDate } from 'date';
 import { maybeRender } from 'lib';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -21,6 +22,10 @@ const livePulse = keyframes`
 const timestampStyles = (isDeadBlog = false): ReturnType<typeof css> => css`
 	color: ${isDeadBlog ? neutral[7] : neutral[100]};
 	${textSans.xxsmall({ lineHeight: 'tight' })}
+
+	${darkModeCss`
+		color: ${isDeadBlog ? neutral[60] : neutral[100]};
+	`}
 `;
 
 const liveSpanStyles = css`

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -16,10 +16,6 @@ import type { FC, ReactElement } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';
 
-const isNotBlog = (format: ArticleFormat): boolean =>
-	format.design !== ArticleDesign.LiveBlog &&
-	format.design !== ArticleDesign.DeadBlog;
-
 const darkStyles = (format: ArticleFormat): SerializedStyles => darkModeCss`
     background-color: ${background.standfirstDark(format)};
     color: ${text.standfirstDark(format)};
@@ -53,7 +49,7 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => css`
 		border-bottom: 0.0625rem solid ${border.standfirstBlogLink(format)};
 	}
 
-	${isNotBlog(format) && darkStyles(format)}
+	${darkStyles(format)}
 `;
 
 interface Props {

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -6,7 +6,6 @@ import {
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign } from '@guardian/libs';
 import { headline, remSpace } from '@guardian/source-foundations';
 import { map, withDefault } from '@guardian/types';
 import type { Item } from 'item';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Fixes darkmode styling for Deadblog standfirst, metadata and live dateline

## Why?

- fixes #6114 

## Screenshots

### Tablet

| Before      | After      |
|-------------|------------|
| ![before1][] | ![after1][] |

### Mobile

| Before      | After      |
|-------------|------------|
| ![before2][] | ![after2][] |

### Wide

| Before      | After      |
|-------------|------------|
| ![before3][] | ![after3][] |

[after1]: https://user-images.githubusercontent.com/705427/193852194-faefd8c5-ab41-4325-aba2-72301a8f8d02.png
[after2]: https://user-images.githubusercontent.com/705427/193852220-dd97ca2f-be1e-46bf-83f1-f2154237c12c.png

[before1]: https://user-images.githubusercontent.com/705427/193852651-93380a30-936c-4dda-8214-16816d77f0d0.png
[before2]: https://user-images.githubusercontent.com/705427/193852635-c7dba172-5ece-4856-bde5-802926d0db3b.png

[before3]: https://user-images.githubusercontent.com/705427/193859049-129d0739-1c12-4756-9c74-8622913d0e0d.png
[after3]: https://user-images.githubusercontent.com/705427/193859063-4a59491b-2b1c-4597-a205-8705576f1d4f.png

