### PR TITLE
Add CONTRIBUTING as to make our contributing docs more discoverable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Welcome to the the Guardian's Apps & Web rendering platforms
+
+Read our [Code of conduct](./CODE_OF_CONDUCT.md) to help keep things approachable and respectful.
+
+Interested in our web rendering platform? [Start here ➡️](./dotcom-rendering/docs/contributing/README.md)
+
+Interested in our apps rendering platform? [Start here ➡️](./apps-rendering/README.md)
+
+
+
+

--- a/dotcom-rendering/docs/contributing/README.md
+++ b/dotcom-rendering/docs/contributing/README.md
@@ -1,0 +1,5 @@
+# Contributing
+
+- [Detailed setup guide](./detailed-setup-guide.md)
+- [Code style](./code-style.md)
+- [Where should my code live?](./where-should-my-code-live.md)


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Creates the CONTRIBUTING document which links through to our existing contribution documents to help surface these in the various places it gets surfaced that [you can see here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors).

This is more a discovery PR, there is a lot more we could do, this is to just get a start.

## Why?

As we have more and more contributors, it would be good to have a place for people to get an understanding of how to contribute more effectively, and hopefully break down barriers when contributing.

Also to help the platform team evolve these documents s the platform matures.

