### PR TITLE
fix: ensure Newsletter Signup Forms display on ExplainerDesign types

### DIFF
--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -219,6 +219,7 @@ export const insertPromotedNewsletter = (
 		case 'InterviewDesign':
 		case 'EditorialDesign':
 		case 'ObituaryDesign':
+		case 'ExplainerDesign':
 			return blocks.map((block: Block) => {
 				return {
 					...block,


### PR DESCRIPTION
## What does this change?

Adds `ExplainerDesign` to list of CAPI formats where we try to insert newsletter forms

## Why?

We weren't trying to insert newsletter sign up forms on ExplainerDesign types which was confusing for editorial (and us!)
