### PR TITLE
Add focus halo to subnav links

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	border,
 	brand,
 	brandAlt,
 	brandText,

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	border,
 	brand,
 	brandAlt,
 	brandText,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds focus halo to subnav links.

Issue: https://github.com/guardian/dotcom-rendering/issues/5976 

## Why?

A11y

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/194043103-4a151efb-bfaf-48d1-b9ed-bc62d4854821.png
[after]: https://user-images.githubusercontent.com/110032454/194259270-35f7b6ae-5550-4028-a39d-2cde1916c867.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
