### PR TITLE
fix: optionally support darkmode on pagination position

### DIFF
--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -131,6 +131,7 @@ const LiveLayout: FC<Props> = ({ item }) => {
 			newer={toNullable(item.pagedBlocks.pagination.newer)}
 			oldest={toNullable(item.pagedBlocks.pagination.oldest)}
 			older={toNullable(item.pagedBlocks.pagination.older)}
+			supportsDarkMode={true}
 		/>
 	);
 

--- a/common-rendering/src/components/Pagination.stories.tsx
+++ b/common-rendering/src/components/Pagination.stories.tsx
@@ -21,7 +21,12 @@ export const notFirstPage = () => {
 	return (
 		<>
 			{formats.map((format) => (
-				<Pagination currentPage={2} totalPages={6} format={format} />
+				<Pagination
+					currentPage={2}
+					totalPages={6}
+					format={format}
+					supportsDarkMode
+				/>
 			))}
 		</>
 	);
@@ -34,7 +39,12 @@ export const firstPageStory = () => {
 	return (
 		<>
 			{formats.map((format) => (
-				<Pagination currentPage={1} totalPages={4} format={format} />
+				<Pagination
+					currentPage={1}
+					totalPages={4}
+					format={format}
+					supportsDarkMode
+				/>
 			))}
 		</>
 	);

--- a/common-rendering/src/components/Pagination.tsx
+++ b/common-rendering/src/components/Pagination.tsx
@@ -22,6 +22,7 @@ type Props = {
 	oldest?: string;
 	older?: string;
 	format: ArticleFormat;
+	supportsDarkMode: boolean;
 };
 
 const NavWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -52,10 +53,6 @@ const FlexSection = ({
 			display: flex;
 			align-items: center;
 			visibility: ${hide ? 'hidden' : 'visible'};
-
-			${darkModeCss(true)`
-				color: ${neutral[60]};
-			`}
 		`}
 	>
 		{children}
@@ -72,12 +69,22 @@ const Bold = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-const Position = ({ children }: { children: React.ReactNode }) => (
+const Position = ({
+	children,
+	supportsDarkMode,
+}: {
+	children: React.ReactNode;
+	supportsDarkMode: boolean;
+}) => (
 	<div
 		css={css`
 			display: flex;
 			flex-direction: row;
 			${textSans.small()}
+
+			${darkModeCss(supportsDarkMode)`
+				color: ${neutral[60]};
+			`}
 		`}
 	>
 		{children}
@@ -113,6 +120,7 @@ const Pagination = ({
 	newest,
 	newer,
 	format,
+	supportsDarkMode,
 }: Props) => {
 	return (
 		<NavWrapper>
@@ -155,7 +163,7 @@ const Pagination = ({
 				</LinkButton>
 			</FlexSection>
 			<FlexSection>
-				<Position>
+				<Position supportsDarkMode={supportsDarkMode}>
 					<Bold>{currentPage}</Bold>
 					<Of />
 					<Bold>{totalPages}</Bold>

--- a/common-rendering/src/components/Pagination.tsx
+++ b/common-rendering/src/components/Pagination.tsx
@@ -97,15 +97,13 @@ const Space = () => (
 	/>
 );
 
-const decidePaginationCss = (format: ArticleFormat): SerializedStyles => {
-	return css`
-		color: ${text.pagination(format)};
-		border: 1px solid ${border.pagination(format)};
-		:hover {
-			border: 1px solid ${hover.pagination(format)};
-		}
-	`;
-};
+const decidePaginationCss = (format: ArticleFormat): SerializedStyles => css`
+	color: ${text.pagination(format)};
+	border: 1px solid ${border.pagination(format)};
+	:hover {
+		border: 1px solid ${hover.pagination(format)};
+	}
+`;
 
 const Pagination = ({
 	currentPage,

--- a/common-rendering/src/components/Pagination.tsx
+++ b/common-rendering/src/components/Pagination.tsx
@@ -1,6 +1,6 @@
 import { SerializedStyles, css } from '@emotion/react';
 
-import { space, textSans, until } from '@guardian/source-foundations';
+import { neutral, space, textSans, until } from '@guardian/source-foundations';
 import {
 	Hide,
 	LinkButton,
@@ -12,6 +12,7 @@ import {
 
 import { border, hover, text } from '../editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
+import { darkModeCss } from '../lib';
 
 type Props = {
 	currentPage: number;
@@ -51,6 +52,10 @@ const FlexSection = ({
 			display: flex;
 			align-items: center;
 			visibility: ${hide ? 'hidden' : 'visible'};
+
+			${darkModeCss(true)`
+				color: ${neutral[60]};
+			`}
 		`}
 	>
 		{children}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -829,6 +829,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
+														supportsDarkMode={false}
 													/>
 												)}
 												<ArticleBody
@@ -930,6 +931,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
+														supportsDarkMode={false}
 													/>
 												)}
 												<StraightLines
@@ -984,6 +986,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
+														supportsDarkMode={false}
 													/>
 												)}
 												<ArticleBody
@@ -1085,6 +1088,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
+														supportsDarkMode={false}
 													/>
 												)}
 												<StraightLines


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds optional darkmode support for the pagination position on live/deadblogs

## Screenshots in Dark Mode

### Apps Rendering

| Before      | After      |
|-------------|------------|
| ![before1][] | ![after1][] |

### DCR

| Before      | After      |
|-------------|------------|
| ![dcrBefore][] | ![dcrAfter][] |

[before1]: https://user-images.githubusercontent.com/705427/194044676-52027f66-60c1-40a3-95ac-3ae9b5b5175c.png
[after1]: https://user-images.githubusercontent.com/705427/194044679-41a72608-cb44-4bde-b0c2-081caca8c87e.png

[dcrBefore]: https://user-images.githubusercontent.com/705427/194046703-5aacd8f6-3c4a-4be1-9b42-b7db84852e86.png
[dcrAfter]: https://user-images.githubusercontent.com/705427/194046893-c62e1294-5ecb-415f-9334-73571f2cafd7.png
