### PR TITLE
fix: add dark mode text styles for `Card` times

### DIFF
--- a/apps-rendering/src/components/Card/index.tsx
+++ b/apps-rendering/src/components/Card/index.tsx
@@ -130,34 +130,18 @@ const imgStyles = css`
 	border-radius: ${remSpace[2]};
 `;
 
-const timeStyles = (
-	type: RelatedItemType,
-	format: ArticleFormat,
-): SerializedStyles => {
-	switch (type) {
-		case RelatedItemType.VIDEO:
-		case RelatedItemType.AUDIO:
-		case RelatedItemType.GALLERY: {
-			return css`
-				${textSans.small()};
-				color: ${text.relatedCardTimeAgo(format)};
-				text-align: right;
-				display: inline-block;
-				vertical-align: top;
-				font-weight: 700;
-			`;
-		}
-		default:
-			return css`
-				${textSans.small()};
-				color: ${text.relatedCardTimeAgo(format)};
-				text-align: right;
-				display: inline-block;
-				vertical-align: top;
-				font-weight: 700;
-			`;
-	}
-};
+const timeStyles = (format: ArticleFormat): SerializedStyles => css`
+	${textSans.small()};
+	color: ${text.relatedCardTimeAgo(format)};
+	text-align: right;
+	display: inline-block;
+	vertical-align: top;
+	font-weight: 700;
+
+	${darkModeCss`
+		color: ${text.relatedCardTimeAgoDark(format)};
+	`}
+`;
 
 const durationStyles = css`
 	margin-left: ${remSpace[3]};
@@ -229,13 +213,12 @@ const imageBackground = (format: ArticleFormat): SerializedStyles => css`
 
 const relativeFirstPublished = (
 	date: Option<Date>,
-	type: RelatedItemType,
 	format: ArticleFormat,
 ): JSX.Element | null =>
 	pipe(
 		date,
 		map((date) => (
-			<time css={[timeStyles(type, format), dateStyles]}>
+			<time css={[timeStyles(format), dateStyles]}>
 				{makeRelativeDate(date)}
 			</time>
 		)),
@@ -409,7 +392,6 @@ const bylineStyles = (format: ArticleFormat): SerializedStyles => css`
 
 const durationMedia = (
 	duration: Option<string>,
-	type: RelatedItemType,
 	format: ArticleFormat,
 ): ReactElement | null => {
 	return pipe(
@@ -418,7 +400,7 @@ const durationMedia = (
 			const seconds = formatSeconds(length);
 			if (seconds.kind === OptionKind.Some) {
 				return (
-					<time css={[timeStyles(type, format), durationStyles]}>
+					<time css={[timeStyles(format), durationStyles]}>
 						{seconds.value}
 					</time>
 				);
@@ -581,7 +563,6 @@ const Card: FC<Props> = ({ relatedItem, image, kickerText }) => {
 		webPublicationDate && type !== RelatedItemType.ADVERTISEMENT_FEATURE
 			? relativeFirstPublished(
 					fromNullable(new Date(webPublicationDate)),
-					type,
 					format,
 			  )
 			: null;
@@ -622,11 +603,7 @@ const Card: FC<Props> = ({ relatedItem, image, kickerText }) => {
 						<section css={parentIconStyles}>
 							{icon(type, format)}
 						</section>
-						{durationMedia(
-							fromNullable(mediaDuration),
-							type,
-							format,
-						)}
+						{durationMedia(fromNullable(mediaDuration), format)}
 						{date}
 					</div>
 					{img}

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -914,6 +914,8 @@ const relatedCardTimeAgo = (format: ArticleFormat): Colour => {
 	return neutral[46];
 };
 
+const relatedCardTimeAgoDark = (_format: ArticleFormat): Colour => neutral[60];
+
 const richLink = (format: ArticleFormat): Colour => {
 	switch (format.theme) {
 		case ArticlePillar.News:
@@ -1131,6 +1133,7 @@ const text = {
 	relatedCardLink,
 	relatedCardLinkDark,
 	relatedCardTimeAgo,
+	relatedCardTimeAgoDark,
 	richLink,
 	richLinkAnchor,
 	richLinkAnchorDark,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a dark mode variant for `Card` time text colour
- Simplifies the logic - all variants are using the same styles

## Why?

- To fix #6133

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://user-images.githubusercontent.com/705427/194054695-657d162b-bf07-4518-b910-6eef5bdb6870.png
[before]: https://user-images.githubusercontent.com/705427/194054687-6949e209-0500-4bcb-870f-05f3d73184af.png

