### PR TITLE
fix: Remove paths_ignore from DCR chromatic builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,11 +3,7 @@ name: Chromatic 👓
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "dotcom-rendering/docs/**"
   pull_request:
-    paths-ignore:
-        - "dotcom-rendering/docs/**"
 
 jobs:
   chromatic:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Always run Chromatic, even if the only files that have changed are the docs files. Turbosnap should kick in and prevent Chromatic from taking any snapshots if the only files changed are doc files.

## Why?

Currently we require the "UI Checks" status to be reported on a PR before we allow it to be merged, this has issues when the only file the PR touches are doc files as Chromatic will never run and report the "UI Checks" status.

Alternatively we could remove the required UI Checks status from our Github settings.

![image](https://user-images.githubusercontent.com/21217225/194303260-66c7184b-864d-4293-82ec-a8a704152b56.png)

I've seen Github fail to kick-off actions one or two times recently and I'm a little hesitant to remove this requirement.