### PR TITLE
fix: add darkmode styling for ClickToView

### DIFF
--- a/apps-rendering/src/components/ClickToView/index.tsx
+++ b/apps-rendering/src/components/ClickToView/index.tsx
@@ -96,6 +96,17 @@ const roleButtonText = (role: ArticleElementRole): string => {
 	}
 };
 
+const buttonStyles = css`
+	${darkModeCss`
+		color: ${neutral[10]};
+		background-color: ${neutral[86]};
+
+		&:hover {
+			background-color: ${neutral[97]};
+		}
+	`}
+`;
+
 const ClickToView: FC<ClickToViewProps> = ({
 	children,
 	role,
@@ -191,6 +202,7 @@ const ClickToView: FC<ClickToViewProps> = ({
 						icon={<SvgCheckmark />}
 						iconSide="left"
 						onClick={handleClick}
+						css={buttonStyles}
 					>
 						{roleButtonText(roleWithDefault)}
 					</Button>

--- a/apps-rendering/src/components/ClickToView/index.tsx
+++ b/apps-rendering/src/components/ClickToView/index.tsx
@@ -3,6 +3,7 @@ import { ArticleElementRole } from '@guardian/libs';
 import {
 	background,
 	border,
+	neutral,
 	remSpace,
 	textSans,
 } from '@guardian/source-foundations';
@@ -12,6 +13,7 @@ import { OptionKind, withDefault } from '@guardian/types';
 import { fold } from 'lib';
 import type { FC } from 'react';
 import React, { useState } from 'react';
+import { darkModeCss } from 'styles';
 
 export type ClickToViewProps = {
 	children: React.ReactNode;
@@ -127,6 +129,11 @@ const ClickToView: FC<ClickToViewProps> = ({
 					padding: ${remSpace[1]} ${remSpace[6]} ${remSpace[3]};
 					margin-bottom: ${remSpace[3]};
 					box-sizing: border-box;
+
+					${darkModeCss`
+						background: ${neutral[20]};
+						border-color: ${neutral[46]};
+					`}
 				`}
 			>
 				<div

--- a/apps-rendering/src/components/ClickToView/index.tsx
+++ b/apps-rendering/src/components/ClickToView/index.tsx
@@ -96,15 +96,13 @@ const roleButtonText = (role: ArticleElementRole): string => {
 	}
 };
 
-const buttonStyles = css`
-	${darkModeCss`
-		color: ${neutral[10]};
-		background-color: ${neutral[86]};
+const buttonStyles = darkModeCss`
+	color: ${neutral[10]};
+	background-color: ${neutral[86]};
 
-		&:hover {
-			background-color: ${neutral[97]};
-		}
-	`}
+	&:hover {
+		background-color: ${neutral[97]};
+	}
 `;
 
 const ClickToView: FC<ClickToViewProps> = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds dark mode styling for `ClickToView`
- Validated passes AA colour contrast using the Axe browser extension

## Why?

- fixes #6130

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[after]: https://user-images.githubusercontent.com/705427/194335581-700d4421-dae3-424c-b9ad-ca349ae6bed0.png

[before]: https://user-images.githubusercontent.com/705427/194330502-e28f49ae-43a4-43d6-ad86-6aee31c444e5.png
