### PR TITLE
fix: use video icon for video figCaption

### DIFF
--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -11,7 +11,7 @@ import {
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
 import FigCaption from '@guardian/common-rendering/src/components/figCaption';
-import { Variant } from '@guardian/common-rendering/src/components/figCaption';
+import { Variant as FigCaptionVariant } from '@guardian/common-rendering/src/components/figCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -576,7 +576,7 @@ const mediaAtomRenderer = (
 		format: format,
 		supportsDarkMode: true,
 		children: some(h(Caption, { caption, format })),
-		variant: Variant.Video,
+		variant: FigCaptionVariant.Video,
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -11,6 +11,7 @@ import {
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
 import FigCaption from '@guardian/common-rendering/src/components/figCaption';
+import { Variant } from '@guardian/common-rendering/src/components/figCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -575,6 +576,7 @@ const mediaAtomRenderer = (
 		format: format,
 		supportsDarkMode: true,
 		children: some(h(Caption, { caption, format })),
+		variant: Variant.Video,
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,8 +10,10 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import FigCaption from '@guardian/common-rendering/src/components/figCaption';
-import { Variant as FigCaptionVariant } from '@guardian/common-rendering/src/components/figCaption';
+import {
+	default as FigCaption,
+	Variant as FigCaptionVariant,
+} from '@guardian/common-rendering/src/components/figCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,9 +10,8 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import {
-	default as FigCaption,
-	Variant as FigCaptionVariant,
+import FigCaption, {
+	IconVariant as FigCaptionIconVariant,
 } from '@guardian/common-rendering/src/components/figCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
@@ -578,7 +577,7 @@ const mediaAtomRenderer = (
 		format: format,
 		supportsDarkMode: true,
 		children: some(h(Caption, { caption, format })),
-		variant: FigCaptionVariant.Video,
+		variant: FigCaptionIconVariant.Video,
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions

--- a/common-rendering/src/components/figCaption.stories.tsx
+++ b/common-rendering/src/components/figCaption.stories.tsx
@@ -5,7 +5,7 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
 import type { FC } from 'react';
-import FigCaption, { Variant } from './figCaption';
+import FigCaption, { IconVariant } from './figCaption';
 
 // ----- Stories ----- //
 
@@ -17,7 +17,7 @@ const Image: FC = () => (
 			theme: ArticlePillar.News,
 		}}
 		supportsDarkMode={true}
-		variant={Variant.Image}
+		variant={IconVariant.Image}
 	>
 		{some(
 			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
@@ -33,7 +33,7 @@ const Video: FC = () => (
 			theme: ArticlePillar.News,
 		}}
 		supportsDarkMode={true}
-		variant={Variant.Video}
+		variant={IconVariant.Video}
 	>
 		{some(
 			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',

--- a/common-rendering/src/components/figCaption.stories.tsx
+++ b/common-rendering/src/components/figCaption.stories.tsx
@@ -2,33 +2,50 @@
 
 // ----- Imports ----- //
 
-import { ArticleDesign, ArticleDisplay, ArticlePillar} from "@guardian/libs";
-import { some } from "@guardian/types";
-import type { FC } from "react";
-import FigCaption from "./figCaption";
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { some } from '@guardian/types';
+import type { FC } from 'react';
+import FigCaption, { Variant } from './figCaption';
 
 // ----- Stories ----- //
 
-const Default: FC = () => (
-  <FigCaption
-    format={{
-      design: ArticleDesign.Standard,
-      display: ArticleDisplay.Standard,
-      theme: ArticlePillar.News,
-    }}
-    supportsDarkMode={true}
-  >
-    {some(
-      "Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images"
-    )}
-  </FigCaption>
+const Image: FC = () => (
+	<FigCaption
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+		supportsDarkMode={true}
+		variant={Variant.Image}
+	>
+		{some(
+			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
+		)}
+	</FigCaption>
+);
+
+const Video: FC = () => (
+	<FigCaption
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+		supportsDarkMode={true}
+		variant={Variant.Video}
+	>
+		{some(
+			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
+		)}
+	</FigCaption>
 );
 
 // ----- Exports ----- //
 
 export default {
-  component: FigCaption,
-  title: "Common/Components/FigCaption",
+	component: FigCaption,
+	title: 'Common/Components/FigCaption',
 };
 
-export { Default };
+export { Image, Video };

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -16,7 +16,7 @@ import { fill, text } from '@guardian/common-rendering/src/editorialPalette';
 
 // ----- Sub-Components ----- //
 
-enum Variant {
+enum IconVariant {
 	Image,
 	Video,
 }
@@ -24,7 +24,7 @@ enum Variant {
 interface IconProps {
 	format: ArticleFormat;
 	supportsDarkMode: boolean;
-	variant: Variant;
+	variant: IconVariant;
 }
 
 const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
@@ -61,7 +61,11 @@ const Icon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
 		default:
 			return (
 				<span css={iconStyles(supportsDarkMode)}>
-					{variant === Variant.Image ? <SvgCamera /> : <SvgVideo />}
+					{variant === IconVariant.Image ? (
+						<SvgCamera />
+					) : (
+						<SvgVideo />
+					)}
 				</span>
 			);
 	}
@@ -75,7 +79,7 @@ type Props = {
 	children: Option<ReactNode>;
 	className?: string;
 	css?: SerializedStyles;
-	variant?: Variant;
+	variant?: IconVariant;
 };
 
 const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
@@ -118,7 +122,7 @@ const FigCaption: FC<Props> = ({
 	supportsDarkMode,
 	children,
 	className,
-	variant = Variant.Image,
+	variant = IconVariant.Image,
 }) => {
 	switch (children.kind) {
 		case OptionKind.Some:
@@ -145,4 +149,4 @@ const FigCaption: FC<Props> = ({
 
 export default FigCaption;
 
-export { Variant };
+export { IconVariant };

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import { remSpace } from '@guardian/source-foundations';
 import { neutral } from '@guardian/source-foundations';
 import { textSans } from '@guardian/source-foundations';
-import { SvgCamera } from '@guardian/source-react-components';
+import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { Option } from '@guardian/types';
@@ -16,12 +16,18 @@ import { fill, text } from '@guardian/common-rendering/src/editorialPalette';
 
 // ----- Sub-Components ----- //
 
-interface CameraProps {
-	format: ArticleFormat;
-	supportsDarkMode: boolean;
+enum Variant {
+	Image,
+	Video,
 }
 
-const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+interface IconProps {
+	format: ArticleFormat;
+	supportsDarkMode: boolean;
+	variant: Variant;
+}
+
+const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	display: inline-block;
 	width: 1.2rem;
 	margin-right: ${remSpace[1]};
@@ -46,7 +52,7 @@ const cameraStyles = (supportsDarkMode: boolean): SerializedStyles => css`
     `}
 `;
 
-const Camera: FC<CameraProps> = ({ format, supportsDarkMode }) => {
+const Icon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
@@ -54,8 +60,8 @@ const Camera: FC<CameraProps> = ({ format, supportsDarkMode }) => {
 			return null;
 		default:
 			return (
-				<span css={cameraStyles(supportsDarkMode)}>
-					<SvgCamera />
+				<span css={iconStyles(supportsDarkMode)}>
+					{variant === Variant.Image ? <SvgCamera /> : <SvgVideo />}
 				</span>
 			);
 	}
@@ -69,6 +75,7 @@ type Props = {
 	children: Option<ReactNode>;
 	className?: string;
 	css?: SerializedStyles;
+	variant?: Variant;
 };
 
 const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
@@ -111,6 +118,7 @@ const FigCaption: FC<Props> = ({
 	supportsDarkMode,
 	children,
 	className,
+	variant = Variant.Image,
 }) => {
 	switch (children.kind) {
 		case OptionKind.Some:
@@ -119,9 +127,10 @@ const FigCaption: FC<Props> = ({
 					className={className}
 					css={getStyles(format, supportsDarkMode)}
 				>
-					<Camera
+					<Icon
 						format={format}
 						supportsDarkMode={supportsDarkMode}
+						variant={variant}
 					/>
 					{children.value}
 				</figcaption>
@@ -135,3 +144,5 @@ const FigCaption: FC<Props> = ({
 // ----- Exports ----- //
 
 export default FigCaption;
+
+export { Variant };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- uses a video icon for figure captions beneath videos

## Why?

- to fix #6145 

## Screenshots

### Video

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/194350072-38f6dd6c-85f5-417e-9828-e428c671e1c9.png
[after]: https://user-images.githubusercontent.com/705427/194350067-b5c1808a-46c6-4979-9016-85b5dda70170.png

### Image


| Before      | After      |
|-------------|------------|
| ![before1][] | ![after1][] |

[before1]: https://user-images.githubusercontent.com/705427/194350637-a194371c-5c33-46db-a1f8-d8ef3385a1fb.png
[after1]: https://user-images.githubusercontent.com/705427/194350643-17f59488-8652-4ff9-aa88-a4e77834e378.png
