### PR TITLE
Turn off bucketing for Long Mandatory Sign In Gate AB debug test run

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-testrun.ts
@@ -4,7 +4,7 @@ import { setOrUseParticipations } from '../lib/ab-exclusions';
 
 // Flag to determine whether the canRun function 'setOrUseParticipations' will set a participation (true)
 // or use localstorage participation key to decide canRun result (false)
-const setParticipationsFlag = true;
+const setParticipationsFlag = false;
 
 export const signInGateMandatoryLongBucketingTestRun: ABTest = {
 	id: 'SignInGateMandatoryLongBucketingTestRun',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Turns off test bucketing for the test in this PR: https://github.com/guardian/dotcom-rendering/pull/6136

This should be merged on Monday Oct 10th in the Morning

