### PR TITLE
Remove `CommercialEndOfQuarterMegaTest`

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
-import type { ServerSideTests, Switches } from '../../types/config';
+import type { Switches } from '../../types/config';
 import type { Palette } from '../../types/palette';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';
@@ -37,7 +37,6 @@ type Props = {
 	filterKeyEvents?: boolean;
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
-	abTests?: ServerSideTests;
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -131,7 +130,6 @@ export const ArticleBody = ({
 	filterKeyEvents,
 	availableTopics,
 	selectedTopics,
-	abTests,
 	keywordIds,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
@@ -215,7 +213,6 @@ export const ArticleBody = ({
 				isDev={isDev}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
-				abTests={abTests}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -38,8 +38,6 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 
 		const serverSideTestsToForceMetrics: Array<ServerSideTestNames> = [
 			/* keep array multi-line */
-			'commercialEndOfQuarterMegaTestVariant',
-			'commercialEndOfQuarterMegaTestControl',
 		];
 
 		const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -31,8 +31,6 @@ export const CoreVitals = () => {
 
 	const serverSideTestsToForceMetrics: Array<ServerSideTestNames> = [
 		/* linter, please keep this array multi-line */
-		'commercialEndOfQuarterMegaTestVariant',
-		'commercialEndOfQuarterMegaTestControl',
 	];
 
 	const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -585,7 +585,6 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
-										abTests={CAPIArticle.config.abTests}
 										keywordIds={
 											CAPIArticle.config.keywordIds
 										}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -402,7 +402,6 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -528,7 +528,6 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										isPreview={CAPIArticle.config.isPreview}
 										idUrl={CAPIArticle.config.idUrl || ''}
 										isDev={!!CAPIArticle.config.isDev}
-										abTests={CAPIArticle.config.abTests}
 										keywordIds={
 											CAPIArticle.config.keywordIds
 										}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -909,10 +909,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													selectedTopics={
 														CAPIArticle.selectedTopics
 													}
-													abTests={
-														CAPIArticle.config
-															.abTests
-													}
 													keywordIds={
 														CAPIArticle.config
 															.keywordIds
@@ -1069,10 +1065,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 													}
 													selectedTopics={
 														CAPIArticle.selectedTopics
-													}
-													abTests={
-														CAPIArticle.config
-															.abTests
 													}
 													keywordIds={
 														CAPIArticle.config

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -543,7 +543,6 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 									keywordIds={CAPIArticle.config.keywordIds}
 								/>
 								{showBodyEndSlot && (

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -663,7 +663,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
-									abTests={CAPIArticle.config.abTests}
 									keywordIds={CAPIArticle.config.keywordIds}
 								/>
 								{format.design === ArticleDesign.MatchReport &&

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import type { ServerSideTests, Switches } from '../../types/config';
+import type { Switches } from '../../types/config';
 import {
 	adCollapseStyles,
 	labelStyles as adLabelStyles,
@@ -43,7 +43,6 @@ export const ArticleRenderer: React.FC<{
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-	abTests?: ServerSideTests;
 }> = ({
 	format,
 	elements,
@@ -62,7 +61,6 @@ export const ArticleRenderer: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	isDev,
-	abTests,
 }) => {
 	const renderedElements = elements.map((element, index) => {
 		return (
@@ -81,7 +79,6 @@ export const ArticleRenderer: React.FC<{
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
 				switches={switches}
-				abTests={abTests}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -7,7 +7,7 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
-import type { ServerSideTests, Switches } from '../../types/config';
+import type { Switches } from '../../types/config';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '../components/CalloutBlockComponent.importable';
@@ -81,7 +81,6 @@ type Props = {
 	isSensitive: boolean;
 	switches: Switches;
 	isPinnedPost?: boolean;
-	abTests?: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -136,16 +135,12 @@ export const renderElement = ({
 	switches,
 	isSensitive,
 	isPinnedPost,
-	abTests,
 }: Props): [boolean, JSX.Element] => {
 	const palette = decidePalette(format);
 
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
-
-	const shouldLazyLoadInteractives =
-		!!abTests?.commercialEndOfQuarterMegaTestControl;
 
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
@@ -394,9 +389,7 @@ export const renderElement = ({
 				true,
 				// Deferring interactives until CPU idle achieves the lowest Cumulative Layout Shift (CLS)
 				// For more information on the experiment we ran see: https://github.com/guardian/dotcom-rendering/pull/4942
-				<Island
-					deferUntil={shouldLazyLoadInteractives ? 'visible' : 'idle'}
-				>
+				<Island deferUntil="idle">
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}


### PR DESCRIPTION
## What does this change?

Removes `CommercialEndOfQuarterMegaTest`

## Why?

The test has concluded so we can safely remove this test now.

Essentially reverts this PR: https://github.com/guardian/dotcom-rendering/pull/5757
