### PR TITLE
Stop Rendering Empty Bylines

### DIFF
--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -18,7 +18,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { fromNullable, map, none } from '@guardian/types';
+import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import type { Body } from 'bodyElement';
 import { parseElements } from 'bodyElement';
@@ -293,6 +293,7 @@ const itemFields = (
 		bylineHtml: pipe(
 			content.fields?.bylineHtml,
 			fromNullable,
+			andThen(html => html !== '' ? some(html) : none),
 			map(context.docParser),
 		),
 		publishDate: maybeCapiDate(content.webPublicationDate),

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -293,7 +293,7 @@ const itemFields = (
 		bylineHtml: pipe(
 			content.fields?.bylineHtml,
 			fromNullable,
-			andThen(html => html !== '' ? some(html) : none),
+			andThen((html) => (html !== '' ? some(html) : none)),
 			map(context.docParser),
 		),
 		publishDate: maybeCapiDate(content.webPublicationDate),


### PR DESCRIPTION
## Why?

Some pieces don't have a byline. In these situations it seems that the `bylineHtml` field is present, but set to an empty string (`""`). This means that an empty byline gets rendered in the markup, which we want to avoid. For immersives, in these cases, the word "by" also appears visually, but without any byline following it (see the screenshots).

We represent `bylineHtml` as an `Option`, so I've chosen to parse `""` directly to a `none`. Our UI code already handles the `none` case by not rendering anything, which is the behaviour we want here.

## Changes

- Convert empty byline HTML to `none`

## Screenshots

| Before | After |
| - | - |
| ![byline-before] | ![byline-after] |

[byline-before]: https://user-images.githubusercontent.com/53781962/195075861-d9277c04-1698-4ddc-9062-4bf53837bd9c.jpg
[byline-after]: https://user-images.githubusercontent.com/53781962/195075866-368aa7bb-71e6-47b8-9364-be937423ea14.jpg
