### PR TITLE
Grey-on-pink pull quotes and epics on DCR analysis

### DIFF
--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -90,6 +90,7 @@ export type Palette = {
 		filterButtonActive: Colour;
 		treat: Colour;
 		designTag: Colour;
+		pullQuote: Colour;
 	};
 	fill: {
 		commentCount: Colour;

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import {
-	from,
-	headline,
-	neutral,
-	text,
-	until,
-} from '@guardian/source-foundations';
+import { from, headline, text, until } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import type { Palette } from '../../types/palette';
 import { QuoteIcon } from './QuoteIcon';
@@ -135,9 +129,7 @@ export const PullQuoteBlockComponent: React.FC<{
 							${headline.xxsmall({ fontWeight: 'light' })};
 							line-height: 25px;
 							position: relative;
-							/* TODO: Source foundation doesn't have this colour, once it does, remove the hex below */
-							/* stylelint-disable-next-line color-no-hex */
-							background-color: #fbe6d5;
+							background-color: ${palette.background.pullQuote};
 							padding-top: 6px;
 							padding-bottom: 12px;
 							margin-bottom: 28px;
@@ -148,9 +140,8 @@ export const PullQuoteBlockComponent: React.FC<{
 								height: 25px;
 								bottom: -25px;
 								position: absolute;
-								/* TODO: Source foundation doesn't have this colour, once it does, remove the hex below */
-								/* stylelint-disable-next-line color-no-hex */
-								background-color: #fbe6d5;
+								background-color: ${palette.background
+									.pullQuote};
 							}
 						`,
 					]}
@@ -204,54 +195,6 @@ export const PullQuoteBlockComponent: React.FC<{
 					</footer>
 				</aside>
 			);
-		case ArticleDesign.Analysis:
-			return (
-				<aside
-					css={[
-						decidePosition(role, design),
-						css`
-							${headline.xxsmall({ fontWeight: 'bold' })};
-							line-height: 25px;
-							position: relative;
-							background-color: ${neutral[100]};
-							padding-left: 10px;
-							padding-right: 10px;
-							padding-top: 6px;
-							padding-bottom: 12px;
-							margin-bottom: 1.75rem;
-							color: ${palette.text.pullQuote};
-
-							:after {
-								content: '';
-								width: 25px;
-								height: 25px;
-								bottom: -25px;
-								position: absolute;
-								background-color: ${neutral[100]};
-							}
-						`,
-					]}
-				>
-					<QuoteIcon colour={palette.fill.quoteIcon} />
-					<blockquote
-						css={css`
-							display: inline;
-						`}
-						dangerouslySetInnerHTML={{
-							__html: unescapeData(html),
-						}}
-					/>
-					<footer>
-						<cite
-							css={css`
-								color: ${palette.text.pullQuoteAttribution};
-							`}
-						>
-							{attribution}
-						</cite>
-					</footer>
-				</aside>
-			);
 		default:
 			return (
 				<aside
@@ -261,7 +204,7 @@ export const PullQuoteBlockComponent: React.FC<{
 							${headline.xxsmall({ fontWeight: 'bold' })};
 							line-height: 25px;
 							position: relative;
-							background-color: ${neutral[97]};
+							background-color: ${palette.background.pullQuote};
 							padding-left: 10px;
 							padding-right: 10px;
 							padding-top: 6px;
@@ -275,7 +218,8 @@ export const PullQuoteBlockComponent: React.FC<{
 								height: 25px;
 								bottom: -25px;
 								position: absolute;
-								background-color: ${neutral[97]};
+								background-color: ${palette.background
+									.pullQuote};
 							}
 						`,
 					]}

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -227,7 +227,7 @@ export const PullQuoteBlockComponent: React.FC<{
 								height: 25px;
 								bottom: -25px;
 								position: absolute;
-								background-color: ${neutral[97]};
+								background-color: ${neutral[100]};
 							}
 						`,
 					]}

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -204,6 +204,54 @@ export const PullQuoteBlockComponent: React.FC<{
 					</footer>
 				</aside>
 			);
+		case ArticleDesign.Analysis:
+			return (
+				<aside
+					css={[
+						decidePosition(role, design),
+						css`
+							${headline.xxsmall({ fontWeight: 'bold' })};
+							line-height: 25px;
+							position: relative;
+							background-color: ${neutral[100]};
+							padding-left: 10px;
+							padding-right: 10px;
+							padding-top: 6px;
+							padding-bottom: 12px;
+							margin-bottom: 1.75rem;
+							color: ${palette.text.pullQuote};
+
+							:after {
+								content: '';
+								width: 25px;
+								height: 25px;
+								bottom: -25px;
+								position: absolute;
+								background-color: ${neutral[97]};
+							}
+						`,
+					]}
+				>
+					<QuoteIcon colour={palette.fill.quoteIcon} />
+					<blockquote
+						css={css`
+							display: inline;
+						`}
+						dangerouslySetInnerHTML={{
+							__html: unescapeData(html),
+						}}
+					/>
+					<footer>
+						<cite
+							css={css`
+								color: ${palette.text.pullQuoteAttribution};
+							`}
+						>
+							{attribution}
+						</cite>
+					</footer>
+				</aside>
+			);
 		default:
 			return (
 				<aside

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1321,6 +1321,19 @@ const fillQuoteIcon = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].main;
 };
 
+const backgroundPullQuote = (format: ArticleFormat): string => {
+	switch (format.design) {
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Comment:
+			return '#fbe6d5';
+		case ArticleDesign.Analysis:
+			return neutral[100];
+		default:
+			return neutral[97];
+	}
+};
+
 const textPullQuoteAttribution = (format: ArticleFormat): string =>
 	fillQuoteIcon(format);
 
@@ -1647,6 +1660,7 @@ export const decidePalette = (
 			filterButtonActive: backgroundFilterButtonActive(format),
 			treat: backgroundTreat(format),
 			designTag: backgroundDesignTag(format),
+			pullQuote: backgroundPullQuote(format),
 		},
 		fill: {
 			commentCount: fillCommentCount(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

Trello ticket: https://trello.com/c/spYocfQB/621-grey-on-pink-pull-quotes-and-epics-dotcom-rendering

This PR tweaks the background colour of pull quotes and epics as the grey-on-pink may be hard to see. A similar change was implemented for tags on analysis articles - see [this PR](https://github.com/guardian/dotcom-rendering/pull/5747#pullrequestreview-1075952548)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/102960825/195079264-af54e07c-4c0c-4b6b-9474-fcdc18590979.png 
[after]: https://user-images.githubusercontent.com/102960825/195392844-52824f3d-e06a-4371-844a-1cd6bb3b715a.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
