### PR TITLE
fix: Dependabot PR's should run with full chromatic tests

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Chromatic - Non Dependency PR / main
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+        if: ${{ github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot'}}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Chromatic - Dependency PR
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.user.login != 'dependabot' }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Chromatic - Non Dependency PR / main
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot'}}
+        if: ${{ github.event_name == 'push' || (!contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.user.login != 'dependabot')}}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Chromatic - Dependency PR
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.user.login != 'dependabot' }}
+        if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.login == 'dependabot') }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add an extra condition to force Dependabot PR's to run a full chromatic build if the PR is opened by dependabot.

## Why?

It seems like the dependency labels are being added to the PR after dependabot has already opened it and the Chromatic github action has already started running.