### PR TITLE
If no keyEvents or availableTopics, don't show the filters or the filter heading in FilterTopicBank

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -83,6 +83,9 @@ export const TopicFilterBank = ({
 	filterKeyEvents = false,
 	id,
 }: Props) => {
+	const showFilters = keyEvents?.length || availableTopics.length;
+	if (!showFilters) return null;
+
 	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
 	const topFiveTopics = availableTopics

--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -83,9 +83,6 @@ export const TopicFilterBank = ({
 	filterKeyEvents = false,
 	id,
 }: Props) => {
-	const showFilters = keyEvents?.length || availableTopics.length;
-	if (!showFilters) return null;
-
 	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
 	const topFiveTopics = availableTopics

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -286,8 +286,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
 
 	const showTopicFilterBank = !!CAPIArticle.config.switches.automaticFilters;
+	const hasAvailableTopics = !!CAPIArticle.availableTopics?.length;
 
-	const showToggle = !showTopicFilterBank || !CAPIArticle.availableTopics;
+	const showToggle = !showTopicFilterBank || !hasAvailableTopics;
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
@@ -750,7 +751,8 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								</Hide>
 
 								{showTopicFilterBank &&
-									CAPIArticle.availableTopics && (
+									CAPIArticle.availableTopics &&
+									hasAvailableTopics && (
 										<Hide until="desktop">
 											<div css={sidePaddingDesktop}>
 												<Island>
@@ -808,7 +810,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										<></>
 									)}
 									{showTopicFilterBank &&
-									CAPIArticle.availableTopics ? (
+									hasAvailableTopics ? (
 										<div css={paddingBody}>
 											<ArticleContainer format={format}>
 												{pagination.currentPage !==

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -111,7 +111,7 @@ export const LiveBlogRenderer = ({
 				<></>
 			)}
 
-			{switches.automaticFilters && availableTopics && (
+			{switches.automaticFilters && !!availableTopics?.length && (
 				<Hide above="desktop">
 					<Island>
 						<TopicFilterBank


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This change updates the check on availableTopics, to ensure that the array has some items in it. If not, we don't show the FilterTopic bank.

## Why?
UX Improvement - We've seen a case when availableTopics exists, but it empty, which meant the Filter headings were visible with no Filter buttons.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1511" alt="image" src="https://user-images.githubusercontent.com/26366706/195285399-4d671a72-9450-4ad0-8372-22a44380db40.png">| <img width="1511" alt="image" src="https://user-images.githubusercontent.com/26366706/195285491-1da92994-6b16-496c-b5a3-de4cd7b938eb.png">|


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
