### PR TITLE
Serve DCR Javascript Bundle variants

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -1,14 +1,26 @@
 /**
  * Controls whether we should build the variant bundle.
- * Set this to true if you want to serve a server-side experiment against
- * the `dcrJsBundleVariant` A/B test.
  *
- * @see https://github.com/guardian/frontend/blob/a602273a/common/app/experiments/Experiments.scala#L20-L27
+ * Set this to `true` if you want to serve a server-side experiment against
+ * the `dcrJavascriptBundle` A/B test.
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
 const BUILD_VARIANT = true;
 
+/**
+ * Server-side test names for `dcr-javascript-bundle`.
+ *
+ * The name is transformed from kebab-case to camelCase,
+ * so we have the `dcrJavascriptBundle` prefix.
+ *
+ * @see https://github.com/guardian/frontend/blob/a602273a/common/app/experiments/Experiments.scala#L20-L27
+ *
+ * @type {(variant: 'Variant' | 'Control') => import("../../src/types/config").ServerSideTestNames}
+ */
+const dcrJavascriptBundle = (variant) => `dcrJavascriptBundle${variant}`;
+
 module.exports = {
 	BUILD_VARIANT,
+	dcrJavascriptBundle,
 };

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -4,6 +4,7 @@ import {
 	getCookie,
 	initCoreWebVitals,
 } from '@guardian/libs';
+import { dcrJavascriptBundle } from '../../../scripts/webpack/bundles';
 import type { ServerSideTestNames } from '../../types/config';
 import { useAB } from '../lib/useAB';
 
@@ -31,6 +32,8 @@ export const CoreVitals = () => {
 
 	const serverSideTestsToForceMetrics: Array<ServerSideTestNames> = [
 		/* linter, please keep this array multi-line */
+		dcrJavascriptBundle('Variant'),
+		dcrJavascriptBundle('Control'),
 	];
 
 	const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,7 +3,10 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
-import { BUILD_VARIANT } from '../../../scripts/webpack/bundles';
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+} from '../../../scripts/webpack/bundles';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -93,7 +96,8 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,
-		CAPIArticle.config.abTests.dcrJsBundleVariant === 'variant',
+		CAPIArticle.config.abTests[dcrJavascriptBundle('Variant')] ===
+			'variant',
 	].every(Boolean);
 
 	/**

--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -2,7 +2,10 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { renderToString } from 'react-dom/server';
-import { BUILD_VARIANT } from '../../../scripts/webpack/bundles';
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+} from '../../../scripts/webpack/bundles';
 import {
 	generateScriptTags,
 	getScriptsFromManifest,
@@ -50,7 +53,7 @@ export const frontToHtml = ({ front }: Props): string => {
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,
-		front.config.abTests.dcrJsBundleVariant === 'variant',
+		front.config.abTests[dcrJavascriptBundle('Variant')] === 'variant',
 	].every(Boolean);
 
 	/**


### PR DESCRIPTION
## What does this change?

Update the DCR Javascript Bundle test name

## Why?

The name was confusing, and has been updated in Frontend. https://github.com/guardian/frontend/pull/25578

## Test

<img width="904" alt="image" src="https://user-images.githubusercontent.com/76776/195315520-6966bd23-3950-4863-9a17-8f37da4a62be.png">
