### PR TITLE
Change gallery caption container to div

### DIFF
--- a/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/GalleryCaption.tsx
@@ -70,12 +70,12 @@ const GalleryCaption: FC<Props> = ({ mainMedia, format }) =>
 		}
 
 		return (
-			<p css={styles(format)}>
+			<div css={styles(format)}>
 				<Caption caption={caption} format={format} />{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>
 				))}
-			</p>
+			</div>
 		);
 	});
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the tag of the gallery main media caption container from a `<p/>` to a `<div/>`

## Why?
In some case, the caption contains other block level tags like `<h2/>`s. When wrapped in a `<p/>` tag this would cause the browser to render the contents outside the container and styling would be lost. 

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="615" alt="image" src="https://user-images.githubusercontent.com/99400613/195318115-1f73bbe9-5aa5-4594-82cb-879a1ed3a889.png"> | <img width="582" alt="image" src="https://user-images.githubusercontent.com/99400613/195317922-f49dba3c-139f-4564-b221-10248b8295e2.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
