### PR TITLE
Remove floating promises linting rule

### DIFF
--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -41,9 +41,7 @@ export const CoreVitals = () => {
 			Object.keys(window.guardian.config.tests).includes(test),
 		);
 
-	/* eslint-disable @typescript-eslint/no-floating-promises -- they’re async methods */
-
-	initCoreWebVitals({
+	void initCoreWebVitals({
 		browserId,
 		pageViewId,
 		isDev,
@@ -52,16 +50,14 @@ export const CoreVitals = () => {
 	});
 
 	if (window.location.hostname === (process.env.HOSTNAME || 'localhost')) {
-		bypassCoreWebVitalsSampling('dotcom');
+		void bypassCoreWebVitalsSampling('dotcom');
 	}
 	if (
 		userInClientSideTestToForceMetrics ||
 		userInServerSideTestToForceMetrics
 	) {
-		bypassCoreWebVitalsSampling('commercial');
+		void bypassCoreWebVitalsSampling('commercial');
 	}
-
-	/* eslint-enable @typescript-eslint/no-floating-promises */
 
 	// don’t render anything
 	return null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use the `void` keyword to indicate promises are not awaited.

## Why?

It was not allowed to use this `void` keyword previously so we had to use disable the ESLint rule in #4513.