### PR TITLE
fix: master asset fallback

### DIFF
--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -79,12 +79,11 @@ const getBestAsset = (assets: Asset[]): Option<Asset> => {
 const parseImage =
 	({ docParser, salt }: Context) =>
 	(element: BlockElement): Option<Image> => {
-		const bestAsset = getBestAsset(element.assets);
-
 		const data = element.imageTypeData;
 
 		return pipe(
-			bestAsset,
+			element.assets,
+			getBestAsset,
 			andThen((asset) => {
 				if (
 					asset.file === undefined ||

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -55,32 +55,32 @@ const sortAscendingWidth = (a: Asset, b: Asset) =>
 		? a.typeData.width - b.typeData.width
 		: 0;
 
-const getHighestResAsset = (assets: Asset[]): Option<Asset> => {
-	const asset = assets
-		.filter((asset) => asset.typeData?.width && asset.typeData?.height)
-		.sort(sortAscendingWidth)
-		.pop();
-	return fromNullable(asset);
-};
+const getHighestResAsset = (assets: Asset[]): Option<Asset> =>
+	fromNullable(
+		assets
+			.filter((asset) => asset.typeData?.width && asset.typeData?.height)
+			.sort(sortAscendingWidth)
+			.pop(),
+	);
 
 const parseImage =
 	({ docParser, salt }: Context) =>
 	(element: BlockElement): Option<Image> => {
-		const maybeMasterAsset = fromNullable(
+		const masterAsset = fromNullable(
 			element.assets.find((asset) => asset.typeData?.isMaster),
 		);
 
-		const maybeHighestResAsset = getHighestResAsset(element.assets);
+		const highestResAsset = getHighestResAsset(element.assets);
 
-		const maybeBestAsset =
-			maybeMasterAsset.kind === OptionKind.Some
-				? maybeMasterAsset
-				: maybeHighestResAsset;
+		const bestAsset =
+			masterAsset.kind === OptionKind.Some
+				? masterAsset
+				: highestResAsset;
 
 		const data = element.imageTypeData;
 
 		return pipe(
-			maybeBestAsset,
+			bestAsset,
 			andThen((asset) => {
 				if (
 					asset.file === undefined ||

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -1,17 +1,24 @@
 // ----- Imports ----- //
 
 import type { Image as CardImage } from '@guardian/apps-rendering-api-models/image';
+import type { Asset } from '@guardian/content-api-models/v1/asset';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
-import { Option, OptionKind } from '@guardian/types';
-import { andThen, fromNullable, map, none, some } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import {
+	andThen,
+	fromNullable,
+	map,
+	none,
+	OptionKind,
+	some,
+} from '@guardian/types';
 import type { Image as ImageData } from 'image/image';
 import { Dpr, src, srcsets } from 'image/srcsets';
 import { pipe } from 'lib';
 import type { Context } from 'parserContext';
 import type { ReactNode } from 'react';
-import { Asset } from '@guardian/content-api-models/v1/asset';
 
 // ----- Types ----- //
 
@@ -50,18 +57,13 @@ const parseRole = (role: string | undefined): ArticleElementRole => {
 	}
 };
 
-const sortAscendingWidth = (a: Asset, b: Asset) =>
+const sortAscendingWidth = (a: Asset, b: Asset): number =>
 	a.typeData?.width && b.typeData?.width
 		? a.typeData.width - b.typeData.width
 		: 0;
 
 const getHighestResAsset = (assets: Asset[]): Option<Asset> =>
-	fromNullable(
-		assets
-			.filter((asset) => asset.typeData?.width && asset.typeData?.height)
-			.sort(sortAscendingWidth)
-			.pop(),
-	);
+	fromNullable(assets.slice().sort(sortAscendingWidth).pop());
 
 const parseImage =
 	({ docParser, salt }: Context) =>

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -60,24 +60,26 @@ const parseRole = (role: string | undefined): ArticleElementRole => {
 const sortAscendingWidth = (a: Asset, b: Asset): number =>
 	a.typeData?.width && b.typeData?.width
 		? a.typeData.width - b.typeData.width
-		: 0;
+		: -1;
 
 const getHighestResAsset = (assets: Asset[]): Option<Asset> =>
 	fromNullable(assets.slice().sort(sortAscendingWidth).pop());
 
+const getBestAsset = (assets: Asset[]): Option<Asset> => {
+	const masterAsset = fromNullable(
+		assets.find((asset) => asset.typeData?.isMaster),
+	);
+	if (masterAsset.kind === OptionKind.Some) {
+		return masterAsset;
+	}
+
+	return getHighestResAsset(assets);
+};
+
 const parseImage =
 	({ docParser, salt }: Context) =>
 	(element: BlockElement): Option<Image> => {
-		const masterAsset = fromNullable(
-			element.assets.find((asset) => asset.typeData?.isMaster),
-		);
-
-		const highestResAsset = getHighestResAsset(element.assets);
-
-		const bestAsset =
-			masterAsset.kind === OptionKind.Some
-				? masterAsset
-				: highestResAsset;
+		const bestAsset = getBestAsset(element.assets);
 
 		const data = element.imageTypeData;
 


### PR DESCRIPTION
## What does this change?

- Prefers an asset with `isMaster: true`, and falls back to the widest asset if not found

## Why?

- fixes https://github.com/guardian/dotcom-rendering/issues/4351
