### PR TITLE
Add support for `nav/list` container type

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -140,10 +140,17 @@ export const enhanceCards = (
 			? enhanceTags(faciaCard.properties.maybeContent.tags.tags)
 			: [];
 
+		// The URL parameter on a Snap header will be a link to the Snap itself, there is a second href
+		// property which contains what the snap is actually linking to.
+		const url =
+			faciaCard.type == 'LinkSnap' && faciaCard.properties.href
+				? faciaCard.properties.href
+				: faciaCard.header.url;
+
 		return {
 			format,
 			dataLinkName,
-			url: faciaCard.header.url,
+			url,
 			headline: faciaCard.header.headline,
 			trailText: faciaCard.card.trailText,
 			starRating: faciaCard.card.starRating,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -143,7 +143,7 @@ export const enhanceCards = (
 		// The URL parameter on a Snap header will be a link to the Snap itself, there is a second href
 		// property which contains what the snap is actually linking to.
 		const url =
-			faciaCard.type == 'LinkSnap' && faciaCard.properties.href
+			faciaCard.type === 'LinkSnap' && faciaCard.properties.href
 				? faciaCard.properties.href
 				: faciaCard.header.url;
 

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -140,8 +140,12 @@ export const enhanceCards = (
 			? enhanceTags(faciaCard.properties.maybeContent.tags.tags)
 			: [];
 
-		// The URL parameter on a Snap header will be a link to the Snap itself, there is a second href
-		// property which contains what the snap is actually linking to.
+		/**
+		 * The URL parameter on a Snap header will be a link to the Snap itself, there is a second href
+		 * property which contains what the snap is actually linking to. This is commonly used in the
+		 * NavList container for linking to non-article pages.
+		 * @see NavList
+		 */
 		const url =
 			faciaCard.type === 'LinkSnap' && faciaCard.properties.href
 				? faciaCard.properties.href

--- a/dotcom-rendering/src/web/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/web/components/NavList.stories.tsx
@@ -1,0 +1,25 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { trails } from '../../../fixtures/manual/trails';
+import { NavList } from './NavList';
+import { Section } from './Section';
+
+export default {
+	component: NavList,
+	title: 'Components/NavList',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
+export const Default = () => (
+	<Section title="NavList" padContent={false} centralBorder="partial">
+		<NavList trails={trails} />
+	</Section>
+);
+Default.story = { name: 'NavList' };

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -1,0 +1,74 @@
+import { css } from '@emotion/react';
+import {
+	between,
+	body,
+	border,
+	from,
+	palette,
+	space,
+	until,
+} from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
+import type { DCRContainerPalette } from 'src/types/front';
+import type { TrailType } from '../../types/trails';
+import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+
+type Props = {
+	trails: TrailType[];
+	containerPalette?: DCRContainerPalette;
+};
+
+const ulStyles = css`
+	${until.tablet} {
+		column-count: 1;
+	}
+	${between.tablet.and.desktop} {
+		column-count: 3;
+	}
+	column-count: 4;
+
+	column-rule: 0.0625rem solid ${border.secondary};
+	column-gap: 0.625rem;
+`;
+
+const divStyles = css`
+	color: ${palette.neutral[7]};
+	border-top: 0.0625rem solid ${palette.neutral[93]};
+	padding-top: ${space[1]}px;
+	padding-bottom: ${space[3]}px;
+
+	${from.tablet} {
+		margin-left: 0.625rem;
+		margin-right: 0.625rem;
+	}
+`;
+
+export const NavList = ({ trails, containerPalette }: Props) => {
+	const containerOverrides =
+		containerPalette && decideContainerOverrides(containerPalette);
+
+	return (
+		<ul css={ulStyles}>
+			{trails.map((trail) => (
+				<li>
+					<div css={divStyles}>
+						<Link
+							href={trail.url}
+							priority="secondary"
+							subdued={true}
+							cssOverrides={css`
+								${body.medium()}
+								font-weight: bold;
+								line-height: ${space[6]}px;
+								${containerOverrides &&
+								`color: ${containerOverrides.text.cardHeadline}`}
+							`}
+						>
+							{trail.headline}
+						</Link>
+					</div>
+				</li>
+			))}
+		</ul>
+	);
+};

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import type { DCRContainerPalette } from 'src/types/front';
+import type { ContainerOverrides } from 'src/types/palette';
 import type { TrailType } from '../../types/trails';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 
@@ -31,9 +32,11 @@ const ulStyles = css`
 	column-gap: 10px;
 `;
 
-const liStyles = css`
-	color: ${palette.neutral[7]};
-	border-top: 1px solid ${palette.neutral[93]};
+const liStyles = (containerOverrides?: ContainerOverrides) => css`
+	border-top: 1px solid
+		${containerOverrides
+			? containerOverrides.topBar.card
+			: palette.neutral[93]};
 	padding-top: ${space[1]}px;
 	padding-bottom: ${space[3]}px;
 
@@ -50,7 +53,7 @@ export const NavList = ({ trails, containerPalette }: Props) => {
 	return (
 		<ul css={ulStyles}>
 			{trails.map((trail) => (
-				<li css={liStyles}>
+				<li css={liStyles(containerOverrides)}>
 					<Link
 						href={trail.url}
 						priority="secondary"

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -31,7 +31,7 @@ const ulStyles = css`
 	column-gap: 0.625rem;
 `;
 
-const divStyles = css`
+const liStyles = css`
 	color: ${palette.neutral[7]};
 	border-top: 0.0625rem solid ${palette.neutral[93]};
 	padding-top: ${space[1]}px;
@@ -50,23 +50,21 @@ export const NavList = ({ trails, containerPalette }: Props) => {
 	return (
 		<ul css={ulStyles}>
 			{trails.map((trail) => (
-				<li>
-					<div css={divStyles}>
-						<Link
-							href={trail.url}
-							priority="secondary"
-							subdued={true}
-							cssOverrides={css`
-								${body.medium()}
-								font-weight: bold;
-								line-height: ${space[6]}px;
-								${containerOverrides &&
-								`color: ${containerOverrides.text.cardHeadline}`}
-							`}
-						>
-							{trail.headline}
-						</Link>
-					</div>
+				<li css={liStyles}>
+					<Link
+						href={trail.url}
+						priority="secondary"
+						subdued={true}
+						cssOverrides={css`
+							${body.medium()}
+							font-weight: bold;
+							line-height: ${space[6]}px;
+							${containerOverrides &&
+							`color: ${containerOverrides.text.cardHeadline}`}
+						`}
+					>
+						{trail.headline}
+					</Link>
 				</li>
 			))}
 		</ul>

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -27,19 +27,19 @@ const ulStyles = css`
 	}
 	column-count: 4;
 
-	column-rule: 0.0625rem solid ${border.secondary};
-	column-gap: 0.625rem;
+	column-rule: 1px solid ${border.secondary};
+	column-gap: 10px;
 `;
 
 const liStyles = css`
 	color: ${palette.neutral[7]};
-	border-top: 0.0625rem solid ${palette.neutral[93]};
+	border-top: 1px solid ${palette.neutral[93]};
 	padding-top: ${space[1]}px;
 	padding-bottom: ${space[3]}px;
 
 	${from.tablet} {
-		margin-left: 0.625rem;
-		margin-right: 0.625rem;
+		margin-left: 10px;
+		margin-right: 10px;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/NavList.tsx
+++ b/dotcom-rendering/src/web/components/NavList.tsx
@@ -58,6 +58,7 @@ export const NavList = ({ trails, containerPalette }: Props) => {
 						href={trail.url}
 						priority="secondary"
 						subdued={true}
+						data-link-name={trail.dataLinkName}
 						cssOverrides={css`
 							${body.medium()}
 							font-weight: bold;

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -19,6 +19,7 @@ import { FixedSmallSlowIII } from '../components/FixedSmallSlowIII';
 import { FixedSmallSlowIV } from '../components/FixedSmallSlowIV';
 import { FixedSmallSlowVMPU } from '../components/FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from '../components/FixedSmallSlowVThird';
+import { NavList } from '../components/NavList';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -160,6 +161,10 @@ export const DecideContainer = ({
 					containerPalette={containerPalette}
 					showAge={showAge}
 				/>
+			);
+		case 'nav/list':
+			return (
+				<NavList trails={trails} containerPalette={containerPalette} />
 			);
 		default:
 			return <p>{containerType} is not yet supported</p>;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for the `nav/list` container type.

## Why?

One step closer to DCR fronts!

Closes #5146 
Merges https://github.com/guardian/frontend/pull/25581

## Screenshots

| Frontend      | DCR      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://user-images.githubusercontent.com/21217225/195337481-417bf364-83d3-4a0d-bdfc-ab2675748bce.png
[after]:https://user-images.githubusercontent.com/21217225/195337513-9c93f44b-e209-4c91-8d50-fa01e63c8b7f.png
[before2]: https://user-images.githubusercontent.com/21217225/195349392-f51953b8-c608-40ae-be9e-0488810c237b.png
[after2]:https://user-images.githubusercontent.com/21217225/195349429-8112e38e-3035-41a8-936d-c2e8d70aa609.png
[before3]: https://user-images.githubusercontent.com/21217225/195351108-d399e6a9-7fa4-4e8b-a240-4d14131e0952.png
[after3]:https://user-images.githubusercontent.com/21217225/195351093-bce87883-ef60-432f-832d-801a3ea3776d.png
