### PR TITLE
Bump `@guardian/libs@9.0.1`

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3586,9 +3586,9 @@
       }
     },
     "@guardian/libs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-7.1.0.tgz",
-      "integrity": "sha512-GTFY5sFyKov2HZFdWEKhnWB1IjBFiFhtzJdG2BlFcRBeRo/8DlBvOMjURY+hnoIdgEo1f3A+hHUBdqLsRP5Uig=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-9.0.0.tgz",
+      "integrity": "sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ=="
     },
     "@guardian/node-riffraff-artifact": {
       "version": "0.3.2",

--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -3586,9 +3586,9 @@
       }
     },
     "@guardian/libs": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-9.0.0.tgz",
-      "integrity": "sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-9.0.1.tgz",
+      "integrity": "sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw=="
     },
     "@guardian/node-riffraff-artifact": {
       "version": "0.3.2",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -44,7 +44,7 @@
     "@guardian/content-atom-model": "^3.4.0",
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/eslint-config-typescript": "^0.7.0",
-    "@guardian/libs": "^7.1.0",
+    "@guardian/libs": "^9.0.0",
     "@guardian/node-riffraff-artifact": "^0.3.2",
     "@guardian/renditions": "^0.2.0",
     "@guardian/types": "^9.0.1",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -44,7 +44,7 @@
     "@guardian/content-atom-model": "^3.4.0",
     "@guardian/discussion-rendering": "^10.1.1",
     "@guardian/eslint-config-typescript": "^0.7.0",
-    "@guardian/libs": "^9.0.0",
+    "@guardian/libs": "^9.0.1",
     "@guardian/node-riffraff-artifact": "^0.3.2",
     "@guardian/renditions": "^0.2.0",
     "@guardian/types": "^9.0.1",

--- a/apps-rendering/src/themeStyles.ts
+++ b/apps-rendering/src/themeStyles.ts
@@ -43,6 +43,7 @@ function themeToPillarString(theme: ArticleTheme): string {
 function themeToPillar(theme: ArticleTheme): ArticlePillar {
 	switch (theme) {
 		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.SpecialReportAlt:
 		case ArticleSpecial.Labs:
 			return ArticlePillar.News;
 		default:

--- a/apps-rendering/webpack.config.ts
+++ b/apps-rendering/webpack.config.ts
@@ -109,6 +109,26 @@ const serverConfig = (
 						},
 					],
 				},
+				{
+					// @guardian packages must be transpiled
+					// https://github.com/guardian/recommendations/blob/main/npm-packages.md#using-guardian-npm-packages
+					test: /@guardian\/.+\.js$/,
+					use: [
+						{
+							loader: 'babel-loader',
+							options: {
+								presets: [
+									[
+										'@babel/preset-env',
+										{
+											targets: { node: '14' },
+										},
+									],
+								],
+							},
+						},
+					],
+				},
 			],
 		},
 		optimization: {

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
-		"@guardian/libs": "^9.0.0",
+		"@guardian/libs": "^9.0.1",
 		"@guardian/types": "^9.0.1",
 		"react": "^17.0.2"
 	},

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"@emotion/react": "^11.4.1",
-		"@guardian/libs": "^7.1.0",
+		"@guardian/libs": "^9.0.0",
 		"@guardian/types": "^9.0.1",
 		"react": "^17.0.2"
 	},

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -17,9 +17,7 @@ import {
 	specialReport,
 	labs,
 	brandAlt,
-	palette,
 } from '@guardian/source-foundations';
-// import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -142,7 +140,7 @@ const richLinkSvg = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
 		case ArticleSpecial.SpecialReportAlt:
-			return specialReport[300];
+			return news[400];
 	}
 };
 
@@ -163,7 +161,7 @@ const liveblogMetadata = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[200];
 		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[200];
+			return news[200];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -17,7 +17,9 @@ import {
 	specialReport,
 	labs,
 	brandAlt,
+	palette,
 } from '@guardian/source-foundations';
+// import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -139,6 +141,8 @@ const richLinkSvg = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return specialReport[300];
 	}
 };
 
@@ -158,6 +162,8 @@ const liveblogMetadata = (format: ArticleFormat): Colour => {
 			return labs[200];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[200];
+		case ArticleSpecial.SpecialReportAlt:
+			return palette.specialReportAlt[200];
 	}
 };
 
@@ -177,6 +183,8 @@ const richLinkSvgDark = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -255,6 +263,8 @@ const bullet = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -319,6 +329,8 @@ const avatar = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[800];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 		case ArticleSpecial.Labs:
 			return labs[400];
 		case ArticlePillar.Opinion:
@@ -346,6 +358,8 @@ const relatedCardBylineImage = (format: ArticleFormat): string => {
 			return lifestyle[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 		case ArticlePillar.News:
 		default:
 			return opinion[400];
@@ -383,6 +397,8 @@ const headlineTag = (format: ArticleFormat): Colour => {
 			return sport[300];
 		case ArticlePillar.News:
 			return news[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 
@@ -402,6 +418,8 @@ const headlineTagDark = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -481,6 +499,8 @@ const relatedCardIcon = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -504,6 +524,8 @@ const calloutSpeechBubble = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -601,6 +623,8 @@ const pinnedPost = (format: ArticleFormat): string => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/background.ts
+++ b/common-rendering/src/editorialPalette/background.ts
@@ -357,7 +357,7 @@ const relatedCardBylineImage = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+			return opinion[400];
 		case ArticlePillar.News:
 		default:
 			return opinion[400];

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -16,6 +16,7 @@ import {
 	specialReport,
 	neutral,
 } from '@guardian/source-foundations';
+import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -79,6 +80,8 @@ const liveBlock = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -98,6 +101,8 @@ const liveBlockDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -129,6 +134,8 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[600];
 	}
 };
 
@@ -158,6 +165,8 @@ const richLink = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -179,6 +188,8 @@ const richLinkSvgDark = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -231,6 +242,8 @@ const pinnedPost = (format: ArticleFormat): string => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return specialReportAlt[300];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -15,7 +15,6 @@ import {
 	labs,
 	specialReport,
 	neutral,
-	palette,
 } from '@guardian/source-foundations';
 import { Colour } from '.';
 
@@ -243,7 +242,7 @@ const pinnedPost = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[300];
+			return news[300];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -15,8 +15,8 @@ import {
 	labs,
 	specialReport,
 	neutral,
+	palette,
 } from '@guardian/source-foundations';
-import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -243,7 +243,7 @@ const pinnedPost = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return specialReportAlt[300];
+			return palette.specialReportAlt[300];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -16,6 +16,7 @@ import {
 	specialReport,
 	neutral,
 } from '@guardian/source-foundations';
+import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -67,6 +68,8 @@ const commentCount = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return specialReportAlt[300];
 	}
 };
 const commentCountDark = (format: ArticleFormat): Colour => {
@@ -92,6 +95,8 @@ const commentCountDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -118,6 +123,8 @@ const commentCountWide = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -175,6 +182,8 @@ const blockquoteIcon = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 		default:
 			switch (format.theme) {
@@ -192,6 +201,8 @@ const blockquoteIcon = (format: ArticleFormat): Colour => {
 					return labs[400];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 	}
 };

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -15,7 +15,6 @@ import {
 	labs,
 	specialReport,
 	neutral,
-	palette,
 } from '@guardian/source-foundations';
 import { Colour } from '.';
 
@@ -69,7 +68,7 @@ const commentCount = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[300];
+			return news[300];
 	}
 };
 const commentCountDark = (format: ArticleFormat): Colour => {

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -68,7 +68,7 @@ const commentCount = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[300];
+			return news[400];
 	}
 };
 const commentCountDark = (format: ArticleFormat): Colour => {

--- a/common-rendering/src/editorialPalette/fill.ts
+++ b/common-rendering/src/editorialPalette/fill.ts
@@ -15,8 +15,8 @@ import {
 	labs,
 	specialReport,
 	neutral,
+	palette,
 } from '@guardian/source-foundations';
-import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 import { Colour } from '.';
 
 // ----- Functions ----- //
@@ -69,7 +69,7 @@ const commentCount = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return specialReportAlt[300];
+			return palette.specialReportAlt[300];
 	}
 };
 const commentCountDark = (format: ArticleFormat): Colour => {

--- a/common-rendering/src/editorialPalette/hover.ts
+++ b/common-rendering/src/editorialPalette/hover.ts
@@ -31,6 +31,8 @@ const pagination = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -999,7 +999,7 @@ const richLink = (format: ArticleFormat): Colour => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[500];
+			return news[400];
 	}
 };
 

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -54,6 +54,8 @@ const mediaArticleBodyLinkDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -89,6 +91,8 @@ const bylineAnchor = (format: ArticleFormat): Colour => {
 				return labs[300];
 			case ArticleSpecial.SpecialReport:
 				return brandAlt[300];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[300];
 			case ArticlePillar.News:
 			default:
 				return news[300];
@@ -109,6 +113,8 @@ const bylineAnchor = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -144,6 +150,8 @@ const bylineAnchorDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -163,6 +171,8 @@ const calloutFormAnchor = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -194,6 +204,8 @@ const commentCount = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -220,6 +232,9 @@ const commentCountDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
+
 	}
 };
 
@@ -243,6 +258,8 @@ const dropCap = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 
@@ -262,6 +279,8 @@ const dropCapDark = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -336,6 +355,8 @@ const bylineLeftColumn = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 		case ArticleDesign.LiveBlog:
 			switch (format.theme) {
@@ -353,6 +374,8 @@ const bylineLeftColumn = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[300];
 			}
 		default:
 			switch (format.theme) {
@@ -370,6 +393,8 @@ const bylineLeftColumn = (format: ArticleFormat): Colour => {
 					return labs[400];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 	}
 };
@@ -448,6 +473,8 @@ const follow = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -474,6 +501,8 @@ const followDark = (format: ArticleFormat): Colour => {
 					return specialReport[500];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
 			}
 	}
 };
@@ -494,6 +523,8 @@ const bylineDark = (format: ArticleFormat): Colour => {
 			return specialReport[500];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -513,6 +544,8 @@ const linkDark = (format: ArticleFormat): Colour => {
 			return specialReport[500];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -535,6 +568,8 @@ const articleLink = (format: ArticleFormat): Colour => {
 					return specialReport[400];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 		case ArticleDesign.Gallery:
 			return neutral[86];
@@ -554,6 +589,8 @@ const articleLink = (format: ArticleFormat): Colour => {
 					return specialReport[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[300];
 			}
 	}
 };
@@ -574,6 +611,8 @@ const interactiveAtomLink = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+				return news[400];
 	}
 };
 
@@ -593,6 +632,8 @@ const keyEventsInline = ({ theme }: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -612,6 +653,8 @@ const keyEventsLeftColumn = ({ theme }: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -631,6 +674,8 @@ const mediaArticleSeries = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -679,6 +724,8 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+						return news[400];
 			}
 		case ArticleDesign.Gallery:
 			return neutral[86];
@@ -699,6 +746,8 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
 			}
 		default: {
 			switch (format.theme) {
@@ -716,6 +765,8 @@ const standfirstLink = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 		}
 	}
@@ -744,6 +795,8 @@ const standfirstLinkDark = (format: ArticleFormat): Colour => {
 					return labs[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[500];
 			}
 		default: {
 			return neutral[60];
@@ -861,6 +914,8 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 					return labs[400];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 			}
 
 		case ArticleDesign.LiveBlog:
@@ -879,6 +934,8 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 					return labs[400];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[600];
 			}
 	}
 	switch (format.theme) {
@@ -896,6 +953,8 @@ const seriesTitle = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -939,6 +998,8 @@ const richLink = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -974,6 +1035,8 @@ const seriesTitleDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 
@@ -993,6 +1056,8 @@ const pagination = (format: ArticleFormat): Colour => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+			case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1012,6 +1077,8 @@ const pullquote = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1031,6 +1098,8 @@ const pullquoteDark = (format: ArticleFormat): Colour => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[500];
+			case ArticleSpecial.SpecialReportAlt:
+			return news[500];
 	}
 };
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -67,7 +67,7 @@
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.11.1",
     "@guardian/discussion-rendering": "^10.3.0",
-    "@guardian/libs": "^7.1.0",
+    "@guardian/libs": "^9.0.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/support-dotcom-components": "^1.0.5",
     "@guardian/tsconfig": "^0.1.4",

--- a/dotcom-rendering/src/lib/pillars.ts
+++ b/dotcom-rendering/src/lib/pillars.ts
@@ -134,6 +134,16 @@ export const pillarPalette_DO_NOT_USE: Record<
 		500: specialReport[500],
 		800: specialReport[800],
 	},
+	[ArticleSpecial.SpecialReportAlt]: {
+		dark: specialReport[300],
+		main: specialReport[400],
+		bright: specialReport[500],
+		faded: specialReport[800],
+		300: specialReport[300],
+		400: specialReport[400],
+		500: specialReport[500],
+		800: specialReport[800],
+	},
 };
 
 /*
@@ -150,6 +160,7 @@ export const pillarMap: <T>(f: (name: ArticleTheme) => T) => {
 	[ArticlePillar.Lifestyle]: f(ArticlePillar.Lifestyle),
 	[ArticleSpecial.Labs]: f(ArticleSpecial.Labs),
 	[ArticleSpecial.SpecialReport]: f(ArticleSpecial.SpecialReport),
+	[ArticleSpecial.SpecialReportAlt]: f(ArticleSpecial.SpecialReportAlt),
 });
 /*
 Further notes on this function:

--- a/dotcom-rendering/src/lib/pillars.ts
+++ b/dotcom-rendering/src/lib/pillars.ts
@@ -10,6 +10,7 @@ import {
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
+import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 
 type ColourType = string;
 
@@ -48,11 +49,24 @@ type LabsPalette = {
 	800: ColourType;
 };
 
+type SpecialAltPalette = {
+	dark: ColourType;
+	main: ColourType;
+	bright: ColourType;
+	pastel: ColourType;
+	faded: ColourType;
+	100: ColourType;
+	200: ColourType;
+	300: ColourType;
+	700: ColourType;
+	800: ColourType;
+};
+
 // pillarPalette_DO_NOT_USE should no longer be used. Use palette from  decidePalette instead
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const pillarPalette_DO_NOT_USE: Record<
 	ArticleTheme,
-	PillarPalette | SpecialPalette | LabsPalette
+	PillarPalette | SpecialPalette | LabsPalette | SpecialAltPalette
 > = {
 	[ArticlePillar.News]: {
 		dark: news[300],
@@ -135,14 +149,16 @@ export const pillarPalette_DO_NOT_USE: Record<
 		800: specialReport[800],
 	},
 	[ArticleSpecial.SpecialReportAlt]: {
-		dark: specialReport[300],
-		main: specialReport[400],
-		bright: specialReport[500],
-		faded: specialReport[800],
-		300: specialReport[300],
-		400: specialReport[400],
-		500: specialReport[500],
-		800: specialReport[800],
+		dark: specialReportAlt[100],
+		main: specialReportAlt[200],
+		bright: specialReportAlt[300],
+		pastel: specialReportAlt[700],
+		faded: specialReportAlt[800],
+		100: specialReportAlt[100],
+		200: specialReportAlt[200],
+		300: specialReportAlt[300],
+		700: specialReportAlt[700],
+		800: specialReportAlt[800],
 	},
 };
 

--- a/dotcom-rendering/src/lib/pillars.ts
+++ b/dotcom-rendering/src/lib/pillars.ts
@@ -7,10 +7,10 @@ import {
 	lifestyle,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
-import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 
 type ColourType = string;
 
@@ -149,16 +149,16 @@ export const pillarPalette_DO_NOT_USE: Record<
 		800: specialReport[800],
 	},
 	[ArticleSpecial.SpecialReportAlt]: {
-		dark: specialReportAlt[100],
-		main: specialReportAlt[200],
-		bright: specialReportAlt[300],
-		pastel: specialReportAlt[700],
-		faded: specialReportAlt[800],
-		100: specialReportAlt[100],
-		200: specialReportAlt[200],
-		300: specialReportAlt[300],
-		700: specialReportAlt[700],
-		800: specialReportAlt[800],
+		dark: palette.specialReportAlt[100],
+		main: palette.specialReportAlt[200],
+		bright: palette.specialReportAlt[300],
+		pastel: palette.specialReportAlt[700],
+		faded: palette.specialReportAlt[800],
+		100: palette.specialReportAlt[100],
+		200: palette.specialReportAlt[200],
+		300: palette.specialReportAlt[300],
+		700: palette.specialReportAlt[700],
+		800: palette.specialReportAlt[800],
 	},
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -20,6 +20,7 @@ import {
 	sport,
 	text,
 } from '@guardian/source-foundations';
+import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../../lib/pillars';
 import type { DCRContainerPalette } from '../../types/front';
@@ -383,6 +384,8 @@ const textKeyEvent = (format: ArticleFormat): string => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 
@@ -545,9 +548,13 @@ const textCardKicker = (format: ArticleFormat): string => {
 				case ArticlePillar.Opinion:
 					return opinion[550];
 				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
 				case ArticlePillar.Culture:
-				default:
-					return pillarPalette[format.theme][500];
+					return culture[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[600];
 			}
 		default:
 			return pillarPalette[format.theme].main;
@@ -798,6 +805,8 @@ const backgroundStandfirst = (format: ArticleFormat): string => {
 					return news[200];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[200];
 			}
 		case ArticleDesign.DeadBlog:
 			switch (format.theme) {
@@ -1133,6 +1142,8 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 			switch (format.theme) {
 				case ArticleSpecial.SpecialReport:
 					return brandAlt[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[400];
 				case ArticlePillar.News:
 					return news[600];
 				case ArticlePillar.Sport:
@@ -1140,9 +1151,11 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 				case ArticlePillar.Opinion:
 					return opinion[550];
 				case ArticlePillar.Lifestyle:
+					return lifestyle[500];
 				case ArticlePillar.Culture:
-				default:
-					return pillarPalette[format.theme][500];
+					return culture[500];
+				case ArticleSpecial.Labs:
+					return labs[400];
 			}
 		default:
 			switch (format.theme) {
@@ -1213,6 +1226,8 @@ const textRichLink = (format: ArticleFormat): string => {
 			return BLACK;
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1238,8 +1253,9 @@ const borderRichLink: (format: ArticleFormat) => string = (format) => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
-	return pillarPalette[ArticlePillar.News][400];
 };
 
 const borderNavPillar: (format: ArticleFormat) => string = (format) =>
@@ -1306,6 +1322,8 @@ const fillRichLink = (format: ArticleFormat): string => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1418,7 +1436,24 @@ const backgroundHeadlineTag = (format: ArticleFormat): string =>
 	pillarPalette[format.theme].dark;
 
 const backgroundCarouselDot = (format: ArticleFormat): string => {
-	return pillarPalette[format.theme][400];
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticleSpecial.Labs:
+			return labs[400];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
 };
 
 const backgroundCarouselDotFocus = (format: ArticleFormat): string => {
@@ -1479,6 +1514,8 @@ const backgroundSummaryEventBullet = (format: ArticleFormat): string => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1498,6 +1535,8 @@ const backgroundTreat = (format: ArticleFormat): string => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 
@@ -1517,6 +1556,8 @@ const backgroundDesignTag = (format: ArticleFormat): string => {
 			return labs[300];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
 	}
 };
 
@@ -1536,6 +1577,8 @@ const hoverKeyEventLink = (format: ArticleFormat): string => {
 			return labs[400];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -1557,6 +1600,8 @@ const hoverSummaryEventBullet = (format: ArticleFormat): string => {
 			return labs[200];
 		case ArticleSpecial.SpecialReport:
 			return specialReport[200];
+		case ArticleSpecial.SpecialReportAlt:
+			return specialReportAlt[200];
 	}
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -16,7 +16,6 @@ import {
 	neutral,
 	news,
 	opinion,
-	palette,
 	specialReport,
 	sport,
 	text,
@@ -1621,7 +1620,7 @@ const hoverSummaryEventBullet = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[200];
 		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[200];
+			return news[200];
 	}
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -16,11 +16,11 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 	text,
 } from '@guardian/source-foundations';
-import { specialReportAlt } from '@guardian/source-foundations/dist/cjs/colour/palette';
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../../lib/pillars';
 import type { DCRContainerPalette } from '../../types/front';
@@ -1621,7 +1621,7 @@ const hoverSummaryEventBullet = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[200];
 		case ArticleSpecial.SpecialReportAlt:
-			return specialReportAlt[200];
+			return palette.specialReportAlt[200];
 	}
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1162,7 +1162,7 @@ const borderCardSupporting = (format: ArticleFormat): string => {
 				case ArticleSpecial.SpecialReport:
 					return brandAlt[400];
 				case ArticleSpecial.SpecialReportAlt:
-					return news[400];
+					return news[600];
 				case ArticlePillar.News:
 					return news[600];
 				case ArticlePillar.Sport:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -215,6 +215,8 @@ const textLastUpdated = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[600];
 		}
 	}
 	return BLACK;
@@ -319,6 +321,8 @@ const textArticleLink = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
 		}
 	}
 	if (format.design === ArticleDesign.Analysis) {
@@ -337,6 +341,8 @@ const textArticleLink = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[300];
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
@@ -452,6 +458,8 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[100];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
 		}
 	}
 	if (format.design === ArticleDesign.Analysis) {
@@ -470,6 +478,8 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[100];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[300];
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
@@ -765,6 +775,8 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[600];
 		}
 	}
 
@@ -930,6 +942,8 @@ const fillShareIcon = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
 		}
 	}
 	if (format.design === ArticleDesign.Analysis) {
@@ -948,6 +962,8 @@ const fillShareIcon = (format: ArticleFormat): string => {
 				return BLACK;
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[300];
 		}
 	}
 	if (
@@ -1043,6 +1059,8 @@ const borderLiveBlock = (format: ArticleFormat): string => {
 				return labs[400];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[400];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
 		}
 	}
 
@@ -1077,6 +1095,8 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[600];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)

--- a/dotcom-rendering/stories/generated/Layout.stories.tsx
+++ b/dotcom-rendering/stories/generated/Layout.stories.tsx
@@ -108,6 +108,19 @@ StandardStandardLabs.story = {
 	name: 'StandardDisplay StandardDesign Labs'
 };
 
+export const StandardStandardSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Standard"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardStandardSpecialReportAltTheme.story = {
+	name: 'StandardDisplay StandardDesign SpecialReportAltTheme'
+};
+
 export const StandardGalleryNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -197,6 +210,19 @@ export const StandardGalleryLabs = () => {
 };
 StandardGalleryLabs.story = {
 	name: 'StandardDisplay GalleryDesign Labs'
+};
+
+export const StandardGallerySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Gallery"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardGallerySpecialReportAltTheme.story = {
+	name: 'StandardDisplay GalleryDesign SpecialReportAltTheme'
 };
 
 export const StandardAudioNews = () => {
@@ -290,6 +316,19 @@ StandardAudioLabs.story = {
 	name: 'StandardDisplay AudioDesign Labs'
 };
 
+export const StandardAudioSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Audio"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardAudioSpecialReportAltTheme.story = {
+	name: 'StandardDisplay AudioDesign SpecialReportAltTheme'
+};
+
 export const StandardVideoNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -379,6 +418,19 @@ export const StandardVideoLabs = () => {
 };
 StandardVideoLabs.story = {
 	name: 'StandardDisplay VideoDesign Labs'
+};
+
+export const StandardVideoSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Video"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardVideoSpecialReportAltTheme.story = {
+	name: 'StandardDisplay VideoDesign SpecialReportAltTheme'
 };
 
 export const StandardReviewNews = () => {
@@ -472,6 +524,19 @@ StandardReviewLabs.story = {
 	name: 'StandardDisplay ReviewDesign Labs'
 };
 
+export const StandardReviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Review"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardReviewSpecialReportAltTheme.story = {
+	name: 'StandardDisplay ReviewDesign SpecialReportAltTheme'
+};
+
 export const StandardAnalysisNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -561,6 +626,19 @@ export const StandardAnalysisLabs = () => {
 };
 StandardAnalysisLabs.story = {
 	name: 'StandardDisplay AnalysisDesign Labs'
+};
+
+export const StandardAnalysisSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Analysis"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardAnalysisSpecialReportAltTheme.story = {
+	name: 'StandardDisplay AnalysisDesign SpecialReportAltTheme'
 };
 
 export const StandardExplainerNews = () => {
@@ -654,6 +732,19 @@ StandardExplainerLabs.story = {
 	name: 'StandardDisplay ExplainerDesign Labs'
 };
 
+export const StandardExplainerSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Explainer"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardExplainerSpecialReportAltTheme.story = {
+	name: 'StandardDisplay ExplainerDesign SpecialReportAltTheme'
+};
+
 export const StandardCommentNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -743,6 +834,19 @@ export const StandardCommentLabs = () => {
 };
 StandardCommentLabs.story = {
 	name: 'StandardDisplay CommentDesign Labs'
+};
+
+export const StandardCommentSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Comment"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardCommentSpecialReportAltTheme.story = {
+	name: 'StandardDisplay CommentDesign SpecialReportAltTheme'
 };
 
 export const StandardLetterNews = () => {
@@ -836,6 +940,19 @@ StandardLetterLabs.story = {
 	name: 'StandardDisplay LetterDesign Labs'
 };
 
+export const StandardLetterSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Letter"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardLetterSpecialReportAltTheme.story = {
+	name: 'StandardDisplay LetterDesign SpecialReportAltTheme'
+};
+
 export const StandardFeatureNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -925,6 +1042,19 @@ export const StandardFeatureLabs = () => {
 };
 StandardFeatureLabs.story = {
 	name: 'StandardDisplay FeatureDesign Labs'
+};
+
+export const StandardFeatureSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Feature"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardFeatureSpecialReportAltTheme.story = {
+	name: 'StandardDisplay FeatureDesign SpecialReportAltTheme'
 };
 
 export const StandardLiveBlogNews = () => {
@@ -1018,6 +1148,19 @@ StandardLiveBlogLabs.story = {
 	name: 'StandardDisplay LiveBlogDesign Labs'
 };
 
+export const StandardLiveBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="LiveBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardLiveBlogSpecialReportAltTheme.story = {
+	name: 'StandardDisplay LiveBlogDesign SpecialReportAltTheme'
+};
+
 export const StandardDeadBlogNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -1107,6 +1250,19 @@ export const StandardDeadBlogLabs = () => {
 };
 StandardDeadBlogLabs.story = {
 	name: 'StandardDisplay DeadBlogDesign Labs'
+};
+
+export const StandardDeadBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="DeadBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardDeadBlogSpecialReportAltTheme.story = {
+	name: 'StandardDisplay DeadBlogDesign SpecialReportAltTheme'
 };
 
 export const StandardRecipeNews = () => {
@@ -1200,6 +1356,19 @@ StandardRecipeLabs.story = {
 	name: 'StandardDisplay RecipeDesign Labs'
 };
 
+export const StandardRecipeSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Recipe"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardRecipeSpecialReportAltTheme.story = {
+	name: 'StandardDisplay RecipeDesign SpecialReportAltTheme'
+};
+
 export const StandardMatchReportNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -1289,6 +1458,19 @@ export const StandardMatchReportLabs = () => {
 };
 StandardMatchReportLabs.story = {
 	name: 'StandardDisplay MatchReportDesign Labs'
+};
+
+export const StandardMatchReportSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="MatchReport"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardMatchReportSpecialReportAltTheme.story = {
+	name: 'StandardDisplay MatchReportDesign SpecialReportAltTheme'
 };
 
 export const StandardInterviewNews = () => {
@@ -1382,6 +1564,19 @@ StandardInterviewLabs.story = {
 	name: 'StandardDisplay InterviewDesign Labs'
 };
 
+export const StandardInterviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Interview"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardInterviewSpecialReportAltTheme.story = {
+	name: 'StandardDisplay InterviewDesign SpecialReportAltTheme'
+};
+
 export const StandardEditorialNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -1471,6 +1666,19 @@ export const StandardEditorialLabs = () => {
 };
 StandardEditorialLabs.story = {
 	name: 'StandardDisplay EditorialDesign Labs'
+};
+
+export const StandardEditorialSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Editorial"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardEditorialSpecialReportAltTheme.story = {
+	name: 'StandardDisplay EditorialDesign SpecialReportAltTheme'
 };
 
 export const StandardQuizNews = () => {
@@ -1564,6 +1772,19 @@ StandardQuizLabs.story = {
 	name: 'StandardDisplay QuizDesign Labs'
 };
 
+export const StandardQuizSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Quiz"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardQuizSpecialReportAltTheme.story = {
+	name: 'StandardDisplay QuizDesign SpecialReportAltTheme'
+};
+
 export const StandardInteractiveNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -1653,6 +1874,19 @@ export const StandardInteractiveLabs = () => {
 };
 StandardInteractiveLabs.story = {
 	name: 'StandardDisplay InteractiveDesign Labs'
+};
+
+export const StandardInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Interactive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardInteractiveSpecialReportAltTheme.story = {
+	name: 'StandardDisplay InteractiveDesign SpecialReportAltTheme'
 };
 
 export const StandardPhotoEssayNews = () => {
@@ -1746,6 +1980,19 @@ StandardPhotoEssayLabs.story = {
 	name: 'StandardDisplay PhotoEssayDesign Labs'
 };
 
+export const StandardPhotoEssaySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="PhotoEssay"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardPhotoEssaySpecialReportAltTheme.story = {
+	name: 'StandardDisplay PhotoEssayDesign SpecialReportAltTheme'
+};
+
 export const StandardPrintShopNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -1835,6 +2082,19 @@ export const StandardPrintShopLabs = () => {
 };
 StandardPrintShopLabs.story = {
 	name: 'StandardDisplay PrintShopDesign Labs'
+};
+
+export const StandardPrintShopSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="PrintShop"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardPrintShopSpecialReportAltTheme.story = {
+	name: 'StandardDisplay PrintShopDesign SpecialReportAltTheme'
 };
 
 export const StandardObituaryNews = () => {
@@ -1928,6 +2188,19 @@ StandardObituaryLabs.story = {
 	name: 'StandardDisplay ObituaryDesign Labs'
 };
 
+export const StandardObituarySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Obituary"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardObituarySpecialReportAltTheme.story = {
+	name: 'StandardDisplay ObituaryDesign SpecialReportAltTheme'
+};
+
 export const StandardCorrectionNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2017,6 +2290,19 @@ export const StandardCorrectionLabs = () => {
 };
 StandardCorrectionLabs.story = {
 	name: 'StandardDisplay CorrectionDesign Labs'
+};
+
+export const StandardCorrectionSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="Correction"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardCorrectionSpecialReportAltTheme.story = {
+	name: 'StandardDisplay CorrectionDesign SpecialReportAltTheme'
 };
 
 export const StandardFullPageInteractiveNews = () => {
@@ -2110,6 +2396,19 @@ StandardFullPageInteractiveLabs.story = {
 	name: 'StandardDisplay FullPageInteractiveDesign Labs'
 };
 
+export const StandardFullPageInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="FullPageInteractive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardFullPageInteractiveSpecialReportAltTheme.story = {
+	name: 'StandardDisplay FullPageInteractiveDesign SpecialReportAltTheme'
+};
+
 export const StandardNewsletterSignupNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2199,6 +2498,19 @@ export const StandardNewsletterSignupLabs = () => {
 };
 StandardNewsletterSignupLabs.story = {
 	name: 'StandardDisplay NewsletterSignupDesign Labs'
+};
+
+export const StandardNewsletterSignupSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Standard"
+			designName="NewsletterSignup"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+StandardNewsletterSignupSpecialReportAltTheme.story = {
+	name: 'StandardDisplay NewsletterSignupDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveStandardNews = () => {
@@ -2292,6 +2604,19 @@ ImmersiveStandardLabs.story = {
 	name: 'ImmersiveDisplay StandardDesign Labs'
 };
 
+export const ImmersiveStandardSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Standard"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveStandardSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay StandardDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveGalleryNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2381,6 +2706,19 @@ export const ImmersiveGalleryLabs = () => {
 };
 ImmersiveGalleryLabs.story = {
 	name: 'ImmersiveDisplay GalleryDesign Labs'
+};
+
+export const ImmersiveGallerySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Gallery"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveGallerySpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay GalleryDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveAudioNews = () => {
@@ -2474,6 +2812,19 @@ ImmersiveAudioLabs.story = {
 	name: 'ImmersiveDisplay AudioDesign Labs'
 };
 
+export const ImmersiveAudioSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Audio"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveAudioSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay AudioDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveVideoNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2563,6 +2914,19 @@ export const ImmersiveVideoLabs = () => {
 };
 ImmersiveVideoLabs.story = {
 	name: 'ImmersiveDisplay VideoDesign Labs'
+};
+
+export const ImmersiveVideoSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Video"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveVideoSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay VideoDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveReviewNews = () => {
@@ -2656,6 +3020,19 @@ ImmersiveReviewLabs.story = {
 	name: 'ImmersiveDisplay ReviewDesign Labs'
 };
 
+export const ImmersiveReviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Review"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveReviewSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay ReviewDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveAnalysisNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2745,6 +3122,19 @@ export const ImmersiveAnalysisLabs = () => {
 };
 ImmersiveAnalysisLabs.story = {
 	name: 'ImmersiveDisplay AnalysisDesign Labs'
+};
+
+export const ImmersiveAnalysisSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Analysis"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveAnalysisSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay AnalysisDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveExplainerNews = () => {
@@ -2838,6 +3228,19 @@ ImmersiveExplainerLabs.story = {
 	name: 'ImmersiveDisplay ExplainerDesign Labs'
 };
 
+export const ImmersiveExplainerSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Explainer"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveExplainerSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay ExplainerDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveCommentNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -2927,6 +3330,19 @@ export const ImmersiveCommentLabs = () => {
 };
 ImmersiveCommentLabs.story = {
 	name: 'ImmersiveDisplay CommentDesign Labs'
+};
+
+export const ImmersiveCommentSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Comment"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveCommentSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay CommentDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveLetterNews = () => {
@@ -3020,6 +3436,19 @@ ImmersiveLetterLabs.story = {
 	name: 'ImmersiveDisplay LetterDesign Labs'
 };
 
+export const ImmersiveLetterSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Letter"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveLetterSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay LetterDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveFeatureNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -3109,6 +3538,19 @@ export const ImmersiveFeatureLabs = () => {
 };
 ImmersiveFeatureLabs.story = {
 	name: 'ImmersiveDisplay FeatureDesign Labs'
+};
+
+export const ImmersiveFeatureSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Feature"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveFeatureSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay FeatureDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveLiveBlogNews = () => {
@@ -3202,6 +3644,19 @@ ImmersiveLiveBlogLabs.story = {
 	name: 'ImmersiveDisplay LiveBlogDesign Labs'
 };
 
+export const ImmersiveLiveBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="LiveBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveLiveBlogSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay LiveBlogDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveDeadBlogNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -3291,6 +3746,19 @@ export const ImmersiveDeadBlogLabs = () => {
 };
 ImmersiveDeadBlogLabs.story = {
 	name: 'ImmersiveDisplay DeadBlogDesign Labs'
+};
+
+export const ImmersiveDeadBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="DeadBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveDeadBlogSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay DeadBlogDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveRecipeNews = () => {
@@ -3384,6 +3852,19 @@ ImmersiveRecipeLabs.story = {
 	name: 'ImmersiveDisplay RecipeDesign Labs'
 };
 
+export const ImmersiveRecipeSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Recipe"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveRecipeSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay RecipeDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveMatchReportNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -3473,6 +3954,19 @@ export const ImmersiveMatchReportLabs = () => {
 };
 ImmersiveMatchReportLabs.story = {
 	name: 'ImmersiveDisplay MatchReportDesign Labs'
+};
+
+export const ImmersiveMatchReportSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="MatchReport"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveMatchReportSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay MatchReportDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveInterviewNews = () => {
@@ -3566,6 +4060,19 @@ ImmersiveInterviewLabs.story = {
 	name: 'ImmersiveDisplay InterviewDesign Labs'
 };
 
+export const ImmersiveInterviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Interview"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveInterviewSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay InterviewDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveEditorialNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -3655,6 +4162,19 @@ export const ImmersiveEditorialLabs = () => {
 };
 ImmersiveEditorialLabs.story = {
 	name: 'ImmersiveDisplay EditorialDesign Labs'
+};
+
+export const ImmersiveEditorialSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Editorial"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveEditorialSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay EditorialDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveQuizNews = () => {
@@ -3748,6 +4268,19 @@ ImmersiveQuizLabs.story = {
 	name: 'ImmersiveDisplay QuizDesign Labs'
 };
 
+export const ImmersiveQuizSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Quiz"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveQuizSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay QuizDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveInteractiveNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -3837,6 +4370,19 @@ export const ImmersiveInteractiveLabs = () => {
 };
 ImmersiveInteractiveLabs.story = {
 	name: 'ImmersiveDisplay InteractiveDesign Labs'
+};
+
+export const ImmersiveInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Interactive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveInteractiveSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay InteractiveDesign SpecialReportAltTheme'
 };
 
 export const ImmersivePhotoEssayNews = () => {
@@ -3930,6 +4476,19 @@ ImmersivePhotoEssayLabs.story = {
 	name: 'ImmersiveDisplay PhotoEssayDesign Labs'
 };
 
+export const ImmersivePhotoEssaySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="PhotoEssay"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersivePhotoEssaySpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay PhotoEssayDesign SpecialReportAltTheme'
+};
+
 export const ImmersivePrintShopNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4019,6 +4578,19 @@ export const ImmersivePrintShopLabs = () => {
 };
 ImmersivePrintShopLabs.story = {
 	name: 'ImmersiveDisplay PrintShopDesign Labs'
+};
+
+export const ImmersivePrintShopSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="PrintShop"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersivePrintShopSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay PrintShopDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveObituaryNews = () => {
@@ -4112,6 +4684,19 @@ ImmersiveObituaryLabs.story = {
 	name: 'ImmersiveDisplay ObituaryDesign Labs'
 };
 
+export const ImmersiveObituarySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Obituary"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveObituarySpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay ObituaryDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveCorrectionNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4201,6 +4786,19 @@ export const ImmersiveCorrectionLabs = () => {
 };
 ImmersiveCorrectionLabs.story = {
 	name: 'ImmersiveDisplay CorrectionDesign Labs'
+};
+
+export const ImmersiveCorrectionSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="Correction"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveCorrectionSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay CorrectionDesign SpecialReportAltTheme'
 };
 
 export const ImmersiveFullPageInteractiveNews = () => {
@@ -4294,6 +4892,19 @@ ImmersiveFullPageInteractiveLabs.story = {
 	name: 'ImmersiveDisplay FullPageInteractiveDesign Labs'
 };
 
+export const ImmersiveFullPageInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="FullPageInteractive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveFullPageInteractiveSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay FullPageInteractiveDesign SpecialReportAltTheme'
+};
+
 export const ImmersiveNewsletterSignupNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4383,6 +4994,19 @@ export const ImmersiveNewsletterSignupLabs = () => {
 };
 ImmersiveNewsletterSignupLabs.story = {
 	name: 'ImmersiveDisplay NewsletterSignupDesign Labs'
+};
+
+export const ImmersiveNewsletterSignupSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Immersive"
+			designName="NewsletterSignup"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ImmersiveNewsletterSignupSpecialReportAltTheme.story = {
+	name: 'ImmersiveDisplay NewsletterSignupDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseStandardNews = () => {
@@ -4476,6 +5100,19 @@ ShowcaseStandardLabs.story = {
 	name: 'ShowcaseDisplay StandardDesign Labs'
 };
 
+export const ShowcaseStandardSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Standard"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseStandardSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay StandardDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseGalleryNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4565,6 +5202,19 @@ export const ShowcaseGalleryLabs = () => {
 };
 ShowcaseGalleryLabs.story = {
 	name: 'ShowcaseDisplay GalleryDesign Labs'
+};
+
+export const ShowcaseGallerySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Gallery"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseGallerySpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay GalleryDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseAudioNews = () => {
@@ -4658,6 +5308,19 @@ ShowcaseAudioLabs.story = {
 	name: 'ShowcaseDisplay AudioDesign Labs'
 };
 
+export const ShowcaseAudioSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Audio"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseAudioSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay AudioDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseVideoNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4747,6 +5410,19 @@ export const ShowcaseVideoLabs = () => {
 };
 ShowcaseVideoLabs.story = {
 	name: 'ShowcaseDisplay VideoDesign Labs'
+};
+
+export const ShowcaseVideoSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Video"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseVideoSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay VideoDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseReviewNews = () => {
@@ -4840,6 +5516,19 @@ ShowcaseReviewLabs.story = {
 	name: 'ShowcaseDisplay ReviewDesign Labs'
 };
 
+export const ShowcaseReviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Review"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseReviewSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay ReviewDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseAnalysisNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -4929,6 +5618,19 @@ export const ShowcaseAnalysisLabs = () => {
 };
 ShowcaseAnalysisLabs.story = {
 	name: 'ShowcaseDisplay AnalysisDesign Labs'
+};
+
+export const ShowcaseAnalysisSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Analysis"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseAnalysisSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay AnalysisDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseExplainerNews = () => {
@@ -5022,6 +5724,19 @@ ShowcaseExplainerLabs.story = {
 	name: 'ShowcaseDisplay ExplainerDesign Labs'
 };
 
+export const ShowcaseExplainerSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Explainer"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseExplainerSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay ExplainerDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseCommentNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -5111,6 +5826,19 @@ export const ShowcaseCommentLabs = () => {
 };
 ShowcaseCommentLabs.story = {
 	name: 'ShowcaseDisplay CommentDesign Labs'
+};
+
+export const ShowcaseCommentSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Comment"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseCommentSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay CommentDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseLetterNews = () => {
@@ -5204,6 +5932,19 @@ ShowcaseLetterLabs.story = {
 	name: 'ShowcaseDisplay LetterDesign Labs'
 };
 
+export const ShowcaseLetterSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Letter"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseLetterSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay LetterDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseFeatureNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -5293,6 +6034,19 @@ export const ShowcaseFeatureLabs = () => {
 };
 ShowcaseFeatureLabs.story = {
 	name: 'ShowcaseDisplay FeatureDesign Labs'
+};
+
+export const ShowcaseFeatureSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Feature"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseFeatureSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay FeatureDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseLiveBlogNews = () => {
@@ -5386,6 +6140,19 @@ ShowcaseLiveBlogLabs.story = {
 	name: 'ShowcaseDisplay LiveBlogDesign Labs'
 };
 
+export const ShowcaseLiveBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="LiveBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseLiveBlogSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay LiveBlogDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseDeadBlogNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -5475,6 +6242,19 @@ export const ShowcaseDeadBlogLabs = () => {
 };
 ShowcaseDeadBlogLabs.story = {
 	name: 'ShowcaseDisplay DeadBlogDesign Labs'
+};
+
+export const ShowcaseDeadBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="DeadBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseDeadBlogSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay DeadBlogDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseRecipeNews = () => {
@@ -5568,6 +6348,19 @@ ShowcaseRecipeLabs.story = {
 	name: 'ShowcaseDisplay RecipeDesign Labs'
 };
 
+export const ShowcaseRecipeSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Recipe"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseRecipeSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay RecipeDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseMatchReportNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -5657,6 +6450,19 @@ export const ShowcaseMatchReportLabs = () => {
 };
 ShowcaseMatchReportLabs.story = {
 	name: 'ShowcaseDisplay MatchReportDesign Labs'
+};
+
+export const ShowcaseMatchReportSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="MatchReport"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseMatchReportSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay MatchReportDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseInterviewNews = () => {
@@ -5750,6 +6556,19 @@ ShowcaseInterviewLabs.story = {
 	name: 'ShowcaseDisplay InterviewDesign Labs'
 };
 
+export const ShowcaseInterviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Interview"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseInterviewSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay InterviewDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseEditorialNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -5839,6 +6658,19 @@ export const ShowcaseEditorialLabs = () => {
 };
 ShowcaseEditorialLabs.story = {
 	name: 'ShowcaseDisplay EditorialDesign Labs'
+};
+
+export const ShowcaseEditorialSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Editorial"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseEditorialSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay EditorialDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseQuizNews = () => {
@@ -5932,6 +6764,19 @@ ShowcaseQuizLabs.story = {
 	name: 'ShowcaseDisplay QuizDesign Labs'
 };
 
+export const ShowcaseQuizSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Quiz"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseQuizSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay QuizDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseInteractiveNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6021,6 +6866,19 @@ export const ShowcaseInteractiveLabs = () => {
 };
 ShowcaseInteractiveLabs.story = {
 	name: 'ShowcaseDisplay InteractiveDesign Labs'
+};
+
+export const ShowcaseInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Interactive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseInteractiveSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay InteractiveDesign SpecialReportAltTheme'
 };
 
 export const ShowcasePhotoEssayNews = () => {
@@ -6114,6 +6972,19 @@ ShowcasePhotoEssayLabs.story = {
 	name: 'ShowcaseDisplay PhotoEssayDesign Labs'
 };
 
+export const ShowcasePhotoEssaySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="PhotoEssay"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcasePhotoEssaySpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay PhotoEssayDesign SpecialReportAltTheme'
+};
+
 export const ShowcasePrintShopNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6203,6 +7074,19 @@ export const ShowcasePrintShopLabs = () => {
 };
 ShowcasePrintShopLabs.story = {
 	name: 'ShowcaseDisplay PrintShopDesign Labs'
+};
+
+export const ShowcasePrintShopSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="PrintShop"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcasePrintShopSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay PrintShopDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseObituaryNews = () => {
@@ -6296,6 +7180,19 @@ ShowcaseObituaryLabs.story = {
 	name: 'ShowcaseDisplay ObituaryDesign Labs'
 };
 
+export const ShowcaseObituarySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Obituary"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseObituarySpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay ObituaryDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseCorrectionNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6385,6 +7282,19 @@ export const ShowcaseCorrectionLabs = () => {
 };
 ShowcaseCorrectionLabs.story = {
 	name: 'ShowcaseDisplay CorrectionDesign Labs'
+};
+
+export const ShowcaseCorrectionSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="Correction"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseCorrectionSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay CorrectionDesign SpecialReportAltTheme'
 };
 
 export const ShowcaseFullPageInteractiveNews = () => {
@@ -6478,6 +7388,19 @@ ShowcaseFullPageInteractiveLabs.story = {
 	name: 'ShowcaseDisplay FullPageInteractiveDesign Labs'
 };
 
+export const ShowcaseFullPageInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="FullPageInteractive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseFullPageInteractiveSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay FullPageInteractiveDesign SpecialReportAltTheme'
+};
+
 export const ShowcaseNewsletterSignupNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6567,6 +7490,19 @@ export const ShowcaseNewsletterSignupLabs = () => {
 };
 ShowcaseNewsletterSignupLabs.story = {
 	name: 'ShowcaseDisplay NewsletterSignupDesign Labs'
+};
+
+export const ShowcaseNewsletterSignupSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="Showcase"
+			designName="NewsletterSignup"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+ShowcaseNewsletterSignupSpecialReportAltTheme.story = {
+	name: 'ShowcaseDisplay NewsletterSignupDesign SpecialReportAltTheme'
 };
 
 export const NumberedListStandardNews = () => {
@@ -6660,6 +7596,19 @@ NumberedListStandardLabs.story = {
 	name: 'NumberedListDisplay StandardDesign Labs'
 };
 
+export const NumberedListStandardSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Standard"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListStandardSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay StandardDesign SpecialReportAltTheme'
+};
+
 export const NumberedListGalleryNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6749,6 +7698,19 @@ export const NumberedListGalleryLabs = () => {
 };
 NumberedListGalleryLabs.story = {
 	name: 'NumberedListDisplay GalleryDesign Labs'
+};
+
+export const NumberedListGallerySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Gallery"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListGallerySpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay GalleryDesign SpecialReportAltTheme'
 };
 
 export const NumberedListAudioNews = () => {
@@ -6842,6 +7804,19 @@ NumberedListAudioLabs.story = {
 	name: 'NumberedListDisplay AudioDesign Labs'
 };
 
+export const NumberedListAudioSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Audio"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListAudioSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay AudioDesign SpecialReportAltTheme'
+};
+
 export const NumberedListVideoNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -6931,6 +7906,19 @@ export const NumberedListVideoLabs = () => {
 };
 NumberedListVideoLabs.story = {
 	name: 'NumberedListDisplay VideoDesign Labs'
+};
+
+export const NumberedListVideoSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Video"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListVideoSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay VideoDesign SpecialReportAltTheme'
 };
 
 export const NumberedListReviewNews = () => {
@@ -7024,6 +8012,19 @@ NumberedListReviewLabs.story = {
 	name: 'NumberedListDisplay ReviewDesign Labs'
 };
 
+export const NumberedListReviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Review"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListReviewSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay ReviewDesign SpecialReportAltTheme'
+};
+
 export const NumberedListAnalysisNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -7113,6 +8114,19 @@ export const NumberedListAnalysisLabs = () => {
 };
 NumberedListAnalysisLabs.story = {
 	name: 'NumberedListDisplay AnalysisDesign Labs'
+};
+
+export const NumberedListAnalysisSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Analysis"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListAnalysisSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay AnalysisDesign SpecialReportAltTheme'
 };
 
 export const NumberedListExplainerNews = () => {
@@ -7206,6 +8220,19 @@ NumberedListExplainerLabs.story = {
 	name: 'NumberedListDisplay ExplainerDesign Labs'
 };
 
+export const NumberedListExplainerSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Explainer"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListExplainerSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay ExplainerDesign SpecialReportAltTheme'
+};
+
 export const NumberedListCommentNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -7295,6 +8322,19 @@ export const NumberedListCommentLabs = () => {
 };
 NumberedListCommentLabs.story = {
 	name: 'NumberedListDisplay CommentDesign Labs'
+};
+
+export const NumberedListCommentSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Comment"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListCommentSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay CommentDesign SpecialReportAltTheme'
 };
 
 export const NumberedListLetterNews = () => {
@@ -7388,6 +8428,19 @@ NumberedListLetterLabs.story = {
 	name: 'NumberedListDisplay LetterDesign Labs'
 };
 
+export const NumberedListLetterSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Letter"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListLetterSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay LetterDesign SpecialReportAltTheme'
+};
+
 export const NumberedListFeatureNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -7477,6 +8530,19 @@ export const NumberedListFeatureLabs = () => {
 };
 NumberedListFeatureLabs.story = {
 	name: 'NumberedListDisplay FeatureDesign Labs'
+};
+
+export const NumberedListFeatureSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Feature"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListFeatureSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay FeatureDesign SpecialReportAltTheme'
 };
 
 export const NumberedListLiveBlogNews = () => {
@@ -7570,6 +8636,19 @@ NumberedListLiveBlogLabs.story = {
 	name: 'NumberedListDisplay LiveBlogDesign Labs'
 };
 
+export const NumberedListLiveBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="LiveBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListLiveBlogSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay LiveBlogDesign SpecialReportAltTheme'
+};
+
 export const NumberedListDeadBlogNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -7659,6 +8738,19 @@ export const NumberedListDeadBlogLabs = () => {
 };
 NumberedListDeadBlogLabs.story = {
 	name: 'NumberedListDisplay DeadBlogDesign Labs'
+};
+
+export const NumberedListDeadBlogSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="DeadBlog"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListDeadBlogSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay DeadBlogDesign SpecialReportAltTheme'
 };
 
 export const NumberedListRecipeNews = () => {
@@ -7752,6 +8844,19 @@ NumberedListRecipeLabs.story = {
 	name: 'NumberedListDisplay RecipeDesign Labs'
 };
 
+export const NumberedListRecipeSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Recipe"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListRecipeSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay RecipeDesign SpecialReportAltTheme'
+};
+
 export const NumberedListMatchReportNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -7841,6 +8946,19 @@ export const NumberedListMatchReportLabs = () => {
 };
 NumberedListMatchReportLabs.story = {
 	name: 'NumberedListDisplay MatchReportDesign Labs'
+};
+
+export const NumberedListMatchReportSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="MatchReport"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListMatchReportSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay MatchReportDesign SpecialReportAltTheme'
 };
 
 export const NumberedListInterviewNews = () => {
@@ -7934,6 +9052,19 @@ NumberedListInterviewLabs.story = {
 	name: 'NumberedListDisplay InterviewDesign Labs'
 };
 
+export const NumberedListInterviewSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Interview"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListInterviewSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay InterviewDesign SpecialReportAltTheme'
+};
+
 export const NumberedListEditorialNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -8023,6 +9154,19 @@ export const NumberedListEditorialLabs = () => {
 };
 NumberedListEditorialLabs.story = {
 	name: 'NumberedListDisplay EditorialDesign Labs'
+};
+
+export const NumberedListEditorialSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Editorial"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListEditorialSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay EditorialDesign SpecialReportAltTheme'
 };
 
 export const NumberedListQuizNews = () => {
@@ -8116,6 +9260,19 @@ NumberedListQuizLabs.story = {
 	name: 'NumberedListDisplay QuizDesign Labs'
 };
 
+export const NumberedListQuizSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Quiz"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListQuizSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay QuizDesign SpecialReportAltTheme'
+};
+
 export const NumberedListInteractiveNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -8205,6 +9362,19 @@ export const NumberedListInteractiveLabs = () => {
 };
 NumberedListInteractiveLabs.story = {
 	name: 'NumberedListDisplay InteractiveDesign Labs'
+};
+
+export const NumberedListInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Interactive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListInteractiveSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay InteractiveDesign SpecialReportAltTheme'
 };
 
 export const NumberedListPhotoEssayNews = () => {
@@ -8298,6 +9468,19 @@ NumberedListPhotoEssayLabs.story = {
 	name: 'NumberedListDisplay PhotoEssayDesign Labs'
 };
 
+export const NumberedListPhotoEssaySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="PhotoEssay"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListPhotoEssaySpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay PhotoEssayDesign SpecialReportAltTheme'
+};
+
 export const NumberedListPrintShopNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -8387,6 +9570,19 @@ export const NumberedListPrintShopLabs = () => {
 };
 NumberedListPrintShopLabs.story = {
 	name: 'NumberedListDisplay PrintShopDesign Labs'
+};
+
+export const NumberedListPrintShopSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="PrintShop"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListPrintShopSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay PrintShopDesign SpecialReportAltTheme'
 };
 
 export const NumberedListObituaryNews = () => {
@@ -8480,6 +9676,19 @@ NumberedListObituaryLabs.story = {
 	name: 'NumberedListDisplay ObituaryDesign Labs'
 };
 
+export const NumberedListObituarySpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Obituary"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListObituarySpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay ObituaryDesign SpecialReportAltTheme'
+};
+
 export const NumberedListCorrectionNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -8569,6 +9778,19 @@ export const NumberedListCorrectionLabs = () => {
 };
 NumberedListCorrectionLabs.story = {
 	name: 'NumberedListDisplay CorrectionDesign Labs'
+};
+
+export const NumberedListCorrectionSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="Correction"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListCorrectionSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay CorrectionDesign SpecialReportAltTheme'
 };
 
 export const NumberedListFullPageInteractiveNews = () => {
@@ -8662,6 +9884,19 @@ NumberedListFullPageInteractiveLabs.story = {
 	name: 'NumberedListDisplay FullPageInteractiveDesign Labs'
 };
 
+export const NumberedListFullPageInteractiveSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="FullPageInteractive"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListFullPageInteractiveSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay FullPageInteractiveDesign SpecialReportAltTheme'
+};
+
 export const NumberedListNewsletterSignupNews = () => {
 	return (
 		<HydratedLayoutWrapper
@@ -8751,4 +9986,17 @@ export const NumberedListNewsletterSignupLabs = () => {
 };
 NumberedListNewsletterSignupLabs.story = {
 	name: 'NumberedListDisplay NewsletterSignupDesign Labs'
+};
+
+export const NumberedListNewsletterSignupSpecialReportAltTheme = () => {
+	return (
+		<HydratedLayoutWrapper
+			displayName="NumberedList"
+			designName="NewsletterSignup"
+			theme="SpecialReportAltTheme"
+		/>
+	);
+};
+NumberedListNewsletterSignupSpecialReportAltTheme.story = {
+	name: 'NumberedListDisplay NewsletterSignupDesign SpecialReportAltTheme'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,6 +2869,11 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
+"@guardian/libs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+
 "@guardian/libs@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,9 +2394,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.18.3":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
-  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2878,6 +2878,11 @@
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
   integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+
+"@guardian/libs@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
+  integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
 
 "@guardian/prettier@^1.0.0":
   version "1.0.0"
@@ -4924,9 +4929,9 @@
     "@babel/types" "^7.3.0"
 
 "@types/babel__traverse@^7.0.4":
-  version "7.18.1"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.1.tgz#ce5e2c8c272b99b7a9fd69fa39f0b4cd85028bd9"
-  integrity sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.2.tgz#235bf339d17185bdec25e024ca19cce257cc7309"
+  integrity sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -5311,9 +5316,9 @@
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
 "@types/prettier@^2.0.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
-  integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
+  integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
 
 "@types/pretty-hrtime@^1.0.0":
   version "1.0.1"
@@ -18673,7 +18678,14 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@7.x:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,10 +2869,10 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
-  integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
+"@guardian/libs@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"
+  integrity sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw==
 
 "@guardian/prettier@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,16 +2869,6 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.0.tgz#1c80905e29df158d09f4681ec13f37fdbcbbe5f2"
-  integrity sha512-GTFY5sFyKov2HZFdWEKhnWB1IjBFiFhtzJdG2BlFcRBeRo/8DlBvOMjURY+hnoIdgEo1f3A+hHUBdqLsRP5Uig==
-
-"@guardian/libs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
-
 "@guardian/libs@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

* Bumps `@guardian/libs@9.0.1` in DCR and AR
* Handles the new format in switch statements. For the scope of this PR (upgrading the library) we agreed with @HarryFischer to use `news` pillar colours for `SpecialReportAlt` format. Other PRs are in progress to use the correct styles for articles and cards, e.g. https://github.com/guardian/dotcom-rendering/pull/6201
* Adds the new stories generated by `gen-stories` in article layouts format variation and cards format variations.

## Why?
We need the new `@guardian/libs` version in order to style the `SpecialReportAlt` articles and cards in DCR and AR.
