### PR TITLE
Remove overflow:hidden from bylineLarge avatars on Opinion pages

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -213,7 +213,6 @@ const minHeightWithAvatar = css`
 const avatarPositionStyles = css`
 	display: flex;
 	justify-content: flex-end;
-	overflow: hidden;
 	position: relative;
 	margin-bottom: -29px;
 	margin-top: -50px;

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -217,6 +217,9 @@ const avatarPositionStyles = css`
 	margin-bottom: -29px;
 	margin-top: -50px;
 	pointer-events: none;
+	${until.tablet} {
+		overflow: hidden;
+	}
 
 	/*  Why target img element?
 


### PR DESCRIPTION
Co-authored by @HarryFischer.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This ensures higly templated and predictable Large Byline pictures at the top of Comment pieces have no cut off shoulders. This is also for parity with frontend. Also, @HarryFischer says 👍.
## Why?
Cut off shoulders are worse than intact shoulders.
## Screenshots

![sdfsdfsdfsdf](https://user-images.githubusercontent.com/6032869/195371776-3259fe01-e891-4e9d-b0ea-9f726b26f30b.gif)

I have not tested it in any way, apsrt from that GIF above.