### PR TITLE
remove feature switch for newsletter signup layout

### DIFF
--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -118,19 +118,8 @@ export const DecideLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						/>
 					);
 				case ArticleDesign.NewsletterSignup:
-					// eslint and prettier have an argument if I use the switch directly in the ternary operator
-					// This is a compromise where eslint gives me a warning over an error
-					const showSignupLayout =
-						CAPIArticle.config.switches.newsletterSignupLayout;
-
-					return showSignupLayout ? (
+					return (
 						<NewsletterSignupLayout
-							CAPIArticle={CAPIArticle}
-							NAV={NAV}
-							format={format}
-						/>
-					) : (
-						<StandardLayout
 							CAPIArticle={CAPIArticle}
 							NAV={NAV}
 							format={format}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes feature switch logic to determine whether to use the new `NewsletterSignupLayout` or not

## Why?

We're happy with the new `NewsletterSignupLayout` so can turn this feature on properly now
