### PR TITLE
Fix Sentry tag

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -1,7 +1,10 @@
 import * as Sentry from '@sentry/browser';
 import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
-import { BUILD_VARIANT } from '../../../../scripts/webpack/bundles';
+import {
+	BUILD_VARIANT,
+	dcrJavascriptBundle,
+} from '../../../../scripts/webpack/bundles';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,
@@ -52,12 +55,11 @@ Sentry.init({
 	},
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- dcrJsBundleVariant could also be `undefined`
-if (BUILD_VARIANT && !!window.guardian.config.tests.dcrJsBundleVariant) {
-	Sentry.setTag(
-		'dcr.bundle',
-		window.guardian.config.tests.dcrJsBundleVariant,
-	);
+if (
+	BUILD_VARIANT &&
+	window.guardian.config.tests[dcrJavascriptBundle('Variant')] === 'variant'
+) {
+	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
 export const reportError = (error: Error, feature?: string): void => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the Sentry tag used for the dcr-javascript-bundle test

## Why?

Forgot to update it in #6168