### PR TITLE
Shady pie test updates

### DIFF
--- a/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
@@ -1,12 +1,12 @@
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+//import type { ArticleFormat } from '@guardian/libs';
+//import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { ShadyPie } from './ShadyPie';
 
-const labsFormat: ArticleFormat = {
+/*const labsFormat: ArticleFormat = {
 	theme: ArticlePillar.Lifestyle,
 	design: ArticleDesign.Standard,
 	display: ArticleDisplay.Standard,
-};
+};*/
 
 export default {
 	component: ShadyPie,
@@ -24,7 +24,8 @@ Default.story = {
 	name: 'Default',
 };
 
-export const UKLabs = () => {
+//commenting out these components as we update the logic around shady pie for the ab test
+/*export const UKLabs = () => {
 	return (
 		<div style={{ width: '300px' }}>
 			<ShadyPie format={labsFormat} editionId={'UK'} />
@@ -45,3 +46,4 @@ export const USLabs = () => {
 USLabs.story = {
 	name: 'US Labs',
 };
+*/

--- a/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.stories.tsx
@@ -1,12 +1,4 @@
-//import type { ArticleFormat } from '@guardian/libs';
-//import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { ShadyPie } from './ShadyPie';
-
-/*const labsFormat: ArticleFormat = {
-	theme: ArticlePillar.Lifestyle,
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-};*/
 
 export default {
 	component: ShadyPie,
@@ -23,27 +15,3 @@ export const Default = () => {
 Default.story = {
 	name: 'Default',
 };
-
-//commenting out these components as we update the logic around shady pie for the ab test
-/*export const UKLabs = () => {
-	return (
-		<div style={{ width: '300px' }}>
-			<ShadyPie format={labsFormat} editionId={'UK'} />
-		</div>
-	);
-};
-UKLabs.story = {
-	name: 'UK Labs',
-};
-
-export const USLabs = () => {
-	return (
-		<div style={{ width: '300px' }}>
-			<ShadyPie format={labsFormat} editionId={'US'} />
-		</div>
-	);
-};
-USLabs.story = {
-	name: 'US Labs',
-};
-*/

--- a/dotcom-rendering/src/web/components/ShadyPie.tsx
+++ b/dotcom-rendering/src/web/components/ShadyPie.tsx
@@ -23,10 +23,12 @@ export const ShadyPie = ({
 	format?: ArticleFormat;
 	abTest?: boolean;
 }) => {
-	const queryString = abTest
-		? 'utm_source=shady-pie-variant'
-		: 'utm_source=shady-pie';
-	if (format?.theme == ArticlePillar.Lifestyle && editionId == 'UK') {
+	const queryString = 'utm_source=shady-pie-variant';
+	if (
+		format?.theme == ArticlePillar.Lifestyle &&
+		editionId == 'UK' &&
+		abTest
+	) {
 		return (
 			<LabsShadyPie
 				title="Can you feel it? How to use texture to give your home sensory appeal"
@@ -35,7 +37,11 @@ export const ShadyPie = ({
 				sponsorLogoLink="https://static.theguardian.com/commercial/sponsor/15/Sep/2022/0cd11bda-eeb4-4bf6-a328-da8cbc0ffe45-ebay_logo.png"
 			/>
 		);
-	} else if (format?.theme == ArticlePillar.Lifestyle && editionId == 'US') {
+	} else if (
+		format?.theme == ArticlePillar.Lifestyle &&
+		editionId == 'US' &&
+		abTest
+	) {
 		return (
 			<LabsShadyPie
 				title="Taiwan’s wind power revolution: leading the way in Asia-Pacific"

--- a/dotcom-rendering/src/web/experiments/tests/shady-pie-click-through.ts
+++ b/dotcom-rendering/src/web/experiments/tests/shady-pie-click-through.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const shadyPieClickThrough: ABTest = {
 	id: 'ShadyPieClickThrough',
 	start: '2022-09-26',
-	expiry: '2022-10-25',
+	expiry: '2022-11-16',
 	author: 'Emma Imber',
 	description:
 		'Test the click through rate of the new labs shady pie component',


### PR DESCRIPTION
## Why?

- Extending the duration of the shady pie clickthrough rate test
- Updating the shady pie component logic so that the labs shady pie only renders when a reader is in the AB test
- Updates the shady pie story to temporarily comment out the test variants to prevent errors