### PR TITLE
Fix Sign-in Gate gradient 

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -143,9 +143,11 @@ export const hideElementsCss = [
     }`,
 	// 3. mask the first and second with a gradient overlay
 	`.article-body-commercial-selector > p:nth-of-type(1) {
+        -webkit-mask-image: linear-gradient(black, rgba(0, 0, 0, 0.5));
         mask-image: linear-gradient(black, rgba(0, 0, 0, 0.5));
     }
 	.article-body-commercial-selector > p:nth-of-type(2) {
+        -webkit-mask-image: linear-gradient(rgba(0, 0, 0, 0.5), transparent);
         mask-image: linear-gradient(rgba(0, 0, 0, 0.5), transparent);
     }
 	`,


### PR DESCRIPTION
## What does this change?

Add webkit vendor prefix to `mask-image`.

## Why?

Chrome and Edge need it: [see MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image#browser_compatibility). This approach was introduced in #6102 

Reported by @vlbee & @coldlink 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/195556648-70f5f08c-fa98-427f-b2d8-1bb925b900e9.png
[after]: https://user-images.githubusercontent.com/76776/195556304-d9b3d311-066a-4cc3-a4a0-0698bc206d87.png