### PR TITLE
Update node version manager recommendations

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -6,25 +6,24 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Dotcom Rendering](#dotcom-rendering)
-	- [Quick start](#quick-start)
-		- [Install Node.js](#install-nodejs)
-		- [Running instructions](#running-instructions)
-		- [Environment Variables](#environment-variables)
-		- [Detailed Setup](#detailed-setup)
-		- [Technologies](#technologies)
-		- [Architecture Diagram](#architecture-diagram)
-		- [UI Design System](#ui-design-system)
-		- [Concepts](#concepts)
-		- [Visual Debugging](#visual-debugging)
-		- [Feedback](#feedback)
-	- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
-	- [Code Quality](#code-quality)
-		- [Snyk Code Scanning](#snyk-code-scanning)
-	- [IDE setup](#ide-setup)
-		- [Extensions](#extensions)
-		- [Auto fix on save](#auto-fix-on-save)
-	- [Thanks](#thanks)
+- [Quick start](#quick-start)
+  - [Install Node.js](#install-nodejs)
+  - [Running instructions](#running-instructions)
+  - [Environment Variables](#environment-variables)
+  - [Detailed Setup](#detailed-setup)
+  - [Technologies](#technologies)
+  - [Architecture Diagram](#architecture-diagram)
+  - [UI Design System](#ui-design-system)
+  - [Concepts](#concepts)
+  - [Visual Debugging](#visual-debugging)
+  - [Feedback](#feedback)
+- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+- [Code Quality](#code-quality)
+  - [Snyk Code Scanning](#snyk-code-scanning)
+- [IDE setup](#ide-setup)
+  - [Extensions](#extensions)
+  - [Auto fix on save](#auto-fix-on-save)
+- [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -36,7 +35,12 @@ This guide will help you get the `dotcom-rendering` application running on your 
 
 The only thing you need to make sure you have installed before you get going is [Node.js](https://nodejs.org).
 
-We recommend using [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
+We recommend using a tool to help manage multiple versions of Node.js on on machine.
+[fnm](https://github.com/Schniz/fnm) is popular in the department at the moment, although
+[nvm](https://github.com/creationix/nvm) and [asdf](https://github.com/asdf-vm/asdf) are
+sometimes used instead.
+If you use nvm, you might find
+[this gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb) helpful.
 
 ### Running instructions
 

--- a/dotcom-rendering/docs/contributing/detailed-setup-guide.md
+++ b/dotcom-rendering/docs/contributing/detailed-setup-guide.md
@@ -4,17 +4,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Detailed setup guide](#detailed-setup-guide)
-	- [High level diagram](#high-level-diagram)
-	- [Developing](#developing)
-		- [Setup](#setup)
-		- [Start](#start)
-		- [Previewing article on local](#previewing-article-on-local)
-		- [Previewing AMP on local](#previewing-amp-on-local)
-		- [Note on rebasing vs merging](#note-on-rebasing-vs-merging)
-		- [Debugging tools](#debugging-tools)
-		- [Running alongside identity](#running-alongside-identity)
-	- [Production](#production)
+- [High level diagram](#high-level-diagram)
+- [Developing](#developing)
+  - [Setup](#setup)
+    - [Node.js](#nodejs)
+    - [Yarn](#yarn)
+  - [Start](#start)
+  - [Previewing article on local](#previewing-article-on-local)
+  - [Previewing AMP on local](#previewing-amp-on-local)
+  - [Note on rebasing vs merging](#note-on-rebasing-vs-merging)
+  - [Debugging tools](#debugging-tools)
+  - [Running alongside identity](#running-alongside-identity)
+- [Production](#production)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -28,14 +29,39 @@ This high level diagram shows the difference between the data flow when DCR is u
 
 ### Setup
 
-The only thing you need to make sure you have installed before you get going is Node.
+The only things you need to make sure you have installed before you get going are Node and yarn.
 
-We recommend [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
+#### Node.js
+We recommend using a tool to help manage multiple versions of Node.js on on machine.
+[fnm](https://github.com/Schniz/fnm) is popular in the department at the moment, although
+[nvm](https://github.com/creationix/nvm) and [asdf](https://github.com/asdf-vm/asdf) are
+sometimes used instead.
+If you use nvm, you might find
+[this gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb) helpful.
 
 If you prefer to [install Node.js manually](https://nodejs.org),
 check the [.nvmrc](https://github.com/guardian/dotcom-rendering/blob/main/.nvmrc) for the current required version.
 
-That's it – everything else should be installed for you on demand.
+#### Yarn
+Node packages for this project are managed using the 'classic' version of [Yarn](https://classic.yarnpkg.com/).
+Currently [the recommended way to install Yarn](https://classic.yarnpkg.com/lang/en/docs/install/)
+is with npm, which should be available if you have already installed Node.js. To install Yarn
+globally using npm, you can run:
+
+```
+npm install --global yarn
+```
+
+If you don't want to install it globally, you could add an alias to your shell config which runs
+Yarn via [npx](https://www.npmjs.com/package/npx):
+
+```
+alias yarn="npx yarn"
+```
+
+Once you have installed Yarn, run `yarn` in the repo's root directory to install the npm packages
+for this project. Once these are installed, `cd` into the `dotcom-rendering` directory in order to
+run the `make` commands described below.
 
 ### Start
 

--- a/dotcom-rendering/scripts/env/check-node.js
+++ b/dotcom-rendering/scripts/env/check-node.js
@@ -21,14 +21,19 @@ const ensure = require('./ensure');
 				`You are using v${nodeVersion}`,
 			);
 			if (process.env.NVM_DIR) {
-				prompt('Run `nvm install` and try again.');
+				prompt('Run `nvm install` from the repo root and try again.');
 				log(
 					'See also: https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb',
 				);
+			} else if (process.env.FNM_DIR) {
+				prompt(
+					'It looks like you have fnm installed',
+					'Run `fnm use` from the repo root and try again.',
+				);
 			} else {
 				prompt(
-					`NVM can make managing Node versions a lot easier:`,
-					'https://github.com/creationix/nvm',
+					`Using a Node version manager can make things easier.`,
+					`Our recommendation is fnm: https://github.com/Schniz/fnm`,
 				);
 			}
 			process.exit(1);


### PR DESCRIPTION
## What does this change?
- Update recommendations from `nvm` to `fnm`.
- Add section on installing Yarn to the detailed setup guide.
- Re-run `createtoc`. (nb. this seems to have picked up some prior changes which hadn't been reflected in the TOC until now.)
- Update the checks and hints in `check-node.js`.

## Why?
My understanding from recent conversations in the department is that `nvm` is no longer the recommended way of managing Node versions. I believe the official department-wide recommendation is currently to use `asdf`. But people have also reported difficulties with using it, and if a new contributor is in the position of needing to install a Node version manager then it seems like the extra difficulty of `asdf` isn't worth it, given that its benefits seem to be seen mainly when managing other kinds of environments.

I'm very happy for the `fnm` recommendation to be challenged, but thought that this PR could be seen as a 'soft RFC' for the recommendation itself. (Suggested changes to the wording are also welcome, of course!)

I added the Yarn docs because it wasn't listed before  but it seems like a necessary step for running the project, unless I've missed something?