### PR TITLE
Should we ask people to raise an RFC prior to making changes to the platform?

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -1,5 +1,5 @@
 ---
-name: DCR Request for change
+name: DCR Request for comments
 about: Tell us about a feature that you're planning to implement in dotcom rendering
 title: "[RFC]"
 labels: RFC, dotcom-rendering

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -10,4 +10,4 @@ assignees: ''
 The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback.
 
 **Who is responsible for completing this RFC process?**
-Once the RFC is raised, it is the responsibility of the _Dotcom team_ to complete this process
+Once the RFC is raised, it is the responsibility of the _Dotcom team_ to provide feedback and help you get your change to the finish line.

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -15,4 +15,4 @@ This is an optional process. If you own the code you're working on or feel confi
 However, if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.
 
 **Who is responsible for completing this RFC process?**
-Once the RFC is raised, it is the responsibility of the _Dotcom team_ to provide feedback and help you get your change to the finish line.
+Once the RFC is raised, it is the responsibility of the _Dotcom team_ (@guardian/dotcom-platform) to provide feedback and help you get your change to the finish line.

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -12,7 +12,7 @@ The Dotcom team would like to help you with your proposed change. Please provide
 **When should this RFC be used?**
 This is an optional process. If you own the code you're working on or feel confident about the change you're making then you should simply raise a PR as normal. We want developers and teams to feel empowered to make the choice about when to reach out.
 
-But if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.
+However, if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.
 
 **Who is responsible for completing this RFC process?**
 Once the RFC is raised, it is the responsibility of the _Dotcom team_ to provide feedback and help you get your change to the finish line.

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -1,8 +1,8 @@
 ---
-name: Request for change
+name: DCR Request for change
 about: Tell us about a feature that you're working on
 title: "[RFC]"
-labels: RFC
+labels: RFC, dotcom-rendering
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -9,7 +9,7 @@ assignees: ''
 
 The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback or advice.
 
-**When should this RFC be used?**
+**When should an RFC be used?**
 This is an optional process. If you own the code you're working on or feel confident about the change you're making then you should simply raise a PR as normal. We want developers and teams to feel empowered to make the choice about when to reach out.
 
 However, if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -1,13 +1,18 @@
 ---
 name: DCR Request for change
-about: Tell us about a feature that you're working on
+about: Tell us about a feature that you're planning to implement in dotcom rendering
 title: "[RFC]"
 labels: RFC, dotcom-rendering
 assignees: ''
 
 ---
 
-The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback.
+The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback or advice.
+
+**When should this RFC be used?**
+This is an optional process. If you own the code you're working on or feel confident about the change you're making then you should simply raise a PR as normal. We want developers and teams to feel empowered to make the choice about when to reach out.
+
+But if your change affects core platform code or is introducing a new concept or pattern, or if you're just looking for more eyes and input then this process is for you.
 
 **Who is responsible for completing this RFC process?**
 Once the RFC is raised, it is the responsibility of the _Dotcom team_ to provide feedback and help you get your change to the finish line.

--- a/.github/ISSUE_TEMPLATE/request-for-change.md
+++ b/.github/ISSUE_TEMPLATE/request-for-change.md
@@ -1,0 +1,13 @@
+---
+name: Request for change
+about: Tell us about a feature that you're working on
+title: "[RFC]"
+labels: RFC
+assignees: ''
+
+---
+
+The Dotcom team would like to help you with your proposed change. Please provide us with a brief and concise explanation for what you're looking to do we will try to make the process easier with early feedback.
+
+**Who is responsible for completing this RFC process?**
+Once the RFC is raised, it is the responsibility of the _Dotcom team_ to complete this process


### PR DESCRIPTION
## What?
This PR proposes asking teams to raise an RFC issue before making changes to Dotcom Rendering.

## Why?
To make the developer experience when making changes to DCR better.

We've noticed that teams have had a more positive experience with making changes when a member of Dotcom is involved early on and that, conversely, there have been examples where late involvement from the team has led to long PRs with lots of comments and requests for changes.

## Isn't this gate-keeping 😡 🚫 ?
No. We absolutely do not want this RFC process to be seen as gate-keeping. We want to be very explicit about the fact we see it as our responsibility to keep these RFCs moving through to successful completion, not the teams raising them.

We want this process to be seen as a positive, helpful experience, enabling teams to reach their goals sooner, with less friction.

## What about Apps Rendering?
This process is, initially, only for DCR and the naming convention signifies this. It could be that we extend it later to encompass both platforms.