### PR TITLE
Move isDev and enableSentryReporting checks

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/init.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.ts
@@ -3,6 +3,12 @@ import { isAdBlockInUse } from '@guardian/commercial-core';
 import { startup } from '../startup';
 
 const init = async (): Promise<void> => {
+	// We don't send errors on the dev server, or if the enableSentryReporting switch is off.
+	const {
+		switches: { enableSentryReporting },
+		isDev,
+	} = window.guardian.config;
+	const dontSend = isDev || !enableSentryReporting;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that
@@ -10,7 +16,7 @@ const init = async (): Promise<void> => {
 	// Sentry 99% of the time. So instead we just do some basic math here
 	// and use that to prevent the Sentry script from ever loading.
 	const randomCentile = Math.floor(Math.random() * 100) + 1; // A number between 1 - 100
-	if (randomCentile <= 99) {
+	if (randomCentile <= 99 || dontSend) {
 		// 99% of the time we don't want to remotely log errors with Sentry and so
 		// we just console them out
 		window.guardian.modules.sentry.reportError = (error) => {

--- a/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/sentry.ts
@@ -28,8 +28,6 @@ const ignoreErrors = [
 
 const { config } = window.guardian;
 const {
-	switches: { enableSentryReporting },
-	isDev,
 	page: { dcrSentryDsn },
 	stage,
 } = config;
@@ -42,14 +40,6 @@ Sentry.init({
 	integrations: [new CaptureConsole({ levels: ['error'] })],
 	maxBreadcrumbs: 50,
 	// sampleRate: // We use Math.random in init.ts to sample errors
-	beforeSend(event) {
-		// Skip sending events in certain situations
-		const dontSend = isDev || !enableSentryReporting;
-		if (dontSend) {
-			return null;
-		}
-		return event;
-	},
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- dcrJsBundleVariant could also be `undefined`


### PR DESCRIPTION
A 'beforeSend' hook was being used inside the Sentry options to check whether `isDev` or `enableSentryReporting` were true.

These values are available prior to Sentry being loaded at all, so this moves the check earlier in the process. (There doesn't seem much point in loading the code if errors are never going to be sent.)

**Disclaimer**: This was a pass-by refactor. I don't fully understand the Sentry setup so I might be missing something about how it works. However, I thought that raising the PR would provide an easier way to discuss this. @oliverlloyd I think you worked on the lazy loading code previously -- do you know if I'm missing something?