### PR TITLE
Update Logos On Article Layouts

### DIFF
--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -26,6 +26,7 @@ import {
 	onwardStyles,
 } from 'styles';
 import HeadlineTag from '../HeadlineTag';
+import Logo from 'components/Logo';
 
 // ----- Styles ----- //
 
@@ -66,6 +67,7 @@ const AnalysisLayout: FC<Props> = ({ item, children }) => (
 						<Standfirst item={item} />
 						<StraightLines cssOverrides={lineStyles} count={4} />
 						<Metadata item={item} />
+						<Logo item={item} />
 					</section>
 				</header>
 				<ArticleBody className={[articleWidthStyles]} format={item}>

--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -10,6 +10,7 @@ import ArticleBody from 'components/ArticleBody';
 import Byline from 'components/Byline';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import Logo from 'components/Logo';
 import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
@@ -26,7 +27,6 @@ import {
 	onwardStyles,
 } from 'styles';
 import HeadlineTag from '../HeadlineTag';
-import Logo from 'components/Logo';
 
 // ----- Styles ----- //
 

--- a/apps-rendering/src/components/Layout/GalleryLayout.tsx
+++ b/apps-rendering/src/components/Layout/GalleryLayout.tsx
@@ -9,6 +9,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import Byline from 'components/Byline';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import Logo from 'components/Logo';
 import MainMedia, { GalleryCaption } from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
@@ -41,6 +42,10 @@ const wrapperStyles = (format: ArticleFormat): SerializedStyles => css`
 	`}
 `;
 
+const logoStyles = css`
+	${grid.column.centre}
+`;
+
 type Props = {
 	item: Item;
 };
@@ -63,6 +68,9 @@ const GalleryLayout: FC<Props> = ({ item, children }) => {
 							mainMedia={item.mainMedia}
 							format={format}
 						/>
+						<div css={logoStyles}>
+							<Logo item={item} />
+						</div>
 					</header>
 					{children}
 					<Tags item={item} />

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -11,6 +11,7 @@ import { between, from, remSpace } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import Logo from 'components/Logo';
 import MainMedia, { ImmersiveCaption } from 'components/MainMedia';
 import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
@@ -50,7 +51,7 @@ const bodyStyles = css`
 	}
 
 	${from.leftCol} {
-		grid-row: 1 / 4;
+		grid-row: 1 / 6;
 	}
 `;
 
@@ -70,6 +71,14 @@ const linesStyles = (format: ArticleFormat): SerializedStyles => css`
 	${darkModeCss`
 		stroke: ${fill.linesDark(format)};
 	`}
+`;
+
+const logoStyles = css`
+	${grid.column.centre}
+
+	${from.leftCol} {
+		${grid.column.left}
+	}
 `;
 
 type Props = {
@@ -97,6 +106,9 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => {
 					<div css={mainContentStyles(format)}>
 						<LeftCentreBorder rows={[1, 5]} />
 						<StraightLines cssOverrides={linesStyles(format)} />
+						<div css={logoStyles}>
+							<Logo item={item} />
+						</div>
 						<Metadata item={item} />
 						<div css={bodyStyles}>{children}</div>
 						<Tags item={item} />

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -3,12 +3,11 @@ import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import { none, Option } from '@guardian/types';
-import { some, withDefault } from '@guardian/types';
+import type { Option } from '@guardian/types';
+import { none, some, withDefault } from '@guardian/types';
 import AnalysisLayout from 'components/Layout/AnalysisLayout';
 import Comment from 'components/Layout/CommentLayout';
 import Standard from 'components/Layout/StandardLayout';
-import ImmersiveLayout from './ImmersiveLayout';
 import {
 	analysis,
 	article,
@@ -32,8 +31,9 @@ import type { Item } from 'item';
 import type { ReactElement } from 'react';
 import { renderAll } from 'renderer';
 import { Result } from 'result';
-import Live from './LiveLayout';
 import GalleryLayout from './GalleryLayout';
+import ImmersiveLayout from './ImmersiveLayout';
+import Live from './LiveLayout';
 
 // ----- Functions ----- //
 

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -3,11 +3,12 @@ import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import type { Option } from '@guardian/types';
+import { none, Option } from '@guardian/types';
 import { some, withDefault } from '@guardian/types';
 import AnalysisLayout from 'components/Layout/AnalysisLayout';
 import Comment from 'components/Layout/CommentLayout';
 import Standard from 'components/Layout/StandardLayout';
+import ImmersiveLayout from './ImmersiveLayout';
 import {
 	analysis,
 	article,
@@ -15,6 +16,8 @@ import {
 	editorial,
 	explainer,
 	feature,
+	gallery,
+	immersive,
 	interview,
 	letter,
 	matchReport,
@@ -30,6 +33,7 @@ import type { ReactElement } from 'react';
 import { renderAll } from 'renderer';
 import { Result } from 'result';
 import Live from './LiveLayout';
+import GalleryLayout from './GalleryLayout';
 
 // ----- Functions ----- //
 
@@ -233,6 +237,36 @@ export const DeadBlog = (): ReactElement => (
 	/>
 );
 DeadBlog.story = { name: 'DeadBlog ' };
+
+export const Immersive = (): ReactElement => (
+	<ImmersiveLayout
+		item={{
+			...immersive,
+			edition: Edition.UK,
+		}}
+	>
+		{renderAll(
+			formatFromItem(immersive, none),
+			Result.partition(immersive.body).oks,
+		)}
+	</ImmersiveLayout>
+);
+Immersive.story = { name: 'Immersive ' };
+
+export const Gallery = (): ReactElement => (
+	<GalleryLayout
+		item={{
+			...gallery,
+			edition: Edition.UK,
+		}}
+	>
+		{renderAll(
+			formatFromItem(gallery, none),
+			Result.partition(gallery.body).oks,
+		)}
+	</GalleryLayout>
+);
+Gallery.story = { name: 'Gallery ' };
 
 export default {
 	title: 'AR/Layouts/Standard',

--- a/apps-rendering/src/components/Logo/index.tsx
+++ b/apps-rendering/src/components/Logo/index.tsx
@@ -69,7 +69,10 @@ const blogStyles = css`
 	}
 `;
 
-const galleryStyles = (lightModeImage: string, darkModeImage?: string) => css`
+const galleryStyles = (
+	lightModeImage: string,
+	darkModeImage?: string,
+): SerializedStyles => css`
 	img {
 		content: url('${darkModeImage ?? lightModeImage}');
 	}

--- a/apps-rendering/src/components/Logo/index.tsx
+++ b/apps-rendering/src/components/Logo/index.tsx
@@ -69,6 +69,12 @@ const blogStyles = css`
 	}
 `;
 
+const galleryStyles = (lightModeImage: string, darkModeImage?: string) => css`
+	img {
+		content: url("${darkModeImage ?? lightModeImage}");
+	}
+`;
+
 const getStyles = (
 	format: ArticleFormat,
 	lightModeImage: string,
@@ -80,6 +86,11 @@ const getStyles = (
 			return css(
 				styles(format, lightModeImage, darkModeImage),
 				blogStyles,
+			);
+		case ArticleDesign.Gallery:
+			return css(
+				styles(format, lightModeImage, darkModeImage),
+				galleryStyles(lightModeImage, darkModeImage),
 			);
 		default:
 			return styles(format, lightModeImage, darkModeImage);

--- a/apps-rendering/src/components/Logo/index.tsx
+++ b/apps-rendering/src/components/Logo/index.tsx
@@ -71,7 +71,7 @@ const blogStyles = css`
 
 const galleryStyles = (lightModeImage: string, darkModeImage?: string) => css`
 	img {
-		content: url("${darkModeImage ?? lightModeImage}");
+		content: url('${darkModeImage ?? lightModeImage}');
 	}
 `;
 

--- a/apps-rendering/src/components/Tags/ImmersiveTags.tsx
+++ b/apps-rendering/src/components/Tags/ImmersiveTags.tsx
@@ -14,7 +14,7 @@ const styles = css`
 	${grid.column.centre}
 
 	${from.leftCol} {
-		grid-row: 4;
+		grid-row: 6;
 	}
 `;
 

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -376,7 +376,17 @@ const fields = {
 	commentable: false,
 	tags: tags,
 	shouldHideReaderRevenue: false,
-	branding: none,
+	branding: some({
+		aboutUri:
+			'x-gu://item/mobile.guardianapis.com/uk/items/info/2016/jan/25/content-funding',
+		altLogo:
+			'https://static.theguardian.com/commercial/sponsor/05/May/2020/ca7c95d2-6aef-4710-ac1b-ad539763ed9f-JNI_rgb_rev_180.png',
+		brandingType: 'sponsored',
+		label: 'Supported by',
+		logo: 'https://static.theguardian.com/commercial/sponsor/05/May/2020/2b724f07-add3-4abb-b7a3-b6bbb05a3bd0-JNI_rgb_180.png',
+		sponsorName: 'Judith Nielson Institute',
+		sponsorUri: 'https://jninstitute.org/',
+	}),
 	internalShortId: none,
 	commentCount: none,
 	relatedContent: relatedContent,
@@ -502,6 +512,18 @@ const explainer: Explainer = {
 	outline: outlineFromItem(fields.body),
 };
 
+const immersive: Standard = {
+	design: ArticleDesign.Standard,
+	...fields,
+	display: ArticleDisplay.Immersive,
+};
+
+const gallery: Standard = {
+	design: ArticleDesign.Gallery,
+	...fields,
+	body: body.filter(element => element.isErr() || (element.isOk() && element.value.kind === ElementKind.Image)),
+};
+
 // ----- Exports ----- //
 
 export {
@@ -525,4 +547,6 @@ export {
 	quiz,
 	pinnedBlock,
 	explainer,
+	immersive,
+	gallery,
 };

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -521,7 +521,11 @@ const immersive: Standard = {
 const gallery: Standard = {
 	design: ArticleDesign.Gallery,
 	...fields,
-	body: body.filter(element => element.isErr() || (element.isOk() && element.value.kind === ElementKind.Image)),
+	body: body.filter(
+		(element) =>
+			element.isErr() ||
+			(element.isOk() && element.value.kind === ElementKind.Image),
+	),
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -245,7 +245,17 @@ const fields = {
 	commentable: true,
 	tags: tags,
 	shouldHideReaderRevenue: false,
-	branding: none,
+	branding: some({
+		aboutUri:
+			'x-gu://item/mobile.guardianapis.com/uk/items/info/2016/jan/25/content-funding',
+		altLogo:
+			'https://static.theguardian.com/commercial/sponsor/05/May/2020/ca7c95d2-6aef-4710-ac1b-ad539763ed9f-JNI_rgb_rev_180.png',
+		brandingType: 'sponsored',
+		label: 'Supported by',
+		logo: 'https://static.theguardian.com/commercial/sponsor/05/May/2020/2b724f07-add3-4abb-b7a3-b6bbb05a3bd0-JNI_rgb_180.png',
+		sponsorName: 'Judith Nielson Institute',
+		sponsorUri: 'https://jninstitute.org/',
+	}),
 	internalShortId: none,
 	commentCount: some(1223),
 	relatedContent: none,

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -57,8 +57,13 @@ const mediaArticleBodyLinkDark = (format: ArticleFormat): Colour => {
 	}
 };
 
-const branding = (_format: ArticleFormat): Colour => {
-	return neutral[20];
+const branding = (format: ArticleFormat): Colour => {
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+			return neutral[86];
+		default:
+			return neutral[20];
+	}
 };
 
 const brandingDark = (_format: ArticleFormat): Colour => {
@@ -531,6 +536,8 @@ const articleLink = (format: ArticleFormat): Colour => {
 				case ArticleSpecial.SpecialReport:
 					return specialReport[400];
 			}
+		case ArticleDesign.Gallery:
+			return neutral[86];
 		default:
 			switch (format.theme) {
 				case ArticlePillar.News:


### PR DESCRIPTION
## Why?

To make sure logos display correctly across all article layouts. This PR also adds a logo to the default fixtures for all layouts, so that it appears in storybook, and adds missing stories for Immersives and Galleries (therefore closing #5539).

## Changes

- Updated Analysis, Gallery and Immersive layouts
- Added stories for Gallery and Immersive
- Updated logo to use dark mode version on galleries
- Updated logo link colours on galleries
- Added branding to all fixtures

## Screenshots

| | Mobile | Wide |
| - | - | - |
| Analysis | ![analysis-mobile] | ![analysis-wide] |
| Gallery | ![gallery-mobile] | ![gallery-wide] |
| Immersive | ![immersive-mobile] | ![immersive-wide] |

[gallery-wide]: https://user-images.githubusercontent.com/53781962/195624566-18f1ddeb-9f2c-4d0f-93b2-76b24899dde9.jpg
[gallery-mobile]: https://user-images.githubusercontent.com/53781962/195624570-ab79ceee-1382-4a72-a744-f0102ee1cf48.jpg
[analysis-wide]: https://user-images.githubusercontent.com/53781962/195624542-341fe1c4-de1a-4cb2-b0fb-465659a99b9a.jpg
[analysis-mobile]: https://user-images.githubusercontent.com/53781962/195624555-b05779e0-dd0a-4f4b-b281-560b96687261.jpg
[immersive-mobile]: https://user-images.githubusercontent.com/53781962/195624562-9b28355d-d1d3-47db-8daa-902c840d53bb.jpg
[immersive-wide]: https://user-images.githubusercontent.com/53781962/195624563-e3b64fe1-fefb-445b-818e-ed6eac320865.jpg
