### PR TITLE
update footer urls for UK/INTL and AUS

### DIFF
--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -247,11 +247,11 @@ const decideSignupLink = (edition: EditionId): string => {
 		case 'US':
 			return 'https://www.theguardian.com/info/2018/sep/17/guardian-us-morning-briefing-sign-up-to-stay-informed';
 		case 'AU':
-			return 'https://www.theguardian.com/world/guardian-australia-morning-mail/2014/jun/24/-sp-guardian-australias-morning-mail-subscribe-by-email';
+			return 'https://www.theguardian.com/australia-news/2022/sep/23/morning-mail-newsletter-best-daily-news-email-guardian-australia-free-sign-up-inbox-subscribe';
 		case 'UK':
 		case 'INT': // There's no international version so we default to UK
 		default:
-			return 'https://www.theguardian.com/global/ng-interactive/2022/apr/13/first-edition-sign-up-guardian';
+			return 'https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email';
 	}
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the hard coded relative URLs used on the 'Sign-up for our email' buttons  (for UK/INTL and Aus)in the `Footer` component. The old pages are currently redirected to the new ones.

## Why?
We've updated the sign-up pages for the newsletters and they have new URL. Updating the buttons so they work without redirecting the user.

equivalent change for frontend: https://github.com/guardian/frontend/pull/25588
