### PR TITLE
Add styles for articles for theme specialReportAlt 

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2796,9 +2796,9 @@
       }
     },
     "@guardian/atoms-rendering": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz",
-      "integrity": "sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==",
+      "version": "23.7.2",
+      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-23.7.2.tgz",
+      "integrity": "sha512-BgTfnecyWAZlyf3uqT/JwXyQegIv017DKbUlV0cjVjeHThkGhK+vDapxtelwqx2BClkbaCgAtngqSLOrnTMakA==",
       "requires": {
         "is-mobile": "^3.1.1"
       }

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -37,7 +37,7 @@
     "@creditkarma/thrift-server-core": "^1.0.4",
     "@emotion/jest": "^11.10.0",
     "@guardian/apps-rendering-api-models": "^1.1.1",
-    "@guardian/atoms-rendering": "^23.6.0",
+    "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/bridget": "^1.11.0",
     "@guardian/cdk": "^47.3.3",
     "@guardian/content-api-models": "^17.3.0",

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -20,7 +20,9 @@ type ThemePillar =
 	| 'SportPillar'
 	| 'CulturePillar'
 	| 'LifestylePillar';
-type ThemeSpecial = 'SpecialReportTheme' | 'Labs';
+
+// TODO: We don't know yet what CAPI will give for SpecialReportAlt so leaving this as placeholder
+type ThemeSpecial = 'SpecialReportTheme' | 'Labs' | 'SpecialReportAltTheme';
 type CAPITheme = ThemePillar | ThemeSpecial;
 
 // CAPIDesign is what CAPI gives us on the Format field

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.7.1",
+    "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/braze-components": "^8.0.0",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.3.0",

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2352,6 +2352,7 @@
                 "LifestylePillar",
                 "NewsPillar",
                 "OpinionPillar",
+                "SpecialReportAltTheme",
                 "SpecialReportTheme",
                 "SportPillar"
             ],

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2631,6 +2631,7 @@
                 "LifestylePillar",
                 "NewsPillar",
                 "OpinionPillar",
+                "SpecialReportAltTheme",
                 "SpecialReportTheme",
                 "SportPillar"
             ],

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -57,6 +57,7 @@ export type Palette = {
 		filterButtonActive: Colour;
 		betaLabel: Colour;
 		designTag: Colour;
+		dateLine: Colour;
 	};
 	background: {
 		article: Colour;

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -676,6 +676,32 @@ export const SpecialReport = () => {
 };
 SpecialReport.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReportAlt,
+	};
+	return (
+		<Section fullWidth={true}>
+			<Flex>
+				<LeftColumn borderType="full">
+					<></>
+				</LeftColumn>
+				<ArticleContainer format={format}>
+					<ArticleHeadline
+						headlineString="This is the headline you see when pillar is SpecialReportAlt"
+						format={format}
+						tags={[]}
+						webPublicationDateDeprecated=""
+					/>
+				</ArticleContainer>
+			</Flex>
+		</Section>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const LiveBlog = () => {
 	const format = {
 		display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
@@ -245,6 +245,32 @@ export const SpecialReportStory = () => {
 };
 SpecialReportStory.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Wrapper>
+			<ArticleMeta
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Feature,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				pageId=""
+				webTitle=""
+				byline="Lanre Bakare"
+				tags={tagsWithLargeBylineImage}
+				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
+				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
+				isCommentable={false}
+				discussionApiUrl=""
+				shortUrlId=""
+				ajaxUrl=""
+				showShareCount={true}
+			/>
+		</Wrapper>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const CommentStory = () => {
 	return (
 		<Wrapper>

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -309,6 +309,29 @@ export const SpecialReportTitle = () => {
 };
 SpecialReportTitle.story = { name: 'Special report' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Wrapper>
+			<ArticleTitle
+				{...CAPIArticle}
+				format={{
+					display: ArticleDisplay.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+					design: ArticleDesign.Standard,
+				}}
+				tags={[
+					{
+						id: '',
+						title: 'Special Report Alt',
+						type: 'Series',
+					},
+				]}
+			/>
+		</Wrapper>
+	);
+};
+SpecialReportAlt.story = { name: 'Special report Alt' };
+
 export const ArticleNoTags = () => {
 	return (
 		<Wrapper>

--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { text, textSans, until } from '@guardian/source-foundations';
+import { textSans, until } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 
-const captionFont = css`
+const captionFont = (palette: Palette) => css`
 	${textSans.xxsmall()};
-	color: ${text.supporting};
+	color: ${palette.text.dateLine};
 `;
 
 const datelineStyles = css`
@@ -51,7 +51,7 @@ export const Dateline: React.FC<{
 			<details
 				css={[
 					datelineStyles,
-					captionFont,
+					captionFont(palette),
 					format.design === ArticleDesign.LiveBlog &&
 						standfirstColouring(palette),
 				]}
@@ -67,7 +67,7 @@ export const Dateline: React.FC<{
 		<div
 			css={[
 				datelineStyles,
-				captionFont,
+				captionFont(palette),
 				format.design === ArticleDesign.LiveBlog &&
 					standfirstColouring(palette),
 			]}

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -314,6 +314,22 @@ export const SpecialReport = () => {
 };
 SpecialReport.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Section fullWidth={true}>
+			<Standfirst
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				standfirst="This is how SpecialReportAlt standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
+			/>
+		</Section>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const Editorial = () => {
 	return (
 		<Section fullWidth={true}>

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -57,6 +57,10 @@ const textHeadline = (format: ArticleFormat): string => {
 				format.design !== ArticleDesign.Interview
 			)
 				return specialReport[100];
+
+			if (format.theme === ArticleSpecial.SpecialReportAlt)
+				return neutral[7];
+
 			switch (format.design) {
 				case ArticleDesign.Review:
 				case ArticleDesign.Recipe:
@@ -194,6 +198,7 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 
 const textStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 	return BLACK;
 };
 
@@ -418,6 +423,10 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -758,6 +767,11 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.DeadBlog) {
 		return neutral[60];
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
+		return palette.specialReportAlt[100];
+	}
+
 	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -774,8 +788,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
-			case ArticleSpecial.SpecialReportAlt:
-				return news[600];
 		}
 	}
 
@@ -1095,7 +1107,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];
 			case ArticleSpecial.SpecialReportAlt:
-				return news[600];
+				return neutral[46];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -34,9 +34,21 @@ const BLACK = neutral[7];
 const blogsGrayBackgroundPalette = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.News:
-			return pillarPalette[format.theme].main;
-		default:
-			return pillarPalette[format.theme].dark;
+			return news[400];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+		case ArticleSpecial.Labs:
+			return labs[300];
 	}
 };
 
@@ -59,7 +71,11 @@ const textHeadline = (format: ArticleFormat): string => {
 			)
 				return specialReport[100];
 
-			if (format.theme === ArticleSpecial.SpecialReportAlt)
+			if (
+				format.theme === ArticleSpecial.SpecialReportAlt &&
+				format.design !== ArticleDesign.LiveBlog &&
+				format.design !== ArticleDesign.DeadBlog
+			)
 				return neutral[7];
 
 			switch (format.design) {
@@ -87,7 +103,11 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 		return BLACK;
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -158,7 +178,9 @@ const textByline = (format: ArticleFormat): string => {
 		format.design === ArticleDesign.DeadBlog
 	)
 		return blogsGrayBackgroundPalette(format);
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
@@ -199,15 +221,25 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 				return pillarPalette[format.theme].main;
 		}
 	}
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (
+		format.theme === ArticleSpecial.SpecialReport &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return specialReport[300];
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	return pillarPalette[format.theme].main;
 };
 
 const textStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return neutral[7];
+
 	return BLACK;
 };
 
@@ -254,7 +286,12 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return neutral[7];
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
@@ -305,7 +342,11 @@ const textSubMetaLabel = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design != ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 	return text.supporting;
 };
@@ -322,7 +363,11 @@ const textSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;
@@ -373,15 +418,24 @@ const textArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[200];
 
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
 			return pillarPalette[format.theme].dark;
-		default:
-			return pillarPalette[format.theme].main;
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -517,7 +571,10 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[200];
 
 	switch (format.theme) {
@@ -711,11 +768,16 @@ const backgroundSectionTitle = (format: ArticleFormat): string => {
 };
 
 const backgroundAvatar = (format: ArticleFormat): string => {
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return palette.specialReportAlt[300];
+
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[800];
-		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[300];
 		case ArticlePillar.Opinion:
 			return pillarPalette[ArticlePillar.Opinion].main;
 		default:
@@ -804,10 +866,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 		return neutral[60];
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return palette.specialReportAlt[100];
-	}
-
 	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -824,8 +882,13 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[600];
 		}
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
@@ -838,6 +901,8 @@ const backgroundHeader = (format: ArticleFormat): string => {
 					return news[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[700];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[300];
 				default:
 					return pillarPalette[format.theme][300];
 			}
@@ -1027,14 +1092,34 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
-	return pillarPalette[format.theme].main;
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
 };
 
 const fillShareCountIcon = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return neutral[46];
@@ -1067,13 +1152,41 @@ const fillBlockquoteIcon = (format: ArticleFormat): string => {
 				return pillarPalette[format.theme].main;
 		}
 	}
+
+	if (
+		format.design === ArticleDesign.DeadBlog ||
+		format.design === ArticleDesign.LiveBlog
+	) {
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Opinion:
+				return opinion[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Culture:
+				return culture[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[400];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
+			case ArticleSpecial.Labs:
+				return labs[400];
+		}
+	}
+
 	return pillarPalette[format.theme].main;
 };
 
 const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return neutral[46];
@@ -1087,7 +1200,11 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return border.secondary;
@@ -1131,16 +1248,36 @@ const borderLiveBlock = (format: ArticleFormat): string => {
 };
 
 const borderPinnedPost = (format: ArticleFormat): string => {
-	return pillarPalette[format.theme][300];
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
+	}
 };
 
 const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	if (format.theme === ArticleSpecial.SpecialReport)
+
+	if (
+		format.theme === ArticleSpecial.SpecialReport &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return palette.specialReportAlt[200];
 	return border.secondary;
 };
 
@@ -1162,7 +1299,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];
 			case ArticleSpecial.SpecialReportAlt:
-				return neutral[46];
+				return news[600];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -1265,7 +1402,11 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[200];
 
 	if (format.design === ArticleDesign.Analysis) {
@@ -1494,12 +1635,19 @@ const textBetaLabel = (): string => neutral[46];
 const textDesignTag = (): string => neutral[100];
 
 const textDateLine = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
+
 	return neutral[46];
 };
 
 const textBlockquote = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -1572,7 +1720,11 @@ const backgroundMostViewedTab = (format: ArticleFormat): string => {
 };
 
 const textShareCount = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;
@@ -1581,7 +1733,10 @@ const textShareCount = (format: ArticleFormat): string => {
 const textShareCountUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -85,6 +85,10 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 	) {
 		return BLACK;
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 	switch (format.display) {
@@ -156,6 +160,10 @@ const textByline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	switch (format.display) {
 		case ArticleDisplay.Immersive:
 			return WHITE;
@@ -230,6 +238,9 @@ const textTwitterHandle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
@@ -242,6 +253,9 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return neutral[7];
+
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
 	switch (format.design) {
@@ -350,9 +364,12 @@ const textArticleLink = (format: ArticleFormat): string => {
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport) {
+	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
-	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -493,6 +510,10 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -641,6 +662,8 @@ const backgroundArticle = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.Analysis) return news[800];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[800]; // Note, check theme rather than design here
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[800];
 	if (
 		format.theme === ArticleSpecial.Labs &&
 		format.display !== ArticleDisplay.Immersive
@@ -680,6 +703,8 @@ const backgroundAvatar = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[800];
+		case ArticleSpecial.SpecialReportAlt:
+			return palette.specialReportAlt[300];
 		case ArticlePillar.Opinion:
 			return pillarPalette[ArticlePillar.Opinion].main;
 		default:
@@ -919,6 +944,10 @@ const fillCommentCount = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -987,6 +1016,9 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return pillarPalette[format.theme].main;
 };
 
@@ -1026,6 +1058,9 @@ const fillBlockquoteIcon = (format: ArticleFormat): string => {
 
 const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return neutral[46];
 };
@@ -1086,6 +1121,9 @@ const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
 	return border.secondary;
 };
 
@@ -1209,6 +1247,10 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -1298,6 +1340,9 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 		format.design === ArticleDesign.DeadBlog
 	)
 		return '#CDCDCD';
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[86];
+
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;
 };
@@ -1430,6 +1475,12 @@ const textDropCap = (format: ArticleFormat): string => {
 const textBetaLabel = (): string => neutral[46];
 
 const textDesignTag = (): string => neutral[100];
+
+const textDateLine = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+	return neutral[46];
+};
 
 const textBlockquote = (format: ArticleFormat): string => {
 	switch (format.design) {
@@ -1703,6 +1754,7 @@ export const decidePalette = (
 			filterButtonActive: textFilterButtonActive(),
 			betaLabel: textBetaLabel(),
 			designTag: textDesignTag(),
+			dateLine: textDateLine(format),
 		},
 		background: {
 			article: backgroundArticle(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -16,6 +16,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 	text,

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -253,8 +253,7 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return neutral[7];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
@@ -305,6 +304,8 @@ const textSubMetaLabel = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 	return text.supporting;
 };
 
@@ -319,6 +320,10 @@ const textSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
@@ -1022,13 +1027,16 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].main;
 };
 
-const fillShareCountIcon = (): string => {
+const fillShareCountIcon = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return neutral[46];
 };
 
 const fillShareCountIconUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
-	return fillShareCountIcon();
+	return fillShareCountIcon(format);
 };
 
 const fillShareIconGrayBackground = (format: ArticleFormat): string => {
@@ -1073,6 +1081,9 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return border.secondary;
 };
 
@@ -1554,12 +1565,18 @@ const backgroundMostViewedTab = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].dark;
 };
 
-const textShareCount = (): string => {
+const textShareCount = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
 const textShareCountUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return text.supporting;
 };
@@ -1744,7 +1761,7 @@ export const decidePalette = (
 			numberedTitle: textNumberedTitle(format),
 			numberedPosition: textNumberedPosition(),
 			overlaidCaption: textOverlaid(),
-			shareCount: textShareCount(),
+			shareCount: textShareCount(format),
 			shareCountUntilDesktop: textShareCountUntilDesktop(format),
 			cricketScoreboardLink: textCricketScoreboardLink(),
 			keyEvent: textKeyEvent(format),
@@ -1794,7 +1811,7 @@ export const decidePalette = (
 			commentCount: fillCommentCount(format),
 			commentCountUntilDesktop: fillCommentCountUntilDesktop(format),
 			shareIcon: fillShareIcon(format),
-			shareCountIcon: fillShareCountIcon(),
+			shareCountIcon: fillShareCountIcon(format),
 			shareCountIconUntilDesktop: fillShareCountIconUntilDesktop(format),
 			shareIconGrayBackground: fillShareIconGrayBackground(format),
 			cameraCaptionIcon: fillCaptionCamera(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -681,9 +681,14 @@ const backgroundArticle = (format: ArticleFormat): string => {
 const backgroundSeriesTitle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
+
 	switch (format.display) {
-		case ArticleDisplay.Immersive:
+		case ArticleDisplay.Immersive: {
+			if (format.theme === ArticleSpecial.SpecialReportAlt)
+				return palette.specialReportAlt[300];
+
 			return pillarPalette[format.theme].main;
+		}
 		case ArticleDisplay.Showcase:
 		case ArticleDisplay.NumberedList:
 		case ArticleDisplay.Standard:

--- a/dotcom-rendering/src/web/lib/decideTheme.ts
+++ b/dotcom-rendering/src/web/lib/decideTheme.ts
@@ -14,6 +14,8 @@ export const decideTheme = ({ theme }: Partial<CAPIFormat>): ArticleTheme => {
 			return ArticlePillar.Lifestyle;
 		case 'SpecialReportTheme':
 			return ArticleSpecial.SpecialReport;
+		case 'SpecialReportAltTheme':
+			return ArticleSpecial.SpecialReportAlt;
 		case 'Labs':
 			return ArticleSpecial.Labs;
 		default:

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,
@@ -54,6 +54,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 		createEmotionServer(cache);
 
 	const format: ArticleFormat = decideFormat(CAPIArticle.format);
+	format.theme = ArticleSpecial.SpecialReportAlt;
 
 	const html = renderToString(
 		<CacheProvider value={cache}>

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,
@@ -54,7 +54,6 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 		createEmotionServer(cache);
 
 	const format: ArticleFormat = decideFormat(CAPIArticle.format);
-	format.theme = ArticleSpecial.SpecialReportAlt;
 
 	const html = renderToString(
 		<CacheProvider value={cache}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,6 +2869,11 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
+"@guardian/libs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+
 "@guardian/libs@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,11 +2869,6 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
-
 "@guardian/libs@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,10 +2806,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.7.1":
-  version "23.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.7.1.tgz#c696e1a028c9cd2aa20b1baa014726335d1be1ee"
-  integrity sha512-ebf7w7S5IeDQH7SyfhQ6WSXrpBTLsCT4YXtHUUjHGHlV08wbGr+63X9QOWGTIbG6OIfQud0YlfTAUNNFkyk06g==
+"@guardian/atoms-rendering@^23.7.2":
+  version "23.7.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.7.2.tgz#3ec66b9e7c5f029cd0024429fea2740c95bc5161"
+  integrity sha512-BgTfnecyWAZlyf3uqT/JwXyQegIv017DKbUlV0cjVjeHThkGhK+vDapxtelwqx2BClkbaCgAtngqSLOrnTMakA==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
Co-authored-by: Daniel Clifton <daniel.clifton@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| SpecialReportAlt      | 
|-------------|
| ![image](https://user-images.githubusercontent.com/19683595/196476207-7ec21df8-e7f9-44b8-b793-ed94a70fbcb7.png) | 
| ![image](https://user-images.githubusercontent.com/19683595/197218185-2862716c-b758-40df-aa08-5af4827cf481.png) | 
| ![image](https://user-images.githubusercontent.com/19683595/196476556-5370f4b6-feda-4456-af72-4355e299ce08.png) | 
| ![image](https://user-images.githubusercontent.com/19683595/197217995-aee77e2b-6de4-409c-b2e9-3d3e56163401.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
