### PR TITLE
fix: use 5:3 crop for Card stories

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -24,7 +24,7 @@ const basicCardProps: CardProps = {
 	kickerText: '',
 	webPublicationDate: '2019-11-11T09:45:30.000Z',
 	imageUrl:
-		'https://i.guim.co.uk/img/media/6537e163c9164d25ec6102641f6a04fa5ba76560/0_0_5472_3648/master/5472.jpg?width=1140&quality=85&s=15053eb16d6829d670fb348d8d26aabd',
+		'https://i.guim.co.uk/img/media/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg?width=1140&quality=85&s=4d24eb891f991a2cc2f46e9a821fe9e6',
 	imagePosition: 'top',
 	showAge: true,
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Set the ratio of the test image used in `Card` stories to be a 5:3 crop.

## Why?

Card are always in 5:3 ratio, so I have added a crop in Grid for the image we currently use, and updated the URL in the stories. See also:

- https://media.gutools.co.uk/images/6537e163c9164d25ec6102641f6a04fa5ba76560?crop=0_210_5472_3283
- https://api.media.gutools.co.uk/images/6537e163c9164d25ec6102641f6a04fa5ba76560

Working on #6065, this change reduces the number of Chromatic changes which simply come from a change in the image ratio.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/196188470-80fb5649-77f8-44a1-932d-8444f3a24ae7.png
[after]: https://user-images.githubusercontent.com/76776/196191009-08cfb7c7-7a17-447c-8436-d6b9c8b2c76d.png
