### PR TITLE
Bump @guardian/atoms-rendering@23.7.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.6.0",
+    "@guardian/atoms-rendering": "^23.7.1",
     "@guardian/braze-components": "^7.4.0",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,10 +2806,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.6.0":
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz#624dc68120f00d47f21bae0ca059f31e65f56f59"
-  integrity sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==
+"@guardian/atoms-rendering@^23.7.1":
+  version "23.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.7.1.tgz#c696e1a028c9cd2aa20b1baa014726335d1be1ee"
+  integrity sha512-ebf7w7S5IeDQH7SyfhQ6WSXrpBTLsCT4YXtHUUjHGHlV08wbGr+63X9QOWGTIbG6OIfQud0YlfTAUNNFkyk06g==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
## What does this change?

From @guardian/atoms-rendering@23.7.1:

- Add ad label to YouTube IMA integration
- Bump `@guardian/libs@^7.1.0` to align with DCR prop types

## Screenshots

![Screenshot 2022-10-13 at 10 59 27](https://user-images.githubusercontent.com/7014230/195608839-2350dce1-92e9-422f-a4e5-12cc5372d30f.png)


