### PR TITLE
RFC: Refactor slices which require complex `shouldPadWrappableRows` logic

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/web/components/DynamicFast.tsx
@@ -258,33 +258,85 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 				/>
 			</LI>
 			<LI percentage="75%">
-				<UL direction="row" wrapCards={true} showDivider={true}>
-					{remaining.map((card, cardIndex) => {
-						const columns = 3;
-						return (
-							<LI
-								key={card.url}
-								percentage="33.333%"
-								stretch={true}
-								padSides={true}
-								showDivider={cardIndex % columns !== 0}
-								offsetBottomPaddingOnDivider={shouldPadWrappableRows(
-									cardIndex,
-									remaining.length -
-										(remaining.length % columns),
-									columns,
-								)}
-							>
-								<FrontCard
-									trail={card}
-									containerPalette={containerPalette}
-									showAge={showAge}
-									imageUrl={undefined}
-									headlineSize="small"
-								/>
-							</LI>
-						);
-					})}
+				<UL showDivider={true}>
+					<LI>
+						<UL
+							direction="row"
+							showDivider={false}
+							padBottom={false}
+						>
+							{remaining.slice(0, 3).map((card, cardIndex) => {
+								return (
+									<LI
+										key={card.url}
+										percentage="33.333%"
+										stretch={true}
+										padSides={true}
+										offsetBottomPaddingOnDivider={true}
+										showDivider={cardIndex !== 0}
+									>
+										<FrontCard
+											trail={card}
+											containerPalette={containerPalette}
+											showAge={showAge}
+											imageUrl={undefined}
+											headlineSize="small"
+										/>
+									</LI>
+								);
+							})}
+						</UL>
+					</LI>
+					<LI>
+						<UL direction="row" showDivider={false}>
+							{remaining.slice(3, 6).map((card, cardIndex) => {
+								return (
+									<LI
+										key={card.url}
+										percentage="33.333%"
+										stretch={true}
+										padSides={true}
+										showDivider={cardIndex !== 0}
+									>
+										<FrontCard
+											trail={card}
+											containerPalette={containerPalette}
+											showAge={showAge}
+											imageUrl={undefined}
+											headlineSize="small"
+										/>
+									</LI>
+								);
+							})}
+						</UL>
+					</LI>
+					<LI>
+						<UL
+							direction="row"
+							wrapCards={true}
+							showDivider={false}
+						>
+							{remaining.slice(6, 8).map((card, cardIndex) => {
+								return (
+									<LI
+										key={card.url}
+										percentage="50%"
+										stretch={true}
+										padSides={true}
+										showDivider={cardIndex !== 0}
+									>
+										<FrontCard
+											trail={card}
+											containerPalette={containerPalette}
+											showAge={showAge}
+											imageUrl={undefined}
+											headlineSize="small"
+										/>
+									</LI>
+								);
+							})}
+						</UL>
+					</LI>
 				</UL>
 			</LI>
 		</UL>


### PR DESCRIPTION
The current implementation is just for a single slice, as a proof of concept. imo this is a worthwhile refactor, but it's not super urgent, so it would seems sensible to check whether people like the proposed pattern before doing a full refactor.

The `shouldPadWrappableRows` function: https://github.com/guardian/dotcom-rendering/blob/d5dcc14ccdbaa557d52e7d215c57814eddfa3768/dotcom-rendering/src/web/lib/dynamicSlices.tsx#L403-L407 
is used to determine whether cards in a wrappable slice should have bottom padding added to them, to allow for wrapped rows to have continuous vertical dividers between them. The bottom row of a wrappable row shouldn't have padding added, because the vertical divider should finish at the bottom of the card.

The decision function works fairly straightforwardly when the cards on the bottom row are the same width as the ones on the top. But in the case where the bottom cards should stretch to fill the bottom row, we've ended up with [some pretty complicated logic](https://github.com/guardian/dotcom-rendering/blob/d5dcc14ccdbaa557d52e7d215c57814eddfa3768/dotcom-rendering/src/web/components/DynamicFast.tsx#L168-L173) to get the right answer.

The current situation works, but the logic is quite hard to reason about. It has [recently been discussed](https://github.com/guardian/dotcom-rendering/pull/5959#issuecomment-1277816972) that we might refactor some of this code. My proposal is that we could simplify the rendering logic in the case of slices like the  one used for `oneBig` in `DynamicFast` so that instead of having a single `<UL>` with multiple rows of wrapping cards, we instead have three separate 'sub-slices' within the slice.

We can do this here because we know that there shouldn't be any more than 3 rows of cards in the right hand side of this slice. As far as I know this slice _shouldn't_ end up being used with fewer cards, but if it is passed fewer cards then the current proposal should work for variable numbers of cards as long as there are ~more than 3~ (**edit:** actually more than 6) remaining for the right hand section (in theory there should always be 8 anyway).

If this approach looks promising then I'm happy to look at how it might be extended to cover other similar cases.

Comments from anyone are welcome, but I'm going to tag @OllysCoding and @oliverlloyd in particular, because I believe that they've worked on the related code the most, recently.

## Caveats

1. I haven't kept up with all of the recent work on slices and flex-gap, so I might be mis-using the current props for things like `<UL>` a bit. It seems to work as is, but any suggestions are welcome!
2. It does mean having a lot of separate `<ul>` elements in a single container. I think that this is not ideal, but at the same time it doesn't deviate  too much from the status quo, where we already have multiple  lists embedded in lists inside a single container/slice.
3. Probably it means a bit less DRY code. But given the complexity of the logic for the current case, this feels worthwhile to me. We don't need to get rid of `shouldPadWrappableRows` entirely as part of this, as it applies more straightforwardly elsewhere. Open to suggestions on this!
4. I'm not 100% on what the desired behaviour is for `DynamicSlow`. Judging by the storybook, it's meant to take a variable number of cards in its second slice, and if there is an odd number then there should be an overhang, rather than the last card stretching to cover the whole row. (Can you confirm the intended functionality here @OllysCoding?) In which case we might be able to simplify the existing logic for that case while still using a wrapping container, though I need to double check.. 🤔
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/37048459/196382911-23d912d3-e320-400b-998a-99bf7be8d683.png">
