### PR TITLE
Convert DCR mobile subnav search button to input

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -255,6 +255,7 @@ export const Columns: React.FC<{
 						placeholder="Search"
 						data-link-name="nav2 : search"
 						className="selectableMenuItem"
+						tabIndex={-1}
 					/>
 
 					<Label hideLabel={true} text="google-search">
@@ -276,7 +277,7 @@ export const Columns: React.FC<{
 						cssOverrides={searchSubmit}
 						data-link-name="nav2 : search : submit"
 						type="submit"
-						className="selectableMenuItem"
+						tabIndex={-1}
 					></Button>
 					<input
 						type="hidden"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Brings search input styling in line with frontend.
## Why?
This is the desired styling
## Screenshots

| Frontend      | Before      | After      |
|-------------|-------------|------------|
| ![frontend][] | ![before][] | ![after][] |

[frontend]: https://user-images.githubusercontent.com/110032454/196665770-02bbec15-3013-4a87-869c-383cc490e077.png
[before]: https://user-images.githubusercontent.com/110032454/196233855-0896c35b-944f-4a15-be9d-b4f580155a01.png
[after]:https://user-images.githubusercontent.com/110032454/196665579-e85a970e-2e00-4aec-8734-12416bad7db6.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
