### PR TITLE
fix: link the Interview headline tag to the Interview tone listing

### DIFF
--- a/apps-rendering/src/components/Headline/InterviewHeadline.tsx
+++ b/apps-rendering/src/components/Headline/InterviewHeadline.tsx
@@ -4,6 +4,7 @@ import {
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
 import { from, headline, remSpace } from '@guardian/source-foundations';
+import { fromNullable, OptionKind } from '@guardian/types';
 import HeadlineByline from 'components/HeadlineByline';
 import HeadlineTag from 'components/HeadlineTag';
 import type { Item } from 'item';
@@ -26,6 +27,10 @@ const interviewStyles = css`
 
 const InterviewHeadline: React.FC<Props> = ({ item }) => {
 	const format = getFormat(item);
+	const interviewToneTag = fromNullable(
+		item.tags.find((tag) => tag.id === 'tone/interview'),
+	);
+	const headlineTag = <HeadlineTag tagText="Interview" format={format} />;
 
 	return (
 		<div
@@ -39,9 +44,13 @@ const InterviewHeadline: React.FC<Props> = ({ item }) => {
 				}
 			`}
 		>
-			<a href="https://www.theguardian.com/tone/interview">
-				<HeadlineTag tagText="Interview" format={format} />
-			</a>
+			{interviewToneTag.kind === OptionKind.Some ? (
+				<nav>
+					<a href={interviewToneTag.value.webUrl}>{headlineTag}</a>
+				</nav>
+			) : (
+				headlineTag
+			)}
 			<h1 css={css(defaultStyles(item), interviewStyles)}>
 				<span
 					css={css`

--- a/apps-rendering/src/components/Headline/InterviewHeadline.tsx
+++ b/apps-rendering/src/components/Headline/InterviewHeadline.tsx
@@ -39,7 +39,9 @@ const InterviewHeadline: React.FC<Props> = ({ item }) => {
 				}
 			`}
 		>
-			<HeadlineTag tagText="Interview" format={format} />
+			<a href="https://www.theguardian.com/tone/interview">
+				<HeadlineTag tagText="Interview" format={format} />
+			</a>
 			<h1 css={css(defaultStyles(item), interviewStyles)}>
 				<span
 					css={css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Links the Interview headline tag to the Interview tone listing page (https://www.theguardian.com/tone/interview)

## Why?

- To fix #6213 

## Demonstration

This video shows tapping the interview headline tag and the app navigating to the listing page:

https://user-images.githubusercontent.com/705427/196479691-f9fd9cb4-6f16-4d3d-904a-6503a6efafef.mov


