### PR TITLE
fix: show icon on immersive main media caption

### DIFF
--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -2,6 +2,10 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import {
+	CaptionIcon,
+	IconVariant,
+} from '@guardian/common-rendering/src/components/figCaption';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace, textSans } from '@guardian/source-foundations';
@@ -56,6 +60,11 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 
 		return (
 			<p id={immersiveCaptionId} css={styles(format)}>
+				<CaptionIcon
+					variant={IconVariant.Image}
+					format={format}
+					supportsDarkMode={true}
+				/>
 				<Caption caption={caption} format={format} />{' '}
 				{maybeRender(credit, (cred) => (
 					<>{cred}</>

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -2,10 +2,9 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import {
-	CaptionIcon,
-	IconVariant,
-} from '@guardian/common-rendering/src/components/figCaption';
+import CaptionIcon, {
+	CaptionIconVariant,
+} from '@guardian/common-rendering/src/components/captionIcon';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace, textSans } from '@guardian/source-foundations';
@@ -61,7 +60,7 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 		return (
 			<p id={immersiveCaptionId} css={styles(format)}>
 				<CaptionIcon
-					variant={IconVariant.Image}
+					variant={CaptionIconVariant.Image}
 					format={format}
 					supportsDarkMode={true}
 				/>

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,8 +10,8 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import FigCaption from '@guardian/common-rendering/src/components/figCaption';
 import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import FigCaption from '@guardian/common-rendering/src/components/figCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,9 +10,8 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import FigCaption, {
-	IconVariant as FigCaptionIconVariant,
-} from '@guardian/common-rendering/src/components/figCaption';
+import FigCaption from '@guardian/common-rendering/src/components/figCaption';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -577,7 +576,7 @@ const mediaAtomRenderer = (
 		format: format,
 		supportsDarkMode: true,
 		children: some(h(Caption, { caption, format })),
-		variant: FigCaptionIconVariant.Video,
+		variant: CaptionIconVariant.Video,
 	});
 	return styledH('figure', figureAttributes, [
 		isEditions

--- a/common-rendering/src/components/captionIcon.stories.tsx
+++ b/common-rendering/src/components/captionIcon.stories.tsx
@@ -18,11 +18,7 @@ const Image: FC = () => (
 		}}
 		supportsDarkMode={true}
 		variant={CaptionIconVariant.Image}
-	>
-		{some(
-			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
-		)}
-	</CaptionIcon>
+	></CaptionIcon>
 );
 
 const Video: FC = () => (
@@ -34,11 +30,7 @@ const Video: FC = () => (
 		}}
 		supportsDarkMode={true}
 		variant={CaptionIconVariant.Video}
-	>
-		{some(
-			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
-		)}
-	</CaptionIcon>
+	></CaptionIcon>
 );
 
 // ----- Exports ----- //

--- a/common-rendering/src/components/captionIcon.stories.tsx
+++ b/common-rendering/src/components/captionIcon.stories.tsx
@@ -5,13 +5,12 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
 import type { FC } from 'react';
-import { CaptionIconVariant } from './captionIcon';
-import FigCaption from './figCaption';
+import CaptionIcon, { CaptionIconVariant } from './captionIcon';
 
 // ----- Stories ----- //
 
 const Image: FC = () => (
-	<FigCaption
+	<CaptionIcon
 		format={{
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
@@ -23,11 +22,11 @@ const Image: FC = () => (
 		{some(
 			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
 		)}
-	</FigCaption>
+	</CaptionIcon>
 );
 
 const Video: FC = () => (
-	<FigCaption
+	<CaptionIcon
 		format={{
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
@@ -39,14 +38,14 @@ const Video: FC = () => (
 		{some(
 			'Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images',
 		)}
-	</FigCaption>
+	</CaptionIcon>
 );
 
 // ----- Exports ----- //
 
 export default {
-	component: FigCaption,
-	title: 'Common/Components/FigCaption',
+	component: CaptionIcon,
+	title: 'Common/Components/CaptionIcon',
 };
 
 export { Image, Video };

--- a/common-rendering/src/components/captionIcon.stories.tsx
+++ b/common-rendering/src/components/captionIcon.stories.tsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { some } from '@guardian/types';
 import type { FC } from 'react';
 import CaptionIcon, { CaptionIconVariant } from './captionIcon';
 

--- a/common-rendering/src/components/captionIcon.tsx
+++ b/common-rendering/src/components/captionIcon.tsx
@@ -1,0 +1,65 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { ArticleDesign, ArticleFormat } from '@guardian/libs';
+import { remSpace } from '@guardian/source-foundations';
+import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
+import { FC } from 'react';
+import { fill } from '../editorialPalette';
+import { darkModeCss } from '../lib';
+
+enum CaptionIconVariant {
+	Image,
+	Video,
+}
+
+interface IconProps {
+	format: ArticleFormat;
+	supportsDarkMode: boolean;
+	variant: CaptionIconVariant;
+}
+
+const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+	display: inline-block;
+	width: 1.2rem;
+	margin-right: ${remSpace[1]};
+	fill: ${fill.cameraCaptionIcon()};
+	position: relative;
+
+	::before {
+		content: ' ';
+		display: block;
+		padding-top: 0.85rem;
+	}
+
+	svg {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+	}
+
+	${darkModeCss(supportsDarkMode)`
+        fill: ${fill.cameraCaptionIconDark()};
+    `}
+`;
+
+const CaptionIcon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video:
+			return null;
+		default:
+			return (
+				<span css={iconStyles(supportsDarkMode)}>
+					{variant === CaptionIconVariant.Image ? (
+						<SvgCamera />
+					) : (
+						<SvgVideo />
+					)}
+				</span>
+			);
+	}
+};
+
+export default CaptionIcon;
+export { CaptionIconVariant };

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -149,4 +149,4 @@ const FigCaption: FC<Props> = ({
 
 export default FigCaption;
 
-export { IconVariant };
+export { IconVariant, Icon as CaptionIcon };

--- a/common-rendering/src/components/figCaption.tsx
+++ b/common-rendering/src/components/figCaption.tsx
@@ -5,71 +5,14 @@ import { css } from '@emotion/react';
 import { remSpace } from '@guardian/source-foundations';
 import { neutral } from '@guardian/source-foundations';
 import { textSans } from '@guardian/source-foundations';
-import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
 import { darkModeCss } from '../lib';
-import { fill, text } from '@guardian/common-rendering/src/editorialPalette';
-
-// ----- Sub-Components ----- //
-
-enum IconVariant {
-	Image,
-	Video,
-}
-
-interface IconProps {
-	format: ArticleFormat;
-	supportsDarkMode: boolean;
-	variant: IconVariant;
-}
-
-const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
-	display: inline-block;
-	width: 1.2rem;
-	margin-right: ${remSpace[1]};
-	fill: ${fill.cameraCaptionIcon()};
-	position: relative;
-
-	::before {
-		content: ' ';
-		display: block;
-		padding-top: 0.85rem;
-	}
-
-	svg {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-	}
-
-	${darkModeCss(supportsDarkMode)`
-        fill: ${fill.cameraCaptionIconDark()};
-    `}
-`;
-
-const Icon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
-	switch (format.design) {
-		case ArticleDesign.Gallery:
-		case ArticleDesign.Audio:
-		case ArticleDesign.Video:
-			return null;
-		default:
-			return (
-				<span css={iconStyles(supportsDarkMode)}>
-					{variant === IconVariant.Image ? (
-						<SvgCamera />
-					) : (
-						<SvgVideo />
-					)}
-				</span>
-			);
-	}
-};
+import { text } from '@guardian/common-rendering/src/editorialPalette';
+import CaptionIcon, { CaptionIconVariant } from './captionIcon';
 
 // ----- Component ----- //
 
@@ -79,7 +22,7 @@ type Props = {
 	children: Option<ReactNode>;
 	className?: string;
 	css?: SerializedStyles;
-	variant?: IconVariant;
+	variant?: CaptionIconVariant;
 };
 
 const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
@@ -122,7 +65,7 @@ const FigCaption: FC<Props> = ({
 	supportsDarkMode,
 	children,
 	className,
-	variant = IconVariant.Image,
+	variant = CaptionIconVariant.Image,
 }) => {
 	switch (children.kind) {
 		case OptionKind.Some:
@@ -131,7 +74,7 @@ const FigCaption: FC<Props> = ({
 					className={className}
 					css={getStyles(format, supportsDarkMode)}
 				>
-					<Icon
+					<CaptionIcon
 						format={format}
 						supportsDarkMode={supportsDarkMode}
 						variant={variant}
@@ -148,5 +91,3 @@ const FigCaption: FC<Props> = ({
 // ----- Exports ----- //
 
 export default FigCaption;
-
-export { IconVariant, Icon as CaptionIcon };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Shows an icon next to main media captions in Immersives
- Splits the caption icon out into its own component, `captionIcon`
- Adds Storybook stories for the new `captionIcon` component

## Why?

- To fix #6214 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[after]: https://user-images.githubusercontent.com/705427/196246432-e33df4f7-10dc-4a19-b0c9-afbbf01a7e28.png
[before]: https://user-images.githubusercontent.com/705427/196246554-cb44b39b-4b48-4463-b19e-f5e10c4dc057.png
