### PR TITLE
🏝️ Islands: deferUntil="interaction"

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -574,7 +574,7 @@ declare namespace JSX {
 	interface IntrinsicElements {
 		'gu-island': {
 			name: string;
-			deferUntil?: 'idle' | 'visible';
+			deferUntil?: 'idle' | 'visible' | 'interaction';
 			clientOnly?: boolean;
 			expediteLoading?: boolean;
 			props: any;

--- a/dotcom-rendering/src/web/browser/initDiscussion/init.ts
+++ b/dotcom-rendering/src/web/browser/initDiscussion/init.ts
@@ -20,7 +20,7 @@ function forceHydration() {
 		props.expanded = true;
 
 		// Force hydration
-		doHydration(name, props, guElement);
+		void doHydration(name, props, guElement);
 	} catch (err) {
 		// Do nothing
 	}

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access -- necessary for calling our async loaded modules */
 import { log } from '@guardian/libs';
-import type { Attributes } from 'preact';
 import { h, hydrate, render } from 'preact';
 import { initPerf } from '../initPerf';
 
@@ -15,11 +14,11 @@ import { initPerf } from '../initPerf';
  * @param data The deserialised props we want to use for hydration
  * @param element The location on the DOM where the component to hydrate exists
  */
-export const doHydration = (
+export const doHydration = async (
 	name: string,
-	data: Attributes | null,
+	data: { [key: string]: unknown } | null,
 	element: HTMLElement,
-): void => {
+): Promise<void> => {
 	// If this function has already been run for an element then don't try to
 	// run it a second time
 	const alreadyHydrated = element.dataset.guReady;
@@ -27,7 +26,7 @@ export const doHydration = (
 
 	const { start, end } = initPerf(`hydrate-${name}`);
 	start();
-	import(
+	return import(
 		/* webpackInclude: /\.importable\.tsx$/ */
 		/* webpackChunkName: "[request]" */
 		`../../components/${name}.importable`

--- a/dotcom-rendering/src/web/browser/islands/doHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/doHydration.ts
@@ -26,7 +26,7 @@ export const doHydration = async (
 
 	const { start, end } = initPerf(`hydrate-${name}`);
 	start();
-	return import(
+	await import(
 		/* webpackInclude: /\.importable\.tsx$/ */
 		/* webpackChunkName: "[request]" */
 		`../../components/${name}.importable`

--- a/dotcom-rendering/src/web/browser/islands/initHydration.ts
+++ b/dotcom-rendering/src/web/browser/islands/initHydration.ts
@@ -1,6 +1,7 @@
 import { doHydration } from './doHydration';
 import { getName } from './getName';
 import { getProps } from './getProps';
+import { onInteraction } from './onInteraction';
 import { whenIdle } from './whenIdle';
 import { whenVisible } from './whenVisible';
 
@@ -27,18 +28,28 @@ export const initHydration = (elements: NodeListOf<Element>): void => {
 			switch (deferUntil) {
 				case 'idle': {
 					whenIdle(() => {
-						doHydration(name, props, element);
+						void doHydration(name, props, element);
 					});
 					break;
 				}
 				case 'visible': {
 					whenVisible(element, () => {
-						doHydration(name, props, element);
+						void doHydration(name, props, element);
+					});
+					break;
+				}
+				case 'interaction': {
+					onInteraction(element, (targetElement) => {
+						void doHydration(name, props, element).then(() => {
+							targetElement.dispatchEvent(
+								new MouseEvent('click'),
+							);
+						});
 					});
 					break;
 				}
 				default: {
-					doHydration(name, props, element);
+					void doHydration(name, props, element);
 				}
 			}
 		}

--- a/dotcom-rendering/src/web/browser/islands/onInteraction.ts
+++ b/dotcom-rendering/src/web/browser/islands/onInteraction.ts
@@ -1,0 +1,21 @@
+/**
+ * Use this function to delay execution of something until an element is interacted
+ * with
+ *
+ * @param element : The html element that we want to wait for an interaction on;
+ * @param callback : This is fired when the element is clicked on
+ */
+export const onInteraction = (
+	element: HTMLElement,
+	callback: (e: HTMLElement) => void,
+): void => {
+	element.addEventListener(
+		'click',
+		(e) => {
+			if (e.target instanceof HTMLElement) {
+				callback(e.target);
+			}
+		},
+		{ once: true },
+	);
+};

--- a/dotcom-rendering/src/web/components/Island.tsx
+++ b/dotcom-rendering/src/web/components/Island.tsx
@@ -2,7 +2,7 @@
 
 import { Placeholder } from './Placeholder';
 
-type When = 'idle' | 'visible' | 'interaction';
+type When = 'idle' | 'visible';
 
 interface HydrateProps {
 	deferUntil?: When;
@@ -22,10 +22,10 @@ interface ClientOnlyProps {
 
 interface InteractionProps {
 	deferUntil: 'interaction';
-	clientOnly?: false;
+	clientOnly?: never;
 	placeholderHeight?: never;
 	children: JSX.Element;
-	expediteLoading?: false;
+	expediteLoading?: never;
 }
 
 /**
@@ -60,7 +60,7 @@ const decideChildren = (
  * namimg convention
  *
  * @param {HydrateProps | ClientOnlyProps} props - JSX Props
- * @param {When} props.deferUntil - Delay when client code should execute
+ * @param {When | 'interaction'} props.deferUntil - Delay when client code should execute
  * 		- idle - Execute when browser idle
  * 		- visible - Execute when component appears in viewport
  *      - interaction - Execute when component is clicked on in the viewport

--- a/dotcom-rendering/src/web/components/Island.tsx
+++ b/dotcom-rendering/src/web/components/Island.tsx
@@ -2,7 +2,7 @@
 
 import { Placeholder } from './Placeholder';
 
-type When = 'idle' | 'visible';
+type When = 'idle' | 'visible' | 'interaction';
 
 interface HydrateProps {
 	deferUntil?: When;
@@ -20,13 +20,21 @@ interface ClientOnlyProps {
 	expediteLoading?: boolean;
 }
 
+interface InteractionProps {
+	deferUntil: 'interaction';
+	clientOnly?: false;
+	placeholderHeight?: never;
+	children: JSX.Element;
+	expediteLoading?: false;
+}
+
 /**
  * Props
  *
  * We use a union type here to support conditional typing. This means you
  * can only supply placeholderHeight if clientOnly is true.
  */
-type Props = HydrateProps | ClientOnlyProps;
+type Props = HydrateProps | ClientOnlyProps | InteractionProps;
 
 const decideChildren = (
 	children: JSX.Element,
@@ -55,6 +63,7 @@ const decideChildren = (
  * @param {When} props.deferUntil - Delay when client code should execute
  * 		- idle - Execute when browser idle
  * 		- visible - Execute when component appears in viewport
+ *      - interaction - Execute when component is clicked on in the viewport
  * @param {boolean} props.clientOnly - Should the component be server side rendered
  * @param {number} props.placeholderHeight - The height for the placeholder element
  * @param {JSX.Element} props.children - The component being inserted. Must be a single JSX Element

--- a/dotcom-rendering/src/web/components/Island.tsx
+++ b/dotcom-rendering/src/web/components/Island.tsx
@@ -2,10 +2,8 @@
 
 import { Placeholder } from './Placeholder';
 
-type When = 'idle' | 'visible';
-
 interface HydrateProps {
-	deferUntil?: When;
+	deferUntil?: 'idle' | 'visible';
 	clientOnly?: false;
 	placeholderHeight?: never;
 	children: JSX.Element;
@@ -13,7 +11,7 @@ interface HydrateProps {
 }
 
 interface ClientOnlyProps {
-	deferUntil?: When;
+	deferUntil?: 'idle' | 'visible';
 	clientOnly: true;
 	placeholderHeight?: number;
 	children: JSX.Element;
@@ -60,7 +58,7 @@ const decideChildren = (
  * namimg convention
  *
  * @param {HydrateProps | ClientOnlyProps} props - JSX Props
- * @param {When | 'interaction'} props.deferUntil - Delay when client code should execute
+ * @param {'idle' | 'visible' | 'interaction'} props.deferUntil - Delay when client code should execute
  * 		- idle - Execute when browser idle
  * 		- visible - Execute when component appears in viewport
  *      - interaction - Execute when component is clicked on in the viewport


### PR DESCRIPTION
Working with @oliverlloyd, this PR adds support for deferring the loading of an island until its content is 'interacted' with.

## Why do we want this pattern?

The ability to defer loading javascript for a feature until the user interacts with it will enable us to fundamentally change how we think about adding javascript to the page.

Until now, when writing javascript features on DCR, we had to consider that the javascript would be downloaded by every user on the page it would appear on. We improved things with the deferUntil options `idle` (waiting till the CPU thread isn't busy) and `visible` (great if the content is much lower on the page), however fundamentally, building complex javascript features would mean adding weight to the page for everyone, even if they weren't used by the majority of users.

However with `deferUntil="interaction"`, we can put off loading _any_ additional code on the client until a user actually interacts with the islands content, theoretically allowing us to develop feature-rich experiences that don't impact users who aren't interested in them.

_However,_ we should still consider
- We need to keep considering how writing javascript can impact accessibility & our no JS experience
- Maintaining complex javascript features can requires additional dev work & time
- The HTML of the gu-island & its props will add to the initial page weight, even if the JS isn't downloaded ([example](https://user-images.githubusercontent.com/9575458/196423239-489b0b79-9e5f-40ad-b9dd-dcd383f2aa20.png))

### Some examples of where this might be useful are:
- Lightbox on articles (https://github.com/guardian/dotcom-rendering/pull/6154)
- 'Show more' on fronts (https://github.com/guardian/dotcom-rendering/issues/6181)
- Existing islands like 'SubNav'?

## How does this work? 

Upgraded from the original trial implementation in #6154, this relatively simple implementation works by:
- Islands marked as `deferUntil="interactive"` will receive a 'click' event listener when the islands/init script runs on page load
- If the user interacts with (clicks) in the island area, the island will be downloaded and hydrated
- Once the island is hydrated, we 'replay' the click event, enabling the island to now receive it, and act as it would have if it was downloaded initially (e.g incrementing a counter)
- After this the event listener is removed - the island is now hydrated, and can work as a normal react component

The 'event replay' approach is really quite powerful, as it enables us to write the our `.importable` components just as we'd write any other island, with no special considerations needed

## How do I implement it?

Since the initial interaction (e.g button press) is repeated once the island is hydrated, you can essentially write your island as you would write any regular 'hydratable' island:

```tsx
// MyIsland.importable.tsx
import { useState } from 'react';

export const TestInteraction = ({ title }: { title: string }) => {
	const [clicks, setClicks] = useState(0);

	return (
		<>
			<h2>Hello World: {clicks}</h2>
			<button type="button" onClick={() => setClicks(clicks + 1)}>
				Click me
			</button>
		</>
	);
};
```
Then, add your island to the page
```tsx
<Island deferUntil="interaction">
	<MyIsland title="Hello World" />
</Island>
```

Because your component _must_ be rendered on the server as well as the client (otherwise there would be no content for the user to interact with), you cannot pass `clientOnly` or `placeholderHeight`, you also cannot pass `expediteLoading`, as this would defeat the purpose.

### Demo

Initial load click on interactive element (button)

https://user-images.githubusercontent.com/9575458/196464122-119c9706-a2ab-40a9-9dbf-09c4c8f94948.mov

Initial load click on non-interactive element (empty space / text in the island)

https://user-images.githubusercontent.com/9575458/196464303-9ee41ba5-65ff-4436-8f9d-5d045beee351.mov

Initial load click on interactive element with keyboard controls (button - pressed enter)

https://user-images.githubusercontent.com/9575458/196464424-22d79959-9a6f-44cf-8ebe-29040492ad81.mov

