### PR TITLE
Look up artifact bucket name from SSM

### DIFF
--- a/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
+++ b/apps-rendering/cdk/lib/__snapshots__/mobile-apps-rendering.test.ts.snap
@@ -53,6 +53,10 @@ Object {
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueaccountservicesartifactbucketC96584B6F00A464EAD1953AFF4B05118Parameter": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "VpcId": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
@@ -182,7 +186,11 @@ export Stack=mobile
 export Stage=TEST
 export NODE_ENV=production
 
-aws s3 cp s3://mobile-dist/mobile/TEST/mobile-apps-rendering/mobile-apps-rendering.zip /tmp
+aws s3 cp s3://",
+                Object {
+                  "Ref": "SsmParameterValueaccountservicesartifactbucketC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+                "/mobile/TEST/mobile-apps-rendering/mobile-apps-rendering.zip /tmp
 mkdir -p /opt/mobile-apps-rendering
 unzip /tmp/mobile-apps-rendering.zip -d /opt/mobile-apps-rendering
 chown -R mobile-apps-rendering:mapi /opt/mobile-apps-rendering
@@ -965,6 +973,10 @@ Object {
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueaccountservicesartifactbucketC96584B6F00A464EAD1953AFF4B05118Parameter": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "VpcId": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
@@ -1094,7 +1106,11 @@ export Stack=mobile-preview
 export Stage=TEST
 export NODE_ENV=production
 
-aws s3 cp s3://mobile-dist/mobile-preview/TEST/mobile-apps-rendering/mobile-apps-rendering.zip /tmp
+aws s3 cp s3://",
+                Object {
+                  "Ref": "SsmParameterValueaccountservicesartifactbucketC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+                "/mobile-preview/TEST/mobile-apps-rendering/mobile-apps-rendering.zip /tmp
 mkdir -p /opt/mobile-apps-rendering
 unzip /tmp/mobile-apps-rendering.zip -d /opt/mobile-apps-rendering
 chown -R mobile-apps-rendering:mapi /opt/mobile-apps-rendering

--- a/apps-rendering/cdk/lib/mobile-apps-rendering.ts
+++ b/apps-rendering/cdk/lib/mobile-apps-rendering.ts
@@ -18,6 +18,7 @@ import {
 	RecordTarget,
 	RecordType,
 } from 'aws-cdk-lib/aws-route53';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 interface AppsStackProps extends GuStackProps {
 	recordPrefix: string;
@@ -43,6 +44,10 @@ export class MobileAppsRendering extends GuStack {
 		);
 
 		const scalingTargetCpuUtilisation = props.targetCpuUtilisation;
+		const artifactBucketName = ssm.StringParameter.valueForStringParameter(
+			this,
+			'/account/services/artifact.bucket',
+		);
 
 		const appsRenderingApp = new GuEc2App(this, {
 			applicationPort: 3040,
@@ -79,7 +84,7 @@ export Stack=${this.stack}
 export Stage=${this.stage}
 export NODE_ENV=production
 
-aws s3 cp s3://mobile-dist/${this.stack}/${this.stage}/${appName}/${appName}.zip /tmp
+aws s3 cp s3://${artifactBucketName}/${this.stack}/${this.stage}/${appName}/${appName}.zip /tmp
 mkdir -p /opt/${appName}
 unzip /tmp/${appName}.zip -d /opt/${appName}
 chown -R ${appName}:mapi /opt/${appName}

--- a/apps-rendering/riff-raff.yaml
+++ b/apps-rendering/riff-raff.yaml
@@ -33,7 +33,7 @@ deployments:
   mobile-apps-rendering:
     type: autoscaling
     parameters:
-      bucket: mobile-dist
+      bucketSsmLookup: true
     dependencies: [mobile-apps-rendering-cfn, mobile-apps-rendering-preview-cfn]
   mobile-assets:
     type: aws-s3


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Updates the `mobile-apps-rendering` autoscaling deployment in `riff-raff.yaml` to look up the bucket name from the default SSM key: `/account/services/artifact.bucket`
- Updates the CDK to look up the artifact bucket name from SSM, for usage in EC2 `userData` field

> **Note**
> There is another hardcoded bucket name for the S3 deployment. SSM lookup for S3 deployment bucket names is not currently supported in RiffRaff

## Why?

- To resolve #6191

## How to test

- [x] tested on CODE
  - [Link to the successful RiffRaff deployment](https://riffraff.gutools.co.uk/deployment/view/d363ac47-6ad2-4885-8cc7-18893d4e1a22)