### PR TITLE
feat: hide client-only islands in noscript

### DIFF
--- a/dotcom-rendering/src/web/components/Island.tsx
+++ b/dotcom-rendering/src/web/components/Island.tsx
@@ -79,3 +79,12 @@ export const Island = ({
 		{decideChildren(children, clientOnly, placeholderHeight)}
 	</gu-island>
 );
+
+/**
+ * If JavaScript is disabled, hide client-only islands
+ */
+export const islandNoscriptStyles = `
+<style>
+	gu-island[clientOnly=true] { display: none; }
+</style>
+`;

--- a/dotcom-rendering/src/web/server/pageTemplate.ts
+++ b/dotcom-rendering/src/web/server/pageTemplate.ts
@@ -2,6 +2,7 @@ import { brandBackground, resets } from '@guardian/source-foundations';
 import he from 'he';
 import { ASSET_ORIGIN } from '../../lib/assets';
 import { getFontsCss } from '../../lib/fonts-css';
+import { islandNoscriptStyles } from '../components/Island';
 import { getHttp3Url } from '../lib/getHttp3Url';
 
 export const pageTemplate = ({
@@ -324,6 +325,8 @@ https://workforus.theguardian.com/careers/product-engineering/
 							comscorekw: keywords,
 						},
 					).toString()}" />
+
+					${islandNoscriptStyles}
                 </noscript>
                 ${priorityScriptTags.join('\n')}
                 <style class="webfont">${getFontsCss()}</style>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When JavaScript is disabled, hide client-only Islands.

## Why?

Otherwise, readers without JavaScript get large empty areas.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/196641131-7e6d42e8-1e26-40bd-9f16-f283b37c3161.png
[after]: https://user-images.githubusercontent.com/76776/196640984-0164a79c-eba7-4aa5-b068-54bd2cee6bc6.png
