### PR TITLE
Hides the Topic Filter Bank if there are no availableTopics (with count > 2)

### DIFF
--- a/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.importable.tsx
@@ -5,7 +5,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { FilterButton } from './FilterButton.importable';
 
 type Props = {
-	availableTopics: Topic[];
+	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
 	format: ArticleFormat;
 	filterKeyEvents: boolean;
@@ -75,19 +75,27 @@ const isEqual = (selectedTopic: Topic, availableTopic: Topic) =>
 	availableTopic.type === selectedTopic.type &&
 	availableTopic.value === selectedTopic.value;
 
+const getTopFiveTopics = (availableTopics: Topic[]) =>
+	availableTopics
+		.slice(0, 5)
+		.filter((topic) => !!topic.count && topic.count > 2);
+
+export const hasRelevantTopics = (availableTopics?: Topic[]) => {
+	return !!(availableTopics && getTopFiveTopics(availableTopics).length);
+};
+
 export const TopicFilterBank = ({
-	availableTopics,
+	availableTopics = [],
 	selectedTopics,
 	format,
 	keyEvents,
 	filterKeyEvents = false,
 	id,
 }: Props) => {
+	if (!hasRelevantTopics(availableTopics) && !keyEvents?.length) return null;
 	const palette = decidePalette(format);
 	const selectedTopic = selectedTopics?.[0];
-	const topFiveTopics = availableTopics
-		.slice(0, 5)
-		.filter((topic) => !!topic.count && topic.count > 2);
+	const topFiveTopics = getTopFiveTopics(availableTopics);
 
 	if (selectedTopic) {
 		const selectedIndex = availableTopics.findIndex((availableTopic) =>
@@ -132,6 +140,7 @@ export const TopicFilterBank = ({
 							onClick={() =>
 								handleTopicClick(isActive, buttonParams, id)
 							}
+							key={`filter-${topic.value}`}
 						/>
 					);
 				})}

--- a/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.stories.tsx
@@ -23,6 +23,10 @@ const availableTopicsWithLowerCount: Topic[] = [
 	{ type: 'PERSON', value: 'Cameron', count: 1 },
 ];
 
+const onlyAvailableTopicsWithLowCount: Topic[] = [
+	{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 },
+];
+
 const selectedTopics: Topic[] = [{ type: 'GPE', value: 'United Kingdom' }];
 
 const format = {
@@ -123,4 +127,22 @@ export const notShowingTopicsWithLowerCounts = () => {
 };
 notShowingTopicsWithLowerCounts.story = {
 	name: 'notShowingTopicsWithLowerCounts',
+};
+
+export const doesNotRenderWhenNoKeyEventsOrRelevantTopics = () => {
+	return (
+		<Wrapper>
+			<TopicFilterBank
+				id="key-events-carousel-desktop"
+				availableTopics={onlyAvailableTopicsWithLowCount}
+				selectedTopics={selectedTopics}
+				format={format}
+				keyEvents={[]}
+				filterKeyEvents={false}
+			/>
+		</Wrapper>
+	);
+};
+doesNotRenderWhenNoKeyEventsOrRelevantTopics.story = {
+	name: 'doesNotRenderWhenNoKeyEventsOrRelevantTopics',
 };

--- a/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
@@ -1,0 +1,95 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { render, screen } from '@testing-library/react';
+import { SingleKeyEvent } from '../../../fixtures/manual/live-blog-key-events';
+import {
+	hasRelevantTopics,
+	TopicFilterBank,
+} from './TopicFilterBank.importable';
+
+describe('hasRelevantTopics', () => {
+	describe('should be false', () => {
+		it('when availableTopics is undefined', () => {
+			expect(hasRelevantTopics(undefined)).toBe(false);
+		});
+		it('when availableTopics is empty', () => {
+			expect(hasRelevantTopics([])).toBe(false);
+		});
+		it('when availableTopics has no topic with a count greater than 2', () => {
+			expect(
+				hasRelevantTopics([
+					{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 },
+					{ type: 'PERSON', value: 'Anne-Marie Trevelyan', count: 1 },
+				]),
+			).toBe(false);
+		});
+	});
+	describe('should be true', () => {
+		it('when availableTopics has a topic with a count greater than 2', () => {
+			expect(
+				hasRelevantTopics([
+					{ type: 'PERSON', value: 'Liz Truss', count: 3 },
+					{ type: 'PERSON', value: 'Iain Duncan Smith', count: 1 },
+					{ type: 'PERSON', value: 'Anne-Marie Trevelyan', count: 1 },
+				]),
+			).toBe(true);
+		});
+	});
+});
+
+describe('TopicFilterBank', () => {
+	const renderTopicFilterBank = (
+		keyEvents: Block[],
+		availableTopics?: Topic[],
+	) => {
+		render(
+			<TopicFilterBank
+				availableTopics={availableTopics}
+				keyEvents={keyEvents}
+				selectedTopics={[]}
+				format={{
+					theme: ArticlePillar.Lifestyle,
+					design: ArticleDesign.Interactive,
+					display: ArticleDisplay.Immersive,
+				}}
+				filterKeyEvents={false}
+				id="key-events-carousel-desktop"
+			/>,
+		);
+	};
+
+	it('It renders a button for Key Events', () => {
+		renderTopicFilterBank(SingleKeyEvent, []);
+		expect(screen.getByText('Filters')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Activate Key events filter' }),
+		).toBeInTheDocument();
+	});
+
+	it('It should render a button for each topic with count greater than 2', () => {
+		renderTopicFilterBank(
+			[],
+			[
+				{ type: 'PERSON', value: 'Liz Truss', count: 3 },
+				{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 },
+			],
+		);
+
+		expect(screen.getByText('Filters')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Activate Liz Truss filter' }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', {
+				name: 'Activate Iain Duncan Smith filter',
+			}),
+		).not.toBeInTheDocument();
+	});
+
+	it('It should not show filters when there are no relevant topics or key events', () => {
+		renderTopicFilterBank(
+			[],
+			[{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 }],
+		);
+		expect(screen.queryByText('Filters')).not.toBeInTheDocument();
+	});
+});

--- a/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
+++ b/dotcom-rendering/src/web/components/TopicFilterBank.test.tsx
@@ -1,10 +1,4 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { render, screen } from '@testing-library/react';
-import { SingleKeyEvent } from '../../../fixtures/manual/live-blog-key-events';
-import {
-	hasRelevantTopics,
-	TopicFilterBank,
-} from './TopicFilterBank.importable';
+import { hasRelevantTopics } from './TopicFilterBank.importable';
 
 describe('hasRelevantTopics', () => {
 	describe('should be false', () => {
@@ -33,63 +27,5 @@ describe('hasRelevantTopics', () => {
 				]),
 			).toBe(true);
 		});
-	});
-});
-
-describe('TopicFilterBank', () => {
-	const renderTopicFilterBank = (
-		keyEvents: Block[],
-		availableTopics?: Topic[],
-	) => {
-		render(
-			<TopicFilterBank
-				availableTopics={availableTopics}
-				keyEvents={keyEvents}
-				selectedTopics={[]}
-				format={{
-					theme: ArticlePillar.Lifestyle,
-					design: ArticleDesign.Interactive,
-					display: ArticleDisplay.Immersive,
-				}}
-				filterKeyEvents={false}
-				id="key-events-carousel-desktop"
-			/>,
-		);
-	};
-
-	it('It renders a button for Key Events', () => {
-		renderTopicFilterBank(SingleKeyEvent, []);
-		expect(screen.getByText('Filters')).toBeInTheDocument();
-		expect(
-			screen.getByRole('button', { name: 'Activate Key events filter' }),
-		).toBeInTheDocument();
-	});
-
-	it('It should render a button for each topic with count greater than 2', () => {
-		renderTopicFilterBank(
-			[],
-			[
-				{ type: 'PERSON', value: 'Liz Truss', count: 3 },
-				{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 },
-			],
-		);
-
-		expect(screen.getByText('Filters')).toBeInTheDocument();
-		expect(
-			screen.getByRole('button', { name: 'Activate Liz Truss filter' }),
-		).toBeInTheDocument();
-		expect(
-			screen.queryByRole('button', {
-				name: 'Activate Iain Duncan Smith filter',
-			}),
-		).not.toBeInTheDocument();
-	});
-
-	it('It should not show filters when there are no relevant topics or key events', () => {
-		renderTopicFilterBank(
-			[],
-			[{ type: 'PERSON', value: 'Iain Duncan Smith', count: 2 }],
-		);
-		expect(screen.queryByText('Filters')).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -55,7 +55,10 @@ import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { TopicFilterBank } from '../components/TopicFilterBank.importable';
+import {
+	hasRelevantTopics,
+	TopicFilterBank,
+} from '../components/TopicFilterBank.importable';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
@@ -285,10 +288,12 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 	const cricketMatchUrl =
 		CAPIArticle.matchType === 'CricketMatchType' && CAPIArticle.matchUrl;
 
-	const showTopicFilterBank = !!CAPIArticle.config.switches.automaticFilters;
-	const hasAvailableTopics = !!CAPIArticle.availableTopics?.length;
+	const showTopicFilterBank =
+		!!CAPIArticle.config.switches.automaticFilters &&
+		hasRelevantTopics(CAPIArticle.availableTopics);
 
-	const showToggle = !showTopicFilterBank || !hasAvailableTopics;
+	const hasKeyEvents = !!CAPIArticle.keyEvents.length;
+	const showKeyEventsToggle = !showTopicFilterBank && hasKeyEvents;
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
@@ -580,7 +585,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						</GridItem>
 					</StandFirstGrid>
 				</Section>
-				{CAPIArticle.keyEvents.length > 0 ? (
+				{hasKeyEvents ? (
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
@@ -750,34 +755,32 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									</div>
 								</Hide>
 
-								{showTopicFilterBank &&
-									CAPIArticle.availableTopics &&
-									hasAvailableTopics && (
-										<Hide until="desktop">
-											<div css={sidePaddingDesktop}>
-												<Island>
-													<TopicFilterBank
-														availableTopics={
-															CAPIArticle.availableTopics
-														}
-														selectedTopics={
-															CAPIArticle.selectedTopics
-														}
-														format={format}
-														keyEvents={
-															CAPIArticle.keyEvents
-														}
-														filterKeyEvents={
-															CAPIArticle.filterKeyEvents
-														}
-														id={
-															'key-events-carousel-desktop'
-														}
-													/>
-												</Island>
-											</div>
-										</Hide>
-									)}
+								{showTopicFilterBank && (
+									<Hide until="desktop">
+										<div css={sidePaddingDesktop}>
+											<Island>
+												<TopicFilterBank
+													availableTopics={
+														CAPIArticle.availableTopics
+													}
+													selectedTopics={
+														CAPIArticle.selectedTopics
+													}
+													format={format}
+													keyEvents={
+														CAPIArticle.keyEvents
+													}
+													filterKeyEvents={
+														CAPIArticle.filterKeyEvents
+													}
+													id={
+														'key-events-carousel-desktop'
+													}
+												/>
+											</Island>
+										</div>
+									</Hide>
+								)}
 								{/* Match stats */}
 								{!!footballMatchUrl && (
 									<Island
@@ -794,8 +797,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							</GridItem>
 							<GridItem area="body">
 								<div id="maincontent" css={bodyWrapper}>
-									{CAPIArticle.keyEvents.length &&
-									showToggle ? (
+									{showKeyEventsToggle ? (
 										<Hide below="desktop">
 											<Island deferUntil="visible">
 												<FilterKeyEventsToggle
@@ -809,8 +811,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									) : (
 										<></>
 									)}
-									{showTopicFilterBank &&
-									hasAvailableTopics ? (
+									{showTopicFilterBank ? (
 										<div css={paddingBody}>
 											<ArticleContainer format={format}>
 												{pagination.currentPage !==

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -7,7 +7,10 @@ import { KeyEventsCarousel } from '../components/KeyEventsCarousel.importable';
 import { LiveBlock } from '../components/LiveBlock';
 import { LiveBlogEpic } from '../components/LiveBlogEpic.importable';
 import { PinnedPost } from '../components/PinnedPost';
-import { TopicFilterBank } from '../components/TopicFilterBank.importable';
+import {
+	hasRelevantTopics,
+	TopicFilterBank,
+} from '../components/TopicFilterBank.importable';
 
 type Props = {
 	format: ArticleFormat;
@@ -111,7 +114,7 @@ export const LiveBlogRenderer = ({
 				<></>
 			)}
 
-			{switches.automaticFilters && !!availableTopics?.length && (
+			{switches.automaticFilters && hasRelevantTopics(availableTopics) && (
 				<Hide above="desktop">
 					<Island>
 						<TopicFilterBank


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This fixes a bug where if there were availableTopics, but none of them had a count greater than two, the filter topic bank would render with a heading but no filter buttons.
  - Checks that there are relevant topics before rendering the TopicFilterBank in both LiveLayout.tsx and LiveBlogRenderer.tsx
  - Adds a check to make sure that there are keyEvents or relevantTopics in the TopicFilterBank itself
  - Adds tests for the TopicFilterBank component

## Why?
In edge cases the TopicFilterBank component was rendering with a heading but no buttons (see image below)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1499" alt="image" src="https://user-images.githubusercontent.com/26366706/196699719-d15d5285-d3aa-4f97-aa67-e76c72b2112d.png"> | <img width="1499" alt="image" src="https://user-images.githubusercontent.com/26366706/196698120-bb8857f4-30ae-4307-aa58-a916e0f75594.png">|


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
