### PR TITLE
chore: remove unneeded desktop font-size on Key Event

### DIFF
--- a/common-rendering/src/components/keyEvents.tsx
+++ b/common-rendering/src/components/keyEvents.tsx
@@ -156,10 +156,6 @@ const textStyles = (
 	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
-	/* TODO update with Source value when it's added */
-	${from.desktop} {
-		font-size: 15px;
-	}
 	color: ${text.keyEventsInline(format)};
 	display: block;
 	text-decoration: none;


### PR DESCRIPTION
## What does this change?

- Removes desktop `font-size` styling in Key Events

## Why?

- The parent style is `textSans.small()` which already has a font-size of 15px

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/705427/196713061-8d5c20b9-b5ba-47a5-a82e-477476f78b3e.png


[after]: https://user-images.githubusercontent.com/705427/196713048-962a686a-edfc-4f23-95cc-6f42ec973920.png

