### PR TITLE
Fixing grey on pink rich links in analysis articles on Dotcom

### DIFF
--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -39,8 +39,10 @@ export interface RichLinkImageData {
 	height: string;
 }
 
-const neutralBackground = css`
-	background-color: ${neutral[97]};
+const neutralBackground = (format: ArticleFormat) => css`
+	background-color: ${format.design === ArticleDesign.Analysis
+		? neutral[100]
+		: neutral[97]};
 	a {
 		color: inherit;
 	}
@@ -247,7 +249,7 @@ export const RichLink = ({
 			css={pillarBackground(palette)}
 			data-name={(isPlaceholder && 'placeholder') || ''}
 		>
-			<div css={neutralBackground}>
+			<div css={neutralBackground(format)}>
 				<a css={richLinkLink} href={url}>
 					<div css={richLinkTopBorder(palette)} />
 					{!!showImage && (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

We recently implemented a [change to the background colour of pull quotes](https://github.com/guardian/dotcom-rendering/pull/6163) on 'Analysis' articles. This pull request implements a similar change for rich links as we are trying to move away from using the 'grey on pink' colour scheme in analysis articles. 

In the screenshots below, note how the background colour has changed on analysis articles but not on other types of articles. 

## Screenshots

|  | Before      | After      |
|-------------|-------------|------------|
| Analysis | ![before][] | ![after][] |
| NOT analysis| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/102960825/196752738-1fa4a9ef-3f21-4b0f-8e0a-cc0a1d5b98c3.png

[after]: https://user-images.githubusercontent.com/102960825/196752748-4850be6a-8956-494b-86f3-35522d1203c5.png

[before2]: https://user-images.githubusercontent.com/102960825/196753163-1ca5a44b-2bed-4b76-8d89-42dfe5eb4857.png

[after2]: https://user-images.githubusercontent.com/102960825/196753191-eff1fb19-fe54-47c1-8654-eea44dd4063c.png
