### PR TITLE
Stop bucketing for mandatory long ab test

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-test.ts
+++ b/dotcom-rendering/src/web/experiments/tests/sign-in-gate-mandatory-long-test.ts
@@ -5,7 +5,7 @@ import { setOrUseParticipations } from '../lib/ab-exclusions';
 
 // Flag to determine whether the canRun function 'setOrUseParticipations' will set a participation (true)
 // or use localstorage participation key to decide canRun result (false)
-const setParticipationsFlag = true;
+const setParticipationsFlag = false;
 
 const EuropeList: (CountryCode | '')[] = [
 	'AX',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Stops the ab test bucketing for the long-running mandatory sign in gate test launched in #6031 