### PR TITLE
Fix focus ring on filter button

### DIFF
--- a/dotcom-rendering/src/web/components/FilterButton.importable.tsx
+++ b/dotcom-rendering/src/web/components/FilterButton.importable.tsx
@@ -44,7 +44,7 @@ const buttonStyles = (palette: Palette) => css`
 	/* This hides the Source spacedFocusHalo so we only see the DCR halo.
 	*  Without the !important we see both styles simultaneously.
 	*/
-	*:focus {
+	&:focus {
 		/* stylelint-disable-next-line declaration-no-important */
 		outline: none !important;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes the focus ring on the filter buttons.

## Why?

Recent Source updates introduced an additional focus ring. Discussed with Akemi and decided the best approach for now is to override the Source focus ring and allow the DCR focus ring as it was.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/77005274/196955937-2bb3ba08-930b-4315-9de9-ea97a7311e0a.png
[after]: https://user-images.githubusercontent.com/77005274/196956021-75bbfe45-3b27-48c9-99cc-7332703cc1a7.png


