### PR TITLE
Support 1, 2, 3 & 4 cards on fixed/small/slow-V-MPU

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.stories.tsx
@@ -17,13 +17,66 @@ export default {
 	},
 };
 
-export const Default = () => (
+export const FourCards = () => (
 	<Section
 		title="FixedSmallSlowVMPU"
 		padContent={false}
 		centralBorder="partial"
 	>
-		<FixedSmallSlowVMPU trails={trails} showAge={true} index={1} />
+		<FixedSmallSlowVMPU
+			trails={trails.slice(0, 4)}
+			showAge={true}
+			index={1}
+		/>
 	</Section>
 );
-Default.story = { name: 'FixedSmallSlowVMPU' };
+
+FourCards.story = { name: 'With 4 cards' };
+
+export const ThreeCards = () => (
+	<Section
+		title="FixedSmallSlowVMPU"
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowVMPU
+			trails={trails.slice(0, 3)}
+			showAge={true}
+			index={1}
+		/>
+	</Section>
+);
+
+ThreeCards.story = { name: 'With 3 cards' };
+
+export const TwoCards = () => (
+	<Section
+		title="FixedSmallSlowVMPU"
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowVMPU
+			trails={trails.slice(0, 2)}
+			showAge={true}
+			index={1}
+		/>
+	</Section>
+);
+
+TwoCards.story = { name: 'With 2 cards' };
+
+export const OneCard = () => (
+	<Section
+		title="FixedSmallSlowVMPU"
+		padContent={false}
+		centralBorder="partial"
+	>
+		<FixedSmallSlowVMPU
+			trails={trails.slice(0, 1)}
+			showAge={true}
+			index={1}
+		/>
+	</Section>
+);
+
+OneCard.story = { name: 'With 1 card' };

--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -19,6 +19,8 @@ export const FixedSmallSlowVMPU = ({
 	showAge,
 	index,
 }: Props) => {
+	if (!trails[0]) return null;
+
 	return (
 		<UL direction="row">
 			<LI percentage="33.333%" padSides={true}>
@@ -30,33 +32,17 @@ export const FixedSmallSlowVMPU = ({
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
 				<UL direction="column">
-					<LI>
-						<FrontCard
-							trail={trails[1]}
-							containerPalette={containerPalette}
-							showAge={showAge}
-							imageUrl={undefined}
-							headlineSize="small"
-						/>
-					</LI>
-					<LI>
-						<FrontCard
-							trail={trails[2]}
-							containerPalette={containerPalette}
-							showAge={showAge}
-							imageUrl={undefined}
-							headlineSize="small"
-						/>
-					</LI>
-					<LI>
-						<FrontCard
-							trail={trails[3]}
-							containerPalette={containerPalette}
-							showAge={showAge}
-							imageUrl={undefined}
-							headlineSize="small"
-						/>
-					</LI>
+					{trails.slice(1, 4).map((trail) => (
+						<LI>
+							<FrontCard
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								imageUrl={undefined}
+								headlineSize="small"
+							/>
+						</LI>
+					))}
 				</UL>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -55,6 +55,7 @@ export const DecideContainer = ({
 				/>
 			);
 		case 'dynamic/slow-mpu':
+			// return null;
 			return (
 				<DynamicSlowMPU
 					groupedTrails={groupedTrails}

--- a/dotcom-rendering/src/web/lib/DecideContainer.tsx
+++ b/dotcom-rendering/src/web/lib/DecideContainer.tsx
@@ -55,7 +55,6 @@ export const DecideContainer = ({
 				/>
 			);
 		case 'dynamic/slow-mpu':
-			// return null;
 			return (
 				<DynamicSlowMPU
 					groupedTrails={groupedTrails}


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>


<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Support 1-4 (5th is an Advert) cards on the `fixed/small/slow-V-MPU` container

+Added stories to cover these cases :)


## Why?

Fixed != Fixed

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/197171931-baf93d51-385b-4cd2-81fc-965c99ef7e92.png
[after]: https://user-images.githubusercontent.com/9575458/197171968-406450f2-26ec-40d5-adb8-7abcba87491f.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
