### PR TITLE
fix: Don't enhance H2s if theres a Table Of Contents

### DIFF
--- a/dotcom-rendering/src/model/enhance-H2s.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.ts
@@ -1,10 +1,12 @@
 import { JSDOM } from 'jsdom';
+import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 
-const hasInteractiveContentsElement = (elements: CAPIElement[]): boolean => {
+const shouldUseLegacyIDs = (elements: CAPIElement[]): boolean => {
 	return elements.some(
 		(element) =>
 			element._type ===
-			'model.dotcomrendering.pageElements.InteractiveContentsBlockElement',
+				'model.dotcomrendering.pageElements.InteractiveContentsBlockElement' ||
+			isLegacyTableOfContents(element),
 	);
 };
 
@@ -61,7 +63,7 @@ const generateId = (element: SubheadingBlockElement, existingIds: string[]) => {
 const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 	const slugifiedIds: string[] = [];
 	const enhanced: CAPIElement[] = [];
-	const shouldUseElementId = hasInteractiveContentsElement(elements);
+	const shouldUseElementId = shouldUseLegacyIDs(elements);
 	elements.forEach((element) => {
 		if (
 			element._type ===

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -1,23 +1,10 @@
+import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 import { stripHTML } from './sanitise';
-
-const scriptUrls = [
-	'https://interactive.guim.co.uk/page-enhancers/nav/boot.js',
-	'https://uploads.guim.co.uk/2019/03/20/boot.js',
-	'https://uploads.guim.co.uk/2019/12/11/boot.js',
-	'https://interactive.guim.co.uk/testing/2020/11/voterSlideshow/boot.js',
-	'https://uploads.guim.co.uk/2021/10/15/boot.js',
-];
-
-const isInteractiveContentsBlockElement = (element: CAPIElement): boolean =>
-	element._type ===
-		'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
-	!!element.scriptUrl &&
-	scriptUrls.includes(element.scriptUrl);
 
 const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 	const updatedElements: CAPIElement[] = [];
 	const hasInteractiveContentsBlockElement = elements.some((element) =>
-		isInteractiveContentsBlockElement(element),
+		isLegacyTableOfContents(element),
 	);
 
 	if (hasInteractiveContentsBlockElement) {
@@ -40,7 +27,7 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 
 		// replace interactive content block
 		elements.forEach((element) => {
-			if (isInteractiveContentsBlockElement(element)) {
+			if (isLegacyTableOfContents(element)) {
 				updatedElements.push({
 					_type: 'model.dotcomrendering.pageElements.DividerBlockElement',
 					size: 'full',

--- a/dotcom-rendering/src/model/isLegacyTableOfContents.ts
+++ b/dotcom-rendering/src/model/isLegacyTableOfContents.ts
@@ -1,0 +1,13 @@
+const scriptUrls = [
+	'https://interactive.guim.co.uk/page-enhancers/nav/boot.js',
+	'https://uploads.guim.co.uk/2019/03/20/boot.js',
+	'https://uploads.guim.co.uk/2019/12/11/boot.js',
+	'https://interactive.guim.co.uk/testing/2020/11/voterSlideshow/boot.js',
+	'https://uploads.guim.co.uk/2021/10/15/boot.js',
+];
+
+export const isLegacyTableOfContents = (element: CAPIElement): boolean =>
+	element._type ===
+		'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
+	!!element.scriptUrl &&
+	scriptUrls.includes(element.scriptUrl);


### PR DESCRIPTION
## What does this change?

Fixes Table Of Content atoms by only enhancing H2's if there is no table of contents on the page.

## Why?

Editorial like having functional table of contents 😄 