### PR TITLE
Fix timeline `KeyEventCard` underline height

### DIFF
--- a/dotcom-rendering/src/web/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventCard.tsx
@@ -45,7 +45,7 @@ const linkStyles = (palette: Palette) => css`
 		}
 		div {
 			text-decoration: underline ${palette.text.keyEvent};
-			text-underline-offset: 3px;
+			text-underline-offset: 1px;
 		}
 	}
 `;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes an issue with underline height on the key events timeline

## Why?

Recent updates to the TextSans line-height were causing issues with how this looked now. Ben W approved this fix. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/77005274/197553131-d945d767-7e7e-4611-92f4-fbee81f1f37a.png
[after]: https://user-images.githubusercontent.com/77005274/197553233-21b421b8-b47f-406f-8e35-5a4c4610bd5c.png

