### PR TITLE
Fix typo

### DIFF
--- a/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-exclusions.test.ts
@@ -26,7 +26,7 @@ describe('canRun using participations', () => {
 	});
 
 	test('canRun using participations returns true if setParticipationsFlag is true and participation already set', () => {
-		storage.local.set('gu.ab_participations', currentTestParticipation);
+		storage.local.set('gu.ab._participations', currentTestParticipation);
 
 		expect(setOrUseParticipations(true, abTestId, variantId)).toBe(true);
 		expect(getParticipationsFromLocalStorage()).toStrictEqual(


### PR DESCRIPTION
## What does this change?

Changes the AB test participations localstorage key in a spec from: 

`'gu.ab_participations'` 

to  

`'gu.ab._participations'`

## Why?

It's `'gu.ab._participations'` everywhere else so I believe this was a typo.
