### PR TITLE
Better page titles

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -411,6 +411,9 @@
                         "webTitle": {
                             "type": "string"
                         },
+                        "title": {
+                            "type": "string"
+                        },
                         "description": {
                             "type": "string"
                         }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -415,6 +415,7 @@ type FESeoDataType = {
 	id: string;
 	navSection: string;
 	webTitle: string;
+	title?: string;
 	description: string;
 };
 

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -48,6 +48,9 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
 	return {
 		...data,
+		webTitle: data.pressedPage.seoData.title
+			? `${data.pressedPage.seoData.title} | The Guardian`
+			: data.webTitle,
 		pressedPage: {
 			...data.pressedPage,
 			collections: enhanceCollections(

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -48,9 +48,9 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 	const data: FEFrontType = validateAsFrontType(body);
 	return {
 		...data,
-		webTitle: data.pressedPage.seoData.title
-			? `${data.pressedPage.seoData.title} | The Guardian`
-			: data.webTitle,
+		webTitle: `${
+			data.pressedPage.seoData.title ?? data.pressedPage.seoData.webTitle
+		} | The Guardian`,
 		pressedPage: {
 			...data.pressedPage,
 			collections: enhanceCollections(


### PR DESCRIPTION
## What?
This PR improves the [page titles](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) we use for DCR fronts. Fixes #5748 

There are two properties that can provide the title text, `pressedPage.seoData.title` and `pressedPage.seoData.webTitle`. 
`title` was not part of the DCR model so it has now been added and, when present, we now favour this value as it provides a longer, more descriptive indication of the page contents. If `title` is not available, we fallback to `webTitle`

In addition, we now append '| The Guardian' to the string we use.

## Why?
Having a descriptive title improves our SEO and offers readers better looking results when using search engines.

### Why append 'The Guardian'?
The text provided for the page title lacks the context of the fact it is a _Guardian_ page so by adding '| The Guardian' we surface this information in search results better.