### PR TITLE
Use @guardian-browserlist-config

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -6,7 +6,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = true;
+const BUILD_VARIANT = false;
 
 /**
  * Server-side test names for `dcr-javascript-bundle`.

--- a/dotcom-rendering/scripts/webpack/webpack.config.browser.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.browser.js
@@ -47,6 +47,7 @@ const getLoaders = (bundle) => {
 				},
 			];
 		case 'variant':
+		case 'modern':
 			return [
 				{
 					loader: 'babel-loader',
@@ -59,34 +60,6 @@ const getLoaders = (bundle) => {
 									bugfixes: true,
 									targets:
 										'extends @guardian/browserslist-config',
-								},
-							],
-						],
-						compact: true,
-					},
-				},
-				{
-					loader: 'ts-loader',
-					options: {
-						configFile: 'tsconfig.build.json',
-						transpileOnly: true,
-					},
-				},
-			];
-		case 'modern':
-			return [
-				{
-					loader: 'babel-loader',
-					options: {
-						presets: [
-							'@babel/preset-react',
-							[
-								'@babel/preset-env',
-								{
-									bugfixes: true,
-									targets: {
-										esmodules: true,
-									},
 								},
 							],
 						],


### PR DESCRIPTION
## What does this change?

Use `@guardian-browserlist-config` for our modern build.

## Why?

We ran a test in #5899 & #6168  on 1% of our users and our data analyst has confirmed that it has had no negative impact on our core web vitals or engagement.