### PR TITLE
Dateline spacing

### DIFF
--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -113,7 +113,7 @@ export const ContainerTitle = ({
 				/>
 			)}
 			{showDateHeader && editionId && (
-				<div>
+				<>
 					<span
 						css={dateTextStyles(
 							overrides?.text.containerDate || news[400],
@@ -137,7 +137,7 @@ export const ContainerTitle = ({
 							year: 'numeric',
 						})}
 					</span>
-				</div>
+				</>
 			)}
 		</div>
 	);

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -35,7 +35,7 @@ const linkStyles = css`
 const headerStyles = (fontColour?: string) => css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${fontColour || text.primary};
-	padding-bottom: ${space[2]}px;
+	padding-bottom: ${space[1]}px;
 	padding-top: ${space[1]}px;
 `;
 
@@ -53,10 +53,10 @@ const descriptionStyles = (fontColour?: string) => css`
 `;
 
 const bottomMargin = css`
-	margin-bottom: ${space[4]}px;
+	margin-bottom: ${space[2]}px;
 `;
 
-const leftMarginStyles = css`
+const marginStyles = css`
 	margin-left: 0;
 	${between.tablet.and.leftCol} {
 		margin-left: 10px;
@@ -65,6 +65,7 @@ const leftMarginStyles = css`
 	${from.leftCol} {
 		margin-left: 0;
 	}
+	margin-bottom: ${space[4]}px;
 `;
 
 const dateTextStyles = (color: Colour) => css`
@@ -96,7 +97,7 @@ export const ContainerTitle = ({
 	const locale = editionId && getEditionFromId(editionId).locale;
 
 	return (
-		<div css={leftMarginStyles}>
+		<div css={[marginStyles]}>
 			{url ? (
 				<a css={[linkStyles, bottomMargin]} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -61,10 +61,6 @@ const marginStyles = css`
 	${between.tablet.and.leftCol} {
 		margin-left: 10px;
 	}
-
-	${from.leftCol} {
-		margin-left: 0;
-	}
 	margin-bottom: ${space[2]}px;
 `;
 

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -38,15 +38,6 @@ const headerStyles = (fontColour?: string) => css`
 	color: ${fontColour || text.primary};
 	padding-bottom: ${space[2]}px;
 	padding-top: ${space[1]}px;
-	margin-left: 0;
-
-	${from.tablet} {
-		margin-left: 10px;
-	}
-
-	${from.leftCol} {
-		margin-left: 0;
-	}
 `;
 
 const descriptionStyles = (fontColour?: string) => css`
@@ -60,12 +51,20 @@ const descriptionStyles = (fontColour?: string) => css`
 		color: ${text.primary};
 		text-decoration: none;
 	}
+
+	${until.leftCol} {
+		margin-bottom: ${space[4]}px;
+	}
+`;
+
+const leftMarginStyles = css`
+	margin-left: 0;
 	${between.tablet.and.leftCol} {
 		margin-left: 10px;
 	}
 
-	${until.leftCol} {
-		margin-bottom: ${space[4]}px;
+	${from.leftCol} {
+		margin-left: 0;
 	}
 `;
 
@@ -98,7 +97,7 @@ export const ContainerTitle = ({
 	const locale = editionId && getEditionFromId(editionId).locale;
 
 	return (
-		<div>
+		<div css={leftMarginStyles}>
 			{url ? (
 				<a css={linkStyles} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -35,7 +35,7 @@ const linkStyles = css`
 const headerStyles = (fontColour?: string) => css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${fontColour || text.primary};
-	padding-bottom: ${space[2]}px;
+	padding-bottom: ${space[1]}px;
 	padding-top: ${space[1]}px;
 `;
 

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -65,7 +65,7 @@ const marginStyles = css`
 	${from.leftCol} {
 		margin-left: 0;
 	}
-	margin-bottom: ${space[4]}px;
+	margin-bottom: ${space[2]}px;
 `;
 
 const dateTextStyles = (color: Colour) => css`

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -35,7 +35,7 @@ const linkStyles = css`
 const headerStyles = (fontColour?: string) => css`
 	${headline.xsmall({ fontWeight: 'bold' })};
 	color: ${fontColour || text.primary};
-	padding-bottom: ${space[1]}px;
+	padding-bottom: ${space[2]}px;
 	padding-top: ${space[1]}px;
 `;
 

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -6,7 +6,6 @@ import {
 	news,
 	space,
 	text,
-	until,
 } from '@guardian/source-foundations';
 import type { EditionId } from '../../types/edition';
 import type { DCRContainerPalette } from '../../types/front';
@@ -52,9 +51,7 @@ const descriptionStyles = (fontColour?: string) => css`
 		text-decoration: none;
 	}
 
-	${until.leftCol} {
-		margin-bottom: ${space[4]}px;
-	}
+	margin-bottom: ${space[4]}px;
 `;
 
 const leftMarginStyles = css`

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -50,7 +50,9 @@ const descriptionStyles = (fontColour?: string) => css`
 		color: ${text.primary};
 		text-decoration: none;
 	}
+`;
 
+const bottomMargin = css`
 	margin-bottom: ${space[4]}px;
 `;
 
@@ -96,7 +98,7 @@ export const ContainerTitle = ({
 	return (
 		<div css={leftMarginStyles}>
 			{url ? (
-				<a css={linkStyles} href={url}>
+				<a css={[linkStyles, bottomMargin]} href={url}>
 					<h2 css={headerStyles(fontColour)}>{title}</h2>
 				</a>
 			) : (
@@ -104,7 +106,7 @@ export const ContainerTitle = ({
 			)}
 			{!!description && (
 				<p
-					css={descriptionStyles(fontColour)}
+					css={[descriptionStyles(fontColour), bottomMargin]}
 					dangerouslySetInnerHTML={{ __html: description }}
 				/>
 			)}
@@ -125,6 +127,7 @@ export const ContainerTitle = ({
 							dateTextStyles(
 								overrides?.text.containerDate || news[400],
 							),
+							bottomMargin,
 						]}
 					>
 						{now.toLocaleDateString(locale, {

--- a/dotcom-rendering/src/web/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/web/components/ContainerTitle.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import {
 	between,
-	from,
 	headline,
 	news,
 	space,

--- a/dotcom-rendering/src/web/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/web/components/Palettes.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source-foundations';
 import { trails } from '../../../fixtures/manual/trails';
 import { DynamicFast } from './DynamicFast';
 import { Section } from './Section';
@@ -37,6 +38,17 @@ export const EventPalette = () => (
 		/>
 	</Section>
 );
+EventPalette.story = {
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+};
 
 export const EventAltPalette = () => (
 	<Section


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR fixes #5269 by refactoring and adjusting the spacing shown around the dateline, which appears on certain containers

## Why?
There was [an issue](https://github.com/guardian/dotcom-rendering/issues/5269) previously where spacing broke at `tablet` and in general was not completely in line with Frontend. @HarryFischer what do you think of space showing below the dateline now when below `tablet`?


| Before      | After      |
|-------------|------------|
| ![2022-10-26 14 36 54](https://user-images.githubusercontent.com/1336821/198042399-d42d774f-8f52-47c6-8fb8-663c89f13b4b.gif) | ![2022-10-26 14 25 18](https://user-images.githubusercontent.com/1336821/198037986-a9a2b03d-8544-4a9f-93e6-139ad08a9535.gif) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
