### PR TITLE
Capture CWV & Commercial metrics on fronts

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -38,6 +38,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 
 		const serverSideTestsToForceMetrics: Array<ServerSideTestNames> = [
 			/* keep array multi-line */
+			'dcrFrontsVariant',
 		];
 
 		const userInServerSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -34,6 +34,7 @@ export const CoreVitals = () => {
 		/* linter, please keep this array multi-line */
 		dcrJavascriptBundle('Variant'),
 		dcrJavascriptBundle('Control'),
+		'dcrFrontsVariant',
 	];
 
 	const userInServerSideTestToForceMetrics =


### PR DESCRIPTION
## What does this change?

Always capture Core Web Vitals and Commercial metrics when a user is in the DCR fronts test.

## Why?

If a user is in the test variant, we want to capture these metrics all the time, as there is only a small number of users that are currently in the test–it’s opt-in only.

We want to be able to get a throrough reporting, jointly with @guardian/commercial-dev.