### PR TITLE
fix: Mark Card comment counts as untabbable and hidden until Hydration

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -259,6 +259,8 @@ export const Card = ({
 							data-container-palette={containerPalette}
 							data-ignore="global-link-styling"
 							data-link-name="Comment count"
+							tabIndex={-1}
+							aria-hidden={true}
 							href={`${linkTo}#comments`}
 							cssOverrides={css`
 								/* See: https://css-tricks.com/nested-links/ */

--- a/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
@@ -152,6 +152,8 @@ function insertCount({
 		`[data-discussion-id="${id}"]`,
 	);
 	countContainers.forEach((container) => {
+		container.removeAttribute('tabindex');
+		container.removeAttribute('aria-hidden');
 		container.setAttribute('aria-label', `${short} Comments`);
 		container.innerHTML = html;
 	});


### PR DESCRIPTION
## What does this change?

Makes comment count anchor links untabbable and invisible to screen readers until they've been hydrated.

## Why?

Fixes #6111 

## Alternative

Alternatively you could defer adding the anchor tag to the page until the comment count is retrieved, but I wasn't too sure what impact this might have on SEO. 

https://github.com/guardian/dotcom-rendering/commit/649cc4a9d7e58b72d51d9795c12deee62f17c419