### PR TITLE
Migrate `articleFormat` Module To Optional

### DIFF
--- a/apps-rendering/src/articleFormat.ts
+++ b/apps-rendering/src/articleFormat.ts
@@ -6,9 +6,7 @@
 
 import type { ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
-import { none, some, withDefault } from '@guardian/types';
-import type { Option } from '@guardian/types';
-import { pipe } from 'lib';
+import { Optional } from 'optional';
 
 // ----- Functions ----- //
 
@@ -19,33 +17,33 @@ import { pipe } from 'lib';
  * the culture pillar.
  *
  * @param pillarId A pillar expressed as a `string`, e.g. `"pillar/news"`.
- * @returns An `Option`, with a `Some` corresponding to an
+ * @returns An `Optional`, with a `Some` corresponding to an
  * {@linkcode ArticlePillar} if the id is valid, otherwise `None`.
  *
  * @example
  * const maybePillar = getPillarFromId("pillar/arts") // Some<ArticlePillar.Culture>
  */
-const getPillarFromId = (pillarId: string): Option<ArticlePillar> => {
+const getPillarFromId = (pillarId: string): Optional<ArticlePillar> => {
 	switch (pillarId) {
 		case 'pillar/opinion':
-			return some(ArticlePillar.Opinion);
+			return Optional.some(ArticlePillar.Opinion);
 		case 'pillar/sport':
-			return some(ArticlePillar.Sport);
+			return Optional.some(ArticlePillar.Sport);
 		case 'pillar/arts':
-			return some(ArticlePillar.Culture);
+			return Optional.some(ArticlePillar.Culture);
 		case 'pillar/lifestyle':
-			return some(ArticlePillar.Lifestyle);
+			return Optional.some(ArticlePillar.Lifestyle);
 		case 'pillar/news':
-			return some(ArticlePillar.News);
+			return Optional.some(ArticlePillar.News);
 		default:
-			return none;
+			return Optional.none();
 	}
 };
 
 /**
  * Does the same as {@linkcode getPillarFromId}, but falls back to
  * {@linkcode ArticlePillar.News} if parsing fails, instead of returning an
- * `Option`.
+ * `Optional`.
  *
  * @param pillarId A pillar expressed as a `string`, e.g. `"pillar/news"`.
  * @returns An {@linkcode ArticlePillar} if the id is valid, otherwise
@@ -56,11 +54,7 @@ const getPillarFromId = (pillarId: string): Option<ArticlePillar> => {
  * const pillar = getPillarOrElseNews("invalid id") // ArticlePillar.News
  */
 const getPillarOrElseNews = (pillarId: string): ArticlePillar =>
-	pipe(
-		pillarId,
-		getPillarFromId,
-		withDefault<ArticlePillar>(ArticlePillar.News),
-	);
+	getPillarFromId(pillarId).withDefault(ArticlePillar.News);
 
 /**
  * Converts an {@linkcode ArticlePillar} into a `string`. The `string` will be

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -30,13 +30,13 @@ import {
 	notificationsClient,
 	userClient,
 } from 'native/nativeApi';
+import { Optional } from 'optional';
 import type { ReactElement } from 'react';
 import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
 import { logger } from '../logger';
 import { hydrate as hydrateAtoms } from './atoms';
 import { initSignupForms } from './signupForm';
-import { Optional } from 'optional';
 
 // ----- Run ----- //
 
@@ -152,9 +152,9 @@ function insertEpic(): void {
 
 function renderComments(): void {
 	const commentContainer = document.getElementById('comments');
-	const pillar = Optional
-		.fromNullable(commentContainer?.getAttribute('data-pillar'))
-		.flatMap(getPillarFromId);
+	const pillar = Optional.fromNullable(
+		commentContainer?.getAttribute('data-pillar'),
+	).flatMap(getPillarFromId);
 	const shortUrl = commentContainer?.getAttribute('data-short-id');
 	const isClosedForComments = !!commentContainer?.getAttribute('pillar');
 

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -7,7 +7,6 @@ import { AudioAtom } from '@guardian/atoms-rendering';
 import type { ICommentResponse as CommentResponse } from '@guardian/bridget';
 import { Topic } from '@guardian/bridget/Topic';
 import { App } from '@guardian/discussion-rendering/build/App';
-import { andThen, fromNullable, OptionKind } from '@guardian/types';
 import { getPillarFromId } from 'articleFormat';
 import {
 	ads,
@@ -22,7 +21,7 @@ import { createEmbedComponentFromProps } from 'components/EmbedWrapper';
 import EpicContent from 'components/EpicContent';
 import FollowStatus from 'components/FollowStatus';
 import FooterContent from 'components/FooterContent';
-import { handleErrors, isObject, pipe } from 'lib';
+import { handleErrors, isObject } from 'lib';
 import {
 	acquisitionsClient,
 	commercialClient,
@@ -37,6 +36,7 @@ import ReactDOM from 'react-dom';
 import { logger } from '../logger';
 import { hydrate as hydrateAtoms } from './atoms';
 import { initSignupForms } from './signupForm';
+import { Optional } from 'optional';
 
 // ----- Run ----- //
 
@@ -152,15 +152,13 @@ function insertEpic(): void {
 
 function renderComments(): void {
 	const commentContainer = document.getElementById('comments');
-	const pillar = pipe(
-		commentContainer?.getAttribute('data-pillar'),
-		fromNullable,
-		andThen(getPillarFromId),
-	);
+	const pillar = Optional
+		.fromNullable(commentContainer?.getAttribute('data-pillar'))
+		.flatMap(getPillarFromId);
 	const shortUrl = commentContainer?.getAttribute('data-short-id');
 	const isClosedForComments = !!commentContainer?.getAttribute('pillar');
 
-	if (pillar.kind === OptionKind.Some && shortUrl) {
+	if (pillar.isSome() && shortUrl) {
 		const user = {
 			userId: 'abc123',
 			displayName: 'Jane Smith',

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -18,13 +18,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import {
-	andThen,
-	fromNullable,
-	map,
-	none,
-	some,
-} from '@guardian/types';
+import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { getPillarFromId } from 'articleFormat';
 import type { Body } from 'bodyElement';
@@ -287,8 +281,7 @@ const itemFields = (
 ): ItemFields => {
 	const { content, commentCount, relatedContent } = request;
 	return {
-		theme: Optional
-			.fromNullable(content.pillarId)
+		theme: Optional.fromNullable(content.pillarId)
 			.flatMap(getPillarFromId)
 			.withDefault(ArticlePillar.News),
 		display: getDisplay(content),

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -11,7 +11,7 @@ import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Element } from '@guardian/content-api-models/v1/element';
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
-import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -24,7 +24,6 @@ import {
 	map,
 	none,
 	some,
-	withDefault,
 } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { getPillarFromId } from 'articleFormat';
@@ -288,12 +287,10 @@ const itemFields = (
 ): ItemFields => {
 	const { content, commentCount, relatedContent } = request;
 	return {
-		theme: pipe(
-			content.pillarId,
-			fromNullable,
-			andThen(getPillarFromId),
-			withDefault<ArticleTheme>(ArticlePillar.News),
-		),
+		theme: Optional
+			.fromNullable(content.pillarId)
+			.flatMap(getPillarFromId)
+			.withDefault(ArticlePillar.News),
 		display: getDisplay(content),
 		headline: content.fields?.headline ?? '',
 		standfirst: pipe(


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages.

## Changes

- Updated `articleFormat` functions to use and return `Optional`
- Migrated client `article` module to `Optional`
- Migrated `theme` parsing in `item.ts` to `Optional`
