### PR TITLE
Add articles styles for SpecialReportAlt

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2796,9 +2796,9 @@
       }
     },
     "@guardian/atoms-rendering": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-23.6.0.tgz",
-      "integrity": "sha512-GMeDnvEXXXtSu1YvBvm9UO015GS2OhR9tog/ebMXWJ+Y8qfW35OrniualVtLRxwmuTU3Bs5bM1kShKBU8P7yGQ==",
+      "version": "23.7.2",
+      "resolved": "https://registry.npmjs.org/@guardian/atoms-rendering/-/atoms-rendering-23.7.2.tgz",
+      "integrity": "sha512-BgTfnecyWAZlyf3uqT/JwXyQegIv017DKbUlV0cjVjeHThkGhK+vDapxtelwqx2BClkbaCgAtngqSLOrnTMakA==",
       "requires": {
         "is-mobile": "^3.1.1"
       }

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -37,7 +37,7 @@
     "@creditkarma/thrift-server-core": "^1.0.4",
     "@emotion/jest": "^11.10.0",
     "@guardian/apps-rendering-api-models": "^1.1.1",
-    "@guardian/atoms-rendering": "^23.6.0",
+    "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/bridget": "^1.11.2",
     "@guardian/cdk": "^47.3.3",
     "@guardian/content-api-models": "^17.3.0",

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -20,7 +20,9 @@ type ThemePillar =
 	| 'SportPillar'
 	| 'CulturePillar'
 	| 'LifestylePillar';
-type ThemeSpecial = 'SpecialReportTheme' | 'Labs';
+
+// TODO: We don't know yet what CAPI will give for SpecialReportAlt so leaving this as placeholder
+type ThemeSpecial = 'SpecialReportTheme' | 'Labs' | 'SpecialReportAltTheme';
 type CAPITheme = ThemePillar | ThemeSpecial;
 
 // CAPIDesign is what CAPI gives us on the Format field

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -21,7 +21,6 @@ type ThemePillar =
 	| 'CulturePillar'
 	| 'LifestylePillar';
 
-// TODO: We don't know yet what CAPI will give for SpecialReportAlt so leaving this as placeholder
 type ThemeSpecial = 'SpecialReportTheme' | 'Labs' | 'SpecialReportAltTheme';
 type CAPITheme = ThemePillar | ThemeSpecial;
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -61,7 +61,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.7.1",
+    "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/braze-components": "^8.0.0",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.3.0",

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2352,6 +2352,7 @@
                 "LifestylePillar",
                 "NewsPillar",
                 "OpinionPillar",
+                "SpecialReportAltTheme",
                 "SpecialReportTheme",
                 "SportPillar"
             ],

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2634,6 +2634,7 @@
                 "LifestylePillar",
                 "NewsPillar",
                 "OpinionPillar",
+                "SpecialReportAltTheme",
                 "SpecialReportTheme",
                 "SportPillar"
             ],

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -129,6 +129,7 @@ export type Palette = {
 		cardSupporting: Colour;
 		keyEvent: Colour;
 		filterButton: Colour;
+		secondary: Colour;
 	};
 	topBar: {
 		card: Colour;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -57,6 +57,7 @@ export type Palette = {
 		filterButtonActive: Colour;
 		betaLabel: Colour;
 		designTag: Colour;
+		dateLine: Colour;
 	};
 	background: {
 		article: Colour;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -105,6 +105,7 @@ export type Palette = {
 		quoteIcon: Colour;
 		blockquoteIcon: Colour;
 		twitterHandleBelowDesktop: Colour;
+		twitterHandle: Colour;
 		guardianLogo: Colour;
 	};
 	border: {

--- a/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.stories.tsx
@@ -676,6 +676,32 @@ export const SpecialReport = () => {
 };
 SpecialReport.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReportAlt,
+	};
+	return (
+		<Section fullWidth={true}>
+			<Flex>
+				<LeftColumn borderType="full">
+					<></>
+				</LeftColumn>
+				<ArticleContainer format={format}>
+					<ArticleHeadline
+						headlineString="This is the headline you see when pillar is SpecialReportAlt"
+						format={format}
+						tags={[]}
+						webPublicationDateDeprecated=""
+					/>
+				</ArticleContainer>
+			</Flex>
+		</Section>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const LiveBlog = () => {
 	const format = {
 		display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
@@ -245,6 +245,32 @@ export const SpecialReportStory = () => {
 };
 SpecialReportStory.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Wrapper>
+			<ArticleMeta
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Feature,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				pageId=""
+				webTitle=""
+				byline="Lanre Bakare"
+				tags={tagsWithLargeBylineImage}
+				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
+				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
+				isCommentable={false}
+				discussionApiUrl=""
+				shortUrlId=""
+				ajaxUrl=""
+				showShareCount={true}
+			/>
+		</Wrapper>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const CommentStory = () => {
 	return (
 		<Wrapper>

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -309,6 +309,29 @@ export const SpecialReportTitle = () => {
 };
 SpecialReportTitle.story = { name: 'Special report' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Wrapper>
+			<ArticleTitle
+				{...CAPIArticle}
+				format={{
+					display: ArticleDisplay.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+					design: ArticleDesign.Standard,
+				}}
+				tags={[
+					{
+						id: '',
+						title: 'Special Report Alt',
+						type: 'Series',
+					},
+				]}
+			/>
+		</Wrapper>
+	);
+};
+SpecialReportAlt.story = { name: 'Special report Alt' };
+
 export const ArticleNoTags = () => {
 	return (
 		<Wrapper>

--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.stories.tsx
@@ -162,6 +162,27 @@ export const Quoted = () => {
 				})}
 				quoted={true}
 			/>
+			<h1>SpecialReportAlt Standard</h1>
+			<BlockquoteBlockComponent
+				html={blockquoteHtml}
+				palette={decidePalette({
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+				})}
+				quoted={true}
+			/>
+
+			<h1>SpecialReportAlt Comment</h1>
+			<BlockquoteBlockComponent
+				html={blockquoteHtml}
+				palette={decidePalette({
+					design: ArticleDesign.Comment,
+					display: ArticleDisplay.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+				})}
+				quoted={true}
+			/>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/web/components/Border.tsx
+++ b/dotcom-rendering/src/web/components/Border.tsx
@@ -1,14 +1,26 @@
 import { css } from '@emotion/react';
+import { ArticleSpecial } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 
-export const Border = ({ format }: { format: ArticleFormat }) => (
-	<div
-		css={css`
+const borderStyles = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
+		return css`
 			${from.leftCol} {
-				border-left: 1px solid ${decidePalette(format).border.article};
+				border-left: 1px solid rgba(60, 60, 60, 0.3);
 				height: 100%;
 			}
-		`}
-	/>
+		`;
+	}
+
+	return css`
+		${from.leftCol} {
+			border-left: 1px solid ${decidePalette(format).border.article};
+			height: 100%;
+		}
+	`;
+};
+
+export const Border = ({ format }: { format: ArticleFormat }) => (
+	<div css={borderStyles(format)} />
 );

--- a/dotcom-rendering/src/web/components/Border.tsx
+++ b/dotcom-rendering/src/web/components/Border.tsx
@@ -1,26 +1,23 @@
 import { css } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
-import { from } from '@guardian/source-foundations';
+import { from, neutral } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
+import { transparentColour } from '../lib/transparentColour';
 
-const borderStyles = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return css`
-			${from.leftCol} {
-				border-left: 1px solid rgba(60, 60, 60, 0.3);
-				height: 100%;
-			}
-		`;
-	}
+const decideBorderColour = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return transparentColour(neutral[60], 0.3);
 
-	return css`
-		${from.leftCol} {
-			border-left: 1px solid ${decidePalette(format).border.article};
-			height: 100%;
-		}
-	`;
+	return decidePalette(format).border.article;
 };
 
 export const Border = ({ format }: { format: ArticleFormat }) => (
-	<div css={borderStyles(format)} />
+	<div
+		css={css`
+			${from.leftCol} {
+				border-left: 1px solid ${decideBorderColour(format)};
+				height: 100%;
+			}
+		`}
+	/>
 );

--- a/dotcom-rendering/src/web/components/Border.tsx
+++ b/dotcom-rendering/src/web/components/Border.tsx
@@ -1,21 +1,12 @@
 import { css } from '@emotion/react';
-import { ArticleSpecial } from '@guardian/libs';
-import { from, neutral } from '@guardian/source-foundations';
+import { from } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
-import { transparentColour } from '../lib/transparentColour';
-
-const decideBorderColour = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return transparentColour(neutral[60], 0.3);
-
-	return decidePalette(format).border.article;
-};
 
 export const Border = ({ format }: { format: ArticleFormat }) => (
 	<div
 		css={css`
 			${from.leftCol} {
-				border-left: 1px solid ${decideBorderColour(format)};
+				border-left: 1px solid ${decidePalette(format).border.article};
 				height: 100%;
 			}
 		`}

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import {
-	from,
-	headline,
-	neutral,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
+import { from, headline, textSans, until } from '@guardian/source-foundations';
 import { getSoleContributor } from '../../lib/byline';
 import TwitterIcon from '../../static/icons/twitter.svg';
 import type { Palette } from '../../types/palette';
@@ -29,7 +23,7 @@ const twitterHandleColour = (palette: Palette) => css`
 		color: ${palette.text.twitterHandle};
 
 		svg {
-			fill: ${neutral[46]};
+			fill: ${palette.fill.twitterHandle};
 		}
 
 		a {

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -12,23 +12,15 @@ const twitterHandleColour = (palette: Palette) => css`
 	color: ${palette.text.twitterHandleBelowDesktop};
 
 	svg {
-		fill: ${palette.fill.twitterHandleBelowDesktop};
+		fill: currentColor;
 	}
 
 	a {
-		color: ${palette.text.twitterHandleBelowDesktop};
+		color: inherit;
 	}
 
 	${from.desktop} {
 		color: ${palette.text.twitterHandle};
-
-		svg {
-			fill: ${palette.fill.twitterHandle};
-		}
-
-		a {
-			color: ${palette.text.twitterHandle};
-		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/Counts.tsx
+++ b/dotcom-rendering/src/web/components/Counts.tsx
@@ -1,19 +1,12 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { border, neutral, until } from '@guardian/source-foundations';
-import { transparentColour } from '../lib/transparentColour';
+import { ArticleDesign } from '@guardian/libs';
+import { until } from '@guardian/source-foundations';
+import { decidePalette } from '../lib/decidePalette';
 
 type Props = {
 	children: React.ReactNode;
 	format: ArticleFormat;
-};
-
-const decideVerticalDividerColour = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return transparentColour(neutral[60], 0.3);
-
-	return border.secondary;
 };
 
 const containerStyles = (format: ArticleFormat) => css`
@@ -24,7 +17,7 @@ const containerStyles = (format: ArticleFormat) => css`
 		/* This css to show a vertical divider  will only be applied to the second
            non empty meta-number element. (We only want the border to show when both share
            and comment counts are displayed) */
-		border-left: 1px solid ${decideVerticalDividerColour(format)};
+		border-left: 1px solid ${decidePalette(format).border.secondary};
 		margin-left: 4px;
 		padding-left: 4px;
 		height: 40px;

--- a/dotcom-rendering/src/web/components/Counts.tsx
+++ b/dotcom-rendering/src/web/components/Counts.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { border, until } from '@guardian/source-foundations';
+import { border, neutral, until } from '@guardian/source-foundations';
+import { transparentColour } from '../lib/transparentColour';
 
 type Props = {
 	children: React.ReactNode;
@@ -10,7 +11,7 @@ type Props = {
 
 const decideVerticalDividerColour = (format: ArticleFormat) => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return 'rgba(60, 60, 60, 0.3)';
+		return transparentColour(neutral[60], 0.3);
 
 	return border.secondary;
 };

--- a/dotcom-rendering/src/web/components/Counts.tsx
+++ b/dotcom-rendering/src/web/components/Counts.tsx
@@ -1,13 +1,21 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { border, until } from '@guardian/source-foundations';
 
 type Props = {
 	children: React.ReactNode;
 	format: ArticleFormat;
 };
-const containerStyles = css`
+
+const decideVerticalDividerColour = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return 'rgba(60, 60, 60, 0.3)';
+
+	return border.secondary;
+};
+
+const containerStyles = (format: ArticleFormat) => css`
 	display: flex;
 	flex-direction: row;
 	align-items: flex-start;
@@ -15,7 +23,7 @@ const containerStyles = css`
 		/* This css to show a vertical divider  will only be applied to the second
            non empty meta-number element. (We only want the border to show when both share
            and comment counts are displayed) */
-		border-left: 1px solid ${border.secondary};
+		border-left: 1px solid ${decideVerticalDividerColour(format)};
 		margin-left: 4px;
 		padding-left: 4px;
 		height: 40px;
@@ -33,7 +41,7 @@ const standfirstColouring = css`
 export const Counts = ({ children, format }: Props) => (
 	<div
 		css={[
-			containerStyles,
+			containerStyles(format),
 			format.design === ArticleDesign.LiveBlog && standfirstColouring,
 		]}
 	>

--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { text, textSans, until } from '@guardian/source-foundations';
+import { textSans, until } from '@guardian/source-foundations';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 
-const captionFont = css`
+const captionFont = (palette: Palette) => css`
 	${textSans.xxsmall()};
-	color: ${text.supporting};
+	color: ${palette.text.dateLine};
 `;
 
 const datelineStyles = css`
@@ -51,7 +51,7 @@ export const Dateline: React.FC<{
 			<details
 				css={[
 					datelineStyles,
-					captionFont,
+					captionFont(palette),
 					format.design === ArticleDesign.LiveBlog &&
 						standfirstColouring(palette),
 				]}
@@ -67,7 +67,7 @@ export const Dateline: React.FC<{
 		<div
 			css={[
 				datelineStyles,
-				captionFont,
+				captionFont(palette),
 				format.design === ArticleDesign.LiveBlog &&
 					standfirstColouring(palette),
 			]}

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
@@ -208,7 +208,7 @@ SpecialReportInline.story = {
 export const SportSupporting = () => {
 	const format = {
 		...defaultFormat,
-		theme: ArticlePillar.News,
+		theme: ArticlePillar.Sport,
 	};
 
 	return (

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
@@ -5,12 +5,61 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import { decidePalette } from '../lib/decidePalette';
-import { Section } from './Section';
 import { PullQuoteBlockComponent } from './PullQuoteBlockComponent';
+import { Section } from './Section';
 
 export default {
 	component: PullQuoteBlockComponent,
 	title: 'Components/PullQuoteBlockComponent',
+};
+
+const format = {
+	news: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
+	opinion: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Comment,
+		theme: ArticlePillar.Opinion,
+	},
+	sport: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Sport,
+	},
+	culture: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Culture,
+	},
+	lifestyle: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Lifestyle,
+	},
+	specialReport: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReport,
+	},
+	specialReportAlt: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReportAlt,
+	},
+	labs: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.Labs,
+	},
+};
+
+const photoEssayNews = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.PhotoEssay,
+	theme: ArticlePillar.News,
 };
 
 // Inline
@@ -22,12 +71,8 @@ export const SportInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Sport,
-				})}
+				format={format.sport}
+				palette={decidePalette(format.sport)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -47,12 +92,8 @@ export const LabsInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.Labs,
-				})}
+				format={format.labs}
+				palette={decidePalette(format.labs)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -72,12 +113,8 @@ export const LifestyleInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Lifestyle,
-				})}
+				format={format.lifestyle}
+				palette={decidePalette(format.lifestyle)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -97,12 +134,8 @@ export const CultureInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Culture,
-				})}
+				format={format.culture}
+				palette={decidePalette(format.culture)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -122,12 +155,8 @@ export const NewsInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
+				format={format.news}
+				palette={decidePalette(format.news)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -147,12 +176,8 @@ export const OpinionInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Comment}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Comment,
-					theme: ArticlePillar.Opinion,
-				})}
+				format={format.opinion}
+				palette={decidePalette(format.opinion)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -172,12 +197,8 @@ export const SpecialReportInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.SpecialReport,
-				})}
+				format={format.specialReport}
+				palette={decidePalette(format.specialReport)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -198,12 +219,8 @@ export const SportSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Sport,
-				})}
+				format={format.sport}
+				palette={decidePalette(format.sport)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -223,12 +240,8 @@ export const LabsSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.Labs,
-				})}
+				format={format.labs}
+				palette={decidePalette(format.labs)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -248,12 +261,8 @@ export const LifestyleSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Lifestyle,
-				})}
+				format={format.lifestyle}
+				palette={decidePalette(format.lifestyle)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -273,12 +282,8 @@ export const CultureSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.Culture,
-				})}
+				format={format.culture}
+				palette={decidePalette(format.culture)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -298,12 +303,8 @@ export const NewsSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticlePillar.News,
-				})}
+				format={format.news}
+				palette={decidePalette(format.news)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -323,12 +324,8 @@ export const OpinionSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Comment}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Comment,
-					theme: ArticlePillar.Opinion,
-				})}
+				format={format.opinion}
+				palette={decidePalette(format.opinion)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -348,12 +345,8 @@ export const SpecialReportSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.Standard}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: ArticleSpecial.SpecialReport,
-				})}
+				format={format.specialReport}
+				palette={decidePalette(format.specialReport)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -365,6 +358,48 @@ SpecialReportSupporting.story = {
 	name: 'SpecialReport, supporting, Article',
 };
 
+export const SpecialReportAltInline = () => {
+	return (
+		<Section
+			showTopBorder={false}
+			centralBorder="full"
+			showSideBorders={false}
+		>
+			<PullQuoteBlockComponent
+				format={format.specialReportAlt}
+				palette={decidePalette(format.specialReportAlt)}
+				html="Even if part of my job is filthy, I still love it – it’s my work"
+				role="inline"
+				attribution="Julie-Lou Dubreuilh"
+			/>
+		</Section>
+	);
+};
+SpecialReportAltInline.story = {
+	name: 'SpecialReportAlt, inline, Article',
+};
+
+export const SpecialReportAltSupporting = () => {
+	return (
+		<Section
+			showTopBorder={false}
+			centralBorder="full"
+			showSideBorders={false}
+		>
+			<PullQuoteBlockComponent
+				format={format.specialReportAlt}
+				palette={decidePalette(format.specialReportAlt)}
+				html="Even if part of my job is filthy, I still love it – it’s my work"
+				role="supporting"
+				attribution="Julie-Lou Dubreuilh"
+			/>
+		</Section>
+	);
+};
+SpecialReportAltSupporting.story = {
+	name: 'SpecialReportAlt, supporting, Article',
+};
+
 // PhotoEssay
 export const PhotoEssayInline = () => {
 	return (
@@ -374,12 +409,8 @@ export const PhotoEssayInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.PhotoEssay}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.PhotoEssay,
-					theme: ArticlePillar.News,
-				})}
+				format={photoEssayNews}
+				palette={decidePalette(photoEssayNews)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -399,12 +430,8 @@ export const PhotoEssaySupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				design={ArticleDesign.PhotoEssay}
-				palette={decidePalette({
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.PhotoEssay,
-					theme: ArticlePillar.News,
-				})}
+				format={photoEssayNews}
+				palette={decidePalette(photoEssayNews)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
@@ -13,47 +13,10 @@ export default {
 	title: 'Components/PullQuoteBlockComponent',
 };
 
-const format = {
-	news: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
-	opinion: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Comment,
-		theme: ArticlePillar.Opinion,
-	},
-	sport: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Sport,
-	},
-	culture: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Culture,
-	},
-	lifestyle: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Lifestyle,
-	},
-	specialReport: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReport,
-	},
-	specialReportAlt: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReportAlt,
-	},
-	labs: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.Labs,
-	},
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.News,
 };
 
 const photoEssayNews = {
@@ -64,6 +27,11 @@ const photoEssayNews = {
 
 // Inline
 export const SportInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Sport,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -71,8 +39,8 @@ export const SportInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.sport}
-				palette={decidePalette(format.sport)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -85,6 +53,11 @@ SportInline.story = {
 };
 
 export const LabsInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.Labs,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -92,8 +65,8 @@ export const LabsInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.labs}
-				palette={decidePalette(format.labs)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -106,6 +79,11 @@ LabsInline.story = {
 };
 
 export const LifestyleInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Lifestyle,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -113,8 +91,8 @@ export const LifestyleInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.lifestyle}
-				palette={decidePalette(format.lifestyle)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -127,6 +105,11 @@ LifestyleInline.story = {
 };
 
 export const CultureInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Culture,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -134,8 +117,8 @@ export const CultureInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.culture}
-				palette={decidePalette(format.culture)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -155,8 +138,8 @@ export const NewsInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.news}
-				palette={decidePalette(format.news)}
+				format={defaultFormat}
+				palette={decidePalette(defaultFormat)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -169,6 +152,11 @@ NewsInline.story = {
 };
 
 export const OpinionInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Opinion,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -176,8 +164,8 @@ export const OpinionInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.opinion}
-				palette={decidePalette(format.opinion)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -190,6 +178,11 @@ OpinionInline.story = {
 };
 
 export const SpecialReportInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.SpecialReport,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -197,8 +190,8 @@ export const SpecialReportInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.specialReport}
-				palette={decidePalette(format.specialReport)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -212,6 +205,11 @@ SpecialReportInline.story = {
 
 // Supporting
 export const SportSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.News,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -219,8 +217,8 @@ export const SportSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.sport}
-				palette={decidePalette(format.sport)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -233,6 +231,11 @@ SportSupporting.story = {
 };
 
 export const LabsSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.Labs,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -240,8 +243,8 @@ export const LabsSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.labs}
-				palette={decidePalette(format.labs)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -254,6 +257,11 @@ LabsSupporting.story = {
 };
 
 export const LifestyleSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Lifestyle,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -261,8 +269,8 @@ export const LifestyleSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.lifestyle}
-				palette={decidePalette(format.lifestyle)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -275,6 +283,11 @@ LifestyleSupporting.story = {
 };
 
 export const CultureSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Culture,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -282,8 +295,8 @@ export const CultureSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.culture}
-				palette={decidePalette(format.culture)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -303,8 +316,8 @@ export const NewsSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.news}
-				palette={decidePalette(format.news)}
+				format={defaultFormat}
+				palette={decidePalette(defaultFormat)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -317,6 +330,11 @@ NewsSupporting.story = {
 };
 
 export const OpinionSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticlePillar.Opinion,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -324,8 +342,8 @@ export const OpinionSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.opinion}
-				palette={decidePalette(format.opinion)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -338,6 +356,11 @@ OpinionSupporting.story = {
 };
 
 export const SpecialReportSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.SpecialReport,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -345,8 +368,8 @@ export const SpecialReportSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.specialReport}
-				palette={decidePalette(format.specialReport)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"
@@ -359,6 +382,11 @@ SpecialReportSupporting.story = {
 };
 
 export const SpecialReportAltInline = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.SpecialReportAlt,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -366,8 +394,8 @@ export const SpecialReportAltInline = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.specialReportAlt}
-				palette={decidePalette(format.specialReportAlt)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="inline"
 				attribution="Julie-Lou Dubreuilh"
@@ -380,6 +408,11 @@ SpecialReportAltInline.story = {
 };
 
 export const SpecialReportAltSupporting = () => {
+	const format = {
+		...defaultFormat,
+		theme: ArticleSpecial.SpecialReportAlt,
+	};
+
 	return (
 		<Section
 			showTopBorder={false}
@@ -387,8 +420,8 @@ export const SpecialReportAltSupporting = () => {
 			showSideBorders={false}
 		>
 			<PullQuoteBlockComponent
-				format={format.specialReportAlt}
-				palette={decidePalette(format.specialReportAlt)}
+				format={format}
+				palette={decidePalette(format)}
 				html="Even if part of my job is filthy, I still love it – it’s my work"
 				role="supporting"
 				attribution="Julie-Lou Dubreuilh"

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.stories.tsx
@@ -154,6 +154,7 @@ NewsInline.story = {
 export const OpinionInline = () => {
 	const format = {
 		...defaultFormat,
+		design: ArticleDesign.Comment,
 		theme: ArticlePillar.Opinion,
 	};
 
@@ -332,6 +333,7 @@ NewsSupporting.story = {
 export const OpinionSupporting = () => {
 	const format = {
 		...defaultFormat,
+		design: ArticleDesign.Comment,
 		theme: ArticlePillar.Opinion,
 	};
 

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -139,16 +139,6 @@ export const PullQuoteBlockComponent: React.FC<{
 							padding-top: 6px;
 							padding-bottom: 12px;
 							margin-bottom: 28px;
-
-							:after {
-								content: '';
-								width: 25px;
-								height: 25px;
-								bottom: -25px;
-								position: absolute;
-								background-color: ${palette.background
-									.pullQuote};
-							}
 						`,
 					]}
 				>

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { from, headline, text, until } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import type { Palette } from '../../types/palette';
@@ -98,6 +98,12 @@ function decidePosition(role: string, design: ArticleDesign) {
 	return role === 'supporting' ? partiallyLeft : partiallyInline;
 }
 
+const decideFontWeight = (theme: ArticleTheme) => {
+	if (theme === ArticleSpecial.SpecialReportAlt) return 'light';
+
+	return 'bold';
+};
+
 function decideFont(role: string) {
 	if (role === 'supporting') {
 		return css`
@@ -112,19 +118,19 @@ function decideFont(role: string) {
 export const PullQuoteBlockComponent: React.FC<{
 	html?: string;
 	palette: Palette;
-	design: ArticleDesign;
+	format: ArticleFormat;
 	role: string;
 	attribution?: string;
-}> = ({ html, palette, design, attribution, role }) => {
+}> = ({ html, palette, format, attribution, role }) => {
 	if (!html) return <></>;
-	switch (design) {
+	switch (format.design) {
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
 			return (
 				<aside
 					css={[
-						decidePosition(role, design),
+						decidePosition(role, format.design),
 						css`
 							${headline.xxsmall({ fontWeight: 'light' })};
 							line-height: 25px;
@@ -164,7 +170,7 @@ export const PullQuoteBlockComponent: React.FC<{
 			return (
 				<aside
 					css={[
-						decidePosition(role, design),
+						decidePosition(role, format.design),
 						decideFont(role),
 						css`
 							color: ${palette.text.pullQuote};
@@ -199,9 +205,11 @@ export const PullQuoteBlockComponent: React.FC<{
 			return (
 				<aside
 					css={[
-						decidePosition(role, design),
+						decidePosition(role, format.design),
 						css`
-							${headline.xxsmall({ fontWeight: 'bold' })};
+							${headline.xxsmall({
+								fontWeight: decideFontWeight(format.theme),
+							})};
 							line-height: 25px;
 							position: relative;
 							background-color: ${palette.background.pullQuote};

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -1,9 +1,16 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import { from, headline, text, until } from '@guardian/source-foundations';
+import {
+	from,
+	headline,
+	neutral,
+	text,
+	until,
+} from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import type { Palette } from '../../types/palette';
 import { QuoteIcon } from './QuoteIcon';
+import { transparentColour } from '../lib/transparentColour';
 
 const partiallyLeft = css`
 	width: 220px;
@@ -139,6 +146,22 @@ export const PullQuoteBlockComponent: React.FC<{
 							padding-top: 6px;
 							padding-bottom: 12px;
 							margin-bottom: 28px;
+							border: 1px solid
+								${transparentColour(neutral[60], 0.3)};
+
+							:after {
+								content: '';
+								width: 25px;
+								height: 25px;
+								bottom: -25px;
+								position: absolute;
+								background-color: ${palette.background
+									.pullQuote};
+								border: 1px solid
+									${transparentColour(neutral[60], 0.3)};
+								border-top: none;
+								left: -1px;
+							}
 						`,
 					]}
 				>

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -98,18 +98,35 @@ const fullyInline = css`
 	display: block;
 `;
 
+const specialReportAltStyles = (palette: Palette) => css`
+	${headline.xxsmall({ fontWeight: 'light' })};
+	line-height: 25px;
+	position: relative;
+	background-color: ${palette.background.pullQuote};
+	padding-top: 6px;
+	padding-bottom: 12px;
+	margin-bottom: 28px;
+	border: 1px solid ${transparentColour(neutral[60], 0.3)};
+
+	:after {
+		content: '';
+		width: 25px;
+		height: 25px;
+		bottom: -25px;
+		position: absolute;
+		background-color: ${palette.background.pullQuote};
+		border: 1px solid ${transparentColour(neutral[60], 0.3)};
+		border-top: none;
+		left: -1px;
+	}
+`;
+
 function decidePosition(role: string, design: ArticleDesign) {
 	if (design === ArticleDesign.PhotoEssay) {
 		return role === 'supporting' ? fullyLeft : fullyInline;
 	}
 	return role === 'supporting' ? partiallyLeft : partiallyInline;
 }
-
-const decideFontWeight = (theme: ArticleTheme) => {
-	if (theme === ArticleSpecial.SpecialReportAlt) return 'light';
-
-	return 'bold';
-};
 
 function decideFont(role: string) {
 	if (role === 'supporting') {
@@ -136,29 +153,7 @@ export const PullQuoteBlockComponent: React.FC<{
 			<aside
 				css={[
 					decidePosition(role, format.design),
-					css`
-						${headline.xxsmall({ fontWeight: 'light' })};
-						line-height: 25px;
-						position: relative;
-						background-color: ${palette.background.pullQuote};
-						padding-top: 6px;
-						padding-bottom: 12px;
-						margin-bottom: 28px;
-						border: 1px solid ${transparentColour(neutral[60], 0.3)};
-
-						:after {
-							content: '';
-							width: 25px;
-							height: 25px;
-							bottom: -25px;
-							position: absolute;
-							background-color: ${palette.background.pullQuote};
-							border: 1px solid
-								${transparentColour(neutral[60], 0.3)};
-							border-top: none;
-							left: -1px;
-						}
-					`,
+					specialReportAltStyles(palette),
 				]}
 			>
 				<QuoteIcon colour={palette.fill.quoteIcon} />
@@ -260,9 +255,7 @@ export const PullQuoteBlockComponent: React.FC<{
 					css={[
 						decidePosition(role, format.design),
 						css`
-							${headline.xxsmall({
-								fontWeight: decideFontWeight(format.theme),
-							})};
+							${headline.xxsmall({ fontWeight: 'bold' })};
 							line-height: 25px;
 							position: relative;
 							background-color: ${palette.background.pullQuote};

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -9,8 +9,8 @@ import {
 } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
 import type { Palette } from '../../types/palette';
-import { QuoteIcon } from './QuoteIcon';
 import { transparentColour } from '../lib/transparentColour';
+import { QuoteIcon } from './QuoteIcon';
 
 const partiallyLeft = css`
 	width: 220px;
@@ -130,6 +130,52 @@ export const PullQuoteBlockComponent: React.FC<{
 	attribution?: string;
 }> = ({ html, palette, format, attribution, role }) => {
 	if (!html) return <></>;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return (
+			<aside
+				css={[
+					decidePosition(role, format.design),
+					css`
+						${headline.xxsmall({ fontWeight: 'light' })};
+						line-height: 25px;
+						position: relative;
+						background-color: ${palette.background.pullQuote};
+						padding-top: 6px;
+						padding-bottom: 12px;
+						margin-bottom: 28px;
+						border: 1px solid ${transparentColour(neutral[60], 0.3)};
+
+						:after {
+							content: '';
+							width: 25px;
+							height: 25px;
+							bottom: -25px;
+							position: absolute;
+							background-color: ${palette.background.pullQuote};
+							border: 1px solid
+								${transparentColour(neutral[60], 0.3)};
+							border-top: none;
+							left: -1px;
+						}
+					`,
+				]}
+			>
+				<QuoteIcon colour={palette.fill.quoteIcon} />
+				<blockquote
+					css={css`
+						display: inline;
+					`}
+					dangerouslySetInnerHTML={{
+						__html: unescapeData(html),
+					}}
+				/>
+				<footer>
+					<cite>{attribution}</cite>
+				</footer>
+			</aside>
+		);
+
 	switch (format.design) {
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
@@ -146,8 +192,6 @@ export const PullQuoteBlockComponent: React.FC<{
 							padding-top: 6px;
 							padding-bottom: 12px;
 							margin-bottom: 28px;
-							border: 1px solid
-								${transparentColour(neutral[60], 0.3)};
 
 							:after {
 								content: '';
@@ -157,10 +201,6 @@ export const PullQuoteBlockComponent: React.FC<{
 								position: absolute;
 								background-color: ${palette.background
 									.pullQuote};
-								border: 1px solid
-									${transparentColour(neutral[60], 0.3)};
-								border-top: none;
-								left: -1px;
 							}
 						`,
 					]}

--- a/dotcom-rendering/src/web/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.stories.tsx
@@ -314,6 +314,22 @@ export const SpecialReport = () => {
 };
 SpecialReport.story = { name: 'SpecialReport' };
 
+export const SpecialReportAlt = () => {
+	return (
+		<Section fullWidth={true}>
+			<Standfirst
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				standfirst="This is how SpecialReportAlt standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas <ul><li><a href=\'https://www.theguardian.com/uk'>Bullet 1</a></li><li><a href=\'https://www.theguardian.com/uk'>Bullet 2</a></li></ul>"
+			/>
+		</Section>
+	);
+};
+SpecialReportAlt.story = { name: 'SpecialReportAlt' };
+
 export const Editorial = () => {
 	return (
 		<Section fullWidth={true}>

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -49,7 +49,6 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { transparentColour } from '../lib/transparentColour';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -209,12 +208,6 @@ const avatarHeadlineWrapper = css`
 const minHeightWithAvatar = css`
 	min-height: 259px;
 `;
-
-const straightLinesColour = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return transparentColour(neutral[60], 0.3);
-	else return undefined;
-};
 
 // If in mobile increase the margin top and margin right deficit
 const avatarPositionStyles = css`
@@ -414,7 +407,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							cssOverrides={css`
 								display: block;
 							`}
-							color={straightLinesColour(format)}
+							color={palette.border.article}
 						/>
 					</Section>
 				</SendToBack>
@@ -481,7 +474,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											cssOverrides={css`
 												display: block;
 											`}
-											color={straightLinesColour(format)}
+											color={palette.border.article}
 										/>
 									</div>
 								</div>
@@ -495,7 +488,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
-										color={straightLinesColour(format)}
+										color={palette.border.article}
 									/>
 								</Hide>
 							</div>
@@ -645,7 +638,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
-										color={straightLinesColour(format)}
+										color={palette.border.article}
 									/>
 									<SubMeta
 										format={format}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -407,7 +407,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							cssOverrides={css`
 								display: block;
 							`}
-							color={palette.border.article}
+							color={palette.border.secondary}
 						/>
 					</Section>
 				</SendToBack>
@@ -474,7 +474,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											cssOverrides={css`
 												display: block;
 											`}
-											color={palette.border.article}
+											color={palette.border.secondary}
 										/>
 									</div>
 								</div>
@@ -488,7 +488,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
-										color={palette.border.article}
+										color={palette.border.secondary}
 									/>
 								</Hide>
 							</div>
@@ -638,7 +638,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
-										color={palette.border.article}
+										color={palette.border.secondary}
 									/>
 									<SubMeta
 										format={format}

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -49,6 +49,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { transparentColour } from '../lib/transparentColour';
 import { BannerWrapper, SendToBack, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -208,6 +209,12 @@ const avatarHeadlineWrapper = css`
 const minHeightWithAvatar = css`
 	min-height: 259px;
 `;
+
+const straightLinesColour = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return transparentColour(neutral[60], 0.3);
+	else return undefined;
+};
 
 // If in mobile increase the margin top and margin right deficit
 const avatarPositionStyles = css`
@@ -407,6 +414,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							cssOverrides={css`
 								display: block;
 							`}
+							color={straightLinesColour(format)}
 						/>
 					</Section>
 				</SendToBack>
@@ -473,6 +481,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											cssOverrides={css`
 												display: block;
 											`}
+											color={straightLinesColour(format)}
 										/>
 									</div>
 								</div>
@@ -486,6 +495,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
+										color={straightLinesColour(format)}
 									/>
 								</Hide>
 							</div>
@@ -635,6 +645,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										cssOverrides={css`
 											display: block;
 										`}
+										color={straightLinesColour(format)}
 									/>
 									<SubMeta
 										format={format}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -449,7 +449,9 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								)}
 								<StraightLines
 									count={4}
-									color={decidePalette(format).border.article}
+									color={
+										decidePalette(format).border.secondary
+									}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -47,6 +47,7 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { ImmersiveHeader } from './headers/ImmersiveHeader';
 import { BannerWrapper } from './lib/stickiness';
+import { transparentColour } from '../lib/transparentColour';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -190,6 +191,12 @@ const decideCaption = (mainMedia: ImageBlockElement): string => {
 	}
 
 	return caption.join(' ');
+};
+
+const straightLinesColour = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return transparentColour(neutral[60], 0.3);
+	else return undefined;
 };
 
 export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
@@ -338,7 +345,12 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										ArticleSpecial.Labs ? (
 											<GuardianLabsLines />
 										) : (
-											<DecideLines format={format} />
+											<DecideLines
+												format={format}
+												color={straightLinesColour(
+													format,
+												)}
+											/>
 										)}
 									</div>
 								</div>
@@ -441,7 +453,10 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										/>
 									</Island>
 								)}
-								<StraightLines count={4} />
+								<StraightLines
+									count={4}
+									color={straightLinesColour(format)}
+								/>
 								<SubMeta
 									format={format}
 									subMetaKeywordLinks={

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -47,7 +47,6 @@ import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { ImmersiveHeader } from './headers/ImmersiveHeader';
 import { BannerWrapper } from './lib/stickiness';
-import { transparentColour } from '../lib/transparentColour';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -191,12 +190,6 @@ const decideCaption = (mainMedia: ImageBlockElement): string => {
 	}
 
 	return caption.join(' ');
-};
-
-const straightLinesColour = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return transparentColour(neutral[60], 0.3);
-	else return undefined;
 };
 
 export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
@@ -347,9 +340,10 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										) : (
 											<DecideLines
 												format={format}
-												color={straightLinesColour(
-													format,
-												)}
+												color={
+													decidePalette(format).border
+														.article
+												}
 											/>
 										)}
 									</div>
@@ -455,7 +449,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								)}
 								<StraightLines
 									count={4}
-									color={straightLinesColour(format)}
+									color={decidePalette(format).border.article}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -57,6 +57,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
+import { transparentColour } from '../lib/transparentColour';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -270,6 +271,12 @@ const stretchLines = css`
 	}
 `;
 
+const straightLinesColour = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return transparentColour(neutral[60], 0.3);
+	else return undefined;
+};
+
 const starWrapper = css`
 	margin-bottom: 18px;
 	margin-top: 6px;
@@ -441,6 +448,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
+									color={straightLinesColour(format)}
 								/>
 							</Section>
 						</>
@@ -591,7 +599,10 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									{format.theme === ArticleSpecial.Labs ? (
 										<GuardianLabsLines />
 									) : (
-										<DecideLines format={format} />
+										<DecideLines
+											format={format}
+											color={straightLinesColour(format)}
+										/>
 									)}
 								</div>
 							</div>
@@ -723,6 +734,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
+									color={straightLinesColour(format)}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -441,7 +441,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
-									color={palette.border.article}
+									color={palette.border.secondary}
 								/>
 							</Section>
 						</>
@@ -727,7 +727,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
-									color={palette.border.article}
+									color={palette.border.secondary}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -57,7 +57,6 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decidePalette } from '../lib/decidePalette';
 import { decideTrail } from '../lib/decideTrail';
 import { getCurrentPillar } from '../lib/layoutHelpers';
-import { transparentColour } from '../lib/transparentColour';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const StandardGrid = ({
@@ -271,12 +270,6 @@ const stretchLines = css`
 	}
 `;
 
-const straightLinesColour = (format: ArticleFormat) => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return transparentColour(neutral[60], 0.3);
-	else return undefined;
-};
-
 const starWrapper = css`
 	margin-bottom: 18px;
 	margin-top: 6px;
@@ -448,7 +441,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
-									color={straightLinesColour(format)}
+									color={palette.border.article}
 								/>
 							</Section>
 						</>
@@ -601,7 +594,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									) : (
 										<DecideLines
 											format={format}
-											color={straightLinesColour(format)}
+											color={palette.border.article}
 										/>
 									)}
 								</div>
@@ -734,7 +727,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									cssOverrides={css`
 										display: block;
 									`}
-									color={straightLinesColour(format)}
+									color={palette.border.article}
 								/>
 								<SubMeta
 									format={format}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -57,6 +57,10 @@ const textHeadline = (format: ArticleFormat): string => {
 				format.design !== ArticleDesign.Interview
 			)
 				return specialReport[100];
+
+			if (format.theme === ArticleSpecial.SpecialReportAlt)
+				return neutral[7];
+
 			switch (format.design) {
 				case ArticleDesign.Review:
 				case ArticleDesign.Recipe:
@@ -194,6 +198,7 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 
 const textStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 	return BLACK;
 };
 
@@ -418,6 +423,10 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -758,6 +767,11 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.DeadBlog) {
 		return neutral[60];
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt) {
+		return palette.specialReportAlt[100];
+	}
+
 	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -774,8 +788,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
-			case ArticleSpecial.SpecialReportAlt:
-				return news[600];
 		}
 	}
 
@@ -1095,7 +1107,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];
 			case ArticleSpecial.SpecialReportAlt:
-				return news[600];
+				return neutral[46];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -253,8 +253,7 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return neutral[7];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
@@ -305,6 +304,8 @@ const textSubMetaLabel = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 	return text.supporting;
 };
 
@@ -319,6 +320,10 @@ const textSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
@@ -1022,13 +1027,16 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].main;
 };
 
-const fillShareCountIcon = (): string => {
+const fillShareCountIcon = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return neutral[46];
 };
 
 const fillShareCountIconUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
-	return fillShareCountIcon();
+	return fillShareCountIcon(format);
 };
 
 const fillShareIconGrayBackground = (format: ArticleFormat): string => {
@@ -1073,6 +1081,9 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return border.secondary;
 };
 
@@ -1556,12 +1567,18 @@ const backgroundMostViewedTab = (format: ArticleFormat): string => {
 	return pillarPalette[format.theme].dark;
 };
 
-const textShareCount = (): string => {
+const textShareCount = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
 const textShareCountUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return text.supporting;
 };
@@ -1746,7 +1763,7 @@ export const decidePalette = (
 			numberedTitle: textNumberedTitle(format),
 			numberedPosition: textNumberedPosition(),
 			overlaidCaption: textOverlaid(),
-			shareCount: textShareCount(),
+			shareCount: textShareCount(format),
 			shareCountUntilDesktop: textShareCountUntilDesktop(format),
 			cricketScoreboardLink: textCricketScoreboardLink(),
 			keyEvent: textKeyEvent(format),
@@ -1796,7 +1813,7 @@ export const decidePalette = (
 			commentCount: fillCommentCount(format),
 			commentCountUntilDesktop: fillCommentCountUntilDesktop(format),
 			shareIcon: fillShareIcon(format),
-			shareCountIcon: fillShareCountIcon(),
+			shareCountIcon: fillShareCountIcon(format),
 			shareCountIconUntilDesktop: fillShareCountIconUntilDesktop(format),
 			shareIconGrayBackground: fillShareIconGrayBackground(format),
 			cameraCaptionIcon: fillCaptionCamera(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1520,7 +1520,7 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 	)
 		return '#CDCDCD';
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[86];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[60];
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -217,10 +217,23 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 		switch (format.theme) {
 			case ArticlePillar.News:
 				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Opinion:
+				return opinion[400];
+			case ArticlePillar.Culture:
+				return culture[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticleSpecial.Labs:
+				return labs[400];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[400];
+			case ArticleSpecial.SpecialReportAlt:
+				return palette.specialReportAlt[100];
 		}
 	}
+
 	if (
 		format.theme === ArticleSpecial.SpecialReport &&
 		format.design !== ArticleDesign.LiveBlog &&
@@ -411,7 +424,7 @@ const textArticleLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
 			case ArticleSpecial.SpecialReportAlt:
-				return news[300];
+				return palette.specialReportAlt[200];
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
@@ -722,11 +735,19 @@ const backgroundArticle = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.Letter) return opinion[800];
 	if (format.design === ArticleDesign.Comment) return opinion[800];
 	if (format.design === ArticleDesign.Editorial) return opinion[800];
-	if (format.design === ArticleDesign.Analysis) return news[800];
+
+	if (format.design === ArticleDesign.Analysis) {
+		if (format.theme === ArticleSpecial.SpecialReportAlt)
+			return palette.specialReportAlt[800];
+		else return news[800];
+	}
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[800]; // Note, check theme rather than design here
+
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return palette.specialReportAlt[800];
+
 	if (
 		format.theme === ArticleSpecial.Labs &&
 		format.display !== ArticleDisplay.Immersive
@@ -1079,7 +1100,7 @@ const fillShareIcon = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[300];
 			case ArticleSpecial.SpecialReportAlt:
-				return news[300];
+				return palette.specialReportAlt[100];
 		}
 	}
 	if (
@@ -1632,7 +1653,12 @@ const textDropCap = (format: ArticleFormat): string => {
 
 const textBetaLabel = (): string => neutral[46];
 
-const textDesignTag = (): string => neutral[100];
+const textDesignTag = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[800];
+
+	return neutral[100];
+};
 
 const textDateLine = (format: ArticleFormat): string => {
 	if (
@@ -1819,7 +1845,7 @@ const backgroundDesignTag = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[300];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[300];
+			return palette.specialReportAlt[100];
 	}
 };
 
@@ -1933,7 +1959,7 @@ export const decidePalette = (
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
 			betaLabel: textBetaLabel(),
-			designTag: textDesignTag(),
+			designTag: textDesignTag(format),
 			dateLine: textDateLine(format),
 		},
 		background: {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -34,9 +34,21 @@ const BLACK = neutral[7];
 const blogsGrayBackgroundPalette = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticlePillar.News:
-			return pillarPalette[format.theme].main;
-		default:
-			return pillarPalette[format.theme].dark;
+			return news[400];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+		case ArticleSpecial.Labs:
+			return labs[300];
 	}
 };
 
@@ -59,7 +71,11 @@ const textHeadline = (format: ArticleFormat): string => {
 			)
 				return specialReport[100];
 
-			if (format.theme === ArticleSpecial.SpecialReportAlt)
+			if (
+				format.theme === ArticleSpecial.SpecialReportAlt &&
+				format.design !== ArticleDesign.LiveBlog &&
+				format.design !== ArticleDesign.DeadBlog
+			)
 				return neutral[7];
 
 			switch (format.design) {
@@ -87,7 +103,11 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 		return BLACK;
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -158,7 +178,9 @@ const textByline = (format: ArticleFormat): string => {
 		format.design === ArticleDesign.DeadBlog
 	)
 		return blogsGrayBackgroundPalette(format);
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
@@ -199,15 +221,25 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 				return pillarPalette[format.theme].main;
 		}
 	}
-	if (format.theme === ArticleSpecial.SpecialReport)
+	if (
+		format.theme === ArticleSpecial.SpecialReport &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return specialReport[300];
+
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	return pillarPalette[format.theme].main;
 };
 
 const textStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return neutral[7];
+
 	return BLACK;
 };
 
@@ -254,7 +286,12 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return neutral[7];
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
@@ -305,7 +342,11 @@ const textSubMetaLabel = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design != ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 	return text.supporting;
 };
@@ -322,7 +363,11 @@ const textSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;
@@ -373,15 +418,24 @@ const textArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[200];
 
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
 			return pillarPalette[format.theme].dark;
-		default:
-			return pillarPalette[format.theme].main;
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
 	}
 };
 
@@ -517,7 +571,10 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[200];
 
 	switch (format.theme) {
@@ -711,11 +768,16 @@ const backgroundSectionTitle = (format: ArticleFormat): string => {
 };
 
 const backgroundAvatar = (format: ArticleFormat): string => {
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
+		return palette.specialReportAlt[300];
+
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[800];
-		case ArticleSpecial.SpecialReportAlt:
-			return palette.specialReportAlt[300];
 		case ArticlePillar.Opinion:
 			return pillarPalette[ArticlePillar.Opinion].main;
 		default:
@@ -804,10 +866,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 		return neutral[60];
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt) {
-		return palette.specialReportAlt[100];
-	}
-
 	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -824,8 +882,13 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 				return news[600];
 			case ArticleSpecial.SpecialReport:
 				return specialReport[700];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[600];
 		}
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
@@ -838,6 +901,8 @@ const backgroundHeader = (format: ArticleFormat): string => {
 					return news[300];
 				case ArticleSpecial.SpecialReport:
 					return specialReport[700];
+				case ArticleSpecial.SpecialReportAlt:
+					return news[300];
 				default:
 					return pillarPalette[format.theme][300];
 			}
@@ -1027,14 +1092,34 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
-	return pillarPalette[format.theme].main;
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
 };
 
 const fillShareCountIcon = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return neutral[46];
@@ -1067,13 +1152,41 @@ const fillBlockquoteIcon = (format: ArticleFormat): string => {
 				return pillarPalette[format.theme].main;
 		}
 	}
+
+	if (
+		format.design === ArticleDesign.DeadBlog ||
+		format.design === ArticleDesign.LiveBlog
+	) {
+		switch (format.theme) {
+			case ArticlePillar.News:
+				return news[400];
+			case ArticlePillar.Opinion:
+				return opinion[400];
+			case ArticlePillar.Sport:
+				return sport[400];
+			case ArticlePillar.Culture:
+				return culture[400];
+			case ArticlePillar.Lifestyle:
+				return lifestyle[400];
+			case ArticleSpecial.SpecialReport:
+				return specialReport[400];
+			case ArticleSpecial.SpecialReportAlt:
+				return news[400];
+			case ArticleSpecial.Labs:
+				return labs[400];
+		}
+	}
+
 	return pillarPalette[format.theme].main;
 };
 
 const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return neutral[46];
@@ -1087,7 +1200,11 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return border.secondary;
@@ -1131,16 +1248,36 @@ const borderLiveBlock = (format: ArticleFormat): string => {
 };
 
 const borderPinnedPost = (format: ArticleFormat): string => {
-	return pillarPalette[format.theme][300];
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[300];
+	}
 };
 
 const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	if (format.theme === ArticleSpecial.SpecialReport)
+
+	if (
+		format.theme === ArticleSpecial.SpecialReport &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return specialReport[300];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return palette.specialReportAlt[200];
 	return border.secondary;
 };
 
@@ -1162,7 +1299,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[450];
 			case ArticleSpecial.SpecialReportAlt:
-				return neutral[46];
+				return news[600];
 		}
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)
@@ -1265,7 +1402,11 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.LiveBlog &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[200];
 
 	if (format.design === ArticleDesign.Analysis) {
@@ -1494,12 +1635,19 @@ const textBetaLabel = (): string => neutral[46];
 const textDesignTag = (): string => neutral[100];
 
 const textDateLine = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
+
 	return neutral[46];
 };
 
 const textBlockquote = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -1574,7 +1722,11 @@ const backgroundMostViewedTab = (format: ArticleFormat): string => {
 };
 
 const textShareCount = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog &&
+		format.design !== ArticleDesign.LiveBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;
@@ -1583,7 +1735,10 @@ const textShareCount = (format: ArticleFormat): string => {
 const textShareCountUntilDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		format.design !== ArticleDesign.DeadBlog
+	)
 		return palette.specialReportAlt[100];
 
 	return text.supporting;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -71,12 +71,16 @@ const textHeadline = (format: ArticleFormat): string => {
 			)
 				return specialReport[100];
 
-			if (
-				format.theme === ArticleSpecial.SpecialReportAlt &&
-				format.design !== ArticleDesign.LiveBlog &&
-				format.design !== ArticleDesign.DeadBlog
-			)
-				return neutral[7];
+			if (format.theme === ArticleSpecial.SpecialReportAlt) {
+				if (format.design === ArticleDesign.Interview)
+					return palette.specialReportAlt[800];
+
+				if (
+					format.design !== ArticleDesign.LiveBlog &&
+					format.design !== ArticleDesign.DeadBlog
+				)
+					return neutral[7];
+			}
 
 			switch (format.design) {
 				case ArticleDesign.Review:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1594,7 +1594,7 @@ const borderSecondary = (format: ArticleFormat) => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return transparentColour(neutral[60], 0.3);
 
-	return border.secondary;
+	return neutral[86];
 };
 
 const fillRichLink = (format: ArticleFormat): string => {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -85,6 +85,10 @@ const textSeriesTitle = (format: ArticleFormat): string => {
 	) {
 		return BLACK;
 	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 	switch (format.display) {
@@ -156,6 +160,10 @@ const textByline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	switch (format.display) {
 		case ArticleDisplay.Immersive:
 			return WHITE;
@@ -230,6 +238,9 @@ const textTwitterHandle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return text.supporting;
 };
 
@@ -242,6 +253,9 @@ const textTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 const textCaption = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return neutral[7];
+
 	if (format.theme === ArticleSpecial.Labs) return neutral[20];
 
 	switch (format.design) {
@@ -350,9 +364,12 @@ const textArticleLink = (format: ArticleFormat): string => {
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	if (format.theme === ArticleSpecial.SpecialReport) {
+	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
-	}
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -493,6 +510,10 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	switch (format.theme) {
 		case ArticlePillar.Opinion:
 		case ArticlePillar.Culture:
@@ -641,6 +662,8 @@ const backgroundArticle = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.Analysis) return news[800];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[800]; // Note, check theme rather than design here
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[800];
 	if (
 		format.theme === ArticleSpecial.Labs &&
 		format.display !== ArticleDisplay.Immersive
@@ -680,6 +703,8 @@ const backgroundAvatar = (format: ArticleFormat): string => {
 	switch (format.theme) {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[800];
+		case ArticleSpecial.SpecialReportAlt:
+			return palette.specialReportAlt[300];
 		case ArticlePillar.Opinion:
 			return pillarPalette[ArticlePillar.Opinion].main;
 		default:
@@ -919,6 +944,10 @@ const fillCommentCount = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -987,6 +1016,9 @@ const fillShareIcon = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	return pillarPalette[format.theme].main;
 };
 
@@ -1026,6 +1058,9 @@ const fillBlockquoteIcon = (format: ArticleFormat): string => {
 
 const fillTwitterHandleBelowDesktop = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
 
 	return neutral[46];
 };
@@ -1086,6 +1121,9 @@ const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
 	return border.secondary;
 };
 
@@ -1209,6 +1247,10 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[100];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[200];
+
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case ArticlePillar.News:
@@ -1298,6 +1340,9 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 		format.design === ArticleDesign.DeadBlog
 	)
 		return '#CDCDCD';
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[86];
+
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;
 };
@@ -1430,6 +1475,12 @@ const textDropCap = (format: ArticleFormat): string => {
 const textBetaLabel = (): string => neutral[46];
 
 const textDesignTag = (): string => neutral[100];
+
+const textDateLine = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+	return neutral[46];
+};
 
 const textBlockquote = (format: ArticleFormat): string => {
 	switch (format.design) {
@@ -1705,6 +1756,7 @@ export const decidePalette = (
 			filterButtonActive: textFilterButtonActive(),
 			betaLabel: textBetaLabel(),
 			designTag: textDesignTag(),
+			dateLine: textDateLine(format),
 		},
 		background: {
 			article: backgroundArticle(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1547,28 +1547,23 @@ const borderNavPillar: (format: ArticleFormat) => string = (format) =>
 	pillarPalette[format.theme].bright;
 
 const borderArticle: (format: ArticleFormat) => string = (format) => {
-	if (
-		format.design === ArticleDesign.LiveBlog ||
-		format.design === ArticleDesign.DeadBlog
-	)
-		return '#CDCDCD';
-
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return transparentColour(neutral[60], 0.3);
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
-	return border.secondary;
+
+	return neutral[86];
 };
 
 const borderLines = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.Labs) return border.primary;
+	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	if (
 		format.theme === ArticleSpecial.SpecialReport &&
 		(format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Letter)
 	)
 		return neutral[46];
-	return border.secondary;
+	return neutral[86];
 };
 
 const backgroundRichLink = (format: ArticleFormat): string => {
@@ -1594,6 +1589,13 @@ const borderCricketScoreboardDivider = (): string => {
 const borderKeyEvent = (): string => neutral[46];
 
 const borderFilterButton = (): string => neutral[60];
+
+const borderSecondary = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return transparentColour(neutral[60], 0.3);
+
+	return border.secondary;
+};
 
 const fillRichLink = (format: ArticleFormat): string => {
 	switch (format.theme) {
@@ -2070,6 +2072,7 @@ export const decidePalette = (
 			cardSupporting: borderCardSupporting(format),
 			keyEvent: borderKeyEvent(),
 			filterButton: borderFilterButton(),
+			secondary: borderSecondary(format),
 		},
 		topBar: {
 			card: overrides?.topBar.card ?? topBarCard(format),

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -16,6 +16,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 	text,

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -234,15 +234,25 @@ const textHeadlineByline = (format: ArticleFormat): string => {
 		}
 	}
 
-	if (
-		format.theme === ArticleSpecial.SpecialReport &&
-		format.design !== ArticleDesign.LiveBlog &&
-		format.design !== ArticleDesign.DeadBlog
-	)
+	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
-	return pillarPalette[format.theme].main;
+
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Opinion:
+			return opinion[400];
+		case ArticlePillar.Sport:
+			return sport[400];
+		case ArticlePillar.Culture:
+			return culture[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return palette.specialReportAlt[100];
+	}
 };
 
 const textStandfirst = (format: ArticleFormat): string => {
@@ -251,7 +261,7 @@ const textStandfirst = (format: ArticleFormat): string => {
 		format.theme === ArticleSpecial.SpecialReportAlt &&
 		format.design !== ArticleDesign.DeadBlog
 	)
-		return neutral[7];
+		return palette.specialReportAlt[100];
 
 	return BLACK;
 };
@@ -577,7 +587,7 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 			case ArticleSpecial.SpecialReport:
 				return specialReport[100];
 			case ArticleSpecial.SpecialReportAlt:
-				return news[300];
+				return palette.specialReportAlt[200];
 		}
 	}
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
@@ -1293,11 +1303,11 @@ const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 
 	if (
-		format.theme === ArticleSpecial.SpecialReport &&
+		format.theme === ArticleSpecial.SpecialReportAlt &&
 		format.design !== ArticleDesign.DeadBlog &&
 		format.design !== ArticleDesign.LiveBlog
 	)
-		return specialReport[300];
+		return 'rgba(60, 60, 60, 0.3)';
 
 	return border.secondary;
 };
@@ -1325,6 +1335,10 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 	}
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[400];
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return 'rgba(60, 60, 60, 0.3)';
+
 	return border.secondary;
 };
 
@@ -1520,7 +1534,8 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 	)
 		return '#CDCDCD';
 
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[60];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return 'rgba(60, 60, 60, 0.3)';
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1307,7 +1307,7 @@ const borderArticleLink = (format: ArticleFormat): string => {
 		format.design !== ArticleDesign.DeadBlog &&
 		format.design !== ArticleDesign.LiveBlog
 	)
-		return 'rgba(60, 60, 60, 0.3)';
+		return transparentColour(neutral[60], 0.3);
 
 	return border.secondary;
 };
@@ -1337,7 +1337,7 @@ const borderStandfirstLink = (format: ArticleFormat): string => {
 		return specialReport[400];
 
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return 'rgba(60, 60, 60, 0.3)';
+		return transparentColour(neutral[60], 0.3);
 
 	return border.secondary;
 };
@@ -1535,7 +1535,7 @@ const borderArticle: (format: ArticleFormat) => string = (format) => {
 		return '#CDCDCD';
 
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return 'rgba(60, 60, 60, 0.3)';
+		return transparentColour(neutral[60], 0.3);
 
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	return border.secondary;

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1307,6 +1307,9 @@ const borderPinnedPost = (format: ArticleFormat): string => {
 const borderArticleLink = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 
+	if (format.theme === ArticleSpecial.SpecialReport)
+		return specialReport[300];
+
 	if (
 		format.theme === ArticleSpecial.SpecialReportAlt &&
 		format.design !== ArticleDesign.DeadBlog &&

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -743,7 +743,12 @@ const backgroundArticle = (format: ArticleFormat): string => {
 		return neutral[97];
 	// Order matters. We want comment special report pieces to have the opinion background
 	if (format.design === ArticleDesign.Letter) return opinion[800];
-	if (format.design === ArticleDesign.Comment) return opinion[800];
+	if (format.design === ArticleDesign.Comment) {
+		if (format.theme === ArticleSpecial.SpecialReportAlt)
+			return palette.specialReportAlt[800];
+
+		return opinion[800];
+	}
 	if (format.design === ArticleDesign.Editorial) return opinion[800];
 
 	if (format.design === ArticleDesign.Analysis) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1595,6 +1595,9 @@ const fillQuoteIcon = (format: ArticleFormat): string => {
 };
 
 const backgroundPullQuote = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[800];
+
 	switch (format.design) {
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
@@ -1602,6 +1605,7 @@ const backgroundPullQuote = (format: ArticleFormat): string => {
 			return '#fbe6d5';
 		case ArticleDesign.Analysis:
 			return neutral[100];
+
 		default:
 			return neutral[97];
 	}

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1234,6 +1234,13 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 	return WHITE;
 };
 
+const fillTwitterHandle = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
+	return neutral[46];
+};
+
 const borderSyndicationButton = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return neutral[60];
 	if (
@@ -2035,6 +2042,7 @@ export const decidePalette = (
 			quoteIcon: fillQuoteIcon(format),
 			blockquoteIcon: fillBlockquoteIcon(format),
 			twitterHandleBelowDesktop: fillTwitterHandleBelowDesktop(format),
+			twitterHandle: fillTwitterHandle(format),
 			guardianLogo: fillGuardianLogo(format),
 		},
 		border: {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -681,9 +681,14 @@ const backgroundArticle = (format: ArticleFormat): string => {
 const backgroundSeriesTitle = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
+
 	switch (format.display) {
-		case ArticleDisplay.Immersive:
+		case ArticleDisplay.Immersive: {
+			if (format.theme === ArticleSpecial.SpecialReportAlt)
+				return palette.specialReportAlt[300];
+
 			return pillarPalette[format.theme].main;
+		}
 		case ArticleDisplay.Showcase:
 		case ArticleDisplay.NumberedList:
 		case ArticleDisplay.Standard:

--- a/dotcom-rendering/src/web/lib/decideTheme.ts
+++ b/dotcom-rendering/src/web/lib/decideTheme.ts
@@ -14,6 +14,8 @@ export const decideTheme = ({ theme }: Partial<CAPIFormat>): ArticleTheme => {
 			return ArticlePillar.Lifestyle;
 		case 'SpecialReportTheme':
 			return ArticleSpecial.SpecialReport;
+		case 'SpecialReportAltTheme':
+			return ArticleSpecial.SpecialReportAlt;
 		case 'Labs':
 			return ArticleSpecial.Labs;
 		default:

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -496,7 +496,7 @@ export const renderElement = ({
 					key={index}
 					html={element.html}
 					palette={palette}
-					design={format.design}
+					format={format}
 					attribution={element.attribution}
 					role={element.role}
 				/>,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,
@@ -54,6 +54,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 		createEmotionServer(cache);
 
 	const format: ArticleFormat = decideFormat(CAPIArticle.format);
+	format.theme = ArticleSpecial.SpecialReportAlt;
 
 	const html = renderToString(
 		<CacheProvider value={cache}>

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -1,7 +1,7 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
-import { ArticleDesign, ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
 import {
 	BUILD_VARIANT,
@@ -54,7 +54,6 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 		createEmotionServer(cache);
 
 	const format: ArticleFormat = decideFormat(CAPIArticle.format);
-	format.theme = ArticleSpecial.SpecialReportAlt;
 
 	const html = renderToString(
 		<CacheProvider value={cache}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,6 +2869,11 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
+"@guardian/libs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+
 "@guardian/libs@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,11 +2869,6 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
-
 "@guardian/libs@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,10 +2806,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.7.1":
-  version "23.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.7.1.tgz#c696e1a028c9cd2aa20b1baa014726335d1be1ee"
-  integrity sha512-ebf7w7S5IeDQH7SyfhQ6WSXrpBTLsCT4YXtHUUjHGHlV08wbGr+63X9QOWGTIbG6OIfQud0YlfTAUNNFkyk06g==
+"@guardian/atoms-rendering@^23.7.2":
+  version "23.7.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.7.2.tgz#3ec66b9e7c5f029cd0024429fea2740c95bc5161"
+  integrity sha512-BgTfnecyWAZlyf3uqT/JwXyQegIv017DKbUlV0cjVjeHThkGhK+vDapxtelwqx2BClkbaCgAtngqSLOrnTMakA==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
Co-authored-by: Daniel Clifton [daniel.clifton@guardian.co.uk](mailto:daniel.clifton@guardian.co.uk)

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
* Adds styling and stories for articles for specialReportAlt
* Makes sure specialReportAlt Liveblog and Deadblog looks like news

## Why?
To match the [designs](https://www.figma.com/file/agVeiMZULSWlf4JxNgkng4/Fronts-Palettes)

## Stories

* StandardDisplay / StandardDesign / SpecialReportAlt: https://5dfcbf3012392c0020e7140b-avbjehulnq.chromatic.com/?path=/story/components-layout-format-variations--standard-standard-special-report-alt-theme
* StandardDisplay / CommentDesign / SpecialReportAlt: https://5dfcbf3012392c0020e7140b-avbjehulnq.chromatic.com/?path=/story/components-layout-format-variations--standard-comment-special-report-alt-theme
* Standard / Explainer / SpecialReportAlt: https://5dfcbf3012392c0020e7140b-avbjehulnq.chromatic.com/?path=/story/components-layout-format-variations--standard-explainer-special-report-alt-theme
* Standard / Analysis / SpecialReportAlt: https://5dfcbf3012392c0020e7140b-avbjehulnq.chromatic.com/?path=/story/components-layout-format-variations--standard-analysis-special-report-alt-theme
* Immersive / Standard / SpecialReportAlt: https://5dfcbf3012392c0020e7140b-avbjehulnq.chromatic.com/?path=/story/components-layout-format-variations--immersive-standard-special-report-alt-theme


