### PR TITLE
Add cards styles for SpecialReportAlt

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -258,6 +258,51 @@ export const WithMediaType = () => {
 	);
 };
 
+export const WithMediaTypeSpecialReportAlt = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Video,
+						theme: ArticleSpecial.SpecialReportAlt,
+					}}
+					mediaType="Video"
+					mediaDuration={30}
+					headlineText="Video"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Audio,
+						theme: ArticleSpecial.SpecialReportAlt,
+					}}
+					mediaType="Audio"
+					mediaDuration={90}
+					headlineText="Audio"
+				/>
+			</CardWrapper>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Gallery,
+						theme: ArticleSpecial.SpecialReportAlt,
+					}}
+					mediaType="Gallery"
+					headlineText="Gallery"
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
 export const WithDifferentImagePositions = () => {
 	return (
 		<>
@@ -334,6 +379,48 @@ export const WithPulsingDot = () => {
 				{...basicCardProps}
 				showPulsingDot={true}
 				kickerText="Pulsing Dot"
+			/>
+		</CardWrapper>
+	);
+};
+
+export const WithPulsingDotSpecialReportAlt = () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.LiveBlog,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				showPulsingDot={true}
+				kickerText="Pulsing Dot"
+			/>
+		</CardWrapper>
+	);
+};
+
+export const WithQuotes = () => {
+	return (
+		<CardWrapper>
+			<Card {...basicCardProps} showQuotes={true} kickerText="Quotes" />
+		</CardWrapper>
+	);
+};
+
+export const WithQuotesSpecialReportAlt = () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: ArticleSpecial.SpecialReportAlt,
+				}}
+				showQuotes={true}
+				kickerText="Quotes"
 			/>
 		</CardWrapper>
 	);

--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -84,7 +84,10 @@ const cardStyles = (
 		`;
 	}
 
-	if (format.theme === ArticleSpecial.SpecialReport) {
+	if (
+		format.theme === ArticleSpecial.SpecialReport ||
+		format.theme === ArticleSpecial.SpecialReportAlt
+	) {
 		return css`
 			${baseCardStyles};
 			:hover {

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -1,6 +1,12 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { TrailType } from '../../types/trails';
+import { consentlessAds } from '../experiments/tests/consentless-ads';
 import { Carousel } from './Carousel.importable';
 import { Section } from './Section';
 
@@ -260,3 +266,33 @@ export const Immersive = () => (
 );
 
 Immersive.story = 'Immersive carousel';
+
+export const SpecialReportAlt = () => {
+	const specialReportTrails = trails.forEach(
+		(trail) =>
+			(trail.format = {
+				theme: ArticleSpecial.SpecialReportAlt,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}),
+	);
+	console.log(specialReportTrails);
+	return (
+		<>
+			<Section fullWidth={true}>
+				<Carousel
+					heading="Cottonopolis"
+					trails={specialReportTrails}
+					onwardsSource="curated-content"
+					format={{
+						theme: ArticleSpecial.SpecialReportAlt,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+				/>
+			</Section>
+		</>
+	);
+};
+
+SpecialReportAlt.story = 'SpecialReportAlt';

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -1,12 +1,6 @@
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticlePillar,
-	ArticleSpecial,
-} from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { TrailType } from '../../types/trails';
-import { consentlessAds } from '../experiments/tests/consentless-ads';
 import { Carousel } from './Carousel.importable';
 import { Section } from './Section';
 
@@ -267,32 +261,32 @@ export const Immersive = () => (
 
 Immersive.story = 'Immersive carousel';
 
-export const SpecialReportAlt = () => {
-	const specialReportTrails = trails.forEach(
-		(trail) =>
-			(trail.format = {
-				theme: ArticleSpecial.SpecialReportAlt,
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-			}),
-	);
-	console.log(specialReportTrails);
-	return (
-		<>
-			<Section fullWidth={true}>
-				<Carousel
-					heading="Cottonopolis"
-					trails={specialReportTrails}
-					onwardsSource="curated-content"
-					format={{
-						theme: ArticleSpecial.SpecialReportAlt,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
-				/>
-			</Section>
-		</>
-	);
-};
+// export const SpecialReportAlt = () => {
+// 	const specialReportTrails = trails.map(
+// 		(trail) =>
+// 			(trail.format = {
+// 				theme: ArticleSpecial.SpecialReportAlt,
+// 				design: ArticleDesign.Standard,
+// 				display: ArticleDisplay.Standard,
+// 			}),
+// 	);
+// 	console.log(specialReportTrails);
+// 	return (
+// 		<>
+// 			<Section fullWidth={true}>
+// 				<Carousel
+// 					heading="Cottonopolis"
+// 					trails={specialReportTrails}
+// 					onwardsSource="curated-content"
+// 					format={{
+// 						theme: ArticleSpecial.SpecialReportAlt,
+// 						design: ArticleDesign.Standard,
+// 						display: ArticleDisplay.Standard,
+// 					}}
+// 				/>
+// 			</Section>
+// 		</>
+// 	);
+// };
 
-SpecialReportAlt.story = 'SpecialReportAlt';
+// SpecialReportAlt.story = 'SpecialReportAlt';

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -1,4 +1,9 @@
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { TrailType } from '../../types/trails';
 import { Carousel } from './Carousel.importable';
@@ -261,32 +266,34 @@ export const Immersive = () => (
 
 Immersive.story = 'Immersive carousel';
 
-// export const SpecialReportAlt = () => {
-// 	const specialReportTrails = trails.map(
-// 		(trail) =>
-// 			(trail.format = {
-// 				theme: ArticleSpecial.SpecialReportAlt,
-// 				design: ArticleDesign.Standard,
-// 				display: ArticleDisplay.Standard,
-// 			}),
-// 	);
-// 	console.log(specialReportTrails);
-// 	return (
-// 		<>
-// 			<Section fullWidth={true}>
-// 				<Carousel
-// 					heading="Cottonopolis"
-// 					trails={specialReportTrails}
-// 					onwardsSource="curated-content"
-// 					format={{
-// 						theme: ArticleSpecial.SpecialReportAlt,
-// 						design: ArticleDesign.Standard,
-// 						display: ArticleDisplay.Standard,
-// 					}}
-// 				/>
-// 			</Section>
-// 		</>
-// 	);
-// };
+export const SpecialReportAlt = () => {
+	const specialReportTrails = [...trails];
 
-// SpecialReportAlt.story = 'SpecialReportAlt';
+	specialReportTrails.forEach(
+		(trail) =>
+			(trail.format = {
+				theme: ArticleSpecial.SpecialReportAlt,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}),
+	);
+
+	return (
+		<>
+			<Section fullWidth={true}>
+				<Carousel
+					heading="Cottonopolis"
+					trails={specialReportTrails}
+					onwardsSource="curated-content"
+					format={{
+						theme: ArticleSpecial.SpecialReportAlt,
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+					}}
+				/>
+			</Section>
+		</>
+	);
+};
+
+SpecialReportAlt.story = 'SpecialReportAlt';

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -282,7 +282,7 @@ export const SpecialReportAlt = () => {
 		<>
 			<Section fullWidth={true}>
 				<Carousel
-					heading="Cottonopolis"
+					heading="SpecialReportAlt"
 					trails={specialReportTrails}
 					onwardsSource="curated-content"
 					format={{

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1658,6 +1658,8 @@ const textSignInLink = (format: ArticleFormat): string => {
 };
 
 const textCarouselTitle = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
 			case ArticlePillar.News:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -6,10 +6,8 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import {
-	border,
 	brand,
 	brandAlt,
-	brandAltBackground,
 	culture,
 	labs,
 	lifestyle,
@@ -657,7 +655,8 @@ const textCardKicker = (format: ArticleFormat): string => {
 			format.design === ArticleDesign.Letter)
 	)
 		return brandAlt[400];
-	if (format.theme === ArticleSpecial.SpecialReportAlt) return palette.specialReportAlt[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[300];
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -1478,8 +1477,7 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 };
 
 const topBarCard = (format: ArticleFormat): string => {
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return neutral[60];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[60];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
 	if (format.design === ArticleDesign.Analysis) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1770,7 +1770,7 @@ const backgroundCarouselDot = (format: ArticleFormat): string => {
 		case ArticleSpecial.SpecialReport:
 			return specialReport[400];
 		case ArticleSpecial.SpecialReportAlt:
-			return news[400];
+			return palette.specialReportAlt[100];
 	}
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -657,6 +657,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 			format.design === ArticleDesign.Letter)
 	)
 		return brandAlt[400];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return palette.specialReportAlt[300];
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -826,6 +827,8 @@ const backgroundAvatar = (format: ArticleFormat): string => {
 };
 
 const backgroundCard = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[700];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return specialReport[300];
 	switch (format.design) {
@@ -1475,6 +1478,8 @@ const borderArticleLinkHover = (format: ArticleFormat): string => {
 };
 
 const topBarCard = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return neutral[60];
 	if (format.theme === ArticleSpecial.SpecialReport)
 		return brandAltBackground.primary;
 	if (format.design === ArticleDesign.Analysis) {

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1573,6 +1573,14 @@ const borderLines = (format: ArticleFormat): string => {
 			format.design === ArticleDesign.Letter)
 	)
 		return neutral[46];
+
+	if (
+		format.theme === ArticleSpecial.SpecialReportAlt &&
+		(format.design === ArticleDesign.Comment ||
+			format.design === ArticleDesign.Letter)
+	)
+		return transparentColour(neutral[60], 0.3);
+
 	return neutral[86];
 };
 

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -615,6 +615,10 @@ const textArticleLinkHover = (format: ArticleFormat): string => {
 
 const textCardHeadline = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReport) return WHITE;
+
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	if (format.display === ArticleDisplay.Immersive) return BLACK;
 	switch (format.design) {
 		case ArticleDesign.Interview:
@@ -657,8 +661,8 @@ const textCardKicker = (format: ArticleFormat): string => {
 			format.design === ArticleDesign.Letter)
 	)
 		return brandAlt[400];
-	if (format.theme === ArticleSpecial.SpecialReportAlt)
-		return palette.specialReportAlt[300];
+	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
+
 	if (format.theme === ArticleSpecial.SpecialReport) return brandAlt[400];
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
@@ -691,6 +695,9 @@ const textCardKicker = (format: ArticleFormat): string => {
 };
 
 const textCardFooter = (format: ArticleFormat): string => {
+	if (format.theme === ArticleSpecial.SpecialReportAlt)
+		return palette.specialReportAlt[100];
+
 	switch (format.design) {
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -6,8 +6,10 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import {
+	border,
 	brand,
 	brandAlt,
+	brandAltBackground,
 	culture,
 	labs,
 	lifestyle,
@@ -682,8 +684,6 @@ const textCardKicker = (format: ArticleFormat): string => {
 					return culture[500];
 				case ArticleSpecial.Labs:
 					return labs[400];
-				case ArticleSpecial.SpecialReportAlt:
-					return news[600];
 			}
 		default:
 			return pillarPalette[format.theme].main;


### PR DESCRIPTION
Co-authored-by: Daniel Clifton [daniel.clifton@guardian.co.uk](mailto:daniel.clifton@guardian.co.uk)

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
* Adds styling and stories for cards for specialReportAlt

## Why?
To match the [designs](https://www.figma.com/file/agVeiMZULSWlf4JxNgkng4/Fronts-Palettes)

## Screenshots

### Carousel
![carousel](https://user-images.githubusercontent.com/19683595/198967482-7576c2f1-9270-43bc-8a9e-7f1c585f9487.png)

### Standard
![standardCards](https://user-images.githubusercontent.com/19683595/198967518-53b0bc4c-55e1-4748-adba-afd2886aa0e4.png)

### With media type
![image](https://user-images.githubusercontent.com/19683595/198978038-58817f15-276f-4162-9c75-fe1c4317f882.png)

### With quotes
![image](https://user-images.githubusercontent.com/19683595/198978131-9920e10f-02d0-4dde-9cb3-46576e0f7cda.png)

### Live
![image](https://user-images.githubusercontent.com/19683595/198977792-d0be0b96-0263-47b5-9f46-2d9f92976b70.png)


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
