### PR TITLE
SDC 1.0.6

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
     "@guardian/discussion-rendering": "^10.3.0",
     "@guardian/libs": "^9.0.1",
     "@guardian/shimport": "^1.0.2",
-    "@guardian/support-dotcom-components": "^1.0.5",
+    "@guardian/support-dotcom-components": "^1.0.6",
     "@guardian/tsconfig": "^0.1.4",
     "@percy/cli": "^1.4.0",
     "@percy/cypress": "^3.1.2",

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -156,18 +156,11 @@ const subMessageStyles = css`
 `;
 
 const ReaderRevenueLinksRemote: React.FC<{
-	editionId: EditionId;
 	countryCode: string;
 	pageViewId: string;
 	contributionsServiceUrl: string;
 	ophanRecord: OphanRecordFunction;
-}> = ({
-	editionId,
-	countryCode,
-	pageViewId,
-	contributionsServiceUrl,
-	ophanRecord,
-}) => {
+}> = ({ countryCode, pageViewId, contributionsServiceUrl, ophanRecord }) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
 	const [SupportHeader, setSupportHeader] = useState<React.FC | null>(null);
@@ -185,7 +178,6 @@ const ReaderRevenueLinksRemote: React.FC<{
 			},
 			targeting: {
 				showSupportMessaging: !shouldHideSupportMessaging(),
-				edition: editionId,
 				countryCode,
 				modulesVersion: MODULES_VERSION,
 				mvtId: Number(
@@ -393,7 +385,6 @@ export const ReaderRevenueLinks = ({
 		if (inHeader && remoteHeader) {
 			return (
 				<ReaderRevenueLinksRemote
-					editionId={editionId}
 					countryCode={countryCode}
 					pageViewId={pageViewId}
 					contributionsServiceUrl={contributionsServiceUrl}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,10 +2908,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-9.0.0.tgz#9a91775dd6405d9461f7d18b836d8df688143204"
   integrity sha512-A0d0QrqJ+LN+zb8vBLtHqB+aT9gk056tsi2S5oOc0v+pLifZ/y0tOK1htX5EKtjdIjlbsXj0UZc3s+bZtmkHzg==
 
-"@guardian/support-dotcom-components@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.5.tgz#659720c332c62b211efab9a45350c042184a5082"
-  integrity sha512-BVvGeyS5dAD9Qu7NwFUsDou9LN5o9LZH5I4BnVf2Tg7Rj/mxdnO5qPygwI0dKFEbNHql4BEhJqSBdWI9MUSPWw==
+"@guardian/support-dotcom-components@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.6.tgz#47c1c110ba94e29617b9cd0eca6ced87f622cff6"
+  integrity sha512-4VmpVrZ/QOIr1r7nFXI839tavmc7PpXGQ0tJajy/d0YBwYFRswa4Yf+xM2vmM+x5tOZWFnJIlsZifkz10MpbBw==
 
 "@guardian/tsconfig@^0.1.4":
   version "0.1.4"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the support-dotcom-components dependency to 1.0.6

## Why?
This version no longer requires the `edition` field for header links targeting. (See https://github.com/guardian/support-dotcom-components/pull/779)
This is good because we're adding a new EUR edition.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
