### PR TITLE
fix: spell “cannot” properly

### DIFF
--- a/dotcom-rendering/src/web/components/DiscussionContainer.importable.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionContainer.importable.tsx
@@ -14,7 +14,7 @@ import { DiscussionWhenSignedIn } from './DiscussionWhenSignedIn';
  *
  * If not, it simply renders Discussion
  *
- * We use component composition like this here because you cannoy call react
+ * We use component composition like this here because you cannot call react
  * hooks conditionally and we're using a hook to make the fetch request
  *
  * Note. We allow the ...props pattern here because it makes sense when we're


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Spell “cannot” properly 

## Why?

Why not?