### PR TITLE
feat: bump discussion-rendering to v11

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -66,7 +66,7 @@
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.3.0",
     "@guardian/consent-management-platform": "10.11.1",
-    "@guardian/discussion-rendering": "^10.3.0",
+    "@guardian/discussion-rendering": "^11.0.3",
     "@guardian/libs": "^9.0.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/support-dotcom-components": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,10 +2835,10 @@
   dependencies:
     "@guardian/libs" "^7.1.4"
 
-"@guardian/discussion-rendering@^10.3.0":
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-10.3.0.tgz#aed59af1693ef3a2d3adf2ab822eed701b684055"
-  integrity sha512-Qmm6BxUhbPG2xGiDSQYlyjB0vm1z7o+YSwS+kdAsXYXfJg85LvrVWWQJ7shQ7tu0s6svcDRzAGyrW30XJY+JDg==
+"@guardian/discussion-rendering@^11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-11.0.3.tgz#4e18a9e28a0d12a4dc61739b3877478c780b36a9"
+  integrity sha512-2hsYGUzuXHKzyCIOGP42X3CVK11I32krP6fffyP5BuCFSQNgrpje4L9ngWIpOGvHi12T2anYnXI7HyouQDGo0A==
 
 "@guardian/eslint-config-typescript@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
## What does this change?

Bump the @guardian/discussion-rendering package to [v11.0.3](https://github.com/guardian/discussion-rendering/releases/tag/v11.0.3) – [discussion-rendering#640](https://github.com/guardian/discussion-rendering/pull/640)

This release aligns other @guardian packages so we can capture the new underlines that been introduced in `Link` and `LinkButton` components.

## Why?

Take two of #6293 and its demise #6329

## Screenshots

No out-of-memory error!

<img width="529" alt="image" src="https://user-images.githubusercontent.com/76776/199250324-71aae5fe-a309-4a1b-87e0-7bd0779e7bf5.png">

`apps-rendering` works!

<img width="643" alt="image" src="https://user-images.githubusercontent.com/76776/199278541-32254e26-f8cb-4c78-b206-d2b7f19e9b37.png">
