### PR TITLE
Add AB test for skipping Prebid in Canada

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -6,6 +6,7 @@ import {
 import { getCookie } from '@guardian/libs';
 import type { ServerSideTestNames } from '../../types/config';
 import { tests } from '../experiments/ab-tests';
+import { removePrebidA9Canada } from '../experiments/tests/remove-prebid-a9-canada';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -28,6 +29,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 		// For these tests switch off sampling and collect metrics for 100% of views
 		const clientSideTestsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
+			removePrebidA9Canada,
 		];
 
 		const userInClientSideTestToForceMetrics = ABTestAPI?.allRunnableTests(

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -6,6 +6,7 @@ import {
 } from '@guardian/libs';
 import { dcrJavascriptBundle } from '../../../scripts/webpack/bundles';
 import type { ServerSideTestNames } from '../../types/config';
+import { removePrebidA9Canada } from '../experiments/tests/remove-prebid-a9-canada';
 import { useAB } from '../lib/useAB';
 
 export const CoreVitals = () => {
@@ -23,6 +24,7 @@ export const CoreVitals = () => {
 	// For these tests switch off sampling and collect metrics for 100% of views
 	const clientSideTestsToForceMetrics: ABTest[] = [
 		/* keep array multi-line */
+		removePrebidA9Canada,
 	];
 
 	const userInClientSideTestToForceMetrics =

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -6,6 +6,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from './tests/newsletter-merch-unit-test';
+import { removePrebidA9Canada } from './tests/remove-prebid-a9-canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 import {
@@ -37,4 +38,5 @@ export const tests: ABTest[] = [
 	signInGateMandatoryLongTestVariantNa,
 	signInGateMandatoryLongTestVariantEu,
 	signInGateMandatoryLongTestVariantUk,
+	removePrebidA9Canada,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/consentless-ads.ts
+++ b/dotcom-rendering/src/web/experiments/tests/consentless-ads.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const consentlessAds: ABTest = {
 	id: 'ConsentlessAds',
-	author: '@commercial-dev',
+	author: '@guardian/commercial-dev',
 	start: '2022-08-11',
 	expiry: '2023-06-01',
 	audience: 0 / 100,

--- a/dotcom-rendering/src/web/experiments/tests/remove-prebid-a9-canada.ts
+++ b/dotcom-rendering/src/web/experiments/tests/remove-prebid-a9-canada.ts
@@ -3,7 +3,7 @@ import { getCountryCodeSync } from '../../lib/getCountryCode';
 
 export const removePrebidA9Canada: ABTest = {
 	id: 'RemovePrebidA9Canada',
-	author: '@commercial-dev',
+	author: '@guardian/commercial-dev',
 	start: '2022-11-01',
 	expiry: '2023-01-31',
 	audience: 10 / 100,

--- a/dotcom-rendering/src/web/experiments/tests/remove-prebid-a9-canada.ts
+++ b/dotcom-rendering/src/web/experiments/tests/remove-prebid-a9-canada.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { getCountryCodeSync } from '../../lib/getCountryCode';
+
+export const removePrebidA9Canada: ABTest = {
+	id: 'RemovePrebidA9Canada',
+	author: '@commercial-dev',
+	start: '2022-11-01',
+	expiry: '2023-01-31',
+	audience: 10 / 100,
+	audienceOffset: 20 / 100,
+	audienceCriteria: 'Canada users only',
+	successMeasure:
+		'There are significant benefits of not initialising Prebid and A9 in Canada',
+	description:
+		'Testing the benefits of not initialising Prebid and A9 in Canada',
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => getCountryCodeSync() == 'CA',
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Introduce a corresponding AB test to https://github.com/guardian/frontend/pull/25629.

Note we use `getCountryCodeSync()` as there isn't a corresponding `isInCanada` function available in DCR.

## Why?

So that test is available to the DCR platform.