### PR TITLE
Add Europe edition in DCR

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -23,53 +23,6 @@ export const Analysis: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'k',
-					value: [
-						'sinn-fein',
-						'world',
-						'europe-news',
-						'ireland',
-						'fianna-fail',
-						'fine-gael',
-					],
-				},
-				{
-					name: 'tn',
-					value: ['analysis', 'explainers'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/d9vgg',
-				},
-				{
-					name: 'url',
-					value: '/world/2020/feb/10/irish-general-election-everything-you-need-to-know',
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'co',
-					value: ['rorycarroll'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -164,6 +117,53 @@ export const Analysis: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'k',
+					value: [
+						'sinn-fein',
+						'world',
+						'europe-news',
+						'ireland',
+						'fianna-fail',
+						'fine-gael',
+					],
+				},
+				{
+					name: 'tn',
+					value: ['analysis', 'explainers'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d9vgg',
+				},
+				{
+					name: 'url',
+					value: '/world/2020/feb/10/irish-general-election-everything-you-need-to-know',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: ['rorycarroll'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -188,6 +188,53 @@ export const Analysis: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d9vgg',
+				},
+				{
+					name: 'url',
+					value: '/world/2020/feb/10/irish-general-election-everything-you-need-to-know',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: ['rorycarroll'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'k',
+					value: [
+						'sinn-fein',
+						'world',
+						'europe-news',
+						'ireland',
+						'fianna-fail',
+						'fine-gael',
+					],
+				},
+				{
+					name: 'tn',
+					value: ['analysis', 'explainers'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -892,6 +939,10 @@ export const Analysis: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1876,7 +1927,7 @@ export const Analysis: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '612dfaaa-b22d-4334-a073-87149bc0fb07',
+			elementId: '0cc990fc-0757-4f07-a99c-589a01572bec',
 		},
 	],
 	canonicalUrl:
@@ -1888,17 +1939,17 @@ export const Analysis: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Who won Ireland’s general election?</h2>',
-					elementId: 'dc5df909-2029-4057-a43d-036dd9902763',
+					elementId: '7742ec69-0b87-4adf-a7cd-9d747aba157f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Sinn Féin <a href="https://www.theguardian.com/world/2020/feb/09/sinn-fein-to-try-to-form-ruling-coalition-after-irish-election-success">won the most first-preference votes</a> – 24.5% – making it the most popular party and a strong contender to be included in the next government. <a href="https://www.theguardian.com/world/2020/jan/31/leo-varadkar-paradox-feted-abroad-can-pm-arrest-polls-slump-in-ireland-election">Leo Varadkar</a>’s ruling Fine Gael party slid to 20.8%, coming third, and Fianna Fáil, the main opposition party, also slipped, falling to 22.1% in second place. The rest of the vote was split between the Greens, on 7.1%, and small leftwing parties and independent candidates.</p>',
-					elementId: '97011c2c-1764-4777-a3f1-352e58745ba6',
+					elementId: 'd3e12a0a-3bb1-46f9-9804-9208fab92ff8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Sinn Féin fielded too few candidates to fully translate its support into seats so Fianna Fáil is expected to be the biggest party in Dáil Éireann, the Irish parliament’s lower house, which has 160 members, when all seats are allocated under Ireland’s single transferrable vote system of proportional representation.</p>',
-					elementId: '6491d63a-5b51-4575-bb07-cbde7fefab32',
+					elementId: '17adcab6-db78-4c4d-a786-4ffe8ffac265',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1906,32 +1957,32 @@ export const Analysis: CAPIArticleType = {
 					text: 'Ireland election: latest results',
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '02ab1ad0-7a9f-4c01-902c-6ccbc5a042ea',
+					elementId: '9ac229f9-9502-4876-bb55-6d51dccf9bf4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Current projections give Fianna Fáil around 42, with Sinn Féin and <a href="https://www.theguardian.com/world/fine-gael" data-component="auto-linked-tag">Fine Gael</a> each in the mid to high 30s. Full results are expected later on Monday or Tuesday.</p>',
-					elementId: '39951d0a-79c2-4f38-93e9-abbc868eca69',
+					elementId: 'c9e0802b-7a06-4518-88fe-b4f82fd2245c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Was Sinn Féin’s success a surprise?</h2>',
-					elementId: '511009f6-c722-4d32-8042-40c7b92bb2a9',
+					elementId: 'ba46cd0b-cdc2-4767-bdee-e4fecf3d91e6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>An opinion poll signalled it last week but the result is still a big shock. Fine Gael and Fianna Fáil, centrist rivals, dominated Irish politics for the past century, taking turns to rule. That era appears over.</p>',
-					elementId: 'c3769ced-76e0-4332-87ce-5de7869e2925',
+					elementId: 'f494a028-53c4-43c4-87a5-388119d35c25',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Is Varadkar going to lose power?</h2>',
-					elementId: '8a4f235a-e09c-46fe-bf43-1c86aad83996',
+					elementId: '732d7dcd-e3ef-4904-9a83-08082f0c6515',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Very possibly, but there’s a chance he could hang on as taoiseach after negotiations between party leaders to form a coalition with 80 seats, the magic number for a parliamentary majority. Varadkar says he would be willing to lead Fine Gael in opposition.</p>',
-					elementId: 'd4803535-9f4c-42cf-a3b6-1f5b163d0bf5',
+					elementId: '2e3b001f-887d-4918-9eba-488c7d99a8df',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.QABlockElement',
@@ -1939,62 +1990,62 @@ export const Analysis: CAPIArticleType = {
 					title: 'What are the main political parties in Ireland?',
 					html: '<p><a href="https://www.theguardian.com/politics/fine-gael">Fine Gael</a><br></p><p>Its name can be translated as family or tribe of the Irish. A centre-right party with a socially progressive tilt. In office since 2011, first led by Enda Kenny, then&nbsp;<a href="https://www.theguardian.com/world/leo-varadkar">Leo Varadkar</a>, with support from smaller coalition partners. Traces roots to Michael Collins and the winning side in Ireland’s 1922-23 civil war. The party traditionally advocates market economics and fiscal discipline. Appeals to the urban middle class and well-off farmers.</p><p><a href="https://www.theguardian.com/politics/fianna-fail">Fianna Fáil</a></p><p>Its name means Soldiers of Destiny. A centrist, ideologically malleable party that dominated Irish politics until it steered the Celtic Tiger economy over a cliff, prompting decade-long banishment to opposition benches. Under Micheál Martin, a nimble political veteran, it has clawed back support and may overtake Fine Gael as the biggest party and lead the next coalition government. Founded by Éamon de Valera, who backed the civil war’s losing side but turned Fianna Fáil into an election-winning machine.</p><p><a href="https://www.theguardian.com/politics/sinn-fein">Sinn Féin</a></p><p>Its name means We Ourselves, signifying Irish sovereignty. A leftwing republican party that competes in Northern Ireland as well as the Republic. Traces roots to 1905. Emerged in current form during the Troubles, when it was linked to the IRA. Peace in Northern Ireland helped Sinn Féin rebrand as a working-class advocate opposed to austerity. Under Mary Lou McDonald, a Dubliner without paramilitary baggage, Sinn Féin has become the third-biggest party, and its vote share surged in the 2020 election.&nbsp;</p><p>Others</p><p>Partnership with Fine Gael during post-Celtic Tiger austerity tainted the centre-left <b>Labour</b> party. The political arm of the trade union movement, it is led by Brendan Howlin, a former teacher and government minister.</p><p>The <b>Social Democrats</b> and <b>Solidarity-People Before Profit</b> are part of an alphabet soup of smaller, more leftwing parties. The <b>Greens</b>, wiped out in 2011 after a ruinous coalition with Fianna Fáil, have campaigned on the back of climate crisis anxiety and youth-led protests. Independent TDs have prospered in recent elections, turning some into outsized players in ruling coalitions. <b>Rory Carroll</b></p>',
 					credit: '',
-					elementId: 'b657cc59-a188-4f9c-8309-93dd568221db',
+					elementId: '029715d9-551b-460f-8b36-54efa7f89813',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Why did Sinn Féin do so well?</h2>',
-					elementId: '962ceae1-178d-4c2a-a89b-dd82e2d9ce89',
+					elementId: '5bbba16d-ba60-49bd-b6f3-6fceb0494f08',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It rode a wave of anger over homelessness, soaring rents, hospital waiting lists and and fraying public services. Its leader, <a href="https://www.theguardian.com/politics/2020/feb/07/mary-lou-mcdonald-sinn-fein-leader-kingmaker-ireland-election-ireland">Mary Lou McDonald</a>, and party colleagues such as Eoin Ó Broin and Pearse Doherty offered leftwing solutions, such as an ambitious public housing building programme, that enthused voters, especially those under 50.</p>',
-					elementId: '0c987519-1033-4c78-a3b4-cdcae4ad77bd',
+					elementId: '3933a02c-d45e-49b0-82bb-3aba59d04bd8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Varadkar’s attempt to frame the election around his Brexit diplomacy and the humming economy fell flat. Fianna Fáil was contaminated by its confidence-and-supply deal that had propped up Varadkar’s minority administration, leaving Sinn Féin to cast itself as the agent of real change. Voters forgot, forgave or did not care about its past as the IRA’s political wing during the Troubles.</p>',
-					elementId: 'a302e7fc-27c6-4b14-92b4-ce798849ca9d',
+					elementId: '2a430b49-5f68-4eff-a38e-fd7d0782c531',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>What happens next?</h2>',
-					elementId: '21aa0193-62e5-4ff5-a1e0-e140e4d37f4c',
+					elementId: '00916885-b451-46b0-b32b-7bd5dad773c5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Weeks – possibly months – of negotiations between party leaders. McDonald is floating an alliance of leftwing parties led by Sinn Féin but that’s unlikely – it would be far short of 80 seats. The only viable looking option entails an alliance between two of the three main parties plus perhaps the Greens.</p>',
-					elementId: 'c2f71bb0-9d20-4d11-a6de-3220c33dfe9c',
+					elementId: '3fb9049d-4268-4315-8a30-4241a043d6e6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Varadkar has ruled out a pact with Sinn Féin and floated a deal with Fianna Fáil. During the campaign the Fianna Fáil leader, Micheál Martin, ruled out entering government with Fine Gael or Sinn Féin but since Sunday has hinted he may do a deal with one or the other.</p>',
-					elementId: '495b9c90-0aa6-442a-ab5d-31c6d8668232',
+					elementId: 'e88ee0fd-bf5b-438b-b453-4cf5647325f4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Expect shadow boxing. Sinn Féin will be very wary about entering government as a junior partner – a recipe for punishment at the next election, as other parties have discovered. Some suspect its preferred outcome is a Fianna Fáil-Fine Gael government – an unpopular continuation of the status quo that would consolidate Sinn Féin as leader-in-waiting of the subsequent government.</p>',
-					elementId: '5b3bec5c-d544-491d-8e2f-27975dbd42d5',
+					elementId: '971f144d-1e28-4585-9b36-91c31beb362f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For that reason Fianna Fáil will hesitate to do a deal with Fine Gael. But Fianna Fáil may oust Martin if he does not become taoiseach.</p>',
-					elementId: '7c441080-ead4-4b81-9dfd-0ed5ec4e6ff4',
+					elementId: 'cb74f7c5-d98d-41ee-9929-a3cfd5f22140',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>One plausible outcome: deadlock, and another election.</p>',
-					elementId: 'db7e6813-841a-495d-846e-f0065c06586a',
+					elementId: '1afda839-a316-4789-b14d-6f18240767a9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Read more</strong></p>',
-					elementId: '726b1564-c39a-4356-b09e-55e999cfb662',
+					elementId: '9d20f727-83a5-4fc5-928c-5c87cdbb5fcf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><a href="https://www.theguardian.com/politics/2020/feb/07/mary-lou-mcdonald-sinn-fein-leader-kingmaker-ireland-election-ireland">Mary Lou McDonald: Sinn Féin leader who may play Dublin kingmaker</a><br><a href="https://www.theguardian.com/world/2020/feb/08/sinn-fein-on-election-day-shane-obrien">‘It’s a sea change’: Sinn Féin dares to dream on election day</a><br><a href="https://www.theguardian.com/commentisfree/2020/jan/31/sinn-fein-ireland-left-election-ira">Opinion: Can Sinn Féin’s young voters finally pull Ireland to the left?</a><br><a href="https://www.theguardian.com/world/2020/jan/31/leo-varadkar-paradox-feted-abroad-can-pm-arrest-polls-slump-in-ireland-election">The Varadkar paradox: feted abroad, can PM arrest polls slump in Ireland?</a></p>',
-					elementId: 'cbe95172-281e-409b-a02e-1471f87ec557',
+					elementId: '9d496ec6-2416-4a21-a6ba-601eb0b55da5',
 				},
 			],
 			attributes: {
@@ -2018,7 +2069,7 @@ export const Analysis: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2020/feb/10/irish-general-election-everything-you-need-to-know',
+			'@id': 'https://www.theguardian.com/world/2020/feb/10/irish-general-election-everything-you-need-to-know',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Audio.ts
@@ -27,63 +27,6 @@ export const Audio: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['glenn-greenwald-security-liberty'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['news'],
-				},
-				{
-					name: 'co',
-					value: ['glenn-greenwald'],
-				},
-				{
-					name: 'k',
-					value: [
-						'business',
-						'us-national-security',
-						'world',
-						'data-protection',
-						'us-politics',
-						'technology',
-						'nsa',
-						'telecoms',
-						'privacy',
-						'the-nsa-files',
-						'verizon-communications',
-						'us-news',
-					],
-				},
-				{
-					name: 'url',
-					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/3gc62',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -198,6 +141,63 @@ export const Audio: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -252,6 +252,63 @@ export const Audio: CAPIArticleType = {
 				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -944,6 +1001,10 @@ export const Audio: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1749,7 +1810,7 @@ export const Audio: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '5f811d8d-b6df-4f0d-8302-12ad9f4f7d85',
+			elementId: 'fb1db287-b9c7-430d-871e-24045275513f',
 		},
 	],
 	canonicalUrl:
@@ -1761,152 +1822,152 @@ export const Audio: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The National Security Agency is currently collecting the telephone records of millions of US customers of Verizon, one of America's largest telecoms providers, under a top secret court order issued in April.</p>",
-					elementId: '06211056-acd3-4d0f-9ba9-39bf172e02ca',
+					elementId: '65c05e34-9a10-4803-bdf7-289260644a5f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, a copy of which has been obtained by the Guardian, <a href="https://www.theguardian.com/world/interactive/2013/jun/06/verizon-telephone-data-court-order">requires Verizon on an "ongoing, daily basis" to give the NSA information on all telephone calls in its systems</a>, both within the US and between the US and other countries.</p>',
-					elementId: '8afac6ff-0fd7-4735-a981-a49bce4326cd',
+					elementId: '6976c2fe-24ee-40c3-b401-eab47fb36bd4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The document shows for the first time that under the Obama administration the communication records of millions of US citizens are being collected indiscriminately and in bulk – regardless of whether they are suspected of any wrongdoing.</p>',
-					elementId: '26624453-6ff8-47c0-9877-7c7bdc723a7c',
+					elementId: 'f3f7d4dc-afc4-4a29-8ed9-bbadb3b6606d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The secret Foreign Intelligence Surveillance Court (Fisa) granted the order to the FBI on April 25, giving the government unlimited authority to obtain the data for a specified three-month period ending on July 19.</p>',
-					elementId: '09aa2572-e30a-49ec-84a3-1db5c2ee9e1d',
+					elementId: 'c09ed46f-a63f-4c8c-b3f6-2b85a5e13674',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the terms of the blanket order, the numbers of both parties on a call are handed over, as is location data, call duration, unique identifiers, and the time and duration of all calls. The contents of the conversation itself are not covered.</p>',
-					elementId: '0d5f51dd-17f6-449c-befd-8c90c02c11cd',
+					elementId: '51a270c7-a1f5-46d7-8000-660b4e115099',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The disclosure is likely to reignite longstanding debates in the US over the proper extent of the government's domestic spying powers.</p>",
-					elementId: '59247a6f-2922-408d-bf7f-90d7cd73adc3',
+					elementId: 'fd586067-7dec-4b52-b576-28c7916b1b32',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the Bush administration, officials in security agencies had disclosed to reporters the large-scale collection of call records data by the <a href="https://www.theguardian.com/us-news/nsa" data-component="auto-linked-tag">NSA</a>, but this is the first time significant and top-secret documents have revealed the continuation of the practice on a massive scale under President Obama.</p>',
-					elementId: 'ac46bf31-5be1-4bc6-8bbf-0d2c4e2cbc2b',
+					elementId: '2e3c152c-96cc-4f11-9f8b-00c793c71efb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The unlimited nature of the records being handed over to the NSA is extremely unusual. Fisa court orders typically direct the production of records pertaining to a specific named target who is suspected of being an agent of a terrorist group or foreign state, or a finite set of individually named targets.</p>',
-					elementId: 'ce285644-8b32-464b-a0d9-2bc2259915d0',
+					elementId: '81b0a5bf-fb6f-425f-b1e4-9920073b7ea0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Guardian approached the National Security Agency, the White House and the Department of Justice for comment in advance of publication on Wednesday. All declined. The agencies were also offered the opportunity to raise specific security concerns regarding the publication of the court order.</p>',
-					elementId: 'fb1ffdae-873f-41e5-99f8-c078dc97dcb4',
+					elementId: '7c1ca8d2-aba3-4f32-88c1-d8a16ce42beb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order expressly bars Verizon from disclosing to the public either the existence of the FBI's request for its customers' records, or the court order itself. </p>",
-					elementId: '83bf6f56-8093-431e-b9bd-ba5681736d5c',
+					elementId: '1ff59311-8abb-4888-aba7-7905ccc42eb9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We decline comment," said Ed McFadden, a Washington-based Verizon spokesman.</p>',
-					elementId: '8f2d633e-c22d-47cb-8351-fbe8940a0b01',
+					elementId: 'c1415bb8-a223-4642-b106-29cb1dd6a8b3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, signed by Judge Roger Vinson, compels Verizon to produce to the NSA electronic copies of "all call detail records or \'telephony metadata\' created by Verizon for communications between the United States and abroad" or "wholly within the United States, including local telephone calls".</p>',
-					elementId: '7cfa4071-a906-4e90-acaf-80194742a6b0',
+					elementId: '1f3a30a0-1915-4eb4-bc5d-dca7b25aac53',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order directs Verizon to "continue production on an ongoing daily basis thereafter for the duration of this order". It specifies that the records to be produced include "session identifying information", such as "originating and terminating number", the duration of each call, telephone calling card numbers, trunk identifiers, International Mobile Subscriber Identity (IMSI) number, and "comprehensive communication routing information".</p>',
-					elementId: '51d0ca48-5368-4a4c-b2db-4c43928171df',
+					elementId: '88ec42d3-82ea-4655-afed-17ebf941e0e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The information is classed as "metadata", or transactional information, rather than communications, and so does not require individual warrants to access. The document also specifies that such "metadata" is not limited to the aforementioned items. A 2005 court ruling judged that cell site location data – the nearest cell tower a phone was connected to – was also transactional data, and so could potentially fall under the scope of the order.</p>',
-					elementId: 'b0b4712c-3741-417c-a565-f639b64aba3d',
+					elementId: '70f20e34-5f7e-4bad-9ba0-0a08dffa2b24',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>While the order itself does not include either the contents of messages or the personal information of the subscriber of any particular cell number, its collection would allow the NSA to build easily a comprehensive picture of who any individual contacted, how and when, and possibly from where, retrospectively.</p>',
-					elementId: '2ac3c098-fc02-4ebc-834a-00db209cc76a',
+					elementId: '4e3c0270-8779-473c-81f6-ab8940559e6c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It is not known whether Verizon is the only cell-phone provider to be targeted with such an order, although previous reporting has suggested the NSA has collected cell records from all major mobile networks. It is also unclear from the leaked document whether the three-month order was a one-off, or the latest in a series of similar orders.</p>',
-					elementId: '33494bbe-bf8e-4215-b872-45ac4f9045c5',
+					elementId: 'a5e97dcd-f8af-4d8b-a469-fb1d754c3393',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order appears to explain the numerous cryptic public warnings by two US senators, Ron Wyden and Mark Udall, about the scope of the Obama administration's surveillance activities.</p>",
-					elementId: '88b1f609-292f-4920-8c50-a78da13e5dbc',
+					elementId: '37b8e4a7-2992-475e-9c2f-a61269cc7b4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For roughly two years, the two Democrats have been stridently advising the public that the US government is relying on "secret legal interpretations" to claim surveillance powers so broad that the American public would be "stunned" to learn of the kind of domestic spying being conducted.</p>',
-					elementId: 'e10de05d-5091-49aa-bdc0-ee853e15ea0a',
+					elementId: '0c59ec83-42aa-442b-aa07-5fb13eef369b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Because those activities are classified, the senators, both members of the Senate intelligence committee, have been prevented from specifying which domestic surveillance programs they find so alarming. But the information they have been able to disclose in their public warnings perfectly tracks both the specific law cited by the April 25 court order as well as the vast scope of record-gathering it authorized.</p>',
-					elementId: '4bb4bccc-ff59-4c9c-9774-90659d5179d6',
+					elementId: 'ef897c27-aa74-4475-a242-7d7f69bc6581',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Julian Sanchez, a surveillance expert with the Cato Institute, explained: \"We've certainly seen the government increasingly strain the bounds of 'relevance' to collect large numbers of records at once — everyone at one or two degrees of separation from a target — but vacuuming all metadata up indiscriminately would be an extraordinary repudiation of any pretence of constraint or particularized suspicion.\" The April order requested by the FBI and NSA does precisely that.</p>",
-					elementId: 'e1dd9fce-15a5-4bb3-95d9-8eb8fe56437e',
+					elementId: 'efa50f1b-37b4-4c8c-9567-671fcb58cf75',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The law on which the order explicitly relies is the so-called "business records" provision of the Patriot Act, 50 USC section 1861. That is the provision which Wyden and Udall have repeatedly cited when warning the public of what they believe is the Obama administration\'s extreme interpretation of the law to engage in excessive domestic surveillance.</p>',
-					elementId: '4ce4666e-397b-44d9-bea9-2f01b0e7640d',
+					elementId: '750355d7-c80c-4d71-a764-7f3409082d7a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In a letter to attorney general Eric Holder last year, they argued that "there is now a significant gap between what most Americans <em>think</em> the law allows and what the government secretly <em>claims</em> the law allows."</p>',
-					elementId: '245ae1cc-098a-4b54-a1fc-ddc29a824d86',
+					elementId: '60b5f816-a078-4ff5-9660-b8a9de32d90e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We believe," they wrote, "that most Americans would be stunned to learn the details of how these secret court opinions have interpreted" the "business records" provision of the Patriot Act.</p>',
-					elementId: '2cf330d5-8dd1-439e-b920-607122911bce',
+					elementId: '5492dbad-205a-41b5-bbfd-76002727c742',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Privacy advocates have long warned that allowing the government to collect and store unlimited "metadata" is a highly invasive form of surveillance of citizens\' communications activities. Those records enable the government to know the identity of every person with whom an individual communicates electronically, how long they spoke, and their location at the time of the communication.</p>',
-					elementId: '25c6681c-10a3-44f6-8353-7c5957fe926c',
+					elementId: '70a55761-a463-4002-84ab-a19fc43ce8cd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Such metadata is what the US government has long attempted to obtain in order to discover an individual's network of associations and communication patterns. The request for the bulk collection of all Verizon domestic telephone records indicates that the agency is continuing some version of the data-mining program begun by the Bush administration in the immediate aftermath of the 9/11 attack.</p>",
-					elementId: '8497f2c2-4218-4899-8671-ee0b1d5b24de',
+					elementId: '419ce3e8-ac48-4f2b-be9a-2dcda2bb4be2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The NSA, as part of a program secretly authorized by President Bush on 4 October 2001, implemented a bulk collection program of domestic telephone, internet and email records. A furore erupted in 2006 when USA Today reported that the NSA had "been secretly collecting the phone call records of tens of millions of Americans, using data provided by AT&amp;T, Verizon and BellSouth" and was "using the data to analyze calling patterns in an effort to detect terrorist activity." Until now, there has been no indication that the Obama administration implemented a similar program.</p>',
-					elementId: '40629f84-dc73-4442-844f-d55d969d6587',
+					elementId: '3827b42e-7171-4126-ba7c-d56d8211c591',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>These recent events reflect how profoundly the NSA's mission has transformed from an agency exclusively devoted to foreign intelligence gathering, into one that focuses increasingly on domestic communications. A 30-year employee of the NSA, William Binney, resigned from the agency shortly after 9/11 in protest at the agency's focus on domestic activities.</p>",
-					elementId: '402c5263-4fc6-4bd5-af1c-ffeb3e26cef9',
+					elementId: '22b9561e-79c8-42ab-b75c-4511a176327c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In the mid-1970s, Congress, for the first time, investigated the surveillance activities of the US government. Back then, the mandate of the NSA was that it would never direct its surveillance apparatus domestically.</p>',
-					elementId: 'e5a2a421-83f0-45fb-a517-f9e2dd81c9ff',
+					elementId: 'e8ea0b57-f404-47b2-aa3d-496fc8a27150',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>At the conclusion of that investigation, Frank Church, the Democratic senator from Idaho who chaired the investigative committee, warned: "The NSA\'s capability at any time could be turned around on the American people, and no American would have any privacy left, such is the capability to monitor everything: telephone conversations, telegrams, it doesn\'t matter."</p>',
-					elementId: 'a37da07f-dc1f-44a6-bd54-82733c707c1c',
+					elementId: '635654ed-4091-4bdb-9b1f-65d81b9a1a83',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Additional reporting by Ewen MacAskill and Spencer Ackerman</em></p>',
-					elementId: '32204131-eeb7-49ce-a978-1483e2df1418',
+					elementId: 'c08571e7-f5e3-4870-a14c-d5e303485cf6',
 				},
 			],
 			attributes: {
@@ -1927,7 +1988,7 @@ export const Audio: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+			'@id': 'https://www.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -27,58 +27,6 @@ export const Comment: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'co',
-					value: ['johnharris'],
-				},
-				{
-					name: 'k',
-					value: [
-						'uk/uk',
-						'austerity',
-						'conservativehome',
-						'economics',
-						'politics',
-						'business',
-						'conservatives',
-					],
-				},
-				{
-					name: 'tn',
-					value: ['comment'],
-				},
-				{
-					name: 'bl',
-					value: ['commentisfree'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/d8n8j',
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'url',
-					value: '/commentisfree/2020/feb/10/austerity-level-up-newcastle-budget-cuts',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -183,6 +131,58 @@ export const Comment: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'co',
+					value: ['johnharris'],
+				},
+				{
+					name: 'k',
+					value: [
+						'uk/uk',
+						'austerity',
+						'conservativehome',
+						'economics',
+						'politics',
+						'business',
+						'conservatives',
+					],
+				},
+				{
+					name: 'tn',
+					value: ['comment'],
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d8n8j',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'url',
+					value: '/commentisfree/2020/feb/10/austerity-level-up-newcastle-budget-cuts',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -216,6 +216,58 @@ export const Comment: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d8n8j',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'url',
+					value: '/commentisfree/2020/feb/10/austerity-level-up-newcastle-budget-cuts',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'co',
+					value: ['johnharris'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'k',
+					value: [
+						'uk/uk',
+						'austerity',
+						'conservativehome',
+						'economics',
+						'politics',
+						'business',
+						'conservatives',
+					],
+				},
+				{
+					name: 'tn',
+					value: ['comment'],
 				},
 				{
 					name: 'bl',
@@ -912,6 +964,10 @@ export const Comment: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1695,7 +1751,7 @@ export const Comment: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '7c51568b-c031-41f6-a9a5-fd6af8b1a659',
+			elementId: 'e68617df-682b-4e90-aeb4-9e449ce11535',
 		},
 	],
 	canonicalUrl:
@@ -1707,44 +1763,44 @@ export const Comment: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Seven years ago, pretty much to the week, I paid my <a href="https://www.theguardian.com/commentisfree/2013/feb/04/newcastle-cold-fear-little-sense-of-hope" title="">first visit as a journalist</a> to Newcastle upon Tyne. The ostensible reason was a fuss about the city council’s proposal to cut its arts budget to zero, and a <a href="https://www.theguardian.com/uk/2012/dec/16/newcastle-arts-cuts-disastrous-stars" title="">campaign of opposition</a> endorsed by such alumni of the city as Bryan Ferry and Gordon “Sting” Sumner. But that controversy was only a small, distracting aspect of a much bigger story: the fact that the coalition government’s austerity was now threatening some of the most basic parts of Newcastle’s social fabric, as councillors faced cuts of around £100m, spread over three years. Then as now, they were led by Nick Forbes, the imaginative, engaging politician who remains in post, and is these days also the leader of the Local Government Association’s Labour group, which represents councillors from across England and Wales, and had its annual conference at the weekend.</p>',
-					elementId: '5c2f382a-a35a-4389-81a3-03568ce9335c',
+					elementId: 'b304bbf3-b927-430a-ae30-5ea799ba6ece',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement',
 					html: '£37m was cut in 2013-14, followed by £38m, then £40m and so on, until the council had lost £300m by the end of 2019',
 					role: 'supporting',
 					isThirdPartyTracking: false,
-					elementId: '82488351-9e5b-4754-9598-8ad1358088c0',
+					elementId: 'ebfa66d2-b0fb-4b06-9cce-c8cf5921780e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As the government hacked back the money that went from Whitehall to councils and the need for child and adult social care services continued to rise, <a href="https://www.chroniclelive.co.uk/news/north-east-news/tax-freeze-cuts-newcastle-city-6464052" title="">£37m</a> was cut from Newcastle’s budgets in 2013-14, followed by <a href="https://www.chroniclelive.co.uk/news/north-east-news/newcastle-city-council-reveals-40m-7276999" title="">£38m, then £40m</a> and <a href="https://www.bbc.co.uk/news/uk-england-tyne-38145319" title="">£30m</a> – and so on, until the council had lost <a href="https://www.chroniclelive.co.uk/news/north-east-news/20m-cuts-newcastle-council-mean-17414937" title="">an estimated £300m</a> by the end of 2019. Each time I have gone back, I have heard about what has happened to libraries, seen closed youth clubs that were among the first things to be axed, and talked to people about cuts to early-years provision leading to four in 10 of the north-east’s children’s centres being shut. There is an awful symbolism in the fall in the <a href="https://www.bbc.co.uk/news/uk-politics-46514670" title="">number of lollipop men and women</a> from 64 to seven; on one trip, I was struck by the quiet poignancy of parks smattered with broken slides and swings.</p>',
-					elementId: 'e4bcdb0a-145a-4495-9adb-cf821e1550aa',
+					elementId: 'cc0c4e40-08d0-49c2-b09e-5f016430ecde',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But despite cliches about places in “the north” being social deserts, Newcastle is full of initiative and innovation – and as austerity hit, there was plenty of <a href="https://www.theguardian.com/business/2015/nov/23/newcastle-cuts-save-library-lose-pool-john-harris" title="">grassroots work</a> aimed at parrying the cuts, bringing in new approaches and making parts of the city more resilient. But hacked-back spending has taken an inevitable toll, and reflects something happening all over the country: the government using local and city government to administer policies that reflect ideological prejudices coursing through Westminster and Whitehall.</p>',
-					elementId: '6f729f43-2d61-4263-9236-0396e887462d',
+					elementId: '69b7db8a-3493-411d-98bf-af5c241424d4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Of late, by contrast, we have heard a lot of talk about Boris Johnson and his allies turning on the fiscal taps, and somehow marking the “end of austerity”. When he moved into Downing Street, <a href="https://www.bbc.co.uk/news/uk-politics-49102495" title="">the prime minister said</a> he would be “answering at last the plea of the forgotten people and left-behind towns, by physically and literally renewing the ties that bind us together, so that with safer streets and better education, and fantastic new road and rail infrastructure and full-fibre broadband, we level up across Britain”. Some of this is likely to happen, but all over the country austerity is nonetheless grinding on.</p>',
-					elementId: '22febce8-2e64-42ef-931e-adbdb2bc0cdb',
+					elementId: '130c4b9d-cabc-4f8c-8754-97f8725f5846',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Whatever paltry financial extras the government may now be granting councils, rising costs and increased need far outstrip them. Leeds <a href="https://www.yorkshireeveningpost.co.uk/news/politics/leeds-council-reveals-ps28m-cuts-coming-year-1385168" title="">faces cuts</a> in the next financial year of £28m. On the Wirral, the <a href="https://www.wirralglobe.co.uk/news/18213040.council-budget-clash/" title="">figure is £30m</a>; across the water in Liverpool, where <a href="https://www.liverpoolecho.co.uk/news/liverpool-news/joe-anderson-refuse-carry-out-17659928" title="">the mayor, Joe Anderson</a>, now says he will refuse to put through any further cuts beyond April 2021, there is a funding gap of £30m, only £7.2m of which will come from putting up council tax. In Doncaster, <a href="https://www.doncasterfreepress.co.uk/news/politics/council-tax-rise-and-job-cuts-way-doncaster-council-announces-its-budget-1384199" title="">new cuts</a> must total £18m; in Blackpool, to meet its obligations in children’s services, the council must somehow <a href="https://www.blackpoolgazette.co.uk/news/politics/ps20m-savings-plus-more-job-losses-blackpool-council-unveils-budget-proposals-1380603" title="">save £20m</a> from its other work. In Newcastle, the council will have to <a href="https://www.chroniclelive.co.uk/news/north-east-news/20m-cuts-newcastle-council-mean-17414937" title="">cut £20m</a> across its budgets in 2020-21 – and, on current projections, another £17-18m the year after that.</p>',
-					elementId: '7a27dffe-77a8-4031-b2e5-42090fef81f1',
+					elementId: '9ff13d4c-72a2-49f8-8d81-d413320b718b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I spoke to Forbes last week. “We’ve cut every other service that the council provides to the absolute minimum, to try to protect social care,” he told me. “This is the first year we haven’t been able to do anything other than take money out of social care budgets … in some cases, we’re going to have to take away support that people have previously had.”</p>',
-					elementId: 'bd01cfc8-6b8b-449c-8461-978c0ed34020',
+					elementId: 'b9dec0dd-2e57-4c01-b11b-e7aa6046b214',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>By way of cold comfort, last year’s autumn statement meant an injection by the government of £11m into the city’s finances, but it will be largely eaten up by the recent increase in the minimum wage. Embracing the Conservatives’ proposal that councils can raise council tax by up to 2% to cover rising pressures on adult social care, Forbes says, will bring a paltry £2m. Next year “looks even more scary, because it looks like we’re going to have to start dismantling various aspects of our social work teams”. This seems set to affect children’s services, which up to now have been protected.</p>',
-					elementId: '6ca2311d-b0f9-40d2-9c5c-a2eb8a038f23',
+					elementId: '14a5b3c0-596e-4a3b-b050-c4ae8ecbdbf1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1752,32 +1808,32 @@ export const Comment: CAPIArticleType = {
 					text: 'Tory plans to ‘level up’ the north are laughably inadequate | Polly Toynbee',
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: 'b6be4770-8490-44df-a7bf-52024d48e929',
+					elementId: '4e31124a-7327-42b9-86db-dde849d822a7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The politics of continuing austerity are often maddeningly contradictory. I have been to plenty of places where cuts have intensified people’s conviction that they have been neglected by Westminster and Whitehall. That impulse was one of the reasons behind the Brexit vote. In turn, the frustrations of three years of post-referendum politics and Johnson’s cynical approximation of optimism convinced people in lots of these areas to vote Conservative. And so it is that austerity continues, while the government tries to escape the blame by cosmetically positioning itself against its own policies.</p>',
-					elementId: '6bfe8996-81c7-4527-ad34-5fcc8890cf40',
+					elementId: 'cf724ce4-d9f9-4579-b0bf-13da12ef1e6b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For the people involved in councils, other aspects of the picture are equally confounding. Rather than being able to plan for the long term, they have to wait every year for news of what the government will give them; thanks partly to the December election, even with the start of the next financial year looming, the next set of figures was confirmed only last week. In the spring, the government will reveal its new system of so-called “fair funding”. Recent reports have suggested that allocations for social care in some of England’s most deprived areas (including many places that were until recently part of the “red wall” of Labour constituencies) will <a href="https://www.theguardian.com/society/2020/jan/25/former-red-wall-areas-could-lose-millions-in-council-funding-review" title="">fall by £320m</a>, while those in more affluent places will rise by around the same amount.</p>',
-					elementId: 'a52047e6-605e-4caf-a20d-171d02a4ca8a',
+					elementId: 'eeb45796-abaf-457f-98b0-bc37583b8a64',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Possibly in response to the anxiety these projections sparked, subsequent predictions have suggested that other changes could balance these unfairnesses out – although many injustices would seemingly get worse. <a href="https://www.countycouncilsnetwork.org.uk/lgc-article-on-fair-funding-review-modelling-ccn-response/" title="">One report</a> suggests that inner London boroughs could lose as much as a quarter of their funding. The consequences of that would be unimaginable. To cap it all, there is the mess of uncertainty surrounding Brexit, and what it may mean for the public finances.</p>',
-					elementId: '11b79ac2-32bf-487e-a915-820e7a6ab92a',
+					elementId: '7817d604-6a2b-4c9d-899e-b65bcbc6cc44',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>We know that the chancellor has already told departments to come up with <a href="https://www.theguardian.com/society/2020/jan/29/ministers-told-to-find-5-savings-to-refocus-on-pms-priorities" title="">savings of 5%</a>. Some people say that if the government has any intention of easing the predicament of councils and the people who need their services, the last chance for a rethink will come with the autumn statement. But whatever happens, most of the people I have spoken to are worried and angry for one incurable reason: the fact that after 10 years of cuts, so much damage has been done. Most of what has been closed will not come back; countless instances of need and hardship now feel like they are locked in. Brexit flags and banners, and some of those overhyped infrastructure projects, are hardly going to make up for the pain.</p>',
-					elementId: '7f03e7c4-7828-4c72-858b-4ff3eb87c8c5',
+					elementId: '2e9f17b8-d5ed-4a3a-9b28-8a30938129fb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>• John Harris is a Guardian columnist</p>',
-					elementId: '3184ffb1-a540-4b5e-bbfa-c623761ba7e9',
+					elementId: '4fb0b32a-2fc1-4f12-94ea-9aa77f4d5452',
 				},
 			],
 			attributes: {
@@ -1798,7 +1854,7 @@ export const Comment: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/commentisfree/2020/feb/10/austerity-level-up-newcastle-budget-cuts',
+			'@id': 'https://www.theguardian.com/commentisfree/2020/feb/10/austerity-level-up-newcastle-budget-cuts',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -23,54 +23,6 @@ export const Dead: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'k',
-					value: [
-						'world',
-						'astronomy',
-						'space',
-						'us-news',
-						'nasa',
-						'science',
-						'mars',
-					],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/gfc2f',
-				},
-				{
-					name: 'url',
-					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'ct',
-					value: 'liveblog',
-				},
-				{
-					name: 'tn',
-					value: ['minutebyminute', 'news'],
-				},
-				{
-					name: 'co',
-					value: ['natalie-grover', 'tommccarthy'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -167,6 +119,54 @@ export const Dead: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: [
+						'world',
+						'astronomy',
+						'space',
+						'us-news',
+						'nasa',
+						'science',
+						'mars',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gfc2f',
+				},
+				{
+					name: 'url',
+					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'ct',
+					value: 'liveblog',
+				},
+				{
+					name: 'tn',
+					value: ['minutebyminute', 'news'],
+				},
+				{
+					name: 'co',
+					value: ['natalie-grover', 'tommccarthy'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -196,6 +196,54 @@ export const Dead: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'ct',
+					value: 'liveblog',
+				},
+				{
+					name: 'tn',
+					value: ['minutebyminute', 'news'],
+				},
+				{
+					name: 'co',
+					value: ['natalie-grover', 'tommccarthy'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: [
+						'world',
+						'astronomy',
+						'space',
+						'us-news',
+						'nasa',
+						'science',
+						'mars',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gfc2f',
+				},
+				{
+					name: 'url',
+					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -889,6 +937,10 @@ export const Dead: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1838,7 +1890,7 @@ export const Dead: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'c09a5ae2-72f5-4ea3-8e76-061aa7344781',
+			elementId: '4a5a62af-0446-4af6-96d7-9b1946655310',
 		},
 	],
 	canonicalUrl:
@@ -1850,17 +1902,17 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-					elementId: '2f549e1f-3fff-4bc2-b1a2-1e4694e8970c',
+					elementId: '1b7ea8dd-6040-4d1b-847f-01f18a68d57b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>To recap:</p>',
-					elementId: '00d94290-a7cb-4c4b-92a3-253483b2973b',
+					elementId: '95d1094d-48b3-445a-a403-1dab00bcc063',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from Mars as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on Mars for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on Mars and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-					elementId: '03d76995-341c-4c07-8f6d-59757c3762f2',
+					elementId: '7743fd17-abed-42fd-a7d1-8f58f6459789',
 				},
 			],
 			attributes: {
@@ -1886,7 +1938,7 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>#TBT</p>',
-					elementId: '236d14c7-18b3-40d0-a0a2-3c64f514de3b',
+					elementId: 'aa0aea09-8bba-49e2-b3c8-199d0f7076ea',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
@@ -1919,7 +1971,7 @@ export const Dead: CAPIArticleType = {
 					],
 					expired: false,
 					duration: 142,
-					elementId: '5d91117b-d9fd-4983-bd39-47b6e40544c1',
+					elementId: '1ba59c9b-235c-48f8-9e39-041e85ca1c8b',
 				},
 			],
 			attributes: {
@@ -1944,7 +1996,7 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>#FF</p>',
-					elementId: '5dc4b0a8-3e01-40fb-bf74-3208a041d4f8',
+					elementId: 'de590e5d-7dac-4fff-a49a-fb5f80171058',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TweetBlockElement',
@@ -1955,7 +2007,7 @@ export const Dead: CAPIArticleType = {
 					role: 'inline',
 					isThirdPartyTracking: false,
 					source: 'Twitter',
-					elementId: 'f6f27f8d-9bc7-4063-ae69-29b247e4d40a',
+					elementId: '6173faf2-5a25-41e7-9cc9-4aa39ce56862',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TweetBlockElement',
@@ -1966,7 +2018,7 @@ export const Dead: CAPIArticleType = {
 					role: 'inline',
 					isThirdPartyTracking: false,
 					source: 'Twitter',
-					elementId: 'ccf4f16a-ca94-428c-a10e-9f14f2df5563',
+					elementId: '51ee9f35-5e16-4ea1-b779-4bd6259aaf0c',
 				},
 			],
 			attributes: {
@@ -1991,7 +2043,7 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Have you typed “<a href="https://www.google.com/search?q=perseverance&amp;oq=pers&amp;aqs=chrome.0.69i59j69i57j0l3j46j69i60j69i61.1091j0j7&amp;sourceid=chrome&amp;ie=UTF-8">perseverance</a>” into Google today? </p>',
-					elementId: 'ccebf1b3-9aa6-4aa8-8a58-03ec18dd8dfa',
+					elementId: '97eb82f4-a6e1-4c34-a307-91e397461690',
 				},
 			],
 			attributes: {
@@ -2016,12 +2068,12 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Now that Perseverance persevered through the “seven minutes of terror” – a new era of space exploration has officially begun. </p>',
-					elementId: '89dfe8c1-0dcf-4bf9-9925-486cfeb180fb',
+					elementId: '54957a25-9375-49ab-98d8-dc7ba0bde601',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Next up, the science team will make crucial decisions on which direction to take the rover in as it kicks off its search for ancient life. <br></p>',
-					elementId: '1226a770-76d5-4e6c-9e7e-17b2f2212e03',
+					elementId: '09dc5e93-5ed9-47c4-b595-f87d3d7363b2',
 				},
 			],
 			attributes: {
@@ -2050,17 +2102,17 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The event is concluding. They’ll be back for a 2pm ET news conference on Monday. Mission updates can be found meanwhile on the <a href="https://mars.nasa.gov/mars2020/">Nasa web site</a>.</p>',
-					elementId: '53e16bbc-3c43-463a-b1e4-80ee7af113c2',
+					elementId: 'aa38c96d-b1a2-4a63-8026-89c4e84b3d2a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>McGregor signs off:</p>',
-					elementId: 'd46619b4-7125-4a1c-a251-8803ec774dbe',
+					elementId: '3eab3113-a7cd-4411-aba7-f3ac3b145a3d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Everyone have a great day, on Earth and on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a>.”</p>',
-					elementId: 'f739228f-6bc0-4d69-ab8f-87a2b5b1993b',
+					elementId: '754d389c-fa88-4c5f-836a-0630cd2da4b4',
 				},
 			],
 			attributes: {
@@ -2085,12 +2137,12 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Nasa scientists have worked for years to support this mission, and kept things going despite the ongoing coronavirus disruption. </p>',
-					elementId: 'af57cb76-4355-4975-bf8a-526203f855ef',
+					elementId: 'c4ebbcb7-393d-47a2-a6f8-0899f5b3aefc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>After the landing success yesterday, one team says they had a “socially distanced ice cream” event, while the engineering team had a virtual happy hour! <br></p>',
-					elementId: '5836abf7-84cf-44fa-b1c2-9171ab8fb620',
+					elementId: '1d1deda9-755f-4a1d-b28a-34f070953f55',
 				},
 			],
 			attributes: {
@@ -2119,17 +2171,17 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Next question: <strong>How did you celebrate?</strong></p>',
-					elementId: 'eab5a7a6-07a1-4710-9630-81d35e70eb52',
+					elementId: '0e67533f-8e21-4f26-bb88-2fd157f1c052',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Answers include: </p>',
-					elementId: 'cd69022a-e8a3-459d-8581-1b5649f01734',
+					elementId: 'ca4549f3-d4ba-45e0-9a6b-2cf9f39d6d3f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>Virtual happy hour</li> \n <li>“Socially distanced consumption of ice cream outdoors”</li> \n <li>“I went home and just passed out from just the excitement of the day”</li> \n <li>“In the coming days I’ll definitely be having a glass of wine”</li> \n <li>“It was super-exciting”</li> \n <li>“We’re working two shifts a day almost 20 hours a day... it is kind of a really cool thing”</li> \n <li>“Business as usual for a science team working on a <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> rover”</li> \n</ul>',
-					elementId: '10ef1c9f-ab68-4746-af58-e83902c4ab1f',
+					elementId: 'de638ba0-355b-48b7-a4c2-8321d7cb98a3',
 				},
 			],
 			attributes: {
@@ -2154,27 +2206,27 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Another key question: <strong>When will the rover drive? </strong></p>',
-					elementId: '6afed39d-9258-4c24-97c4-2ad8c0060f16',
+					elementId: 'c497139f-5764-46b1-bda0-65e188730092',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We’re anticipating the earliest... would be sol 8 or 9... our current best estimate.</p>',
-					elementId: '94452586-d947-41db-9a70-72bce577fe8e',
+					elementId: 'd6b11889-6117-46cf-8fbb-f37d73e03d0f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Maybe a short drive just to check everything out...</p>',
-					elementId: '438f8417-20c9-4894-bf01-a32f1b23340b',
+					elementId: '261d712f-aa9c-4c66-a19c-a3702e6e218e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We’ll also be figuring out the route and direction we need to go.”</p>',
-					elementId: '2d74f0b3-f721-47fd-92ba-92e88e4cede2',
+					elementId: '26070292-d996-4d2b-8985-e6f006ccd191',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That means rover could rove before February is out. </p>',
-					elementId: '52f8f86c-2715-4162-95df-a5942116e788',
+					elementId: '0af3018f-52e9-4993-8750-0df804714e7d',
 				},
 			],
 			attributes: {
@@ -2199,7 +2251,7 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The team members have described their fascination with the holes in the rocks visible next to the rover’s wheel in this photograph just released by <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a>. It is unknown whether the holes indicate volcanic or sedimentary rock. </p>',
-					elementId: '1d328d82-ee92-45b6-857d-aef1f0da2d29',
+					elementId: '4ca42a09-8562-4522-b5b6-601375f5a477',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2508,7 +2560,7 @@ export const Dead: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'c85e7725-26e3-472a-a43d-846e392bcc63',
+					elementId: 'e0d5013e-b4ac-4e79-951a-6ac0c42e8594',
 				},
 			],
 			attributes: {
@@ -2533,12 +2585,12 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Attached to the rover’s belly is a diminutive helicopter called Ingenuity. </p>',
-					elementId: '254f3663-51a5-42be-9995-5838395241e7',
+					elementId: 'dfec6f27-3a15-413c-b878-b95bc2c93b11',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 1.8kg drone-like rotorcraft is the first flying machine ever sent to another planet — it has the ability to take colour pictures and video. The rover can also take images of Ingenuity. <br></p>',
-					elementId: 'f289a2e2-ac14-48db-805e-3e2c41aa0d52',
+					elementId: '42deadaa-4f4d-444b-ab11-b26ed83263e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2847,7 +2899,7 @@ export const Dead: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'eedccf13-9dad-4cfe-94da-30f2374bdb6d',
+					elementId: 'ca21790a-4f22-42bc-b8da-2b5de834e472',
 				},
 			],
 			attributes: {
@@ -2876,12 +2928,12 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Key question: <strong>how long till they fly the helicopter?</strong> </p>',
-					elementId: 'ec15a439-aef3-477c-a6fd-af2226c1e3c7',
+					elementId: '5925ac22-d63c-49ac-8033-c03464cc33ce',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Caveat caveat caveat,” the scientist says. “Super-fast” would be “sol 60.” With a sol being 37 minutes longer than and earth days, that would be 60 earth days plus 37 hours = 61 days, 13 hours. Sometime in April. Best-case scenario. </p>',
-					elementId: '4322abae-4536-45a0-b3fe-ecd15c1ea069',
+					elementId: '03a76873-6db6-4c0c-b2c3-8cc17db477e1',
 				},
 			],
 			attributes: {
@@ -3210,7 +3262,7 @@ export const Dead: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '39854d89-33fd-48d9-b2f7-979908e478c1',
+					elementId: '32fdf7b5-460e-4fb3-924b-65e2d9003a04',
 				},
 			],
 			attributes: {
@@ -3234,7 +3286,7 @@ export const Dead: CAPIArticleType = {
 		{
 			'@type': 'LiveBlogPosting',
 			'@context': 'http://schema.org',
-			'@id': 'https://amp.theguardian.com/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+			'@id': 'https://www.theguardian.com/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',
@@ -3953,17 +4005,17 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-					elementId: '1b921949-ea34-46ca-a3dc-9b525e82d378',
+					elementId: '851a6b44-84b4-43a8-8f5f-5043ff49b140',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>To recap:</p>',
-					elementId: '108096f4-bbd3-43df-8bc0-f4fe7b5496a1',
+					elementId: '12cc54dd-f62c-4cd7-a85f-fa0de8dc723a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from Mars as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on Mars for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on Mars and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-					elementId: 'a151b327-a2e0-489c-9c21-710d6c638d05',
+					elementId: '7a30e885-3469-49e6-9f34-ca6809cead8a',
 				},
 			],
 			attributes: {
@@ -4293,7 +4345,7 @@ export const Dead: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '35b8aab0-f75c-4a92-a37d-f7377ecce28e',
+					elementId: '55acdb0a-2cbc-4848-87ce-bb78ea949a55',
 				},
 			],
 			attributes: {
@@ -4319,12 +4371,12 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Steltzner is showing some of the most fantastic images from space explorations past, from moonshots to the Hubble telescope. </p>',
-					elementId: 'aa0126c4-4322-4578-a5ca-e5b46f85e40f',
+					elementId: '6355826e-5487-44e0-b272-ced87852ef4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>He proposes an image of the dangling Perseverance Rover taken yesterday – it looks like a futuristic marionette – as the next entry in this cosmic scrapbook. <br></p>',
-					elementId: 'b39d6a8d-1e5d-4957-bc3f-482bcd4a43fd',
+					elementId: '318ab0ba-bfb0-4c6e-a442-6a4b80cc758e',
 				},
 			],
 			attributes: {
@@ -4350,27 +4402,27 @@ export const Dead: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Members of the National Aeronautics and <a href="https://www.theguardian.com/science/space" data-component="auto-linked-tag">Space</a> Administration (Nasa) team that put a rover on Mars on Thursday are preparing to host a news conference and answer questions about the mission.</p>',
-					elementId: 'fb015c23-d751-4c6d-b716-10dc1ee7b8be',
+					elementId: '1abc2906-f442-4dfd-b8e5-2cd8a0c55cfc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The rover, called Perseverance or Percy for short, is on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> to search for signs of ancient life and collect samples to be returned by a future mission. About the size of a car, the wheeled rover is equipped with cameras, microphones, drills and even a small helicopter. </p>',
-					elementId: 'b599a909-1d2a-4f5a-8f91-1a6a28aac6f0',
+					elementId: 'a9516579-ae67-4eae-8a9b-f2f62a99ecad',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Guardian science correspondent Natalie Grover reports of Percy’s mission:</p>',
-					elementId: 'f6e05994-bf02-4062-8ab1-cfd089bf7840',
+					elementId: '00be0417-053d-4258-a349-479272807d9b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
 					html: '<blockquote class="quoted"> \n <p>Previous Mars missions including <a href="https://viewer.gutools.co.uk/science/2013/jul/28/curiosity-rover-descent-mars-nasa">Curiosity</a> and Opportunity have suggested Mars was once a wet planet with an environment likely to have been supportive of life billions of years ago. Astrobiologists hope this latest mission can offer some evidence to prove whether that was the case.</p> \n</blockquote>',
-					elementId: '61e79e99-47ea-413f-96e2-8c7bc2135f80',
+					elementId: 'c6768a57-422f-40e6-b34c-5f203666ad54',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a> scientists appear to feel they may be tantalizingly close to a discovery that could change the way we see the universe and our home in it. Here was the scene in the control room near Los Angeles just before 1pm local time on Thursday when Percy’s safe touchdown on Mars was confirmed:<br></p>',
-					elementId: 'b57ee71b-d3df-45bf-a933-0de11c9a7c03',
+					elementId: '94e8ceb9-60d6-4d13-9a41-b74689674aba',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
@@ -4385,17 +4437,17 @@ export const Dead: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'YouTube',
 					sourceDomain: 'youtube-nocookie.com',
-					elementId: 'ef34ff27-21cb-4315-a065-a349ebc72bf2',
+					elementId: '3e04b701-0dc7-4a48-9430-a4a4d5e57eb8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The robotic vehicle sailed through space for nearly seven months, covering 293m miles (472m km) before piercing the Martian atmosphere at 12,000mph (19,000km/h) to begin its approach to touchdown on the planet’s surface.</p>',
-					elementId: 'fc5fae28-54b3-4680-b491-0866b508ee97',
+					elementId: '79942673-56fc-4fa8-91a3-27e8436de57a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Thank you for joining our live coverage. </p>',
-					elementId: 'ba74c0da-51a9-438d-a4a5-8f05875d141d',
+					elementId: '57e872b4-725c-4190-b492-9cd65e7f5138',
 				},
 			],
 			attributes: {

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -27,60 +27,6 @@ export const Editorial: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'k',
-					value: [
-						'health',
-						'society',
-						'infectiousdiseases',
-						'coronavirus-outbreak',
-						'politics',
-						'conservatives',
-						'vaccines',
-						'uk/uk',
-						'boris-johnson',
-					],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['editorials', 'comment'],
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/gaj9m',
-				},
-				{
-					name: 'co',
-					value: ['editorial'],
-				},
-				{
-					name: 'bl',
-					value: ['commentisfree'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'url',
-					value: '/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -189,6 +135,60 @@ export const Editorial: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'k',
+					value: [
+						'health',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+						'politics',
+						'conservatives',
+						'vaccines',
+						'uk/uk',
+						'boris-johnson',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gaj9m',
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'url',
+					value: '/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -240,6 +240,60 @@ export const Editorial: CAPIArticleType = {
 				{
 					name: 'url',
 					value: '/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'k',
+					value: [
+						'health',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+						'politics',
+						'conservatives',
+						'vaccines',
+						'uk/uk',
+						'boris-johnson',
+					],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'url',
+					value: '/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gaj9m',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -932,6 +986,10 @@ export const Editorial: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1642,7 +1700,7 @@ export const Editorial: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '7c97a8c0-2ae1-4ed1-8ae2-e6ffd08a849c',
+			elementId: 'd036486d-115f-4cc4-b735-e65d5dae5923',
 		},
 	],
 	canonicalUrl:
@@ -1654,32 +1712,32 @@ export const Editorial: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The greatest advances in the battle against the coronavirus have been made by modern science, but before there were vaccines, countries had to rely on older techniques: stopping people mingling; preventing new cases of the disease arriving from overseas. Britain’s record with lockdowns is not great (late to implement, premature in lifting), but with quarantine at the border there is barely even a record to defend. For much of last year there was a notional obligation on travellers from various countries to self-isolate on arrival in the UK, but with a shifting roster of places that qualified for “safe” travel corridors.</p>',
-					elementId: '6de3fe28-5e03-45af-8922-bd9fde587ab8',
+					elementId: '876d2ddd-264b-409f-af2f-d4c72744c6be',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>There were many categories of exemption. The regulations were unclear and poorly implemented. <a href="https://www.theguardian.com/world/commentisfree/2021/jan/28/uk-covid-travel-quarantine-hotel" title="">Efforts at enforcement have been patchy</a>. Essentially, self-isolation has been self-policed. Only towards the end of last year, as it became clear that mutant strains of the virus were spreading – and that Britain’s approach was persistently failing – did the government start focusing on <a href="https://www.theguardian.com/world/2021/jan/27/how-quarantine-rules-work-and-what-uk-government-is-planning" title="">quarantine as part of the anti-virus arsenal</a>. More travellers are now required to show proof of a negative Covid test and there are tighter restrictions on arrivals from certain “hotspot” countries. That approach is still flawed. People, and the virus they might carry, do not always travel straight from the heart of an outbreak to the UK. Mutations are dispersed along multiple paths.</p>',
-					elementId: 'ebcb2e01-d618-4790-96aa-6a369875c96d',
+					elementId: 'e10b23cd-c977-4924-9ed2-3ab8bd2538c3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Ministers have said further border measures are required, but cannot say when they will be applied. The new regime is expected to involve diverting large numbers of arrivals to government-approved hotels for up to 10 days, with an option of getting out sooner with a negative test. The Department for Transport and the Treasury <a href="https://www.theguardian.com/world/2021/feb/03/grant-shapps-resists-blanket-border-controls-to-stem-covid-in-britain" title="">have been squeamish</a> about the cost of such a regime. Passengers would get a bill, but the whole system would still be expensive and inflict another wound on an already injured aviation sector.</p>',
-					elementId: 'f2751426-37b1-4e82-acbe-aef19c7bf060',
+					elementId: 'd0d28929-fe8f-4acf-bb50-439cb4ed1658',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But, as has been demonstrated many times in the pandemic, resisting tighter restrictions to avoid an immediate financial burden is a false economy. Delay allows the disease to spread. The onerous measures are still required and have to be in place for longer. That remains true even as the vaccination programme is rolled out. Not enough is yet known about vaccine resilience in the face of recently discovered coronavirus variants, let alone any future mutations. <a href="https://www.theguardian.com/world/2021/jan/22/covid-vaccines-what-are-the-implications-of-new-variants-of-virus" title="">The risk is not negligible.</a></p>',
-					elementId: '5af48d17-3179-4258-9d32-5edc1de69207',
+					elementId: 'c7a4b4a9-84d7-4c56-9938-fc40fb644bea',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Countries with the strongest records against disease have applied the full range of containment measures quickly and thoroughly, including efficient testing, contact tracing, and a presumption that all new arrivals face quarantine (with some flexibility for humanitarian exceptions, naturally). That principle should be the basis for the UK’s regime. A speedy vaccination roll-out has given Boris Johnson <a href="https://www.theguardian.com/society/2021/jan/31/daily-record-as-600000-people-in-the-uk-receive-covid-jabs-on-saturday" title="">cause to celebrate</a> his government’s accomplishments relative to other countries. Ministerial relief at having something to cheer is palpable, but it must not lead to neglect of other fronts in the battle or feed the culture of impatience and denial that causes many Conservative MPs to demand unwarranted easing of restrictions.</p>',
-					elementId: 'b3e0993b-8e78-41db-8530-4f8679e13591',
+					elementId: '9388cf6c-bd43-4355-8ab4-743c485d8851',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>No one should belittle the social, economic and psychological cost of anti-Covid restrictions. Quarantine, like lockdown, is a harsh instrument to be used only as an emergency resort. But we are now a year into such an emergency. The government’s haphazard approach, justified by a pursuit of short-term economic relief, has only prolonged the ordeal. The vaccine programme illuminates a way out. It would be a tragic squandering of that success if overreliance on new technology were to breed complacency regarding older but no less vital methods of protecting the public.</p>',
-					elementId: '087bc657-1373-4425-87f9-62c99840612d',
+					elementId: '50c68e52-e382-4b34-aef2-6c23de2d9751',
 				},
 			],
 			attributes: {
@@ -1700,7 +1758,7 @@ export const Editorial: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
+			'@id': 'https://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Explainer.ts
@@ -23,51 +23,6 @@ export const Explainer: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'tn',
-					value: ['explainers'],
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/m493v',
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'k',
-					value: [
-						'indigenous-peoples',
-						'uluru-statement-from-the-heart',
-						'australia-news',
-						'indigenous-australians',
-					],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'co',
-					value: ['lorena-allam'],
-				},
-				{
-					name: 'url',
-					value: '/australia-news/2022/aug/21/what-is-an-indigenous-treaty-and-how-would-it-work-in-australia',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -158,6 +113,51 @@ export const Explainer: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'tn',
+					value: ['explainers'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/m493v',
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'indigenous-peoples',
+						'uluru-statement-from-the-heart',
+						'australia-news',
+						'indigenous-australians',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['lorena-allam'],
+				},
+				{
+					name: 'url',
+					value: '/australia-news/2022/aug/21/what-is-an-indigenous-treaty-and-how-would-it-work-in-australia',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -179,6 +179,51 @@ export const Explainer: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'k',
+					value: [
+						'indigenous-peoples',
+						'uluru-statement-from-the-heart',
+						'australia-news',
+						'indigenous-australians',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['lorena-allam'],
+				},
+				{
+					name: 'url',
+					value: '/australia-news/2022/aug/21/what-is-an-indigenous-treaty-and-how-would-it-work-in-australia',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'tn',
+					value: ['explainers'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/m493v',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'k',
@@ -876,6 +921,10 @@ export const Explainer: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1727,7 +1776,7 @@ export const Explainer: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'bf5218f6-4d7e-4082-8be7-f7df7e0ae65d',
+			elementId: 'acb2ffc1-ad5f-4990-9e1b-0f39233a2bbe',
 		},
 	],
 	canonicalUrl:
@@ -1739,17 +1788,17 @@ export const Explainer: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In 2017, the <a href="https://www.theguardian.com/australia-news/uluru-statement-from-the-heart" data-component="auto-linked-tag">Uluru Statement from the Heart</a> called for three things: voice, treaty and truth. Or, a voice to parliament enshrined in the constitution and a Makarrata<em><strong> </strong></em>commission to oversee a process of treaty-making and truth-telling.</p>',
-					elementId: '99b970c7-ab71-42c5-bac3-c58efeb902e7',
+					elementId: '171c4cb2-4d33-4a69-9378-be1b1c31d91c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Successive prime ministers rejected those calls. In 2017, Malcolm Turnbull dismissed the voice as a “third chamber” – a position he has since changed, <a href="https://www.theguardian.com/australia-news/commentisfree/2022/aug/15/i-will-be-voting-yes-to-establish-an-indigenous-voice-to-parliament">publicly declaring on Monday</a> he would vote yes in a referendum. In 2020, Scott Morrison <a href="https://www.smh.com.au/politics/federal/why-would-i-morrison-rules-out-referendum-on-indigenous-voice-if-re-elected-20220502-p5ahue.html">simply ruled it out</a>.</p>',
-					elementId: 'e672a4fc-3618-436c-b0d7-449c6459a433',
+					elementId: 'a39b65a0-aa02-4870-aea8-87172129bc77',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In May, Labor was elected on a promise to implement the Uluru statement in full. But in the intervening five years, state and territory governments went ahead with treaty-making and truth-telling processes, and a couple of big milestones were reached this week.</p>',
-					elementId: '9d902c64-151e-45c0-9ee1-29a359d6a261',
+					elementId: '734178e7-16a5-4262-b93c-b251fe72061e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
@@ -1758,22 +1807,22 @@ export const Explainer: CAPIArticleType = {
 					html: '<div class="interactive-wrapper">\n\t\n\t<div id="toc"></div>\n\n</div>',
 					css: '@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Light.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Light.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Light.ttf) format("truetype");font-weight:300;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-LightItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-LightItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-LightItalic.ttf) format("truetype");font-weight:300;font-style:italic}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Regular.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Regular.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Regular.ttf) format("truetype");font-weight:400;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-RegularItalic.ttf) format("truetype");font-weight:400;font-style:italic}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Medium.ttf) format("truetype");font-weight:500;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-MediumItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-MediumItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-MediumItalic.ttf) format("truetype");font-weight:500;font-style:italic}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Semibold.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Semibold.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Semibold.ttf) format("truetype");font-weight:600;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-SemiboldItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-SemiboldItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-SemiboldItalic.ttf) format("truetype");font-weight:600;font-style:italic}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Bold.ttf) format("truetype");font-weight:700;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BoldItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BoldItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BoldItalic.ttf) format("truetype");font-weight:700;font-style:italic}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Black.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Black.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-Black.ttf) format("truetype");font-weight:900;font-style:normal}@font-face{font-family:"Guardian Headline Full";src:url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BlackItalic.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BlackItalic.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GHGuardianHeadline-BlackItalic.ttf) format("truetype");font-weight:900;font-style:italic}@font-face{font-family:"Guardian Titlepiece";src:url(https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2) format("woff2"),url(https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff) format("woff"),url(https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf) format("truetype");font-weight:700;font-style:normal}.interactive-atom{margin:0;padding:0}.interactive-wrapper,body{background-color:#fff}iframe.interactive-atom-fence{width:100%;display:inline-block}#toc{width:100%;display:none;position:relative;text-align:left}#toc .table_of_contents_container{width:100%;margin-bottom:10px;margin-top:10px;background-color:#ececec;color:#000;box-sizing:border-box;padding:10px;font-family:\'Guardian Text Sans Web\';font-size:13px;display:block}#toc td{padding-bottom:7px;padding-top:7px}#toc th{font-weight:700}#toc .table_of_contents{width:100%}#toc .table_of_contents td{cursor:pointer}#toc .table_of_contents td:hover{color:#a9a9a9}#toc .table_of_contents tr{padding:30px}#toc .table_of_contents tr:last-child{border-bottom:none;padding-bottom:0}#toc .back_to_table_of_contents{cursor:pointer;width:1rem;height:1rem;border-radius:50%;background-color:#005689;float:left}',
 					js: '!function(n){var o={};function r(e){if(o[e])return o[e].exports;var t=o[e]={i:e,l:!1,exports:{}};return n[e].call(t.exports,t,t.exports,r),t.l=!0,t.exports}r.m=n,r.c=o,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},r.t=function(t,e){if(1&e&&(t=r(t)),8&e)return t;if(4&e&&"object"==typeof t&&t&&t.__esModule)return t;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,"default",{enumerable:!0,value:t}),2&e&&"string"!=typeof t)for(var o in t)r.d(n,o,function(e){return t[e]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,"a",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p="",r(r.s=108)}({108:function(e,t,n){e.exports=n(109)},109:function(e,t){var n,o,r,i,u=document.createElement("script");u.src="https://interactive.guim.co.uk/atoms/2020/04/tableizer/default/v/1629349235321/app.js",document.body.appendChild(u),setTimeout(function(){var e,t;window.resize&&(e=document.querySelector("html"),t=document.querySelector("body"),e.style.overflow="hidden",e.style.margin="0px",e.style.padding="0px",t.style.overflow="hidden",t.style.margin="0px",t.style.padding="0px",window.resize())},100),window.frameElement&&(console.log("We are inside an iframe universe."),n=document.body,o=function(){window.frameElement.height=document.body.offsetHeight+150},i=n.clientHeight,function e(){r=n.clientHeight,i!=r&&o(),i=r,n.onElementHeightChangeTimer&&clearTimeout(n.onElementHeightChangeTimer),n.onElementHeightChangeTimer=setTimeout(e,250)}())}});',
-					elementId: '51457b1c-7e71-45d5-85b7-21ef64197be0',
+					elementId: 'b0de494b-7c37-448d-baec-da9b91093a2b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>So what is a treaty and how do they work?</h2>',
-					elementId: '99455cc7-3c06-4ca4-81b5-40b5dc6981aa',
+					elementId: 'fc19feed-be97-4f11-b0f1-3288268a6f50',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A treaty is a binding agreement between two or more parties. A treaty sets out the terms of engagement and obligations of all sides to maintain the agreement.</p>',
-					elementId: '2f917983-c962-4e4a-895b-f55ff826acb0',
+					elementId: '7c6f1c82-f659-4ac9-bdd0-2bba1492d9e7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>New Zealand (Aotearoa), Canada, Norway, Sweden, Finland, Japan, Greenland and the US have all negotiated treaties with <a href="https://www.theguardian.com/world/indigenous-peoples" data-component="auto-linked-tag">Indigenous peoples</a>.</p>',
-					elementId: 'a24e925c-7b8d-4f6a-88b1-b3391a2867dd',
+					elementId: '6ed5de5a-b9cc-4aa0-9ca2-56beb4c32451',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1781,17 +1830,17 @@ export const Explainer: CAPIArticleType = {
 					text: 'Victoria passes landmark legislation to create First Nations treaty authority',
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '23d93de1-09cc-4c7c-a07c-424fd7a5ec7c',
+					elementId: '598f7153-4c49-4752-bb93-ca3ac68371c4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Canada<strong> </strong>has made about 70<a href="https://www.rcaanc-cirnac.gc.ca/eng/1100100028574/1529354437231"> recognised treaties</a> with First Nations peoples since 1701. In some cases, such as Nunavut in northern Canada, they have led to self-government. But not all treaties are <a href="https://indigenousstudies.utoronto.ca/news/treaty-myths/">easily understood</a>, workable or extant.</p>',
-					elementId: 'ec6d8f03-2d62-4a1e-808f-deba8fb005f2',
+					elementId: '212f0be9-c7de-477a-87ed-acb67aef754f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The United States government ratified more than 364 treaties between 1778 and 1868. Treaties were largely used by the US to put an end to conflict, and later used to <a href="http://recordsofrights.org/themes/4/rights-of-native-americans#the-end-of-treaty-making">force Native Americans off their </a>lands. The vast majority of treaties were<a href="https://theintercept.com/2020/07/17/mcgirt-v-oklahoma-indian-native-treaties/"> broken or never honoured</a> by the US government.</p>',
-					elementId: 'f3ca490d-f6b2-4ce6-a3f5-7d54edf09ff8',
+					elementId: '768c2707-74ad-42d9-a1aa-9a4a9918f1e5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2100,77 +2149,77 @@ export const Explainer: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'f03cc334-346e-4d95-b3b2-aaa801aafb03',
+					elementId: '6f30f68c-657e-42cc-975b-8a96731eae46',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In New Zealand (Aotearoa), Māori and the British signed the treaty of Waitangi in 1840. It is still being grappled with. There were two versions – one in English and one in Māori - and they were not exact translations, so there were major differences in interpretation, especially around Māori sovereignty. In 1975, the <a href="https://waitangitribunal.govt.nz/treaty-of-waitangi/meaning-of-the-treaty/">Waitangi tribunal</a> was set up to determine the issues raised by these different meanings. In 2014 it decided the Māori leaders who signed did not cede sovereignty, a big step forward.</p>',
-					elementId: '6cb1c769-50c0-44e9-8051-dde5fd46eb36',
+					elementId: '609714ea-5e4e-4c21-b916-ecd0b37bdd6b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>How long has treaty-making been on the agenda in Australia?</h2>',
-					elementId: '88616804-209e-4983-a2fd-bcc8e2efee69',
+					elementId: 'e608ff5e-d649-4289-8b0c-ac324ca656e4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In Australia, there has never been a treaty negotiated between Aboriginal and Islander nations and the commonwealth.</p>',
-					elementId: '355072c4-6cfd-4a88-8876-efcdea9cc7ab',
+					elementId: '1e23f2a4-2cc6-4e04-a2ea-2832fdf389d2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Calls for treaty<strong>-</strong>making go back decades. A line is often traced from the 1963 Yirrkala bark petition – in which Yolngu (the Indigenous people of north-east Arnhem Land) asserted their sovereignty over lands where the federal government had allowed a bauxite mine – through the 1966 <a href="https://www.nma.gov.au/defining-moments/resources/wave-hill-walk-off">Gurindji walk-off</a> at Wave Hill station, and the NT Aboriginal Land Rights Act in 1976, all the way to 1988, when the Treaty 88 campaign took off amid <a href="https://www.youtube.com/watch?v=5nlCxz650Yo&amp;ab_channel=DreamscapePublishing">huge Aboriginal protests </a>against the bicentennial.</p>',
-					elementId: 'b3b1d068-152c-44dd-a320-2761f5dcddc7',
+					elementId: '834a8fb9-e0ed-41ce-98d8-10d8aecd0b3d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In June that year, traditional owners presented <a href="https://aiatsis.gov.au/explore/barunga-statement">the Barunga statement</a> to Bob Hawke, who promised there’d be a treaty by the end of 1990. As Yothu Yindi sang in Treaty, a 1991 song about the events that day, “promises can disappear, just like writing in the sand”.</p>',
-					elementId: '8bc0ed90-c5b1-451e-bd70-8ffa1def8f35',
+					elementId: '66bc7f90-4196-4f1f-ba7f-0636d9afcb30',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In 2007, in perhaps an attempt to derail further treaty calls, the Howard government developed a plan for symbolic constitutional recognition. Successive governments have committed to some form of recognition.</p>',
-					elementId: 'ada310b1-c741-40ad-b759-77baafe99b1e',
+					elementId: 'f9634998-7525-4d73-b4da-73101c8e35a3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>What are the states doing on treaty-making?</h2>',
-					elementId: '1d6a6023-db62-496d-8ee9-b5244d3d5b8e',
+					elementId: '4d2dae53-4fb6-42b7-bed1-e0c470591955',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>At least three states have formally embarked on treaty processes, and some are also exploring truth-telling.</p>',
-					elementId: 'be42c49e-84d6-4d4e-ad20-98d57e2e21c9',
+					elementId: 'b36255db-18a7-457f-83e7-ef836d4d5c9e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Queensland government <a href="https://www.theguardian.com/australia-news/2022/aug/16/queensland-to-unveil-indigenous-truth-telling-inquiry-as-part-of-path-to-treaty">announced on Monday</a> it would set up an independent treaty institute to design a framework for agreement making with the government and it will support a three-year long truth-telling inquiry.</p>',
-					elementId: 'c92a7570-3a2a-47ba-a1d4-dae0c1a847e0',
+					elementId: 'dede3025-4d53-4a2f-8fe8-31fed88bfc56',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>On Tuesday, Victoria became the first state to pass legislation to set up an independent <a href="https://www.theguardian.com/australia-news/2022/jun/07/decolonisation-in-action-victorian-treaty-negotiations-to-be-overseen-by-independent-authority">Indigenous treaty authority</a>, to “umpire” treaty negotiations and resolve disputes between traditional owner groups and the state government.</p>',
-					elementId: '154f2cf2-3819-4171-b144-e6c4c7e51784',
+					elementId: '96c0abd4-077b-4096-a405-c90fed006ead',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Victoria has also embarked on truth-telling, which is proving challenging for many reasons. The Yoorrook justice commission handed down its first report in July, outlining elders’ experiences of colonisation and the stolen generations. It is seeking a two-year extension on its final report to 2026, to ensure the truth-telling process does not “<a href="https://www.theguardian.com/australia-news/2022/jul/09/yoorrook-the-fight-for-victorias-truth-telling-commission-to-achieve-its-groundbreaking-goals">replicate colonial injustices</a>” and re-traumatise Aboriginal people.</p>',
-					elementId: 'c462199d-61c8-4b5d-84b4-278f6d2e26af',
+					elementId: 'b247c423-2ebe-461a-a6c3-304e2626f447',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Northern Territory treaty commission handed its final report to the government in March, after four years of consultation with communities. It said the firm focus of any treaties must be to <a href="https://www.theguardian.com/australia-news/2022/jun/29/nt-treaties-must-achieve-highest-levels-of-self-determination-for-first-nations-commissioner-says">enable First Nations self-government</a>. The NT should establish a First Nations forum and develop a territory-wide agreement that would set the minimum standards for all subsequent treaties. Importantly, treaty-making could be between Indigenous nations as well as with governments.</p>',
-					elementId: 'ef66df13-5c29-4d25-ab90-f182f0d4cbfb',
+					elementId: '49877157-18d8-4f7d-9b13-9b1f25cd1ced',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The government said it would provide a comprehensive response by the end of 2022.</p>',
-					elementId: '526ff644-cded-4b38-ad55-1352f476cffe',
+					elementId: '269e0d41-abdc-45ea-b3bc-9b1fa38436b8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In March, Tasmania’s<strong> </strong>then<strong> </strong>premier, Peter Gutwein, said there was<strong> “</strong>broad support to take further steps” on truth-telling and treaty. There are plans for an advisory body, Gutwein said, and all registered Aboriginal community organisations were invited to be involved.</p>',
-					elementId: 'b71ebd1b-d181-4b59-850f-30f7ab3afe67',
+					elementId: 'e3f0a366-27bd-4a5c-b44b-52d0f65a0099',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -2178,37 +2227,37 @@ export const Explainer: CAPIArticleType = {
 					text: 'Queensland to unveil Indigenous truth-telling inquiry as part of path to treaty',
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '7d2460fd-ad51-4170-ab92-edd77fd6d902',
+					elementId: 'ccd81816-3cc8-46db-b35a-3560cf5e3876',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In Western Australia, the landmark <a href="https://www.wa.gov.au/organisation/department-of-the-premier-and-cabinet/south-west-native-title-settlement">south-west native title settlement </a>is often cited as Australia’s first treaty. It is the most comprehensive native title agreement negotiated in history, a $1.3bn settlement of Noongar peoples’ native title over 200,000 square kilometres of their traditional lands including Perth.</p>',
-					elementId: 'fd0ed3d3-b575-4c29-9af3-df086ff5f9ec',
+					elementId: '8eb87e58-ce0b-466c-9b72-f1b3f1372ed5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>South Australia’s<strong> </strong>process had<strong> </strong>stalled under the previous government, but the new Labor attorney general, Kyam Maher, has said he is determined to reignite the process.</p>',
-					elementId: '9b253a1f-17d5-4b3f-88c0-1c3e2254e52f',
+					elementId: '7d7ea0ed-9cc2-4f89-806f-3bdd03a0f983',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>New South Wales is the outlier. There has been no commitment to a treaty, but a broad commitment to the principles of the Uluru statement.</p>',
-					elementId: '95b9e58f-6213-447a-b23f-1ef080f664e1',
+					elementId: '5eaa43eb-a85c-45f1-b3a7-482f82cfcf22',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>What about a national treaty?</h2>',
-					elementId: 'ee7d3344-dacc-495d-9bd0-b49f5b2bba7e',
+					elementId: 'cf61dc16-e5dd-43b8-a4c1-be14fff0bed9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In 2017 at Uluru, the <a href="https://www.referendumcouncil.org.au/">Referendum Council</a> convened the First Nations constitutional convention, where the Uluru Statement from the Heart called for sequential reforms: a voice, treaty and truth.</p>',
-					elementId: '25032a30-c7da-4bc5-8d87-01fbe020269d',
+					elementId: '857868ee-d1a3-4b85-954c-207994ec242c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In July this year the prime minister, Anthony Albanese, released <a href="https://www.theguardian.com/australia-news/2022/jul/29/anthony-albanese-reveals-simple-and-clear-wording-of-referendum-question-on-indigenous-voice">a preferred form of words</a> he wants to put to the Australian people in a referendum, to amend the constitution to enable a voice to parliament to be established.</p>',
-					elementId: '88103920-34de-458f-b8b9-73ea437b53ff',
+					elementId: '1fb4d489-57fd-479e-bbf8-5dddefb8faf8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2517,72 +2566,72 @@ export const Explainer: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '665b2523-1353-4d4f-972e-3dc730797ef8',
+					elementId: '97ca798c-561a-45f1-96e7-1bfccb848be9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>If successful, it will give parliament the enabling power to settle on the details of the voice after a referendum. The Balnaves chair for constitutional law at the University of New South Wales, Prof Megan Davis, said in early August it was a “<a href="https://www.theguardian.com/australia-news/2022/aug/06/a-civil-mature-conversation-architects-of-the-uluru-statement-make-plea-for-consensus-on-referendum">common constitutional technique” to defer detail </a>to the parliament at a later date.</p>',
-					elementId: '567cdf52-93e5-4180-a107-5f9cc94584aa',
+					elementId: 'a597e055-ce64-49f9-bbbe-604669dc7b74',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“That’s how, for example, the high court was set up,” Davis said. “The enabling provision has passed, and the institution’s been set up later.”</p>',
-					elementId: '7841ef35-65fc-4070-af7a-c5895c134b4f',
+					elementId: '840624d3-2f27-4904-9314-a7af6d00ab5f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>On Friday, the minister for <a href="https://www.theguardian.com/australia-news/indigenous-australians" data-component="auto-linked-tag">Indigenous Australians</a>, Linda Burney, said the government’s “priority” is to conduct the referendum.</p>',
-					elementId: 'c009218c-ea13-4c9a-927b-08a5d958d8fe',
+					elementId: 'c769d796-1ad2-4388-bf93-8c89b2068eff',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“I’m not sure people appreciate just how complex and how involving that is,” Burney told the ABC.</p>',
-					elementId: 'a80e7d90-3eca-4955-ae49-417f35605eab',
+					elementId: 'ea51a03a-df7c-4db0-8351-814c4ca08b1b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>So, to follow the sequence, any federally negotiated treaties are still a long way off.</p>',
-					elementId: '1ca30353-f9bc-4c9d-80e0-e1b3a8ad429d',
+					elementId: 'bf800b97-da49-446d-9b7c-4d6960379da3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Why do First Nations want to negotiate a treaty or treaties?</h2>',
-					elementId: 'c29937b7-ecaf-4db3-9075-4d9f5e556c9b',
+					elementId: '4fab5e1f-28cb-49c6-95b1-27b31da9954f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“So that we can overcome those huge injustices that still, unfortunately, persist in our society,” the Queensland treaty advancement committee co-chair Dr Jackie Huggins said this week.</p>',
-					elementId: '8a9af265-7051-48d0-a85f-8d5ac0fc557c',
+					elementId: '5636f6ac-d2ad-4d71-9a2c-4f6adde31b27',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“The path to treaty is about how we mend the very fabric of our society.”</p>',
-					elementId: '1d5bcfdf-1611-496b-9680-fcfba2953438',
+					elementId: '6c08c28a-5cdd-4a9c-a0b7-ebedc082a415',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>And what about the view that treaties are only symbolic; they don’t achieve practical change?</h2>',
-					elementId: 'ba748d9f-93ae-4538-9c9c-dac32b6cc0a2',
+					elementId: 'b42c8d49-db36-4ec4-8e82-639e2a72039a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>If done right, treaties allow Aboriginal people to run their own affairs, the NT acting treaty commissioner, Tony McAvoy, <a href="https://www.abc.net.au/news/2022-06-29/nt-treaty-report-released-by-commissioner/101192202">told the ABC</a> in March.</p>',
-					elementId: 'f4d19b3b-da8f-413d-b87d-f4ad15ca0876',
+					elementId: '5ebe9da3-fdb9-4937-bf4e-3c76e6d7425d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“When Aboriginal communities [and] Aboriginal organisations design and deliver the services for Aboriginal people, those services are the most effective at that time. We would see a significant change in the levels of disadvantage if we’re able to ensure those governments are supported and properly resourced to do the work,” McAvoy said.</p>',
-					elementId: 'f69efa85-806e-40e4-ba7f-24784b7d393c',
+					elementId: '420671d1-4080-4fc2-853b-28ae3e101cd2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Pat Anderson, one of the key campaigners for the Uluru statement, said these reforms <a href="https://www.theguardian.com/australia-news/2022/aug/06/a-civil-mature-conversation-architects-of-the-uluru-statement-make-plea-for-consensus-on-referendum">allow for Aboriginal people to directly tell governments</a> what they want and need.</p>',
-					elementId: 'ae1a8d23-fca6-463a-991e-fabeae434b17',
+					elementId: 'c37024c9-8d43-4ca3-b0e7-ea39dd43538b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We won’t have to beg anymore, we won’t have to justify ourselves. We will set the agenda by sitting at that table, with what our priorities are,” Anderson said.<br></p>',
-					elementId: '49202554-c198-4748-8281-aecdf3cafda2',
+					elementId: 'cd29c0e9-9a14-4e80-a106-292446ec1c29',
 				},
 			],
 			attributes: {
@@ -2606,7 +2655,7 @@ export const Explainer: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/australia-news/2022/aug/21/what-is-an-indigenous-treaty-and-how-would-it-work-in-australia',
+			'@id': 'https://www.theguardian.com/australia-news/2022/aug/21/what-is-an-indigenous-treaty-and-how-would-it-work-in-australia',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -23,57 +23,6 @@ export const Feature: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'k',
-					value: [
-						'chris-rock',
-						'taika-waititi',
-						'oscars-2020',
-						'sigourney-weaver',
-						'bradpitt',
-						'laura-dern',
-						'culture',
-						'bong-joon-ho',
-						'film',
-						'joaquin-phoenix',
-					],
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/d8qaf',
-				},
-				{
-					name: 'url',
-					value: '/film/2020/feb/10/quotes-of-the-oscars-2020',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'co',
-					value: ['lanre-bakare'],
-				},
-				{
-					name: 'tn',
-					value: ['features'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -176,6 +125,57 @@ export const Feature: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'k',
+					value: [
+						'chris-rock',
+						'taika-waititi',
+						'oscars-2020',
+						'sigourney-weaver',
+						'bradpitt',
+						'laura-dern',
+						'culture',
+						'bong-joon-ho',
+						'film',
+						'joaquin-phoenix',
+					],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d8qaf',
+				},
+				{
+					name: 'url',
+					value: '/film/2020/feb/10/quotes-of-the-oscars-2020',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['lanre-bakare'],
+				},
+				{
+					name: 'tn',
+					value: ['features'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -212,6 +212,57 @@ export const Feature: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['lanre-bakare'],
+				},
+				{
+					name: 'tn',
+					value: ['features'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: [
+						'chris-rock',
+						'taika-waititi',
+						'oscars-2020',
+						'sigourney-weaver',
+						'bradpitt',
+						'laura-dern',
+						'culture',
+						'bong-joon-ho',
+						'film',
+						'joaquin-phoenix',
+					],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d8qaf',
+				},
+				{
+					name: 'url',
+					value: '/film/2020/feb/10/quotes-of-the-oscars-2020',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -917,6 +968,10 @@ export const Feature: CAPIArticleType = {
 					},
 				],
 			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
+			},
 		],
 		brandExtensions: [
 			{
@@ -1398,7 +1453,7 @@ export const Feature: CAPIArticleType = {
 			duration: 207,
 			altText:
 				"Press Room - 92nd Academy Awards<br>epa08208148 Joaquin Phoenix poses in the press room with the Oscar for Best Actor for his performance in 'Joker' during the 92nd annual Academy Awards ceremony at the Dolby Theatre in Hollywood, California, USA, 09 February 2020. The Oscars are presented for outstanding individual or collective efforts in filmmaking in 24 categories.  EPA/DAVID SWANSON",
-			elementId: 'c0e1cdb2-1373-4d36-bafe-8bbf177622bb',
+			elementId: '64a26697-c0ea-4541-bfe2-743ff3862670',
 		},
 	],
 	canonicalUrl:
@@ -1410,22 +1465,22 @@ export const Feature: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Chris Rock on Jeff Bezos and Marriage Story</h2>',
-					elementId: 'e103aad0-e46d-4ae8-b8ed-c106a566ab55',
+					elementId: 'bcd7acf7-c72e-4da6-ac9b-0813324cbea3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Bezos is so rich, he got divorced and he is still the richest man in the world. He saw <a href="https://www.theguardian.com/film/2019/nov/15/marriage-story-review-noah-baumbach-adam-driver-scarlett-johansson">Marriage Story</a> and thought it was a comedy.”</p>',
-					elementId: '1e0534f5-1dca-48e6-bd01-45937cb3ffbd',
+					elementId: '924a5377-04c3-48f6-b7fc-68ae5505e630',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong><a href="https://www.theguardian.com/film/2020/feb/10/joaquin-phoenixs-oscars-speech-in-full">Joaquin Phoenix</a> …</strong></h2>',
-					elementId: '423ce7c6-1fe2-4784-9349-6474be432169',
+					elementId: '74d9c8b3-88f3-400c-b9bb-06cae67c64b4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>… on veganism</strong><strong> and social justice<br></strong>“I think at times we feel or are made to feel that we champion different causes. But for me I see commonality. I think whether we’re talking about gender inequality or racism or queer rights or indigenous rights, or animal rights – we’re talking about the fight against injustice.”</p>',
-					elementId: '7f0e994c-70d7-4b54-a6bb-72b9deae8f9a',
+					elementId: 'bd456d11-648d-420c-961d-45107b7d9268',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1433,22 +1488,22 @@ export const Feature: CAPIArticleType = {
 					text: "Joaquin Phoenix's Oscars speech in full: 'We feel entitled to artificially inseminate a cow and steal her baby'",
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '17ce9f37-e215-4918-ba29-e576e26d6484',
+					elementId: 'ba3bb503-3d6e-4bb4-bb0e-4dc2c83e32fe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We’re talking about the fight against the belief that one nation, one people, one race, one gender, one species has the right to dominate, use and control another with impunity.”</p>',
-					elementId: '9dda36d4-4e76-42c0-b0c6-f15f12e05c2b',
+					elementId: 'e24143e8-3cc5-4a5d-9742-ff8760183b38',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>… on dairy products<br></strong>“I think we’ve become very disconnected from the natural world, many of us are guilty of an egocentric worldview and we believe that we’re the centre of the universe. We go into the natural world and we plunder it for its resources, we feel entitled to artificially inseminate a cow and steal her baby even though her cries of anguish are unmistakeable. Then we take her milk intended for her calf and we put it in our coffee and our cereal.”</p>',
-					elementId: 'cdf4991f-27d6-4a20-a031-8341b658413e',
+					elementId: 'a9c5020b-271f-42d7-92ef-e86498a85561',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>… on forgiveness<br></strong>“I have been a scoundrel all my life, I’ve been selfish. I’ve been cruel at times, hard to work with and I’m grateful that so many of you in this room have given me a second chance. I think that’s when we’re at our best: when we support each other. Not when we cancel each other out for our past mistakes, but when we help each other to grow. When we educate each other. When we guide each other to redemption.”</p>',
-					elementId: 'e891d5bb-9f57-448f-be22-8f26018feec0',
+					elementId: '2c0eb9e6-8148-49a7-a6c9-906a33f1ed52',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1456,17 +1511,17 @@ export const Feature: CAPIArticleType = {
 					text: "Parasite's best picture triumph could begin a new era for the Oscars",
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: 'ce3bef56-8c69-4b0e-9617-00241dcb57d7',
+					elementId: 'f162de81-b758-4bbe-a4cb-aa7d423bdcc4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Laura Dern on meeting your heroes</strong></h2>',
-					elementId: '8ef7551a-40ea-49a0-98f9-9263a9ffabff',
+					elementId: 'a688a57e-aed0-475e-91b5-7a4cd96289c1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Noah [Baumbach] wrote a movie about love and breaching divisions in the name and the honour of family and home and hopefully for our planet. Some say never meet your heroes. I say if you’re really blessed you get them as your parents. I share this with my acting legends Diane Ladd and Bruce Dern. You got game, I love you. Thank you all for this gift. This is the best birthday present ever.”</p>',
-					elementId: '3c7c7b9e-9eec-4a79-bda8-09eb2c76eb8b',
+					elementId: '8b54f90b-34b8-408c-9638-70b2feba1487',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1775,32 +1830,32 @@ export const Feature: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '5d6dcda6-c032-4e26-b1f2-b8d58cc7858d',
+					elementId: 'db761aff-82da-4f58-b3c3-f29bd3451b6c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Taika Waititi on far-right extremism and indigenous kids</strong></h2>',
-					elementId: '96b07f8d-179f-4c30-88c3-fa7b3e5e8c99',
+					elementId: '2651b34b-256b-47dd-8583-27f4a76d7940',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Backstage: “If you were a Nazi, you would go to jail. Now you’re a Nazi, feel free to have a rally down in the square with your mates.”</p>',
-					elementId: 'e5e0824a-d8c1-42b2-b433-7bbe625898ff',
+					elementId: '4928e38e-d2ab-41a7-97e3-dac44c5825ad',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>On stage he said: “I want to dedicate this to all the indigenous kids in the world who want to do art, we are the original storytellers and we can make it here as well.”</p>',
-					elementId: 'f6771831-f7c2-4ede-ae98-e1d24a9411aa',
+					elementId: '3a25a9d7-0f95-4f65-aec9-837a60af79db',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Brad Pitt on Trump’s impeachment, John Bolton and the Republican party</strong></h2>',
-					elementId: '6d7480f9-714b-4c2d-9338-9313661505d9',
+					elementId: 'f5c8ab2b-751b-47cc-ab94-9fec0ca9c739',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Thank you to the Academy for this honour of honours. They told me I only have 45 seconds up here which is 45 more than the Senate gave John Bolton.”</p>',
-					elementId: '96a7d76e-b1ad-4a65-9873-d9a9f6226063',
+					elementId: '6996d238-c9d7-4077-868c-ccfe68e77552',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1808,32 +1863,32 @@ export const Feature: CAPIArticleType = {
 					text: "Parasite's best picture triumph could begin a new era for the Oscars",
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '78056976-5a61-4727-b9ec-d45e6aa937d1',
+					elementId: 'b36a3669-364e-4e16-af49-63ce706533b9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Bong Joon-Ho on booze and Scorsese and Tarantino</h2>',
-					elementId: '2f6cafaa-d3f5-4385-aefb-da7c709ff672',
+					elementId: '048cdc6a-ba61-4f82-94fc-d76c8e349a1e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“The [international feature film] category has a new name and I’m so happy to be its first recipient under its new name. I applaud and support the new direction that this change symbolises. I’m ready to drink tonight.</p>',
-					elementId: '49df0b22-bbbc-4dec-9e1e-801b3621dccf',
+					elementId: 'fddb71f8-6ffd-4906-a816-8da2b5062b0b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“When I was young and starting in cinema there was a saying that I carved deep into my heart, which is, ‘The most personal is the most creative.’ That quote was from our great Martin Scorsese. When I was in school I studied Scorsese’s films. Just to be nominated was a huge honour, I never felt I would win. When people in the US were not familiar with my films Quentin [Tarantino] would always put my films on his list – Quentin, I love you.”</p>',
-					elementId: 'bb54e9e5-bb39-4c87-b1a8-cc71226bda2e',
+					elementId: 'ec8ac2dd-f213-44d4-ac26-00d21dfb2516',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Hildur Guðnadóttir on female composers</strong></h2>',
-					elementId: '486b48f6-47f0-4fd1-ac8e-ebf6acd1bda7',
+					elementId: '008574a5-dbc3-4910-851a-a7d66191058b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“To the girls to the women, to the mothers to the daughters who hear the music bubbling within please speak up – we need to hear your voices.”</p>',
-					elementId: '0002c5d6-6421-4cb1-bf48-5eeb66bf71d7',
+					elementId: 'abb19bfd-eda8-4217-b0d1-5c18b0cee7cb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2143,42 +2198,42 @@ export const Feature: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '80ea2c63-9f0e-448b-aefc-66f0e99ed145',
+					elementId: 'f5477ac6-0953-4ac6-8655-b8cc0fe1947a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Sigourney Weaver, Gal Gadot and Brie Larson’s Fight Club</h2>',
-					elementId: 'b9c28d87-46ea-453c-8506-348eeb977c7d',
+					elementId: 'caeff03a-ac4a-495a-a2f4-78ec31e052d7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We decided that after the show we’re going to start a fight club. Men are invited but no shirts allowed. The winner will get a lifetime’s supply of deodorant, sushi, and tequila. The loser gets a lifetime of questions about what it’s like as a woman in Hollywood.</p>',
-					elementId: '503473ed-99b5-432b-b200-b09d44ec604e',
+					elementId: '2997c165-404e-45eb-8275-c2f1349a411a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Ford v Ferrari</strong><strong> sound editor Donald Sylvester</strong><strong> on sharing</strong></h2>',
-					elementId: '47eb55f8-156a-4e64-ae94-253f8c36f206',
+					elementId: '66f1fbb6-5238-4279-8f2c-a400432e2e77',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“If I could I would break this off [statuette] and give James [Mangold] the head so he could put it in a jar.”</p>',
-					elementId: 'e4c4be15-b268-44b9-aa77-6662ca343f41',
+					elementId: '1927c961-1a0f-4341-ad31-ccef60516d4f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Hair Love’s directors on … hair</strong></h2>',
-					elementId: 'ddcc3204-9772-48ef-9d86-dba57ba3087e',
+					elementId: '0cf78c65-4eea-458a-804d-75b45b4b3232',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Matthew A Cherry and Karen Rupert Toliver said their film Hair Love, which won for best animated short, was made because they “wanted to normalise black hair” and make cartoons more diverse. The directors invited black teenager <a href="https://www.theguardian.com/us-news/2020/jan/23/deandre-arnold-texas-school-district-student-dreadlocks">Deandre Arnold</a>, who was told he wouldn’t be able to take part in his graduation if he didn’t cut his dreadlocks, as their guest.</p>',
-					elementId: 'ccb5eb74-dd0f-46da-880c-c70b01db0b52',
+					elementId: '319eaa64-8231-41ca-9094-8ebe19d798f9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We have a firm belief that representation matters deeply, especially in cartoons because in cartoons that’s how we first see our movies and think about how we shape the world,” said Karen Rupert Toliver.</p>',
-					elementId: '78cac094-323d-4234-bbc5-93d75329bd0f',
+					elementId: '5d263b5e-0a06-4eaa-bb73-befca3da325d',
 				},
 			],
 			attributes: {
@@ -2202,7 +2257,7 @@ export const Feature: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/film/2020/feb/10/quotes-of-the-oscars-2020',
+			'@id': 'https://www.theguardian.com/film/2020/feb/10/quotes-of-the-oscars-2020',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Gallery.ts
@@ -27,63 +27,6 @@ export const Gallery: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['glenn-greenwald-security-liberty'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['news'],
-				},
-				{
-					name: 'co',
-					value: ['glenn-greenwald'],
-				},
-				{
-					name: 'k',
-					value: [
-						'business',
-						'us-national-security',
-						'world',
-						'data-protection',
-						'us-politics',
-						'technology',
-						'nsa',
-						'telecoms',
-						'privacy',
-						'the-nsa-files',
-						'verizon-communications',
-						'us-news',
-					],
-				},
-				{
-					name: 'url',
-					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/3gc62',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -198,6 +141,63 @@ export const Gallery: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -252,6 +252,63 @@ export const Gallery: CAPIArticleType = {
 				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -944,6 +1001,10 @@ export const Gallery: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1749,7 +1810,7 @@ export const Gallery: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '5f811d8d-b6df-4f0d-8302-12ad9f4f7d85',
+			elementId: 'fb1db287-b9c7-430d-871e-24045275513f',
 		},
 	],
 	canonicalUrl:
@@ -1761,152 +1822,152 @@ export const Gallery: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The National Security Agency is currently collecting the telephone records of millions of US customers of Verizon, one of America's largest telecoms providers, under a top secret court order issued in April.</p>",
-					elementId: '06211056-acd3-4d0f-9ba9-39bf172e02ca',
+					elementId: '65c05e34-9a10-4803-bdf7-289260644a5f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, a copy of which has been obtained by the Guardian, <a href="https://www.theguardian.com/world/interactive/2013/jun/06/verizon-telephone-data-court-order">requires Verizon on an "ongoing, daily basis" to give the NSA information on all telephone calls in its systems</a>, both within the US and between the US and other countries.</p>',
-					elementId: '8afac6ff-0fd7-4735-a981-a49bce4326cd',
+					elementId: '6976c2fe-24ee-40c3-b401-eab47fb36bd4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The document shows for the first time that under the Obama administration the communication records of millions of US citizens are being collected indiscriminately and in bulk – regardless of whether they are suspected of any wrongdoing.</p>',
-					elementId: '26624453-6ff8-47c0-9877-7c7bdc723a7c',
+					elementId: 'f3f7d4dc-afc4-4a29-8ed9-bbadb3b6606d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The secret Foreign Intelligence Surveillance Court (Fisa) granted the order to the FBI on April 25, giving the government unlimited authority to obtain the data for a specified three-month period ending on July 19.</p>',
-					elementId: '09aa2572-e30a-49ec-84a3-1db5c2ee9e1d',
+					elementId: 'c09ed46f-a63f-4c8c-b3f6-2b85a5e13674',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the terms of the blanket order, the numbers of both parties on a call are handed over, as is location data, call duration, unique identifiers, and the time and duration of all calls. The contents of the conversation itself are not covered.</p>',
-					elementId: '0d5f51dd-17f6-449c-befd-8c90c02c11cd',
+					elementId: '51a270c7-a1f5-46d7-8000-660b4e115099',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The disclosure is likely to reignite longstanding debates in the US over the proper extent of the government's domestic spying powers.</p>",
-					elementId: '59247a6f-2922-408d-bf7f-90d7cd73adc3',
+					elementId: 'fd586067-7dec-4b52-b576-28c7916b1b32',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the Bush administration, officials in security agencies had disclosed to reporters the large-scale collection of call records data by the <a href="https://www.theguardian.com/us-news/nsa" data-component="auto-linked-tag">NSA</a>, but this is the first time significant and top-secret documents have revealed the continuation of the practice on a massive scale under President Obama.</p>',
-					elementId: 'ac46bf31-5be1-4bc6-8bbf-0d2c4e2cbc2b',
+					elementId: '2e3c152c-96cc-4f11-9f8b-00c793c71efb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The unlimited nature of the records being handed over to the NSA is extremely unusual. Fisa court orders typically direct the production of records pertaining to a specific named target who is suspected of being an agent of a terrorist group or foreign state, or a finite set of individually named targets.</p>',
-					elementId: 'ce285644-8b32-464b-a0d9-2bc2259915d0',
+					elementId: '81b0a5bf-fb6f-425f-b1e4-9920073b7ea0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Guardian approached the National Security Agency, the White House and the Department of Justice for comment in advance of publication on Wednesday. All declined. The agencies were also offered the opportunity to raise specific security concerns regarding the publication of the court order.</p>',
-					elementId: 'fb1ffdae-873f-41e5-99f8-c078dc97dcb4',
+					elementId: '7c1ca8d2-aba3-4f32-88c1-d8a16ce42beb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order expressly bars Verizon from disclosing to the public either the existence of the FBI's request for its customers' records, or the court order itself. </p>",
-					elementId: '83bf6f56-8093-431e-b9bd-ba5681736d5c',
+					elementId: '1ff59311-8abb-4888-aba7-7905ccc42eb9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We decline comment," said Ed McFadden, a Washington-based Verizon spokesman.</p>',
-					elementId: '8f2d633e-c22d-47cb-8351-fbe8940a0b01',
+					elementId: 'c1415bb8-a223-4642-b106-29cb1dd6a8b3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, signed by Judge Roger Vinson, compels Verizon to produce to the NSA electronic copies of "all call detail records or \'telephony metadata\' created by Verizon for communications between the United States and abroad" or "wholly within the United States, including local telephone calls".</p>',
-					elementId: '7cfa4071-a906-4e90-acaf-80194742a6b0',
+					elementId: '1f3a30a0-1915-4eb4-bc5d-dca7b25aac53',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order directs Verizon to "continue production on an ongoing daily basis thereafter for the duration of this order". It specifies that the records to be produced include "session identifying information", such as "originating and terminating number", the duration of each call, telephone calling card numbers, trunk identifiers, International Mobile Subscriber Identity (IMSI) number, and "comprehensive communication routing information".</p>',
-					elementId: '51d0ca48-5368-4a4c-b2db-4c43928171df',
+					elementId: '88ec42d3-82ea-4655-afed-17ebf941e0e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The information is classed as "metadata", or transactional information, rather than communications, and so does not require individual warrants to access. The document also specifies that such "metadata" is not limited to the aforementioned items. A 2005 court ruling judged that cell site location data – the nearest cell tower a phone was connected to – was also transactional data, and so could potentially fall under the scope of the order.</p>',
-					elementId: 'b0b4712c-3741-417c-a565-f639b64aba3d',
+					elementId: '70f20e34-5f7e-4bad-9ba0-0a08dffa2b24',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>While the order itself does not include either the contents of messages or the personal information of the subscriber of any particular cell number, its collection would allow the NSA to build easily a comprehensive picture of who any individual contacted, how and when, and possibly from where, retrospectively.</p>',
-					elementId: '2ac3c098-fc02-4ebc-834a-00db209cc76a',
+					elementId: '4e3c0270-8779-473c-81f6-ab8940559e6c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It is not known whether Verizon is the only cell-phone provider to be targeted with such an order, although previous reporting has suggested the NSA has collected cell records from all major mobile networks. It is also unclear from the leaked document whether the three-month order was a one-off, or the latest in a series of similar orders.</p>',
-					elementId: '33494bbe-bf8e-4215-b872-45ac4f9045c5',
+					elementId: 'a5e97dcd-f8af-4d8b-a469-fb1d754c3393',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order appears to explain the numerous cryptic public warnings by two US senators, Ron Wyden and Mark Udall, about the scope of the Obama administration's surveillance activities.</p>",
-					elementId: '88b1f609-292f-4920-8c50-a78da13e5dbc',
+					elementId: '37b8e4a7-2992-475e-9c2f-a61269cc7b4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For roughly two years, the two Democrats have been stridently advising the public that the US government is relying on "secret legal interpretations" to claim surveillance powers so broad that the American public would be "stunned" to learn of the kind of domestic spying being conducted.</p>',
-					elementId: 'e10de05d-5091-49aa-bdc0-ee853e15ea0a',
+					elementId: '0c59ec83-42aa-442b-aa07-5fb13eef369b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Because those activities are classified, the senators, both members of the Senate intelligence committee, have been prevented from specifying which domestic surveillance programs they find so alarming. But the information they have been able to disclose in their public warnings perfectly tracks both the specific law cited by the April 25 court order as well as the vast scope of record-gathering it authorized.</p>',
-					elementId: '4bb4bccc-ff59-4c9c-9774-90659d5179d6',
+					elementId: 'ef897c27-aa74-4475-a242-7d7f69bc6581',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Julian Sanchez, a surveillance expert with the Cato Institute, explained: \"We've certainly seen the government increasingly strain the bounds of 'relevance' to collect large numbers of records at once — everyone at one or two degrees of separation from a target — but vacuuming all metadata up indiscriminately would be an extraordinary repudiation of any pretence of constraint or particularized suspicion.\" The April order requested by the FBI and NSA does precisely that.</p>",
-					elementId: 'e1dd9fce-15a5-4bb3-95d9-8eb8fe56437e',
+					elementId: 'efa50f1b-37b4-4c8c-9567-671fcb58cf75',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The law on which the order explicitly relies is the so-called "business records" provision of the Patriot Act, 50 USC section 1861. That is the provision which Wyden and Udall have repeatedly cited when warning the public of what they believe is the Obama administration\'s extreme interpretation of the law to engage in excessive domestic surveillance.</p>',
-					elementId: '4ce4666e-397b-44d9-bea9-2f01b0e7640d',
+					elementId: '750355d7-c80c-4d71-a764-7f3409082d7a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In a letter to attorney general Eric Holder last year, they argued that "there is now a significant gap between what most Americans <em>think</em> the law allows and what the government secretly <em>claims</em> the law allows."</p>',
-					elementId: '245ae1cc-098a-4b54-a1fc-ddc29a824d86',
+					elementId: '60b5f816-a078-4ff5-9660-b8a9de32d90e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We believe," they wrote, "that most Americans would be stunned to learn the details of how these secret court opinions have interpreted" the "business records" provision of the Patriot Act.</p>',
-					elementId: '2cf330d5-8dd1-439e-b920-607122911bce',
+					elementId: '5492dbad-205a-41b5-bbfd-76002727c742',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Privacy advocates have long warned that allowing the government to collect and store unlimited "metadata" is a highly invasive form of surveillance of citizens\' communications activities. Those records enable the government to know the identity of every person with whom an individual communicates electronically, how long they spoke, and their location at the time of the communication.</p>',
-					elementId: '25c6681c-10a3-44f6-8353-7c5957fe926c',
+					elementId: '70a55761-a463-4002-84ab-a19fc43ce8cd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Such metadata is what the US government has long attempted to obtain in order to discover an individual's network of associations and communication patterns. The request for the bulk collection of all Verizon domestic telephone records indicates that the agency is continuing some version of the data-mining program begun by the Bush administration in the immediate aftermath of the 9/11 attack.</p>",
-					elementId: '8497f2c2-4218-4899-8671-ee0b1d5b24de',
+					elementId: '419ce3e8-ac48-4f2b-be9a-2dcda2bb4be2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The NSA, as part of a program secretly authorized by President Bush on 4 October 2001, implemented a bulk collection program of domestic telephone, internet and email records. A furore erupted in 2006 when USA Today reported that the NSA had "been secretly collecting the phone call records of tens of millions of Americans, using data provided by AT&amp;T, Verizon and BellSouth" and was "using the data to analyze calling patterns in an effort to detect terrorist activity." Until now, there has been no indication that the Obama administration implemented a similar program.</p>',
-					elementId: '40629f84-dc73-4442-844f-d55d969d6587',
+					elementId: '3827b42e-7171-4126-ba7c-d56d8211c591',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>These recent events reflect how profoundly the NSA's mission has transformed from an agency exclusively devoted to foreign intelligence gathering, into one that focuses increasingly on domestic communications. A 30-year employee of the NSA, William Binney, resigned from the agency shortly after 9/11 in protest at the agency's focus on domestic activities.</p>",
-					elementId: '402c5263-4fc6-4bd5-af1c-ffeb3e26cef9',
+					elementId: '22b9561e-79c8-42ab-b75c-4511a176327c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In the mid-1970s, Congress, for the first time, investigated the surveillance activities of the US government. Back then, the mandate of the NSA was that it would never direct its surveillance apparatus domestically.</p>',
-					elementId: 'e5a2a421-83f0-45fb-a517-f9e2dd81c9ff',
+					elementId: 'e8ea0b57-f404-47b2-aa3d-496fc8a27150',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>At the conclusion of that investigation, Frank Church, the Democratic senator from Idaho who chaired the investigative committee, warned: "The NSA\'s capability at any time could be turned around on the American people, and no American would have any privacy left, such is the capability to monitor everything: telephone conversations, telegrams, it doesn\'t matter."</p>',
-					elementId: 'a37da07f-dc1f-44a6-bd54-82733c707c1c',
+					elementId: '635654ed-4091-4bdb-9b1f-65d81b9a1a83',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Additional reporting by Ewen MacAskill and Spencer Ackerman</em></p>',
-					elementId: '32204131-eeb7-49ce-a978-1483e2df1418',
+					elementId: 'c08571e7-f5e3-4870-a14c-d5e303485cf6',
 				},
 			],
 			attributes: {
@@ -1927,7 +1988,7 @@ export const Gallery: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+			'@id': 'https://www.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -27,50 +27,6 @@ export const Interview: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'co',
-					value: ['elle-hunt'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ob',
-					value: 't',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['interview', 'features'],
-				},
-				{
-					name: 'url',
-					value: '/global/2020/feb/09/halima-aden-model-activist-hijab-refugee-fashion-we-all-deserve-representation',
-				},
-				{
-					name: 'k',
-					value: ['fashion', 'women', 'lifeandstyle', 'models'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/d7nqb',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -159,6 +115,50 @@ export const Interview: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: ['elle-hunt'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ob',
+					value: 't',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['interview', 'features'],
+				},
+				{
+					name: 'url',
+					value: '/global/2020/feb/09/halima-aden-model-activist-hijab-refugee-fashion-we-all-deserve-representation',
+				},
+				{
+					name: 'k',
+					value: ['fashion', 'women', 'lifeandstyle', 'models'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d7nqb',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -192,6 +192,50 @@ export const Interview: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d7nqb',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: ['elle-hunt'],
+				},
+				{
+					name: 'ob',
+					value: 't',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['interview', 'features'],
+				},
+				{
+					name: 'url',
+					value: '/global/2020/feb/09/halima-aden-model-activist-hijab-refugee-fashion-we-all-deserve-representation',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'k',
+					value: ['fashion', 'women', 'lifeandstyle', 'models'],
 				},
 				{
 					name: 'p',
@@ -872,6 +916,10 @@ export const Interview: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1804,7 +1852,7 @@ export const Interview: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '04cf857d-2e55-47d1-ae4e-7964a9d816ad',
+			elementId: '40fa84e2-edb1-491f-aa61-2d2047d34904',
 		},
 	],
 	canonicalUrl:
@@ -1816,22 +1864,22 @@ export const Interview: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Halima Aden, then aged 19, became the first contestant in the Miss USA 2016 beauty pageant to wear a hijab and burkini, attracting the attention of French fashion legend <a href="https://www.theguardian.com/fashion/carine-roitfeld" title="">Carine Roitfeld</a>. The following year she became the first hijab-wearing model to sign with a global modelling agency, IMG, and then the first to walk at New York fashion week, for Yeezy, the Kanye West brand. She later became the first hijab-wearing model to make the cover of <em>Vogue</em> – twice (first <em>Vogue Arabia</em>, then British <em>Vogue</em>) – and soon afterwards a <em>Sports Illustrated</em> swimsuit shoot followed. By that point she’d already become a Unicef ambassador, and a go-to voice on diversity in the fashion industry. In 2017 she gave the first <a href="https://www.ted.com/talks/halima_aden_how_i_went_from_child_refugee_to_international_model?language=en" title="">TED</a> talk at a refugee camp in Kakuma, Kenya. <em>Teen Vogue</em> went with her.</p>',
-					elementId: '427fbd23-fe0f-4657-92b3-c51e3edf5555',
+					elementId: 'feabdbd4-8d6d-4642-aa03-9570af5c59d0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>When we meet, at a hotel near King’s Cross, I ask if it ever gets tiring, being the first in so many different ways, shouldering the burden of representation. “Somebody needs to,” Aden says. “I want my sister, my little nieces, even my nephews to see representations of somebody who wears a hijab in modern ways, in such a way that they can relate to.” We’re sitting side by side on a window seat, Aden holding court before a little audience of PRs, management and her best friend, Lizeth, who has travelled with her from the US. Though she looks very much the high-fashion figure, all in black – sequins and brocade lace, knee-high stiletto boots – she seems younger than her 22 years, gabbing away in the stream-of-conscious slang and asides of a teenager still starstruck by the turns her life has taken.</p>',
-					elementId: '9a9eacc2-3b79-46f0-b5a5-d3c7f0b001a5',
+					elementId: 'cd2149df-79c7-4dd6-b363-9f2c4785352b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But on the topics of diversity, representation and sustainability, she speaks with passion and conviction. She has said in the past that, growing up in the US: “The only times I saw somebody dressed like me was on CNN – and they weren’t doing anything I approve of.”</p>',
-					elementId: '44f47f4e-1192-4b55-84e6-640eec67276a',
+					elementId: 'b0eae950-bbe7-4c33-ad8b-5a96aeb29e8f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“I feel like we all deserve representation and I didn’t have that,” Aden says now. “I never got to flip through a magazine and see somebody who looks like me.” Lizeth digs out the latest issue of <em>Essence</em> magazine, Aden proud in pink on the cover. Aden takes it from her, somewhat wonderingly. “Sometimes it’s so wild for me,” she says. “I still catch myself… When my friend went and got that from the newsstand, I was like: ‘Oh my God.’”</p>',
-					elementId: '04381a69-f86d-45a9-8347-233ba27d3603',
+					elementId: '51a83236-808d-44ec-9d3a-8adc9a0d48b5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2141,27 +2189,27 @@ export const Interview: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'c88baa42-3784-43b1-a2ef-5e80460e082f',
+					elementId: 'c4758370-5c80-4e8d-a739-baf4d8f6af30',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The fact she has been able to have a global career in fashion at all is proof that the industry is increasingly open to diversity. Aden is 5ft 5in, petite for a model, and a resident of Minnesota, far from the industry capitals of New York, London, Paris or Milan. “And the fact that I’m able to do runway, the fact that I have graced these magazine covers and wear a hijab on top of that, be who I am, have my identity, wear it proudly… I think fashion is doing a beautiful job.”</p>',
-					elementId: '7d3b46aa-e731-49d4-b032-6beaa3c181c1',
+					elementId: '54a8ed17-367d-49a8-af4f-c324ea158523',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Aden now has her own 47-piece hijab collection, Halima x Modanisa, and her hijab is stipulated as non-negotiable in her contract with IMG. “It’s a big part of my identity,” she says. “It’s not because I don’t think people are going to listen – it’s more so they know what to expect. I always bring extras – my own set of turbans, turtlenecks, tights – because it’s a collaboration. I also recognise that for a lot of people, in my first year especially, I was the only hijab-wearing girl they’d worked with. So they’re not going to necessarily know 100% what to expect, just like I didn’t know what to expect with fashion, because it’s not the world that I come from.”</p>',
-					elementId: 'cff112fe-57fe-4808-9113-a114bf3ef2b4',
+					elementId: 'c5126707-20ec-4dfc-a590-41b5c4ed7b02',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>She does have certain requirements, such as a pop-up tent in which to change backstage at shows, but she says she’s never been uncomfortably set apart, or made to feel othered. She remembers her experience of walking for Yeezy at New York fashion week in 2017, her breakout year, as a watershed moment. The first outfit she was presented with “was just not going to work,” she says, gesturing above her knee – too short. “Even then I knew: walking away when something doesn’t fit is always better than feeling you need to force something.”</p>',
-					elementId: '4d94c3d3-32fe-4762-b2ac-4a0310ebb7c0',
+					elementId: '09af10ad-950d-4c3c-a4fa-915f32654c5e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>She returned to her hotel, disappointed but resolute. “And then, without having to say anything, they called back: ‘We have a second option.’ I tried it on and it was perfect. I just knew it was a pivotal moment in my life. The people who you want to work with, they’re willing to work with you just the way you are.”</p>',
-					elementId: '9d12ab55-3fd0-4d70-a3af-ef00c4b40b47',
+					elementId: '3badf87f-e3e6-45ea-91ae-b65daa6a3d44',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2460,32 +2508,32 @@ export const Interview: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '2abf835f-5c41-4bc5-9d16-31770a3760bd',
+					elementId: '8b45b1f9-7e30-4bec-afd2-e6a41f2d444b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That same year, Aden remembers walking for MaxMara at Milan fashion week in a look that had been designed with her in mind. When she posted it on Instagram, a woman commented: “He keeps you in mind, he keeps us in mind. Now this Muslim shopper will keep MaxMara in mind.” Aden shared it with the brand. “I was like – wink-wink-wink!”</p>',
-					elementId: '27df43f2-f326-4f52-beee-2c05b227f985',
+					elementId: 'b2565d45-3b37-4083-88fa-c30bed76811b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It led to an exclusive capsule collection in the Middle East, for which Aden was the face. “It’s a win for designers when they’re diverse; it’s a win for the brand, it’s a win for everybody – we all want to see a little piece of ourselves reflecting back.” And it makes a difference, she says. The year after Aden became the first contestant to wear a hijab in Miss USA, there were seven others. Last year she was one of two hijabi models on the MaxMara catwalk in Milan, and one of three for her second <em>Vogue Arabia</em> cover.</p>',
-					elementId: '26238bd7-e75d-417d-92d8-e5dc4767a481',
+					elementId: 'a3aa9f65-bf02-413d-a4bd-fa01cfa78efd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>When Aden was seven, she used to pray for rain – the kind of torrential rain that would wash away her new home in the American Midwest. “I remember thinking: ‘Then our neighbours could come out and play,’” she says. Even the structure of her apartment building felt alienating. “I was like, ‘God, everybody is so isolated.’”</p>',
-					elementId: 'd173d2a7-4788-4d42-a17a-e463a224cfc9',
+					elementId: '13ccdfe3-6cc6-4c71-b8e9-dd2e9f0354d8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Aden was born a refugee in the United Nations Kakuma camp in northwestern Kenya, where her mother had fled the Somali civil war in 1994. There their house was made of mud, scraps, sticks – anything her mother could find. “It would be normal for me to go to nursery school, come back and find it had washed away,” she says. But then the community would come together to rebuild it, “and then it’s the kids’ time to play around.”</p>',
-					elementId: 'a961f858-d182-427e-9f15-29229f9787b6',
+					elementId: '6dd9a190-5d22-4f5a-8f9e-97cb72502156',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The model remembers her childhood in the camp as being joyful and supportive. “There’s no walls keeping you apart from your neighbour,” she says. In her new home in Missouri, where she was relocated with her family in 2004, before moving to Minnesota, where they live today, the barriers stood strong.</p>',
-					elementId: 'b9e2dbbb-1b97-4326-b69e-c8ae9f00d7d0',
+					elementId: '6d59881a-71a1-449d-ab5f-e9d5f28dd31c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2795,27 +2843,27 @@ export const Interview: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '4590121b-dbc2-4b30-9d3d-498289fecb7d',
+					elementId: 'ae6c971a-851f-4632-9ec6-6a7a4f0e2620',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Kakuma” translates from Swahili as “middle of nowhere”. “Sometimes, when I’m like, ‘I was born in the middle of nowhere,’ people think I’m joking,” Aden says. “But if you actually look at Google Maps…” People tend to think of a refugee camp as being a temporary settlement. But Kakuma is “more of a city of its own,” says Aden, in both permanence and size. Established by the UN in 1992 with a 70,000-person capacity, it has since ballooned to about 192,000 registered refugees and asylum seekers, the vast majority of whom are never resettled (the global figure is less than 1%).</p>',
-					elementId: 'b03b634e-8ae2-421d-b2ed-fbb44e2690e0',
+					elementId: '425f88a8-5ec3-464f-8a75-a06e8883e124',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As a child, Aden remembers thriving under the collective care of the community, which was two thirds women and children. She was bright – she spoke Somali and Swahili, sometimes translating for the grown-ups – and popular, roaming the camp with up to 30 playmates of mixed ages and ethnicities. (“If you could keep up, you were in the group.”)</p>',
-					elementId: 'dec00343-0729-4feb-a472-0b48f404c0e1',
+					elementId: '3dc7b6ae-2725-4989-a91b-3bdffb6aa0cf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Aden is well aware that her happy stories of childhood challenge the stereotype of the “tragic refugee”, though she credits her mother with working hard to shield her young family from hardship. Aden never knew her father. He was lost during the Somali civil war, and assumed dead by her mother; he made contact after they had moved to the US, but died before Aden could develop a relationship. “It was both the scars and the smiles,” she says. “It was a happy childhood and also, we lived in uncertainty.”</p>',
-					elementId: '7697a48d-d4fd-4215-bae2-e0baa1c14163',
+					elementId: 'e4d85d94-b48e-4177-91aa-96ca45c46562',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Symbolic of this limbo was a noticeboard that was updated with the names and destinations of those lucky few bound for resettlement. Aden remembers it as larger than life, “like something out of <em>The Hunger Games</em>”: “It would control your entire future – it was literally the difference between life and death. For parents it meant a brand new life: ‘We’re starting over, we won the lottery.’ But for the kids it is: ‘I’m never seeing my friends again’.”</p>',
-					elementId: 'e4f6feb8-e401-4924-9a0c-f0dc10c6a6f4',
+					elementId: '205f932b-88ec-4d89-9114-070787cea4f6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3114,32 +3162,32 @@ export const Interview: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '4fa5c202-b1bb-47ad-8f63-acefb4a6fd70',
+					elementId: 'a1234de1-a008-4a1a-a7ef-7ce634eff2c5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Another common misconception of being a refugee, Aden says, “is that you get a say where you go”. Her family were relocated to a poverty-stricken, crime-rife neighbourhood in St Louis, Missouri, which – compared to the “nurturing” community of Kakuma – came as a shock. That was when she felt most isolated, when she wished for her house to wash away. It was the first time she’d heard gunshots. “But nonetheless, did I have the fear of malaria? No – so, in a way, it was like trading one obstacle for another.”</p>',
-					elementId: 'ea6d55c8-80f1-4717-9b28-baba255294e9',
+					elementId: '6c352f03-b23b-4e67-97d5-75ca09e0e9bf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The biggest hurdle was learning English: Aden’s school in St Louis did not have an English language programme. After two weeks of presenteeism, Aden recalls her mother asking her to read some written English aloud. “I literally started mouthing the words to <a href="https://www.youtube.com/watch?v=8WYHDfJDPDc" title="">Dilemma</a>” – rapper Nelly and Kelly Rowland’s syrupy duet, which she knew from the radio. Aden mimics a haltering recital: “‘No matt-er. Whatido. All I think about. Is you’ – I just couldn’t stand the idea of disappointing her.”</p>',
-					elementId: '0aede065-172e-4075-a7f4-4fdd2c769b46',
+					elementId: '5a83e237-5f4b-4d07-a682-68d717a28bd0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Eventually Aden’s mother decided to relocate the family to St Cloud, Minnesota, where they found a community like the one that they had left at the camp. At first they were heavily reliant on it, living on food stamps and even, for six months, in a women’s shelter. Aden remembers the kindness of neighbours, taking the family to the grocery store during the punishing winters, giving her mother lifts when she couldn’t drive. “It’s why I’m so loyal,” she says. “I love my state.” She lives in St Paul now, closer to the airport, but only 40 minutes from her mother, who’s still in St Cloud. Minnesota is known for high taxes, but Aden says she is happy to pay them. “I relied on welfare when I was little... I think of it as my way of paying back.”</p>',
-					elementId: '17ef1552-7327-4b21-8d8e-597f441b72d4',
+					elementId: 'c7d57262-e86c-49d3-9a6b-6e4e2689decf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Before we meet, Aden’s team is adamant that I don’t ask her about Trump or US politics, so instead I ask her how superficial diversity in fashion tallies with a more fractious, divided world.</p>',
-					elementId: '5d6b4cc8-9cfe-4441-b31c-2f46346dabe1',
+					elementId: 'ec9343b4-1f0c-4fbb-aac6-90037ba88186',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“I don’t even really avoid politics,” she says, “but it’s not something that I’ve needed in order to connect with people. Once I share my story, there’s always some common ground. It doesn’t have to be: ‘I grew up in a refugee camp.’ I get just as many messages, believe it or not, from parents who are not Muslim, who are not black, who say, ‘Thank you for making modesty look cool and young’.”</p>',
-					elementId: '439bd268-d11c-4487-a67e-48c5e1afe5eb',
+					elementId: '50833ecb-d893-483b-be14-592697a63fa2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3438,67 +3486,67 @@ export const Interview: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '36b56f1b-8d03-41ce-96b7-644783583d6e',
+					elementId: '86733a58-d149-4b78-a5fc-8a5cb1b57b47',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>When she entered the Miss Minnesota USA pageant in 2016, as a freshman at St Cloud State University, Aden told local media that she wanted to represent Muslim women and counter the image that they were oppressed. “The hijab is a symbol we wear on our heads,” she said. “But I want people to know that it is my choice.” Today she says her motivations for entering were less lofty. “College tuition is expensive in the States, muuuuuucho expensive!” And the top 15 at the pageant were offered scholarships. Did Aden think she’d win? “No, God, no.” She laughs. “But top 15? I was like, ‘I think I could do that’.”</p>',
-					elementId: '1f203920-97eb-4732-a22d-51bbe63f9f1b',
+					elementId: '308d3c01-1236-4fc2-b027-fdce23a77614',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Aden’s mother was strongly against her entering the pageant, arguing it would distract from her studies, and that the two-piece burkini was too skimpy. Though they have since been able to find common ground through her advocacy and work with Unicef, it can feel like they are from two different cultures sometimes. She didn’t tell her mum about the <em>Sports Illustrated</em> shoot “until it hit newsstands”.</p>',
-					elementId: 'b927ee40-02be-430d-9642-41b6354d8a8a',
+					elementId: '1061f313-1796-4ed9-9b23-51fe70d4238c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>She was also criticised by members of the Muslim community who saw modelling as <em>haram – </em>forbidden by Islamic law. “It was scary to put myself out there, because I didn’t know if I would get backlash, or how bad it was going to be,” she says. Two days before the pageant, Aden almost pulled out. But as she told the newspaper at the time: “You don’t let being the first to do it stop you.”</p>',
-					elementId: '4dfb2cb2-a006-4af0-a10b-60d34d7aec25',
+					elementId: '9aadc381-f7cf-4c20-ad26-5f6954591321',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>She ended up making the semi-finals, “braces and all. And then IMG came calling – like, ‘Well, well, <em>well</em>… maybe I don’t need school.’” She leans back, for a second jokily triumphant – then seems to feel a chill coming in from across the Atlantic. “I’m kidding. Sorry, Mom!”</p>',
-					elementId: '5b8abd5b-905b-4002-9415-c9eb7d882c32',
+					elementId: '17364f7e-56a0-4cc1-a1d8-71991e57b4cc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The global spotlight on Aden caught the eye of Carine Roitfeld, who flew her to New York to shoot the cover of <em><a href="https://www.crfashionbook.com/" title="">CR Fashion Book</a></em> with <a href="https://www.theguardian.com/fashion/gigi-hadid" title="">Gigi Hadid</a>, Paris Jackson and legendary photographer Mario Sorrenti. Aden agonised about asking for a selfie with Gigi (“So cringy,” she says now). As for Sorrenti, though, she had to Google her later.</p>',
-					elementId: 'df8f9840-eede-4fe0-a51d-76346e40ec8a',
+					elementId: '55f50c8d-e22b-4db1-b7cf-14badb442ec9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>His direction to her was, “Give me sexy”, she seems a little abashed to say. “I didn’t know fashion lingo, I didn’t know photographers. I’m a Minnesota girl – very small town.” Even after signing with IMG, she watched all of Tyra Banks’s outlandish reality series <em>America’s Next Top Model</em> “to practise”. Seven months into her modelling career, she was still working part-time as a housekeeper in St Cloud.</p>',
-					elementId: 'b140198a-274b-44a2-bc6c-0ba5444803a8',
+					elementId: 'e3bc0754-efc5-4fa0-b460-d4ec3c38fcca',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But rather than asking Aden to change, fashion’s royalty has made room for her as she is. Last week she was back in Kenya for a shoot and “I was just thinking, how crazy is it that, in one lifetime, I’ve gotten to experience both extremes.” Aden says she does not feel angry about the inequality she has seen – partly because she does not find it to be productive. “It’s like when I say: ‘We don’t want your pity.’ Let’s talk about solutions, invite refugees to the table. They’re part of the conversation – no policies should be enacted without their say.”</p>',
-					elementId: '15cdf581-1da8-4533-88f5-1a73aef9d97f',
+					elementId: '22ace532-b08c-4157-919d-f278a267a86a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Though she rules out a career in politics (“for now”), in the future she hopes to return to Kakuma with Unicef to inspire hope within the camp for a new life beyond it. “I couldn’t tell you what that would have meant to me as a six or seven-year-old – like, ‘Wait, there’s a life outside these walls?’ Hopefully, it’s not going to be so rare to see kids from the camps grow up and become teachers, lawmakers, presidents and CEOs of Fortune 500 companies. There’s talent everywhere.”</p>',
-					elementId: '8b861fe8-ec3c-4962-b699-458412a22bc9',
+					elementId: 'f56cf9ba-369d-4b51-9aa6-85ff84868f3c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For now Aden is pursuing opportunities in “fashion activism”. This month she was announced as the new face of the British accessories brand <a href="https://bottletop.org/" title="">Bottletop</a>, which was ahead of its time in positioning itself as “sustainable luxury” in 2002. Its handbags and clutches, which are made from sustainable leather and upcycled metal ring pulls, help to alleviate poverty in Brazil, Nepal and Kenya. Aden is optimistic in general, but particularly about the potential for consumer choice to be a force for positive change: “I think we’re at a place where people want to support brands and organisations they know are giving back.” She is also an ambassador for Bottletop’s <a href="https://togetherband.org/" title="">#Togetherband</a> campaign, which is tasked with raising awareness of the <a href="https://www.un.org/sustainabledevelopment/sustainable-development-goals/" title="">UN’s Sustainable Development Goals</a>. Aden is probably one of the few celebrities who can “relate personally” to all 17 of them. She has been assigned the eighth goal: “Decent work and economic growth.” The fact that the Swiss multinational bank UBS is a founding partner seems to suggest which way the wind is blowing.</p>',
-					elementId: '6671eb0f-2a23-4456-b26d-d1f2438e3636',
+					elementId: '999c342d-6f7f-45c8-950f-d91be21698bc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“My career in fashion is not just, ‘I want to work with this brand, I want to get on that catwalk’ – we’re not sitting here talking about ‘Buy this heel, because this heel will make you feel sexy.’” She kicks up her stiletto boot, knee-high in black patent leather (admittedly very sexy). “I’m proud that I can say I combined fashion and activism. I can’t do one without the other.”</p>',
-					elementId: '20a9ba23-5487-4ad3-a06a-c4d0c96b1235',
+					elementId: 'bdaade55-6f54-427a-a251-f2737f3015f2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Aden sees that her story, from refugee camp to the cover of <em>Vogue</em>, is an unusual one. But she has had to navigate it herself – down to mentioning, at her very first meeting with IMG as a teenager in New York, that she would like to work with Unicef. “I had to learn, in the beginning especially, that maybe I’d never find another model who I could relate to. But I’m making my own path, and it works perfectly for me.”</p>',
-					elementId: 'e0da9be0-018b-4f82-8a0e-87b1fe7b5820',
+					elementId: '43dc7b95-7077-408e-9048-7a7150d28088',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Fashion editor Jo Jones; photographer’s assistant Dan Ross; fashion assistant Lena Young; makeup by Dina at Frank Agency using Dior Forever and Dior Capture Totale C.E.L.L. Energy; nails by Kim Nkosi at Premier Hair and Makeup using Dior Vernis and Miss Dior Hand Cream; shot at Waddington Studios</em></p>',
-					elementId: '42e6f9cb-7595-4fc4-a4b0-8ee16a65e4db',
+					elementId: 'a07a41f8-607f-42d2-b269-bb2bfaf5f9a4',
 				},
 			],
 			attributes: {
@@ -3522,7 +3570,7 @@ export const Interview: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/global/2020/feb/09/halima-aden-model-activist-hijab-refugee-fashion-we-all-deserve-representation',
+			'@id': 'https://www.theguardian.com/global/2020/feb/09/halima-aden-model-activist-hijab-refugee-fashion-we-all-deserve-representation',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -18,63 +18,6 @@ export const Labs: CAPIArticleType = {
 	main: '<figure class="element element-image" data-media-id="8b723eb4d94368efc040dc26313a01cec69b588a"> <img src="https://media.guim.co.uk/8b723eb4d94368efc040dc26313a01cec69b588a/0_0_3000_1800/1000.jpg" alt="Are you royal?" width="1000" height="600" class="gu-image" /> </figure>',
 	subMetaSectionLinks: [],
 	commercialProperties: {
-		UK: {
-			branding: {
-				brandingType: {
-					name: 'paid-content',
-				},
-				sponsorName: 'Amazon',
-				logo: {
-					src: 'https://static.theguardian.com/commercial/sponsor/04/Oct/2018/6b15ba78-da66-415d-8540-a34cc4d3156b-romanoffs_TT_PO-center.png',
-					dimensions: {
-						width: 140,
-						height: 90,
-					},
-					link: 'https://www.amazon.com/dp/B07FV6K8HF',
-					label: 'Paid for by',
-				},
-				aboutThisLink:
-					'https://www.theguardian.com/info/2016/jan/25/content-funding',
-			},
-			adTargeting: [
-				{
-					name: 'k',
-					value: ['whats-in-your-blood-'],
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'br',
-					value: 'p',
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'url',
-					value: '/whats-in-your-blood-/2018/oct/11/royal-ancestry-genetics-things-to-consider',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/9djqm',
-				},
-				{
-					name: 'tn',
-					value: ['advertisement-features'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-			],
-		},
 		US: {
 			branding: {
 				brandingType: {
@@ -189,6 +132,63 @@ export const Labs: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			branding: {
+				brandingType: {
+					name: 'paid-content',
+				},
+				sponsorName: 'Amazon',
+				logo: {
+					src: 'https://static.theguardian.com/commercial/sponsor/04/Oct/2018/6b15ba78-da66-415d-8540-a34cc4d3156b-romanoffs_TT_PO-center.png',
+					dimensions: {
+						width: 140,
+						height: 90,
+					},
+					link: 'https://www.amazon.com/dp/B07FV6K8HF',
+					label: 'Paid for by',
+				},
+				aboutThisLink:
+					'https://www.theguardian.com/info/2016/jan/25/content-funding',
+			},
+			adTargeting: [
+				{
+					name: 'k',
+					value: ['whats-in-your-blood-'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'br',
+					value: 'p',
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/whats-in-your-blood-/2018/oct/11/royal-ancestry-genetics-things-to-consider',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/9djqm',
+				},
+				{
+					name: 'tn',
+					value: ['advertisement-features'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+			],
+		},
 		INT: {
 			branding: {
 				brandingType: {
@@ -243,6 +243,63 @@ export const Labs: CAPIArticleType = {
 				{
 					name: 'p',
 					value: 'ng',
+				},
+			],
+		},
+		EUR: {
+			branding: {
+				brandingType: {
+					name: 'paid-content',
+				},
+				sponsorName: 'Amazon',
+				logo: {
+					src: 'https://static.theguardian.com/commercial/sponsor/04/Oct/2018/6b15ba78-da66-415d-8540-a34cc4d3156b-romanoffs_TT_PO-center.png',
+					dimensions: {
+						width: 140,
+						height: 90,
+					},
+					link: 'https://www.amazon.com/dp/B07FV6K8HF',
+					label: 'Paid for by',
+				},
+				aboutThisLink:
+					'https://www.theguardian.com/info/2016/jan/25/content-funding',
+			},
+			adTargeting: [
+				{
+					name: 'k',
+					value: ['whats-in-your-blood-'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'br',
+					value: 'p',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/whats-in-your-blood-/2018/oct/11/royal-ancestry-genetics-things-to-consider',
+				},
+				{
+					name: 'tn',
+					value: ['advertisement-features'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/9djqm',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -915,6 +972,10 @@ export const Labs: CAPIArticleType = {
 					},
 				],
 			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
+			},
 		],
 		brandExtensions: [
 			{
@@ -1511,7 +1572,7 @@ export const Labs: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'b6720e4a-0e70-4e70-8dd3-aea5829f888c',
+			elementId: '821bd321-f200-49da-b95f-b442739b38e1',
 		},
 	],
 	canonicalUrl:
@@ -1523,37 +1584,37 @@ export const Labs: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>What are the odds that you have royal blood? It’s a question more and more of us are asking these days. As genetic testing gets faster, cheaper and more accurate, the age-old fantasy of suddenly learning you’re descended from a king or a queen – the premise of countless movies, books and daydreams – is inching closer to reality.</p>',
-					elementId: 'd98681a5-e6f8-4ef8-bb4f-c1d3eefb8453',
+					elementId: 'a2de623e-a653-42e7-b921-1f3133fb902a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But we’re not there just yet. While a genetic test can tell us a lot – 23andme can even pinpoint how much Neanderthal we have in us – there’s still no single test for royal blood.</p>',
-					elementId: 'c8e20696-32f1-4807-b51b-73c0e828ae46',
+					elementId: '6b3c22af-7a05-4599-aa73-1901dff242c8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“DNA testing only reveals a general ethnic breakdown that changes over time, as the science becomes further refined,” says<a href="https://www.djoshuataylor.com/" rel="nofollow"> Joshua Taylor</a>, president of the New York Genealogical &amp; Biographical Society. It “might identify that two individuals share a common ancestor within a certain number of generations, but research is still needed to identify <em>who</em> that common ancestor might be.”</p>',
-					elementId: '0c749037-ca20-4fe0-8598-7c981678f6ac',
+					elementId: '4521dde7-188f-44e1-bac5-787b523e8ca0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>And ancestral math is messy. The number of ancestors we have increases exponentially, not linearly — more like a meshed web than a branched family tree, says the geneticist<a href="http://adamrutherford.com/" rel="nofollow"> Adam Rutherford</a>. If we went back a thousand years, each of us would have over a trillion direct ancestors, which is more than all the humans who have ever lived. This paradox exists because, as Rutherford writes: “Pedigrees begin to fold in on themselves a few generations back.” Meaning “you can be, and in fact are, descended from the same individual many times over”.</p>',
-					elementId: 'fef5cb54-05c2-4236-bb5d-c9141e0620ec',
+					elementId: '4559e3c3-4188-48a6-9554-0ae73a356f8c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Throw in other factors that enlarge and complicate lineage – invasions and migrations, wars and revolutions – and you can see that humanity is indeed a web of overlapping and enmeshed networks of descent.</p>',
-					elementId: '8ba6a152-74b7-429e-81a8-2d2ee8603b46',
+					elementId: 'cf24f911-f8c4-4ab8-86f8-82a0f6b61f69',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Genealogists say that the work of identifying royal lineage – whether to establish “direct descent” (a key to inheritance and social status) or simply to satisfy curiosity – is helped and hindered by a number of factors. If you’re thinking of climbing your family tree in search of royal fruit, here are a few things to consider.</p>',
-					elementId: 'a5d277cd-d076-4a97-b5ab-e78fb1a37aba',
+					elementId: 'eb33dfdd-7de3-4ee5-a726-1ae7f7e72f04',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>1. If you’re European – or even descended from Europeans – you’re probably related to royalty</strong></h2>',
-					elementId: '2a4b3f80-1e67-4234-8fd1-a4c5ee9b005d',
+					elementId: '275dd414-d5de-4b50-af0c-4cc842c5bd6a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1858,62 +1919,62 @@ export const Labs: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'd90ae427-dbab-4153-9172-ee98a1950ba2',
+					elementId: '2c87eaf9-c368-4098-93ec-50317da3f980',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Credit: The Guardian Labs</p></li> \n</ul>',
-					elementId: 'fdb4bd44-d094-4ac9-a03a-6af2a56d0589',
+					elementId: '725cb256-3519-43ca-9578-700e20366d2a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In 1999, the <a href="http://www.stat.yale.edu/~jtc5/papers/CommonAncestors/AAP_99_CommonAncestors_paper.pdf" rel="nofollow">Yale statistician Joseph Chang</a> showed that if you go back far enough – say, 32 generations, or 900 years – you’d find that everyone alive today shares a common ancestor. In Europe, where lineages have been closely studied, that ancestor was someone who lived just 600 years ago.</p>',
-					elementId: 'db495385-6f79-4624-b45c-44d6cbb28782',
+					elementId: '0f23aff8-9308-4635-8f81-144c6ed9a6fe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A <a href="https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001555" rel="nofollow">2013 study from Peter Ralph and Graham Coop</a> built on Chang’s research, proving that all Europeans come from the same people. More recently, Rutherford has demonstrated that virtually everyone in Europe is indeed descended from royalty – specifically from Charlemagne, who ruled western Europe from 768 to 814.</p>',
-					elementId: '478d5c4a-53f5-4a03-b67f-398b4365c248',
+					elementId: 'c5f9977a-9d51-4106-a995-afac1d43baf0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A <a href="https://www.theatlantic.com/magazine/archive/2002/05/the-royal-we/302497/" rel="nofollow">2002 article</a> offers more clarifying examples: “Almost everyone in the New World [aka the Americas, including Bermuda and the Caribbean] must be descended from English royalty – even people of predominantly African or Native American ancestry, because of the long history of intermarriage in the Americas. Similarly, everyone of European ancestry must descend from Muhammad.” Meanwhile, “Confucius, Nefertiti, and just about any other ancient historical figure who was even moderately prolific must today be counted among everyone’s ancestors”.</p>',
-					elementId: '6e149ec1-2c61-45ba-bd54-0ff139f26584',
+					elementId: '8ab52db3-5166-49df-80bd-a116626bbf9b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In other words, mathematically speaking, we’re all related to royalty.</p>',
-					elementId: '06ee798f-fc63-4ad4-bcf1-fdfb784c9b12',
+					elementId: '608cc8d5-7ea8-4eff-946b-b9e5bb827172',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>2. Royal + commoner + intermarriage = higher odds of regal descent</strong></h2>',
-					elementId: 'ac823966-facb-4b1e-b3d1-d40f6ee077cb',
+					elementId: 'ae341f32-c9d1-4776-acb3-36f5ea5e899c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As Chang acknowledged in his study, most mating isn’t random – it’s assortative. That means that people tend to mate with those who are most like themselves in terms of geography, language and socioeconomic status. A wealthy Scandinavian man is far more likely to marry a well-to-do woman from Sweden or Norway than a poor one from Saskatchewan.</p>',
-					elementId: '0a0de4ed-9f6d-464a-aaf2-f6413f8420a9',
+					elementId: '06229807-4fff-454a-b1c5-0fb8c9312bf6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“In most cases,” says Taylor, “royal families work to marry within the same social circle.” <a href="http://faculty.econ.ucdavis.edu/faculty/gclark/" rel="nofollow">Gregory Clark</a>, an economics professor at UC Davis who studies the genealogy of social mobility, says that means “the likelihood that you are related to royalty, if you went back as far as 1300 or 1066, depends on how closed a class nobles were”.</p>',
-					elementId: '104c8065-ae15-4207-98fc-7c722753dca8',
+					elementId: '0ed1b01a-b508-49c7-b414-643eeeffd0df',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In some countries, that class door is firmly shut. But in England, says Clark, the “noble classes have always been fairly open to incorporating wealthy commoners … So a large share of the modern English will be related to someone in the past who was part of the nobility.”</p>',
-					elementId: 'c6b5942b-e8a3-47c8-91f2-5fe88b47ba9a',
+					elementId: '02af914e-6804-428e-848e-451cf1b5ef77',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Translation: if your ancestors hailed from a country or region where royals and commoners intermarried, you have a better chance of being descended from royalty.</p>',
-					elementId: '5c625607-de10-45b8-8859-3e773adc94a6',
+					elementId: '1f63aa19-6776-4597-87e1-d8ad9fc179b5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>3. You don’t need to be fully – or even legitimately – royal to have royal blood</strong></h2>',
-					elementId: '0b910a65-5764-4b72-957c-768c0d7f76b1',
+					elementId: '7fcc433a-bc1c-4690-9dbb-a2e5810442f6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2208,57 +2269,57 @@ export const Labs: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '84f2a7ff-f72c-4dff-ad68-8ae1b96a79f6',
+					elementId: '6150dd48-097d-470c-8f20-15cb67e8c7b7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Here’s another way to look at it: if you’re descended from royalty, it might be via a prince, a princess – or a pauper. In recent years morganatic marriages – aka when a royal marries someone of lesser status, à la Prince William and Kate Middleton – have become more and more common around the world, increasing the number of people with a royal claim.</p>',
-					elementId: '29944c57-e175-41aa-84b8-6ef9a65dbde9',
+					elementId: '2575668f-9193-4b19-b083-acceb799b955',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><a href="https://twitter.com/rusgenproject?lang=en" rel="nofollow">Kirill Chashchin</a>, a Russian genealogical researcher, says that “almost royals” – illegitimate children and those (like Princess Diana) who show <em>some</em> royal connections but not a clear lineage – have muddied the waters. <a href="https://www.cgr2018.com/" rel="nofollow">Dale Myers</a>, founder of the Colorado Genealogical Research Company, agrees. “Kings tended to have a wife and many consorts or mistresses,” he says. “As a result, King Richard I … may not [have been] related to King Edward after all.”</p>',
-					elementId: '96b3248b-4e06-440d-8ffc-d51f666c3a55',
+					elementId: 'e2473dc4-c01d-4059-90a9-8b29543e11df',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Plus, royalty isn’t necessarily static. “In the US,” Taylor says, “millions can trace their ancestry back to European royalty through ‘gateway ancestors’ — early colonial Americans with documented lineage to royal lines.” Today, “these ancestors often have millions of living descendants who can claim royal descent. The odds are increased the longer a family has been in a country or region.”</p>',
-					elementId: '957e868b-7384-4201-9661-4b82dfec8a18',
+					elementId: 'd4fb27d6-55ec-4378-99af-0bbef5b94642',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The bottom line: if someone in your family mated with a royal, or was born to one, it may be enough to link you to a throne.</p>',
-					elementId: '2d49420d-ec53-4fa2-a89d-f169f16b5691',
+					elementId: '815b0b0a-17c5-42f2-822c-c2aa027a8715',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>4. Can you find your family’s name in a historical record? It could be the link to a royal ancestry</strong></h2>',
-					elementId: '1bfec34a-d0cb-4717-9a04-ba4f808be9b7',
+					elementId: '16cf4df5-15a9-4853-bb4d-18bd2338831d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In many places a dearth of historical records makes it tricky to track royal lines. “If you consider that those of noble birth or wealth were often the only individuals that had written records that were created (and have survived),” says Taylor, “it makes a lot of sense as to why those royal lines are some of the earliest lineages an individual can connect to. While church records might take a family back to the 1600s, landownership and other materials can trace a family back centuries before that date.”</p>',
-					elementId: 'b17a3dc4-151f-48ae-ae1c-d12b4de6212a',
+					elementId: '3588a70d-280a-499e-972e-b87f7a116da4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In non-European cultures, he says, “accessible records to connect living individuals to those lines differ … Some areas of the world where oral histories and traditions are prevalent make it even more difficult, as the lineage itself might only exist in the memories of elders.”</p>',
-					elementId: 'f95ed934-8529-443c-9e6b-e8d8b7a0fa1d',
+					elementId: 'a3fde801-5747-4753-8f36-8d8bfa4c18fa',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><a href="http://www.doorstothepast.com/" rel="nofollow">Nydia Hanna</a>, who runs the genealogical research firm Doors to the Past, says: “Connecting genealogies in the New World to the Old World may be difficult for several reasons.” Central America and the Caribbean, for instance, have been afflicted by “many wars and changeovers as far as governing bodies. Although documents and vital records were kept in the Old World, some of those documents were not kept in the New World unless for tax purposes. This meant that only the upper class have records, in most cases.”</p>',
-					elementId: '477e617f-f205-402d-ab64-e7cfcfee5583',
+					elementId: '18177929-a00f-4b34-8674-18be9c958078',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Think of it this way: if you’re able to find a paper trail, you might want to see where it leads.</p>',
-					elementId: '0a5fd1ef-09bb-43de-8435-1fa85799d37f',
+					elementId: '927f8767-df89-4f7c-9aa7-0165ba58d34a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>5. Europe doesn’t have a monopoly on royalty</strong></h2>',
-					elementId: '052d6871-47f2-4c52-8e41-fd9fba995df2',
+					elementId: '5c4b5bcf-96b9-4bf3-a63f-0923884f967f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2563,79 +2624,79 @@ export const Labs: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '677761c8-d7e1-4dc6-b6cd-7d61f0a1fc52',
+					elementId: '15a4a76c-2029-4e72-9e3c-0da834c7a905',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Credit: The Guardian Labs</p></li> \n</ul>',
-					elementId: '2007270b-8d84-4c2a-a593-2d67c79bc6b8',
+					elementId: 'a3ee8aa8-1890-4ea2-8d4e-5a3716ead110',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Of course, not all royal roots reach back to Europe. It may be where many records have survived, and the subject of much genealogical research. But if your family origins can be traced elsewhere, you may still be in luck – here are a few notable findings.</p>',
-					elementId: 'd774cdd4-765e-4d16-b5ec-93271bf5504d',
+					elementId: 'd90cab43-1e00-42fa-b128-5e68e45e783d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In 2003, a<a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1180246/" rel="nofollow"> groundbreaking study</a> showed that one in every 200 men worldwide (and 16 million in central Asia) are direct-line descendants of the 12th-century Mongolian emperor Genghis Khan. Yet Khan’s not the only Asian ruler responsible for millions of Y-chromosome lineages. According to an<a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1285168/" rel="nofollow"> international study in 2005</a>, 10 other men living in Asia and the Middle East between 2100 BC and 700 AD left behind prolific royal lines. One of them was a 16th-century Qing dynasty ruler named Giocangga, whose descendants include 1.5 million men in modern northern China.</p>',
-					elementId: 'd91a92f5-1dc8-4a47-a8f5-422f13af4cb6',
+					elementId: '8e18c41e-0df4-49cd-a87b-eb7b3173ed2a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Over in South America, <a href="https://link.springer.com/article/10.1007/s00438-018-1427-4" rel="nofollow">genetic and historical research</a> has found noble bloodlines directly connecting Atahualpa, the last Incan emperor (who died 1533), to some of modern Peru’s humblest families.</p>',
-					elementId: '8e80312b-f9c0-4b37-9045-7e78a091a067',
+					elementId: '1eca2dbf-fc95-4ab3-98a3-d0dd4df87688',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>And don’t forget about the Egyptian pharaoh Tutankhamun, aka King Tut. Half of all men living in western Europe are related to him, <a href="https://uk.reuters.com/article/oukoe-uk-britain-tutankhamun-dna/half-of-european-men-share-king-tuts-dna-idUKTRE7704OR20110801" rel="nofollow">geneticists in Switzerland say</a>, including up to 70% of men in Great Britain.</p>',
-					elementId: '5af4fe76-2b5a-464b-a179-5be87a3c0ee3',
+					elementId: '89766573-7ec2-4fa5-80a5-d7445553b2eb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>6. A royal lineage may be the culprit for spreading certain undesirable traits</strong></h2>',
-					elementId: '1ee0e643-55db-4c7a-9dcc-b000f8d34d98',
+					elementId: '80b137cb-8698-4aaf-a723-79338eb50923',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>King Tut left something else behind as well: a legacy of inbreeding, genetic deformities and recessive ailments.</p>',
-					elementId: 'edbd4c54-26bb-44a5-8284-b0b12ee1c806',
+					elementId: '6ddef212-3f94-4c61-a5d9-f9da4a5c8fee',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In royal families in ancient Egypt – and in many dynasties around the world, for much of human history – brothers and sisters were expected to marry, to keep the bloodline pure. This led to homozygosity — two identical forms of a gene, one inherited from each parent — which can cause a host of genetic woes: hemophilia, cystic fibrosis, Habsburg jaw, facial asymmetry, suppressed immune systems and certain kinds of cancer.</p>',
-					elementId: '9eb52322-9e96-452c-ae00-6bcfea08658e',
+					elementId: 'b8104bed-d56a-40f2-b073-c38764e6555f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>King Tut himself is an example. Born to parents who were brother and sister, he had a club foot, a cleft palate, scoliosis and missing bones in his feet. Geneticists think that when he died, around 1324 BC, sickle-cell disease – an inherited blood disorder – was the culprit. (Cleopatra, the last pharaoh, was married to her own brother, too.)</p>',
-					elementId: '43d09c2b-e8a2-478e-8495-a0f6eb957a0b',
+					elementId: 'e82c99b2-1135-448a-8b39-28b3bcfac894',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The jutting Habsburg jaw is another well-known woe. The first royal to have one was the Roman Emperor Maximilian I, who ruled from 1486 to 1519. But soon it turned up all over medieval Europe. Switzerland’s House of Habsburg got stuck with the name because so many of its members had the condition. (Spain’s current ruler, King Juan Carlos I, a distant descendant of the House of Hapsburg, has a correspondingly mild case of Habsburg Jaw.)</p>',
-					elementId: 'd0c8cbc7-b22f-4248-b3a5-7f87a0eb66f9',
+					elementId: 'bc3c4ea0-2a24-475e-acfb-87aa8328a578',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Then there’s hemophilia. While it’s not necessarily the direct product of inbreeding, it does stem from a gene carried by the incestuous monarchies of Europe, who spread the disease far and wide. Queen Victoria, “the grandmother of modern Europe” who ruled England from 1837 to 1901, is said to have inherited the gene from her father, Prince Edward. She in turn passed it along to her son, Leopold, and to some of her daughters, who then passed it on as well — sometimes beyond continental Europe.<strong> </strong>Tsarevich Alexei Nikolaevich, the heir apparent to the Russian Empire, inherited hemophilia from his mother, the Empress Alexandra Feodorovna (a granddaughter of Queen Victoria).</p>',
-					elementId: '675759c5-a426-4ca1-9d08-378ebc7b0af9',
+					elementId: '4e98c967-1529-45c3-9ea1-ce38e6e1f95c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>So what does all this mean for today’s royal descendants? “Traits like the Hapsburg jaw, hemophilia, etc, <em>are</em> certainly seen in individuals today,” says Taylor. But while these ailments have spread, at least in part, via royalty, they’re not definite indicators of monarchic ties today.</p>',
-					elementId: '255b5346-570d-4e91-98de-e1b82aa45fad',
+					elementId: '948867f4-886b-4a9f-b100-7c9239f5c285',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In other words, when it comes to royal descent, not every past is prologue.</p>',
-					elementId: '27d8b3ee-d0d9-416f-b5d4-cced590631cb',
+					elementId: '182b6e69-bfa7-419c-b4b1-438e9996a9a6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.InteractiveBlockElement',
 					alt: 'action button emebed',
 					scriptUrl:
 						'https://labs.theguardian.com/2021/test/action_buttons/v2/boot.js',
-					elementId: 'fdd1ec21-5c45-41c4-b7fa-310980a52c4f',
+					elementId: '8ba75e51-2460-46d8-9748-70afdd77a5db',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -2646,14 +2707,14 @@ export const Labs: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'Youtube',
 					sourceDomain: 'youtube-nocookie.com',
-					elementId: 'f25daaee-117d-4ce4-a8f9-c8f41e478b4d',
+					elementId: '8f34111f-095a-433d-ae8c-1f32a29821f2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.InteractiveBlockElement',
 					alt: 'Amazon The Romanoffs footer',
 					scriptUrl:
 						'https://labs.theguardian.com/2018/amazon_romanoffs/footer/boot.js',
-					elementId: '2f0dba05-814c-42ec-a226-6ca60c7cee89',
+					elementId: 'cdb807f2-99aa-4ceb-833c-18a7697f60d2',
 				},
 			],
 			attributes: {
@@ -2677,7 +2738,7 @@ export const Labs: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/whats-in-your-blood-/2018/oct/11/royal-ancestry-genetics-things-to-consider',
+			'@id': 'https://www.theguardian.com/whats-in-your-blood-/2018/oct/11/royal-ancestry-genetics-things-to-consider',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -23,42 +23,6 @@ export const Letter: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'url',
-					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'k',
-					value: ['women', 'family', 'gender'],
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/hx6ty',
-				},
-				{
-					name: 'tn',
-					value: ['letters'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -131,6 +95,42 @@ export const Letter: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: ['women', 'family', 'gender'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/hx6ty',
+				},
+				{
+					name: 'tn',
+					value: ['letters'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -144,6 +144,42 @@ export const Letter: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: ['women', 'family', 'gender'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/hx6ty',
+				},
+				{
+					name: 'tn',
+					value: ['letters'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -840,6 +876,10 @@ export const Letter: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1539,7 +1579,7 @@ export const Letter: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'b661537e-4ec9-47fe-b73b-7feecd193196',
+			elementId: '31e18cc5-f89b-49ff-ac87-39306c622662',
 		},
 	],
 	canonicalUrl:
@@ -1551,17 +1591,17 @@ export const Letter: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Your article (<a href="https://www.theguardian.com/society/2021/mar/30/bob-pape-was-a-beloved-father-and-foster-carer-did-eat-out-to-help-out-cost-him-his-life">Lost to the virus</a>, 30 March) and the <a href="https://www.theguardian.com/uk-news/2021/apr/01/peace-camp-support-for-swiss-army-underwear-move">subsequent letter</a> about women at home “not working” (1 April) reminded me of the 1971-72 television series Budgie,&nbsp;written by Keith Waterhouse and Willis Hall. In one episode, the Soho&nbsp;gangster Charlie&nbsp;Endell (played by Iain Cuthbertson) declared proudly: “Mrs Endell, since the day&nbsp;I married her, has not done a stroke of work – except cooking, cleaning, and bringing up the kids.”<br><strong>Rosemary </strong><strong>Johnson<br></strong><em>Byfield, Northamptonshire</em></p>',
-					elementId: 'd2fe904c-ce13-4aaa-86d9-209cb46e908b',
+					elementId: 'e12cf77f-ad77-4e71-b4c2-9bae6fd460ab',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>• In the 1970s, when feminism was&nbsp;working well, before it lost its way, we referred to women who stay at home as “women who&nbsp;don’t work outside the home”. In other words they had one job, unlike women who “work outside the home”, having two jobs. Then&nbsp;along came Thatcher.<br><strong>Margaret Davis<br></strong><em>Loanhead, Midlothian</em></p>',
-					elementId: '78ab9f81-13a6-4c55-8d57-0b5ce8b21780',
+					elementId: '02e7ec53-a499-43fc-84ca-93c09ad50e9c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>• Maybe the hurried “census” carried out in 1939 got it right by defining wives as undertaking “<a href="https://www.theguardian.com/news/datablog/2015/nov/02/the-1939-register-a-tale-of-a-country-ravaged-by-war">unpaid domestic duties</a>”.<br><strong>Brian Saperia<br></strong><em>Harrow, London</em></p>',
-					elementId: '5a7eae93-1f06-435f-a8bb-5a497e550685',
+					elementId: '51d6a74c-4ecd-451a-ba76-b0f622f0e1ef',
 				},
 			],
 			attributes: {
@@ -1585,7 +1625,7 @@ export const Letter: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
+			'@id': 'https://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -23,54 +23,6 @@ export const Live: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'k',
-					value: [
-						'world',
-						'astronomy',
-						'space',
-						'us-news',
-						'nasa',
-						'science',
-						'mars',
-					],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/gfc2f',
-				},
-				{
-					name: 'url',
-					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'ct',
-					value: 'liveblog',
-				},
-				{
-					name: 'tn',
-					value: ['minutebyminute', 'news'],
-				},
-				{
-					name: 'co',
-					value: ['natalie-grover', 'tommccarthy'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -167,6 +119,54 @@ export const Live: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: [
+						'world',
+						'astronomy',
+						'space',
+						'us-news',
+						'nasa',
+						'science',
+						'mars',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gfc2f',
+				},
+				{
+					name: 'url',
+					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'ct',
+					value: 'liveblog',
+				},
+				{
+					name: 'tn',
+					value: ['minutebyminute', 'news'],
+				},
+				{
+					name: 'co',
+					value: ['natalie-grover', 'tommccarthy'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -196,6 +196,54 @@ export const Live: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'ct',
+					value: 'liveblog',
+				},
+				{
+					name: 'tn',
+					value: ['minutebyminute', 'news'],
+				},
+				{
+					name: 'co',
+					value: ['natalie-grover', 'tommccarthy'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'k',
+					value: [
+						'world',
+						'astronomy',
+						'space',
+						'us-news',
+						'nasa',
+						'science',
+						'mars',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gfc2f',
+				},
+				{
+					name: 'url',
+					value: '/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -889,6 +937,10 @@ export const Live: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1838,7 +1890,7 @@ export const Live: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '1e026eb3-b0b1-4fb4-a441-f1ed2ddb6ccd',
+			elementId: '4a5a62af-0446-4af6-96d7-9b1946655310',
 		},
 	],
 	canonicalUrl:
@@ -1850,17 +1902,17 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-					elementId: '1625b42a-221f-4042-9ee7-b74db8f825c7',
+					elementId: '1b7ea8dd-6040-4d1b-847f-01f18a68d57b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>To recap:</p>',
-					elementId: '8b4bd7cd-610d-4385-824f-a8ceb0aede90',
+					elementId: '95d1094d-48b3-445a-a403-1dab00bcc063',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from Mars as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on Mars for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on Mars and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-					elementId: '9cb6f5c0-b28f-4a11-8787-8f2f0228339a',
+					elementId: '7743fd17-abed-42fd-a7d1-8f58f6459789',
 				},
 			],
 			attributes: {
@@ -1886,7 +1938,7 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>#TBT</p>',
-					elementId: '4300b0f7-9f7f-44d1-b101-14c4aab42f56',
+					elementId: 'aa0aea09-8bba-49e2-b3c8-199d0f7076ea',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
@@ -1919,7 +1971,7 @@ export const Live: CAPIArticleType = {
 					],
 					expired: false,
 					duration: 142,
-					elementId: '89fcd3e0-1019-4cfc-a677-b7d3563f8f59',
+					elementId: '1ba59c9b-235c-48f8-9e39-041e85ca1c8b',
 				},
 			],
 			attributes: {
@@ -1944,7 +1996,7 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>#FF</p>',
-					elementId: '0b40e88d-9ac8-49bd-8841-dd924bc5f76a',
+					elementId: 'de590e5d-7dac-4fff-a49a-fb5f80171058',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TweetBlockElement',
@@ -1955,7 +2007,7 @@ export const Live: CAPIArticleType = {
 					role: 'inline',
 					isThirdPartyTracking: false,
 					source: 'Twitter',
-					elementId: '13eea321-0a90-44ce-afb8-e0757bbf165e',
+					elementId: '6173faf2-5a25-41e7-9cc9-4aa39ce56862',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TweetBlockElement',
@@ -1966,7 +2018,7 @@ export const Live: CAPIArticleType = {
 					role: 'inline',
 					isThirdPartyTracking: false,
 					source: 'Twitter',
-					elementId: '6a87c8ec-0010-4066-9bbf-c18db1bc3740',
+					elementId: '51ee9f35-5e16-4ea1-b779-4bd6259aaf0c',
 				},
 			],
 			attributes: {
@@ -1991,7 +2043,7 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Have you typed “<a href="https://www.google.com/search?q=perseverance&amp;oq=pers&amp;aqs=chrome.0.69i59j69i57j0l3j46j69i60j69i61.1091j0j7&amp;sourceid=chrome&amp;ie=UTF-8">perseverance</a>” into Google today? </p>',
-					elementId: '5f021bd9-aab4-4ab4-ae7f-030262c40b64',
+					elementId: '97eb82f4-a6e1-4c34-a307-91e397461690',
 				},
 			],
 			attributes: {
@@ -2016,12 +2068,12 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Now that Perseverance persevered through the “seven minutes of terror” – a new era of space exploration has officially begun. </p>',
-					elementId: 'fe29d82b-7c0d-4d7b-a1d3-fa2f49c183a2',
+					elementId: '54957a25-9375-49ab-98d8-dc7ba0bde601',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Next up, the science team will make crucial decisions on which direction to take the rover in as it kicks off its search for ancient life. <br></p>',
-					elementId: '84249515-c6cc-4262-bec3-81533f17e8c1',
+					elementId: '09dc5e93-5ed9-47c4-b595-f87d3d7363b2',
 				},
 			],
 			attributes: {
@@ -2050,17 +2102,17 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The event is concluding. They’ll be back for a 2pm ET news conference on Monday. Mission updates can be found meanwhile on the <a href="https://mars.nasa.gov/mars2020/">Nasa web site</a>.</p>',
-					elementId: '965daaaa-507e-4f21-a012-b407a1a02998',
+					elementId: 'aa38c96d-b1a2-4a63-8026-89c4e84b3d2a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>McGregor signs off:</p>',
-					elementId: '63dac79c-ce76-4e0b-9017-01bd4991831b',
+					elementId: '3eab3113-a7cd-4411-aba7-f3ac3b145a3d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Everyone have a great day, on Earth and on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a>.”</p>',
-					elementId: 'c742b552-ba9d-4723-bbed-4ff75d7763ce',
+					elementId: '754d389c-fa88-4c5f-836a-0630cd2da4b4',
 				},
 			],
 			attributes: {
@@ -2085,12 +2137,12 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Nasa scientists have worked for years to support this mission, and kept things going despite the ongoing coronavirus disruption. </p>',
-					elementId: 'cb5c5393-0c29-41b0-9288-e0816c89a0ce',
+					elementId: 'c4ebbcb7-393d-47a2-a6f8-0899f5b3aefc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>After the landing success yesterday, one team says they had a “socially distanced ice cream” event, while the engineering team had a virtual happy hour! <br></p>',
-					elementId: '06142519-7c3d-4837-995d-ef1fd2182f94',
+					elementId: '1d1deda9-755f-4a1d-b28a-34f070953f55',
 				},
 			],
 			attributes: {
@@ -2119,17 +2171,17 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Next question: <strong>How did you celebrate?</strong></p>',
-					elementId: 'e511cdee-b256-401d-92aa-7f9a55e22bed',
+					elementId: '0e67533f-8e21-4f26-bb88-2fd157f1c052',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Answers include: </p>',
-					elementId: '54a9c1e1-fd6c-4e70-ae6d-d11bbe4485bc',
+					elementId: 'ca4549f3-d4ba-45e0-9a6b-2cf9f39d6d3f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>Virtual happy hour</li> \n <li>“Socially distanced consumption of ice cream outdoors”</li> \n <li>“I went home and just passed out from just the excitement of the day”</li> \n <li>“In the coming days I’ll definitely be having a glass of wine”</li> \n <li>“It was super-exciting”</li> \n <li>“We’re working two shifts a day almost 20 hours a day... it is kind of a really cool thing”</li> \n <li>“Business as usual for a science team working on a <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> rover”</li> \n</ul>',
-					elementId: '113ab9d7-9af5-49ca-b843-d1b4ee884dce',
+					elementId: 'de638ba0-355b-48b7-a4c2-8321d7cb98a3',
 				},
 			],
 			attributes: {
@@ -2154,27 +2206,27 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Another key question: <strong>When will the rover drive? </strong></p>',
-					elementId: '388ca7c7-e5cb-4ee9-94f9-69155d881348',
+					elementId: 'c497139f-5764-46b1-bda0-65e188730092',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We’re anticipating the earliest... would be sol 8 or 9... our current best estimate.</p>',
-					elementId: '2e90cb80-cf85-4798-a763-078fe1bbd669',
+					elementId: 'd6b11889-6117-46cf-8fbb-f37d73e03d0f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Maybe a short drive just to check everything out...</p>',
-					elementId: '9bdc2d17-d54f-44e3-97ff-65850ee100d8',
+					elementId: '261d712f-aa9c-4c66-a19c-a3702e6e218e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We’ll also be figuring out the route and direction we need to go.”</p>',
-					elementId: 'ccd37a67-0874-4315-9ad5-025d3d31d386',
+					elementId: '26070292-d996-4d2b-8985-e6f006ccd191',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That means rover could rove before February is out. </p>',
-					elementId: '9d85acfb-0331-40ed-938c-51b4792b8dc6',
+					elementId: '0af3018f-52e9-4993-8750-0df804714e7d',
 				},
 			],
 			attributes: {
@@ -2199,7 +2251,7 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The team members have described their fascination with the holes in the rocks visible next to the rover’s wheel in this photograph just released by <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a>. It is unknown whether the holes indicate volcanic or sedimentary rock. </p>',
-					elementId: '1d9c4f76-fc36-436e-b5ae-05e6354310eb',
+					elementId: '4ca42a09-8562-4522-b5b6-601375f5a477',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2508,7 +2560,7 @@ export const Live: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'b24d7c2f-301d-4c5e-9354-58334ec8d88c',
+					elementId: 'e0d5013e-b4ac-4e79-951a-6ac0c42e8594',
 				},
 			],
 			attributes: {
@@ -2533,12 +2585,12 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Attached to the rover’s belly is a diminutive helicopter called Ingenuity. </p>',
-					elementId: '0e7da40f-4109-4bcc-b7b6-c9fae274c81d',
+					elementId: 'dfec6f27-3a15-413c-b878-b95bc2c93b11',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 1.8kg drone-like rotorcraft is the first flying machine ever sent to another planet — it has the ability to take colour pictures and video. The rover can also take images of Ingenuity. <br></p>',
-					elementId: 'b012ef80-79c3-4b14-a85b-48f73e708c9a',
+					elementId: '42deadaa-4f4d-444b-ab11-b26ed83263e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2847,7 +2899,7 @@ export const Live: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '292ddbbe-f428-4755-a615-ab65a96fb632',
+					elementId: 'ca21790a-4f22-42bc-b8da-2b5de834e472',
 				},
 			],
 			attributes: {
@@ -2876,12 +2928,12 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Key question: <strong>how long till they fly the helicopter?</strong> </p>',
-					elementId: '4739250f-a73e-46dc-8949-884d6e829c23',
+					elementId: '5925ac22-d63c-49ac-8033-c03464cc33ce',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“Caveat caveat caveat,” the scientist says. “Super-fast” would be “sol 60.” With a sol being 37 minutes longer than and earth days, that would be 60 earth days plus 37 hours = 61 days, 13 hours. Sometime in April. Best-case scenario. </p>',
-					elementId: 'be07af38-dbe0-4fc6-960c-e49d46e85b9c',
+					elementId: '03a76873-6db6-4c0c-b2c3-8cc17db477e1',
 				},
 			],
 			attributes: {
@@ -3210,7 +3262,7 @@ export const Live: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '30ff2781-7dc2-4856-9d0e-083eda55d980',
+					elementId: '32fdf7b5-460e-4fb3-924b-65e2d9003a04',
 				},
 			],
 			attributes: {
@@ -3234,7 +3286,7 @@ export const Live: CAPIArticleType = {
 		{
 			'@type': 'LiveBlogPosting',
 			'@context': 'http://schema.org',
-			'@id': 'https://amp.theguardian.com/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
+			'@id': 'https://www.theguardian.com/science/live/2021/feb/19/mars-landing-nasa-perseverance-rover-briefing-latest-live-news-updates',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',
@@ -3953,17 +4005,17 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-					elementId: '392f3f68-56e8-4b92-af3a-b8e93186d1c0',
+					elementId: '851a6b44-84b4-43a8-8f5f-5043ff49b140',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>To recap:</p>',
-					elementId: 'ff203a45-0132-4d26-8ccf-740f1620fe65',
+					elementId: '12cc54dd-f62c-4cd7-a85f-fa0de8dc723a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from Mars as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on Mars for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on Mars and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-					elementId: 'ad51bbf1-a5b4-4c02-91bb-8f612c196df1',
+					elementId: '7a30e885-3469-49e6-9f34-ca6809cead8a',
 				},
 			],
 			attributes: {
@@ -4293,7 +4345,7 @@ export const Live: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '1bc2665f-9c32-4a5b-bbfa-14986c058bab',
+					elementId: '55acdb0a-2cbc-4848-87ce-bb78ea949a55',
 				},
 			],
 			attributes: {
@@ -4319,12 +4371,12 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Steltzner is showing some of the most fantastic images from space explorations past, from moonshots to the Hubble telescope. </p>',
-					elementId: '65e2ccd3-1ea8-4bfd-9619-c6434634e521',
+					elementId: '6355826e-5487-44e0-b272-ced87852ef4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>He proposes an image of the dangling Perseverance Rover taken yesterday – it looks like a futuristic marionette – as the next entry in this cosmic scrapbook. <br></p>',
-					elementId: 'eca7dd6b-4e71-4741-b569-d6b5a461d32b',
+					elementId: '318ab0ba-bfb0-4c6e-a442-6a4b80cc758e',
 				},
 			],
 			attributes: {
@@ -4350,27 +4402,27 @@ export const Live: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Members of the National Aeronautics and <a href="https://www.theguardian.com/science/space" data-component="auto-linked-tag">Space</a> Administration (Nasa) team that put a rover on Mars on Thursday are preparing to host a news conference and answer questions about the mission.</p>',
-					elementId: '1f207232-c1e0-410d-86b7-5dc9ddbdcb6d',
+					elementId: '1abc2906-f442-4dfd-b8e5-2cd8a0c55cfc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The rover, called Perseverance or Percy for short, is on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> to search for signs of ancient life and collect samples to be returned by a future mission. About the size of a car, the wheeled rover is equipped with cameras, microphones, drills and even a small helicopter. </p>',
-					elementId: '3267f6e1-13a5-4878-ad88-41a4dbc94661',
+					elementId: 'a9516579-ae67-4eae-8a9b-f2f62a99ecad',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Guardian science correspondent Natalie Grover reports of Percy’s mission:</p>',
-					elementId: '1ab0ae9e-0907-4aca-9ce0-7d679a3f1afd',
+					elementId: '00be0417-053d-4258-a349-479272807d9b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement',
 					html: '<blockquote class="quoted"> \n <p>Previous Mars missions including <a href="https://viewer.gutools.co.uk/science/2013/jul/28/curiosity-rover-descent-mars-nasa">Curiosity</a> and Opportunity have suggested Mars was once a wet planet with an environment likely to have been supportive of life billions of years ago. Astrobiologists hope this latest mission can offer some evidence to prove whether that was the case.</p> \n</blockquote>',
-					elementId: '8ce10ea0-472c-413f-aa11-c08c8d084a68',
+					elementId: 'c6768a57-422f-40e6-b34c-5f203666ad54',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a> scientists appear to feel they may be tantalizingly close to a discovery that could change the way we see the universe and our home in it. Here was the scene in the control room near Los Angeles just before 1pm local time on Thursday when Percy’s safe touchdown on Mars was confirmed:<br></p>',
-					elementId: 'b9a2ba6b-5e54-4470-858d-8660eca51201',
+					elementId: '94e8ceb9-60d6-4d13-9a41-b74689674aba',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
@@ -4385,17 +4437,17 @@ export const Live: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'YouTube',
 					sourceDomain: 'youtube-nocookie.com',
-					elementId: '140dc5fc-ebc6-4565-a9de-17b200a642a8',
+					elementId: '3e04b701-0dc7-4a48-9430-a4a4d5e57eb8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The robotic vehicle sailed through space for nearly seven months, covering 293m miles (472m km) before piercing the Martian atmosphere at 12,000mph (19,000km/h) to begin its approach to touchdown on the planet’s surface.</p>',
-					elementId: '5722406b-156b-4aa8-a34f-c153c037f3bf',
+					elementId: '79942673-56fc-4fa8-91a3-27e8436de57a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Thank you for joining our live coverage. </p>',
-					elementId: '7d38cea8-390a-479d-8929-8f5da6dc99bd',
+					elementId: '57e872b4-725c-4190-b492-9cd65e7f5138',
 				},
 			],
 			attributes: {

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -24,52 +24,6 @@ export const MatchReport: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'co',
-					value: ['ben-fisher'],
-				},
-				{
-					name: 'url',
-					value: '/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'k',
-					value: [
-						'norwichcity',
-						'sport',
-						'football',
-						'swansea',
-						'championship',
-					],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'tn',
-					value: ['matchreports'],
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/gba7d',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -162,6 +116,52 @@ export const MatchReport: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: ['ben-fisher'],
+				},
+				{
+					name: 'url',
+					value: '/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'k',
+					value: [
+						'norwichcity',
+						'sport',
+						'football',
+						'swansea',
+						'championship',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'tn',
+					value: ['matchreports'],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gba7d',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -179,6 +179,52 @@ export const MatchReport: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'url',
+					value: '/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'k',
+					value: [
+						'norwichcity',
+						'sport',
+						'football',
+						'swansea',
+						'championship',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/gba7d',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'tn',
+					value: ['matchreports'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'co',
+					value: ['ben-fisher'],
 				},
 				{
 					name: 'url',
@@ -881,6 +927,10 @@ export const MatchReport: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1596,7 +1646,7 @@ export const MatchReport: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '3702482a-3258-4ddd-87d0-e34aa2b128a0',
+			elementId: 'cf055ee7-971f-4331-8af0-6ae8452a1bee',
 		},
 	],
 	canonicalUrl:
@@ -1608,17 +1658,17 @@ export const MatchReport: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>When does a blip become something more major? Whatever this sticky patch is for <a href="https://www.theguardian.com/football/norwichcity" data-component="auto-linked-tag">Norwich City</a>, it is impossible to ignore the changing landscape at the top of the Championship after Swansea cut their lead at the summit to two points courtesy of goals by André Ayew and Conor Hourihane.</p>',
-					elementId: '33665010-fce3-47fd-bb49-113ce7ff74aa',
+					elementId: 'b8c5d2ec-8fed-4959-a459-a4742fb58191',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Norwich may have fired blanks for the fourth successive game but Hourihane is on quite the streak, with a superb strike here his third goal since arriving on loan from Aston Villa a fortnight ago. It looks an increasingly shrewd piece of business.</p>',
-					elementId: '83a6d095-a33d-4cee-96a5-1a3d3dc1c1c8',
+					elementId: '1b261850-5e56-43af-a9ab-2fd075bd6df3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Swansea have a game in hand on the leaders but Brentford and Reading, both of whom also have games up their sleeve, will be equally encouraged by a Norwich team stuck in a rut. Ayew capitalised on an uncharacteristic error by Tim Krul to open the scoring before Hourihane sent a rasping strike beyond the Norwich goalkeeper from distance after the interval.</p>',
-					elementId: '7fbfdbfe-17f3-4b4b-81d5-1129a3e3802e',
+					elementId: '0ce03321-c146-4542-8588-a9c4fc3d6965',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement',
@@ -1626,37 +1676,37 @@ export const MatchReport: CAPIArticleType = {
 					text: "Tim Krul: 'The way we play at Norwich is similar to Holland'",
 					prefix: 'Related: ',
 					role: 'thumbnail',
-					elementId: '1c9bdc56-7dda-471c-9837-9f66cb98913a',
+					elementId: '12fd28ed-5efe-4e27-a776-d795c30cf72a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Swansea should have had a late penalty too, but the referee Simon Hooper waved away appeals despite Ben Gibson appearing to fell the substitute Jordan Morris after Grant Hanley collided with the all-action Connor Roberts.</p>',
-					elementId: '2c707319-2956-4955-951f-b4a7ce72f6d3',
+					elementId: 'd4d53266-74ea-4027-8ab2-b0d3df928f46',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>On the eve of this game, Swansea’s unpopular American owners gave a rare interview in which they broke their silence on a multitude of longstanding issues but also made a point of stressing they have not been “taking a victory lap” on the back of their impressive start under Steve Cooper.</p>',
-					elementId: '57741a27-c88b-4217-a3b4-57d01487a7e8',
+					elementId: 'b300c8f8-d9fa-458c-acc0-3eb7b1d6c9f2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“There were no expectations at the start of the season so I think it would be unfair to start doing it [building them] now with 19 games to go,” Cooper said. “There are clubs not even in the top 10 with much more resources than us but we’re going well and enjoying the journey and that’s how we work.”</p>',
-					elementId: '23c03428-a8ec-43b8-a44a-4d185dac5dd7',
+					elementId: 'ba080731-580d-43e0-bb86-6103690b50fe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Perhaps it was kidology but Daniel Farke had been at pains to play down the significance of the occasion after stuttering to a point at Millwall on Tuesday. Todd Cantwell, among those of interest to the watching England Under-21s manager Aidy Boothroyd, showed touches of class, setting Teemu Pukki free with a wonderfully weighted pass and later Kenny McLean after twirling away from Matt Grimes but the killer instinct again eluded them.</p>',
-					elementId: 'a349a0b0-4719-4b04-b6de-c7f4d5131ca0',
+					elementId: 'd363bf2c-f0e6-4327-a460-db027be4ff2b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Swansea seized the advantage three minutes before the interval but the goal was a tragicomedy from a Norwich perspective. Krul flapped at Roberts’ in-swinging corner and when the ball dropped, Marc Guehi, another player on Boothroyd’s radar, scooped the ball away from the Norwich goalkeeper’s grasp, allowing Swansea to feast on the leftovers. Jake Bidwell tried his luck and then Ayew fired in his ninth goal of the season. Farke sought a response and Freddie Woodman saved superbly to keep out Grant Hanley’s header on the brink of the interval after the captain met Przemyslaw Placheta’s free-kick.</p>',
-					elementId: '2b19b364-a7ce-4e10-b17f-b0e695a008e7',
+					elementId: 'a3575234-35f7-49e6-893a-99959effda35',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Krul came out early to limber up for the second half but, before Norwich had a chance to write the wrongs, they found themselves two goals down. Jay Fulton gobbled up possession following a loose pass by McLean and played a sliderule pass infield to Hourihane, who joined on loan last month in search of regular game time. The midfielder steadied himself with first touch and then arrowed a piercing left-footed strike into the corner with his second.</p>',
-					elementId: 'a4d8091d-dc9f-472d-a362-eab0c4dde89c',
+					elementId: '797284ad-1769-4b04-ba4a-cb6832aec69e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -1667,17 +1717,17 @@ export const MatchReport: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'The Guardian',
 					sourceDomain: 'theguardian.com',
-					elementId: '4a53d108-e37a-4180-9326-ee3d80754801',
+					elementId: '8b885956-8f69-439c-badb-d2c6601341fe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>“We didn’t think he was going to come in and score three goals in first three league games, but we’ll take it,” said Cooper. “As soon as it fell to Conor I think everybody in the stadium thought ‘there’s a good chance of this going in.’ Once we lost Morgan [Gibbs-White, who returned to Wolves], I felt we needed a player you fancy to get goals. Conor’s numbers are really good.”</p>',
-					elementId: '7c78077f-67e5-4727-a11b-bcbc3ebc6a65',
+					elementId: '4f77234c-1b86-473f-8fa0-ea9ac8ec39e6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Krul shook his head in disbelief and Farke admitted his players are hurting. “When you lose such a spotlight game, of course, you are disappointed,” he said. “I will allow my players to be disappointed because it’s important to feel this and be greedy for this next game. We want this winning feeling back.”</p>',
-					elementId: '9ff1f148-b100-46fd-a3b4-97f18b066004',
+					elementId: '067b2ff7-88da-4e40-9f3f-6365be559494',
 				},
 			],
 			attributes: {
@@ -1701,7 +1751,7 @@ export const MatchReport: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+			'@id': 'https://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -27,6 +27,96 @@ export const NewsletterSignup: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
+		US: {
+			adTargeting: [
+				{
+					name: 'co',
+					value: ['suzanne-wrack'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['moving-the-goalposts'],
+				},
+				{
+					name: 'edition',
+					value: 'us',
+				},
+				{
+					name: 'url',
+					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/y5xnj',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'newsletter-sign-up',
+						'sport',
+						'football',
+						'womensfootball',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+			],
+		},
+		AU: {
+			adTargeting: [
+				{
+					name: 'co',
+					value: ['suzanne-wrack'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['moving-the-goalposts'],
+				},
+				{
+					name: 'edition',
+					value: 'au',
+				},
+				{
+					name: 'url',
+					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/y5xnj',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'newsletter-sign-up',
+						'sport',
+						'football',
+						'womensfootball',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+			],
+		},
 		UK: {
 			adTargeting: [
 				{
@@ -50,6 +140,15 @@ export const NewsletterSignup: CAPIArticleType = {
 					value: 'article',
 				},
 				{
+					name: 'k',
+					value: [
+						'newsletter-sign-up',
+						'sport',
+						'football',
+						'womensfootball',
+					],
+				},
+				{
 					name: 'p',
 					value: 'ng',
 				},
@@ -60,90 +159,6 @@ export const NewsletterSignup: CAPIArticleType = {
 				{
 					name: 'url',
 					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
-				},
-				{
-					name: 'k',
-					value: ['sport', 'football', 'womensfootball'],
-				},
-			],
-		},
-		US: {
-			adTargeting: [
-				{
-					name: 'co',
-					value: ['suzanne-wrack'],
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['moving-the-goalposts'],
-				},
-				{
-					name: 'edition',
-					value: 'us',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/y5xnj',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'url',
-					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
-				},
-				{
-					name: 'k',
-					value: ['sport', 'football', 'womensfootball'],
-				},
-			],
-		},
-		AU: {
-			adTargeting: [
-				{
-					name: 'co',
-					value: ['suzanne-wrack'],
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['moving-the-goalposts'],
-				},
-				{
-					name: 'edition',
-					value: 'au',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/y5xnj',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'url',
-					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
-				},
-				{
-					name: 'k',
-					value: ['sport', 'football', 'womensfootball'],
 				},
 			],
 		},
@@ -162,12 +177,25 @@ export const NewsletterSignup: CAPIArticleType = {
 					value: ['moving-the-goalposts'],
 				},
 				{
+					name: 'url',
+					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
+				},
+				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/y5xnj',
 				},
 				{
 					name: 'ct',
 					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'newsletter-sign-up',
+						'sport',
+						'football',
+						'womensfootball',
+					],
 				},
 				{
 					name: 'edition',
@@ -177,13 +205,50 @@ export const NewsletterSignup: CAPIArticleType = {
 					name: 'p',
 					value: 'ng',
 				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'co',
+					value: ['suzanne-wrack'],
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['moving-the-goalposts'],
+				},
 				{
 					name: 'url',
 					value: '/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
 				},
 				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/y5xnj',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
 					name: 'k',
-					value: ['sport', 'football', 'womensfootball'],
+					value: [
+						'newsletter-sign-up',
+						'sport',
+						'football',
+						'womensfootball',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
 				},
 			],
 		},
@@ -191,7 +256,7 @@ export const NewsletterSignup: CAPIArticleType = {
 	beaconURL: '//phar.gu-web.net',
 	hasRelated: true,
 	webPublicationSecondaryDateDisplay:
-		'Last modified on Thu 4 Aug 2022 09.52 BST',
+		'Last modified on Tue 18 Oct 2022 08.57 BST',
 	editionLongForm: 'UK edition',
 	publication: 'theguardian.com',
 	trailText:
@@ -200,6 +265,10 @@ export const NewsletterSignup: CAPIArticleType = {
 		{
 			url: '/football/womensfootball',
 			title: "Women's football",
+		},
+		{
+			url: '/info/newsletter-sign-up',
+			title: 'Newsletter sign-up',
 		},
 	],
 	contentType: 'Article',
@@ -853,6 +922,10 @@ export const NewsletterSignup: CAPIArticleType = {
 					},
 				],
 			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
+			},
 		],
 		brandExtensions: [
 			{
@@ -1028,7 +1101,7 @@ export const NewsletterSignup: CAPIArticleType = {
 	designType: 'Article',
 	editionId: 'UK',
 	format: {
-		design: 'ArticleDesign',
+		design: 'NewsletterSignupDesign',
 		theme: 'SportPillar',
 		display: 'StandardDisplay',
 	},
@@ -1043,9 +1116,9 @@ export const NewsletterSignup: CAPIArticleType = {
 			'gnmguardian://football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts?contenttype=Article&source=applinks',
 		'article:publisher': 'https://www.facebook.com/theguardian',
 		'og:title':
-			'Sign up for our women’s football newsletter – Moving the Goalposts',
+			'Sign up for the Moving the Goalposts newsletter: our free women’s football email',
 		'fb:app_id': '180444840287',
-		'article:modified_time': '2022-08-04T08:52:53.000Z',
+		'article:modified_time': '2022-10-18T07:57:21.000Z',
 		'og:image:height': '720',
 		'og:description':
 			'No topic is too small or too big for us to cover as we deliver a weekly roundup of the wonderful world of women’s football',
@@ -1053,7 +1126,7 @@ export const NewsletterSignup: CAPIArticleType = {
 		'al:ios:app_store_id': '409128287',
 		'article:section': 'Football',
 		'article:published_time': '2022-03-22T16:57:35.000Z',
-		'article:tag': "Football,Women's football,Sport",
+		'article:tag': "Football,Women's football,Sport,Newsletter sign-up",
 		'al:ios:app_name': 'The Guardian',
 		'og:site_name': 'the Guardian',
 	},
@@ -1082,6 +1155,16 @@ export const NewsletterSignup: CAPIArticleType = {
 			id: 'sport/sport',
 			type: 'Keyword',
 			title: 'Sport',
+		},
+		{
+			id: 'info/newsletter-sign-up',
+			type: 'Keyword',
+			title: 'Newsletter sign-up',
+		},
+		{
+			id: 'campaign/email/moving-the-goalposts',
+			type: 'Campaign',
+			title: 'Moving the Goalposts (newsletter signup)',
 		},
 		{
 			id: 'type/article',
@@ -1293,7 +1376,18 @@ export const NewsletterSignup: CAPIArticleType = {
 	contributionsServiceUrl: 'https://contributions.guardianapis.com',
 	byline: 'Suzanne Wrack',
 	headline:
-		'Sign up for our women’s football newsletter – Moving the Goalposts',
+		'Sign up for the Moving the Goalposts newsletter: our free women’s football email',
+	promotedNewsletter: {
+		identityName: 'moving-the-goalposts',
+		name: 'Moving the Goalposts',
+		theme: 'sport',
+		description:
+			'Informative, passionate, entertaining. Sign up to our weekly round-up of women’s football now.',
+		frequency: 'Weekly',
+		listId: 6020,
+		group: 'Sport',
+		successDescription: "We'll send you Moving the Goalposts every week",
+	},
 	guardianBaseURL: 'https://www.theguardian.com',
 	isLegacyInteractive: false,
 	webPublicationDate: '2022-03-22T16:57:35.000Z',
@@ -1544,7 +1638,7 @@ export const NewsletterSignup: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '2fb486c6-e120-48b6-8b4b-229053ad0bc2',
+			elementId: 'e691e970-fe7f-472e-aad1-297b98cd8f6c',
 		},
 	],
 	canonicalUrl:
@@ -1556,7 +1650,7 @@ export const NewsletterSignup: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Join us as we delve deeper into the wonderful world of women’s football in our weekly newsletter. It is informative, entertaining, global, critical – when needed – and, above all, passionate. Written mainly by <a href="https://www.theguardian.com/profile/julia-belas-trindade">Júlia Belas Trindade</a> and <a href="https://www.theguardian.com/profile/sophie-downey">Sophie Downey</a>, expect guest appearances from stars such as Anita Asante, Ada Hegerberg and many more.</p>',
-					elementId: 'b2c71466-f03d-46ef-91f1-5e86082a8b35',
+					elementId: '7359a4e9-8741-40e4-a99f-748c4b0c237e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -1567,22 +1661,22 @@ export const NewsletterSignup: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'The Guardian',
 					sourceDomain: 'theguardian.com',
-					elementId: 'ddf56c5b-205c-42c4-b9de-3cc1eae1c503',
+					elementId: 'b758a1e9-c9fa-41cf-a8b0-2d41d966ad82',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Try our other sports emails: as well as the occasionally funny football email <a href="https://www.theguardian.com/info/2016/jan/05/the-fiver-email-sign-up">The Fiver </a>from Monday to Friday, there are weekly catch-ups for cricket in <a href="https://www.theguardian.com/sport/2016/aug/18/sign-up-to-the-spin">The Spin</a> and rugby union in <a href="https://www.theguardian.com/sport/2016/aug/18/sign-up-to-the-breakdown">The Breakdown</a>, and our seven-day roundup of the best of our sports journalism in <a href="https://www.theguardian.com/sport/2017/may/15/the-recap-sign-up-for-the-best-of-the-guardians-sport-coverage">The Recap</a>.</p></li> \n <li><p>Living in Australia? Try the <a href="https://www.theguardian.com/info/2015/jun/05/guardian-australia-sport-newsletter-subscribe-by-email">Guardian Australia’s daily sports newsletter</a></p></li> \n</ul>',
-					elementId: 'd249b73e-7690-462a-a91a-db0b2486abc1',
+					elementId: '3dcb307f-340e-4774-8bf0-6ec0825bc776',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>***</p>',
-					elementId: 'ab6ca3a4-3a0c-4349-aef3-2d7ac3c86a9e',
+					elementId: '4cb7598b-efcc-417d-a97a-e191edc96dfb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong><a href="https://www.theguardian.com/email-newsletters">Explore all our newsletters:</a></strong><a href="https://www.theguardian.com/email-newsletters"> whether you love film, football, fashion or food, we’ve got something for you</a></p>',
-					elementId: '168c8e5a-6a21-4b00-aca3-eb1d6dea7451',
+					elementId: 'b55487c6-5457-47b7-a5a1-4912d6008909',
 				},
 			],
 			attributes: {
@@ -1599,14 +1693,14 @@ export const NewsletterSignup: CAPIArticleType = {
 			blockFirstPublishedDisplayNoTimezone: '16.57',
 			contributors: [],
 			primaryDateLine: 'Tue 22 Mar 2022 16.57 GMT',
-			secondaryDateLine: 'Last modified on Thu 4 Aug 2022 09.52 BST',
+			secondaryDateLine: 'Last modified on Tue 18 Oct 2022 08.57 BST',
 		},
 	],
 	linkedData: [
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
+			'@id': 'https://www.theguardian.com/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',
@@ -1646,8 +1740,8 @@ export const NewsletterSignup: CAPIArticleType = {
 			],
 			datePublished: '2022-03-22T16:57:35.000Z',
 			headline:
-				'Sign up for our women’s football newsletter – Moving the Goalposts',
-			dateModified: '2022-08-04T08:52:53.000Z',
+				'Sign up for the Moving the Goalposts newsletter: our free women’s football email',
+			dateModified: '2022-10-18T07:57:21.000Z',
 			mainEntityOfPage:
 				'https://www.theguardian.com/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts',
 		},
@@ -1664,7 +1758,7 @@ export const NewsletterSignup: CAPIArticleType = {
 	webPublicationDateDisplay: 'Tue 22 Mar 2022 16.57 GMT',
 	shouldHideAds: false,
 	webTitle:
-		'Sign up for our women’s football newsletter – Moving the Goalposts',
+		'Sign up for the Moving the Goalposts newsletter: our free women’s football email',
 	isSpecialReport: false,
 	isCommentable: false,
 	keyEvents: [],

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -27,64 +27,6 @@ export const NumberedList: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'tn',
-					value: ['reviews'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/dv58t',
-				},
-				{
-					name: 'k',
-					value: [
-						'ios',
-						'alphabet',
-						'google',
-						'smartphones',
-						'technology',
-						'mobilephones',
-						'xiaomi',
-						'apple',
-						'android',
-						'sony',
-						'huawei',
-						'iphone',
-						'samsung',
-					],
-				},
-				{
-					name: 'se',
-					value: ['buyers-guides'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'co',
-					value: ['samuel-gibbs'],
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'url',
-					value: '/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -201,6 +143,64 @@ export const NumberedList: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'tn',
+					value: ['reviews'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/dv58t',
+				},
+				{
+					name: 'k',
+					value: [
+						'ios',
+						'alphabet',
+						'google',
+						'smartphones',
+						'technology',
+						'mobilephones',
+						'xiaomi',
+						'apple',
+						'android',
+						'sony',
+						'huawei',
+						'iphone',
+						'samsung',
+					],
+				},
+				{
+					name: 'se',
+					value: ['buyers-guides'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['samuel-gibbs'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -256,6 +256,64 @@ export const NumberedList: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'tn',
+					value: ['reviews'],
+				},
+				{
+					name: 'k',
+					value: [
+						'ios',
+						'alphabet',
+						'google',
+						'smartphones',
+						'technology',
+						'mobilephones',
+						'xiaomi',
+						'apple',
+						'android',
+						'sony',
+						'huawei',
+						'iphone',
+						'samsung',
+					],
+				},
+				{
+					name: 'se',
+					value: ['buyers-guides'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['samuel-gibbs'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/dv58t',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -949,6 +1007,10 @@ export const NumberedList: CAPIArticleType = {
 					},
 				],
 			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
+			},
 		],
 		brandExtensions: [
 			{
@@ -1453,7 +1515,9 @@ export const NumberedList: CAPIArticleType = {
 			type: 'Contributor',
 			title: 'Samuel Gibbs',
 			bylineImageUrl:
-				'https://i.guim.co.uk/img/static/sys-images/guardian/Pix/pictures/2013/10/18/1382089843887/Samuel-Gibbs.-Guardian-st-003.jpg?width=300&quality=85&auto=format&fit=max&s=0943704e7e7e22b4dd2284ba78bf3af6',
+				'https://i.guim.co.uk/img/uploads/2022/10/03/Samuel_Gibbs.jpg?width=300&quality=85&auto=format&fit=max&s=8e2797d50a8b5a98da6a92a088af20b2',
+			bylineLargeImageUrl:
+				'https://i.guim.co.uk/img/uploads/2022/10/03/Samuel_Gibbs.png?width=300&quality=85&auto=format&fit=max&s=c428cf01ac63fa8f77e0b2ba60c6c601',
 		},
 		{
 			id: 'tracking/commissioningdesk/consumer-tech--commissioning-',
@@ -1661,7 +1725,7 @@ export const NumberedList: CAPIArticleType = {
 					'300': 'https://i.guim.co.uk/img/media/3b11e9285fbd7f3945a72de492296c75c44c3a2d/0_69_5000_3000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=40ba0cb00cf6d86377f22795c7ceff1d',
 					'460': 'https://i.guim.co.uk/img/media/3b11e9285fbd7f3945a72de492296c75c44c3a2d/0_69_5000_3000/master/5000.jpg?width=460&quality=85&auto=format&fit=max&s=4bd688c1ee9f6054eb8aa44519759dd5',
 				},
-				ageWarning: '3 months',
+				ageWarning: '4 months',
 				isLiveBlog: false,
 				pillar: 'news',
 				designType: 'Article',
@@ -1674,6 +1738,30 @@ export const NumberedList: CAPIArticleType = {
 				headline:
 					'EU deal will force iPhones to use USB-C charger by 2024',
 				shortUrl: 'https://www.theguardian.com/p/ytt7j',
+			},
+			{
+				url: 'https://www.theguardian.com/world/2022/oct/04/eu-votes-to-force-all-phones-to-use-same-charger-by-2024',
+				linkText:
+					'EU votes to force all phones to use same charger by 2024',
+				showByline: false,
+				byline: 'Dan Milmo and agency',
+				image: 'https://i.guim.co.uk/img/media/014b6456e9f2b316c03d02ba00dcc8d6122cb085/0_258_5906_3545/master/5906.jpg?width=300&quality=85&auto=format&fit=max&s=c70ee134c0ee3d53b14d72fb6dfc9ed0',
+				carouselImages: {
+					'300': 'https://i.guim.co.uk/img/media/014b6456e9f2b316c03d02ba00dcc8d6122cb085/0_258_5906_3545/master/5906.jpg?width=300&quality=85&auto=format&fit=max&s=c70ee134c0ee3d53b14d72fb6dfc9ed0',
+					'460': 'https://i.guim.co.uk/img/media/014b6456e9f2b316c03d02ba00dcc8d6122cb085/0_258_5906_3545/master/5906.jpg?width=460&quality=85&auto=format&fit=max&s=b11621cdb5e756be78c2d3be91c2daf8',
+				},
+				isLiveBlog: false,
+				pillar: 'news',
+				designType: 'Article',
+				format: {
+					design: 'ArticleDesign',
+					theme: 'NewsPillar',
+					display: 'StandardDisplay',
+				},
+				webPublicationDate: '2022-10-04T15:16:18.000Z',
+				headline:
+					'EU votes to force all phones to use same charger by 2024',
+				shortUrl: 'https://www.theguardian.com/p/mcnx4',
 			},
 			{
 				url: 'https://www.theguardian.com/uk-news/2021/aug/09/vodaphone-to-reintroduce-roaming-fees-for-uk-customers-in-europe',
@@ -1811,7 +1899,7 @@ export const NumberedList: CAPIArticleType = {
 					'300': 'https://i.guim.co.uk/img/media/052ba41b6e01156ff428ff25244b07c564d12f35/0_178_3500_2100/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=be535d1a85feb3ea408554ce90bb0800',
 					'460': 'https://i.guim.co.uk/img/media/052ba41b6e01156ff428ff25244b07c564d12f35/0_178_3500_2100/master/3500.jpg?width=460&quality=85&auto=format&fit=max&s=4634b91d1efaa0361ca2de743eabbd5c',
 				},
-				ageWarning: '2 years',
+				ageWarning: '3 years',
 				isLiveBlog: false,
 				pillar: 'news',
 				designType: 'Article',
@@ -1836,7 +1924,7 @@ export const NumberedList: CAPIArticleType = {
 					'300': 'https://i.guim.co.uk/img/media/24743531a1d6b61a170fcf3c033402c45296b2cc/220_50_3756_2254/master/3756.jpg?width=300&quality=85&auto=format&fit=max&s=97a90f58133cc091185db568e95d0ea3',
 					'460': 'https://i.guim.co.uk/img/media/24743531a1d6b61a170fcf3c033402c45296b2cc/220_50_3756_2254/master/3756.jpg?width=460&quality=85&auto=format&fit=max&s=1710f18ea560ebf7a0103547985f0f6e',
 				},
-				ageWarning: '2 years',
+				ageWarning: '3 years',
 				isLiveBlog: false,
 				pillar: 'news',
 				designType: 'Article',
@@ -1874,31 +1962,6 @@ export const NumberedList: CAPIArticleType = {
 				headline:
 					'Samsung Galaxy Note 10 launch: big screens and stylus air gestures',
 				shortUrl: 'https://www.theguardian.com/p/c4chq',
-			},
-			{
-				url: 'https://www.theguardian.com/technology/2019/may/21/honor-20-launch-huawei-quad-camera-phone',
-				linkText:
-					'Honor 20: Huawei Android phone launch defies Donald Trump',
-				showByline: false,
-				byline: 'Samuel Gibbs',
-				image: 'https://i.guim.co.uk/img/media/8cbcc01d95fc2470ff6acc1f4782ffb14f7dc222/314_204_4360_2617/master/4360.jpg?width=300&quality=85&auto=format&fit=max&s=6a8cc95cfad6603d731e0f226551f4e4',
-				carouselImages: {
-					'300': 'https://i.guim.co.uk/img/media/8cbcc01d95fc2470ff6acc1f4782ffb14f7dc222/314_204_4360_2617/master/4360.jpg?width=300&quality=85&auto=format&fit=max&s=6a8cc95cfad6603d731e0f226551f4e4',
-					'460': 'https://i.guim.co.uk/img/media/8cbcc01d95fc2470ff6acc1f4782ffb14f7dc222/314_204_4360_2617/master/4360.jpg?width=460&quality=85&auto=format&fit=max&s=d7dbccc6c34b88e4cfc234e888400419',
-				},
-				ageWarning: '3 years',
-				isLiveBlog: false,
-				pillar: 'news',
-				designType: 'Article',
-				format: {
-					design: 'ArticleDesign',
-					theme: 'NewsPillar',
-					display: 'StandardDisplay',
-				},
-				webPublicationDate: '2019-05-21T14:46:14.000Z',
-				headline:
-					'Honor 20: Huawei Android phone launch defies Donald Trump',
-				shortUrl: 'https://www.theguardian.com/p/bgcja',
 			},
 		],
 	},
@@ -2165,7 +2228,7 @@ export const NumberedList: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '4a7b2936-523a-47af-88be-b878728a6be9',
+			elementId: 'c186ea9c-ea20-485a-9a18-a51d1663182a',
 		},
 	],
 	canonicalUrl:
@@ -2177,17 +2240,17 @@ export const NumberedList: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Need a new smartphone but don’t know which one is the very best? Here’s a guide comparing the current top-end smartphones from Apple, <a href="https://www.theguardian.com/technology/samsung" data-component="auto-linked-tag">Samsung</a>, Huawei, OnePlus and others to help you pick the best handset for you.</p>',
-					elementId: '016f3a20-2a1c-4f38-8196-a4a44841b275',
+					elementId: '4e541f1b-1cfc-46d5-8999-0b79ed74bd2e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>There has never been a better time to buy a new flagship smartphone with many quality handsets available at a wider range of prices than ever before. Whether your priority is two-day battery life, fantastic camera performance or a spectacular screen, there’s plenty to choose from.</p>',
-					elementId: '176ff325-2f7b-4e28-9841-68242a3c75d3',
+					elementId: '3c2f602f-e8c0-4855-8e7f-2141ccc1b615',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>This Guardian buyer’s guide to top-end smartphones was last updated on 17 December 2019, and represents the best available models at the time. As new models are released and tested, this guide will be updated to help you choose the right flagship phone for you.</p>',
-					elementId: '7ed93a97-40ad-4927-a88f-0907bd56b2b1',
+					elementId: '3caaf7e7-ded3-4411-a7aa-680df2a9a7c8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.QABlockElement',
@@ -2195,27 +2258,27 @@ export const NumberedList: CAPIArticleType = {
 					title: "What is a buyer's guide?",
 					html: "<p>Welcome to one of the Guardian’s new buyer’s guides. This article represents hundreds of hours of testing by the author to bring together a succinct list of recommended products or services so you can pick from the best and ignore the rest without having to do hours of your own research.</p><p>While the Guardian may earn a small commission from items bought through affiliate links, the items featured in this buyer's guide have been tested and included without influence from any advertiser or commercial initiative.</p>",
 					credit: '',
-					elementId: 'a4d16f3a-9c36-442a-8525-5f05c3a20f91',
+					elementId: '22ad59e3-81a1-41af-82d4-a0d1660d1857',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.InteractiveBlockElement',
 					scriptUrl: 'https://uploads.guim.co.uk/2019/03/20/boot.js',
-					elementId: 'bc16880f-96f8-4c5a-b280-e0ac2d859f61',
+					elementId: '4774cc27-6daf-49a3-b862-ec45361e3dc1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Best overall: </strong>OnePlus 7T Pro</h2>',
-					elementId: '05450b88-8945-44ca-94e0-43a01c6a5b5c',
+					elementId: '3daed212-3c81-4ede-8078-2f48dd484f21',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.oneplus.com%2Fuk%2Foneplus-7t-pro&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£699</a></p>',
-					elementId: '598e70cc-ef52-43d8-b410-8310cdf4d5d5',
+					elementId: '97e0a389-9072-4240-9b4e-f01781751e0b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '29e856a0-d047-4581-bcfd-b0e839c0a57f',
+					elementId: '6a36eda9-d289-4947-8c6f-7afc4a1fb35a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2524,7 +2587,7 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '84a5f07d-05e3-4fb0-8aaa-54a37078984b',
+					elementId: 'cb60c280-82d5-4492-bb06-c6656c2ac256',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -2537,82 +2600,82 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: 'ce8b8882-b7d7-43b9-b192-85a55166398a',
+					elementId: 'ffb8760b-0ea0-4c87-9b49-5bb7c2b81bed',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The follow-up to the <a href="https://www.theguardian.com/technology/2019/may/31/oneplus-7-pro-review-an-absolute-beast-in-every-way">best smartphone of the first half of 2019</a> is, unsurprisingly, the best phone to end 2019. The OnePlus 7T Pro is a minor update to the stellar OnePlus 7 Pro that keeps all the good bits, improves the camera, and speeds up the fingerprint scanner.</p>',
-					elementId: 'ce9c9ea2-b416-4419-9a24-8bfcbb248ffd',
+					elementId: 'eb96b3ce-05b9-4ab6-8359-18d993688325',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The monster 6.67in QHD+ AMOLED screen runs at 90Hz – compared with 60Hz for most of the competition – is arguably the best in the business. It’s bright, crisp and super smooth, plus it’s free of holes or camera notches. The selfie camera pops up from the top on command – a consistent crowd-pleaser.</p>',
-					elementId: '851c48a5-434d-4eec-8b14-562dcd042842',
+					elementId: '99bc5aa7-0680-4275-8bbc-bb9a542de098',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 7T Pro is the fastest-feeling phone – everything zips along. It has Qualcomm’s top chip, the Snapdragon 855+, 8GB of RAM and 256GB of fast UFS3.0 storage – plenty for practically everything. The optical in-display fingerprint scanner is even faster than before continuing to put the competition to shame.</p>',
-					elementId: '68a87511-a5b4-4e41-898c-121e82ce0ba0',
+					elementId: '360217fd-e0fd-41bd-9ce3-d5c75330c862',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The latest OxygenOS 10, the firm’s super-slick version of <a href="https://www.theguardian.com/technology/2019/sep/04/android-10-released-everything-you-need-to-know-about-google-update">Android 10</a>, is arguably the best in the business too, and you’ll get prompt updates for three years.</p>',
-					elementId: '89d2d627-40a0-4158-944b-21259c7df5ec',
+					elementId: 'c8049df6-f9d2-4da0-a232-50e9bc9c95de',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The triple camera system on the back is good too, combining a 48MP main, a 16MP ultra-wide angle and an 8MP telephoto camera. New for the 7T Pro is a super-macro mode, which is surprisingly good, producing crisp images up to just 2.5cm from the lens – great fun. The 7T Pro can’t quite beat the <a href="https://www.theguardian.com/technology/iphone" data-component="auto-linked-tag">iPhone</a> 11 Pro or Pixel 4XL, but it matches or beats the rest on detail and utility.</p>',
-					elementId: 'cf94114b-749b-4fc2-bfbb-2278f7d6a111',
+					elementId: 'e1b2e206-33a2-43b3-9f04-461dd4a5fd01',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 7T Pro lasts about 32 hours between charges, making it one of the better performers. Charging is exceptionally fast via the firm’s WarpCharge system too, hitting 70% in just 34 minutes via cable. There’s no wireless charging though.</p>',
-					elementId: '5bc8a7a2-aebf-4468-b084-092617c873fb',
+					elementId: '142eb6ea-9b64-4714-9e64-df19ba49aa18',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Dual-sim support is handy for work or travelling. It’s water resistant to some extent, but has no IP rating. There’s a McLaren limited edition and a 5G version in the US, but not UK where the OnePlus 7 Pro 5G is still the current model.</p>',
-					elementId: 'bf93f640-6eb8-4394-b107-2571b771ca5e',
+					elementId: 'c8744fe9-34e4-4edd-a4bb-0b0469c42cc4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Why should you buy it?</strong></p>',
-					elementId: '46e5934d-e8ae-43d3-be69-b40c4b3c1f56',
+					elementId: '469ff005-0d75-42ae-830c-92ffe8b4111a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The unrivalled screen, sheer speed and in-display fingerprint scanner, combined with the slick OxygenOS 10 make even mundane tasks a joy. The massive OnePlus 7T Pro is a stretch worth making.</p>',
-					elementId: 'c948dd3b-9383-4862-bccc-5974245f8fdb',
+					elementId: 'e34e9350-01af-4ae0-90de-ab02df0ee74f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy if:</strong> you want the best and fastest superphone experience</p>',
-					elementId: '965b4d79-c8c5-4aa9-8929-c6e4da0644d1',
+					elementId: '9512c05d-a750-48c7-b7ce-e11386a3c36c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Don’t buy if:</strong> you don’t want to stretch to such a big phone</p>',
-					elementId: '09fe19e0-1149-461f-b7d0-6e1e9fc7be49',
+					elementId: '382d58d6-4265-4ffa-b3d5-09aafa6da61d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/22/oneplus-7t-pro-review-the-best-kind-of-deja-vu">OnePlus 7T Pro review: the best kind of deja vu</a></p></li> \n</ul>',
-					elementId: '73a5f527-4f09-4922-84fc-f69f8aee8d2f',
+					elementId: 'c895ad4f-1ab9-4945-b691-cc5d30663e98',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Best iOS:</strong> Apple iPhone 11 Pro</h2>',
-					elementId: 'ebaf8f4f-8e4a-4f67-98cd-bb7a38e7bec3',
+					elementId: '10f856bd-301f-407b-9b8b-7c1bff966510',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fuk%2Fshop%2Fbuy-iphone%2Fiphone-11-pro&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£1,049</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fshop%2Fbuy-iphone%2Fiphone-11-pro&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$999</a></p>',
-					elementId: 'eb279820-1dc8-4fab-8b55-74ad4ced20e6',
+					elementId: '4070199f-8c09-48b9-84b2-52567b57f88d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: 'e5d1d8cd-89a1-4046-8dde-28d35b227c10',
+					elementId: '6742d470-03e6-4f80-9426-9eed5093efcc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2921,7 +2984,7 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'ebe8b0a1-0e40-4b6d-8f3a-ec61ba07d088',
+					elementId: '0684cb0b-54db-4360-93cc-f9242d305d0c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -2934,82 +2997,82 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '50721da9-09c1-4f7d-9ba9-9e053ff24b54',
+					elementId: '079af495-baf3-4b04-84e3-cc1a7fd84b52',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Good things come in smaller packages. The iPhone 11 Pro isn’t the biggest or the most expensive of Apple’s 2019 smartphones, but it is the best and very nearly the best phone of the year.</p>',
-					elementId: 'a6c83ab6-45a8-46e1-8063-cf66d4d83ab2',
+					elementId: '568aa134-d06e-4ecb-8925-0349d0f46ebe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The iPhone 11 Pro combines a stunning, big-enough 5.8in screen, svelte, luxurious-feeling body, top-notch performance and battery life to keep up with most of the competition.</p>',
-					elementId: '9570e7e1-1ea6-4af8-9cd2-750a7e327d15',
+					elementId: '02fba586-d7b2-4149-a326-0c700e86719c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Truth be told, the design is basically uncharged since the mould-breaking <a href="https://www.theguardian.com/technology/2017/nov/10/iphone-x-review-apple-face-id-all-screen-design-home-button">iPhone X from 2017</a>. The back is now frosted glass, which looks particularly good in silver, and has a triple camera lump in the top left. The rest stays pretty much unchanged.</p>',
-					elementId: 'b49020c1-022b-4872-a4f8-27bc95d5d04e',
+					elementId: 'e18c8502-8344-48db-9900-5d4669205d09',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Apple’s Face ID is still the best, most widely-supported face recognition system in the business. The new A13 Bionic chip continues to lead the pack. The gesture navigation system continues to be one of the best, and you’re in line for around five years of <a href="https://www.theguardian.com/technology/ios" data-component="auto-linked-tag">iOS</a> software updates from release - at least two more than any other manufacturer will provide.</p>',
-					elementId: '1bf1d9e5-c657-4212-8cf1-9ccb17a7c2a4',
+					elementId: '46f4e306-c79b-4da1-9529-ccf07ce4255a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>This year the iPhone 11 Pro introduces a significantly improved triple camera with ultra-wide, wide and telephoto lenses, which matches the best rivals in photography and beats them in video. It even has an effective night mode now.</p>',
-					elementId: '64679e34-e807-4b9d-b94f-d0aa3f782f4f',
+					elementId: 'c0f8d520-a483-49a3-a5ff-7c9f2b17931d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It’s not all gravy – starting with just 64GB of storage is poor. The old Lightning connector still persists, rather than the newer standard of USB-C. There’s no 5G option and it is exceedingly expensive – you don’t buy the iPhone 11 Pro looking for value for money. Plus iOS 13 has been a mixed bag since its introduction, with a lot of bugs that needed fixing.</p>',
-					elementId: 'a4b778ac-b680-406f-9296-341840cdbb60',
+					elementId: '101e6a05-8fd0-442f-a259-83b971cd4fa2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>But as a whole, no other phone can match the iPhone 11 Pro in power, capability and size. The iPhone 11 Pro is the smaller phone to buy and the best running iOS.</p>',
-					elementId: 'a4397941-409c-418f-bd70-75ecc583fe2a',
+					elementId: '1a722120-3d2b-419d-a813-2c83b223eed6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Why should you buy it?</strong></p>',
-					elementId: 'ba03e431-ee75-4a69-8628-cf73076cdb5d',
+					elementId: 'b73d7ef3-c0d0-47b4-a659-52ac09c8fba4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>You want the best smaller phone, or simply the best Apple phone, then the iPhone 11 Pro is fantastic, but comes at a considerable cost</p>',
-					elementId: 'd646e13b-d48c-4e59-8cdb-b0d4fe2b1c45',
+					elementId: '12ce7be7-5ae1-4d5c-bbbb-36e88e5b7083',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy if:</strong> you want the best iPhone</p>',
-					elementId: 'cb92a69d-218c-4262-a3c6-9467f501638e',
+					elementId: '146852f9-a1e4-49e5-b11b-5efcc047ef45',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Don’t buy if:</strong> you don’t want to spend £1,049 or want to use Android</p>',
-					elementId: '230ae61f-e370-45ba-8492-ae5007f52b9f',
+					elementId: '8e4c99bc-765d-44a1-9a6a-6903db45070f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/07/iphone-11-pro-the-best-small-phone-available">iPhone 11 Pro review: the best small phone available</a></p></li> \n</ul>',
-					elementId: '6f602bed-b2d9-4718-af37-754e7e4d67df',
+					elementId: 'a929e9e5-6e68-4c6a-ae5f-b18fb09486d2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Best smaller Android:</strong> Samsung Galaxy S10</h2>',
-					elementId: '6dc3a211-ce37-48a2-a501-0d304ae9a3a6',
+					elementId: '0fe816bc-581c-42c3-b388-1c8bd26bb563',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fuk%2Fsmartphones%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£799</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fus%2Fmobile%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$899</a></p>',
-					elementId: '54eb61a6-33a7-4dfa-8e4a-4620a6033392',
+					elementId: '32ef8026-ce28-4c99-a6de-791133aeffff',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '360251cb-97ca-4547-8020-2fe9a5b2852f',
+					elementId: 'cb1dc86b-3be2-4012-949f-edcefc160fdc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3318,7 +3381,7 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '94dccb4b-2f4a-413c-bf02-5476fb456548',
+					elementId: 'f2c197c6-84b7-49d5-aeea-40ef3130fb15',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -3331,77 +3394,77 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.',
-					elementId: '6ad36d78-2c8a-43c1-bda8-3d249b4d101d',
+					elementId: '739e359a-c46f-4d8d-b117-d9de992568c1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>If you want the Android sweet-spot between a big, stunning screen and smaller phone size that’s easier to handle and fit in a pocket, that’s the Galaxy S10.</p>',
-					elementId: '15f937c0-71b4-4099-b64b-2ebbe9600777',
+					elementId: 'b0b85870-d304-486a-a13d-882c600fba1a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 6.1in QHD+ AMOLED screen with a small hole-punch notch in the top right is one of the best on the market and is big enough to make the most of apps and movies look great.</p>',
-					elementId: '77bb8f0c-c767-4fe5-84cd-54d1a84ea0c3',
+					elementId: '293fe904-63e3-48c7-aadf-1ad4e6173d2d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Small bezels all round make the phone pretty compact compared with rivals, and it’s light too. It’s still a glass and metal sandwich, which means you might need a case to protect against falls.</p>',
-					elementId: '6326f0c2-dbdd-43c8-bbd1-23856d86c83d',
+					elementId: 'def7ed95-0121-4384-9aa4-21574ccd14a4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Galaxy S10 was recently updated with Samsung’s new One UI 2 software, based on the latest Android 10 including much-improved navigation gestures. You should get about three years of software support from release from Samsung, although the company is usually slower than <a href="https://www.theguardian.com/technology/google" data-component="auto-linked-tag">Google</a> and OnePlus to deliver big Android version updates.</p>',
-					elementId: '26c82758-28e5-4de7-bbe0-a53e338167ea',
+					elementId: '842f8931-434f-412d-b6ec-d7f761eed9c5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The rear triple camera is good allowing you to zoom from 0.5 through 2x, and on to a 10x hybrid zoom. It won’t beat the <a href="https://www.theguardian.com/technology/2019/oct/29/google-pixel-4-xl-review-not-quite-ready-for-primetime">Pixel 4 XL</a> or <a href="https://www.theguardian.com/technology/2019/oct/07/iphone-11-pro-the-best-small-phone-available">iPhone 11 Pro</a>, but gets the job done. The selfie camera pokes straight though the screen and is one of the better ones on the market.</p>',
-					elementId: '310b860f-25df-4445-982e-247a5d91c352',
+					elementId: 'e6d15ae7-aef6-4231-b701-27dea04e7598',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Performance is good but battery life is a bit weak, lasting a day of usage but not much more. The ultrasonic fingerprint sensor mounted under the display has proved to be a bit slow and finickity over time, which can be annoying.</p>',
-					elementId: 'b87cdb67-ad92-4133-992d-6c06b4022659',
+					elementId: 'df66681e-4587-4fd2-a679-3abb3f547969',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Why should you buy it?</strong></p>',
-					elementId: '8cd36db9-af9a-442b-8cad-6b10f5c8c533',
+					elementId: '7f635ff3-017c-4e84-ba05-269708879941',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A big screen Android experience in a relatively small phone is the main selling point, but the good camera, performance and looks help too.</p>',
-					elementId: '54918ee5-c8b4-4373-9592-f1201a0c09f2',
+					elementId: '2e1e42b0-2c36-4650-9e29-95848f022c36',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy if:</strong> you want a good balance of screen and phone size without breaking the bank</p>',
-					elementId: '0baffe1b-a61f-49aa-892d-633f7f9f2d6e',
+					elementId: 'efcdce08-08b7-4475-ae19-8c212036ad94',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Don’t buy if:</strong> you want brilliant battery life</p>',
-					elementId: '245b213c-40f4-4152-94d8-623c95de5f97',
+					elementId: '6a5ea7cd-9157-47c1-9954-6281f5744cbd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review: </strong><a href="https://www.theguardian.com/technology/2019/jun/06/samsung-galaxy-s10-review-the-sweet-spot">Samsung Galaxy S10 review: the sweet spot</a></p></li> \n</ul>',
-					elementId: '0a5e8138-a963-49d9-aba3-6660290847fe',
+					elementId: '961d3bda-15c2-4039-a6bd-4baf5be0621e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Best camera: </strong>Huawei P30 Pro</h2>',
-					elementId: '0168ae8e-0aa9-43f0-84c8-9ed720d616df',
+					elementId: 'e484a593-5614-45c8-a927-9dcfddf4fae2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fconsumer.huawei.com%2Fuk%2Fphones%2Fp30-pro%2F%23buy&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£750</a></p>',
-					elementId: '5bf1fc14-04bc-4db6-8202-3121488bca1e',
+					elementId: '7e118e4e-929e-45d6-9da1-5de437677d8e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '0e3f145f-5e40-4c04-81fa-bb648d520678',
+					elementId: '2ec1a370-a23c-4ea4-85fe-0f06cfbab337',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3710,7 +3773,7 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '75ebaeff-c5bf-48a9-a6e7-75f14cb343c2',
+					elementId: '13b68cdb-56b1-47f8-bbfd-102693bdd0de',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -3723,77 +3786,77 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.',
-					elementId: '4e049235-91c6-4f9e-b565-f94499172c32',
+					elementId: '560908ff-1b1a-4671-a67f-7a2eefc66dc1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The best camera on a phone is the <a href="https://www.theguardian.com/technology/huawei" data-component="auto-linked-tag">Huawei</a> P30 Pro by some margin. Even at the end of 2019, no other phone provides as comprehensive a combination as Huawei’s new Leica quad camera.</p>',
-					elementId: 'ecccb82c-7a2c-45f2-88eb-c93ab3fffa7c',
+					elementId: 'cd531ff1-d23f-4087-b21b-7796707bf5a9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The 20MP 0.6x ultra-wide angle camera is fun, the main 40MP camera is terrific and it’s joined by a new periscopic 5x optical zoom camera that gets you closer than any other smartphone. If five times magnification wasn’t enough, there’s an excellent 10x hybrid zoom on top and then a digital zoom all the way up to 50x. A 3D depth-sensing time-of-flight sensor rounds out the modules on the back.</p>',
-					elementId: '86cdf302-9e24-4346-a6b2-3f53eafb0ded',
+					elementId: 'e5bd9d3e-a32c-4916-938d-ad46c9e7d861',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Remarkable levels of zoom aside, the P30 Pro also has low-light performance that instantly turns night into day without having to wait for a couple of seconds of capture. The P30 Pro might not have the best Night Sight rival, but most of the time it simply doesn’t need it.</p>',
-					elementId: 'e348c0f1-daba-4bec-bd2a-4de2f39f6279',
+					elementId: '137bb50f-36ea-411b-be65-f69ef627a265',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The rest of the phone is excellent, too, with stunning colour options. The large 6.47in FHD+ OLED is great, with a small notch in the top containing the selfie camera and slim bezels all round. The curved edges keep the width of the phone to a narrow 73.4mm wide, meaning it’s still relatively manageable and easier to wield day-to-day particularly compared with the <a href="https://www.theguardian.com/technology/2019/oct/22/oneplus-7t-pro-review-the-best-kind-of-deja-vu">OnePlus 7T Pro</a> or <a href="https://www.theguardian.com/technology/2019/oct/09/iphone-11-pro-max-review-battery-camera-screen">iPhone 11 Pro Max</a>.</p>',
-					elementId: '4e021794-bcd9-4f56-bf50-d5af1ed52b1e',
+					elementId: 'c5311766-9a38-4c05-a9a3-7c59e5e8f670',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The in-screen optical fingerprint sensor is second only to the OnePlus 7T Pro’s. Huawei’s Kirin 980 processor, 8GB of RAM and 128GB of storage, provides great performance and a battery that will last about two days. Plus the battery charges super fast and has wireless charging and power sharing.</p>',
-					elementId: 'e8703276-1757-44f8-8dfe-5b9d15ad48b1',
+					elementId: 'bba0da7e-8b50-4465-a8d5-03e43197c8c7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Huawei’s modified Android 10, EMUI 10, is highly customisable and has plenty of features but may not be to everyone’s tastes. Huawei is still facing sanctions from the US as part of the <a href="https://www.theguardian.com/technology/2019/may/20/trump-us-ban-huawei-google-trade-war">US-China trade war</a>, which <a href="https://www.theguardian.com/technology/2019/may/19/google-huawei-trump-blacklist-report">makes its future uncertain</a>. The P30 Pro’s recent Android 10 update showed that it should <a href="https://www.theguardian.com/technology/2019/may/20/huawei-blockade-do-i-need-to-stop-using-my-android-phone">continue to receive updates as normal</a>, however.</p>',
-					elementId: '0e54997e-8bab-4f95-a6c9-9d52e83092ed',
+					elementId: '53c15c4c-a05d-457d-be91-bce57134fa72',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Why should you buy it?</strong></p>',
-					elementId: 'e04c75d7-633e-41ae-be38-1954dcc3528e',
+					elementId: '6defe7c0-958f-4f19-bbd2-eec56c247704',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The camera is game-changing in meaningful, not gimmick-filled ways, while the rest of the phone is excellent</p>',
-					elementId: '2d36633c-07dc-407a-9af3-49fea4af0240',
+					elementId: 'be9cdb26-3e25-4a70-b027-e99721e887c4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy if:</strong> you want the best camera on a great phone</p>',
-					elementId: '14e3b789-f769-4d79-9818-e83162ba5d47',
+					elementId: 'b817d228-ecdc-49ff-9f3f-033156321e40',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Don’t buy if:</strong> you want a smaller phone or are worried about US blockade of Huawei</p>',
-					elementId: 'fc566ba8-f6b0-4e18-a689-93886761bf26',
+					elementId: '850e518f-48e0-46b5-b446-a2f2d001a481',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/apr/24/huawei-p30-pro-review-leica-quad-camera-zoom">Huawei P30 Pro review: game-changing camera, stellar battery life</a></p></li> \n</ul>',
-					elementId: '6459c684-9f1c-460a-a46d-cf100d8635e2',
+					elementId: 'cbe61791-3568-4869-bfc4-9025b58ed207',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Best value:</strong> OnePlus 7T</h2>',
-					elementId: '5ad8a44f-67ec-4893-8786-214164789217',
+					elementId: '39e10dab-a30a-4697-817e-f399b6de4c4b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Price:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.oneplus.com%2Fuk%2Foneplus-7t&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£549</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.oneplus.com%2Foneplus-7t&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$599</a></p>',
-					elementId: '883832e6-165c-43d4-a09e-8b54d83b785b',
+					elementId: '990f36c2-7239-4b2b-bb03-63166e05de0a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '5cb88151-3f17-4d23-9f80-56cd0b2a44d7',
+					elementId: 'dc50ac89-fd78-4d07-b22b-00e25cc51385',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4102,7 +4165,7 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '4180fa4a-bef5-486f-91ef-e56de591ec82',
+					elementId: 'a5c57586-449f-4da9-839c-160f64776aa3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -4115,57 +4178,57 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '724ba3d5-66d1-4dda-b854-2389f3ea4d46',
+					elementId: 'c9c87d93-890b-4102-afd7-3541f4f09832',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Pound for pound the OnePlus 7T offers the best performance, design and experience than any other smartphone.</p>',
-					elementId: '31f3174a-b8b7-48c4-bebd-9a2c52440e04',
+					elementId: '765adcc9-be1c-4c65-a4c0-a89b38b182b4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It’s got the big, good-looking 6.41in full HD OLED screen, with a small, widow’s-peak-like notch at the top for a selfie camera. New for the 7T is a 90Hz refresh rate, which like its <a href="https://www.theguardian.com/technology/2019/oct/22/oneplus-7t-pro-review-the-best-kind-of-deja-vu">bigger sibling the 7T Pro</a>, makes even the mundane silky smooth.</p>',
-					elementId: '73030fec-47d3-4c22-9868-1da7efb79282',
+					elementId: '8cf6bda4-f253-4028-9dca-867371676e9f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It’s got 2019’s top-of-the-line Snapdragon 855+ processor, 8GB of RAM and 128GB of fast UFS3.0 storage. It also lasts a good 31 hours on a charge, and its OxygenOS 10 Android software is fast and slick. OnePlus guarantees two years of software updates and an additional year of bi-monthly security updates from the release date of the phone too.</p>',
-					elementId: '9b798b8a-05a7-42dd-a5c7-5e794d96203c',
+					elementId: '3a6e9cb3-067e-4ea3-8d39-df83662e9d04',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It even has the fastest and best in-display fingerprint scanner currently available, which is as good as the best dedicated capacitive sensors, good haptics and dual-sim support for having two mobile phone network connections at the same time.</p>',
-					elementId: '69e26fcf-3d48-4e8f-816e-5a7f7c1211ae',
+					elementId: 'f163209a-f127-4526-a2df-5abcb06cb54c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The triple camera is good too, with ultra-wide, wide and 2x telephoto lenses, plus a dedicated macro mode, but it can’t beat the very best in the market. There’s no formal water resistance rating and no wireless charging, but WarpCharge sees it hit full charge in 60 minutes flat.</p>',
-					elementId: '695d0667-ec52-4f0b-9d58-c6e2e9ee699f',
+					elementId: 'f8e3fb8f-1fbb-4774-a4ed-7df1f61e9da5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Why should you buy it?</strong></p>',
-					elementId: '85ce4f40-2644-41ef-bfb2-7a389ab341ed',
+					elementId: 'd7f1d7c6-3d30-437b-b765-22462de863d0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A great 90Hz screen, excellent software and the best performance, in-display fingerprint scanner and a good camera mean you have to spend significantly more to get a better phone than this</p>',
-					elementId: '0c120924-af5f-4e4a-ac6f-8dec4c9ded38',
+					elementId: '6f13d8ce-434a-4cd3-b188-291bd8c947ef',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy if:</strong> you want a top-notch phone but don’t want to spend more than £549</p>',
-					elementId: '0b0f751e-7407-428a-bf8e-820f9d7e03bb',
+					elementId: '4efff4d3-ea9a-464a-b2eb-a575e6fafda7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Don’t buy if:</strong> you want a really good camera</p>',
-					elementId: '3601628d-f5a9-4ae7-b3a5-ca340f1e9926',
+					elementId: 'b1a791a1-6fad-4ead-ab9a-58e2031c78f5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/16/oneplus-7t-review-the-new-cut-price-flagship-king">OnePlus 7T review: the new cut-price flagship king</a></p></li> \n</ul>',
-					elementId: '3b742983-7350-4901-9595-7ae754b938de',
+					elementId: '6ae3c0d7-02fd-4bd9-9809-896d1a358ffd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.GuideAtomBlockElement',
@@ -4174,32 +4237,32 @@ export const NumberedList: CAPIArticleType = {
 					title: 'Smartphone jargon',
 					html: "<p><strong>Size</strong></p><p>Smartphones are rated by screen size measured on the diagonal in inches. The bigger the number the larger the phone, but different phones use different ratios of height to width.</p><p>How easy it is to handle comes down to the width of the phone and its weight. The narrower and lighter it is, the easier it is to hold in one hand and the less likely you are to drop it.</p><p><strong>Processor</strong></p><p>What is commonly called the processor in a phone is actually a system-on-a-chip combining the processor, graphics and other essential systems into one.</p><p>Generally the newer the processor the more powerful and battery efficient it will be. Samsung, Huawei and Apple make their own, while Qualcomm is the largest supplier to other brands at the high end, with its Snapdragon 8-series range at the top.</p><p><strong>RAM</strong></p><p>The RAM (memory) is where your apps and processes are stored when in use, so the you more your phone has the better, up to a point.</p><p>Android requires more RAM than iOS, so it's difficult to directly compare them. But with Android at least 4GB of RAM is currently recommended.</p><p><strong>Storage</strong></p><p>Different from memory, storage is where everything is stored on the phone, including apps and media. While a few phones can have their storage expanded with microSD cards, most cannot.</p><p>That means you should aim for 64GB of storage at a minimum, but more if you want to store lots of photos. Cloud services such as Spotify or Google's Photos can help offload your music, photos or videos to the internet.</p><p><strong>Software updates</strong></p><p>Keeping your phone secure from hackers is essential, which makes software updates critical to patch bugs and security holes, as well as adding new features and improving things such as battery life and the camera.</p><p>Not all phones receive regular updates. Apple's support of older phones is the best in the business of around 5 years, followed by Samsung and Google's three years, both from when the phone was released - not when you buy it.</p><p><strong>Battery life</strong></p><p>Battery life varies drastically between devices, and \"all-day battery\" often doesn't mean 24 hours between charges. Some may not last long enough, particularly if you're out in the evening.</p><p>Battery life gets worse as the battery ages too, so a two-day battery will likely make sure the phone lasts at least a day two years later.</p><p><strong>Camera</strong></p><p>Cameras are the current battleground between the big players, but the margins between them are slimming.</p><p>Most use computational photography that combines hardware with advanced software algorithms, typically allowing multiple cameras to combine to make one image.</p><p>As such the camera software makes as much difference as the hardware, and is one of the few areas that actually improves over time with updates.</p><p>Multi-camera systems often offer more, such as useful zooms, portrait modes and better low-light performance, but they are not all created equally. There are also 3D cameras, which can detect facial expressions and other fun tricks.</p><p>The number of megapixels (MP) also makes a difference. Having more MP doesn't necessarily equal a better image, but modern smartphone cameras combine multiple pixels to improve image quality producing 12MP shots from 48MP sensors, for example.</p><p><strong>Other things to consider</strong></p><p><b>Wireless charging:</b>&nbsp;convenient, but slower than via cable and normally a charging pad doesn't come in the box</p><p><b>Durability:</b>&nbsp;generally glass on the front and back of the phone makes it more fragile</p><p><b>Resale value:</b>&nbsp;iPhones hold their value better than most others</p><p><b>OLED versus LCD:</b> OLED screens emit their own light so have much deeper blacks and more vibrant colours, while LCD screens are cheaper</p>",
 					credit: '',
-					elementId: '63cf2aa8-407a-46e9-a3db-eff8dc4342b3',
+					elementId: '35594b50-03e1-4237-a9ac-89cee429f68d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Runners up</h2>',
-					elementId: '9b491ce6-13af-4ffe-863f-602cd6f7ff9d',
+					elementId: '3f99e7c0-d221-4da9-bb49-db35de34703a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>These are good phones still worth buying if none of the top smartphones fit the bill.</p>',
-					elementId: '47954148-8166-4624-8f27-eab99d9043f1',
+					elementId: '9d5aff01-f50b-4512-be37-64fb05f8a026',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Apple iPhone 11</strong></p>',
-					elementId: '4d8dada4-e788-4000-8d4f-d66858f63516',
+					elementId: 'cd176193-490e-431a-95c9-b492525bf048',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fuk%2Fshop%2Fbuy-iphone%2Fiphone-11&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£729</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fus%2Fshop%2Fbuy-iphone%2Fiphone-11&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$699</a></p>',
-					elementId: '737b901e-b5f1-4073-94da-f500c6a71a25',
+					elementId: 'cfdbbadf-6890-41ac-9ff6-9e5cf311eecf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '5482f84d-8409-4e68-9cbb-1e38ff9583ba',
+					elementId: 'b8055e42-366a-40b3-8a3e-536eae62d1f3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4496,17 +4559,17 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '370debcd-1c80-4ca9-bd61-7262f173e832',
+					elementId: '41fbcd24-3e71-4bd0-b907-4040a9ab4f78',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Apple’s cheaper iPhone 11 is the follow-up to last year’s iPhone XR and offers most of the features of the iPhone 11 Pro. It has slightly battery life too, but is missing the excellent ultra-wide angle camera, has a slightly larger, but worse screen. It is made of aluminium and glass, instead of stainless steel, losing its luxurious feel and the knowledge that it’s the best Apple can make.</p>',
-					elementId: 'cf2bb729-229b-4df1-83e7-7755f0169d4a',
+					elementId: 'fde04c81-ba29-4d25-895e-fd8664f1a00f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The iPhone 11 looks great in red or white, but it’s not cheap by any stretch of the imagination, costing as much or more as true flagship phones from competitors. The iPhone 11 certainly holds its own for the money, but the <a href="https://www.theguardian.com/technology/2019/oct/07/iphone-11-pro-the-best-small-phone-available">iPhone 11 Pro</a> still the one to buy if you want the best iPhone. If you want a cheaper phone, switch to Android or buy last <a href="https://www.theguardian.com/technology/2018/oct/31/iphone-xr-review-apple-big-bezels-battery-face-id-screen">year’s iPhone XR</a>.</p>',
-					elementId: '84912d2d-1c2f-401f-98e3-7755e9ffafb8',
+					elementId: 'be30485d-ea29-45c0-aa51-aa837c097494',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -4519,27 +4582,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.',
-					elementId: 'edd40220-499b-431a-973c-edcc7e5254bc',
+					elementId: 'a29bcc77-e0b5-4d2b-811e-1cb3e92abd02',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/01/iphone-11-review-iphone-xr-dual-camera-a13-smartphone">iPhone 11 review: an iPhone XR with a better camera</a></p></li> \n</ul>',
-					elementId: '5e2d1efa-3d4e-4267-9dc1-60e55c86df62',
+					elementId: 'eaf60616-e249-4c02-815d-406cb618aa91',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Apple iPhone 11 Pro Max</strong></p>',
-					elementId: 'ffad4d40-39ae-4975-a275-023b99f1dc6a',
+					elementId: '83fa0e0d-e7a7-4fe1-a08f-027162b30f19',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP: </strong><a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fuk%2Fshop%2Fbuy-iphone%2Fiphone-11-pro&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£1,149</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.apple.com%2Fus%2Fshop%2Fbuy-iphone%2Fiphone-11-pro&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$1,099</a></p>',
-					elementId: 'e13f9319-7616-47bb-806e-5149cfc07e15',
+					elementId: '81b58267-2816-48ee-98c8-9045fb020a82',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: 'eb3890cb-a6ba-4575-b79f-a1dd26823281',
+					elementId: '2e7a19ad-3386-4824-afb0-93c1e6c3c70f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4836,12 +4899,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'e896c8b1-b89c-4338-9b66-6fc5534234ce',
+					elementId: '04dbe040-e70a-4278-80a4-87056dcd3a4e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>If you must have an iPhone and it must have a massive screen or epic battery life then the iPhone 11 Pro Max is your only option. But it has really poor ergonomics, is big, expensive and heavy, making the smaller iPhone 11 Pro or iPhone 11 are better options.</p>',
-					elementId: 'b58cc88d-1ed9-4b7b-9e60-be2b435ebf3b',
+					elementId: '0595c5bb-628b-4731-9d5e-e339acc9f83a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -4854,27 +4917,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '27a0746c-9a9b-4cb5-89db-97f34be00102',
+					elementId: 'b1cd8f5c-c886-46cc-9f65-8e695f48f176',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/09/iphone-11-pro-max-review-battery-camera-screen">iPhone 11 Pro Max review: salvaged by epic battery life</a></p></li> \n</ul>',
-					elementId: '2730a0b9-1df2-45ca-a099-2a86a1158c9c',
+					elementId: 'f877270f-e2c7-4e9c-8360-eb0a5ea14331',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Samsung Galaxy S10e</strong></p>',
-					elementId: '915e2cd0-f928-488f-a530-4a3c001f62d1',
+					elementId: '31e0a396-f72f-48e1-948c-8802cfe9c592',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fuk%2Fsmartphones%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£669</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fus%2Fmobile%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$650</a></p>',
-					elementId: '07a0370b-7992-4578-8e36-907b66ea2cb3',
+					elementId: '4c190f30-36f3-4865-831b-e9396afe292e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '2d8ab564-ba94-4804-9ded-9da7b7fc7262',
+					elementId: '75e12ee7-e5d2-41a8-8d38-e0b573594f54',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5181,17 +5244,17 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'af1b3a4e-9162-4a7f-9e15-b6af6457063b',
+					elementId: 'e56d03b4-7ad3-4b12-bea3-29767b006e1c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The smallest, cheapest variant of Samsung’s current S10 line is still good, but falls slightly short of the high bar set by the regular Galaxy S10. The Galaxy S10e loses the optical zoom with only two cameras on the back, has a flat, slightly smaller screen and a lower capacity battery. It also ditches in the in-screen fingerprint scanner for one embedded in the power button – great for right-handed users but not so for the left handed.</p>',
-					elementId: 'f2eee087-3b30-470d-b5a0-7b6004582ae3',
+					elementId: 'e2d84942-1b7b-4454-81b2-6b7cb8c5a3b7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It doesn’t feel any smaller in the hand, but can be had for less if you must have a top-end Samsung for the lowest possible cost or dislike curved screens.</p>',
-					elementId: 'a51f293e-f641-42d5-bc6b-3dbf9382283e',
+					elementId: 'a0fec2d7-456c-4406-9011-bf567c612c39',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -5204,22 +5267,22 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: 'db7c8f3b-1cf5-4d36-825b-a60b90068cbb',
+					elementId: '5e34d41b-bdf1-4300-92e0-2cc8029671ad',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Samsung Galaxy S10+</strong></p>',
-					elementId: '7905d5d7-dc99-4d26-9a05-abda44731abf',
+					elementId: '73ebf7dc-56a8-4688-bd4e-7b600a215822',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fuk%2Fsmartphones%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£899</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fus%2Fmobile%2Fgalaxy-s10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$999</a></p>',
-					elementId: '2d01e0df-ba83-465c-b1c8-880940640733',
+					elementId: 'a4e14f41-5511-4053-8c6a-25b3b73763fa',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '519c36a2-e11a-4bd8-acdb-75161294a1ea',
+					elementId: 'aae6b232-89a6-4141-aa3d-b08fd0da7268',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5526,12 +5589,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '8325b212-0f2c-4bf7-9e72-08cf2682b99c',
+					elementId: 'bea30b23-ee10-4c16-9382-2882b1762154',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The bigger version of the Galaxy S10 with a 6.4in QHD+ display has the best screen available on any device. The oval-shaped hole-punch notch is novel, containing two good selfie cameras. The triple rear camera is good, but not a patch on the Huawei P30 Pro. Performance is good, so is the software, but the battery life is slightly disappointing compared with the best. The fingerprint scanner is a bit slow and can be frustrating to use.</p>',
-					elementId: '572aac04-e46a-4379-be7a-c05c69f7cf74',
+					elementId: '5e6decfd-211e-401c-8aab-4d9fffdd3a49',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -5544,27 +5607,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: 'e5f5d358-3adc-417e-9c4f-2cbdd959b251',
+					elementId: 'd58c3ed6-4bfa-409d-ba57-c0bf3afee9b1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/mar/11/samsung-galaxy-s10-plus-review-smartphone-ultrasonic-triple-camera">Samsung Galaxy S10+ review: a simply stunning screen</a></p></li> \n</ul>',
-					elementId: 'f2f60305-0777-478a-a71a-3e36da25782e',
+					elementId: '9a736c7c-4ca7-4c6e-b557-61d3e1157579',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Samsung Galaxy Note 10+</strong></p>',
-					elementId: 'aa5126fb-ed5e-46b0-9b06-08916bf7f03f',
+					elementId: '61ba4496-60b5-4aa8-bc35-a1eff86d3103',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fuk%2Fsmartphones%2Fgalaxy-note10plus-sm-n975%2FSM-N975FZSDBTU%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£999</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fus%2Fmobile%2Fgalaxy-note10%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$1,099</a></p>',
-					elementId: '79212ea4-49b5-41ce-862b-4bfc934c577f',
+					elementId: '93833ded-4fc5-43ab-a19e-e2544391eef1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '8d44e1e1-4466-4eed-a4c0-5dbbd46c7391',
+					elementId: '038da891-b794-4acb-8d87-853628ee731a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5861,12 +5924,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '33f7afe5-325b-4953-91ca-4ff47a53bc30',
+					elementId: '813e9904-d225-4d5f-bfb1-06718aea468d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Galaxy Note 10+ is a Samsung super-fan’s dream. It has the biggest screen on a Samsung with a monstrous 6.8in on the diagonal, new faster UFS3.0 storage, reasonable battery life and plenty of party tricks. The stylus can now be used as a magic wand for gestures, there are three cameras on the back and is available in a 5G version too. The fingerprint scanner is a bit slow and can be a bit frustrating to use.</p>',
-					elementId: '1c712de7-e971-4390-9af5-70c285af9c9a',
+					elementId: '603b932c-7db0-44c3-a16b-de4ecd75afaf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -5879,27 +5942,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '6936507b-cb31-48f9-8004-c9b8a48023f2',
+					elementId: '8c58b916-3f6b-458f-81a9-e206bc058fd7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/sep/12/samsung-galaxy-note-10-review-bigger-and-now-with-a-magic-wand">Samsung Galaxy Note 10+ review: bigger and now with a magic wand</a></p></li> \n</ul>',
-					elementId: 'd5efe915-4d4d-4ad8-80af-dee5a150cbfe',
+					elementId: '6f73701c-185f-4ac6-bcbd-1a261c963087',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Samsung Galaxy S10 5G</strong></p>',
-					elementId: 'f9258a69-b9aa-4030-9643-44941d031fc2',
+					elementId: 'ebdcf4af-1c04-4eaf-98fd-beed7a20ad38',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fuk%2Fsmartphones%2Fgalaxy-s10-sm-g977-5g%2FSM-G977BZAABTU%2Fbuy%2F&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">£1,099</a> / <a href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.samsung.com%2Fus%2Fmobile%2Fgalaxy-s10%2Fbuy%2Fv2%2F%3Flink%3Dgalaxy-s10%2B&amp;sref=https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked.json?dcr">$1,299</a></p>',
-					elementId: 'ba9ca3e1-adb8-4e1c-a337-c16b3bb1eeda',
+					elementId: 'c71a1d73-8262-4e4f-bb9f-327c59a2fde6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '5f2fc826-54bc-4da8-981b-30c3978a2805',
+					elementId: '60078592-e8aa-4c61-854c-ca2f29a0244e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6196,12 +6259,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '4e47e1f3-39f1-4ac4-b82c-373813fa7e97',
+					elementId: '572a6ee1-6fab-44bb-8f88-4e9fc16a1d52',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The biggest, most powerful version of Samsung’s S-line is the S10 5G and it’s huge with a 6.7in QHD+ AMOLED screen, long oval-shaped hole-punch notch for the selfie cameras, and four cameras on the back. Performance, software and battery are good, but it’s not as slick or ergonomic as the OnePlus 7 Pro 5G. The fingerprint scanner is a bit slow and can be frustrating to use.</p>',
-					elementId: '03ab2cef-2404-4d8f-ac0e-26d67429349f',
+					elementId: '227d3941-a858-4eb4-8057-568e55a9b8fc',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -6214,27 +6277,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.',
-					elementId: 'b59ab999-fde2-4a5a-ac02-b40abbb82872',
+					elementId: '79cf4755-a9e9-4b34-9215-a97c9e180e1d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/aug/21/samsung-galaxy-s10-5g-review-bigger-faster-and-lasts-longer">Samsung Galaxy S10 5G review: bigger, faster and lasts longer</a></p></li> \n</ul>',
-					elementId: '7459776d-699e-4ee6-8039-9051db937cf1',
+					elementId: 'c799217c-deb0-431a-b1f8-857d2d4f412a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Huawei Mate 20 Pro</strong></p>',
-					elementId: '23792f35-b4c5-4746-82a3-377a3b8d2852',
+					elementId: 'be3c75ab-19d4-43cf-a0ab-a5b94297221f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP: </strong>£899.99</p>',
-					elementId: '094920c2-09d7-4d37-85fb-f8349573e69d',
+					elementId: '81db20d9-1685-4780-b59c-cc8b2ce8288f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★★</p>',
-					elementId: '58fb84a8-92e6-4efa-b875-d1816149c972',
+					elementId: 'fd10df28-9ba6-49e5-8016-ca37f80e6ba0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6541,12 +6604,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '6a87e6ab-51e5-459b-a5fe-263b5120aaf1',
+					elementId: 'aeb3bb63-2c7b-4e2b-89cf-6761fce4f33c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Mate 20 Pro has the big, attractive 6.39in QHD+ screen, svelte body, long battery life and great performance that made it the top phone of 2018. However, its excellent triple camera system with 3x optical zoom has been outdone by Huawei’s newer P30 Pro, which has a Leica quad camera with 5x optical zoom. It recently received EMUI 10 (Android 10) and is worth looking out for deals, particularly if you want the 3D face unlock option.</p>',
-					elementId: 'ff65b147-60cd-45e4-8a79-117d2fe5918a',
+					elementId: '19d3339f-139b-4339-ac79-ba4b90655285',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -6559,27 +6622,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>.',
-					elementId: 'cf92a758-6134-42dd-bb95-cb8c5a1ca5df',
+					elementId: 'f767e511-9487-49e7-b4c5-48ddd71cd7eb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2018/oct/29/huawei-mate-20-pro-cutting-edge-brilliance-in-display-fingerprint-and-3d-face-scanning-triple-camera-long-battery-life">Huawei Mate 20 Pro review: cutting-edge brilliance</a></p></li> \n</ul>',
-					elementId: 'd6b9b8a9-291f-4899-ae8a-448811e347b4',
+					elementId: 'c3fc7c3a-168a-415b-a7fa-d196500c5ad2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Google Pixel 4 XL</strong></p>',
-					elementId: '4398635d-a385-495a-b2c1-87e7169407cf',
+					elementId: 'a69a5e1d-77dc-4f16-b0e0-2f8385f653ff',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://store.google.com/gb/config/pixel_4">£829</a> / <a href="https://store.google.com/config/pixel_4">$899</a></p>',
-					elementId: '5350753c-b577-4301-b2ae-2cc3cbd83303',
+					elementId: '0897f250-b3f4-481c-9dbb-5f92349fa875',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '39c3baa2-e04e-48c6-ad6d-6a47ab45187d',
+					elementId: '2486c103-ca72-4dbf-bb00-a4a9fb205ae5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6876,12 +6939,12 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '7ce74abd-dd61-4b8f-b567-e4d8dd38be6e',
+					elementId: '53fca56c-6e1d-4a97-b607-2e234977a80b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Google Pixel 4 XL is a mixed bag. On the one hand you have a good-looking 6.3in QHD+ AMOLED display running at 90Hz, a stellar camera, new Soli radar gesture system, amazing new on-device AI and super-fast 3D Face Unlock. But on the other you have no fingerprint scanner, meaning until apps are updated to use the Face Unlock you’re forced back to using the old pin or password, the battery life is fairly short and there have been quite a few bugs that have needed fixing since launch. One day it might be great.</p>',
-					elementId: 'a6aa57d8-91ed-42ad-8b6a-a224c34f64a1',
+					elementId: '9720f07a-f2fd-4991-b395-5a7099824965',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -6894,27 +6957,27 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '23208843-b9d6-4693-bdc3-6686410ce3c9',
+					elementId: '664a07b0-badb-4cf0-a7f2-b2ad648e5e6e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/oct/29/google-pixel-4-xl-review-not-quite-ready-for-primetime">Google Pixel 4 XL review: not quite ready for primetime</a></p></li> \n</ul>',
-					elementId: 'b188f055-63d9-4c01-85e3-fc7abcf6fcbd',
+					elementId: 'cf4376fe-43d5-436e-9b47-182e99fa848b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Xiaomi Mi Mix 3</strong></p>',
-					elementId: 'c03f86f8-c982-4a33-baa6-1a9f4b5b5853',
+					elementId: '84dee561-9248-458e-badf-b30c0cff9fb8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>RRP:</strong> <a href="https://buy.mi.com/uk/buy/product/mix3">£499</a></p>',
-					elementId: '3df509b7-d36d-403a-ae59-1f37f6ef8bbe',
+					elementId: '2826d0d6-d9dd-4932-ac7c-aab730ac2e20',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>★★★★☆</p>',
-					elementId: '04676817-500d-4509-964e-ca67442ae081',
+					elementId: 'cb6aa38a-cd01-428a-8800-ebd91ef7bf21',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -7221,17 +7284,17 @@ export const NumberedList: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'd0603133-d506-425f-8b5b-9a0ba12b12ac',
+					elementId: '0ab41cf4-3368-4f97-8fce-0afcfb180ff5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Xiaomi’s first slider phone offers more than most for the money, with top-flight specs for 2018 competing directly with the OnePlus 6T and Honor View20. It takes a different approach to the problem of where to put the selfie camera in an all-screen design, hiding it behind the screen on slide-out section.</p>',
-					elementId: 'f47bdd88-e9cf-40bc-961d-eebc8e88fb54',
+					elementId: 'a62b022c-225b-42da-99d1-cd723ec793af',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Good, but quite as great as its competition, this huge phone is held back by a heavy weight and a software experience that just isn’t as good, despite solid gesture navigation options.</p>',
-					elementId: '3b5f9886-e77a-46b3-be1c-09206a50264b',
+					elementId: 'deb10c59-2f5d-4701-b5ee-2702a7f0b22b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
@@ -7244,42 +7307,42 @@ export const NumberedList: CAPIArticleType = {
 					sourceDomain: 'm.skimresources.com',
 					caption:
 						'These regularly updated deals have been sourced through a third-party price comparison service. The Guardian may make a small commission if a reader clicks through and makes a purchase. <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">More information</a>. ',
-					elementId: '31496183-22b7-4fbb-95b5-717f1c1b72d2',
+					elementId: 'f5f352dc-e9ff-4db0-95c7-cf2d9045bc68',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong>Full review:</strong> <a href="https://www.theguardian.com/technology/2019/feb/27/xiaomi-mi-mix-3-review-novel-slider-finally-hits-the-uk">Xiaomi Mi Mix 3 review: novel slider finally hits the UK</a></p></li> \n</ul>',
-					elementId: 'd4819401-d026-4ba0-a7f1-a41488a9744b',
+					elementId: 'e194d2b8-87de-4da1-86e0-ba9f8f9ffbf0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Not recommended</h2>',
-					elementId: 'a96d1dee-7baf-4263-ae21-cb64b4d44585',
+					elementId: 'be535cdd-0709-4168-a1c5-7382ded06f83',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Google Pixel 4</strong> - Great phone utterly ruined by <a href="https://www.theguardian.com/technology/2019/oct/31/google-pixel-4-review-battery-life-camera">terrible battery life</a> - £669</p>',
-					elementId: '41ac0000-ee48-47e5-91c8-56eb7ed40729',
+					elementId: '32a51456-4f28-418c-afc3-2bf68aac49d6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Razer Phone 2</strong> - Gaming phone beast that falls down on camera performance – £500</p>',
-					elementId: '14193ddd-da7e-4530-9b12-2a636096858f',
+					elementId: '2e74e45e-7418-40c8-b3fa-61407aecca4f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Sony Xperia XZ3</strong> – Good, but not great phone that misses the mark – £699</p>',
-					elementId: '133a26c5-7ad9-4384-a68c-4978385f7526',
+					elementId: 'e092d81b-6161-4926-9958-377047902609',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p><strong><a href="https://www.theguardian.com/technology/2019/may/01/best-true-wireless-earbuds-airpods-samsung-jabra-sennheiser-anker-compared-and-ranked">Best true wireless earbuds: AirPods, Samsung, Jabra and Anker compared and ranked</a></strong></p></li> \n</ul>',
-					elementId: 'f2694f87-a923-4a6a-afaf-79353d82efd2',
+					elementId: '4612c4a3-40a1-4079-af33-140f0cc2a0c9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.DisclaimerBlockElement',
 					html: '\n\n\n\n\n\n\n    <p><em><sup>\n        This article contains affiliate links, which means we may earn a small commission if a reader clicks through and\n        makes a purchase. All our journalism is independent and is in no way influenced by any advertiser or commercial initiative.\n        By clicking on an affiliate link, you accept that third-party cookies will be set.\n        <a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links" data-link-name="in body link" class="u-underline">More information</a>.\n    </sup></em></p>\n\n',
-					elementId: 'ed9dd1c0-a3d7-4267-8f43-482fa3b3dc99',
+					elementId: 'bbc3c51e-15ef-4b50-91a6-48a498fc20d1',
 				},
 			],
 			attributes: {
@@ -7303,7 +7366,7 @@ export const NumberedList: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked',
+			'@id': 'https://www.theguardian.com/technology/2019/dec/17/best-smartphone-2019-iphone-oneplus-samsung-and-huawei-compared-and-ranked',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -23,52 +23,6 @@ export const PhotoEssay: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['features'],
-				},
-				{
-					name: 'url',
-					value: '/travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton',
-				},
-				{
-					name: 'k',
-					value: [
-						'uk',
-						'photography',
-						'travel',
-						'cornwall',
-						'england',
-					],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/fj28j',
-				},
-				{
-					name: 'se',
-					value: ['guardian-picture-essay'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -161,6 +115,52 @@ export const PhotoEssay: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['features'],
+				},
+				{
+					name: 'url',
+					value: '/travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton',
+				},
+				{
+					name: 'k',
+					value: [
+						'uk',
+						'photography',
+						'travel',
+						'cornwall',
+						'england',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fj28j',
+				},
+				{
+					name: 'se',
+					value: ['guardian-picture-essay'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -192,6 +192,52 @@ export const PhotoEssay: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fj28j',
+				},
+				{
+					name: 'se',
+					value: ['guardian-picture-essay'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['features'],
+				},
+				{
+					name: 'url',
+					value: '/travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton',
+				},
+				{
+					name: 'k',
+					value: [
+						'uk',
+						'photography',
+						'travel',
+						'cornwall',
+						'england',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -893,6 +939,10 @@ export const PhotoEssay: CAPIArticleType = {
 					},
 				],
 			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
+			},
 		],
 		brandExtensions: [
 			{
@@ -1565,7 +1615,7 @@ export const PhotoEssay: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'c76bf8e3-d08f-4c9f-8cdf-39ab7250feb4',
+			elementId: '6bdb700c-c735-43c1-bdb6-e19bcd43ce6b',
 		},
 	],
 	canonicalUrl:
@@ -1577,17 +1627,17 @@ export const PhotoEssay: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The last embers of my fire flicker orange and red in the dark. It has warmed me after my evening swim shared with a grey seal, a curious female at the water’s edge, under the soft pink hues of the setting sun.</p>',
-					elementId: '4b089a69-42dc-47e4-9dd5-dcd96d15130d',
+					elementId: '37c76c25-1cf7-4971-95a4-52db8db6c0df',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The nights are beginning to draw in and the temperature is dropping. Tonight’s home is a magical one: a hidden spot somewhere on the Roseland Heritage coast.</p>',
-					elementId: '29932bc5-a66c-4fd2-a803-d1b1450a2114',
+					elementId: '240c726d-d9df-4c7f-bbe7-55463ca18af6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I am curled up in my tiny space with only a canvas shell between me and the elements. Tonight is calm: a beautiful moon path marks the ocean and is my view through the open back of my family’s Land Rover. I drift off to sleep to the sound of waves lapping the shore and the call of tawny owls across the night sky.</p>',
-					elementId: '87812a4c-e2ad-4466-a15f-38e98cb0c543',
+					elementId: '5980ad53-577d-426c-af54-8c1f79e787ee',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1902,32 +1952,32 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'fc2ec3c6-bec9-4cf5-98cb-22fc6b89dee9',
+					elementId: '1f96cbb6-6ed0-4d41-a6b6-864283ea10fe',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Cat Vinton’s home for the past eight months has been her Land Rover</p></li> \n</ul>',
-					elementId: 'c0636de9-8b29-4f3d-a7a8-86219dedcb8e',
+					elementId: 'add62051-7b64-4910-9aee-4c5f60caf877',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For the last few years I’ve not called one place home. Instead, I’ve roamed across the globe – from the High Himalaya to the Arctic Circle, the Gobi Desert to the Andaman Sea<strong> </strong>– weaving my life and work as a photographer, more in tune with a wilder spirit and those who still live connected to nature.</p>',
-					elementId: '9ccba31e-6808-4d97-943c-2cf1c7cae767',
+					elementId: 'c5df101e-f5cf-4cad-a1a6-12152c0cfce3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As the world locked down in March, not only my work but my entire way of life ground to a quiet halt, forcing me to look inward and to grapple with the meaning<em> </em>of “home”.</p>',
-					elementId: 'b3e03e8d-a310-413d-8d86-73759fc4b388',
+					elementId: '07ed4fab-5eaa-4e30-8087-0058e9d3cf04',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>My pull was to the ocean of the south-west of England. Thanks to my friend Louise Middleton, for those three months of lockdown I watched over a wild pocket of the north Cornish coast – an old slate quarry that overlooks the sea at Trebarwith Strand. It is a beautifully curated space, totally off-grid, that Louise has named <a href="https://kudhva.com/">Kudhva</a> (meaning hideout in Cornish). Kudhva is a visionary architectural hideout that draws creative people who thrive on a life connected to the outdoors.</p>',
-					elementId: '2dc9f494-ebf5-4dca-9019-732fa88244f1',
+					elementId: 'd8318a96-6132-493c-b48c-b6c987d65e10',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I became part of a community at Kudhva and my days were spent in fascinating conversation, working on the land with the locals. This is what I do on my projects – immerse myself in a way of life, documenting people who are connected to their land and community around the world. I fell into a way of doing the same on home shores.</p>',
-					elementId: 'cb5c7945-c110-4fd9-a9a0-72a2d69f8b8b',
+					elementId: 'cfd88263-3b4c-4b40-af9a-aaa10b7ec46d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2242,7 +2292,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '1372f404-6091-4d7c-8f27-731c925a6fae',
+					elementId: 'a0b281b7-1635-4c5e-873f-50d327702cf1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2557,17 +2607,17 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '0ad57097-69fd-4188-9cca-dea68418f37b',
+					elementId: '2d6c95f4-7176-40ab-9193-e0338426294e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Louise Middleton bought a 45-acre abandoned quarry in 2015 that she named Kudhva, meaning hideout in Cornish</p></li> \n</ul>',
-					elementId: 'd4ffa425-8fc1-43f1-ac1a-13e9a2630da1',
+					elementId: '0ad4331b-7d3d-4a90-beee-ebba33a1e833',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Sidetracked, an adventure journal which has shared my stories from the remotest corners of the world, joined us as lockdown lifted for some backyard adventures – climbing, biking, cold-water swimming and surfing – with the people who know this land best.</p>',
-					elementId: '708129f4-67d3-4849-98d5-17db803e7d6e',
+					elementId: '75d24dd2-f068-449e-8570-b683a8be2763',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2882,7 +2932,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'a61554ca-028a-4f33-a536-890c4c0493a0',
+					elementId: '49ec49b2-a570-425f-a009-62623ea599c9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3197,7 +3247,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'd04b5dc2-03d7-4500-b85e-99de61f334a5',
+					elementId: 'bd5e1bac-92cc-4aa6-9be0-f1c0bda52c28',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3512,7 +3562,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'dd0fdc66-8729-4c12-8b07-55baf25855af',
+					elementId: 'cc6307d0-b752-46f9-8c19-ade3e1860d45',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3827,12 +3877,12 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '2a7f03e8-8282-4275-a839-2bab2644b9f0',
+					elementId: '5dcb6b27-a5f8-4487-96b0-7897905dc2a9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Backyard adventures in Cornwall with the locals included cold-water swimming, biking and surfing. Shot for Sidetracked magazine at Kudhva and Trebarwith Strand</p></li> \n</ul>',
-					elementId: '11fe233f-2458-4d00-a6b1-ff9fc2291d3b',
+					elementId: 'd74f2e7a-530d-494f-892d-9be9edb2ccd1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4137,29 +4187,29 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'b10775bf-e331-4c9b-91a6-2f2677184f4c',
+					elementId: '0ff4eebd-17e4-4d3b-b321-ede638c8adb2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Then, as the country began to open up again, and Kudhva began to welcome back guests, it was time to move on. I decided this was a gift of time I may never get again. Usually, I’m moving with my work. I had my cameras and a Land Rover that could take me off the beaten track – the perfect companion to explore the Cornish coast and its way of life, and to see if I could still find pockets of solitude, as the tourist floodgates opened.</p>',
-					elementId: 'b70ae3d8-814b-442a-9426-394dd427ce18',
+					elementId: '50b9003c-2ee5-43f3-b05f-5801678e3194',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement',
 					html: 'It’s a simple set-up – I’m free, independent and I am happy',
 					role: 'supporting',
 					isThirdPartyTracking: false,
-					elementId: '9599cbfc-b4f9-4d8b-8c2f-182adeaa754a',
+					elementId: '5130eba7-4af1-413e-83b6-b719ca92adef',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>A small pile of books is stacked between the seats of the Land Rover; a head torch, tide tables, bikini and my knife are at hand. Everything else I need is packed neatly in the open back, covered with a piece of wood that doubles as a table and my bed. It’s simple – I’m free, independent and happy. With no real plan, I set off west along the north coast.</p>',
-					elementId: 'cf55562e-5472-4f26-affc-c55e35a7cb50',
+					elementId: '55a8d1bf-5aad-4c0d-9877-dbc6f1794001',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Cornwall has always felt like a haven to me, but even more so now with its gift of space, fresh air, ocean and local produce far from the hustle of city life. Slate and granite cliffs, small rocky coves and headlands, sand dunes, reefs, sandy beaches, green pathways and water shape Cornwall’s 400 miles of coastline.</p>',
-					elementId: 'c3c1a0bb-2880-49fb-94a8-e64234806cbd',
+					elementId: '2a6e0275-d746-4e2c-a276-3be90e9a0355',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4474,7 +4524,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'f77e1399-f7cd-4d50-8cb0-8ab08aa79f63',
+					elementId: '898c5fd1-091e-4998-bb86-398877fb300d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4789,7 +4839,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '555fced0-10ee-40de-bd8c-452325929f1e',
+					elementId: '04ba4ebc-1d09-471f-b48c-149c43b012f7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5104,17 +5154,17 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'd3db3d83-e6ce-4891-ac8d-3b7582d6001a',
+					elementId: 'a9168311-4394-486b-8a12-0ddc6a1bce93',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Turquoise waters, green pathways and rocky pools shape Cornwall’s 400 miles of coastline</p></li> \n</ul>',
-					elementId: '767f1daa-3ace-4599-a465-7ad8ff90ab53',
+					elementId: '3845c3d2-36e6-462e-9a40-792c28068c37',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As my days slowed, I noticed every detail in the shifting light, the sounds, smells and colours, and tuned into the tidal rhythm, mesmerised by the waves that roll in perfect lines.</p>',
-					elementId: 'a079534c-1b4e-4135-a0b8-8d8ba6accbc6',
+					elementId: 'b26a7c14-d7ce-4507-9677-c36b0350b95d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5429,17 +5479,17 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'be716c2a-d584-45b7-a90b-f7e636ab82ff',
+					elementId: '90a6bb92-0e84-45a3-9a74-e9d843f5be26',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I weaved my way along the north coast from Trebarwith Strand to the lighthouse on Pendeen Point, almost 100 miles of coast flanked by the Atlantic Ocean. This part of the coast is punctuated with derelict buildings and still-noble chimneys of tin and copper mines that once thrived in a harsh industrial past. Climbers are drawn to the granite cliffs and crags of the Penwith peninsula, and I spent some epic days here, with friends, climbing and exploring the Penwith heritage coast.</p>',
-					elementId: '726a19dd-10e7-46c6-b55f-cd960e728c68',
+					elementId: 'ae0de552-e2d7-43ed-ba7d-ebd5e1e5832f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The weather had been mostly kind until late August, but the rumblings of thunder carried a wild energy that stirred up the ocean and I lay awake as lightning lit up the night sky, and wind and driving rain whipped the canvas covering of the Land Rover. For 10 days storms Ellen and Francis raged across the ocean, swirled around the end of land and made me appreciate everything – especially how privileged I am to be able to make the choice to live like this. It’s not the easiest way to live and not what most people would choose – but it’s stripped back, simple and connected. Being immersed in the elements is where I find my energy and my balance, giving me a sense of purpose.</p>',
-					elementId: '079e3fd8-300d-4241-a3cf-9e611c8e3a92',
+					elementId: 'e48a6f7a-5c7c-4250-9e51-19acbffeb8e6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5754,24 +5804,24 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'b6315f94-fdde-411b-8547-40e00b52c155',
+					elementId: '107d9864-909d-4911-bd81-b34cacc49712',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Storm Francis raging across the ocean in August</p></li> \n</ul>',
-					elementId: '36f0a548-c99f-4745-a4a8-9a0f76805ba0',
+					elementId: '71ec6d7b-6a47-4d5c-a4ea-c77a1ba56935',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Every day is different as I move slowly along this stunning coast. I’ve seen pilot whales, dolphins, seals, barn owls, kestrels, peregrines and choughs, met old Cornish fishermen and made new local friends. I have, of course, also seen the hordes of people who’ve flocked here – but I’ve also found so many empty pockets of Kernow magic. The sea mist comes and goes, as do the sun and the clouds. The sea changes every day, every hour, every minute, as do we – our emotions, our energy and our perspectives. It feels like a lesson – a constant reminder that we are part of nature, not separated from it.</p>',
-					elementId: 'e43cdaee-f030-4b03-b515-efa371daf0b5',
+					elementId: '58aa7bee-2d49-48f4-b568-ecbc60ebdd61',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement',
 					html: 'I’ve seen pilot whales, dolphins, seals, met old Cornish fishermen and made new local friends',
 					role: 'supporting',
 					isThirdPartyTracking: false,
-					elementId: '119b23ed-d1be-4a98-be23-06c418fb9e54',
+					elementId: 'd76bcd03-40f1-4350-8582-8560dd6050f8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6086,7 +6136,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '405ad7de-870a-42c8-a501-04abcb76a55b',
+					elementId: '119391fb-67a5-48ef-b26c-a777da265b6a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6401,7 +6451,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'e159a6d7-8dfc-4001-ad29-ee455805c056',
+					elementId: '2b168e35-f250-462e-8899-4b9944d54fd5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6717,22 +6767,22 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '2b2a6d17-da7b-42ca-a23d-b2c2b7e39d20',
+					elementId: '2cc71c66-4881-4c4f-a666-e46850fd2408',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Clockwise from top: White horses carried on the on-shore wind at Dollar Cove, on the Lizard; two different views of Logan Rock</p></li> \n</ul>',
-					elementId: '976783bc-ff6c-4619-bf87-098d342c8a8e',
+					elementId: '224e5efe-6b5c-4b1b-92db-4bdbf8800784',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Friends have joined me, I’ve swum every day, I’ve climbed, explored and watched the days turn to night by a fire on the beach most evenings. I’ve witnessed the change in the coastal palette of the native wildflowers and fallen into the pace of life here. I navigated the coast around the Lizard, up to Falmouth and on to the Roseland Heritage coast; the south coast is gentler, with sheltered beaches, woodland valleys, tree-lined estuaries, tiny winding roads, and picturesque fishing villages scattered along its shores.</p>',
-					elementId: '56e1645d-f8c8-4e59-9fb7-502358426b00',
+					elementId: '0ce03a10-f12a-4966-a9f8-7bd529e6d16e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I’ve been drawn to like-minded people, who share the same values, who’ve made a home on this coast and who are passionately driven to protect the ocean and the land. Conversations, ideas and projects are the beginnings of collaborations, now and in the future.</p>',
-					elementId: '65d9e5d3-0df1-4fda-81d7-39b41161a514',
+					elementId: '2d5ebe5f-713e-4961-9ad5-9965ece86c0f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -7047,17 +7097,17 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'bd978683-72ef-47e2-ad7e-5da9384dda1b',
+					elementId: 'd6dc649d-7dbd-4cc2-9376-07604d7091f7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Joya Burrow, <a href="https://www.therighttoroam.com/">The Right to Roam Films</a> shot for Finisterre, at Kudhva and Trebarwith Strand</p></li> \n</ul>',
-					elementId: '9d916905-5aa4-4a56-87ef-db676ce51b1c',
+					elementId: '2329bdd2-773c-4690-9ef8-2189903f91a4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I made it to Mevagissey on the south coast by the beginning of October, with warnings of another storm. I had a commitment to be on Cornwall’s highest point, Brown Willy on Bodmin Moor, by 3 October to photograph an amazing man, explorer <a href="https://www.theguardian.com/travel/2020/oct/14/nature-has-healing-power-britains-covid-heroes-share-their-favourite-outdoor-spaces">Robin Hanbury-Tenison</a> and his family. His story is one of a remarkable recovery from Covid-19, having spent five weeks in an induced coma with little chance of survival. The key moment in his recovery was when he was wheeled into the healing garden of Derriford hospital. Now raising funds for healing gardens across Cornwall, Robin braved the 60mph winds of Storm Alex to reach the summit and fly the Cornish flag of Saint Piran. Another story of the power of nature.</p>',
-					elementId: '0b624e24-1308-4196-b29d-b531854464a9',
+					elementId: '29338ead-8415-41d1-a97b-030d37434a8f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -7372,7 +7422,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'ce56baa8-592f-4250-998b-350b7934d6f1',
+					elementId: '47448f1a-666f-4e85-b7e6-472aa7615864',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -7687,34 +7737,34 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: 'b7bc0a31-2b11-40b3-bed9-23b15c251358',
+					elementId: '6c5f7b34-5002-4f22-8591-dcfbc128b8b9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Explorer and Covid-19 survivor Robin Hanbury-Tenison climbs Brown Willy on Bodmin Moor in October to raise funds for healing gardens across Cornwall</p></li> \n</ul>',
-					elementId: '50fb5bdb-5e98-4ab1-b303-a05a0c5717e1',
+					elementId: 'a92ab57f-1936-4355-a5e1-228986c172db',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I’ve been in Cornwall for eight months now. That’s the longest I’ve been in one place for a long time. Cornwall has had my heart for many years, but to have lived through the seasons, entirely off-grid, has connected me more deeply.</p>',
-					elementId: 'd9516197-9266-4440-8d8b-a82c0bba4d39',
+					elementId: '131b341e-c38f-46a9-93dd-8d10cc057c94',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement',
 					html: 'There is something incredibly powerful about living so close to nature, in the elements',
 					role: 'supporting',
 					isThirdPartyTracking: false,
-					elementId: '88ef3af1-6914-455c-9583-553e49d2691d',
+					elementId: '7f7499b5-3ecc-4574-9075-f03db1b30e62',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>There is something incredibly powerful about living so close to nature, in the elements. I think it’s something we miss living inside closed walls – we are disconnected.</p>',
-					elementId: '00aea00c-dd0e-4db5-a7bc-b796d8b1bf33',
+					elementId: '2aba71eb-1cac-424e-befb-73691d544b3c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>As the world of free movent has new rules and the future is unknown and precarious, I think it has forced many of us to rethink our pace of life, our relationship to nature, what we really need to be happy and fulfilled, and how we will live our lives on the other side of this.</p>',
-					elementId: '02eb330a-ce50-43a0-8e75-3c250d7d729c',
+					elementId: '200ef0e9-48bc-486d-9ef0-64f1b0c63bce',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -8029,7 +8079,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '7367bf4f-004f-4c08-9463-31d335c61bac',
+					elementId: '70f2a33d-e5c6-489c-be47-7119dc99bfcb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -8344,7 +8394,7 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '3507b092-c55d-4a78-b0a7-de7648214ca0',
+					elementId: '815ad3bd-c204-4584-a80e-4708a36ca3e7',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -8659,17 +8709,17 @@ export const PhotoEssay: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '50e3f306-9241-438d-9c34-24c1a7c7380e',
+					elementId: '9ac21d89-03b2-4625-b7a1-059d44b4f395',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<ul> \n <li><p>Clockwise from top left: Sunrise at Towan Beach, full corn moon on the Penwith Heritage coast and Cat Vinton’s Land Rover parked up on the Cornish coast</p></li> \n</ul>',
-					elementId: 'f269c75d-2f4f-433c-9124-fe2dfee4b835',
+					elementId: '44be779e-7364-4fc1-9b0c-c716ba09ff8d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>I have learned so much about the importance and the purpose of life – a moral and ethical code – from the nomadic people of the world’s most remote corners. About the fragile connection between people and nature, and that wealth and success are not measured in belongings and status, but in the strength of our human spirit. I feel, more than ever, that we have so much to learn from these people who have never lost those visceral connections.</p>',
-					elementId: '07cd41a6-bdd5-4b84-b6c3-9abe5e609a2e',
+					elementId: 'd16fc0eb-9170-419f-b1a7-a6ad32ddd890',
 				},
 			],
 			attributes: {
@@ -8693,7 +8743,7 @@ export const PhotoEssay: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton',
+			'@id': 'https://www.theguardian.com/travel/2020/dec/09/my-year-of-roaming-free-in-cornwall-photo-essay-cat-vinton',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -23,53 +23,6 @@ export const PrintShop: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['guardian-print-shop'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'co',
-					value: ['guardian-sport'],
-				},
-				{
-					name: 'url',
-					value: '/artanddesign/2020/dec/17/buy-a-classic-sport-photograph-the-immortal-bobby-moore',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'k',
-					value: [
-						'photography',
-						'culture',
-						'sport',
-						'artanddesign',
-						'football',
-						'england',
-					],
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/fmxze',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -164,6 +117,53 @@ export const PrintShop: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['guardian-print-shop'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'co',
+					value: ['guardian-sport'],
+				},
+				{
+					name: 'url',
+					value: '/artanddesign/2020/dec/17/buy-a-classic-sport-photograph-the-immortal-bobby-moore',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'k',
+					value: [
+						'photography',
+						'culture',
+						'sport',
+						'artanddesign',
+						'football',
+						'england',
+					],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fmxze',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -185,6 +185,53 @@ export const PrintShop: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'k',
+					value: [
+						'photography',
+						'culture',
+						'sport',
+						'artanddesign',
+						'football',
+						'england',
+					],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fmxze',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['guardian-print-shop'],
+				},
+				{
+					name: 'co',
+					value: ['guardian-sport'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'url',
+					value: '/artanddesign/2020/dec/17/buy-a-classic-sport-photograph-the-immortal-bobby-moore',
 				},
 				{
 					name: 'p',
@@ -880,6 +927,10 @@ export const PrintShop: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1618,47 +1669,47 @@ export const PrintShop: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '5087ec80-4fbd-49ca-8a90-1841db6418c2',
+					elementId: 'a9f0aa45-cfc4-4e36-b82a-529a6d563a5d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>This photograph captures Bobby Moore in 1973, standing statuesque in the twilight of his international career, just a few months after winning his 100th cap for England. It was shot prior to a 1-0 friendly win over Scotland which would prove to be Moore’s final victory in an England shirt at Wembley. It possesses a kind of majesty reminiscent of the bronze statue of him at the new Wembley, beneath which an inscription reads: <em>‘Immaculate footballer. Imperial <a href="https://en.wikipedia.org/wiki/Defender_(association_football)">defender</a>. Immortal hero of <a href="https://en.wikipedia.org/wiki/1966_FIFA_World_Cup_Final">1966</a>. First <a href="https://en.wikipedia.org/wiki/List_of_England_international_footballers">Englishman</a> to raise the <a href="https://en.wikipedia.org/wiki/FIFA_World_Cup_Trophy">World Cup</a> aloft. Favourite son of London’s <a href="https://en.wikipedia.org/wiki/East_End_of_London">East End</a>. Finest legend of <a href="https://en.wikipedia.org/wiki/West_Ham_United_F.C.">West Ham United</a>. National Treasure. Master of <a href="https://en.wikipedia.org/wiki/Wembley_Stadium_(1923)">Wembley</a>. Lord of the game. <a href="https://en.wikipedia.org/wiki/List_of_England_national_football_team_captains">Captain</a> extraordinary. Gentleman of all time.’</em></p>',
-					elementId: '1f237d63-e039-4dbb-b9a3-3816fcd28278',
+					elementId: '8e770d0d-712e-458d-9e69-0308f26e79d5',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Photograph: Gerry Cranham / Offside</em></p>',
-					elementId: 'f03f91c0-4154-4ad7-9982-378c3964900a',
+					elementId: '24d28d2e-35b7-4882-a2d6-f9c8d294f1f8',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Words: Jonny Weeks</em></p>',
-					elementId: '7df11fb2-aca8-4b97-a75e-bb58fec1f920',
+					elementId: '6a2964be-3d70-4e13-9b1f-6fb3d37ce1c2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Buy your exclusive print <a href="https://guardianprintshop.com/collections/the-big-sport-picture">here</a></strong></p>',
-					elementId: '39d598fc-34a5-4ef4-a8e1-8ac81a93ee1b',
+					elementId: 'd6cee88f-8b0d-413b-a42a-d0c8535b5ea2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Price</strong> <br>£55 including free delivery (30x40cm print size).</p>',
-					elementId: '2960e7da-32c7-40e4-ac9e-cf29401f91af',
+					elementId: '579159fd-2ae2-488a-bd91-1ffe8fa9a3f1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Prints<br></strong>Photographs are presented on museum-grade, fine-art paper stocks, with archival standards guaranteeing quality for 100-plus years. All editions are printed and quality checked by experts at theprintspace, the UK’s leading photo and fine-art print provider.</p>',
-					elementId: '56228d3e-7a81-4b87-8b15-527400d4bd88',
+					elementId: '3e4f075c-8f96-4296-a3f4-5b9dda2b2d5e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Delivery<br></strong>Artworks are dispatched via Royal Mail and delivered within three to five working days. Theprintspace takes great care in packaging your artwork, with a no-quibble satisfaction guarantee should you be unhappy in any way. Global shipping is available.</p>',
-					elementId: 'c2fe33cd-6126-4808-abf3-440adfbc1bcd',
+					elementId: '6f47e066-fa96-44b3-9f7e-aff3468757c1',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><strong>Contact</strong><br>Email: <a href="mailto:guardianprintsales@theprintspace.co.uk">guardianprintsales@theprintspace.co.uk</a></p>',
-					elementId: '5fa9e6a6-eff7-43a0-b31d-2cbaac4cd1f3',
+					elementId: '243bc830-2769-4df1-81a0-44b21b8807a8',
 				},
 			],
 			attributes: {
@@ -1682,7 +1733,7 @@ export const PrintShop: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/artanddesign/2020/dec/17/buy-a-classic-sport-photograph-the-immortal-bobby-moore',
+			'@id': 'https://www.theguardian.com/artanddesign/2020/dec/17/buy-a-classic-sport-photograph-the-immortal-bobby-moore',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -27,54 +27,6 @@ export const Quiz: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/e3fga',
-				},
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'bl',
-					value: ['that-1980s-sports-blog'],
-				},
-				{
-					name: 'tn',
-					value: ['quizzes'],
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'k',
-					value: ['sport', 'football'],
-				},
-				{
-					name: 'se',
-					value: ['guardian-sport-network'],
-				},
-				{
-					name: 'co',
-					value: ['steven-pye'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'url',
-					value: '/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -171,6 +123,54 @@ export const Quiz: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/e3fga',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'bl',
+					value: ['that-1980s-sports-blog'],
+				},
+				{
+					name: 'tn',
+					value: ['quizzes'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: ['sport', 'football'],
+				},
+				{
+					name: 'se',
+					value: ['guardian-sport-network'],
+				},
+				{
+					name: 'co',
+					value: ['steven-pye'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'url',
+					value: '/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -212,6 +212,54 @@ export const Quiz: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/e3fga',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'bl',
+					value: ['that-1980s-sports-blog'],
+				},
+				{
+					name: 'tn',
+					value: ['quizzes'],
+				},
+				{
+					name: 'url',
+					value: '/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: ['sport', 'football'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'se',
+					value: ['guardian-sport-network'],
+				},
+				{
+					name: 'co',
+					value: ['steven-pye'],
 				},
 				{
 					name: 'p',
@@ -884,6 +932,10 @@ export const Quiz: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1584,7 +1636,7 @@ export const Quiz: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '02ce0c63-ac40-444f-ab7e-6dd422aa07bc',
+			elementId: 'dfcd0226-3131-4202-a12a-a34dd02e8199',
 		},
 	],
 	canonicalUrl:
@@ -2200,7 +2252,7 @@ export const Quiz: CAPIArticleType = {
 							minScore: 2,
 						},
 					],
-					elementId: '70cdc388-8a0b-48ed-9a1f-ae86724d49f6',
+					elementId: 'd640e3b3-8977-4a76-9580-108476a5c3d6',
 				},
 			],
 			attributes: {
@@ -2224,7 +2276,7 @@ export const Quiz: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s',
+			'@id': 'https://www.theguardian.com/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -27,59 +27,6 @@ export const Recipe: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'url',
-					value: '/food/2021/feb/06/meera-sodhas-vegan-recipe-for-spring-onion-pancakes',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/fz7hz',
-				},
-				{
-					name: 'co',
-					value: ['meera-sodha'],
-				},
-				{
-					name: 'tn',
-					value: ['recipes', 'features'],
-				},
-				{
-					name: 'k',
-					value: [
-						'vegetables',
-						'main-course',
-						'lifeandstyle',
-						'food',
-						'vegan',
-						'starter',
-						'snacks',
-						'chinese',
-					],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'se',
-					value: ['the-new-vegan'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -186,6 +133,59 @@ export const Recipe: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'url',
+					value: '/food/2021/feb/06/meera-sodhas-vegan-recipe-for-spring-onion-pancakes',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fz7hz',
+				},
+				{
+					name: 'co',
+					value: ['meera-sodha'],
+				},
+				{
+					name: 'tn',
+					value: ['recipes', 'features'],
+				},
+				{
+					name: 'k',
+					value: [
+						'vegetables',
+						'main-course',
+						'lifeandstyle',
+						'food',
+						'vegan',
+						'starter',
+						'snacks',
+						'chinese',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'se',
+					value: ['the-new-vegan'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -215,6 +215,59 @@ export const Recipe: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'k',
+					value: [
+						'vegetables',
+						'main-course',
+						'lifeandstyle',
+						'food',
+						'vegan',
+						'starter',
+						'snacks',
+						'chinese',
+					],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'se',
+					value: ['the-new-vegan'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'url',
+					value: '/food/2021/feb/06/meera-sodhas-vegan-recipe-for-spring-onion-pancakes',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/fz7hz',
+				},
+				{
+					name: 'co',
+					value: ['meera-sodha'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
+				},
+				{
+					name: 'tn',
+					value: ['recipes', 'features'],
 				},
 				{
 					name: 'k',
@@ -928,6 +981,10 @@ export const Recipe: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1685,7 +1742,7 @@ export const Recipe: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '70230296-032b-40a1-a895-be4c1d2e63bf',
+			elementId: '1d0ac2f0-082f-451f-9d6c-d7169ba4696e',
 		},
 	],
 	canonicalUrl:
@@ -1697,62 +1754,62 @@ export const Recipe: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p> The world of pancakes is so vast, it is hard to think that on <a href="https://en.wikipedia.org/wiki/Shrove_Tuesday">Pancake Day</a>, there could be only one type proffered across the world. Of course, traditionally, pancakes were a way to use up eggs and animal fats before the Lent fast, but with those ingredients off the table in vegan cooking, a new array of pancakes can take centre stage. Today’s offering is for <em>cong you bing</em>, a flaky, coiled, spring onion pancake ubiquitous across China. It’s as enjoyable to make as it is to eat and, happily, there’s no whiff of abstinence about it.</p>',
-					elementId: '55dba533-5c2b-424d-8d63-9a9ec2f0832e',
+					elementId: '19d66a71-b1d4-48c2-af7e-980dc04947eb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2>Spring onion pancakes with sesame sauce</h2>',
-					elementId: 'c35dc2e2-60f7-4d40-9333-931c3c1c02ae',
+					elementId: '09f10bac-c61d-47fd-9550-feed88ab4b90',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Prep <strong>5 min<br></strong>Rest <strong>30 min<br></strong>Cook<strong> 1 hr<br></strong>Makes <strong>4, to serve 2 for lunch</strong></p>',
-					elementId: '79208a7e-9eba-45d4-913a-b33f0c69f034',
+					elementId: '2b13d58c-0c7d-4386-9673-39bca08ace44',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Making these involves a particular set of processes that includes binding, rolling, folding, squashing and frying. I would have had trouble learning them by myself during the pandemic were it not for the help of a library of online cooks, and in particular Wei Guo of the wonderful <a href="https://redhousespice.com/">Red House Spice blog</a>.</p>',
-					elementId: 'c79d8f05-c228-483b-8f96-d96dcacfd7be',
+					elementId: '4fed9ac9-941b-4bb3-944d-178b6d0baecd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For the pancakes<br><strong>275g plain flour</strong>, plus 2 tbsp extra<br><strong>Fine sea salt<br>Coconut oil</strong><br><strong>½ tsp Chinese five spice</strong> powder – I like <a href="https://bart.co.uk/products/chinese-five-spice-powder">Bart Ingredients</a> <br><strong>6 spring onions</strong>, trimmed and finely sliced</p>',
-					elementId: '72b35958-a743-4f96-93b6-e9e61642c4d9',
+					elementId: 'aea3832a-965b-4f8b-aa87-e2d84c011836',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For the sesame sauce<br><strong>30g tahini<br>75g sweet white miso</strong> – I like <a href="https://www.clearspring.co.uk/products/organic-japanese-sweet-white-miso-paste-pasteurised">Clearspring</a><br><strong>1 tbsp toasted sesame oil<br>2 tbsp white-wine vinegar<br>½ tsp chilli oil sediment plus 1 tbsp oil </strong>– I like <a href="https://uk.lkk.com/products/chiu-chow-chilli-oil">Lee Kum Kee</a></p>',
-					elementId: 'a36c92ab-f499-4ec0-83cd-a901474ac1c4',
+					elementId: '9bd9c679-a741-48d4-a8df-0765876a2c52',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Fill and boil half a kettle of water. In a large heatproof bowl, use a fork to mix the flour, a big pinch of salt and 165ml freshly boiled water until it comes together into a rough dough and is cool enough to handle. Knead for five minutes, then cover with a clean tea towel and set aside to rest for 30 minutes.</p>',
-					elementId: '5615ca1e-86c5-4817-9e7d-0c3720c07015',
+					elementId: 'e3f78b6c-3dfa-45f5-8cd2-9438a1e6ff3a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>While the dough is resting, prepare the filling. Melt two tablespoons of coconut oil in a nonstick pan, then pour into a small heatproof bowl. Put the pan to one side, but don’t wash it up – you’ll use it again later, to cook the pancakes. Add the five spice, the two extra tablespoons of flour and a quarter-teaspoon of salt to the melted oil, stir to combine and set aside.</p>',
-					elementId: '83f952ba-a037-451a-95bc-5f675e4cfd65',
+					elementId: '7ec73526-9a2e-437a-8625-e67957241cff',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Mix all the sauce ingredients in a small bowl, add two tablespoons of cold water to loosen it a little, and set aside.</p>',
-					elementId: '43e32b60-9fb3-4c9c-9905-97ad103265a2',
+					elementId: 'f0892899-4740-4992-ac49-c43ab9fba9e6',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Once the dough has rested, rub a little coconut oil on a worktop and on a rolling pin, then roll the dough into a roughly 20cm x 30cm rectangle. Spread the five spice mix evenly over the top (take care not to tear the dough) and sprinkle the sliced spring onions on top of that. Starting at one short end of the dough rectangle, roll up the whole thing into a tight cigar. Move the dough sausage so it’s horizontally in line with the edge of the worktop, then cut into four even slices. Put the slices cut side down on the worktop and, using the greased rolling pin, gently press each slice into a round pancake shape measuring about 13cm across.</p>',
-					elementId: '7c3c818e-29fa-4c25-b4db-969bdea93ff0',
+					elementId: '76ddbc2d-5fc0-4573-9d33-a7313ba1010c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>When you are ready to cook the pancakes, melt two tablespoons of coconut oil in the nonstick pan, gently lift in one pancake and cook for three to four minutes on each side, until golden brown all over. Remove from the pan and keep somewhere warm while you repeat with the remaining oil and pancakes (keep a close eye on the heat under the pan – you may need to reduce it to make sure the pan doesn’t get too hot).</p>',
-					elementId: '9b9d744f-17f1-42d6-8fe8-247111be9a45',
+					elementId: 'd1856ba5-280d-4d21-8bb2-1a8e341f7730',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Serve the pancakes hot with the sauce for dipping or drizzling over the top.</p>',
-					elementId: 'ee966c20-b84d-4181-ae37-3d7f075966de',
+					elementId: 'fe0161ea-c697-44e6-b79c-a0f5384816cf',
 				},
 			],
 			attributes: {
@@ -1776,7 +1833,7 @@ export const Recipe: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/food/2021/feb/06/meera-sodhas-vegan-recipe-for-spring-onion-pancakes',
+			'@id': 'https://www.theguardian.com/food/2021/feb/06/meera-sodhas-vegan-recipe-for-spring-onion-pancakes',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -27,61 +27,6 @@ export const Review: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'tn',
-					value: ['reviews'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'k',
-					value: [
-						'tv-and-radio',
-						'asa-butterfield',
-						'sex',
-						'youngpeople',
-						'sex-education',
-						'comedy',
-						'gillian-anderson',
-						'netflix',
-						'culture',
-						'television',
-					],
-				},
-				{
-					name: 'url',
-					value: '/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/d4zdy',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'se',
-					value: ['tv-review'],
-				},
-				{
-					name: 'co',
-					value: ['lucymangan'],
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -192,6 +137,61 @@ export const Review: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'tn',
+					value: ['reviews'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'tv-and-radio',
+						'asa-butterfield',
+						'sex',
+						'youngpeople',
+						'sex-education',
+						'comedy',
+						'gillian-anderson',
+						'netflix',
+						'culture',
+						'television',
+					],
+				},
+				{
+					name: 'url',
+					value: '/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d4zdy',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'se',
+					value: ['tv-review'],
+				},
+				{
+					name: 'co',
+					value: ['lucymangan'],
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -232,6 +232,61 @@ export const Review: CAPIArticleType = {
 				{
 					name: 'edition',
 					value: 'int',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'se',
+					value: ['tv-review'],
+				},
+				{
+					name: 'co',
+					value: ['lucymangan'],
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'tn',
+					value: ['reviews'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'k',
+					value: [
+						'tv-and-radio',
+						'asa-butterfield',
+						'sex',
+						'youngpeople',
+						'sex-education',
+						'comedy',
+						'gillian-anderson',
+						'netflix',
+						'culture',
+						'television',
+					],
+				},
+				{
+					name: 'url',
+					value: '/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/d4zdy',
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 				{
 					name: 'p',
@@ -936,6 +991,10 @@ export const Review: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1666,7 +1725,7 @@ export const Review: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '5ee30452-184d-402f-8d55-13136b5ccbe3',
+			elementId: '6c7b56d7-bf1d-4c87-a9b1-e0b7d1bd3a00',
 		},
 	],
 	canonicalUrl:
@@ -1678,12 +1737,12 @@ export const Review: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The new season of <a href="https://www.theguardian.com/tv-and-radio/2019/jan/17/sex-education-asa-butterfield-gillian-anderson-netflix">Sex Education</a> (Netflix) opens with a bravura sequence that swiftly takes its place in the pantheon of peen-based comedy greats. Suffice to say that since we left Otis at the end of the <a href="https://www.theguardian.com/tv-and-radio/2019/jan/11/sex-education-review-netflix-asa-butterfield-gillian-anderson">glorious inaugural run</a> having successfully masturbated for the first time, he has taken gleefully to his new hobby and – I don’t know if you know the French expression to encourage reluctant diners, “the appetite comes with eating”? – but we need to come up with the carnal equivalent for his joyful daily pursuits of the big O.</p>',
-					elementId: 'd830f06e-5668-4ce9-ad82-8ff87103332d',
+					elementId: 'f609b2ca-078d-4d31-96f7-d2f5b9bb1a6a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The scene establishes the tone of the new season – furiously fast, furiously funny, and not for the faint of heart any more than the first series was. And, just like the first series, it underpins the comedy arising from the sixth form students’ sexual escapades, experiments and baffled queries (“My cum tastes like kimchi! Why do I have a fermented dick?”) with deeper explorations of the main characters and the emotional pressures engendered by bigger problems.</p>',
-					elementId: '1115b5cf-df86-48b2-b968-dd11be07ce33',
+					elementId: 'cfbe091e-534b-4a22-b739-880b16438430',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
@@ -1698,12 +1757,12 @@ export const Review: CAPIArticleType = {
 					isThirdPartyTracking: false,
 					source: 'YouTube',
 					sourceDomain: 'youtube-nocookie.com',
-					elementId: '8112af25-b7d0-42b6-aa90-7f061c97f1f5',
+					elementId: '4fdd5fdd-081e-4417-bbf5-2a99d10d2ddf',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>With the help of Miss Sands, Maeve (Emma Mackey) finagles her way back into school and the special ability programme. All she has to do thereafter is wrestle with her unwelcoming and far more privileged peers and the return of her errant mother Erin (Anne-Marie Duff), allegedly clean for a year and with a three-year-old half-sister in tow. Otis (<a href="https://www.theguardian.com/tv-and-radio/2019/dec/28/sex-education-asa-butterfield-feel-more-confident-talking-about-sex">Asa Butterfield</a>) must negotiate his new relationship with Ola (Patricia Allison) while his mother Jean (Gillian Anderson, given a whole heap more to do this time round and rightly relishing every moment) throws more spanners in to his sexual works by dating Ola’s dad. Adam – poor beleaguered Adam (Connor Swindells) – is unjustly expelled from military school and sent back home to a dead-end job and his ever more hateful father. Swindells gives an extraordinary performance with what amounts to barely a hundred lines in the entire eight episodes, and if your heart doesn’t break at at least three points for him then I have no use for you. I don’t want to spoil Eric’s storyline because it doesn’t get going until a few episodes in, but <a href="https://www.theguardian.com/culture/2020/jan/05/ncuti-gatwa-i-will-say-yes-to-anything-sex-education">Ncuti Gatwa</a> remains the find of the age and handles everything thrown at him with such deftness and authenticity that you can only boggle at the fact that Laurie Nunn’s creation is his first major role.</p>',
-					elementId: '8ca65c28-55cd-45bd-b108-35746fc20e82',
+					elementId: '41255593-188f-44b7-8fd9-dddcb2976e6b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2012,17 +2071,17 @@ export const Review: CAPIArticleType = {
 							],
 						},
 					],
-					elementId: '7c9d9eaa-8fc4-4953-b40c-0cc66b73fa36',
+					elementId: '9624fd45-fd48-48ef-9895-0be6e010ea6a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Every performer is wonderful, not least because the script is wonderful, playing the sex for laughs and the search for intimacy as something serious, good and noble. Not a single character is a cipher – even the smallest parts have a sketched backstory and some good gags. It’s all of a piece with the charm and generosity of spirit that suffuses the whole thing. <a href="https://www.theguardian.com/tv-and-radio/sex-education" data-component="auto-linked-tag">Sex Education</a> sets so many conventions cheerily but firmly aside that you feel like an entire forest of received wisdom is being clear-cut. Light floods in, new growth springs up. Such a sense of revelry and optimism abounds that you can feel it doing your heart and soul good as you watch. And all without missing a comic or emotional beat or deviating from its moral core, which urges us all to connect.</p>',
-					elementId: 'b38551f0-3a5e-4f2c-b994-c3e48de3465f',
+					elementId: '139877ab-b4ea-4b50-93f0-7008b3836033',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>So welcome once more, Otis (and your newly excitable penis), Maeve with her troubles to seek, Jackson (Kedar Williams-Stirling) whose mental health plummets to new lows as his swimming career reaches new heights, Aimee through whose experience on a local bus the issue of sexual assault is channelled, and all the magnificent rest of you. Nobody does it better. In fact, nobody does anything quite like it at all.</p>',
-					elementId: '331e44c5-6b85-4f17-9625-64ec1c231723',
+					elementId: '766e75d4-353d-47d4-80bf-2f4132f19eff',
 				},
 			],
 			attributes: {
@@ -2046,7 +2105,7 @@ export const Review: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix',
+			'@id': 'https://www.theguardian.com/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -27,69 +27,6 @@ export const SpecialReport: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'co',
-					value: [
-						'patrick-greenfield',
-						'jonathanwatts',
-						'damiancarrington',
-						'fiona-harvey',
-					],
-				},
-				{
-					name: 'k',
-					value: [
-						'climate-crisis',
-						'business',
-						'fossil-fuels',
-						'oilandgascompanies',
-						'energy',
-						'energy-industry',
-						'carbon-capture-and-storage',
-						'carbon-tax',
-						'coal',
-						'environment',
-						'renewableenergy',
-						'carbon-emissions',
-						'fossil-fuel-divestment',
-					],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'tn',
-					value: ['analysis'],
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'url',
-					value: '/environment/2019/oct/14/how-rein-in-fossil-fuel-industry-eight-ideas',
-				},
-				{
-					name: 'se',
-					value: ['the-polluters'],
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/cekky',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -216,6 +153,69 @@ export const SpecialReport: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: [
+						'patrick-greenfield',
+						'jonathanwatts',
+						'damiancarrington',
+						'fiona-harvey',
+					],
+				},
+				{
+					name: 'k',
+					value: [
+						'climate-crisis',
+						'business',
+						'fossil-fuels',
+						'oilandgascompanies',
+						'energy',
+						'energy-industry',
+						'carbon-capture-and-storage',
+						'carbon-tax',
+						'coal',
+						'environment',
+						'renewableenergy',
+						'carbon-emissions',
+						'fossil-fuel-divestment',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'tn',
+					value: ['analysis'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/environment/2019/oct/14/how-rein-in-fossil-fuel-industry-eight-ideas',
+				},
+				{
+					name: 'se',
+					value: ['the-polluters'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/cekky',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -276,6 +276,69 @@ export const SpecialReport: CAPIArticleType = {
 				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/cekky',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'co',
+					value: [
+						'patrick-greenfield',
+						'jonathanwatts',
+						'damiancarrington',
+						'fiona-harvey',
+					],
+				},
+				{
+					name: 'k',
+					value: [
+						'climate-crisis',
+						'business',
+						'fossil-fuels',
+						'oilandgascompanies',
+						'energy',
+						'energy-industry',
+						'carbon-capture-and-storage',
+						'carbon-tax',
+						'coal',
+						'environment',
+						'renewableenergy',
+						'carbon-emissions',
+						'fossil-fuel-divestment',
+					],
+				},
+				{
+					name: 'tn',
+					value: ['analysis'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'url',
+					value: '/environment/2019/oct/14/how-rein-in-fossil-fuel-industry-eight-ideas',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/cekky',
+				},
+				{
+					name: 'se',
+					value: ['the-polluters'],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -968,6 +1031,10 @@ export const SpecialReport: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1966,7 +2033,7 @@ export const SpecialReport: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: 'f726e8b3-e3ab-4555-b6a8-63c9e9e963fb',
+			elementId: 'c0b8e75c-475b-455e-a5cf-d9934b0d9a7d',
 		},
 	],
 	canonicalUrl:
@@ -1978,22 +2045,22 @@ export const SpecialReport: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Put climate on the ballot paper</strong></h2>',
-					elementId: '7a9a6de6-146e-4136-9ce4-c6b6f4f18cf7',
+					elementId: '0acf3c78-26ff-4af6-9ed1-c6a23f762d03',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Individual actions, such as flying less or buying electric cars, are helpful, but they will be futile without collective political action to slash emissions on a corporate, national and global scale. Politicians need to feel this is a priority for the electorate. That means keeping the subject high on the agenda for MPs with questions, protests, emails, social media posts, lobbying by NGOs and most of all through voting choices. Politicians need to know the public is behind them if they are to take on the petrochemical industry.</p>',
-					elementId: '0517a264-93ab-4462-80d7-100e26a20889',
+					elementId: '68508d52-e481-4243-be1c-819daf908368',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>End</strong><strong> fossil fuel subsidies</strong></h2>',
-					elementId: '2dd04dfa-a485-42b6-97e7-8999d2904261',
+					elementId: '599d0925-833a-4677-8f5d-9ad3ed525a8a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The coal, oil and gas industries benefit from <a href="https://www.imf.org/en/Publications/WP/Issues/2019/05/02/Global-Fossil-Fuel-Subsidies-Remain-Large-An-Update-Based-on-Country-Level-Estimates-46509">$5tn dollars a year</a> – $10m a minute – according to the International Monetary Fund, which described its own estimate as “shocking”. Even <a href="https://www.iea.org/newsroom/news/2019/june/fossil-fuel-consumption-subsidies-bounced-back-strongly-in-2018.html">direct consumption subsidies for fossil fuels</a> are double those for renewables, which the International Energy Agency says “greatly complicates the task” of tackling the climate crisis. The biggest subsidisers, the G20 nations, pledged in 2009 to end the handouts, but progress has been very limited. The UN secretary general, António Guterres, <a href="https://uk.reuters.com/article/global-climatechange-energy/fossil-fuel-subsidies-are-wrecking-the-world-says-u-n-chief-idUKL8N2345F6">attacked</a> the incentives in May, saying: “What we are doing is using taxpayers’ money … to destroy the world.” Any change has to include provisions for social justice. Cuts in fuel subsidies should not be used as an austerity measure that hurts the poor most.</p>',
-					elementId: 'ed663fcd-fceb-4cfb-9f8e-0aef47067dce',
+					elementId: 'a2bcaa03-c680-4416-ac6d-954e632add9e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.QABlockElement',
@@ -2001,62 +2068,62 @@ export const SpecialReport: CAPIArticleType = {
 					title: 'What is the polluters project?',
 					html: '<p>The Guardian has collaborated with leading scientists and NGOs to expose, with exclusive data, investigations and analysis, the fossil fuel companies that are perpetuating the climate crisis – some of which have accelerated their extraction of coal, oil and gas even as the devastating impact on the planet and humanity was becoming clear.<br></p><p>The investigation has involved more than 20 Guardian journalists working across the world for the past six months.</p><p>The project focuses on what the companies have extracted from the ground, and the subsequent emissions they are responsible for, since 1965. The analysis, undertaken by Richard Heede at the <a href="http://climateaccountability.org/">Climate Accountability Institute</a>,&nbsp;calculates how much carbon is emitted throughout the supply chain, from extraction to use by consumers. Heede said: "The fact that consumers combust the fuels to carbon dioxide, water, heat and pollutants does not absolve the fossil fuel companies from responsibility for knowingly perpetuating the carbon era and accelerating the climate crisis toward the existential threat it has now become."</p><p>One aim of the project is to move the focus of debate from individual responsibilities to power structures – so our reporters also examined the financial and lobbying structures that let fossil fuel firms keep growing, and discovered which elected politicians were voting for change.&nbsp;</p><p>Another aim of the project is to press governments and corporations to close the gap between ambitious long-term promises and lacklustre short-term action. The UN says the coming decade is crucial if the world is to avoid the most catastrophic consequences of global heating. Reining in our dependence on fossil fuels and dramatically accelerating the transition to renewable energy has never been more urgent.</p>',
 					credit: '',
-					elementId: '29803c10-79c0-4ef7-9b59-82a7796894f3',
+					elementId: 'e5d567b4-c9a5-46b6-898f-4968553a4f15',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Put a price on carbon</strong></h2>',
-					elementId: '72a06208-0c20-4538-874b-1b459d53956e',
+					elementId: '9af089c0-0c3d-480f-94e7-12da806a9521',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The idea of putting a price on carbon has been around since the early 1990s and a cap-and-trade system was incorporated into the 1997 Kyoto protocol. Under cap-and-trade, a limit is set on emissions and businesses issued with permits to emit carbon. Those cutting their emissions fastest can sell spare permits to laggards, while the cap is ratcheted down over time. But success depends on a strict cap and a scarcity of permits, and <a href="https://www.carbonbrief.org/qa-will-reformed-eu-emissions-trading-system-raise-carbon-prices">the EU’s scheme</a> has been widely criticised. An alternative is a tax, which forces companies to factor the damage caused by climate change into their business decisions, and should encourage them to cut waste, cut emissions and use clean technology. The danger is of carbon leakage: that the extra cost in one country might encourage businesses to look elsewhere to site their factories. This can be dealt with by a border adjustment tax, as the <a href="https://uk.reuters.com/article/uk-eu-commission-timmermans-border-tax/incoming-top-eu-climate-official-pledges-to-tax-polluting-imports-idUKKBN1WN23F">EU’s new commissioner pledged</a> this week. Carbon taxes don’t have to create economic losers, either – <a href="https://www.theguardian.com/world/2018/dec/04/how-to-make-a-carbon-tax-popular-give-the-profits-to-the-people">revenue neutral taxes</a> redistribute the money to the people and are advocated by many.<strong>Scale back demand for fossil fuels</strong></p>',
-					elementId: '43c73913-6683-4815-8e7f-deddc34f6d66',
+					elementId: 'bae416d2-2551-4fad-b9e7-78571ed48087',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Oil companies will sell oil for as long as there are buyers. Public shaming and social and political pressure can work to force companies to own up to their activities but most oil and gas around the world is produced by <a href="https://www.theguardian.com/environment/2019/oct/09/secretive-national-oil-companies-climate">national oil companies</a>, and they need no social licence to operate beyond that granted by their governments, which are often autocratic or unresponsive to public opinion. All companies are responsive to economic pressure, however. The only way to cut emissions from oil in the long term is to stop using oil. Reducing demand is driven by government regulation and by technological development (also driven by regulation), such as cheaper solar panels, offshore windfarms, electric cars and improved public transport.</p>',
-					elementId: '1d748183-96db-421a-be8f-70c22a9ca680',
+					elementId: '5d4fd90a-258a-4348-83e0-455e2cdc4cc4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Stop flaring</strong></h2>',
-					elementId: 'fbddb56e-1a27-4663-8082-10cd4c468c9e',
+					elementId: '1480f900-64c3-4a44-8a97-67cefa15ca78',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>If oil and gas are to be extracted, the least oil companies can do is extract efficiently. The <a href="https://www.worldbank.org/en/programs/zero-routine-flaring-by-2030">World Bank has estimated</a> that the amount of gas wastefully flared globally each year, if used for power generation instead, could supply all of Africa’s electricity needs. <a href="https://www.ft.com/content/6f8f334e-0ebd-11e9-a3aa-118c761d2745">The FT</a> reported earlier this year that flaring in Texas was lighting up the night sky as producers let off the gas to get the oil to market quickly, to turn a faster buck regardless of the environmental consequences. The World Bank wants an end to routine flaring globally by 2030 – yet <a href="https://www.worldbank.org/en/programs/gasflaringreduction#7">in 2018 it increased</a>. </p>',
-					elementId: '95ad658f-6783-4a1c-b951-584b708022d8',
+					elementId: '63922cc6-a719-4374-9dad-6db5debd4c26',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Roll out large scale carbon capture and storage</strong></h2>',
-					elementId: 'da5f7be6-8d32-4eed-b00c-a93cabbcf754',
+					elementId: '48dca554-6f3c-420c-873b-319dcce2dbb3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Trapping and burying the CO2 from fossil fuel burning is possible but not yet deployed at scale. Without this, the Intergovernmental Panel on Climate Change says tackling the climate crisis will be much more expensive. Oil companies have the expertise to roll out CCS but say that without a price on carbon emissions there is no commercial incentive. CCS could be used to actually remove CO2 from the atmosphere by growing trees and plants, burning them for electricity, then sequestering the emissions. But the IPCC has warned that doing this at large scale could conflict with growing food.</p>',
-					elementId: '728a0e9a-bbfb-45d3-ba04-165ef087610c',
+					elementId: '0d8de6ac-a747-491f-afa8-f8e77a29ac41',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Halt investment in fossil fuels</strong></h2>',
-					elementId: '622a162c-325a-4442-acb9-5602f4cdeeff',
+					elementId: 'a42b09f6-f855-44b3-a5fc-3b1b8baa9f07',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The energy transition poses many risks and opportunities for investors, but it cannot be that well-intentioned savers seeking to use their money to support renewable energy businesses and divest from fossil fuels are still inadvertently investing in oil, gas and coal companies. Green investing must be regulated to ensure it really is green.</p>',
-					elementId: 'fd08cb49-3c9b-4ac5-a4c8-a03fb92fdf3f',
+					elementId: '54ec3e79-f40c-49d0-8e31-fdfa7736b534',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
 					html: '<h2><strong>Establish market metrics on climate change</strong></h2>',
-					elementId: '43432986-427d-43f4-a114-2c5ecb8bdf66',
+					elementId: '2be1d90c-b3c9-4097-9cfd-27228c987333',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Nearly three years after the Paris agreement, world markets still have no mandatory, comparable data to measure the risks posed by the climate crisis at a company level. Regulators must act urgently – slow-moving voluntary schemes are not enough. Last week, <a href="https://www.theguardian.com/business/2019/oct/08/corporations-told-to-draw-up-climate-rules-or-have-them-imposed">the governor of the Bank of England warned</a> major corporations that they had two years to agree rules for reporting climate risks before global regulators devised their own and made them compulsory. If markets do not understand what climate change really means for car manufacturers, fossil fuel companies and energy firms, a climate-induced financial crisis is just a matter of time. Investment in fossil fuels must end. The <a href="https://gofossilfree.org/divestment/commitments/">fossil fuel divestment movement</a> now has $11.5tn of assets under management committed to divestment.</p>',
-					elementId: 'a2aac138-372d-436f-a3f0-606c6999f059',
+					elementId: '663667c2-c184-449f-b443-7da8d6450afa',
 				},
 			],
 			attributes: {
@@ -2080,7 +2147,7 @@ export const SpecialReport: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/environment/2019/oct/14/how-rein-in-fossil-fuel-industry-eight-ideas',
+			'@id': 'https://www.theguardian.com/environment/2019/oct/14/how-rein-in-fossil-fuel-industry-eight-ideas',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Standard.ts
@@ -27,63 +27,6 @@ export const Standard: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['glenn-greenwald-security-liberty'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['news'],
-				},
-				{
-					name: 'co',
-					value: ['glenn-greenwald'],
-				},
-				{
-					name: 'k',
-					value: [
-						'business',
-						'us-national-security',
-						'world',
-						'data-protection',
-						'us-politics',
-						'technology',
-						'nsa',
-						'telecoms',
-						'privacy',
-						'the-nsa-files',
-						'verizon-communications',
-						'us-news',
-					],
-				},
-				{
-					name: 'url',
-					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/3gc62',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -198,6 +141,63 @@ export const Standard: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -252,6 +252,63 @@ export const Standard: CAPIArticleType = {
 				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -944,6 +1001,10 @@ export const Standard: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1749,7 +1810,7 @@ export const Standard: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '9a60ae2e-c37b-4572-bd56-b6491cf1f0e0',
+			elementId: 'fb1db287-b9c7-430d-871e-24045275513f',
 		},
 	],
 	canonicalUrl:
@@ -1761,152 +1822,152 @@ export const Standard: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The National Security Agency is currently collecting the telephone records of millions of US customers of Verizon, one of America's largest telecoms providers, under a top secret court order issued in April.</p>",
-					elementId: 'b25402d0-a70e-41cd-be43-eba25fa5452c',
+					elementId: '65c05e34-9a10-4803-bdf7-289260644a5f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, a copy of which has been obtained by the Guardian, <a href="https://www.theguardian.com/world/interactive/2013/jun/06/verizon-telephone-data-court-order">requires Verizon on an "ongoing, daily basis" to give the NSA information on all telephone calls in its systems</a>, both within the US and between the US and other countries.</p>',
-					elementId: '302ba45f-db0b-4e79-ad8b-48f8c168a7f4',
+					elementId: '6976c2fe-24ee-40c3-b401-eab47fb36bd4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The document shows for the first time that under the Obama administration the communication records of millions of US citizens are being collected indiscriminately and in bulk – regardless of whether they are suspected of any wrongdoing.</p>',
-					elementId: 'e9b6ae3f-19db-4941-a322-168548a0e60a',
+					elementId: 'f3f7d4dc-afc4-4a29-8ed9-bbadb3b6606d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The secret Foreign Intelligence Surveillance Court (Fisa) granted the order to the FBI on April 25, giving the government unlimited authority to obtain the data for a specified three-month period ending on July 19.</p>',
-					elementId: 'cdbfc91b-cfbd-409a-8141-92989618dc17',
+					elementId: 'c09ed46f-a63f-4c8c-b3f6-2b85a5e13674',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the terms of the blanket order, the numbers of both parties on a call are handed over, as is location data, call duration, unique identifiers, and the time and duration of all calls. The contents of the conversation itself are not covered.</p>',
-					elementId: '5976bd6e-9bc9-4e34-9100-dfa4f9c38fad',
+					elementId: '51a270c7-a1f5-46d7-8000-660b4e115099',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The disclosure is likely to reignite longstanding debates in the US over the proper extent of the government's domestic spying powers.</p>",
-					elementId: '8106a247-e5b3-4d4f-a273-be150c73da9d',
+					elementId: 'fd586067-7dec-4b52-b576-28c7916b1b32',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the Bush administration, officials in security agencies had disclosed to reporters the large-scale collection of call records data by the <a href="https://www.theguardian.com/us-news/nsa" data-component="auto-linked-tag">NSA</a>, but this is the first time significant and top-secret documents have revealed the continuation of the practice on a massive scale under President Obama.</p>',
-					elementId: '95202c92-5706-4120-8838-bf3abcacbbce',
+					elementId: '2e3c152c-96cc-4f11-9f8b-00c793c71efb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The unlimited nature of the records being handed over to the NSA is extremely unusual. Fisa court orders typically direct the production of records pertaining to a specific named target who is suspected of being an agent of a terrorist group or foreign state, or a finite set of individually named targets.</p>',
-					elementId: '469ae25d-c8bd-4fde-a429-c05ed881f7ec',
+					elementId: '81b0a5bf-fb6f-425f-b1e4-9920073b7ea0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Guardian approached the National Security Agency, the White House and the Department of Justice for comment in advance of publication on Wednesday. All declined. The agencies were also offered the opportunity to raise specific security concerns regarding the publication of the court order.</p>',
-					elementId: '84390e0b-d07b-4e58-abea-297149911825',
+					elementId: '7c1ca8d2-aba3-4f32-88c1-d8a16ce42beb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order expressly bars Verizon from disclosing to the public either the existence of the FBI's request for its customers' records, or the court order itself. </p>",
-					elementId: '80256454-3e38-4214-afae-6744e06f3a33',
+					elementId: '1ff59311-8abb-4888-aba7-7905ccc42eb9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We decline comment," said Ed McFadden, a Washington-based Verizon spokesman.</p>',
-					elementId: '9ad5a963-dc1b-4191-8840-83922959eb27',
+					elementId: 'c1415bb8-a223-4642-b106-29cb1dd6a8b3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, signed by Judge Roger Vinson, compels Verizon to produce to the NSA electronic copies of "all call detail records or \'telephony metadata\' created by Verizon for communications between the United States and abroad" or "wholly within the United States, including local telephone calls".</p>',
-					elementId: 'ed4ef717-b7f2-44bc-8381-26564cb15184',
+					elementId: '1f3a30a0-1915-4eb4-bc5d-dca7b25aac53',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order directs Verizon to "continue production on an ongoing daily basis thereafter for the duration of this order". It specifies that the records to be produced include "session identifying information", such as "originating and terminating number", the duration of each call, telephone calling card numbers, trunk identifiers, International Mobile Subscriber Identity (IMSI) number, and "comprehensive communication routing information".</p>',
-					elementId: '5bf1199e-5e02-4fd8-b464-0189e2942ac6',
+					elementId: '88ec42d3-82ea-4655-afed-17ebf941e0e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The information is classed as "metadata", or transactional information, rather than communications, and so does not require individual warrants to access. The document also specifies that such "metadata" is not limited to the aforementioned items. A 2005 court ruling judged that cell site location data – the nearest cell tower a phone was connected to – was also transactional data, and so could potentially fall under the scope of the order.</p>',
-					elementId: '5eb4c267-6c6d-49ee-b911-d4af9060d798',
+					elementId: '70f20e34-5f7e-4bad-9ba0-0a08dffa2b24',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>While the order itself does not include either the contents of messages or the personal information of the subscriber of any particular cell number, its collection would allow the NSA to build easily a comprehensive picture of who any individual contacted, how and when, and possibly from where, retrospectively.</p>',
-					elementId: '1df91e80-f1c3-467a-a65a-3db248256f39',
+					elementId: '4e3c0270-8779-473c-81f6-ab8940559e6c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It is not known whether Verizon is the only cell-phone provider to be targeted with such an order, although previous reporting has suggested the NSA has collected cell records from all major mobile networks. It is also unclear from the leaked document whether the three-month order was a one-off, or the latest in a series of similar orders.</p>',
-					elementId: 'a2bd8cc3-7c5d-4b64-88d1-7f65b7ce21cb',
+					elementId: 'a5e97dcd-f8af-4d8b-a469-fb1d754c3393',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order appears to explain the numerous cryptic public warnings by two US senators, Ron Wyden and Mark Udall, about the scope of the Obama administration's surveillance activities.</p>",
-					elementId: 'e2803709-76fd-4a89-86f1-d050d4ef1888',
+					elementId: '37b8e4a7-2992-475e-9c2f-a61269cc7b4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For roughly two years, the two Democrats have been stridently advising the public that the US government is relying on "secret legal interpretations" to claim surveillance powers so broad that the American public would be "stunned" to learn of the kind of domestic spying being conducted.</p>',
-					elementId: '626a1ccf-8abc-46c1-90e3-988bbc34d5c1',
+					elementId: '0c59ec83-42aa-442b-aa07-5fb13eef369b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Because those activities are classified, the senators, both members of the Senate intelligence committee, have been prevented from specifying which domestic surveillance programs they find so alarming. But the information they have been able to disclose in their public warnings perfectly tracks both the specific law cited by the April 25 court order as well as the vast scope of record-gathering it authorized.</p>',
-					elementId: '8ef8d6de-3bdf-4196-9b70-5972a1fc12c7',
+					elementId: 'ef897c27-aa74-4475-a242-7d7f69bc6581',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Julian Sanchez, a surveillance expert with the Cato Institute, explained: \"We've certainly seen the government increasingly strain the bounds of 'relevance' to collect large numbers of records at once — everyone at one or two degrees of separation from a target — but vacuuming all metadata up indiscriminately would be an extraordinary repudiation of any pretence of constraint or particularized suspicion.\" The April order requested by the FBI and NSA does precisely that.</p>",
-					elementId: '49c19dd0-03a8-426d-9a1d-d70d438b5ffa',
+					elementId: 'efa50f1b-37b4-4c8c-9567-671fcb58cf75',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The law on which the order explicitly relies is the so-called "business records" provision of the Patriot Act, 50 USC section 1861. That is the provision which Wyden and Udall have repeatedly cited when warning the public of what they believe is the Obama administration\'s extreme interpretation of the law to engage in excessive domestic surveillance.</p>',
-					elementId: 'd78ddce3-37de-417c-9200-1604c5fe84a9',
+					elementId: '750355d7-c80c-4d71-a764-7f3409082d7a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In a letter to attorney general Eric Holder last year, they argued that "there is now a significant gap between what most Americans <em>think</em> the law allows and what the government secretly <em>claims</em> the law allows."</p>',
-					elementId: '6e8421db-9681-418c-a932-da8cf707235b',
+					elementId: '60b5f816-a078-4ff5-9660-b8a9de32d90e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We believe," they wrote, "that most Americans would be stunned to learn the details of how these secret court opinions have interpreted" the "business records" provision of the Patriot Act.</p>',
-					elementId: 'ed4b3ee1-6ea0-4198-abd8-a7abbd4344eb',
+					elementId: '5492dbad-205a-41b5-bbfd-76002727c742',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Privacy advocates have long warned that allowing the government to collect and store unlimited "metadata" is a highly invasive form of surveillance of citizens\' communications activities. Those records enable the government to know the identity of every person with whom an individual communicates electronically, how long they spoke, and their location at the time of the communication.</p>',
-					elementId: 'f415cf62-f8dd-4b07-b587-f7e86c7409e9',
+					elementId: '70a55761-a463-4002-84ab-a19fc43ce8cd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Such metadata is what the US government has long attempted to obtain in order to discover an individual's network of associations and communication patterns. The request for the bulk collection of all Verizon domestic telephone records indicates that the agency is continuing some version of the data-mining program begun by the Bush administration in the immediate aftermath of the 9/11 attack.</p>",
-					elementId: '03d11233-c71a-44eb-a29b-4fb0ebab664c',
+					elementId: '419ce3e8-ac48-4f2b-be9a-2dcda2bb4be2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The NSA, as part of a program secretly authorized by President Bush on 4 October 2001, implemented a bulk collection program of domestic telephone, internet and email records. A furore erupted in 2006 when USA Today reported that the NSA had "been secretly collecting the phone call records of tens of millions of Americans, using data provided by AT&amp;T, Verizon and BellSouth" and was "using the data to analyze calling patterns in an effort to detect terrorist activity." Until now, there has been no indication that the Obama administration implemented a similar program.</p>',
-					elementId: '89002817-a745-4d6b-a6de-8d9a0197d020',
+					elementId: '3827b42e-7171-4126-ba7c-d56d8211c591',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>These recent events reflect how profoundly the NSA's mission has transformed from an agency exclusively devoted to foreign intelligence gathering, into one that focuses increasingly on domestic communications. A 30-year employee of the NSA, William Binney, resigned from the agency shortly after 9/11 in protest at the agency's focus on domestic activities.</p>",
-					elementId: 'c906f4e6-1da1-48bd-a5c4-016604366fd2',
+					elementId: '22b9561e-79c8-42ab-b75c-4511a176327c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In the mid-1970s, Congress, for the first time, investigated the surveillance activities of the US government. Back then, the mandate of the NSA was that it would never direct its surveillance apparatus domestically.</p>',
-					elementId: '0d96ddae-9b0b-4fd4-b244-f90eed6c0827',
+					elementId: 'e8ea0b57-f404-47b2-aa3d-496fc8a27150',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>At the conclusion of that investigation, Frank Church, the Democratic senator from Idaho who chaired the investigative committee, warned: "The NSA\'s capability at any time could be turned around on the American people, and no American would have any privacy left, such is the capability to monitor everything: telephone conversations, telegrams, it doesn\'t matter."</p>',
-					elementId: '8999c0ab-decc-403f-94dd-a50cbc026349',
+					elementId: '635654ed-4091-4bdb-9b1f-65d81b9a1a83',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Additional reporting by Ewen MacAskill and Spencer Ackerman</em></p>',
-					elementId: 'd4ad39be-43ae-4590-9f37-8218ec1db7f1',
+					elementId: 'c08571e7-f5e3-4870-a14c-d5e303485cf6',
 				},
 			],
 			attributes: {
@@ -1927,7 +1988,7 @@ export const Standard: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+			'@id': 'https://www.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Video.ts
@@ -27,63 +27,6 @@ export const Video: CAPIArticleType = {
 		},
 	],
 	commercialProperties: {
-		UK: {
-			adTargeting: [
-				{
-					name: 'su',
-					value: ['0'],
-				},
-				{
-					name: 'se',
-					value: ['glenn-greenwald-security-liberty'],
-				},
-				{
-					name: 'edition',
-					value: 'uk',
-				},
-				{
-					name: 'ct',
-					value: 'article',
-				},
-				{
-					name: 'tn',
-					value: ['news'],
-				},
-				{
-					name: 'co',
-					value: ['glenn-greenwald'],
-				},
-				{
-					name: 'k',
-					value: [
-						'business',
-						'us-national-security',
-						'world',
-						'data-protection',
-						'us-politics',
-						'technology',
-						'nsa',
-						'telecoms',
-						'privacy',
-						'the-nsa-files',
-						'verizon-communications',
-						'us-news',
-					],
-				},
-				{
-					name: 'url',
-					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
-				},
-				{
-					name: 'p',
-					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/3gc62',
-				},
-			],
-		},
 		US: {
 			adTargeting: [
 				{
@@ -198,6 +141,63 @@ export const Video: CAPIArticleType = {
 				},
 			],
 		},
+		UK: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'edition',
+					value: 'uk',
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
 		INT: {
 			adTargeting: [
 				{
@@ -252,6 +252,63 @@ export const Video: CAPIArticleType = {
 				{
 					name: 'sh',
 					value: 'https://www.theguardian.com/p/3gc62',
+				},
+			],
+		},
+		EUR: {
+			adTargeting: [
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'se',
+					value: ['glenn-greenwald-security-liberty'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'tn',
+					value: ['news'],
+				},
+				{
+					name: 'co',
+					value: ['glenn-greenwald'],
+				},
+				{
+					name: 'url',
+					value: '/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/3gc62',
+				},
+				{
+					name: 'k',
+					value: [
+						'business',
+						'us-national-security',
+						'world',
+						'data-protection',
+						'us-politics',
+						'technology',
+						'nsa',
+						'telecoms',
+						'privacy',
+						'the-nsa-files',
+						'verizon-communications',
+						'us-news',
+					],
+				},
+				{
+					name: 'edition',
+					value: 'eur',
 				},
 			],
 		},
@@ -944,6 +1001,10 @@ export const Video: CAPIArticleType = {
 						url: '/crosswords/series/azed',
 					},
 				],
+			},
+			{
+				title: 'Corrections',
+				url: '/theguardian/series/corrections-and-clarifications',
 			},
 		],
 		brandExtensions: [
@@ -1749,7 +1810,7 @@ export const Video: CAPIArticleType = {
 					],
 				},
 			],
-			elementId: '5f811d8d-b6df-4f0d-8302-12ad9f4f7d85',
+			elementId: 'fb1db287-b9c7-430d-871e-24045275513f',
 		},
 	],
 	canonicalUrl:
@@ -1761,152 +1822,152 @@ export const Video: CAPIArticleType = {
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The National Security Agency is currently collecting the telephone records of millions of US customers of Verizon, one of America's largest telecoms providers, under a top secret court order issued in April.</p>",
-					elementId: '06211056-acd3-4d0f-9ba9-39bf172e02ca',
+					elementId: '65c05e34-9a10-4803-bdf7-289260644a5f',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, a copy of which has been obtained by the Guardian, <a href="https://www.theguardian.com/world/interactive/2013/jun/06/verizon-telephone-data-court-order">requires Verizon on an "ongoing, daily basis" to give the NSA information on all telephone calls in its systems</a>, both within the US and between the US and other countries.</p>',
-					elementId: '8afac6ff-0fd7-4735-a981-a49bce4326cd',
+					elementId: '6976c2fe-24ee-40c3-b401-eab47fb36bd4',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The document shows for the first time that under the Obama administration the communication records of millions of US citizens are being collected indiscriminately and in bulk – regardless of whether they are suspected of any wrongdoing.</p>',
-					elementId: '26624453-6ff8-47c0-9877-7c7bdc723a7c',
+					elementId: 'f3f7d4dc-afc4-4a29-8ed9-bbadb3b6606d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The secret Foreign Intelligence Surveillance Court (Fisa) granted the order to the FBI on April 25, giving the government unlimited authority to obtain the data for a specified three-month period ending on July 19.</p>',
-					elementId: '09aa2572-e30a-49ec-84a3-1db5c2ee9e1d',
+					elementId: 'c09ed46f-a63f-4c8c-b3f6-2b85a5e13674',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the terms of the blanket order, the numbers of both parties on a call are handed over, as is location data, call duration, unique identifiers, and the time and duration of all calls. The contents of the conversation itself are not covered.</p>',
-					elementId: '0d5f51dd-17f6-449c-befd-8c90c02c11cd',
+					elementId: '51a270c7-a1f5-46d7-8000-660b4e115099',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The disclosure is likely to reignite longstanding debates in the US over the proper extent of the government's domestic spying powers.</p>",
-					elementId: '59247a6f-2922-408d-bf7f-90d7cd73adc3',
+					elementId: 'fd586067-7dec-4b52-b576-28c7916b1b32',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Under the Bush administration, officials in security agencies had disclosed to reporters the large-scale collection of call records data by the <a href="https://www.theguardian.com/us-news/nsa" data-component="auto-linked-tag">NSA</a>, but this is the first time significant and top-secret documents have revealed the continuation of the practice on a massive scale under President Obama.</p>',
-					elementId: 'ac46bf31-5be1-4bc6-8bbf-0d2c4e2cbc2b',
+					elementId: '2e3c152c-96cc-4f11-9f8b-00c793c71efb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The unlimited nature of the records being handed over to the NSA is extremely unusual. Fisa court orders typically direct the production of records pertaining to a specific named target who is suspected of being an agent of a terrorist group or foreign state, or a finite set of individually named targets.</p>',
-					elementId: 'ce285644-8b32-464b-a0d9-2bc2259915d0',
+					elementId: '81b0a5bf-fb6f-425f-b1e4-9920073b7ea0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The Guardian approached the National Security Agency, the White House and the Department of Justice for comment in advance of publication on Wednesday. All declined. The agencies were also offered the opportunity to raise specific security concerns regarding the publication of the court order.</p>',
-					elementId: 'fb1ffdae-873f-41e5-99f8-c078dc97dcb4',
+					elementId: '7c1ca8d2-aba3-4f32-88c1-d8a16ce42beb',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order expressly bars Verizon from disclosing to the public either the existence of the FBI's request for its customers' records, or the court order itself. </p>",
-					elementId: '83bf6f56-8093-431e-b9bd-ba5681736d5c',
+					elementId: '1ff59311-8abb-4888-aba7-7905ccc42eb9',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We decline comment," said Ed McFadden, a Washington-based Verizon spokesman.</p>',
-					elementId: '8f2d633e-c22d-47cb-8351-fbe8940a0b01',
+					elementId: 'c1415bb8-a223-4642-b106-29cb1dd6a8b3',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order, signed by Judge Roger Vinson, compels Verizon to produce to the NSA electronic copies of "all call detail records or \'telephony metadata\' created by Verizon for communications between the United States and abroad" or "wholly within the United States, including local telephone calls".</p>',
-					elementId: '7cfa4071-a906-4e90-acaf-80194742a6b0',
+					elementId: '1f3a30a0-1915-4eb4-bc5d-dca7b25aac53',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The order directs Verizon to "continue production on an ongoing daily basis thereafter for the duration of this order". It specifies that the records to be produced include "session identifying information", such as "originating and terminating number", the duration of each call, telephone calling card numbers, trunk identifiers, International Mobile Subscriber Identity (IMSI) number, and "comprehensive communication routing information".</p>',
-					elementId: '51d0ca48-5368-4a4c-b2db-4c43928171df',
+					elementId: '88ec42d3-82ea-4655-afed-17ebf941e0e0',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The information is classed as "metadata", or transactional information, rather than communications, and so does not require individual warrants to access. The document also specifies that such "metadata" is not limited to the aforementioned items. A 2005 court ruling judged that cell site location data – the nearest cell tower a phone was connected to – was also transactional data, and so could potentially fall under the scope of the order.</p>',
-					elementId: 'b0b4712c-3741-417c-a565-f639b64aba3d',
+					elementId: '70f20e34-5f7e-4bad-9ba0-0a08dffa2b24',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>While the order itself does not include either the contents of messages or the personal information of the subscriber of any particular cell number, its collection would allow the NSA to build easily a comprehensive picture of who any individual contacted, how and when, and possibly from where, retrospectively.</p>',
-					elementId: '2ac3c098-fc02-4ebc-834a-00db209cc76a',
+					elementId: '4e3c0270-8779-473c-81f6-ab8940559e6c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>It is not known whether Verizon is the only cell-phone provider to be targeted with such an order, although previous reporting has suggested the NSA has collected cell records from all major mobile networks. It is also unclear from the leaked document whether the three-month order was a one-off, or the latest in a series of similar orders.</p>',
-					elementId: '33494bbe-bf8e-4215-b872-45ac4f9045c5',
+					elementId: 'a5e97dcd-f8af-4d8b-a469-fb1d754c3393',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>The court order appears to explain the numerous cryptic public warnings by two US senators, Ron Wyden and Mark Udall, about the scope of the Obama administration's surveillance activities.</p>",
-					elementId: '88b1f609-292f-4920-8c50-a78da13e5dbc',
+					elementId: '37b8e4a7-2992-475e-9c2f-a61269cc7b4d',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>For roughly two years, the two Democrats have been stridently advising the public that the US government is relying on "secret legal interpretations" to claim surveillance powers so broad that the American public would be "stunned" to learn of the kind of domestic spying being conducted.</p>',
-					elementId: 'e10de05d-5091-49aa-bdc0-ee853e15ea0a',
+					elementId: '0c59ec83-42aa-442b-aa07-5fb13eef369b',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Because those activities are classified, the senators, both members of the Senate intelligence committee, have been prevented from specifying which domestic surveillance programs they find so alarming. But the information they have been able to disclose in their public warnings perfectly tracks both the specific law cited by the April 25 court order as well as the vast scope of record-gathering it authorized.</p>',
-					elementId: '4bb4bccc-ff59-4c9c-9774-90659d5179d6',
+					elementId: 'ef897c27-aa74-4475-a242-7d7f69bc6581',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Julian Sanchez, a surveillance expert with the Cato Institute, explained: \"We've certainly seen the government increasingly strain the bounds of 'relevance' to collect large numbers of records at once — everyone at one or two degrees of separation from a target — but vacuuming all metadata up indiscriminately would be an extraordinary repudiation of any pretence of constraint or particularized suspicion.\" The April order requested by the FBI and NSA does precisely that.</p>",
-					elementId: 'e1dd9fce-15a5-4bb3-95d9-8eb8fe56437e',
+					elementId: 'efa50f1b-37b4-4c8c-9567-671fcb58cf75',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The law on which the order explicitly relies is the so-called "business records" provision of the Patriot Act, 50 USC section 1861. That is the provision which Wyden and Udall have repeatedly cited when warning the public of what they believe is the Obama administration\'s extreme interpretation of the law to engage in excessive domestic surveillance.</p>',
-					elementId: '4ce4666e-397b-44d9-bea9-2f01b0e7640d',
+					elementId: '750355d7-c80c-4d71-a764-7f3409082d7a',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In a letter to attorney general Eric Holder last year, they argued that "there is now a significant gap between what most Americans <em>think</em> the law allows and what the government secretly <em>claims</em> the law allows."</p>',
-					elementId: '245ae1cc-098a-4b54-a1fc-ddc29a824d86',
+					elementId: '60b5f816-a078-4ff5-9660-b8a9de32d90e',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>"We believe," they wrote, "that most Americans would be stunned to learn the details of how these secret court opinions have interpreted" the "business records" provision of the Patriot Act.</p>',
-					elementId: '2cf330d5-8dd1-439e-b920-607122911bce',
+					elementId: '5492dbad-205a-41b5-bbfd-76002727c742',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>Privacy advocates have long warned that allowing the government to collect and store unlimited "metadata" is a highly invasive form of surveillance of citizens\' communications activities. Those records enable the government to know the identity of every person with whom an individual communicates electronically, how long they spoke, and their location at the time of the communication.</p>',
-					elementId: '25c6681c-10a3-44f6-8353-7c5957fe926c',
+					elementId: '70a55761-a463-4002-84ab-a19fc43ce8cd',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>Such metadata is what the US government has long attempted to obtain in order to discover an individual's network of associations and communication patterns. The request for the bulk collection of all Verizon domestic telephone records indicates that the agency is continuing some version of the data-mining program begun by the Bush administration in the immediate aftermath of the 9/11 attack.</p>",
-					elementId: '8497f2c2-4218-4899-8671-ee0b1d5b24de',
+					elementId: '419ce3e8-ac48-4f2b-be9a-2dcda2bb4be2',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>The NSA, as part of a program secretly authorized by President Bush on 4 October 2001, implemented a bulk collection program of domestic telephone, internet and email records. A furore erupted in 2006 when USA Today reported that the NSA had "been secretly collecting the phone call records of tens of millions of Americans, using data provided by AT&amp;T, Verizon and BellSouth" and was "using the data to analyze calling patterns in an effort to detect terrorist activity." Until now, there has been no indication that the Obama administration implemented a similar program.</p>',
-					elementId: '40629f84-dc73-4442-844f-d55d969d6587',
+					elementId: '3827b42e-7171-4126-ba7c-d56d8211c591',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: "<p>These recent events reflect how profoundly the NSA's mission has transformed from an agency exclusively devoted to foreign intelligence gathering, into one that focuses increasingly on domestic communications. A 30-year employee of the NSA, William Binney, resigned from the agency shortly after 9/11 in protest at the agency's focus on domestic activities.</p>",
-					elementId: '402c5263-4fc6-4bd5-af1c-ffeb3e26cef9',
+					elementId: '22b9561e-79c8-42ab-b75c-4511a176327c',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>In the mid-1970s, Congress, for the first time, investigated the surveillance activities of the US government. Back then, the mandate of the NSA was that it would never direct its surveillance apparatus domestically.</p>',
-					elementId: 'e5a2a421-83f0-45fb-a517-f9e2dd81c9ff',
+					elementId: 'e8ea0b57-f404-47b2-aa3d-496fc8a27150',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p>At the conclusion of that investigation, Frank Church, the Democratic senator from Idaho who chaired the investigative committee, warned: "The NSA\'s capability at any time could be turned around on the American people, and no American would have any privacy left, such is the capability to monitor everything: telephone conversations, telegrams, it doesn\'t matter."</p>',
-					elementId: 'a37da07f-dc1f-44a6-bd54-82733c707c1c',
+					elementId: '635654ed-4091-4bdb-9b1f-65d81b9a1a83',
 				},
 				{
 					_type: 'model.dotcomrendering.pageElements.TextBlockElement',
 					html: '<p><em>Additional reporting by Ewen MacAskill and Spencer Ackerman</em></p>',
-					elementId: '32204131-eeb7-49ce-a978-1483e2df1418',
+					elementId: 'c08571e7-f5e3-4870-a14c-d5e303485cf6',
 				},
 			],
 			attributes: {
@@ -1927,7 +1988,7 @@ export const Video: CAPIArticleType = {
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
-			'@id': 'https://amp.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
+			'@id': 'https://www.theguardian.com/world/2013/jun/06/nsa-phone-records-verizon-court-order',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',

--- a/dotcom-rendering/fixtures/generated/images.ts
+++ b/dotcom-rendering/fixtures/generated/images.ts
@@ -348,7 +348,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'fc2ec3c6-bec9-4cf5-98cb-22fc6b89dee9',
+		elementId: '1f96cbb6-6ed0-4d41-a6b6-864283ea10fe',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -663,7 +663,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '1372f404-6091-4d7c-8f27-731c925a6fae',
+		elementId: 'a0b281b7-1635-4c5e-873f-50d327702cf1',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -978,7 +978,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '0ad57097-69fd-4188-9cca-dea68418f37b',
+		elementId: '2d6c95f4-7176-40ab-9193-e0338426294e',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1293,7 +1293,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'a61554ca-028a-4f33-a536-890c4c0493a0',
+		elementId: '49ec49b2-a570-425f-a009-62623ea599c9',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1608,7 +1608,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'd04b5dc2-03d7-4500-b85e-99de61f334a5',
+		elementId: 'bd5e1bac-92cc-4aa6-9be0-f1c0bda52c28',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -1923,7 +1923,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'dd0fdc66-8729-4c12-8b07-55baf25855af',
+		elementId: 'cc6307d0-b752-46f9-8c19-ade3e1860d45',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2238,7 +2238,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '2a7f03e8-8282-4275-a839-2bab2644b9f0',
+		elementId: '5dcb6b27-a5f8-4487-96b0-7897905dc2a9',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2543,7 +2543,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'b10775bf-e331-4c9b-91a6-2f2677184f4c',
+		elementId: '0ff4eebd-17e4-4d3b-b321-ede638c8adb2',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -2858,7 +2858,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'f77e1399-f7cd-4d50-8cb0-8ab08aa79f63',
+		elementId: '898c5fd1-091e-4998-bb86-398877fb300d',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3173,7 +3173,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '555fced0-10ee-40de-bd8c-452325929f1e',
+		elementId: '04ba4ebc-1d09-471f-b48c-149c43b012f7',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3488,7 +3488,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'd3db3d83-e6ce-4891-ac8d-3b7582d6001a',
+		elementId: 'a9168311-4394-486b-8a12-0ddc6a1bce93',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -3803,7 +3803,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'be716c2a-d584-45b7-a90b-f7e636ab82ff',
+		elementId: '90a6bb92-0e84-45a3-9a74-e9d843f5be26',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4118,7 +4118,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'b6315f94-fdde-411b-8547-40e00b52c155',
+		elementId: '107d9864-909d-4911-bd81-b34cacc49712',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4433,7 +4433,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '405ad7de-870a-42c8-a501-04abcb76a55b',
+		elementId: '119391fb-67a5-48ef-b26c-a777da265b6a',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -4748,7 +4748,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'e159a6d7-8dfc-4001-ad29-ee455805c056',
+		elementId: '2b168e35-f250-462e-8899-4b9944d54fd5',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5064,7 +5064,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '2b2a6d17-da7b-42ca-a23d-b2c2b7e39d20',
+		elementId: '2cc71c66-4881-4c4f-a666-e46850fd2408',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5379,7 +5379,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'bd978683-72ef-47e2-ad7e-5da9384dda1b',
+		elementId: 'd6dc649d-7dbd-4cc2-9376-07604d7091f7',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -5694,7 +5694,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'ce56baa8-592f-4250-998b-350b7934d6f1',
+		elementId: '47448f1a-666f-4e85-b7e6-472aa7615864',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6009,7 +6009,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: 'b7bc0a31-2b11-40b3-bed9-23b15c251358',
+		elementId: '6c5f7b34-5002-4f22-8591-dcfbc128b8b9',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6324,7 +6324,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '7367bf4f-004f-4c08-9463-31d335c61bac',
+		elementId: '70f2a33d-e5c6-489c-be47-7119dc99bfcb',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6639,7 +6639,7 @@ export const images: [
 				],
 			},
 		],
-		elementId: '3507b092-c55d-4a78-b0a7-de7648214ca0',
+		elementId: '815ad3bd-c204-4584-a80e-4708a36ca3e7',
 	},
 	{
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
@@ -6954,6 +6954,6 @@ export const images: [
 				],
 			},
 		],
-		elementId: '50e3f306-9241-438d-9c34-24c1a7c7380e',
+		elementId: '9ac21d89-03b2-4625-b7a1-059d44b4f395',
 	},
 ];

--- a/dotcom-rendering/fixtures/generated/series.ts
+++ b/dotcom-rendering/fixtures/generated/series.ts
@@ -19,15 +19,44 @@ export const series = {
 	url: 'https://www.theguardian.com/tv-and-radio/series/tv-review',
 	trails: [
 		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/22/john-and-joe-bishop-life-after-deaf-review-the-comic-should-be-proud-of-this-uplifting-documentary',
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/26/kids-tv-the-surprising-story-review-the-fascinating-tale-of-how-cbbc-has-opened-our-minds',
 			linkText:
-				'John and Joe Bishop: Life After Deaf review – the comic should be proud of this uplifting documentary ',
+				'Kids’ TV: The Surprising Story review – the fascinating tale of how CBBC has opened our minds',
+			showByline: false,
+			byline: 'Stuart Jeffries',
+			masterImage:
+				'https://media.guim.co.uk/d8ac969a686cb6faceb1583080fc4926f4f6881b/0_490_4039_2425/master/4039.jpg',
+			image: 'https://i.guim.co.uk/img/media/d8ac969a686cb6faceb1583080fc4926f4f6881b/0_490_4039_2425/master/4039.jpg?width=300&quality=85&auto=format&fit=max&s=38c126c0b35fb9d1bcde4ae99fbb2203',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/d8ac969a686cb6faceb1583080fc4926f4f6881b/0_490_4039_2425/master/4039.jpg?width=300&quality=85&auto=format&fit=max&s=38c126c0b35fb9d1bcde4ae99fbb2203',
+				'460': 'https://i.guim.co.uk/img/media/d8ac969a686cb6faceb1583080fc4926f4f6881b/0_490_4039_2425/master/4039.jpg?width=460&quality=85&auto=format&fit=max&s=262fb0eec17d174c48d0893f58cf57f6',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-10-26T21:00:11.000Z',
+			headline:
+				'Kids’ TV: The Surprising Story review – the fascinating tale of how CBBC has opened our minds',
+			shortUrl: 'https://www.theguardian.com/p/mgq9c',
+			starRating: 4,
+		},
+		{
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/25/the-white-lotus-season-two-review-this-immaculate-seriess-writing-is-utterly-unrivalled',
+			linkText:
+				'The White Lotus season two review – this immaculate show’s writing is utterly unrivalled',
 			showByline: false,
 			byline: 'Lucy Mangan',
-			image: 'https://i.guim.co.uk/img/media/c291fe1df688c0e8aa59aaeeabe64e30b305fbf9/114_0_1800_1080/master/1800.jpg?width=300&quality=85&auto=format&fit=max&s=feca682f57caad08c3409dc5950a1329',
+			masterImage:
+				'https://media.guim.co.uk/cceac926d6098982cf821d8f3029470a03a042d9/0_180_6240_3744/master/6240.jpg',
+			image: 'https://i.guim.co.uk/img/media/cceac926d6098982cf821d8f3029470a03a042d9/0_180_6240_3744/master/6240.jpg?width=300&quality=85&auto=format&fit=max&s=6043fab5f01851e9cc625c254222d80b',
 			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/c291fe1df688c0e8aa59aaeeabe64e30b305fbf9/114_0_1800_1080/master/1800.jpg?width=300&quality=85&auto=format&fit=max&s=feca682f57caad08c3409dc5950a1329',
-				'460': 'https://i.guim.co.uk/img/media/c291fe1df688c0e8aa59aaeeabe64e30b305fbf9/114_0_1800_1080/master/1800.jpg?width=460&quality=85&auto=format&fit=max&s=769bec0104a8584c481d7169ebe6a151',
+				'300': 'https://i.guim.co.uk/img/media/cceac926d6098982cf821d8f3029470a03a042d9/0_180_6240_3744/master/6240.jpg?width=300&quality=85&auto=format&fit=max&s=6043fab5f01851e9cc625c254222d80b',
+				'460': 'https://i.guim.co.uk/img/media/cceac926d6098982cf821d8f3029470a03a042d9/0_180_6240_3744/master/6240.jpg?width=460&quality=85&auto=format&fit=max&s=8b53ceaae9fdf6d1daaa3c0cb51e84ae',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -37,22 +66,78 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2022-09-22T21:05:16.000Z',
+			webPublicationDate: '2022-10-25T16:47:19.000Z',
 			headline:
-				'John and Joe Bishop: Life After Deaf review – the comic should be proud of this uplifting documentary ',
-			shortUrl: 'https://www.theguardian.com/p/madvg',
+				'The White Lotus season two review – this immaculate show’s writing is utterly unrivalled',
+			shortUrl: 'https://www.theguardian.com/p/mgqzf',
+			starRating: 5,
+		},
+		{
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/25/guillermo-del-toro-cabinet-of-curiosities-review-netflix',
+			linkText:
+				'Guillermo del Toro’s Cabinet of Curiosities review – the horror series that’s perfect pre-Halloween viewing',
+			showByline: false,
+			byline: 'Leila Latif',
+			masterImage:
+				'https://media.guim.co.uk/d3aec9bcd31907db04073198a061cb3609dafa76/0_0_3600_2160/master/3600.jpg',
+			image: 'https://i.guim.co.uk/img/media/d3aec9bcd31907db04073198a061cb3609dafa76/0_0_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=e46971f1785c8b0f40d6fc2c0758bf97',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/d3aec9bcd31907db04073198a061cb3609dafa76/0_0_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=e46971f1785c8b0f40d6fc2c0758bf97',
+				'460': 'https://i.guim.co.uk/img/media/d3aec9bcd31907db04073198a061cb3609dafa76/0_0_3600_2160/master/3600.jpg?width=460&quality=85&auto=format&fit=max&s=10fb6ec2f9da65d46e0f4f3e4a958968',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-10-25T15:13:00.000Z',
+			headline:
+				'Guillermo del Toro’s Cabinet of Curiosities review – the horror series that’s perfect pre-Halloween viewing',
+			shortUrl: 'https://www.theguardian.com/p/mgv3c',
+			starRating: 5,
+		},
+		{
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/25/my-massive-cock-review-channel-4',
+			linkText:
+				'My Massive Cock review – you will never be able to unsee this penis documentary',
+			showByline: false,
+			byline: 'Lucy Mangan',
+			masterImage:
+				'https://media.guim.co.uk/96eea5a873a0c5f594094b61c8daa74c99146699/0_162_5390_3236/master/5390.jpg',
+			image: 'https://i.guim.co.uk/img/media/96eea5a873a0c5f594094b61c8daa74c99146699/0_162_5390_3236/master/5390.jpg?width=300&quality=85&auto=format&fit=max&s=d7ef455c9bd00e91dc09b235aa92dfd4',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/96eea5a873a0c5f594094b61c8daa74c99146699/0_162_5390_3236/master/5390.jpg?width=300&quality=85&auto=format&fit=max&s=d7ef455c9bd00e91dc09b235aa92dfd4',
+				'460': 'https://i.guim.co.uk/img/media/96eea5a873a0c5f594094b61c8daa74c99146699/0_162_5390_3236/master/5390.jpg?width=460&quality=85&auto=format&fit=max&s=2dd3d66b61401fe1266ca8473058e4dc',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-10-25T09:00:13.000Z',
+			headline:
+				'My Massive Cock review – you will never be able to unsee this penis documentary',
+			shortUrl: 'https://www.theguardian.com/p/mgznz',
 			starRating: 4,
 		},
 		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/22/thai-cave-rescue-review-netflix-drama-series',
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/24/house-of-the-dragon-finale-review-this-meticulous-series-saved-its-best-episode-for-last',
 			linkText:
-				'Thai Cave Rescue review – Netflix drama series shines a light on the real story ',
+				'House of the Dragon finale review – this meticulous series saved its best episode for last',
 			showByline: false,
-			byline: 'Radheyan Simonpillai',
-			image: 'https://i.guim.co.uk/img/media/b19546a1dffb11541b6085b76b76b83ce6c00e53/0_250_5532_3319/master/5532.jpg?width=300&quality=85&auto=format&fit=max&s=26415c8e97fa24174f2aa84e29b8c2ee',
+			byline: 'Stuart Heritage',
+			masterImage:
+				'https://media.guim.co.uk/3744a5ce0db39b272a1ed75ffb249d130f17ed6d/117_541_5765_3459/master/5765.jpg',
+			image: 'https://i.guim.co.uk/img/media/3744a5ce0db39b272a1ed75ffb249d130f17ed6d/117_541_5765_3459/master/5765.jpg?width=300&quality=85&auto=format&fit=max&s=c4a779ca148a67e1631328922343e809',
 			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/b19546a1dffb11541b6085b76b76b83ce6c00e53/0_250_5532_3319/master/5532.jpg?width=300&quality=85&auto=format&fit=max&s=26415c8e97fa24174f2aa84e29b8c2ee',
-				'460': 'https://i.guim.co.uk/img/media/b19546a1dffb11541b6085b76b76b83ce6c00e53/0_250_5532_3319/master/5532.jpg?width=460&quality=85&auto=format&fit=max&s=7a5f32830416cbacd60a6eb596826180',
+				'300': 'https://i.guim.co.uk/img/media/3744a5ce0db39b272a1ed75ffb249d130f17ed6d/117_541_5765_3459/master/5765.jpg?width=300&quality=85&auto=format&fit=max&s=c4a779ca148a67e1631328922343e809',
+				'460': 'https://i.guim.co.uk/img/media/3744a5ce0db39b272a1ed75ffb249d130f17ed6d/117_541_5765_3459/master/5765.jpg?width=460&quality=85&auto=format&fit=max&s=7969d69bc0479444d699859f0ccc3298',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -62,47 +147,24 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2022-09-22T07:01:51.000Z',
+			webPublicationDate: '2022-10-24T21:10:16.000Z',
 			headline:
-				'Thai Cave Rescue review – Netflix drama series shines a light on the real story ',
-			shortUrl: 'https://www.theguardian.com/p/ma9vd',
-			starRating: 3,
-		},
-		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/21/rogue-one-andor-review-the-best-star-wars-show-since-the-mandalorian',
-			linkText:
-				'Andor review – the best Star Wars show since The Mandalorian',
-			showByline: false,
-			byline: 'Jack Seale',
-			image: 'https://i.guim.co.uk/img/media/1c56c7dc5654b9ebdd4859a84d1e700a02ee37a9/0_251_3000_1800/master/3000.jpg?width=300&quality=85&auto=format&fit=max&s=0610115e88bfabcdbc7e0b6d4921734c',
-			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/1c56c7dc5654b9ebdd4859a84d1e700a02ee37a9/0_251_3000_1800/master/3000.jpg?width=300&quality=85&auto=format&fit=max&s=0610115e88bfabcdbc7e0b6d4921734c',
-				'460': 'https://i.guim.co.uk/img/media/1c56c7dc5654b9ebdd4859a84d1e700a02ee37a9/0_251_3000_1800/master/3000.jpg?width=460&quality=85&auto=format&fit=max&s=96bab1667dfa55a93cf08ef83a1c640f',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2022-09-21T11:04:10.000Z',
-			headline:
-				'Andor review – the best Star Wars show since The Mandalorian',
-			shortUrl: 'https://www.theguardian.com/p/ma4mx',
+				'House of the Dragon finale review – this meticulous series saved its best episode for last',
+			shortUrl: 'https://www.theguardian.com/p/mgkv3',
 			starRating: 4,
 		},
 		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/20/cunk-on-earth-review-diane-morgans-character-is-so-well-written-its-easy-to-forget-shes-not-real',
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/24/28-days-haunted-review-the-ghost-hunting-show-that-will-make-you-roll-your-eyes-like-never-before',
 			linkText:
-				'Cunk on Earth review – Diane Morgan’s character is so well-written it’s easy to forget she’s not real',
+				'28 Days Haunted review – the ghost-hunting show that will make you roll your eyes like never before',
 			showByline: false,
 			byline: 'Rebecca Nicholson',
-			image: 'https://i.guim.co.uk/img/media/97ac5568913ff674883969d2f84ea6e14e77e508/284_251_3526_2115/master/3526.jpg?width=300&quality=85&auto=format&fit=max&s=16ccfa173a39822cc09dd5fc6658fc74',
+			masterImage:
+				'https://media.guim.co.uk/c0dc138961466b1d920051a04770255b2b9bf145/177_4_5306_3186/master/5306.jpg',
+			image: 'https://i.guim.co.uk/img/media/c0dc138961466b1d920051a04770255b2b9bf145/177_4_5306_3186/master/5306.jpg?width=300&quality=85&auto=format&fit=max&s=b00a81a5156ae1109994adb99ff641a5',
 			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/97ac5568913ff674883969d2f84ea6e14e77e508/284_251_3526_2115/master/3526.jpg?width=300&quality=85&auto=format&fit=max&s=16ccfa173a39822cc09dd5fc6658fc74',
-				'460': 'https://i.guim.co.uk/img/media/97ac5568913ff674883969d2f84ea6e14e77e508/284_251_3526_2115/master/3526.jpg?width=460&quality=85&auto=format&fit=max&s=9564d73990b65e6bc94676e69261553d',
+				'300': 'https://i.guim.co.uk/img/media/c0dc138961466b1d920051a04770255b2b9bf145/177_4_5306_3186/master/5306.jpg?width=300&quality=85&auto=format&fit=max&s=b00a81a5156ae1109994adb99ff641a5',
+				'460': 'https://i.guim.co.uk/img/media/c0dc138961466b1d920051a04770255b2b9bf145/177_4_5306_3186/master/5306.jpg?width=460&quality=85&auto=format&fit=max&s=3df25cae424c7d005f9a205aa8caca14',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -112,47 +174,24 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2022-09-20T21:30:10.000Z',
+			webPublicationDate: '2022-10-24T17:01:29.000Z',
 			headline:
-				'Cunk on Earth review – Diane Morgan’s character is so well-written it’s easy to forget she’s not real',
-			shortUrl: 'https://www.theguardian.com/p/m98y7',
-			starRating: 4,
-		},
-		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/20/crossfire-review-keeley-hawes-stars-in-the-worlds-most-stupidly-corridor-based-thriller',
-			linkText:
-				'Crossfire review – Keeley Hawes stars in the world’s most stupidly corridor-based thriller',
-			showByline: false,
-			byline: 'Lucy Mangan',
-			image: 'https://i.guim.co.uk/img/media/898c6d1e33c79591efff833870588ae52d0fe651/0_54_1024_614/master/1024.jpg?width=300&quality=85&auto=format&fit=max&s=3c940f6b2fb715136cdc47cec5d00bfd',
-			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/898c6d1e33c79591efff833870588ae52d0fe651/0_54_1024_614/master/1024.jpg?width=300&quality=85&auto=format&fit=max&s=3c940f6b2fb715136cdc47cec5d00bfd',
-				'460': 'https://i.guim.co.uk/img/media/898c6d1e33c79591efff833870588ae52d0fe651/0_54_1024_614/master/1024.jpg?width=460&quality=85&auto=format&fit=max&s=71b3fe9a4fa7c5607804c0e2320b3152',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2022-09-20T21:00:10.000Z',
-			headline:
-				'Crossfire review – Keeley Hawes stars in the world’s most stupidly corridor-based thriller',
-			shortUrl: 'https://www.theguardian.com/p/m9mkn',
+				'28 Days Haunted review – the ghost-hunting show that will make you roll your eyes like never before',
+			shortUrl: 'https://www.theguardian.com/p/mgkd5',
 			starRating: 2,
 		},
 		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/20/sisterhood-review-an-icelandic-drama-perfect-for-unforgotten-fans',
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/23/una-marson-our-lost-caribbean-voice-review-a-beautiful-moving-portrait-of-bbcs-first-black-broadcaster',
 			linkText:
-				'Sisterhood review – an Icelandic crime drama perfect for Unforgotten fans',
+				'Una Marson: Our Lost Caribbean Voice review – a beautiful, moving portrait of BBC’s first Black broadcaster',
 			showByline: false,
 			byline: 'Rebecca Nicholson',
-			image: 'https://i.guim.co.uk/img/media/8536c38da7bb3bc5ce209a62ffa63988470d2594/0_166_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=998630ce93a55dcbce612e99605c22c0',
+			masterImage:
+				'https://media.guim.co.uk/b4fd52d38ad78b6857978dd3eb739da9b694e700/0_120_4281_2569/master/4281.jpg',
+			image: 'https://i.guim.co.uk/img/media/b4fd52d38ad78b6857978dd3eb739da9b694e700/0_120_4281_2569/master/4281.jpg?width=300&quality=85&auto=format&fit=max&s=ebc6dcbed2ab775a4b92120e287f07c5',
 			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/8536c38da7bb3bc5ce209a62ffa63988470d2594/0_166_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=998630ce93a55dcbce612e99605c22c0',
-				'460': 'https://i.guim.co.uk/img/media/8536c38da7bb3bc5ce209a62ffa63988470d2594/0_166_6000_3600/master/6000.jpg?width=460&quality=85&auto=format&fit=max&s=a0caa0e621e1c011eb78efbef5da8bce',
+				'300': 'https://i.guim.co.uk/img/media/b4fd52d38ad78b6857978dd3eb739da9b694e700/0_120_4281_2569/master/4281.jpg?width=300&quality=85&auto=format&fit=max&s=ebc6dcbed2ab775a4b92120e287f07c5',
+				'460': 'https://i.guim.co.uk/img/media/b4fd52d38ad78b6857978dd3eb739da9b694e700/0_120_4281_2569/master/4281.jpg?width=460&quality=85&auto=format&fit=max&s=562c12574634c9e52b227d08c198af27',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -162,97 +201,24 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2022-09-19T23:45:07.000Z',
+			webPublicationDate: '2022-10-23T21:00:47.000Z',
 			headline:
-				'Sisterhood review – an Icelandic crime drama perfect for Unforgotten fans',
-			shortUrl: 'https://www.theguardian.com/p/m98e2',
-			starRating: 3,
-		},
-		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/18/bloodlands-series-two-review-james-nesbitts-meaningful-stares-are-laugh-out-loud-funny',
-			linkText:
-				'Bloodlands series two review – James Nesbitt’s meaningful stares are laugh-out-loud funny',
-			showByline: false,
-			byline: 'Jack Seale',
-			image: 'https://i.guim.co.uk/img/media/5175a1900410914965090be6ea57df6b5b1f4b4f/172_163_4112_2467/master/4112.jpg?width=300&quality=85&auto=format&fit=max&s=74e3853c78e69b17f262c0e6df631080',
-			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/5175a1900410914965090be6ea57df6b5b1f4b4f/172_163_4112_2467/master/4112.jpg?width=300&quality=85&auto=format&fit=max&s=74e3853c78e69b17f262c0e6df631080',
-				'460': 'https://i.guim.co.uk/img/media/5175a1900410914965090be6ea57df6b5b1f4b4f/172_163_4112_2467/master/4112.jpg?width=460&quality=85&auto=format&fit=max&s=e7f0e55ff4eaa048bf96bc2fdd7c7fd0',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2022-09-18T21:05:23.000Z',
-			headline:
-				'Bloodlands series two review – James Nesbitt’s meaningful stares are laugh-out-loud funny',
-			shortUrl: 'https://www.theguardian.com/p/m9bpt',
-			starRating: 2,
-		},
-		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/15/sins-of-our-mother-review-netflix-this-true-crime-series-gets-more-shocking-with-every-episode',
-			linkText:
-				'Sins of our Mother review – this true-crime series gets more shocking with every episode',
-			showByline: false,
-			byline: 'Rebecca Nicholson',
-			image: 'https://i.guim.co.uk/img/media/26dfb277cbb0c14b25c428bd60f0b66db6b09adf/60_0_1800_1080/master/1800.jpg?width=300&quality=85&auto=format&fit=max&s=92dc2d3d76ca6c61eab84337db688bcd',
-			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/26dfb277cbb0c14b25c428bd60f0b66db6b09adf/60_0_1800_1080/master/1800.jpg?width=300&quality=85&auto=format&fit=max&s=92dc2d3d76ca6c61eab84337db688bcd',
-				'460': 'https://i.guim.co.uk/img/media/26dfb277cbb0c14b25c428bd60f0b66db6b09adf/60_0_1800_1080/master/1800.jpg?width=460&quality=85&auto=format&fit=max&s=ead472c252c2b2df2be074abe2032f67',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2022-09-15T05:00:22.000Z',
-			headline:
-				'Sins of our Mother review – this true-crime series gets more shocking with every episode',
-			shortUrl: 'https://www.theguardian.com/p/m92xq',
-			starRating: 3,
-		},
-		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/14/minx-review-the-joyful-feminist-porn-comedy-that-proves-2022-is-tvs-year-of-male-nudity',
-			linkText:
-				' Minx review – the joyful feminist porn comedy that proves 2022 is TV’s year of male nudity',
-			showByline: false,
-			byline: 'Rebecca Nicholson',
-			image: 'https://i.guim.co.uk/img/media/def9b985f7db841c819e9b0511aaf60fd183567a/0_50_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=f9c3b0da34f1a26a36d0e089328c7db8',
-			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/def9b985f7db841c819e9b0511aaf60fd183567a/0_50_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=f9c3b0da34f1a26a36d0e089328c7db8',
-				'460': 'https://i.guim.co.uk/img/media/def9b985f7db841c819e9b0511aaf60fd183567a/0_50_6000_3600/master/6000.jpg?width=460&quality=85&auto=format&fit=max&s=6b8e914c977442d9e4dfd04a962fa113',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2022-09-14T16:40:59.000Z',
-			headline:
-				' Minx review – the joyful feminist porn comedy that proves 2022 is TV’s year of male nudity',
-			shortUrl: 'https://www.theguardian.com/p/m92xv',
+				'Una Marson: Our Lost Caribbean Voice review – a beautiful, moving portrait of BBC’s first Black broadcaster',
+			shortUrl: 'https://www.theguardian.com/p/mfn6y',
 			starRating: 4,
 		},
 		{
-			url: 'https://www.theguardian.com/tv-and-radio/2022/sep/14/heartbreak-high-review-the-90s-aussie-drama-meets-mean-girls-but-with-more-sex',
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/23/doctor-who-review-jodie-whittaker-bows-out-with-big-bangs-and-even-bigger-heart',
 			linkText:
-				'Heartbreak High review – the 90s Aussie drama meets Mean Girls, but with more sex',
+				'Doctor Who review – Jodie Whittaker bows out with big bangs and even bigger heart',
 			showByline: false,
 			byline: 'Rebecca Nicholson',
-			image: 'https://i.guim.co.uk/img/media/215cbabf0ae4a1d2b40ab11f037f3e32c50c27ca/0_413_6394_3839/master/6394.jpg?width=300&quality=85&auto=format&fit=max&s=c75d84f29d1b0f4c78342f5e071e2dba',
+			masterImage:
+				'https://media.guim.co.uk/8882dbaa0b45872d3efc521f420106972bbf6cdd/0_125_4800_2880/master/4800.jpg',
+			image: 'https://i.guim.co.uk/img/media/8882dbaa0b45872d3efc521f420106972bbf6cdd/0_125_4800_2880/master/4800.jpg?width=300&quality=85&auto=format&fit=max&s=670f475d32058bd1a7cae9c369761dd5',
 			carouselImages: {
-				'300': 'https://i.guim.co.uk/img/media/215cbabf0ae4a1d2b40ab11f037f3e32c50c27ca/0_413_6394_3839/master/6394.jpg?width=300&quality=85&auto=format&fit=max&s=c75d84f29d1b0f4c78342f5e071e2dba',
-				'460': 'https://i.guim.co.uk/img/media/215cbabf0ae4a1d2b40ab11f037f3e32c50c27ca/0_413_6394_3839/master/6394.jpg?width=460&quality=85&auto=format&fit=max&s=e8df150c0038d593f728d6e9948f472f',
+				'300': 'https://i.guim.co.uk/img/media/8882dbaa0b45872d3efc521f420106972bbf6cdd/0_125_4800_2880/master/4800.jpg?width=300&quality=85&auto=format&fit=max&s=670f475d32058bd1a7cae9c369761dd5',
+				'460': 'https://i.guim.co.uk/img/media/8882dbaa0b45872d3efc521f420106972bbf6cdd/0_125_4800_2880/master/4800.jpg?width=460&quality=85&auto=format&fit=max&s=019ab2dd892c58a9f74a0006ddc9911c',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -262,11 +228,65 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2022-09-14T05:00:06.000Z',
+			webPublicationDate: '2022-10-23T20:00:46.000Z',
 			headline:
-				'Heartbreak High review – the 90s Aussie drama meets Mean Girls, but with more sex',
-			shortUrl: 'https://www.theguardian.com/p/m8h4p',
-			starRating: 3,
+				'Doctor Who review – Jodie Whittaker bows out with big bangs and even bigger heart',
+			shortUrl: 'https://www.theguardian.com/p/mgvfx',
+			starRating: 4,
+		},
+		{
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/21/the-peripheral-review-chloe-grace-moretz',
+			linkText:
+				'The Peripheral review - Westworld creators’ new sci-fi is brilliant  … if you can actually understand it',
+			showByline: false,
+			byline: 'Lucy Mangan',
+			masterImage:
+				'https://media.guim.co.uk/1fb6a3d5266bc2c44149fbdd19102a6feb700efe/0_38_3000_1800/master/3000.jpg',
+			image: 'https://i.guim.co.uk/img/media/1fb6a3d5266bc2c44149fbdd19102a6feb700efe/0_38_3000_1800/master/3000.jpg?width=300&quality=85&auto=format&fit=max&s=4331943109f8fd82f6c717a7b43a833b',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/1fb6a3d5266bc2c44149fbdd19102a6feb700efe/0_38_3000_1800/master/3000.jpg?width=300&quality=85&auto=format&fit=max&s=4331943109f8fd82f6c717a7b43a833b',
+				'460': 'https://i.guim.co.uk/img/media/1fb6a3d5266bc2c44149fbdd19102a6feb700efe/0_38_3000_1800/master/3000.jpg?width=460&quality=85&auto=format&fit=max&s=c1fd75fde6f0d08ea9daaac5fe092c8d',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-10-21T05:00:16.000Z',
+			headline:
+				'The Peripheral review - Westworld creators’ new sci-fi is brilliant  … if you can actually understand it',
+			shortUrl: 'https://www.theguardian.com/p/mfq7k',
+			starRating: 4,
+		},
+		{
+			url: 'https://www.theguardian.com/tv-and-radio/2022/oct/20/gangs-of-london-season-two-review-why-do-millions-of-people-watch-this-bloody-dross',
+			linkText:
+				'Gangs of London season two review – why do millions of people watch this bloody dross?',
+			showByline: false,
+			byline: 'Stuart Jeffries',
+			masterImage:
+				'https://media.guim.co.uk/657a9ee5c748ff61c9378dc4257954db97830d62/0_34_8094_4857/master/8094.jpg',
+			image: 'https://i.guim.co.uk/img/media/657a9ee5c748ff61c9378dc4257954db97830d62/0_34_8094_4857/master/8094.jpg?width=300&quality=85&auto=format&fit=max&s=f4076bbe3074148d3c1123216ac86094',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/657a9ee5c748ff61c9378dc4257954db97830d62/0_34_8094_4857/master/8094.jpg?width=300&quality=85&auto=format&fit=max&s=f4076bbe3074148d3c1123216ac86094',
+				'460': 'https://i.guim.co.uk/img/media/657a9ee5c748ff61c9378dc4257954db97830d62/0_34_8094_4857/master/8094.jpg?width=460&quality=85&auto=format&fit=max&s=31d980274aed29ad6443d4d1f0a0b841',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-10-20T21:20:04.000Z',
+			headline:
+				'Gangs of London season two review – why do millions of people watch this bloody dross?',
+			shortUrl: 'https://www.theguardian.com/p/mfkfx',
+			starRating: 1,
 		},
 	],
 };

--- a/dotcom-rendering/fixtures/generated/story-package.ts
+++ b/dotcom-rendering/fixtures/generated/story-package.ts
@@ -20,12 +20,14 @@ export const storyPackage = {
 				'New images from Mars will guide search for evidence of ancient life, says study',
 			showByline: false,
 			byline: 'AFP in Paris',
+			masterImage:
+				'https://media.guim.co.uk/3b74149ceee335ce5e7693683b501feeaa73edfd/255_2_3263_1959/master/3263.jpg',
 			image: 'https://i.guim.co.uk/img/media/3b74149ceee335ce5e7693683b501feeaa73edfd/255_2_3263_1959/master/3263.jpg?width=300&quality=85&auto=format&fit=max&s=9a1e1dd54e647c8c36c80a65209ad8f1',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/3b74149ceee335ce5e7693683b501feeaa73edfd/255_2_3263_1959/master/3263.jpg?width=300&quality=85&auto=format&fit=max&s=9a1e1dd54e647c8c36c80a65209ad8f1',
 				'460': 'https://i.guim.co.uk/img/media/3b74149ceee335ce5e7693683b501feeaa73edfd/255_2_3263_1959/master/3263.jpg?width=460&quality=85&auto=format&fit=max&s=15769d52ba1216057e8665c06f6674da',
 			},
-			ageWarning: '11 months',
+			ageWarning: '1 year',
 			isLiveBlog: false,
 			pillar: 'news',
 			designType: 'Article',
@@ -45,6 +47,8 @@ export const storyPackage = {
 				'China’s Mars rover drives across planet a week after landing',
 			showByline: false,
 			byline: 'Associated Press in Beijing',
+			masterImage:
+				'https://media.guim.co.uk/f2914ed7b5cedbb4f4608e05fdf63f9751b0767f/0_137_2400_1440/master/2400.jpg',
 			image: 'https://i.guim.co.uk/img/media/f2914ed7b5cedbb4f4608e05fdf63f9751b0767f/0_137_2400_1440/master/2400.jpg?width=300&quality=85&auto=format&fit=max&s=1b29b43cc559dbbbd679015601ca275d',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/f2914ed7b5cedbb4f4608e05fdf63f9751b0767f/0_137_2400_1440/master/2400.jpg?width=300&quality=85&auto=format&fit=max&s=1b29b43cc559dbbbd679015601ca275d',
@@ -70,6 +74,8 @@ export const storyPackage = {
 				'Nasa’s Mars helicopter in first powered, controlled flight on another planet',
 			showByline: false,
 			byline: 'Ian Sample',
+			masterImage:
+				'https://media.guim.co.uk/905f7c8d468c0487a7b5f94ee5d0038bb9ca0616/0_81_2000_1200/master/2000.jpg',
 			image: 'https://i.guim.co.uk/img/media/905f7c8d468c0487a7b5f94ee5d0038bb9ca0616/0_81_2000_1200/master/2000.jpg?width=300&quality=85&auto=format&fit=max&s=f030cfdfa7715833b09bedbd046fe584',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/905f7c8d468c0487a7b5f94ee5d0038bb9ca0616/0_81_2000_1200/master/2000.jpg?width=300&quality=85&auto=format&fit=max&s=f030cfdfa7715833b09bedbd046fe584',
@@ -95,6 +101,8 @@ export const storyPackage = {
 				'Nasa preparing to attempt first controlled flight on another world',
 			showByline: false,
 			byline: 'Nadeem Badshah and agency',
+			masterImage:
+				'https://media.guim.co.uk/16287e459f2539308aa510f4d33719555388f2a2/1_0_3998_2398/master/3998.jpg',
 			image: 'https://i.guim.co.uk/img/media/16287e459f2539308aa510f4d33719555388f2a2/1_0_3998_2398/master/3998.jpg?width=300&quality=85&auto=format&fit=max&s=3a4e4fff69ced90a9b1d6c89dad9484e',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/16287e459f2539308aa510f4d33719555388f2a2/1_0_3998_2398/master/3998.jpg?width=300&quality=85&auto=format&fit=max&s=3a4e4fff69ced90a9b1d6c89dad9484e',
@@ -120,6 +128,8 @@ export const storyPackage = {
 				"'Dare mighty things': hidden message found on Nasa Mars rover parachute",
 			showByline: false,
 			byline: 'Martin Belam',
+			masterImage:
+				'https://media.guim.co.uk/16d5a2f2b7d8ff8f454b9cf34a21283941b3ae26/0_160_4000_2400/master/4000.jpg',
 			image: 'https://i.guim.co.uk/img/media/16d5a2f2b7d8ff8f454b9cf34a21283941b3ae26/0_160_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=abcf0b829c4186261eae82027442c3f3',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/16d5a2f2b7d8ff8f454b9cf34a21283941b3ae26/0_160_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=abcf0b829c4186261eae82027442c3f3',
@@ -145,6 +155,8 @@ export const storyPackage = {
 				'Nasa releases video of Perseverance rover landing on Mars',
 			showByline: false,
 			byline: 'Natalie Grover Science correspondent',
+			masterImage:
+				'https://media.guim.co.uk/9fd7f7041490dc6a7974c555b91e102bc1704e33/0_155_4150_2490/master/4150.jpg',
 			image: 'https://i.guim.co.uk/img/media/9fd7f7041490dc6a7974c555b91e102bc1704e33/0_155_4150_2490/master/4150.jpg?width=300&quality=85&auto=format&fit=max&s=fc8b403c03df3d9b24c8cdac635b5d6c',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/9fd7f7041490dc6a7974c555b91e102bc1704e33/0_155_4150_2490/master/4150.jpg?width=300&quality=85&auto=format&fit=max&s=fc8b403c03df3d9b24c8cdac635b5d6c',
@@ -170,6 +182,8 @@ export const storyPackage = {
 				'Nasa launches Mars mission in search of evidence of ancient life',
 			showByline: false,
 			byline: 'PA Media',
+			masterImage:
+				'https://media.guim.co.uk/5333924754eeb72e956aaa81a54d229f36b09b99/199_417_3159_1896/master/3159.jpg',
 			image: 'https://i.guim.co.uk/img/media/5333924754eeb72e956aaa81a54d229f36b09b99/199_417_3159_1896/master/3159.jpg?width=300&quality=85&auto=format&fit=max&s=6b8f88d5465238c1aa0ed42369c6f999',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/5333924754eeb72e956aaa81a54d229f36b09b99/199_417_3159_1896/master/3159.jpg?width=300&quality=85&auto=format&fit=max&s=6b8f88d5465238c1aa0ed42369c6f999',
@@ -195,6 +209,8 @@ export const storyPackage = {
 				'China launches space rocket in ambitious Mars landing mission',
 			showByline: false,
 			byline: 'Associated Press',
+			masterImage:
+				'https://media.guim.co.uk/df7b691328f658cdcd2f9153bd07344601ac895f/0_147_3500_2101/master/3500.jpg',
 			image: 'https://i.guim.co.uk/img/media/df7b691328f658cdcd2f9153bd07344601ac895f/0_147_3500_2101/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=c0de66e40bb9dd9ade0b3a36820d2cc2',
 			carouselImages: {
 				'300': 'https://i.guim.co.uk/img/media/df7b691328f658cdcd2f9153bd07344601ac895f/0_147_3500_2101/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=c0de66e40bb9dd9ade0b3a36820d2cc2',

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -335,15 +335,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[4].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.vendors).toEqual({});
 		expect(usRtcAttribute.vendors).toEqual({});
 		expect(auRtcAttribute.vendors).toEqual({});
 		expect(intRtcAttribute.vendors).toEqual({});
-		expect(eurRtcAttribute.vendors).toEqual({});
 	});
 
 	it('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -13,9 +13,6 @@ describe('RegionalAd', () => {
 		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const intRelevantYieldURL =
 		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
-	const eurRelevantYieldURL =
-		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
-
 	const apsVendorObj = {
 		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
 	};
@@ -39,12 +36,6 @@ describe('RegionalAd', () => {
 		},
 	};
 	const intPubmaticVendorObj = {
-		openwrap: {
-			PROFILE_ID: '6611',
-			PUB_ID: '157207',
-		},
-	};
-	const eurPubmaticVendorObj = {
 		openwrap: {
 			PROFILE_ID: '6611',
 			PUB_ID: '157207',
@@ -94,15 +85,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains just no prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
@@ -148,15 +135,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toEqual([]);
 		expect(usRtcAttribute.urls).toEqual([]);
 		expect(auRtcAttribute.urls).toEqual([]);
 		expect(intRtcAttribute.urls).toEqual([]);
-		expect(eurRtcAttribute.urls).toEqual([]);
 	});
 
 	it('with no ab test running rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
@@ -202,15 +185,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
@@ -256,15 +235,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toHaveLength(0);
 		expect(usRtcAttribute.urls).toHaveLength(0);
 		expect(auRtcAttribute.urls).toHaveLength(0);
 		expect(intRtcAttribute.urls).toHaveLength(0);
-		expect(eurRtcAttribute.urls).toHaveLength(0);
 	});
 
 	it('with no ab test running rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
@@ -310,15 +285,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
-		expect(eurRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
 	it('with no ab test running rtc-config contains no vendor config when `useAmazon` is set to false', () => {
@@ -365,7 +336,7 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
+			ampAdElement[4].getAttribute('rtc-config') || '{}',
 		);
 
 		expect(ukRtcAttribute.vendors).toEqual({});
@@ -421,9 +392,6 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toEqual([ukRelevantYieldURL, permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([usRelevantYieldURL, permutiveURL]);
@@ -432,16 +400,11 @@ describe('RegionalAd', () => {
 			intRelevantYieldURL,
 			permutiveURL,
 		]);
-		expect(eurRtcAttribute.urls).toEqual([
-			eurRelevantYieldURL,
-			permutiveURL,
-		]);
 
 		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
-		expect(eurRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
 	it.skip('with ab test running and in Pubmatic variant, rtc-config contains Permutive UR and Pubmatic vendor when `usePermutive` and `usePrebid` flags are set to true', () => {
@@ -490,15 +453,11 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
-		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 
 		expect(ukRtcAttribute.vendors).toEqual({
 			...ukPubmaticVendorObj,
@@ -514,10 +473,6 @@ describe('RegionalAd', () => {
 		});
 		expect(intRtcAttribute.vendors).toEqual({
 			...intPubmaticVendorObj,
-			...apsVendorObj,
-		});
-		expect(eurRtcAttribute.vendors).toEqual({
-			...eurPubmaticVendorObj,
 			...apsVendorObj,
 		});
 	});

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -13,6 +13,8 @@ describe('RegionalAd', () => {
 		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const intRelevantYieldURL =
 		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
+	const eurRelevantYieldURL =
+		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 
 	const apsVendorObj = {
 		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
@@ -42,6 +44,12 @@ describe('RegionalAd', () => {
 			PUB_ID: '157207',
 		},
 	};
+	const eurPubmaticVendorObj = {
+		openwrap: {
+			PROFILE_ID: '6611',
+			PUB_ID: '157207',
+		},
+	};
 
 	it('with no ab test running rtc-config contains just a permutive URL when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
@@ -60,6 +68,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -85,11 +94,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains just no prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
@@ -109,6 +122,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -134,11 +148,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toEqual([]);
 		expect(usRtcAttribute.urls).toEqual([]);
 		expect(auRtcAttribute.urls).toEqual([]);
 		expect(intRtcAttribute.urls).toEqual([]);
+		expect(eurRtcAttribute.urls).toEqual([]);
 	});
 
 	it('with no ab test running rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
@@ -158,6 +176,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -183,11 +202,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
 	it('with no ab test running rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
@@ -207,6 +230,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -232,11 +256,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toHaveLength(0);
 		expect(usRtcAttribute.urls).toHaveLength(0);
 		expect(auRtcAttribute.urls).toHaveLength(0);
 		expect(intRtcAttribute.urls).toHaveLength(0);
+		expect(eurRtcAttribute.urls).toHaveLength(0);
 	});
 
 	it('with no ab test running rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
@@ -256,6 +284,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -281,11 +310,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(eurRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
 	it('with no ab test running rtc-config contains no vendor config when `useAmazon` is set to false', () => {
@@ -305,6 +338,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -330,11 +364,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.vendors).toEqual({});
 		expect(usRtcAttribute.vendors).toEqual({});
 		expect(auRtcAttribute.vendors).toEqual({});
 		expect(intRtcAttribute.vendors).toEqual({});
+		expect(eurRtcAttribute.vendors).toEqual({});
 	});
 
 	it('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
@@ -357,6 +395,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -382,6 +421,9 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toEqual([ukRelevantYieldURL, permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([usRelevantYieldURL, permutiveURL]);
@@ -390,11 +432,16 @@ describe('RegionalAd', () => {
 			intRelevantYieldURL,
 			permutiveURL,
 		]);
+		expect(eurRtcAttribute.urls).toEqual([
+			eurRelevantYieldURL,
+			permutiveURL,
+		]);
 
 		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
 		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
+		expect(eurRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
 	it.skip('with ab test running and in Pubmatic variant, rtc-config contains Permutive UR and Pubmatic vendor when `usePermutive` and `usePrebid` flags are set to true', () => {
@@ -417,6 +464,7 @@ describe('RegionalAd', () => {
 						US: { adTargeting: [] },
 						AU: { adTargeting: [] },
 						INT: { adTargeting: [] },
+						EUR: { adTargeting: [] },
 					}}
 					adTargeting={{
 						customParams: { sens: 'f', urlkw: [] },
@@ -442,11 +490,15 @@ describe('RegionalAd', () => {
 		const intRtcAttribute: Record<string, unknown> = JSON.parse(
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
+		const eurRtcAttribute: Record<string, unknown> = JSON.parse(
+			ampAdElement[3].getAttribute('rtc-config') || '{}',
+		);
 
 		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
+		expect(eurRtcAttribute.urls).toEqual([permutiveURL]);
 
 		expect(ukRtcAttribute.vendors).toEqual({
 			...ukPubmaticVendorObj,
@@ -462,6 +514,10 @@ describe('RegionalAd', () => {
 		});
 		expect(intRtcAttribute.vendors).toEqual({
 			...intPubmaticVendorObj,
+			...apsVendorObj,
+		});
+		expect(eurRtcAttribute.vendors).toEqual({
+			...eurPubmaticVendorObj,
 			...apsVendorObj,
 		});
 	});

--- a/dotcom-rendering/src/amp/lib/region-classes.ts
+++ b/dotcom-rendering/src/amp/lib/region-classes.ts
@@ -81,5 +81,6 @@ export const regionClasses = {
 	US: usRegionClass,
 	AU: auRegionClass,
 	INT: internationalRegionClass,
+	EUR: internationalRegionClass,
 	ROW: rowRegionClass,
 };

--- a/dotcom-rendering/src/amp/lib/region-classes.ts
+++ b/dotcom-rendering/src/amp/lib/region-classes.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 // Array of possible ad regions
-export const adRegions = ['UK', 'US', 'AU', 'INT'] as const;
+export const adRegions = ['UK', 'US', 'AU', 'INT', 'EUR'] as const;
 
 export type AdRegion = typeof adRegions[number];
 
@@ -71,6 +71,16 @@ const internationalRegionClass = css`
 `;
 
 /**
+ * Class that *should* display an element if the user accesses the AMP page from
+ * the region denoted as "Europe"
+ *
+ * Currently we do not want to show any european ads and this will always fall back to international
+ */
+const europeRegionClass = css`
+	display: none;
+`;
+
+/**
  * Dictionary mapping region code to the associated AMP region style
  *
  * E.g. Applying `regionClasses["US"]` to an element will only display the
@@ -81,6 +91,6 @@ export const regionClasses = {
 	US: usRegionClass,
 	AU: auRegionClass,
 	INT: internationalRegionClass,
-	EUR: internationalRegionClass,
+	EUR: europeRegionClass,
 	ROW: rowRegionClass,
 };

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -3807,6 +3807,7 @@
         "EditionId": {
             "enum": [
                 "AU",
+                "EUR",
                 "INT",
                 "UK",
                 "US"
@@ -4342,10 +4343,14 @@
                 },
                 "INT": {
                     "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "EUR": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
             "required": [
                 "AU",
+                "EUR",
                 "INT",
                 "UK",
                 "US"

--- a/dotcom-rendering/src/model/enhanceCommercialProperties.ts
+++ b/dotcom-rendering/src/model/enhanceCommercialProperties.ts
@@ -44,9 +44,11 @@ export const enhanceCommercialProperties = ({
 	US,
 	AU,
 	INT,
+	EUR,
 }: CommercialProperties): CommercialProperties => ({
 	UK: enhanceEditionCommercialProperties(UK),
 	US: enhanceEditionCommercialProperties(US),
 	AU: enhanceEditionCommercialProperties(AU),
 	INT: enhanceEditionCommercialProperties(INT),
+	EUR: enhanceEditionCommercialProperties(EUR),
 });

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2651,6 +2651,7 @@
         "EditionId": {
             "enum": [
                 "AU",
+                "EUR",
                 "INT",
                 "UK",
                 "US"

--- a/dotcom-rendering/src/types/edition.ts
+++ b/dotcom-rendering/src/types/edition.ts
@@ -1,4 +1,4 @@
-const editions = ['UK', 'US', 'INT', 'AU'] as const;
+const editions = ['UK', 'US', 'INT', 'AU', 'EUR'] as const;
 export type EditionId = typeof editions[number];
 
 export type Edition = {

--- a/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
+++ b/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
@@ -32,7 +32,8 @@ const editionDropdown = css`
 export const EditionDropdown: React.FC<{
 	editionId: EditionId;
 	dataLinkName: string;
-}> = ({ editionId, dataLinkName }) => {
+	isInEuropeTest: boolean;
+}> = ({ editionId, dataLinkName, isInEuropeTest }) => {
 	const links = [
 		{
 			id: 'uk',
@@ -63,6 +64,14 @@ export const EditionDropdown: React.FC<{
 			dataLinkName: 'nav2 : topbar : edition-picker: INT',
 		},
 	];
+	if (isInEuropeTest)
+		links.push({
+			id: 'eur',
+			url: '/preference/edition/eur',
+			isActive: editionId === 'EUR',
+			title: 'Europe edition',
+			dataLinkName: 'nav2 : topbar : edition-picker: EUR',
+		});
 
 	// Find active link, default to UK
 	const activeLink = links.find((link) => link.isActive) || links[0];

--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -26,6 +26,7 @@ type Props = {
 	remoteHeader: boolean;
 	contributionsServiceUrl: string;
 	idApiUrl: string;
+	isInEuropeTest: boolean;
 };
 
 export const Header = ({
@@ -38,6 +39,7 @@ export const Header = ({
 	remoteHeader,
 	contributionsServiceUrl,
 	idApiUrl,
+	isInEuropeTest,
 }: Props) => (
 	<div css={headerStyles}>
 		<Hide when="below" breakpoint="desktop">
@@ -45,6 +47,7 @@ export const Header = ({
 				<EditionDropdown
 					editionId={editionId}
 					dataLinkName="nav2 : topbar : edition-picker: toggle"
+					isInEuropeTest={isInEuropeTest}
 				/>
 			</Island>
 		</Hide>

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -77,36 +77,43 @@ const onwardsWrapper = css`
 	width: 100%;
 `;
 
+// TODO: EUR edition urls are currently pointing to INT edition
+// containers, once the europe edition is live, we may want to change this
 const containerUrls = {
 	headlines: {
 		UK: 'uk-alpha/news/regular-stories',
 		US: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026',
 		AU: 'au-alpha/news/regular-stories',
 		INT: '10f21d96-18f6-426f-821b-19df55dfb831',
+		EUR: '10f21d96-18f6-426f-821b-19df55dfb831',
 	},
 	sport: {
 		UK: '754c-8e8c-fad9-a927',
 		US: 'f6dd-d7b1-0e85-4650',
 		AU: 'c45d-318f-896c-3a85',
 		INT: 'd1ad8ec3-5ee2-4673-94c8-cc3f8d261e52',
+		EUR: 'd1ad8ec3-5ee2-4673-94c8-cc3f8d261e52',
 	},
 	opinion: {
 		UK: '3ff78b30-52f5-4d30-ace8-c887113cbe0d',
 		US: '98df412d-b0e7-4d9a-98c2-062642823e94',
 		AU: 'au-alpha/contributors/feature-stories',
 		INT: 'ee3386bb-9430-4a6d-8bca-b99d65790f3b',
+		EUR: 'ee3386bb-9430-4a6d-8bca-b99d65790f3b',
 	},
 	culture: {
 		UK: 'ae511a89-ef38-4ec9-aab1-3a5ebc96d118',
 		US: 'fb59c1f8-72a7-41d5-8365-a4d574809bed',
 		AU: '22262088-4bce-4290-9810-cb50bbead8db',
 		INT: 'c7154e22-7292-4d93-a14d-22fd4b6b693d',
+		EUR: 'c7154e22-7292-4d93-a14d-22fd4b6b693d',
 	},
 	lifestyle: {
 		UK: 'uk-alpha/features/feature-stories',
 		US: 'us-alpha/features/feature-stories',
 		AU: '13636104-51ce-4264-bb6b-556c80227331',
 		INT: '7b297ef5-a3f9-45e5-b915-b54951d7f6ec',
+		EUR: '7b297ef5-a3f9-45e5-b915-b54951d7f6ec',
 	},
 };
 

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -270,6 +270,9 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -353,6 +356,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={CAPIArticle.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -81,6 +81,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		config: { isPaidContent },
 	} = front;
 
+	const isInEuropeTest =
+		front.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const format = {
 		display: ArticleDisplay.Standard,
 		design: ArticleDesign.Standard,
@@ -134,6 +137,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							remoteHeader={!!front.config.switches.remoteHeader}
 							contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
 							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
+							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 					<Section

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -141,6 +141,9 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 	 */
 	const renderAds = !CAPIArticle.isAdFreeUser && !CAPIArticle.shouldHideAds;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	if (isSlimNav) {
 		return (
 			<div
@@ -228,6 +231,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 								CAPIArticle.contributionsServiceUrl
 							}
 							idApiUrl={CAPIArticle.config.idApiUrl}
+							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 				</div>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -212,6 +212,9 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -288,6 +291,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={CAPIArticle.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
 							/>
 						</Section>
 					</div>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -255,6 +255,9 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -343,6 +346,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							contributionsServiceUrl={contributionsServiceUrl}
 							idApiUrl={CAPIArticle.config.idApiUrl}
+							isInEuropeTest={isInEuropeTest}
 						/>
 					</Section>
 

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -178,6 +178,9 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -247,6 +250,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						}
 						contributionsServiceUrl={contributionsServiceUrl}
 						idApiUrl={CAPIArticle.config.idApiUrl}
+						isInEuropeTest={isInEuropeTest}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -213,6 +213,9 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -297,6 +300,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										contributionsServiceUrl
 									}
 									idApiUrl={CAPIArticle.config.idApiUrl}
+									isInEuropeTest={isInEuropeTest}
 								/>
 							</Section>
 							<Section

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -300,6 +300,9 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 		config: { isPaidContent, host },
 	} = CAPIArticle;
 
+	const isInEuropeTest =
+		CAPIArticle.config.abTests.europeNetworkFrontVariant === 'variant';
+
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: CAPIArticle.isAdFreeUser,
 		isSensitive: CAPIArticle.config.isSensitive,
@@ -393,6 +396,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									contributionsServiceUrl
 								}
 								idApiUrl={CAPIArticle.config.idApiUrl}
+								isInEuropeTest={isInEuropeTest}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/web/lib/edition.ts
+++ b/dotcom-rendering/src/web/lib/edition.ts
@@ -30,6 +30,13 @@ const editionList: EditionLinkType[] = [
 		title: 'International edition',
 		locale: 'en-gb',
 	},
+	{
+		url: '/preference/edition/eur',
+		editionId: 'EUR',
+		longTitle: 'Europe edition',
+		title: 'Europe edition',
+		locale: 'en-gb',
+	},
 ];
 
 export const getEditionFromId = (editionId: EditionId): EditionLinkType => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adding Europe to the edition type and supporting it in the different places that expect it. This is related to this [PR](https://github.com/guardian/frontend/pull/25463) in Frontend.

This PR includes:
- Adding Europe to the dropdown edition picker if the user is in the Europe experiment
- Regenerating Front and Article schemas
- Updating fixtures 
- Adding temporarily hidden Europe ads for amp

## The schema changes mean that DCR can now serve articles within the Europe edition:

Before:
<img width="1204" alt="Screenshot 2022-11-02 at 14 18 12" src="https://user-images.githubusercontent.com/74187452/199513270-464c2b7c-1813-4d40-9164-25a020929872.png">

After:

<img width="1206" alt="Screenshot 2022-11-02 at 14 18 41" src="https://user-images.githubusercontent.com/74187452/199513387-c30048f6-8221-4260-b708-55df440d3b17.png">

## Europe in edition dropdown:
<img width="1426" alt="Screenshot 2022-11-02 at 14 19 41" src="https://user-images.githubusercontent.com/74187452/199513886-03126e89-81fb-40bf-8edb-d1edc9eb2068.png">


## Onward content within the Europe edition:
<img width="1424" alt="Screenshot 2022-11-02 at 14 07 17" src="https://user-images.githubusercontent.com/74187452/199514238-1fd7bd12-25c0-4028-abba-07fc8a1cd7bb.png">


## Ads in amp work as expected (no visible changes)
<img width="1017" alt="Screenshot 2022-11-04 at 13 00 20" src="https://user-images.githubusercontent.com/74187452/199979902-d982ff1a-8691-4600-b812-c7be4a4a1d78.png">

