### PR TITLE
Increase timeout from default 30s to 40s

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -89,7 +89,7 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=card-branding-logo]').first().click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
+		cy.wait('@gaRequest', { responseTimeout: 40_000 }).then(
 			(interception) => {
 				let requestURL = interception.request.url;
 				expect(requestURL).to.include('ec=click');

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -46,12 +46,14 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=branding-logo]').click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest').then((interception) => {
-			let requestURL = interception.request.url;
-			expect(requestURL).to.include('ec=click');
-			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=charlie%20bigham%27s');
-		});
+		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
+			(interception) => {
+				let requestURL = interception.request.url;
+				expect(requestURL).to.include('ec=click');
+				expect(requestURL).to.include('ea=sponsor%20logo');
+				expect(requestURL).to.include('el=charlie%20bigham%27s');
+			},
+		);
 	});
 
 	it('should send Google Analytics message on click of sponsor logo in onwards section', function () {
@@ -87,11 +89,13 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=card-branding-logo]').first().click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest').then((interception) => {
-			let requestURL = interception.request.url;
-			expect(requestURL).to.include('ec=click');
-			expect(requestURL).to.include('ea=sponsor%20logo');
-			expect(requestURL).to.include('el=charlie%20bigham%27s');
-		});
+		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
+			(interception) => {
+				let requestURL = interception.request.url;
+				expect(requestURL).to.include('ec=click');
+				expect(requestURL).to.include('ea=sponsor%20logo');
+				expect(requestURL).to.include('el=charlie%20bigham%27s');
+			},
+		);
 	});
 });

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -46,7 +46,7 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=branding-logo]').click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest', { responseTimeout: 40_000 }).then(
+		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
 			(interception) => {
 				let requestURL = interception.request.url;
 				expect(requestURL).to.include('ec=click');
@@ -89,7 +89,7 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=card-branding-logo]').first().click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest', { responseTimeout: 40_000 }).then(
+		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
 			(interception) => {
 				let requestURL = interception.request.url;
 				expect(requestURL).to.include('ec=click');

--- a/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-6/paid.content.cy.js
@@ -46,7 +46,7 @@ describe('Paid content tests', function () {
 		cy.get('[data-cy=branding-logo]').click();
 
 		// Make sure the call to Google Analytics contains the info we want
-		cy.wait('@gaRequest', { responseTimeout: 40000 }).then(
+		cy.wait('@gaRequest', { responseTimeout: 40_000 }).then(
 			(interception) => {
 				let requestURL = interception.request.url;
 				expect(requestURL).to.include('ec=click');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increases `responseTimeout` in `cy.wait()` called in `paid.content.cy.js` from default 30s to 40s: https://docs.cypress.io/api/commands/wait#Timeouts

## Why?
These two tests are flaky failing with error. This is an attempt to reduce flakiness.

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/19683595/199556299-f236c78c-14a0-4e5d-bf1b-8c1d09fd6945.png">


