### PR TITLE
Add Logo variation on Edition

### DIFF
--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -48,7 +48,7 @@ export const Header = ({
 				/>
 			</Island>
 		</Hide>
-		<Logo />
+		<Logo editionId={editionId} />
 		<Island deferUntil="idle" clientOnly={true}>
 			<ReaderRevenueLinks
 				urls={urls}

--- a/dotcom-rendering/src/web/components/Logo.stories.tsx
+++ b/dotcom-rendering/src/web/components/Logo.stories.tsx
@@ -1,12 +1,38 @@
+import { css } from '@emotion/react';
+import { brand, neutral, space, textSans } from '@guardian/source-foundations';
 import { EditionId } from '../../types/edition';
 import { Logo } from './Logo';
 
 const editionIds: EditionId[] = ['UK', 'US', 'AU', 'INT'];
 
 export const Logos = () => (
-	<ul style={{ listStyleType: 'none', padding: '0' }}>
+	<ul
+		css={css`
+			display: flex;
+			flex-direction: column;
+			list-style-type: none;
+		`}
+	>
 		{editionIds.map((editionId) => (
-			<li>
+			<li
+				css={css`
+					position: relative;
+					margin: ${space[3]}px 0;
+					background-color: ${brand[400]};
+				`}
+			>
+				<h1
+					css={css`
+						position: absolute;
+						top: 20px;
+						left: 20px;
+						color: ${neutral[100]};
+						${textSans.xxxlarge()};
+					`}
+				>
+					{editionId}
+				</h1>
+
 				<Logo editionId={editionId} />
 			</li>
 		))}
@@ -16,5 +42,5 @@ Logos.story = { name: 'Logos for all editions' };
 
 export default {
 	component: Logos,
-	title: 'Components/Logo',
+	title: 'Components/Logos',
 };

--- a/dotcom-rendering/src/web/components/Logo.stories.tsx
+++ b/dotcom-rendering/src/web/components/Logo.stories.tsx
@@ -1,0 +1,20 @@
+import { EditionId } from '../../types/edition';
+import { Logo } from './Logo';
+
+const editionIds: EditionId[] = ['UK', 'US', 'AU', 'INT'];
+
+export const Logos = () => (
+	<ul style={{ listStyleType: 'none', padding: '0' }}>
+		{editionIds.map((editionId) => (
+			<li>
+				<Logo editionId={editionId} />
+			</li>
+		))}
+	</ul>
+);
+Logos.story = { name: 'Logos for all editions' };
+
+export default {
+	component: Logos,
+	title: 'Components/Logo',
+};

--- a/dotcom-rendering/src/web/components/Logo.tsx
+++ b/dotcom-rendering/src/web/components/Logo.tsx
@@ -1,11 +1,15 @@
 import { css } from '@emotion/react';
 import {
 	brandAlt,
-	brandText,
 	from,
+	neutral,
 	visuallyHidden,
 } from '@guardian/source-foundations';
-import { SvgGuardianBestWebsiteLogo } from '@guardian/source-react-components';
+import {
+	SvgGuardianBestWebsiteLogo,
+	SvgGuardianLogo,
+} from '@guardian/source-react-components';
+import { EditionId } from '../../types/edition';
 import { getZIndex } from '../lib/getZIndex';
 
 const linkStyles = css`
@@ -39,20 +43,41 @@ const linkStyles = css`
 	${getZIndex('TheGuardian')}
 `;
 
-export const Logo: React.FC = () => {
-	return (
-		<a css={linkStyles} href="/" data-link-name="nav2 : logo">
-			<span
-				css={css`
-					${visuallyHidden};
-				`}
-			>
-				The Guardian - Back to home
-			</span>
-			<SvgGuardianBestWebsiteLogo
-				textColor={brandText.primary}
-				textAccentColor={brandAlt[400]}
-			/>
-		</a>
-	);
+type Props = {
+	editionId: EditionId;
+};
+
+export const Logo = ({ editionId }: Props) => {
+	switch (editionId) {
+		case 'UK':
+			return (
+				<a css={linkStyles} href="/" data-link-name="nav2 : logo">
+					<span
+						css={css`
+							${visuallyHidden};
+						`}
+					>
+						The Guardian - Back to home
+					</span>
+					<SvgGuardianBestWebsiteLogo
+						textColor={neutral[100]}
+						textAccentColor={brandAlt[400]}
+					/>
+				</a>
+			);
+
+		default:
+			return (
+				<a css={linkStyles} href="/" data-link-name="nav2 : logo">
+					<span
+						css={css`
+							${visuallyHidden};
+						`}
+					>
+						The Guardian - Back to home
+					</span>
+					<SvgGuardianLogo textColor={neutral[100]} />
+				</a>
+			);
+	}
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add variation on the Logo per edition. Captures it in a story.

## Why?

This is [how Frontend does it](https://github.com/guardian/frontend/blob/e8c856a181f53c5043ba7849cd2f0133e91ea8ed/common/app/views/fragments/header.scala.html#L33-L37) and what the expectation is.

The editionalised behaviour was removed in #4690

## Screenshots

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/76776/199692267-4902f603-da48-495f-83b0-b38382934980.png">
