### PR TITLE
refactor: use new deno action

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup deno
-        uses: denolib/setup-deno@v2
+        uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.25.0
+          deno-version: v1.26.2
 
       - name: Run Deno scripts
         run: scripts/ci-deno.sh


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Move to denoland/setup-deno@v1

## Why?

The old version is node 12, and [we get warnings](https://github.com/guardian/dotcom-rendering/actions/runs/3384005415).