### PR TITLE
add aus personalisedAdvertising boolean to consent component event

### DIFF
--- a/dotcom-rendering/src/web/browser/bootCmp/init.ts
+++ b/dotcom-rendering/src/web/browser/bootCmp/init.ts
@@ -92,10 +92,11 @@ const init = async (): Promise<void> => {
 				05: CCPA Do not sell, boolean, with the serialization: true -> "true", false -> "false"
 			    06: AUS (Consent) UUID # Note that the cookie is called "ccpaUUID"
 				07: AUS consentStatus
+				08: AUS personalisedAdvertising, boolean, with the serialization: true -> "true", false -> "false"
 
 			For TCF.v2, an exmaple of array is ["01:TCF.v2", "02:<consent UUID>"", "03:<consent string>""]
 			For CCPA,   an exmaple of array is ["01:CCPA", "04:<consent UUID>", "05:true"]
-			For AUS,    an exmaple of array is ["01:AUS", "06:<consent UUID>", "07:consentedAll"]
+			For AUS,    an exmaple of array is ["01:AUS", "06:<consent UUID>", "07:consentedAll", "08:true"]
 
 			Note: it is possible to deprecate CODES, but they cannot the reused.
 		*/
@@ -119,7 +120,8 @@ const init = async (): Promise<void> => {
 				const ccpaUUID = getCookie({ name: 'ccpaUUID' }) || '';
 				const consentStatus =
 					getCookie({ name: 'consentStatus' }) || '';
-				return ['01:AUS', `06:${ccpaUUID}`, `07:${consentStatus}`];
+				const personalisedAdvertising = consentState.aus.personalisedAdvertising ? 'true' : 'false';
+				return ['01:AUS', `06:${ccpaUUID}`, `07:${consentStatus}`, `08:${personalisedAdvertising}`];
 			}
 			return [];
 		};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds an extra consent attribute to the existing ophan component event that is written on each page view.

## Why?
The [plan](https://docs.google.com/document/d/1fGOxDxcLAv4viBGxEYjDV_N7XS_K0jhALtqn68NkfrM/edit#heading=h.4kpxru711bxf) is to collect consent data for the datalake using ophan's tracker pipeline, instead of routing the data through Sourcepoint.  The CCPA data that sourcepoint returns a boolean opt-in value for Austrialia (equivalent to US do not sell) which isn't represented in the existing component event.  

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
