### PR TITLE
Dependabot AR PRs To 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
         - dependency-name: 'aws-cdk'
         - dependency-name: 'aws-cdk-lib'
         - dependency-name: 'constructs'
+      open-pull-requests-limit: 7
     - package-ecosystem: "npm"
       directory: "/dotcom-rendering"
       schedule:


### PR DESCRIPTION
## Why?

So we can see more dependabot PRs at once.
