### PR TITLE
Handle long `srcdoc` in iframes

### DIFF
--- a/scripts/deno/iframe-titles.ts
+++ b/scripts/deno/iframe-titles.ts
@@ -91,7 +91,18 @@ const promises = results.map(async ({ id, webTitle: title }) => {
 						value,
 					};
 				}
-				case 'srcDoc':
+
+				case 'srcDoc': {
+					return {
+						status: 'missing',
+						attr,
+						// `srcdoc` are too long for github issues!
+						value: value
+							.replace(/<head>.+<\/head>/i, '')
+							.slice(0, 420),
+					};
+				}
+
 				case 'src':
 					return {
 						status: 'missing',


### PR DESCRIPTION
## What does this change?

Show only a slice of iframe’s whose `srcdoc` attribute is set in our iframe-titles Deno script, and strip out the head and show the body content.

Run [no. 3387795177](https://github.com/guardian/dotcom-rendering/actions/runs/3387795177) should result in an update.

**EDIT:** it did!

<img width="802" alt="image" src="https://user-images.githubusercontent.com/76776/199789648-181603f2-d431-430c-afac-a12009844248.png">


## Why?

Long srcdoc meant that our tracking in #5510 has stopped working for a while.