### PR TITLE
Handle Europe edition

### DIFF
--- a/apps-rendering/package-lock.json
+++ b/apps-rendering/package-lock.json
@@ -2767,9 +2767,9 @@
       }
     },
     "@guardian/apps-rendering-api-models": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-1.1.1.tgz",
-      "integrity": "sha512-WR051+HS28SJUPd0iI7trkTFTh5hSt7sPoLuB6hzF4RHvwNKSxmPexstR35W53uiQ6UO4vUYjrCBjI/OhACcPg==",
+      "version": "0.0.0-2022-11-03-SNAPSHOT",
+      "resolved": "https://registry.npmjs.org/@guardian/apps-rendering-api-models/-/apps-rendering-api-models-0.0.0-2022-11-03-SNAPSHOT.tgz",
+      "integrity": "sha512-0Mfzaunk65Mn+PLiSq3nxGBtjoRYNB+IAo+dT3HIDCj5lVqdR9rIpbbrh6Ws9OT5dk9/RX62iiJFSJxg/LT8Iw==",
       "requires": {
         "@guardian/content-api-models": "^17.3.0",
         "@guardian/content-atom-model": "^3.4.0",

--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "^7.15.6",
     "@creditkarma/thrift-server-core": "^1.0.4",
     "@emotion/jest": "^11.10.0",
-    "@guardian/apps-rendering-api-models": "^1.1.1",
+    "@guardian/apps-rendering-api-models": "0.0.0-2022-11-03-SNAPSHOT",
     "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/bridget": "^1.12.0",
     "@guardian/cdk": "^47.3.3",

--- a/apps-rendering/src/datetime.ts
+++ b/apps-rendering/src/datetime.ts
@@ -49,12 +49,14 @@ const formatters = {
 		[Edition.UK]: dateTimeFormatter('Europe/London'),
 		[Edition.US]: dateTimeFormatter('America/New_York'),
 		[Edition.AU]: dateTimeFormatter('Australia/Sydney'),
+		[Edition.EUROPE]: dateTimeFormatter('Europe/Brussels'),
 		[Edition.INTERNATIONAL]: dateTimeFormatter('Europe/London'),
 	},
 	time: {
 		[Edition.UK]: timeFormatter('Europe/London', 'en-GB'),
 		[Edition.US]: timeFormatter('America/New_York', 'en-US'),
 		[Edition.AU]: timeFormatter('Australia/Sydney', 'en-AU'),
+		[Edition.EUROPE]: timeFormatter('Europe/Brussels', 'en-BE'),
 		[Edition.INTERNATIONAL]: timeFormatter('Europe/London', 'en-GB'),
 	},
 };

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -318,6 +318,8 @@ function editionFromString(editionString: string): Edition {
 			return Edition.AU;
 		case 'international':
 			return Edition.INTERNATIONAL;
+		case 'eu':
+			return Edition.EUROPE;
 		case 'uk':
 		default:
 			return Edition.UK;
@@ -411,11 +413,15 @@ app.get('/favicon.ico', (_, res) => res.status(404).end());
 app.get('/fontSize.css', (_, res) => res.status(404).end());
 
 app.get(
-	'/:edition(uk|us|au|international)?/rendered-items/*',
+	'/:edition(uk|us|au|eu|international)?/rendered-items/*',
 	express.raw(),
 	serveArticleGet,
 );
-app.get('/:edition(uk|us|au|international)?/*', express.raw(), serveArticleGet);
+app.get(
+	'/:edition(uk|us|au|eu|international)?/*',
+	express.raw(),
+	serveArticleGet,
+);
 
 app.post('/article', express.raw(), serveArticlePost);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

> **Warning**
> Snapshot dependencies must be removed before merging

- Handles europe edition in the development server with the `eu` symbol: `http://localhost:8080/eu/path/to/content`
- Adds a date and time formatter for the europe edition using `Europe/Brussels` as the timezone and `en-BE` as the locale
- **Must revert**: adds snapshot dependencies for `@guardian/apps-rendering-api-models` to include the Europe edition enum value

## Screenshots

|       | |
|-------------| -|
| Liveblog | ![liveblog][] |
| Article | ![article][] |

[liveblog]: https://user-images.githubusercontent.com/705427/199947209-a242babf-54d4-4edf-b69d-cbed50b7509f.png
[article]: https://user-images.githubusercontent.com/705427/199947214-ac5bc1f4-7609-4534-85de-6c14879cf5f5.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
