### PR TITLE
Set `yarn` Version To Latest

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -3,4 +3,4 @@
 
 
 lastUpdateCheck 1641478836503
-yarn-path ".yarn/releases/yarn-1.22.17.js"
+yarn-path ".yarn/releases/yarn-1.22.19.cjs"


### PR DESCRIPTION
## Why?

Keeps `yarn` up to date for all users.

## Changes

- Used `yarn set version` to retrieve and set latest `yarn` version
- Deleted previous `yarn` version
