### PR TITLE
Add containerPalette in supporting content

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -415,6 +415,7 @@ export const Card = ({
 								supportingContent={supportingContent}
 								alignment="vertical"
 								containerPalette={containerPalette}
+								isDynamo={isDynamo}
 							/>
 						) : (
 							<></>
@@ -426,6 +427,7 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
+					isDynamo={isDynamo}
 					alignment={
 						imagePosition === 'top' ||
 						imagePosition === 'bottom' ||

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -262,8 +262,6 @@ export const CardHeadline = ({
 						css={css`
 							color: ${isDynamo
 								? palette.text.dynamoHeadline
-								: showLine
-								? palette.text.dynamoHeadline
 								: palette.text.cardHeadline};
 						`}
 						className="show-underline"

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -12,6 +12,7 @@ type Props = {
 	supportingContent: DCRSupportingContent[];
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
+	isDynamo?: true;
 };
 
 const wrapperStyles = css`
@@ -66,6 +67,7 @@ export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
+	isDynamo,
 }: Props) => {
 	return (
 		<ul css={[wrapperStyles, directionStyles(alignment)]}>
@@ -93,6 +95,7 @@ export const SupportingContent = ({
 							showLine={true}
 							linkTo={subLink.url}
 							containerPalette={containerPalette}
+							isDynamo={isDynamo}
 						/>
 					</li>
 				);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds containerPalette in supporting content.
## Why?
To style sublinks correctly.

This resolves https://github.com/guardian/dotcom-rendering/issues/6336
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/200023813-05ad6acc-3843-4885-88bb-cda16335747f.png
[after]: https://user-images.githubusercontent.com/110032454/200023638-d4bacbbc-0fdb-4dad-936a-e6902ee94ce4.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
