### PR TITLE
Fix indexing: take first 10 trails for Most Viewed container

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -247,7 +247,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									<MostViewedFooter
 										tabs={[
 											{
-												trails: trails.slice(10),
+												trails: trails.slice(0, 10),
 											},
 										]}
 										sectionName="Most viewed"


### PR DESCRIPTION
## What does this change?

Fix the indexes passed to the `.slice()` that populates the Most Viewed container.

## Why

We want the first 10 cards from the collection for this container; creates parity with Frontend.

See [this comment](https://github.com/guardian/dotcom-rendering/issues/6247#issuecomment-1295160222).

