### PR TITLE
replace dual 'Contribute' and 'Subscribe' CTAs with single 'Support' CTA

### DIFF
--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -331,10 +331,17 @@ const ReaderRevenueLinksNative: React.FC<{
 			Subscribe <ArrowRightIcon />
 		</a>
 	);
+	const SupportButton = () => (
+		<a
+			css={linkStyles}
+			href={getUrl('contribute')}
+			data-link-name={`${dataLinkNamePrefix}contribute-cta`}
+		>
+			Support <ArrowRightIcon />
+		</a>
+	);
 	const PrimaryButton =
 		editionId === 'UK' ? SubscribeButton : ContributeButton;
-	const SecondaryButton =
-		editionId === 'UK' ? ContributeButton : SubscribeButton;
 
 	return (
 		<div ref={setNode} css={inHeader && headerStyles}>
@@ -345,8 +352,7 @@ const ReaderRevenueLinksNative: React.FC<{
 				<div css={subMessageStyles}>
 					<div>Available for everyone, funded by readers</div>
 				</div>
-				<PrimaryButton />
-				<SecondaryButton />
+				<SupportButton />
 			</div>
 
 			<div css={inHeader ? hiddenFromTablet : hidden}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
