### PR TITLE
Add Australia acknowledgement of Country

### DIFF
--- a/dotcom-rendering/src/types/edition.ts
+++ b/dotcom-rendering/src/types/edition.ts
@@ -1,4 +1,4 @@
-const editions = ['UK', 'US', 'INT', 'AU', 'EUR'] as const;
+export const editions = ['UK', 'US', 'INT', 'AU', 'EUR'] as const;
 export type EditionId = typeof editions[number];
 
 export type Edition = {

--- a/dotcom-rendering/src/web/components/Footer.stories.tsx
+++ b/dotcom-rendering/src/web/components/Footer.stories.tsx
@@ -1,0 +1,74 @@
+import { css } from '@emotion/react';
+import { ArticlePillar } from '@guardian/libs';
+import {
+	brand,
+	breakpoints,
+	neutral,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+import { Standard } from '../../../fixtures/generated/articles/Standard';
+import { extractNAV } from '../../model/extract-nav';
+import { editions } from '../../types/edition';
+import { Footer } from './Footer';
+import { Section } from './Section';
+
+const Wrapper = ({ children }: { children: JSX.Element }) => (
+	<Section
+		fullWidth={true}
+		padSides={false}
+		backgroundColour={brand[400]}
+		borderColour={neutral[93]}
+		showSideBorders={false}
+		element="footer"
+	>
+		{children}
+	</Section>
+);
+
+export const Footers = () => (
+	<ul>
+		{editions.map((editionId) => (
+			<li
+				css={css`
+					position: relative;
+					padding: ${space[6]} 0;
+				`}
+			>
+				<h1
+					css={css`
+						color: ${brand[400]};
+						${textSans.xxxlarge()};
+					`}
+				>
+					{editionId} Footer
+				</h1>
+				<Wrapper>
+					<Footer
+						pageFooter={Standard.pageFooter}
+						pillar={ArticlePillar.News}
+						pillars={extractNAV(Standard.nav).pillars}
+						urls={Standard.nav.readerRevenueLinks.header}
+						editionId={editionId}
+						contributionsServiceUrl={
+							Standard.contributionsServiceUrl
+						}
+					/>
+				</Wrapper>
+			</li>
+		))}
+	</ul>
+);
+Footers.story = {
+	name: 'Footer for all editions',
+	parameters: {
+		chromatic: {
+			viewports: Object.values(breakpoints),
+		},
+	},
+};
+
+export default {
+	component: Footers,
+	title: 'Components/Footer',
+};

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -54,19 +54,21 @@ const pillarWrap = css`
 `;
 
 const emailSignup = css`
+	grid-area: signup;
+
 	padding-top: ${space[2]}px;
-	margin-right: 10px;
 	margin-bottom: ${space[3]}px;
 
-	${between.desktop.and.leftCol} {
-		float: left;
+	${from.desktop} {
 		width: 247px;
 	}
-	${between.leftCol.and.wide} {
-		width: 325px;
+
+	${from.leftCol} {
+		width: 298px;
 	}
+
 	${from.wide} {
-		width: 498px;
+		width: 458px;
 	}
 `;
 
@@ -93,6 +95,7 @@ const footerLink = css`
 `;
 
 const footerList = css`
+	grid-area: links;
 	display: flex;
 	flex-wrap: wrap;
 	flex-direction: row;
@@ -128,7 +131,7 @@ const footerList = css`
 		}
 
 		${from.tablet} {
-			margin: 0 10px 36px 0;
+			margin: 0 10px ${space[9]}px 0;
 			width: 150px;
 		}
 
@@ -143,8 +146,7 @@ const footerList = css`
 const readerRevenueLinks = css`
 	border-left: ${footerBorders};
 	flex: 1;
-	padding: 12px 0 0 10px;
-	margin: 0 10px 36px 0;
+	padding: ${space[3]}px 10px ${space[9]}px 10px;
 	width: calc(50% - 10px);
 	${until.tablet} {
 		width: 50%;
@@ -152,21 +154,55 @@ const readerRevenueLinks = css`
 	}
 `;
 
+const acknowledgments = css`
+	grid-area: acknowledgment;
+	align-self: end;
+	${textSans.xxsmall()};
+	padding-top: ${space[3]}px;
+	padding-right: ${space[3]}px;
+	padding-bottom: ${space[3]}px;
+	margin-bottom: ${space[6]}px;
+	max-width: 481px;
+
+	${until.desktop} {
+		border-right: ${footerBorders};
+		position: relative;
+
+		&::after {
+			content: '';
+			position: absolute;
+			height: ${space[9]}px;
+			top: -${space[9]}px;
+			right: -1px;
+			border-right: ${footerBorders};
+		}
+	}
+`;
+
 const copyright = css`
 	${textSans.xxsmall()};
+	padding: ${space[3]}px;
 	padding-left: 20px;
-	padding-right: 12px;
-	padding-top: 12px;
-	padding-bottom: 12px;
 
 	${until.tablet} {
 		margin-top: 11px;
 	}
 `;
 
-const footerItemContainers = css`
-	${from.leftCol} {
-		display: flex;
+const footerGrid = css`
+	display: grid;
+	column-gap: ${space[3]}px;
+
+	grid-template-areas:
+		'signup'
+		'links'
+		'acknowledgment';
+
+	${from.desktop} {
+		grid-template-columns: min-content;
+		grid-template-areas:
+			'signup          links'
+			'acknowledgment  links';
 	}
 
 	clear: both;
@@ -181,7 +217,7 @@ const footerItemContainers = css`
 `;
 
 const bttPosition = css`
-	background-color: ${brandBackground.primary};
+	background-color: ${brand[400]};
 	padding: 0 5px;
 	position: absolute;
 	bottom: -21px;
@@ -211,7 +247,7 @@ const FooterLinks = ({
 				</a>
 			</li>
 		));
-		const key = linkGroup.reduce((acc, { text }) => `acc-${text}`, '');
+		const key = linkGroup.reduce((acc, { text }) => `${acc}-${text}`, '');
 		return <ul key={key}>{linkList}</ul>;
 	});
 
@@ -298,7 +334,7 @@ export const Footer = ({
 				dataLinkName="footer"
 			/>
 		</div>
-		<div css={footerItemContainers}>
+		<div css={footerGrid}>
 			<div css={emailSignup}>
 				<div>
 					Original reporting and incisive analysis, direct from the
@@ -324,6 +360,17 @@ export const Footer = ({
 				editionId={editionId}
 				contributionsServiceUrl={contributionsServiceUrl}
 			/>
+
+			{editionId === 'AU' && (
+				<div css={acknowledgments}>
+					Guardian Australia acknowledges the traditional owners and
+					custodians of Country throughout Australia and their
+					connections to land, waters and community. We pay respect by
+					giving voice to social justice, acknowledging our shared
+					history and valuing the cultures of First Nations.
+				</div>
+			)}
+
 			<div css={bttPosition}>
 				<BackToTop />
 			</div>

--- a/dotcom-rendering/src/web/components/Footer.tsx
+++ b/dotcom-rendering/src/web/components/Footer.tsx
@@ -146,8 +146,10 @@ const footerList = css`
 const readerRevenueLinks = css`
 	border-left: ${footerBorders};
 	flex: 1;
-	padding: ${space[3]}px 10px ${space[9]}px 10px;
+	padding: ${space[3]}px 0 0 10px;
+	margin: 0 10px ${space[9]}px 0;
 	width: calc(50% - 10px);
+
 	${until.tablet} {
 		width: 50%;
 		border-top: ${footerBorders};
@@ -159,12 +161,12 @@ const acknowledgments = css`
 	align-self: end;
 	${textSans.xxsmall()};
 	padding-top: ${space[3]}px;
-	padding-right: ${space[3]}px;
 	padding-bottom: ${space[3]}px;
 	margin-bottom: ${space[6]}px;
-	max-width: 481px;
 
-	${until.desktop} {
+	${between.tablet.and.desktop} {
+		padding-right: ${space[3]}px;
+		max-width: 481px;
 		border-right: ${footerBorders};
 		position: relative;
 
@@ -236,17 +238,19 @@ const FooterLinks = ({
 	contributionsServiceUrl: string;
 }) => {
 	const linkGroups = pageFooter.footerLinks.map((linkGroup) => {
-		const linkList = linkGroup.map((l, index) => (
-			<li key={`${l.url}${index}`}>
-				<a
-					css={[footerLink, l.extraClasses]}
-					href={l.url}
-					data-link-name={l.dataLinkName}
-				>
-					{l.text}
-				</a>
-			</li>
-		));
+		const linkList = linkGroup.map(
+			({ url, extraClasses, dataLinkName, text }) => (
+				<li key={`${url}`}>
+					<a
+						css={[footerLink, extraClasses]}
+						href={url}
+						data-link-name={dataLinkName}
+					>
+						{text}
+					</a>
+				</li>
+			),
+		);
 		const key = linkGroup.reduce((acc, { text }) => `${acc}-${text}`, '');
 		return <ul key={key}>{linkList}</ul>;
 	});

--- a/dotcom-rendering/src/web/components/Logo.stories.tsx
+++ b/dotcom-rendering/src/web/components/Logo.stories.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { brand, neutral, space, textSans } from '@guardian/source-foundations';
-import { EditionId } from '../../types/edition';
+import { editions } from '../../types/edition';
 import { Logo } from './Logo';
-
-const editionIds: EditionId[] = ['UK', 'US', 'AU', 'INT'];
 
 export const Logos = () => (
 	<ul
@@ -13,7 +11,7 @@ export const Logos = () => (
 			list-style-type: none;
 		`}
 	>
-		{editionIds.map((editionId) => (
+		{editions.map((editionId) => (
 			<li
 				css={css`
 					position: relative;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add the following acknoledgement of Country in our Australia edition:

> Guardian Australia acknowledges the traditional owners and
> custodians of Country throughout Australia and their
> connections to land, waters and community. We pay respect by
> giving voice to social justice, acknowledging our shared
> history and valuing the cultures of First Nations.

In order to achieve this, the footer now uses a grid layout.

## Why?

It’s the right thing to do.

Fixes #6353 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/200584082-499d4680-efd7-4cbb-837a-459f2eb029a0.png
[after]: https://user-images.githubusercontent.com/76776/200583973-dcedbf22-610c-4b1c-bc9b-659dcb36001b.png