### PR TITLE
Allow sublinks to take up full width under image.

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -186,10 +186,10 @@ const decideSublinkPosition = (
 	if (!supportingContent || supportingContent.length === 0) {
 		return 'none';
 	}
-	if (imagePosition === 'top') {
+	if (imagePosition === 'top' || supportingContent.length > 2) {
 		return 'outer';
 	}
-	return supportingContent.length > 2 ? 'outer' : 'inner';
+	return 'inner';
 };
 
 export const Card = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds a decideSublinkPosition function which moves supporting content into the correct div to allow 100% width depending on image position.

This resolves https://github.com/guardian/dotcom-rendering/issues/5917
## Why?
Parity with frontend.
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/200839977-07a1b970-7ac2-47a1-ba39-d01381eb15fe.png
[after]: https://user-images.githubusercontent.com/110032454/200839864-c9f25400-6a7e-443c-b581-b3f14a4f274c.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
