### PR TITLE
refactor: remove CAPI ambiguity in article type

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Analysis: CAPIArticleType = {
+export const Analysis: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="59ff93fd27eea2be66feecf0b9a7c0b98d12877a"> \n <img src="https://media.guim.co.uk/59ff93fd27eea2be66feecf0b9a7c0b98d12877a/0_71_6720_4032/1000.jpg" alt="The Sinn Féin leader, Mary Lou McDonald, celebrates with supporters" width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">The Sinn Féin leader, Mary Lou McDonald, celebrates with supporters.</span> \n  <span class="element-image__credit">Photograph: Peter Morrison/AP</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Audio.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Audio: CAPIArticleType = {
+export const Audio: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="gu-image-410269952"> <img src="http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/6/5/1370461050798/Phone-records-data-010.jpg" alt="Phone records data" width="460" height="276" class="gu-image" /> <figcaption> <span class="element-image__caption">Under the terms of the order, the numbers of both parties on a call are handed over, as is location data and the time and duration of all calls. Photograph: Matt Rourke/AP</span> <span class="element-image__credit">Photograph: Matt Rourke/AP</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Comment.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Comment: CAPIArticleType = {
+export const Comment: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="90f6640a4b3a916602353d2158a042b6a7e63726"> <img src="https://media.guim.co.uk/90f6640a4b3a916602353d2158a042b6a7e63726/0_86_3240_1944/1000.jpg" alt="A protest in Newcastle against cuts to library services in 2012. ‘Hacked-back spending has taken an inevitable toll, and reflects something happening all over the country.’" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">A protest in Newcastle against cuts to library services in 2012. ‘Hacked-back spending has taken an inevitable toll, and reflects something happening all over the country.’</span> <span class="element-image__credit">Photograph: Mark Pinder/The Guardian</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Dead.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Dead: CAPIArticleType = {
+export const Dead: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2dbb8d5200a0c46420d3d9145194d7bcb9311d44"> \n <img src="https://media.guim.co.uk/2dbb8d5200a0c46420d3d9145194d7bcb9311d44/0_178_2048_1229/1000.jpg" alt="Perseverance rover as it touched down in the area known as Jezero crater." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Perseverance rover as it touched down in the area known as Jezero crater.</span> \n  <span class="element-image__credit">Photograph: NASA/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Editorial.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Editorial: CAPIArticleType = {
+export const Editorial: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="c8200f3ea53cda44927b11af11e8fc731afc3f34"> <img src="https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/1000.jpg" alt="‘Ministers have said further border measures are required, but cannot say when they will be applied.’ A man waiting at the Heathrow international arrivals hall on 29 January." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘Ministers have said further border measures are required, but cannot say when they will be applied.’</span> <span class="element-image__credit">Photograph: May James/ZUMA Wire/REX/Shutterstock</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Explainer.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Explainer: CAPIArticleType = {
+export const Explainer: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="7a0ffc9b223847aa86a31c5fa362b7b3b3d37c62"> \n <img src="https://media.guim.co.uk/7a0ffc9b223847aa86a31c5fa362b7b3b3d37c62/0_85_4330_2598/1000.jpg" alt="Mick Goodna, Dr Jackie Huggins, Craig Crawford MP, and Queensland premier Annastacia Palaszczuk sign path to treaty documents in Brisbane, Tuesday, 16 August, 2022. " width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Queensland premier Annastacia Palaszczuk co-signs path to treaty documents in Brisbane, 16 August, 2022. A federally negotiated treaty seems a long way off.</span> \n  <span class="element-image__credit">Photograph: Jono Searle/AAP</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Feature.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Feature: CAPIArticleType = {
+export const Feature: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-atom"> \n <gu-atom data-atom-id="d904f65f-f5c1-4786-8d7a-54fc2a4abe72" data-atom-type="media"> \n  <div>\n   <iframe frameborder="0" allowfullscreen="true" src="https://www.youtube-nocookie.com/embed/7z3iv-HkI7o?showinfo=0&amp;rel=0"></iframe>\n  </div>\n </gu-atom> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Gallery.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Gallery: CAPIArticleType = {
+export const Gallery: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="gu-image-410269952"> <img src="http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/6/5/1370461050798/Phone-records-data-010.jpg" alt="Phone records data" width="460" height="276" class="gu-image" /> <figcaption> <span class="element-image__caption">Under the terms of the order, the numbers of both parties on a call are handed over, as is location data and the time and duration of all calls. Photograph: Matt Rourke/AP</span> <span class="element-image__credit">Photograph: Matt Rourke/AP</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Interview.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Interview: CAPIArticleType = {
+export const Interview: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="e193f0cc579ba041293d4616fd9929db9e2b62e8"> <img src="https://media.guim.co.uk/e193f0cc579ba041293d4616fd9929db9e2b62e8/0_889_5480_3288/1000.jpg" alt="‘The hijab is part of my identity’: Halima Aden wears dress by yufash.com; headscarf by Halima x Modanisa, modanisa.com; and bracelet by togetherband.org. " width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘The hijab is part of my identity’: Halima Aden wears dress by <a href="http://yufash.com">yufash.com</a>; headscarf by Halima x Modanisa, <a href="http://modanisa.com">modanisa.com</a>; and bracelet by <a href="http://togetherband.org">togetherband.org</a>. </span> <span class="element-image__credit">Photograph: Jean-Paul Pietrus/The Observer</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Labs.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Labs: CAPIArticleType = {
+export const Labs: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="8b723eb4d94368efc040dc26313a01cec69b588a"> <img src="https://media.guim.co.uk/8b723eb4d94368efc040dc26313a01cec69b588a/0_0_3000_1800/1000.jpg" alt="Are you royal?" width="1000" height="600" class="gu-image" /> </figure>',
 	subMetaSectionLinks: [],

--- a/dotcom-rendering/fixtures/generated/articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Letter.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Letter: CAPIArticleType = {
+export const Letter: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0"> <img src="https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/1000.jpg" alt="Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras a week before making her challenge for the Conservative party leadership in 1975." width="1000" height="797" class="gu-image" /> <figcaption> <span class="element-image__caption">Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras, a week before making her challenge for the Conservative party leadership in 1975.</span> <span class="element-image__credit">Photograph: taken from picture library</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Live.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Live: CAPIArticleType = {
+export const Live: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2dbb8d5200a0c46420d3d9145194d7bcb9311d44"> \n <img src="https://media.guim.co.uk/2dbb8d5200a0c46420d3d9145194d7bcb9311d44/0_178_2048_1229/1000.jpg" alt="Perseverance rover as it touched down in the area known as Jezero crater." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Perseverance rover as it touched down in the area known as Jezero crater.</span> \n  <span class="element-image__credit">Photograph: NASA/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/MatchReport.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const MatchReport: CAPIArticleType = {
+export const MatchReport: FEArticleType = {
 	slotMachineFlags: '',
 	matchType: 'FootballMatchType',
 	main: '<figure class="element element-image" data-media-id="cc1d3dc14ab9104587323ef12ac477004b369637"> <img src="https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/1000.jpg" alt="André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich.</span> <span class="element-image__credit">Photograph: Kieran McManus/BPI/Shutterstock</span> </figcaption> </figure>',

--- a/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NewsletterSignup.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const NewsletterSignup: CAPIArticleType = {
+export const NewsletterSignup: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="6c3d4ac41a205fed233624415dd05e684ee661b2"> <img src="https://media.guim.co.uk/6c3d4ac41a205fed233624415dd05e684ee661b2/0_0_1508_905/1000.png" alt="Our new women’s football newsletter will arrive in your inbox every Wednesday." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Our new women’s football newsletter will arrive in your inbox every Wednesday.</span> <span class="element-image__credit">Illustration: Guardian Design</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const NumberedList: CAPIArticleType = {
+export const NumberedList: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="2ce8db064eabb9e22a69cc45a9b6d4e10d595f06"> \n <img src="https://media.guim.co.uk/2ce8db064eabb9e22a69cc45a9b6d4e10d595f06/392_612_4171_2503/1000.jpg" alt="best smartphone 2019" width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Which is the best premium smartphone for you? Check out this guide to the top mobile phones including iPhone, Samsung, Huawei, OnePlus and Google. </span> \n  <span class="element-image__credit">Photograph: Samuel Gibbs/The Guardian</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PhotoEssay.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const PhotoEssay: CAPIArticleType = {
+export const PhotoEssay: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="00ddc088d562eef31c3dd50729182c4289d06a49"> <img src="https://media.guim.co.uk/00ddc088d562eef31c3dd50729182c4289d06a49/391_441_2719_1632/1000.jpg" alt="Joe Bracegirdle Lanterdan Quarry above Vean Hole Beach, North Coast Shot for Sidetracked Equipped" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Joe Bracegirdle at Lanterdan Quarry, above Vean Hole beach, north Cornwall. All photographs: Cat Vinton/The Guardian</span> <span class="element-image__credit">Photograph: The Guardian</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
+++ b/dotcom-rendering/fixtures/generated/articles/PrintShop.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const PrintShop: CAPIArticleType = {
+export const PrintShop: FEArticleType = {
 	slotMachineFlags: '',
 	main: '',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Quiz.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Quiz: CAPIArticleType = {
+export const Quiz: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="0584dd0a4813e6002e11ff67c28aff9b32da7abf"> \n <img src="https://media.guim.co.uk/0584dd0a4813e6002e11ff67c28aff9b32da7abf/2_0_3020_1814/1000.jpg" alt="Steaua Bucharest, astroturf, Ipswich Town, Italy and Diamond Lights were all big in the 1980s." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Steaua Bucharest, astroturf, Ipswich Town, Italy and Diamond Lights were all big in the 1980s.</span> \n  <span class="element-image__credit">Composite: Allsport/Getty Images; Offside/Getty Images; dpa picture alliance/Alamy</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Recipe.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Recipe: CAPIArticleType = {
+export const Recipe: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="e5a2cb2a63b788eae68ff654f739eff53a0cee28"> <img src="https://media.guim.co.uk/e5a2cb2a63b788eae68ff654f739eff53a0cee28/0_0_3731_4384/851.jpg" alt="Meera Sodha’s spring onion pancakes with sesame sauce" width="851" height="1000" class="gu-image" /> <figcaption> <span class="element-image__caption">Meera Sodha’s spring onion pancakes with sesame sauce.</span> <span class="element-image__credit">Photograph: Louise Hagger/The Guardian. Food styling: Emily Kydd. Prop styling: Jennifer Kay. Food assistant: Susanna Unsworth.</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Review.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Review: CAPIArticleType = {
+export const Review: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image element--showcase" data-media-id="39892d930be2203c5ea452d130772c0279f7dc0c"> <img src="https://media.guim.co.uk/39892d930be2203c5ea452d130772c0279f7dc0c/0_400_6000_3600/1000.jpg" alt="Sex Education." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">So brilliant you can only boggle ... Ncuti Gatwa as Eric in Sex Education.</span> <span class="element-image__credit">Photograph: Sam Taylor/Netflix</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/articles/SpecialReport.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const SpecialReport: CAPIArticleType = {
+export const SpecialReport: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="d302a26f2229a71ab1dfa231208cefc9ae72e3e8"> \n <img src="https://media.guim.co.uk/d302a26f2229a71ab1dfa231208cefc9ae72e3e8/0_200_3000_1800/1000.jpg" alt="Lindsey oil refinery in north Lincolnshire." width="1000" height="600" class="gu-image"> \n <figcaption> \n  <span class="element-image__caption">Lindsey oil refinery in north Lincolnshire.</span> \n  <span class="element-image__credit">Photograph: Christopher Furlong/Getty Images</span> \n </figcaption> \n</figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Standard.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Standard: CAPIArticleType = {
+export const Standard: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="gu-image-410269952"> <img src="http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/6/5/1370461050798/Phone-records-data-010.jpg" alt="Phone records data" width="460" height="276" class="gu-image" /> <figcaption> <span class="element-image__caption">Under the terms of the order, the numbers of both parties on a call are handed over, as is location data and the time and duration of all calls. Photograph: Matt Rourke/AP</span> <span class="element-image__credit">Photograph: Matt Rourke/AP</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/fixtures/generated/articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Video.ts
@@ -11,9 +11,9 @@
  *    gen-fixtures.ts directly.
  */
 
-import type { CAPIArticleType } from '../../../src/types/frontend';
+import type { FEArticleType } from '../../../src/types/frontend';
 
-export const Video: CAPIArticleType = {
+export const Video: FEArticleType = {
 	slotMachineFlags: '',
 	main: '<figure class="element element-image" data-media-id="gu-image-410269952"> <img src="http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/6/5/1370461050798/Phone-records-data-010.jpg" alt="Phone records data" width="460" height="276" class="gu-image" /> <figcaption> <span class="element-image__caption">Under the terms of the order, the numbers of both parties on a call are handed over, as is location data and the time and duration of all calls. Photograph: Matt Rourke/AP</span> <span class="element-image__credit">Photograph: Matt Rourke/AP</span> </figcaption> </figure>',
 	subMetaSectionLinks: [

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -19,7 +19,7 @@ const settings = { rejectDateType: true, required: true };
 module.exports = {
 	getArticleSchema: () => {
 		return JSON.stringify(
-			TJS.generateSchema(program, 'CAPIArticleType', settings),
+			TJS.generateSchema(program, 'FEArticleType', settings),
 			null,
 			4,
 		);

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -1,5 +1,5 @@
 {
-    "description": "WARNING: run `gen-schema` task if changing this to update the associated JSON\nschema definition.",
+    "description": "This type is what we receive from `frontend`,\nhence the FE prefix.\n\nWARNING: run `gen-schema` task if changing this to update the associated JSON\nschema definition.",
     "type": "object",
     "properties": {
         "headline": {

--- a/dotcom-rendering/src/model/enhance-blockquotes.test.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.test.ts
@@ -1,9 +1,9 @@
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
-import type { CAPIArticleType } from '../types/frontend';
+import type { FEArticleType } from '../types/frontend';
 import { enhanceBlockquotes } from './enhance-blockquotes';
 
-const example: CAPIArticleType = ExampleArticle;
+const example: FEArticleType = ExampleArticle;
 
 const formatIsPhotoEssay: CAPIFormat = {
 	...example.format,

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -1,10 +1,10 @@
 // All GA fields should  fall back to default values -
 
 import type { EditionId } from 'src/types/edition';
-import type { CAPIArticleType } from '../types/frontend';
+import type { FEArticleType } from '../types/frontend';
 
 const filterTags = (
-	tags: CAPIArticleType['tags'],
+	tags: FEArticleType['tags'],
 	tagType: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Let’s make a decision to keep this tag getter small and well defined, we don't really want to use tags
 ): TagType['id'] | '' => {
 	const tagArr = tags.filter((tag) => tag.type === tagType);
@@ -20,7 +20,7 @@ const filterTags = (
 
 // Annoyingly we ping GA with commissioningdesk as the title of the tag, not the id so handle that separately
 const getCommissioningDesk = (
-	tags: CAPIArticleType['tags'],
+	tags: FEArticleType['tags'],
 ): TagType['title'] | '' => {
 	const tag = tags.find((thisTag) =>
 		thisTag.id.includes('tracking/commissioningdesk'),

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -3,7 +3,7 @@ import type { Options } from 'ajv';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import type { FEFrontType } from '../../src/types/front';
-import type { CAPIArticleType } from '../types/frontend';
+import type { FEArticleType } from '../types/frontend';
 import articleSchema from './article-schema.json';
 import frontSchema from './front-schema.json';
 
@@ -17,10 +17,10 @@ const options: Options = {
 const ajv = new Ajv(options);
 addFormats(ajv);
 
-const validateArticle = ajv.compile<CAPIArticleType>(articleSchema);
+const validateArticle = ajv.compile<FEArticleType>(articleSchema);
 const validateFront = ajv.compile<FEFrontType>(frontSchema);
 
-export const validateAsCAPIType = (data: unknown): CAPIArticleType => {
+export const validateAsCAPIType = (data: unknown): FEArticleType => {
 	if (validateArticle(data)) return data;
 
 	const url =

--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -6,7 +6,7 @@ import {
 	render as renderAMPArticle,
 	renderPerfTest as renderAMPArticlePerfTest,
 } from '../amp/server';
-import type { CAPIArticleType } from '../types/frontend';
+import type { FEArticleType } from '../types/frontend';
 import {
 	renderArticle,
 	renderArticleJson,
@@ -25,7 +25,7 @@ import { logger } from './lib/logging';
 // Usage: app.post('/Article', logRenderTime, renderArticle);
 const logRenderTime = responseTime(
 	(req: Request, _: Response, time: number) => {
-		const body: CAPIArticleType = req.body;
+		const body: FEArticleType = req.body;
 		logger.info({
 			pageId: body.pageId,
 			renderTime: time,

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -7,10 +7,13 @@ import type { CAPIOnwards } from './onwards';
 import type { CAPITrailType } from './trails';
 
 /**
+ * This type is what we receive from `frontend`,
+ * hence the FE prefix.
+ *
  * WARNING: run `gen-schema` task if changing this to update the associated JSON
  * schema definition.
  */
-export interface CAPIArticleType {
+export interface FEArticleType {
 	headline: string;
 	standfirst: string;
 	webTitle: string;

--- a/dotcom-rendering/src/web/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/web/components/ArticlePage.tsx
@@ -4,7 +4,7 @@ import { brandAlt, focusHalo, neutral } from '@guardian/source-foundations';
 import { StrictMode } from 'react';
 import { filterABTestSwitches } from '../../model/enhance-switches';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { AlreadyVisited } from './AlreadyVisited.importable';
 import { BrazeMessaging } from './BrazeMessaging.importable';
@@ -18,7 +18,7 @@ import { SetABTests } from './SetABTests.importable';
 import { SkipTo } from './SkipTo';
 
 type Props = {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -28,7 +28,7 @@ type Props = {
  * Article is a high level wrapper for article pages on Dotcom. Sets strict mode and some globals
  *
  * @param {Props} props
- * @param {CAPIArticleType} props.CAPIArticle - The article JSON data
+ * @param {FEArticleType} props.CAPIArticle - The article JSON data
  * @param {NAVType} props.NAV - The article JSON data
  * @param {ArticleFormat} props.format - The format model for the article
  * */

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -14,7 +14,7 @@ import { buildAdTargeting } from '../../lib/ad-targeting';
 import { getSoleContributor } from '../../lib/byline';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -260,7 +260,7 @@ const mainMediaWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/DecideLayout.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { CommentLayout } from './CommentLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
 import { ImmersiveLayout } from './ImmersiveLayout';
@@ -12,7 +12,7 @@ import { ShowcaseLayout } from './ShowcaseLayout';
 import { StandardLayout } from './StandardLayout';
 
 type Props = {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -13,7 +13,7 @@ import {
 } from '@guardian/source-foundations';
 import type { NavType } from '../../model/extract-nav';
 import type { Switches } from '../../types/config';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import {
 	adCollapseStyles,
 	labelStyles as adLabelStyles,
@@ -36,7 +36,7 @@ import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -13,7 +13,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -172,7 +172,7 @@ const stretchLines = css`
 	}
 `;
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -16,7 +16,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import React from 'react';
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -202,7 +202,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/Layout.stories.tsx
+++ b/dotcom-rendering/src/web/layouts/Layout.stories.tsx
@@ -22,7 +22,7 @@ import { SpecialReport } from '../../../fixtures/generated/articles/SpecialRepor
 import { Standard } from '../../../fixtures/generated/articles/Standard';
 import { Video } from '../../../fixtures/generated/articles/Video';
 import { extractNAV } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { embedIframe } from '../browser/embedIframe/embedIframe';
 import { doStorybookHydration } from '../browser/islands/doStorybookHydration';
 import { decideFormat } from '../lib/decideFormat';
@@ -30,7 +30,7 @@ import { injectPrivacySettingsLink } from '../lib/injectPrivacySettingsLink';
 import { mockRESTCalls } from '../lib/mockRESTCalls';
 import { DecideLayout } from './DecideLayout';
 
-const Fixtures: { [key: string]: CAPIArticleType } = {
+const Fixtures: { [key: string]: FEArticleType } = {
 	Standard,
 	Gallery,
 	Audio,
@@ -58,7 +58,7 @@ const Fixtures: { [key: string]: CAPIArticleType } = {
 
 mockRESTCalls();
 
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIArticleType }) => {
+const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: FEArticleType }) => {
 	const NAV = extractNAV(ServerCAPI.nav);
 	const format: ArticleFormat = decideFormat(ServerCAPI.format);
 	useEffect(() => {

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -19,7 +19,7 @@ import { Hide } from '@guardian/source-react-components';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -235,7 +235,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -23,7 +23,7 @@ import {
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { Carousel } from '../components/Carousel.importable';
@@ -52,7 +52,7 @@ import { getCurrentPillar } from '../lib/layoutHelpers';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 type Props = {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 };
@@ -164,7 +164,7 @@ const shareDivStyle = css`
 `;
 
 const getMainMediaCaptions = (
-	CAPIArticle: CAPIArticleType,
+	CAPIArticle: FEArticleType,
 ): (string | undefined)[] =>
 	CAPIArticle.mainMediaElements.map((el) =>
 		el._type === 'model.dotcomrendering.pageElements.ImageBlockElement'

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -15,7 +15,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -203,7 +203,7 @@ const PositionHeadline = ({
 };
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -16,7 +16,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -290,7 +290,7 @@ const starWrapper = css`
 `;
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { buildAdTargeting } from '../../../lib/ad-targeting';
 import type { NavType } from '../../../model/extract-nav';
-import type { CAPIArticleType } from '../../../types/frontend';
+import type { FEArticleType } from '../../../types/frontend';
 import type { Palette } from '../../../types/palette';
 import { ArticleHeadline } from '../../components/ArticleHeadline';
 import { ArticleTitle } from '../../components/ArticleTitle';
@@ -41,7 +41,7 @@ const hasMainMediaStyles = css`
 `;
 
 interface Props {
-	CAPIArticle: CAPIArticleType;
+	CAPIArticle: FEArticleType;
 	NAV: NavType;
 	format: ArticleFormat;
 }

--- a/dotcom-rendering/src/web/lib/contributions.ts
+++ b/dotcom-rendering/src/web/lib/contributions.ts
@@ -2,7 +2,7 @@ import { onConsentChange } from '@guardian/consent-management-platform';
 import { getCookie } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useState } from 'react';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import type { IdApiUserData } from './getIdapiUserData';
 import { getIdApiUserData } from './getIdapiUserData';
 import { useOnce } from './useOnce';
@@ -261,7 +261,7 @@ export const lazyFetchEmailWithTimeout =
 	};
 
 export const getContributionsServiceUrl = (
-	CAPIArticle: CAPIArticleType,
+	CAPIArticle: FEArticleType,
 ): string => process.env.SDC_URL ?? CAPIArticle.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];

--- a/dotcom-rendering/src/web/lib/layoutHelpers.ts
+++ b/dotcom-rendering/src/web/lib/layoutHelpers.ts
@@ -1,9 +1,7 @@
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { decideNavTheme } from './decideNavTheme';
 
-export const getCurrentPillar = (
-	CAPIArticle: CAPIArticleType,
-): ArticleTheme => {
+export const getCurrentPillar = (CAPIArticle: FEArticleType): ArticleTheme => {
 	const currentPillar =
 		(CAPIArticle.nav.currentPillarTitle &&
 			(CAPIArticle.nav.currentPillarTitle.toLowerCase() as LegacyPillar)) ||

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -3,11 +3,11 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import { ArticleDesign, ArticlePillar } from '@guardian/libs';
 import { renderToString } from 'react-dom/server';
-import { isAmpSupported } from '../../amp/components/Elements';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 } from '../../../scripts/webpack/bundles';
+import { isAmpSupported } from '../../amp/components/Elements';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -20,7 +20,7 @@ import { escapeData } from '../../lib/escapeData';
 import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { ArticlePage } from '../components/ArticlePage';
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';
@@ -30,35 +30,35 @@ import { pageTemplate } from './pageTemplate';
 import { recipeSchema } from './temporaryRecipeStructuredData';
 
 interface Props {
-	article: CAPIArticleType;
+	article: FEArticleType;
 }
 
-const decideTitle = (CAPIArticle: CAPIArticleType): string => {
+const decideTitle = (article: FEArticleType): string => {
 	if (
-		decideTheme(CAPIArticle.format) === ArticlePillar.Opinion &&
-		CAPIArticle.byline
+		decideTheme(article.format) === ArticlePillar.Opinion &&
+		article.byline
 	) {
-		return `${CAPIArticle.headline} | ${CAPIArticle.byline} | The Guardian`;
+		return `${article.headline} | ${article.byline} | The Guardian`;
 	}
-	return `${CAPIArticle.headline} | ${CAPIArticle.sectionLabel} | The Guardian`;
+	return `${article.headline} | ${article.sectionLabel} | The Guardian`;
 };
 
-export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
-	const NAV = extractNAV(CAPIArticle.nav);
-	const title = decideTitle(CAPIArticle);
+export const articleToHtml = ({ article }: Props): string => {
+	const NAV = extractNAV(article.nav);
+	const title = decideTitle(article);
 	const key = 'dcr';
 	const cache = createCache({ key });
-	const linkedData = CAPIArticle.linkedData;
+	const linkedData = article.linkedData;
 
 	// eslint-disable-next-line @typescript-eslint/unbound-method
 	const { extractCriticalToChunks, constructStyleTagsFromChunks } =
 		createEmotionServer(cache);
 
-	const format: ArticleFormat = decideFormat(CAPIArticle.format);
+	const format: ArticleFormat = decideFormat(article.format);
 
 	const html = renderToString(
 		<CacheProvider value={cache}>
-			<ArticlePage format={format} CAPIArticle={CAPIArticle} NAV={NAV} />
+			<ArticlePage format={format} CAPIArticle={article} NAV={NAV} />
 		</CacheProvider>,
 	);
 
@@ -70,13 +70,13 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name
-	const CAPIElements: CAPIElement[] = CAPIArticle.blocks
+	const CAPIElements: CAPIElement[] = article.blocks
 		.map((block) => block.elements)
 		.flat();
 
 	// Evaluating the performance of HTTP3 over HTTP2
 	// See: https://github.com/guardian/dotcom-rendering/pull/5394
-	const { offerHttp3 = false } = CAPIArticle.config.switches;
+	const { offerHttp3 = false } = article.config.switches;
 
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,URLSearchParams,fetch,NodeList.prototype.forEach,navigator.sendBeacon,performance.now,Promise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
@@ -97,8 +97,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 
 	const shouldServeVariantBundle: boolean = [
 		BUILD_VARIANT,
-		CAPIArticle.config.abTests[dcrJavascriptBundle('Variant')] ===
-			'variant',
+		article.config.abTests[dcrJavascriptBundle('Variant')] === 'variant',
 	].every(Boolean);
 
 	/**
@@ -124,7 +123,7 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 			...getScriptArrayFromFile('bootCmp.js'),
 			...getScriptArrayFromFile('ophan.js'),
 			process.env.COMMERCIAL_BUNDLE_URL ??
-				CAPIArticle.config.commercialBundleUrl,
+				article.config.commercialBundleUrl,
 			...getScriptArrayFromFile('sentryLoader.js'),
 			...getScriptArrayFromFile('dynamicImport.js'),
 			pageHasNonBootInteractiveElements &&
@@ -173,34 +172,34 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	const windowGuardian = escapeData(
 		JSON.stringify(
 			makeWindowGuardian({
-				editionId: CAPIArticle.editionId,
-				stage: CAPIArticle.config.stage,
-				frontendAssetsFullURL: CAPIArticle.config.frontendAssetsFullURL,
-				revisionNumber: CAPIArticle.config.revisionNumber,
-				sentryPublicApiKey: CAPIArticle.config.sentryPublicApiKey,
-				sentryHost: CAPIArticle.config.sentryHost,
-				keywordIds: CAPIArticle.config.keywordIds,
-				dfpAccountId: CAPIArticle.config.dfpAccountId,
-				adUnit: CAPIArticle.config.adUnit,
-				ajaxUrl: CAPIArticle.config.ajaxUrl,
-				googletagUrl: CAPIArticle.config.googletagUrl,
-				switches: CAPIArticle.config.switches,
-				abTests: CAPIArticle.config.abTests,
-				brazeApiKey: CAPIArticle.config.brazeApiKey,
-				isPaidContent: CAPIArticle.pageType.isPaidContent,
-				contentType: CAPIArticle.contentType,
-				shouldHideReaderRevenue: CAPIArticle.shouldHideReaderRevenue,
+				editionId: article.editionId,
+				stage: article.config.stage,
+				frontendAssetsFullURL: article.config.frontendAssetsFullURL,
+				revisionNumber: article.config.revisionNumber,
+				sentryPublicApiKey: article.config.sentryPublicApiKey,
+				sentryHost: article.config.sentryHost,
+				keywordIds: article.config.keywordIds,
+				dfpAccountId: article.config.dfpAccountId,
+				adUnit: article.config.adUnit,
+				ajaxUrl: article.config.ajaxUrl,
+				googletagUrl: article.config.googletagUrl,
+				switches: article.config.switches,
+				abTests: article.config.abTests,
+				brazeApiKey: article.config.brazeApiKey,
+				isPaidContent: article.pageType.isPaidContent,
+				contentType: article.contentType,
+				shouldHideReaderRevenue: article.shouldHideReaderRevenue,
 				GAData: extractGA({
-					webTitle: CAPIArticle.webTitle,
-					format: CAPIArticle.format,
-					sectionName: CAPIArticle.sectionName,
-					contentType: CAPIArticle.contentType,
-					tags: CAPIArticle.tags,
-					pageId: CAPIArticle.pageId,
-					editionId: CAPIArticle.editionId,
-					beaconURL: CAPIArticle.beaconURL,
+					webTitle: article.webTitle,
+					format: article.format,
+					sectionName: article.sectionName,
+					contentType: article.contentType,
+					tags: article.tags,
+					pageId: article.pageId,
+					editionId: article.editionId,
+					beaconURL: article.beaconURL,
 				}),
-				unknownConfig: CAPIArticle.config,
+				unknownConfig: article.config,
 			}),
 		),
 	);
@@ -208,29 +207,29 @@ export const articleToHtml = ({ article: CAPIArticle }: Props): string => {
 	const getAmpLink = (tags: TagType[]) => {
 		if (
 			!isAmpSupported({
-				format: CAPIArticle.format,
+				format: article.format,
 				tags,
-				elements: CAPIArticle.blocks.flatMap((block) => block.elements),
-				switches: CAPIArticle.config.switches,
-				main: CAPIArticle.main,
+				elements: article.blocks.flatMap((block) => block.elements),
+				switches: article.config.switches,
+				main: article.main,
 			})
 		) {
 			return undefined;
 		}
 
-		return `https://amp.theguardian.com/${CAPIArticle.pageId}`;
+		return `https://amp.theguardian.com/${article.pageId}`;
 	};
 
 	// Only include AMP link for interactives which have the 'ampinteractive' tag
-	const ampLink = getAmpLink(CAPIArticle.tags);
+	const ampLink = getAmpLink(article.tags);
 
-	const { openGraphData } = CAPIArticle;
-	const { twitterData } = CAPIArticle;
+	const { openGraphData } = article;
+	const { twitterData } = article;
 	const keywords =
-		typeof CAPIArticle.config.keywords === 'undefined' ||
-		CAPIArticle.config.keywords === 'Network Front'
+		typeof article.config.keywords === 'undefined' ||
+		article.config.keywords === 'Network Front'
 			? ''
-			: CAPIArticle.config.keywords;
+			: article.config.keywords;
 
 	const initTwitter = `
 <script>
@@ -253,7 +252,7 @@ window.twttr = (function(d, s, id) {
 }(document, "script", "twitter-wjs"));
 </script>`;
 
-	const { webURL, canonicalUrl } = CAPIArticle;
+	const { webURL, canonicalUrl } = article;
 
 	const recipeMarkup =
 		webURL in recipeSchema ? recipeSchema[webURL] : undefined;
@@ -265,7 +264,7 @@ window.twttr = (function(d, s, id) {
 		css: extractedCss,
 		html,
 		title,
-		description: CAPIArticle.trailText,
+		description: article.trailText,
 		windowGuardian,
 		gaPath,
 		ampLink,

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -7,7 +7,7 @@ import { enhanceStandfirst } from '../../model/enhanceStandfirst';
 import { enhanceTableOfContents } from '../../model/enhanceTableOfContents';
 import { validateAsCAPIType, validateAsFrontType } from '../../model/validate';
 import type { DCRFrontType, FEFrontType } from '../../types/front';
-import type { CAPIArticleType } from '../../types/frontend';
+import type { FEArticleType } from '../../types/frontend';
 import { articleToHtml } from './articleToHtml';
 import { blocksToHtml } from './blocksToHtml';
 import { frontToHtml } from './frontToHtml';
@@ -17,7 +17,7 @@ function enhancePinnedPost(format: CAPIFormat, block?: Block) {
 	return block ? enhanceBlocks([block], format)[0] : block;
 }
 
-const enhanceCAPIType = (body: unknown): CAPIArticleType => {
+const enhanceCAPIType = (body: unknown): FEArticleType => {
 	const data = validateAsCAPIType(body);
 
 	const enhancedBlocks = enhanceBlocks(
@@ -26,7 +26,7 @@ const enhanceCAPIType = (body: unknown): CAPIArticleType => {
 		data.promotedNewsletter,
 	);
 
-	const CAPIArticle: CAPIArticleType = {
+	const CAPIArticle: FEArticleType = {
 		...data,
 		blocks: enhancedBlocks,
 		pinnedPost: enhancePinnedPost(data.format, data.pinnedPost),


### PR DESCRIPTION
## What does this change?

Rename `CAPIArticleType` to `FEArticleType`, as the it is received from Frontend, not CAPI.

## Why?

This is confusing to newcomers and old timers alike, so we should change it.