### PR TITLE
Refactor Tag types

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -273,16 +273,6 @@ interface CAPINavType {
 
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
-interface TagType {
-	id: string;
-	type: string;
-	title: string;
-	twitterHandle?: string;
-	paidContentType?: string;
-	bylineImageUrl?: string;
-	bylineLargeImageUrl?: string;
-}
-
 /**
  * BlocksRequest is the expected body format for POST requests made to /Blocks
  */

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -1,5 +1,6 @@
 import type { Switches } from 'src/types/config';
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
+import type { TagType } from '../../types/tag';
 import { enhance } from '../lib/enhance';
 import { AudioAtomBlockComponent } from './elements/AudioAtomBlockComponent';
 import { CommentBlockComponent } from './elements/CommentBlockComponent';

--- a/dotcom-rendering/src/amp/components/Onward.tsx
+++ b/dotcom-rendering/src/amp/components/Onward.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import React from 'react';
+import type { TagType } from '../../types/tag';
 import { OnwardContainer } from './OnwardContainer';
 
 const wrapper = css`

--- a/dotcom-rendering/src/amp/components/topMeta/Byline.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/Byline.tsx
@@ -1,4 +1,5 @@
 import { getBylineComponentsFromTokens } from '../../../lib/byline';
+import type { TagType } from '../../../types/tag';
 import { bylineTokens } from '../../lib/byline-tokens';
 
 type Props = {

--- a/dotcom-rendering/src/amp/components/topMeta/SeriesLink.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/SeriesLink.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
 import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
+import type { TagType } from '../../../types/tag';
 
 const seriesStyle = (pillar: ArticleTheme) => css`
 	color: ${pillarPalette_DO_NOT_USE[pillar].main};

--- a/dotcom-rendering/src/amp/lib/byline-tokens.ts
+++ b/dotcom-rendering/src/amp/lib/byline-tokens.ts
@@ -1,3 +1,5 @@
+import type { TagType } from '../../types/tag';
+
 export const bylineTokens = (
 	byline: string,
 	contributorTags: TagType[],

--- a/dotcom-rendering/src/amp/lib/tag-utils.ts
+++ b/dotcom-rendering/src/amp/lib/tag-utils.ts
@@ -1,3 +1,5 @@
+import type { TagType } from '../../types/tag';
+
 export const filterForTagsOfType = (
 	tags: TagType[],
 	tagType: string,

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -1,5 +1,6 @@
 import type { CommercialProperties } from '../../types/commercial';
 import type { EditionId } from '../../types/edition';
+import type { TagType } from '../../types/tag';
 
 // This is a subset of CAPIArticleType for use in AMP and as a result there needs to be parity between the types of shared fields.
 export interface ArticleModel {

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -1,3 +1,5 @@
+import type { TagType } from '../types/tag';
+
 export const getAgeWarning = (
 	tags: TagType[],
 	webPublicationDate: string,

--- a/dotcom-rendering/src/lib/byline.ts
+++ b/dotcom-rendering/src/lib/byline.ts
@@ -1,3 +1,5 @@
+import type { TagType } from '../types/tag';
+
 interface ContributorTag extends TagType {
 	type: 'Contributor';
 }

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -218,7 +218,35 @@
         "tags": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/TagType"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "twitterHandle": {
+                        "type": "string"
+                    },
+                    "paidContentType": {
+                        "type": "string"
+                    },
+                    "bylineImageUrl": {
+                        "type": "string"
+                    },
+                    "bylineLargeImageUrl": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "title",
+                    "type"
+                ]
             }
         },
         "format": {
@@ -3814,37 +3842,6 @@
                 "US"
             ],
             "type": "string"
-        },
-        "TagType": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "twitterHandle": {
-                    "type": "string"
-                },
-                "paidContentType": {
-                    "type": "string"
-                },
-                "bylineImageUrl": {
-                    "type": "string"
-                },
-                "bylineLargeImageUrl": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
         },
         "LegacyPillar": {
             "enum": [

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -6,8 +6,8 @@ import type {
 	DCRSupportingContent,
 	FEFrontCard,
 	FESupportingContent,
-	FETagType,
 } from '../types/front';
+import type { FETagType, TagType } from '../types/tag';
 import { decideFormat } from '../web/lib/decideFormat';
 import { getDataLinkNameCard } from '../web/lib/getDataLinkName';
 import { enhanceSnaps } from './enhanceSnaps';
@@ -96,8 +96,8 @@ const decideAvatarUrl = (
 	return soleContributor?.bylineLargeImageUrl ?? undefined;
 };
 
-const enhanceTags = (tags: { properties: FETagType }[]): TagType[] => {
-	return tags.map((tag) => {
+const enhanceTags = (tags: FETagType[]): TagType[] => {
+	return tags.map(({ properties }) => {
 		const {
 			id,
 			tagType,
@@ -105,7 +105,7 @@ const enhanceTags = (tags: { properties: FETagType }[]): TagType[] => {
 			twitterHandle,
 			bylineImageUrl,
 			contributorLargeImagePath,
-		} = tag.properties;
+		} = properties;
 
 		return {
 			id,

--- a/dotcom-rendering/src/model/extract-ga.ts
+++ b/dotcom-rendering/src/model/extract-ga.ts
@@ -2,6 +2,7 @@
 
 import type { EditionId } from 'src/types/edition';
 import type { FEArticleType } from '../types/frontend';
+import type { TagType } from '../types/tag';
 
 const filterTags = (
 	tags: FEArticleType['tags'],

--- a/dotcom-rendering/src/model/find-pillar.ts
+++ b/dotcom-rendering/src/model/find-pillar.ts
@@ -1,4 +1,5 @@
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { TagType } from '../types/tag';
 
 export const findPillar: (
 	name: string,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -647,6 +647,7 @@
                                                                 "tags": {
                                                                     "type": "array",
                                                                     "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
                                                                         "type": "object",
                                                                         "properties": {
                                                                             "properties": {
@@ -655,25 +656,10 @@
                                                                                     "id": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tagType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "bio": {
@@ -682,18 +668,35 @@
                                                                                     "bylineImageUrl": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "id",
-                                                                                    "sectionId",
-                                                                                    "sectionName",
                                                                                     "tagType",
-                                                                                    "url",
-                                                                                    "webTitle",
-                                                                                    "webUrl"
+                                                                                    "webTitle"
                                                                                 ]
                                                                             }
                                                                         },
@@ -1314,6 +1317,7 @@
                                                                 "tags": {
                                                                     "type": "array",
                                                                     "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
                                                                         "type": "object",
                                                                         "properties": {
                                                                             "properties": {
@@ -1322,25 +1326,10 @@
                                                                                     "id": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tagType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "bio": {
@@ -1349,18 +1338,35 @@
                                                                                     "bylineImageUrl": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "id",
-                                                                                    "sectionId",
-                                                                                    "sectionName",
                                                                                     "tagType",
-                                                                                    "url",
-                                                                                    "webTitle",
-                                                                                    "webUrl"
+                                                                                    "webTitle"
                                                                                 ]
                                                                             }
                                                                         },
@@ -1981,6 +1987,7 @@
                                                                 "tags": {
                                                                     "type": "array",
                                                                     "items": {
+                                                                        "description": "This type comes from `frontend`, hence the FE prefix.",
                                                                         "type": "object",
                                                                         "properties": {
                                                                             "properties": {
@@ -1989,25 +1996,10 @@
                                                                                     "id": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "url": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tagType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "sectionId": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "sectionName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "webTitle": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "webUrl": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "twitterHandle": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "bio": {
@@ -2016,18 +2008,35 @@
                                                                                     "bylineImageUrl": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "bylineLargeImageUrl": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "contributorLargeImagePath": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "paidContentType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "sectionName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "twitterHandle": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "url": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "webUrl": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "id",
-                                                                                    "sectionId",
-                                                                                    "sectionName",
                                                                                     "tagType",
-                                                                                    "url",
-                                                                                    "webTitle",
-                                                                                    "webUrl"
+                                                                                    "webTitle"
                                                                                 ]
                                                                             }
                                                                         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -2,6 +2,7 @@ import type { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import type { ServerSideTests, Switches } from './config';
 import type { EditionId } from './edition';
 import type { FooterType } from './footer';
+import type { FETagType } from './tag';
 import type { TrailType } from './trails';
 
 export interface FEFrontType {
@@ -101,21 +102,6 @@ export type DCRContainerPalette =
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;
 
-export type FETagType = {
-	id: string;
-	url: string;
-	tagType: string;
-	sectionId: string;
-	sectionName: string;
-	webTitle: string;
-	webUrl: string;
-	twitterHandle?: string;
-	/* bio is html */
-	bio?: string;
-	bylineImageUrl?: string;
-	contributorLargeImagePath?: string;
-};
-
 export type FEFrontCard = {
 	properties: {
 		isBreaking: boolean;
@@ -161,7 +147,7 @@ export type FEFrontCard = {
 				standfirst?: string;
 			};
 			elements: Record<string, unknown>;
-			tags: { tags: { properties: FETagType }[] };
+			tags: { tags: FETagType[] };
 		};
 		maybeContentId?: string;
 		isLiveBlog: boolean;

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -4,6 +4,7 @@ import type { ConfigType } from './config';
 import type { EditionId } from './edition';
 import type { FooterType } from './footer';
 import type { CAPIOnwards } from './onwards';
+import type { TagType } from './tag';
 import type { CAPITrailType } from './trails';
 
 /**

--- a/dotcom-rendering/src/types/tag.ts
+++ b/dotcom-rendering/src/types/tag.ts
@@ -1,0 +1,33 @@
+/**
+ * This type comes from `frontend`, hence the FE prefix.
+ *
+ * @see https://github.com/guardian/frontend/blob/5b987289/common/app/model/Tag.scala#L156-L179
+ */
+export type FETagType = {
+	properties: {
+		id: string;
+		tagType: string;
+		webTitle: string;
+		/* bio is html */
+		bio?: string;
+		bylineImageUrl?: string;
+		bylineLargeImageUrl?: string;
+		contributorLargeImagePath?: string;
+		paidContentType?: string;
+		sectionId?: string;
+		sectionName?: string;
+		twitterHandle?: string;
+		url?: string;
+		webUrl?: string;
+	};
+};
+
+export type TagType = {
+	id: string;
+	type: string;
+	title: string;
+	twitterHandle?: string;
+	paidContentType?: string;
+	bylineImageUrl?: string;
+	bylineLargeImageUrl?: string;
+};

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -4,6 +4,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
 import type { Switches } from '../../types/config';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
 import { decidePalette } from '../lib/decidePalette';
 import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -10,6 +10,7 @@ import {
 } from '@guardian/source-foundations';
 import { getAgeWarning } from '../../lib/age-warning';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 import { getZIndex } from '../lib/getZIndex';

--- a/dotcom-rendering/src/web/components/ArticleMeta.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.tsx
@@ -12,6 +12,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { getSoleContributor } from '../../lib/byline';
 import type { Branding as BrandingType } from '../../types/branding';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 import { Avatar } from './Avatar';

--- a/dotcom-rendering/src/web/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
 import type { BadgeType } from '../../types/badge';
+import type { TagType } from '../../types/tag';
 import { Badge } from './Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
 

--- a/dotcom-rendering/src/web/components/BylineLink.tsx
+++ b/dotcom-rendering/src/web/components/BylineLink.tsx
@@ -4,6 +4,7 @@ import {
 	getSoleContributor,
 	isContributor,
 } from '../../lib/byline';
+import type { TagType } from '../../types/tag';
 
 type Props = {
 	byline: string;

--- a/dotcom-rendering/src/web/components/Contributor.tsx
+++ b/dotcom-rendering/src/web/components/Contributor.tsx
@@ -4,6 +4,7 @@ import { from, headline, textSans, until } from '@guardian/source-foundations';
 import { getSoleContributor } from '../../lib/byline';
 import TwitterIcon from '../../static/icons/twitter.svg';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 import { BylineLink } from './BylineLink';

--- a/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/web/components/GetMatchNav.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
 import type { SWRConfiguration } from 'swr';
+import type { TagType } from '../../types/tag';
 import { useApi } from '../lib/useApi';
 import { ArticleHeadline } from './ArticleHeadline';
 import { MatchNav } from './MatchNav';

--- a/dotcom-rendering/src/web/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/web/components/HeadlineByline.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source-foundations';
 import { getSoleContributor } from '../../lib/byline';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { decidePalette } from '../lib/decidePalette';
 import { BylineLink } from './BylineLink';
 

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -7,6 +7,7 @@ import type { EpicPayload } from '@guardian/support-dotcom-components/dist/dotco
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useArticleCounts } from '../../lib/articleCount';
+import type { TagType } from '../../types/tag';
 import { submitComponentEvent } from '../browser/ophan/ophan';
 import {
 	getLastOneOffContributionTimestamp,

--- a/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/web/components/OnwardsUpper.importable.tsx
@@ -3,6 +3,7 @@ import { ArticlePillar } from '@guardian/libs';
 import { joinUrl } from '../../lib/joinUrl';
 import type { EditionId } from '../../types/edition';
 import type { OnwardsSource } from '../../types/onwards';
+import type { TagType } from '../../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Section } from './Section';
 

--- a/dotcom-rendering/src/web/components/RichLink.tsx
+++ b/dotcom-rendering/src/web/components/RichLink.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source-foundations';
 import ArrowInCircle from '../../static/icons/arrow-in-circle.svg';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { decidePalette } from '../lib/decidePalette';
 import { Avatar } from './Avatar';
 import { Hide } from './Hide';

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import type { TagType } from '../../types/tag';
 import { decideFormat } from '../lib/decideFormat';
 import { useApi } from '../lib/useApi';
 import type { RichLinkImageData } from './RichLink';

--- a/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/web/components/SeriesSectionLink.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import type { BadgeType } from '../../types/badge';
 import type { Palette } from '../../types/palette';
+import type { TagType } from '../../types/tag';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';
 import { Badge } from './Badge';

--- a/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/displayRule.ts
@@ -1,6 +1,7 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
 import { onConsent } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { TagType } from '../../../types/tag';
 import type { DailyArticle } from '../../lib/dailyArticleCount';
 import { getDailyArticleCount } from '../../lib/dailyArticleCount';
 import { hasUserDismissedGateMoreThanCount } from './dismissGate';

--- a/dotcom-rendering/src/web/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/web/components/SignInGate/types.ts
@@ -1,3 +1,5 @@
+import type { TagType } from '../../../types/tag';
+
 export type CanShowGateProps = {
 	isSignedIn: boolean;
 	currentTest: CurrentSignInGateABTest;

--- a/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/web/components/SignInGateSelector.importable.tsx
@@ -1,6 +1,7 @@
 import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { constructQuery } from '../../lib/querystring';
+import type { TagType } from '../../types/tag';
 import { useOnce } from '../lib/useOnce';
 import { useSignInGateSelector } from '../lib/useSignInGateSelector';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';

--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -6,6 +6,7 @@ import { getCookie } from '@guardian/libs';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../../lib/articleCount';
+import type { TagType } from '../../types/tag';
 import { getLocaleCode } from '../lib/getCountryCode';
 import type {
 	CandidateConfig,

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -10,6 +10,7 @@ import type {
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
+import type { TagType } from '../../../types/tag';
 import { initPerf } from '../../browser/initPerf';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import {

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -7,6 +7,7 @@ import { getCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import type { ArticleCounts } from '../../lib/articleCount';
 import { getArticleCounts } from '../../lib/articleCount';
+import type { TagType } from '../../types/tag';
 import { getAlreadyVisitedCount } from '../lib/alreadyVisited';
 import { getLocaleCode } from '../lib/getCountryCode';
 import type {

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useState } from 'react';
 import type { ArticleCounts } from '../../../lib/articleCount';
+import type { TagType } from '../../../types/tag';
 import { trackNonClickInteraction } from '../../browser/ga/ga';
 import { submitComponentEvent } from '../../browser/ophan/ophan';
 import {

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { Switches } from '../../types/config';
+import type { TagType } from '../../types/tag';
 import {
 	adCollapseStyles,
 	labelStyles as adLabelStyles,

--- a/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/LiveBlogRenderer.tsx
@@ -1,5 +1,6 @@
 import { Hide } from '@guardian/source-react-components';
 import type { Switches } from '../../types/config';
+import type { TagType } from '../../types/tag';
 import { EnhancePinnedPost } from '../components/EnhancePinnedPost.importable';
 import { FilterKeyEventsToggle } from '../components/FilterKeyEventsToggle.importable';
 import { Island } from '../components/Island';

--- a/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateWillShow.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { TagType } from '../../types/tag';
 import type {
 	CurrentSignInGateABTest,
 	SignInGateComponent,

--- a/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/web/lib/withSignInGateSlot.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { Switches } from '../../types/config';
+import type { TagType } from '../../types/tag';
 import { Island } from '../components/Island';
 import { SignInGateSelector } from '../components/SignInGateSelector.importable';
 

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -21,6 +21,7 @@ import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
 import type { FEArticleType } from '../../types/frontend';
+import type { TagType } from '../../types/tag';
 import { ArticlePage } from '../components/ArticlePage';
 import { decideFormat } from '../lib/decideFormat';
 import { decideTheme } from '../lib/decideTheme';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Clarify `FETagType` & `TagType`: One comes from Frontend, the other is our enhanced DCR one.

## Why?

Explain away the inconsistencies between our tag types and document the source of the data model.