### PR TITLE
stack-sublinks-horizontally-above-phablet

### DIFF
--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -35,6 +35,9 @@ const directionStyles = (alignment: Alignment) => {
 		case 'vertical':
 			return css`
 				flex-direction: column;
+				${from.phablet} {
+					flex-direction: row;
+				}
 			`;
 	}
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/201096776-9142fe09-8e5d-4c41-92e9-50e50e83b339.png
[after]: https://user-images.githubusercontent.com/110032454/201096620-bf0d8ac1-8b54-4fb8-9c9f-83a8f0b7402b.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
