### PR TITLE
Update `ReaderRevenueEpic` to send isSignedIn data

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
     "@guardian/discussion-rendering": "^11.0.3",
     "@guardian/libs": "^9.0.1",
     "@guardian/shimport": "^1.0.2",
-    "@guardian/support-dotcom-components": "^1.0.6",
+    "@guardian/support-dotcom-components": "^1.0.7",
     "@guardian/tsconfig": "^0.1.4",
     "@percy/cli": "^1.4.0",
     "@percy/cypress": "^3.1.2",

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -93,6 +93,7 @@ const buildPayload = async (data: CanShowData): Promise<EpicPayload> => ({
 		browserId: (await hasCmpConsentForBrowserId())
 			? data.browserId
 			: undefined,
+		isSignedIn: data.isSignedIn,
 	},
 });
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates `buildPayload` within the `ReaderRevenueEpic` to send isSignedIn data.

## Why?
For the upcoming US moment we will use Braze for signed-in supporters, and RRCP for everyone else.
This means RRCP needs a new targeting option:

Signed-in status:
- Signed out
- Signed in

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
