### PR TITLE
Use New `yarn.lock` For AR Snyk Action

### DIFF
--- a/.github/workflows/ar-snyk.yml
+++ b/.github/workflows/ar-snyk.yml
@@ -23,4 +23,4 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
                   command: monitor
-                  args: --org=guardian-mobile --project-name=apps-rendering --file=apps-rendering/package-lock.json
+                  args: --org=guardian-mobile --project-name=apps-rendering --file=apps-rendering/yarn.lock


### PR DESCRIPTION
## Why?

AR was migrated to Yarn in #6339. This PR updates the Snyk action to point to the new Yarn lockfile.

## Changes

 - Use new `yarn.lock` for AR Snyk action
