### PR TITLE
DCR FrontsDont show trail text on 25% cards in 75/25 slices

### DIFF
--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -125,13 +125,6 @@ export const Card75_Card25 = ({
 			<FrontCard
 				trail={cards[1]}
 				containerPalette={containerPalette}
-				trailText={
-					// Only show trail text if there is no supportContent
-					cards[1].supportingContent === undefined ||
-					cards[1].supportingContent.length === 0
-						? cards[1].trailText
-						: undefined
-				}
 				supportingContent={cards[1].supportingContent}
 				showAge={showAge}
 			/>
@@ -157,13 +150,6 @@ export const Card25_Card75 = ({
 		<LI percentage="25%" padSides={true}>
 			<FrontCard
 				trail={cards[0]}
-				trailText={
-					// Only show trail text if there is no supportContent
-					cards[0].supportingContent === undefined ||
-					cards[0].supportingContent.length === 0
-						? cards[0].trailText
-						: undefined
-				}
 				supportingContent={cards[0].supportingContent}
 				containerPalette={containerPalette}
 				showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Trail text shouldn't show

## Why?

Parity with frontend

## Screenshots

Before:
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/9575458/201138944-22773ff8-9cc9-48fe-a425-8f060de3b7f6.png">


After:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/9575458/201139184-7586dda5-fb30-486c-a8ab-242d8750c630.png">


Frontend:

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/9575458/201139013-39cccd05-49be-4daf-90e7-04c646fc422e.png">

