### PR TITLE
Add design tag to more article types

### DIFF
--- a/dotcom-rendering/fixtures/manual/tags.ts
+++ b/dotcom-rendering/fixtures/manual/tags.ts
@@ -1,0 +1,17 @@
+export const tags = [
+	{
+		id: 'commentisfree/commentisfree',
+		type: 'Blog',
+		title: 'Opinion',
+	},
+	{
+		id: 'business/austerity',
+		type: 'Keyword',
+		title: 'Austerity',
+	},
+	{
+		id: 'tone/comment',
+		type: 'Tone',
+		title: 'Comment',
+	},
+];

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -516,7 +516,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -550,7 +550,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -591,7 +591,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -631,7 +631,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -680,7 +680,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -721,7 +721,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs
@@ -761,7 +761,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									className={
 										interactiveLegacyClasses.headline
@@ -797,7 +797,7 @@ export const ArticleHeadline = ({
 								}
 								format={format}
 							>
-								<DesignTag format={format} />
+								<DesignTag format={format} tags={tags} />
 								<h1
 									css={[
 										format.theme === ArticleSpecial.Labs

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -476,7 +476,7 @@ export const ArticleHeadline = ({
 						}
 						format={format}
 					>
-						<DesignTag format={format} />
+						<DesignTag format={format} tags={tags} />
 						<h1
 							css={[
 								format.theme === ArticleSpecial.Labs

--- a/dotcom-rendering/src/web/components/DesignTag.stories.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.stories.tsx
@@ -5,6 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
+import { tags } from 'fixtures/manual/tags';
 import { DesignTag } from './DesignTag';
 
 export default {
@@ -20,6 +21,7 @@ export const Analysis = () => {
 				display: ArticleDisplay.Standard,
 				theme: ArticlePillar.News,
 			}}
+			tags={tags}
 		/>
 	);
 };
@@ -38,6 +40,7 @@ export const Interview = () => {
 					display: ArticleDisplay.Standard,
 					theme: ArticlePillar.Sport,
 				}}
+				tags={tags}
 			/>
 		</div>
 	);
@@ -52,6 +55,7 @@ export const SpecialReport = () => {
 				display: ArticleDisplay.Standard,
 				theme: ArticleSpecial.SpecialReport,
 			}}
+			tags={tags}
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -102,7 +102,13 @@ const TagLink = ({
 	);
 };
 
-export const DesignTag = ({ format }: { format: ArticleFormat }) => {
+export const DesignTag = ({
+	format,
+	tags,
+}: {
+	format: ArticleFormat;
+	tags: TagType[];
+}) => {
 	switch (format.design) {
 		case ArticleDesign.Analysis:
 			return (
@@ -144,6 +150,25 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
+		case ArticleDesign.Feature:
+			if (tags.find((tag) => tag.title === 'tone/profiles')) {
+				return (
+					<Margins format={format}>
+						<Tag format={format}>
+							<TagLink href="tone/profiles">Profile</TagLink>
+						</Tag>
+					</Margins>
+				);
+			} else if (tags.find((tag) => tag.title === 'tone/timeline')) {
+				return (
+					<Margins format={format}>
+						<Tag format={format}>
+							<TagLink href="tone/timeline">Timeline</TagLink>
+						</Tag>
+					</Margins>
+				);
+			} else return null;
+
 		default:
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -120,11 +120,27 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
-		case ArticleDesign.Interview:
+		case ArticleDesign.Review:
 			return (
 				<Margins format={format}>
 					<Tag format={format}>
-						<TagLink href="/tone/interview">Interview</TagLink>
+						<TagLink href="/tone/reviews">Review</TagLink>
+					</Tag>
+				</Margins>
+			);
+		case ArticleDesign.Letter:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/letters">Letter</TagLink>
+					</Tag>
+				</Margins>
+			);
+		case ArticleDesign.Obituary:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/obituarys">Obituary</TagLink>
 					</Tag>
 				</Margins>
 			);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
