### PR TITLE
fix: Dont try and render an image if there are no sources

### DIFF
--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -256,6 +256,13 @@ export const ImageComponent = ({
 		};
 		return images.slice().sort(descendingByWidth)[0].url;
 	};
+
+	// Its possible the tools wont send us any images urls
+	// if so, don't try to render
+	if (element.media.allImages.length === 0) {
+		return null;
+	}
+
 	// Legacy images do not have a master so we fallback to the largest available
 	const image =
 		getMaster(element.media.allImages) ??


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Check that there are image assets available before trying to render an image

## Why?

Otherwise we get this error:
<img width="877" alt="image" src="https://user-images.githubusercontent.com/9575458/201338438-20518276-c9fd-4d99-8e17-4be04326c16e.png">


