### PR TITLE
Dropdown ul styles fix

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
@@ -138,7 +138,7 @@ export const dropDownOverrides = css`
 
 	font-weight: bold;
 
-	&:hover {
+	&:not(ul):hover {
 		color: ${neutral[100]};
 		text-decoration: underline;
 	}


### PR DESCRIPTION
## What does this change?
Dropdown component ul list should not inherit parent text-decoration cssOverrides

## Screenshots
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/201341488-c73196c4-74a2-49cd-b4df-d1bb3852ce90.png)  |  ![](https://user-images.githubusercontent.com/2510683/201345008-365b8857-c9f4-45dc-81d1-296917bed1ca.png)
