### PR TITLE
fix: correct headerTopNav switch

### DIFF
--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -303,7 +303,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									idApiUrl={CAPIArticle.config.idApiUrl}
 									headerTopBarSwitch={
 										!!CAPIArticle.config.switches
-											.headerTopBar
+											.headerTopNav
 									}
 									isInEuropeTest={isInEuropeTest}
 								/>
@@ -329,7 +329,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									editionId={CAPIArticle.editionId}
 									headerTopBarSwitch={
 										!!CAPIArticle.config.switches
-											.headerTopBar
+											.headerTopNav
 									}
 								/>
 							</Section>
@@ -407,7 +407,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									editionId={CAPIArticle.editionId}
 									headerTopBarSwitch={
 										!!CAPIArticle.config.switches
-											.headerTopBar
+											.headerTopNav
 									}
 								/>
 							</Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fix the switch name in Showcase Layout.

## Why?

This layout still had the old switch name, so was rendering with the previous header.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/201354949-6935af1d-79f4-4b5c-8cc0-e9711b59cc77.png
[after]: https://user-images.githubusercontent.com/76776/201355284-d7285515-1a94-47ca-9160-f2943e61a047.png
