### PR TITLE
Fix an issue with the epic on amp pages served from Google cache

### DIFF
--- a/dotcom-rendering/src/amp/components/Epic.tsx
+++ b/dotcom-rendering/src/amp/components/Epic.tsx
@@ -494,6 +494,7 @@ export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
 										<a
 											id="primaryCta"
 											data-amp-bind-href="epicState.choiceCards ? epicState.ctaUrl + '&selected-contribution-type=' + epicState.choiceCards.choiceCardSelection.frequency + '&selected-amount=' + epicState.choiceCards.choiceCardSelection.amount : epicState.ctaUrl"
+											target="_blank"
 											css={yellowButtonStyle}
 										>
 											<MoustacheVariable name="text" />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add a `target="_blank"` attribute to the primary CTA in the amp epic

## Why?
There is a bug which has probably been there since launch in the epic on amp when it is served from the Google cache.
If you go to a url such as https://www.google.com/amp/s/amp.theguardian.com/tv-and-radio/2022/nov/10/david-walliams-recorded-derogatory-remarks-britains-got-talent-bgt-contestants
on mobile (you can use Chrome on desktop in device mode) then when you click the Continue button the next page you see fails to load because of a Content Security Policy (CSP) violation.

The epic:
<img width="355" alt="Screenshot 2022-11-11 at 14 28 36" src="https://user-images.githubusercontent.com/181371/201360912-9c678ed3-0377-430c-ab1a-ed9363041173.png">
After clicking the CTA:
<img width="355" alt="Screenshot 2022-11-11 at 14 29 01" src="https://user-images.githubusercontent.com/181371/201360922-def45ab6-907d-4ba8-a1d2-1987af9a7b32.png">

This is because the epic is served in an iFrame and when clicking on the CTA it then tries to load support.theguardian.com in that iframe but the CSP prevents this because the top level domain is still google.com  and support.theguardian.com can only be iframed from www.theguardian.com and two of our salesforce domains.

To fix this issue we need to add a target="_blank" attribute to the CTA to force it to load in a new tab and not in an iFrame.

