### PR TITLE
Optional Image And Video Parsing

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -266,9 +266,8 @@ const parse =
 							kind: ElementKind.Image,
 							...image,
 						}),
-					).withDefault(
-						Result.err("I couldn't find a master asset"),
-					);
+					)
+					.withDefault(Result.err("I couldn't find a master asset"));
 
 			case ElementType.PULLQUOTE: {
 				const { html: quote, attribution } =

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -8,7 +8,7 @@ import type { BlockElement } from '@guardian/content-api-models/v1/blockElement'
 import { ElementType } from '@guardian/content-api-models/v1/elementType';
 import type { ArticleTheme } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import { fromNullable, map, withDefault } from '@guardian/types';
+import { fromNullable } from '@guardian/types';
 import { parseAtom } from 'atoms';
 import { ElementKind } from 'bodyElementKind';
 import { formatDate } from 'date';
@@ -16,7 +16,7 @@ import { parseAudio, parseGeneric, parseInstagram, parseVideo } from 'embed';
 import type { Embed } from 'embed';
 import type { Image as ImageData } from 'image';
 import { parseImage } from 'image';
-import { compose, pipe } from 'lib';
+import { compose } from 'lib';
 import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import type { KnowledgeQuizAtom, PersonalityQuizAtom } from 'quizAtom';
@@ -260,18 +260,15 @@ const parse =
 			}
 
 			case ElementType.IMAGE:
-				return pipe(
-					parseImage(context)(element),
-					map<ImageData, Result<string, Image>>((image) =>
+				return parseImage(context)(element)
+					.map<Result<string, BodyElement>>((image) =>
 						Result.ok({
 							kind: ElementKind.Image,
 							...image,
 						}),
-					),
-					withDefault<Result<string, Image>>(
+					).withDefault(
 						Result.err("I couldn't find a master asset"),
-					),
-				);
+					);
 
 			case ElementType.PULLQUOTE: {
 				const { html: quote, attribution } =

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -15,9 +15,9 @@ import { isLabs } from 'item';
 import { pipe } from 'lib';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
+import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import { parseVideo } from 'video';
-import { Optional } from 'optional';
 
 // ----- Lookups ----- //
 
@@ -68,10 +68,14 @@ const isVideo = (elem: BlockElement): boolean =>
 	elem.contentAtomTypeData?.atomType === 'media';
 
 const articleMainImage = (content: Content): Optional<BlockElement> =>
-	Optional.fromNullable((content.blocks?.main?.elements.filter(isImage) ?? [])[0]);
+	Optional.fromNullable(
+		(content.blocks?.main?.elements.filter(isImage) ?? [])[0],
+	);
 
 const articleMainVideo = (content: Content): Optional<BlockElement> =>
-	Optional.fromNullable((content.blocks?.main?.elements.filter(isVideo) ?? [])[0]);
+	Optional.fromNullable(
+		(content.blocks?.main?.elements.filter(isVideo) ?? [])[0],
+	);
 
 const articleMainMedia = (
 	content: Content,
@@ -79,17 +83,17 @@ const articleMainMedia = (
 ): Optional<MainMedia> => {
 	return (content.blocks?.main?.elements.filter(isImage) ?? [])[0]
 		? articleMainImage(content)
-			.flatMap(parseImage(context))
-			.map<MainMedia>((image) => ({
-				kind: MainMediaKind.Image,
-				image,
-			}))
+				.flatMap(parseImage(context))
+				.map<MainMedia>((image) => ({
+					kind: MainMediaKind.Image,
+					image,
+				}))
 		: articleMainVideo(content)
-			.flatMap(parseVideo(content.atoms))
-			.map<MainMedia>((video) => ({
-				kind: MainMediaKind.Video,
-				video,
-		}));
+				.flatMap(parseVideo(content.atoms))
+				.map<MainMedia>((video) => ({
+					kind: MainMediaKind.Video,
+					video,
+				}));
 };
 
 type ThirdPartyEmbeds = {

--- a/apps-rendering/src/image.test.ts
+++ b/apps-rendering/src/image.test.ts
@@ -91,9 +91,8 @@ describe('parseImage', () => {
 	});
 
 	test('returns image', () => {
-		let actual: Image = withDefault(defaultImage)(
-			parseImage(context)(imageBlock),
-		);
+		let actual: Image =
+			parseImage(context)(imageBlock).withDefault(defaultImage);
 
 		expect(actual.src).toBe(expectedSrc);
 		expect(actual.srcset).toBe(expectedSrcset);
@@ -109,29 +108,29 @@ describe('parseImage', () => {
 
 	test('returns none given no assets in element', () => {
 		imageBlock.assets = [];
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset with no typeData', () => {
 		asset.typeData = undefined;
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset typedata with falsey isMaster', () => {
 		asset.typeData = {
 			isMaster: false,
 		};
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset file is undefined', () => {
 		asset.file = undefined;
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset file is empty', () => {
 		asset.file = '';
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset typedata width is undefined', () => {
@@ -139,7 +138,7 @@ describe('parseImage', () => {
 			isMaster: true,
 			height: assetHeight,
 		};
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('returns none given an asset typedata height is undefined', () => {
@@ -147,7 +146,7 @@ describe('parseImage', () => {
 			isMaster: true,
 			width: assetWidth,
 		};
-		expect(parseImage(context)(imageBlock)).toEqual(none);
+		expect(parseImage(context)(imageBlock).isNone()).toBe(true);
 	});
 
 	test('uses secureFile rather than asset file for srcsets if it exists', () => {
@@ -157,9 +156,8 @@ describe('parseImage', () => {
 		const expectedSecureSrcset =
 			'https://i.guim.co.uk/img/secure-theguardian/?width=140&quality=85&fit=bounds&s=ac6b008b5309f7949d1087af108c1d03 140w, https://i.guim.co.uk/img/secure-theguardian/?width=500&quality=85&fit=bounds&s=4b9b01008452c65efcb547bd5f8ae12b 500w, https://i.guim.co.uk/img/secure-theguardian/?width=1000&quality=85&fit=bounds&s=9b5034dd81e916d352709a20f6635448 1000w, https://i.guim.co.uk/img/secure-theguardian/?width=1500&quality=85&fit=bounds&s=2c439ea2daa935d4a2a268ef7a2a9146 1500w, https://i.guim.co.uk/img/secure-theguardian/?width=2000&quality=85&fit=bounds&s=3877ef3c2ed016cccf1ab7b6e6001841 2000w, https://i.guim.co.uk/img/secure-theguardian/?width=2500&quality=85&fit=bounds&s=81d2b2f5b95615f1d47d61f64f5e61a6 2500w, https://i.guim.co.uk/img/secure-theguardian/?width=3000&quality=85&fit=bounds&s=b362f368e5f123ce2c7b45dedee361db 3000w';
 
-		const parsedImage = withDefault(defaultImage)(
-			parseImage(context)(imageBlock),
-		);
+		const parsedImage =
+			parseImage(context)(imageBlock).withDefault(defaultImage);
 
 		expect(parsedImage.srcset).toEqual(expectedSecureSrcset);
 		expect(parsedImage.dpr2Srcset).toEqual(expectedSecureDpr2Srcset);
@@ -168,9 +166,8 @@ describe('parseImage', () => {
 	test('returns image with no credit given displayCredit is false', () => {
 		imageData.displayCredit = false;
 
-		const parsedImage = withDefault(defaultImage)(
-			parseImage(context)(imageBlock),
-		);
+		const parsedImage =
+			parseImage(context)(imageBlock).withDefault(defaultImage);
 
 		expect(parsedImage.credit).toEqual(none);
 	});
@@ -178,9 +175,8 @@ describe('parseImage', () => {
 	test('returns image with no caption given imageData caption is undefined', () => {
 		imageData.caption = undefined;
 
-		const parsedImage = withDefault(defaultImage)(
-			parseImage(context)(imageBlock),
-		);
+		const parsedImage =
+			parseImage(context)(imageBlock).withDefault(defaultImage);
 
 		expect(parsedImage.caption).toEqual(none);
 		expect(parsedImage.nativeCaption).toEqual(none);
@@ -189,9 +185,8 @@ describe('parseImage', () => {
 	test('returns image with no alt given imageData alt is undefined', () => {
 		imageData.alt = undefined;
 
-		const parsedImage = withDefault(defaultImage)(
-			parseImage(context)(imageBlock),
-		);
+		const parsedImage =
+			parseImage(context)(imageBlock).withDefault(defaultImage);
 
 		expect(parsedImage.alt).toEqual(none);
 	});
@@ -200,9 +195,8 @@ describe('parseImage', () => {
 		test('returns correct role given image data role', () => {
 			imageData.role = roleTestCase.role;
 
-			const parsedImage = withDefault(defaultImage)(
-				parseImage(context)(imageBlock),
-			);
+			const parsedImage =
+				parseImage(context)(imageBlock).withDefault(defaultImage);
 
 			expect(parsedImage.role).toEqual(roleTestCase.roleEnum);
 		});

--- a/apps-rendering/src/image.ts
+++ b/apps-rendering/src/image.ts
@@ -6,19 +6,13 @@ import type { BlockElement } from '@guardian/content-api-models/v1/blockElement'
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import {
-	andThen,
-	fromNullable,
-	map,
-	none,
-	some,
-} from '@guardian/types';
+import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import type { Image as ImageData } from 'image/image';
 import { Dpr, src, srcsets } from 'image/srcsets';
 import { pipe } from 'lib';
+import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import type { ReactNode } from 'react';
-import { Optional } from 'optional';
 
 // ----- Types ----- //
 
@@ -81,34 +75,33 @@ const parseImage =
 	(element: BlockElement): Optional<Image> => {
 		const data = element.imageTypeData;
 
-		return getBestAsset(element.assets)
-			.flatMap((asset) => {
-				if (
-					asset.file === undefined ||
-					asset.file === '' ||
-					asset.typeData?.width === undefined ||
-					asset.typeData.height === undefined
-				) {
-					return Optional.none();
-				}
+		return getBestAsset(element.assets).flatMap((asset) => {
+			if (
+				asset.file === undefined ||
+				asset.file === '' ||
+				asset.typeData?.width === undefined ||
+				asset.typeData.height === undefined
+			) {
+				return Optional.none();
+			}
 
-				return Optional.some({
-					src: src(
-						salt,
-						asset.typeData.secureFile ?? asset.file,
-						500,
-						Dpr.One,
-					),
-					...srcsets(asset.typeData.secureFile ?? asset.file, salt),
-					alt: fromNullable(data?.alt),
-					width: asset.typeData.width,
-					height: asset.typeData.height,
-					caption: pipe(data?.caption, fromNullable, map(docParser)),
-					credit: parseCredit(data?.displayCredit, data?.credit),
-					nativeCaption: fromNullable(data?.caption),
-					role: parseRole(data?.role),
-				});
+			return Optional.some({
+				src: src(
+					salt,
+					asset.typeData.secureFile ?? asset.file,
+					500,
+					Dpr.One,
+				),
+				...srcsets(asset.typeData.secureFile ?? asset.file, salt),
+				alt: fromNullable(data?.alt),
+				width: asset.typeData.width,
+				height: asset.typeData.height,
+				caption: pipe(data?.caption, fromNullable, map(docParser)),
+				credit: parseCredit(data?.displayCredit, data?.credit),
+				nativeCaption: fromNullable(data?.caption),
+				role: parseRole(data?.role),
 			});
+		});
 	};
 
 const parseCardImage = (

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -299,7 +299,7 @@ const itemFields = (
 			map(context.docParser),
 		),
 		publishDate: maybeCapiDate(content.webPublicationDate),
-		mainMedia: articleMainMedia(content, context),
+		mainMedia: articleMainMedia(content, context).toOption(),
 		contributors: parseContributors(context.salt, content),
 		series: articleSeries(content),
 		commentable: content.fields?.commentable ?? false,

--- a/apps-rendering/src/relatedContent.ts
+++ b/apps-rendering/src/relatedContent.ts
@@ -3,10 +3,7 @@ import type { RelatedContent } from '@guardian/apps-rendering-api-models/related
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import type { Content } from '@guardian/content-api-models/v1/content';
 import {
-	andThen,
-	fromNullable,
 	map,
-	OptionKind,
 	withDefault,
 } from '@guardian/types';
 import {
@@ -26,6 +23,7 @@ import {
 	isVideo,
 } from 'item';
 import { compose, index, pipe } from 'lib';
+import { Optional } from 'optional';
 
 const parseRelatedItemType = (content: Content): RelatedItemType => {
 	const { tags } = content;
@@ -53,27 +51,21 @@ const parseRelatedItemType = (content: Content): RelatedItemType => {
 };
 
 const parseHeaderImage = (content: Content): Image | undefined => {
-	const optionalImage = pipe(
-		articleMainImage(content),
-		andThen((element) => {
+	const optionalImage = articleMainImage(content)
+		.flatMap((element) => {
 			const masterAsset = element.assets.find(
 				(asset) => asset.typeData?.isMaster,
 			);
-			const data = element.imageTypeData;
-			return pipe(
-				masterAsset,
-				fromNullable,
-				map((asset) => ({
-					url: asset.file ?? '',
-					height: asset.typeData?.height ?? 360,
-					width: asset.typeData?.width ?? 600,
-					altText: data?.alt,
-				})),
-			);
-		}),
-	);
 
-	if (optionalImage.kind === OptionKind.Some) {
+			return Optional.fromNullable(masterAsset).map((asset) => ({
+				url: asset.file ?? '',
+				height: asset.typeData?.height ?? 360,
+				width: asset.typeData?.width ?? 600,
+				altText: element.imageTypeData?.alt,
+			}));
+		});
+
+	if (optionalImage.isSome()) {
 		return optionalImage.value;
 	} else {
 		return undefined;

--- a/apps-rendering/src/relatedContent.ts
+++ b/apps-rendering/src/relatedContent.ts
@@ -2,10 +2,7 @@ import type { Image } from '@guardian/apps-rendering-api-models/image';
 import type { RelatedContent } from '@guardian/apps-rendering-api-models/relatedContent';
 import { RelatedItemType } from '@guardian/apps-rendering-api-models/relatedItemType';
 import type { Content } from '@guardian/content-api-models/v1/content';
-import {
-	map,
-	withDefault,
-} from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import {
 	articleContributors,
 	articleMainImage,
@@ -51,19 +48,18 @@ const parseRelatedItemType = (content: Content): RelatedItemType => {
 };
 
 const parseHeaderImage = (content: Content): Image | undefined => {
-	const optionalImage = articleMainImage(content)
-		.flatMap((element) => {
-			const masterAsset = element.assets.find(
-				(asset) => asset.typeData?.isMaster,
-			);
+	const optionalImage = articleMainImage(content).flatMap((element) => {
+		const masterAsset = element.assets.find(
+			(asset) => asset.typeData?.isMaster,
+		);
 
-			return Optional.fromNullable(masterAsset).map((asset) => ({
-				url: asset.file ?? '',
-				height: asset.typeData?.height ?? 360,
-				width: asset.typeData?.width ?? 600,
-				altText: element.imageTypeData?.alt,
-			}));
-		});
+		return Optional.fromNullable(masterAsset).map((asset) => ({
+			url: asset.file ?? '',
+			height: asset.typeData?.height ?? 360,
+			width: asset.typeData?.width ?? 600,
+			altText: element.imageTypeData?.alt,
+		}));
+	});
 
 	if (optionalImage.isSome()) {
 		return optionalImage.value;

--- a/apps-rendering/src/video.test.ts
+++ b/apps-rendering/src/video.test.ts
@@ -10,7 +10,7 @@ import { AssetType } from '@guardian/content-atom-model/media/assetType';
 import { Category } from '@guardian/content-atom-model/media/category';
 import { MediaAtom } from '@guardian/content-atom-model/media/mediaAtom';
 import { Platform } from '@guardian/content-atom-model/media/platform';
-import { none, some } from '@guardian/types';
+import { Optional } from 'optional';
 import { Int64 } from 'thrift';
 import { parseVideo } from 'video';
 
@@ -76,23 +76,23 @@ describe('parseVideo', () => {
 	});
 
 	test('returns video', () => {
-		const expected = some({
+		const expected = Optional.some({
 			posterUrl: posterUrl,
 			videoId: assetId,
 			duration: undefined,
 			atomId: atomId,
 			title: mediaAtomTitle,
 		});
-		expect(parseVideo(blockElement, atoms)).toEqual(expected);
+		expect(parseVideo(atoms)(blockElement)).toEqual(expected);
 	});
 
 	test('returns none given no atoms', () => {
-		expect(parseVideo(blockElement)).toEqual(none);
+		expect(parseVideo(undefined)(blockElement).isNone()).toBe(true);
 	});
 
 	test('returns none given no media in atoms', () => {
 		atoms = {};
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 
 	test('returns none given none of the media atoms matches the element atom type id', () => {
@@ -100,7 +100,7 @@ describe('parseVideo', () => {
 			atomId: 'atomId1',
 			atomType: 'someAtomType',
 		};
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 
 	test("returns none given the atom data of the matched media atom does does not have 'media' kind", () => {
@@ -113,21 +113,21 @@ describe('parseVideo', () => {
 			},
 		};
 		atom.data = differentAtomData;
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 
 	test('returns none given matched atom does not have posterUrl', () => {
 		mediaAtom.posterUrl = undefined;
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 
 	test('returns none given media atom does not have any assets', () => {
 		mediaAtom.assets = [];
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 
 	test('returns none given media atom asset version does not match media atom activeVersion', () => {
 		mediaAtom.activeVersion = new Int64(3);
-		expect(parseVideo(blockElement, atoms)).toEqual(none);
+		expect(parseVideo(atoms)(blockElement).isNone()).toBe(true);
 	});
 });

--- a/apps-rendering/src/video.ts
+++ b/apps-rendering/src/video.ts
@@ -1,7 +1,6 @@
 import type { Atoms } from '@guardian/content-api-models/v1/atoms';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
-import type { Option } from '@guardian/types';
-import { none, some } from '@guardian/types';
+import { Optional } from 'optional';
 
 interface Video {
 	posterUrl: string;
@@ -11,16 +10,16 @@ interface Video {
 	title: string;
 }
 
-const parseVideo = (element: BlockElement, atoms?: Atoms): Option<Video> => {
+const parseVideo = (atoms?: Atoms) => (element: BlockElement): Optional<Video> => {
 	if (!atoms) {
-		return none;
+		return Optional.none();
 	}
 
 	const atomId = element.contentAtomTypeData?.atomId;
 	const atom = atoms.media?.find((media) => media.id === atomId);
 
 	if (atom?.data.kind !== 'media') {
-		return none;
+		return Optional.none();
 	}
 
 	const { posterUrl, duration, assets, activeVersion, title } =
@@ -30,10 +29,10 @@ const parseVideo = (element: BlockElement, atoms?: Atoms): Option<Video> => {
 	)?.id;
 
 	if (!posterUrl || !videoId || !atomId) {
-		return none;
+		return Optional.none();
 	}
 
-	return some({
+	return Optional.some({
 		posterUrl,
 		videoId,
 		duration: duration?.toNumber(),

--- a/apps-rendering/src/video.ts
+++ b/apps-rendering/src/video.ts
@@ -10,35 +10,37 @@ interface Video {
 	title: string;
 }
 
-const parseVideo = (atoms?: Atoms) => (element: BlockElement): Optional<Video> => {
-	if (!atoms) {
-		return Optional.none();
-	}
+const parseVideo =
+	(atoms?: Atoms) =>
+	(element: BlockElement): Optional<Video> => {
+		if (!atoms) {
+			return Optional.none();
+		}
 
-	const atomId = element.contentAtomTypeData?.atomId;
-	const atom = atoms.media?.find((media) => media.id === atomId);
+		const atomId = element.contentAtomTypeData?.atomId;
+		const atom = atoms.media?.find((media) => media.id === atomId);
 
-	if (atom?.data.kind !== 'media') {
-		return Optional.none();
-	}
+		if (atom?.data.kind !== 'media') {
+			return Optional.none();
+		}
 
-	const { posterUrl, duration, assets, activeVersion, title } =
-		atom.data.media;
-	const videoId = assets.find(
-		(asset) => asset.version.toNumber() === activeVersion?.toNumber(),
-	)?.id;
+		const { posterUrl, duration, assets, activeVersion, title } =
+			atom.data.media;
+		const videoId = assets.find(
+			(asset) => asset.version.toNumber() === activeVersion?.toNumber(),
+		)?.id;
 
-	if (!posterUrl || !videoId || !atomId) {
-		return Optional.none();
-	}
+		if (!posterUrl || !videoId || !atomId) {
+			return Optional.none();
+		}
 
-	return Optional.some({
-		posterUrl,
-		videoId,
-		duration: duration?.toNumber(),
-		atomId,
-		title,
-	});
-};
+		return Optional.some({
+			posterUrl,
+			videoId,
+			duration: duration?.toNumber(),
+			atomId,
+			title,
+		});
+	};
 
 export { Video, parseVideo };


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages.

## Changes

- Migrated body element image parsing to `Optional`
- Migrated main media parsing to `Optional`
- Updated tests
- Migrated image parsing functions to `Optional`
- Convert back to `Option` for `mainMedia` field in `Item`
- Migrated related content header image parsing to `Optional`
- Migrated video parsing functions to `Optional`
- Split up parameters to video parsing function
