### PR TITLE
Fix `MyAccount` z-index

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
@@ -60,7 +60,7 @@ const myAccountLinkStyles = css`
 		width: 18px;
 		margin: 3px 4px 0 0;
 	}
-	${getZIndex('dropdown')}
+	${getZIndex('myAccountDropdown')}
 `;
 
 export const buildIdentityLinks = (


### PR DESCRIPTION
## What does this change?

Pick the correct z-index for `MyAccount` / `SignIn`.

## Why?

It looks aweful. Signaled by @GHaberis 

`myAccountDropdown` is way below `dropdown`.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/201368858-27ee9494-fed7-43da-b05d-77791e4f9469.png
[after]: https://user-images.githubusercontent.com/76776/201368778-8d8676d1-36bc-4542-b066-6914b8827ad7.png