### PR TITLE
Use `Optional` In `contributor.ts`

### DIFF
--- a/apps-rendering/src/contributor.ts
+++ b/apps-rendering/src/contributor.ts
@@ -4,11 +4,11 @@ import type { Content } from '@guardian/content-api-models/v1/content';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 import { ArticleElementRole } from '@guardian/libs';
 import type { Option } from '@guardian/types';
-import { fromNullable, map, none } from '@guardian/types';
+import { none } from '@guardian/types';
 import { articleContributors } from 'capi';
 import type { Image } from 'image';
 import { Dpr, src, srcsetWithWidths } from 'image/srcsets';
-import { pipe } from 'lib';
+import { Optional } from 'optional';
 
 // ------ Types ----- //
 
@@ -31,10 +31,8 @@ const tagToContributor =
 		id: contributorTag.id,
 		apiUrl: contributorTag.apiUrl,
 		name: contributorTag.webTitle,
-		image: pipe(
-			contributorTag.bylineLargeImageUrl,
-			fromNullable,
-			map((url) => ({
+		image: Optional.fromNullable(contributorTag.bylineLargeImageUrl)
+			.map((url) => ({
 				srcset: contributorSrcset(url, salt, Dpr.One),
 				src: src(salt, url, 140, Dpr.One),
 				dpr2Srcset: contributorSrcset(url, salt, Dpr.Two),
@@ -45,8 +43,8 @@ const tagToContributor =
 				alt: none,
 				role: ArticleElementRole.Standard,
 				nativeCaption: none,
-			})),
-		),
+			}))
+			.toOption(),
 	});
 
 const parseContributors = (salt: string, content: Content): Contributor[] =>


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages, so PRs are easier to review.

## Changes

- Used `Optional` in `contributor.ts`
