### PR TITLE
Feat: Add design tag to Letter template

### DIFF
--- a/apps-rendering/src/components/Byline/index.tsx
+++ b/apps-rendering/src/components/Byline/index.tsx
@@ -35,7 +35,6 @@ const Byline: FC<Props> = ({ bylineHtml, ...format }) => {
 		case ArticleDesign.DeadBlog:
 			return <DeadBlogByline bylineHtml={bylineHtml} format={format} />;
 		case ArticleDesign.Editorial:
-		case ArticleDesign.Letter:
 		case ArticleDesign.Comment:
 			return <CommentByline bylineHtml={bylineHtml} format={format} />;
 		case ArticleDesign.Analysis:

--- a/apps-rendering/src/components/HeadlineTag/index.tsx
+++ b/apps-rendering/src/components/HeadlineTag/index.tsx
@@ -38,6 +38,7 @@ const HeadlineTag: FC<Props> = ({ tagText, format }) => {
 	switch (format.design) {
 		case ArticleDesign.Analysis:
 		case ArticleDesign.Explainer:
+		case ArticleDesign.Letter:
 			return (
 				<div css={headlineTagWrapper}>
 					<span css={headlineTagStyles(format)}>{tagText}</span>

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import { css } from '@emotion/react';
+import { ArticleDesign } from '@guardian/libs';
 import {
 	background,
 	breakpoints,
@@ -15,6 +16,7 @@ import Byline from 'components/Byline';
 import Cutout from 'components/Cutout';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import HeadlineTag from 'components/HeadlineTag';
 import Logo from 'components/Logo';
 import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
@@ -79,6 +81,11 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 		<article css={BorderStyles}>
 			<header>
 				<Series item={item} />
+
+				{item.design === ArticleDesign.Letter && (
+					<HeadlineTag format={item} tagText="Letters" />
+				)}
+
 				<Headline item={item} />
 				<div css={articleWidthStyles}>
 					<Byline {...item} />

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -33,6 +33,7 @@ import { renderAll } from 'renderer';
 import { Result } from 'result';
 import GalleryLayout from './GalleryLayout';
 import ImmersiveLayout from './ImmersiveLayout';
+import LetterLayout from './LetterLayout';
 import Live from './LiveLayout';
 
 // ----- Functions ----- //
@@ -170,12 +171,12 @@ CommentItem.story = { name: 'Comment' };
 
 export const Letter = (): React.ReactNode => {
 	return (
-		<Comment item={letter}>
+		<LetterLayout item={letter}>
 			{renderAll(
 				formatFromItem(letter, some(ArticleDisplay.Standard)),
 				Result.partition(letter.body).oks,
 			)}
-		</Comment>
+		</LetterLayout>
 	);
 };
 Letter.story = { name: 'Letter' };

--- a/apps-rendering/src/components/Layout/LetterLayout.tsx
+++ b/apps-rendering/src/components/Layout/LetterLayout.tsx
@@ -7,7 +7,6 @@ import {
 	neutral,
 	opinion,
 	palette,
-	remSpace,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 import ArticleBody from 'components/ArticleBody';
@@ -15,6 +14,7 @@ import Byline from 'components/Byline';
 import Cutout from 'components/Cutout';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
+import HeadlineTag from 'components/HeadlineTag';
 import Logo from 'components/Logo';
 import MainMedia from 'components/MainMedia';
 import Metadata from 'components/Metadata';
@@ -23,7 +23,7 @@ import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
-import type { Comment as CommentItem, Editorial } from 'item';
+import type { Letter as LetterItem } from 'item';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,
@@ -39,7 +39,7 @@ const Styles = css`
 `;
 
 const DarkStyles = darkModeCss`
-    background: ${palette.neutral[10]};
+	background: ${palette.neutral[10]}
 `;
 
 const BorderStyles = css`
@@ -52,37 +52,24 @@ const BorderStyles = css`
 	}
 `;
 
-const topBorder = css`
-	border-top: solid 1px ${neutral[86]};
-	margin-top: ${remSpace[3]};
-
-	${from.wide} {
-		margin-top: ${remSpace[3]};
-	}
-
-	${darkModeCss`
-        border-top: solid 1px ${neutral[20]};
-    `}
-`;
-
-const commentLineStylePosition = css`
+const linePosition = css`
 	margin-top: 83px;
 `;
 
 interface Props {
-	item: CommentItem | Editorial;
+	item: LetterItem;
 	children: ReactNode[];
 }
 
-const CommentLayout: FC<Props> = ({ item, children }) => (
+const LetterLayout: FC<Props> = ({ item, children }) => (
 	<main css={[Styles, DarkStyles]}>
 		<article css={BorderStyles}>
 			<header>
 				<Series item={item} />
+
+				<HeadlineTag format={item} tagText="Letters" />
+
 				<Headline item={item} />
-				<div css={articleWidthStyles}>
-					<Byline {...item} />
-				</div>
 
 				<Cutout
 					contributors={item.contributors}
@@ -90,17 +77,14 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 					format={item}
 				/>
 				<StraightLines
-					cssOverrides={[commentLineStylePosition, lineStyles]}
+					cssOverrides={[linePosition, lineStyles]}
 					count={8}
 				/>
 				<div css={articleWidthStyles}>
 					<Standfirst item={item} />
-				</div>
-
-				<section css={[articleWidthStyles, topBorder]}>
+					<Byline {...item} />
 					<Metadata item={item} />
-				</section>
-
+				</div>
 				<MainMedia
 					format={getFormat(item)}
 					mainMedia={item.mainMedia}
@@ -125,4 +109,4 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 
 // ----- Exports ----- //
 
-export default CommentLayout;
+export default LetterLayout;

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -20,6 +20,7 @@ import { renderAll, renderAllWithoutStyles } from 'renderer';
 import { Result } from 'result';
 import AnalysisLayout from './AnalysisLayout';
 import ImmersiveLayout from './ImmersiveLayout';
+import LetterLayout from './LetterLayout';
 
 // ----- Functions ----- //
 
@@ -76,12 +77,14 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 
 	if (
 		item.design === ArticleDesign.Comment ||
-		item.design === ArticleDesign.Letter ||
 		item.design === ArticleDesign.Editorial
 	) {
 		return <CommentLayout item={item}>{render(item, body)}</CommentLayout>;
 	}
 
+	if (item.design === ArticleDesign.Letter) {
+		return <LetterLayout item={item}>{render(item, body)}</LetterLayout>;
+	}
 	if (item.design === ArticleDesign.Analysis) {
 		return (
 			<AnalysisLayout item={item}>{render(item, body)}</AnalysisLayout>

--- a/dotcom-rendering/src/web/components/DesignTag.stories.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.stories.tsx
@@ -44,6 +44,44 @@ export const Interview = () => {
 };
 Interview.story = { name: 'with design Interview' };
 
+export const Explainer = () => {
+	return (
+		<div
+			css={css`
+				max-width: 400px;
+			`}
+		>
+			<DesignTag
+				format={{
+					design: ArticleDesign.Explainer,
+					display: ArticleDisplay.Standard,
+					theme: ArticlePillar.Sport,
+				}}
+			/>
+		</div>
+	);
+};
+Explainer.story = { name: 'with design Explainer' };
+
+export const Letter = () => {
+	return (
+		<div
+			css={css`
+				max-width: 400px;
+			`}
+		>
+			<DesignTag
+				format={{
+					design: ArticleDesign.Letter,
+					display: ArticleDisplay.Standard,
+					theme: ArticlePillar.Sport,
+				}}
+			/>
+		</div>
+	);
+};
+Interview.story = { name: 'with design Letter' };
+
 export const SpecialReport = () => {
 	return (
 		<DesignTag

--- a/dotcom-rendering/src/web/components/DesignTag.stories.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.stories.tsx
@@ -80,7 +80,7 @@ export const Letter = () => {
 		</div>
 	);
 };
-Interview.story = { name: 'with design Letter' };
+Letter.story = { name: 'with design Letter' };
 
 export const SpecialReport = () => {
 	return (

--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -128,6 +128,14 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
+		case ArticleDesign.Letter:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/letters">Letters</TagLink>
+					</Tag>
+				</Margins>
+			);
 		default:
 			return null;
 	}


### PR DESCRIPTION
***


# WAITING ON FINAL EDITORIAL APPROVAL : DO NOT MERGE 

***

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add a design tag (or "lozenge") to the DCR letter design that clicks through to the Letters tone page. It also adds a story.

Separates Letter into its own layout in AR and add a design tag.

Design is aware that "Letters" is also in the Byline. Instead of adjusting this in code or retroactively fixing this in CAPI, Editorial will fix forward by not writing this in future Letter articles. 

## Why?
This is a design decision from the Editorial Design team.

## Screenshots - DCR

| Before      | After      |
|-------------|------------|
| ![before-mobile][] | ![after-mobile][] |

[before-mobile]: https://user-images.githubusercontent.com/20416599/201634100-63b59e8e-04c4-42fc-a7f1-9882569f1af7.png
[after-mobile]: https://user-images.githubusercontent.com/20416599/201638135-e05207f7-e912-4b6b-bb1f-08f23e802157.png

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/201633854-378a730f-76c0-40ae-9fc0-2fab51ab27fa.png
[after]: https://user-images.githubusercontent.com/20416599/201638110-4f69b793-a68d-4f36-9e48-4a65fae400ac.png


## Screenshots - AR

| Before      | After      |
|-------------|------------|
| ![before-ar][] | ![after-ar][] |

[before-ar]: https://user-images.githubusercontent.com/20416599/201659537-1b07bd91-48ad-4d3d-af7e-d67f40aa2a6e.png
[after-ar]: https://user-images.githubusercontent.com/20416599/201885639-11fbd786-f153-409a-bdd2-e8abceef12a1.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
