### PR TITLE
Render trail text from desktop only

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -413,6 +413,7 @@ export const Card = ({
 								format={format}
 								imagePosition={imagePosition}
 								imageSize={imageSize}
+								imageType={image?.type}
 							>
 								<div
 									dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/TrailTextWrapper.tsx
@@ -9,13 +9,19 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	imagePosition?: ImagePositionType;
 	imageSize?: ImageSizeType;
+	imageType?: CardImageType | undefined;
 };
 
 const showTrailText = (
 	imagePosition?: ImagePositionType,
 	imageSize?: ImageSizeType,
+	imageType?: CardImageType | undefined,
 ) => {
-	if (imageSize === 'large' && imagePosition === 'right')
+	if (
+		imageSize === 'large' &&
+		imagePosition === 'right' &&
+		imageType !== 'avatar'
+	)
 		return css`
 			${until.desktop} {
 				display: none;
@@ -34,6 +40,7 @@ export const TrailTextWrapper = ({
 	containerPalette,
 	imagePosition,
 	imageSize,
+	imageType,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
@@ -51,7 +58,7 @@ export const TrailTextWrapper = ({
 					padding-right: 5px;
 					padding-bottom: 8px;
 				`,
-				showTrailText(imagePosition, imageSize),
+				showTrailText(imagePosition, imageSize, imageType),
 			]}
 		>
 			{children}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This renders trail text from desktop breakpoint only for boosted card 2 very bigs 1 boosted layout.
## Why?
Parity with Frontend.
This resolves https://github.com/guardian/dotcom-rendering/issues/6416
## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/201700116-19adbc09-c15e-45c1-ad9f-74f1462ffb8a.png
[after]: https://user-images.githubusercontent.com/110032454/201699988-e637f034-d649-46d9-859e-61e46821d261.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
