### PR TITLE
Update Braze Banner and Epic components in Storybook

### DIFF
--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -1,0 +1,220 @@
+import type { CommonEndOfArticleComponentProps as BrazeEpicProps } from '@guardian/braze-components';
+import type { ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+
+type BrazeMessageProps = {
+	[key: string]: string | undefined;
+};
+
+export default {
+	component: 'BrazeEpics',
+	title: 'Components/SlotBodyEnd/BrazeEpics',
+};
+
+// Braze Epic
+// ---------------------------------------
+export const BrazeEpicComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			heading: args.heading,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			paragraph3: args.paragraph3,
+			paragraph4: args.paragraph4,
+			highlightedText: args.highlightedText,
+			buttonText: args.buttonText,
+			buttonUrl: args.buttonUrl,
+			hidePaymentIcons: args.hidePaymentIcons,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicComponent.args = {
+	heading: 'Since you’re here...',
+	paragraph1:
+		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+	paragraph2:
+		'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+	paragraph3:
+		'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+	paragraph4:
+		'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
+	highlightedText:
+		'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
+	buttonText: 'Support The Guardian',
+	buttonUrl: 'https://support.theguardian.com/contribute',
+	hidePaymentIcons: '',
+	ophanComponentId: 'example_ophan_component_id',
+	slotName: 'EndOfArticle',
+	componentName: 'Epic',
+};
+
+BrazeEpicComponent.story = { name: 'Epic' };
+
+// Braze UK Newsletter Epic
+// ---------------------------------------
+export const BrazeUKNewsletterEpicComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeUKNewsletterEpicComponent.args = {
+	slotName: 'EndOfArticle',
+	header: 'The Morning Briefing',
+	frequency: 'Every day',
+	paragraph1:
+		'Whether it’s the latest manoeuvring in global politics or the ‘and finally’ story that everyone’s talking about, you’ll be bang up to date with the news that counts.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'UKNewsletterEpic',
+	ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeUKNewsletterEpicComponent.story = { name: 'UKNewsletterEpic' };
+
+// Braze US Newsletter Epic
+// ---------------------------------------
+export const BrazeUSNewsletterEpicComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeUSNewsletterEpicComponent.args = {
+	slotName: 'EndOfArticle',
+	header: 'First Thing',
+	frequency: 'Daily',
+	paragraph1:
+		'Start your day with a global perspective on America. Get the Guardian’s top stories and must reads in one hit – every weekday.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'USNewsletterEpic',
+	ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeUSNewsletterEpicComponent.story = { name: 'USNewsletterEpic' };

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -89,6 +89,160 @@ BrazeEpicComponent.args = {
 
 BrazeEpicComponent.story = { name: 'Epic' };
 
+// Braze Epic with Reminder CTA
+// ---------------------------------------
+export const BrazeEpicWithReminderComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			heading: args.heading,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			highlightedText: args.highlightedText,
+			buttonText: args.buttonText,
+			buttonUrl: args.buttonUrl,
+			hidePaymentIcons: args.hidePaymentIcons,
+			ophanComponentId: args.ophanComponentId,
+			remindMeButtonText: args.remindMeButtonText,
+			remindMeConfirmationText: args.remindMeConfirmationText,
+			remindMeConfirmationHeaderText: args.remindMeConfirmationHeaderText,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicWithReminderComponent.args = {
+	heading: 'Since you’re here...',
+	paragraph1:
+		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+	paragraph2:
+		'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+	highlightedText:
+		'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
+	buttonText: 'Support The Guardian',
+	buttonUrl: 'https://support.theguardian.com/contribute',
+	hidePaymentIcons: '',
+	ophanComponentId: 'example_ophan_component_id',
+	slotName: 'EndOfArticle',
+	componentName: 'Epic',
+	remindMeButtonText: 'Remind me in May',
+	remindMeConfirmationText: "Okay, we'll send you an email in May.",
+	remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
+};
+
+BrazeEpicWithReminderComponent.story = { name: 'Epic with reminder' };
+
+// Braze Epic with special header
+// ---------------------------------------
+export const BrazeEpicSpecialHeaderComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			paragraph3: args.paragraph3,
+			paragraph4: args.paragraph4,
+			highlightedText: args.highlightedText,
+			buttonText: args.buttonText,
+			buttonUrl: args.buttonUrl,
+			hidePaymentIcons: args.hidePaymentIcons,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeEpicSpecialHeaderComponent.args = {
+	paragraph1:
+		'... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+	paragraph2:
+		'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+	paragraph3:
+		'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+	paragraph4:
+		'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
+	highlightedText:
+		'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
+	buttonText: 'Support The Guardian',
+	buttonUrl: 'https://support.theguardian.com/contribute',
+	hidePaymentIcons: '',
+	ophanComponentId: 'example_ophan_component_id',
+	slotName: 'EndOfArticle',
+	componentName: 'EpicWithSpecialHeader',
+};
+
+BrazeEpicSpecialHeaderComponent.story = { name: 'Epic with special header' };
+
 // Braze UK Newsletter Epic
 // ---------------------------------------
 export const BrazeUKNewsletterEpicComponent = (
@@ -152,7 +306,7 @@ BrazeUKNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeUKNewsletterEpicComponent.story = { name: 'UKNewsletterEpic' };
+BrazeUKNewsletterEpicComponent.story = { name: 'UK newsletter Epic' };
 
 // Braze US Newsletter Epic
 // ---------------------------------------
@@ -217,4 +371,136 @@ BrazeUSNewsletterEpicComponent.args = {
 	ophanComponentId: 'example_ophan_component_id',
 };
 
-BrazeUSNewsletterEpicComponent.story = { name: 'USNewsletterEpic' };
+BrazeUSNewsletterEpicComponent.story = { name: 'US newsletter Epic' };
+
+// Braze Australia Newsletter Epic
+// ---------------------------------------
+export const BrazeAUNewsletterEpicComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeAUNewsletterEpicComponent.args = {
+	slotName: 'EndOfArticle',
+	header: `Guardian Australia's Morning Mail`,
+	frequency: 'Every weekday',
+	paragraph1:
+		'Get early morning news from Guardian Australia straight to your inbox.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'AUNewsletterEpic',
+	ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeAUNewsletterEpicComponent.story = { name: 'Australia newsletter Epic' };
+
+// Braze DownToEarth Newsletter Epic
+// ---------------------------------------
+export const BrazeDownToEarthNewsletterEpicComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeEpicProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeEndOfArticleComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			frequency: args.frequency,
+			paragraph1: args.paragraph1,
+			paragraph2: args.paragraph2,
+			ophanComponentId: args.ophanComponentId,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				subscribeToNewsletter={() => Promise.resolve()}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeDownToEarthNewsletterEpicComponent.args = {
+	slotName: 'EndOfArticle',
+	header: 'Down To Earth',
+	frequency: 'Weekly',
+	paragraph1:
+		'An exclusive weekly piece from our top climate crisis correspondents, as well as a digest of the biggest environment stories – plus the good news, the not-so-good news, and everything else you need to know.',
+	paragraph2:
+		'We thought you should know this newsletter may contain information about Guardian products and services.',
+	componentName: 'DownToEarthNewsletterEpic',
+	ophanComponentId: 'example_ophan_component_id',
+};
+
+BrazeDownToEarthNewsletterEpicComponent.story = {
+	name: 'Down To Earth newsletter Epic',
+};

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -2,19 +2,25 @@ import type { CommonBannerComponentProps as BrazeBannerProps } from '@guardian/b
 import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
 
-export default {
-	component: 'BrazeBanner',
-	title: 'Components/StickyBottomBanner/BrazeBanner',
+type BrazeMessageProps = {
+	[key: string]: string | undefined;
 };
 
-export const DefaultStory = (): ReactElement => {
+export default {
+	component: 'BrazeBanners',
+	title: 'Components/StickyBottomBanner/BrazeBanners',
+};
+
+// Braze Banner
+// ---------------------------------------
+export const BrazeBannerComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
 		useState<React.FC<BrazeBannerProps>>();
 
 	useEffect(() => {
-		import(
-			/* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components'
-		)
+		import('@guardian/braze-components')
 			.then((module) => {
 				setBrazeMessage(() => module.BrazeBannerComponent);
 			})
@@ -26,14 +32,19 @@ export const DefaultStory = (): ReactElement => {
 	}, []);
 
 	if (BrazeMessage) {
-		const header = 'A note to our digital subscribers';
-		const body =
-			'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.';
-		const componentName = 'DigitalSubscriberAppBanner';
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			body: args.body,
+			boldText: args.boldText,
+			buttonText: args.buttonText,
+			buttonUrl: args.buttonUrl,
+			imageUrl: args.imageUrl,
+			ophanComponentId: args.ophanComponentId,
+		};
 
 		return (
 			<BrazeMessage
-				componentName={componentName}
+				componentName={args.componentName}
 				logButtonClickWithBraze={(internalButtonId) => {
 					console.log(
 						`Button with internal ID ${internalButtonId} clicked`,
@@ -45,15 +56,145 @@ export const DefaultStory = (): ReactElement => {
 						componentEvent,
 					);
 				}}
-				brazeMessageProps={{
-					header,
-					body,
-				}}
+				brazeMessageProps={brazeMessageProps}
 			/>
 		);
 	}
-
 	return <div>Loading...</div>;
 };
 
-DefaultStory.story = { name: 'Braze Banner' };
+BrazeBannerComponent.args = {
+	slotName: 'Banner',
+	header: 'The Guardian’s impact in 2021',
+	body: 'Thanks to your generous support in this extraordinary year, our open, independent journalism was read by millions. From the pandemic to our urgent coverage of the climate crisis, our reporting had a powerful impact.',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+	buttonText: 'Take a look back',
+	buttonUrl:
+		'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
+	boldText:
+		'Read our look-back to see how Guardian journalism made a difference.',
+	componentName: 'BannerWithLink',
+	ophanComponentId: 'change_me_ophan_component_id',
+};
+
+BrazeBannerComponent.story = { name: 'BannerWithLink' };
+
+// Braze App Banner
+// ---------------------------------------
+export const BrazeAppBannerComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeBannerProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeBannerComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			body: args.body,
+			cta: args.cta,
+			imageUrl: args.imageUrl,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeAppBannerComponent.args = {
+	slotName: 'Banner',
+	header: 'A note to our digital subscribers',
+	body: 'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.',
+	componentName: 'AppBanner',
+	cta: 'Search for "Guardian live news"',
+	imageUrl:
+		'https://i.guim.co.uk/img/media/de6813b4dd9b9805a2d14dd6af14ae2b48e2e19e/0_0_930_520/master/930.png?quality=45&width=930&s=0beb53509265d32e3d201aa3981323bb',
+};
+
+BrazeAppBannerComponent.story = { name: 'AppBanner' };
+
+// Braze Digital Subscriber App Banner
+// ---------------------------------------
+export const BrazeDigitalSubscriberAppBannerComponent = (
+	args: BrazeMessageProps & { componentName: string },
+): ReactElement => {
+	const [BrazeMessage, setBrazeMessage] =
+		useState<React.FC<BrazeBannerProps>>();
+
+	useEffect(() => {
+		import('@guardian/braze-components')
+			.then((module) => {
+				setBrazeMessage(() => module.BrazeBannerComponent);
+			})
+			.catch((e) =>
+				console.error(
+					`braze-components dynamic import - error: ${String(e)}`,
+				),
+			);
+	}, []);
+
+	if (BrazeMessage) {
+		const brazeMessageProps: BrazeMessageProps = {
+			header: args.header,
+			body: args.body,
+		};
+
+		return (
+			<BrazeMessage
+				componentName={args.componentName}
+				logButtonClickWithBraze={(internalButtonId) => {
+					console.log(
+						`Button with internal ID ${internalButtonId} clicked`,
+					);
+				}}
+				submitComponentEvent={(componentEvent) => {
+					console.log(
+						'submitComponentEvent called with: ',
+						componentEvent,
+					);
+				}}
+				brazeMessageProps={brazeMessageProps}
+			/>
+		);
+	}
+	return <div>Loading...</div>;
+};
+
+BrazeDigitalSubscriberAppBannerComponent.args = {
+	slotName: 'Banner',
+	header: 'A note to our digital subscribers',
+	body: 'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.',
+	componentName: 'DigitalSubscriberAppBanner',
+};
+
+BrazeDigitalSubscriberAppBannerComponent.story = {
+	name: 'DigitalSubscriberAppBanner',
+};

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -22,6 +22,7 @@ export const BrazeBannerComponent = (
 	useEffect(() => {
 		import('@guardian/braze-components')
 			.then((module) => {
+				console.log(module);
 				setBrazeMessage(() => module.BrazeBannerComponent);
 			})
 			.catch((e) =>


### PR DESCRIPTION
## What does this change?
This PR updates Braze Banner components in Storybook, and creates Braze Epic components for Storybook

## Why?
Adding stories to Storybook is always a Good Thing

## Screenshots - Braze Epic stories
![Screenshot 2022-11-15 at 14 11 46](https://user-images.githubusercontent.com/5357530/201940942-e081458d-7779-4c9d-89c1-5e6f21a9013a.png)
![Screenshot 2022-11-15 at 14 11 27](https://user-images.githubusercontent.com/5357530/201940976-bd356776-e7c0-42ef-a327-d73e1214f7bb.png)
![Screenshot 2022-11-15 at 14 11 15](https://user-images.githubusercontent.com/5357530/201941008-a2b55738-aa0d-471f-adec-2336ca14f3ce.png)
![Screenshot 2022-11-15 at 14 10 59](https://user-images.githubusercontent.com/5357530/201941047-d01bc54c-5a57-4ac3-b8b9-0536ff61b59f.png)
![Screenshot 2022-11-15 at 14 10 50](https://user-images.githubusercontent.com/5357530/201941076-a284af6f-9493-4a7d-8a7e-382f970756b1.png)
![Screenshot 2022-11-15 at 14 10 39](https://user-images.githubusercontent.com/5357530/201941126-ac5b0397-d466-42ca-bc82-0b6940cbf915.png)
![Screenshot 2022-11-15 at 14 10 27](https://user-images.githubusercontent.com/5357530/201941179-5b58bab2-89d0-4243-861d-17e243adbf71.png)

## Screenshots - Braze Banner stories
![Screenshot 2022-11-15 at 14 10 10](https://user-images.githubusercontent.com/5357530/201941280-48d785e0-cabd-4512-a2d9-ec47aab18d45.png)
![Screenshot 2022-11-15 at 14 09 58](https://user-images.githubusercontent.com/5357530/201941297-8d8697ec-b6ad-4c5a-8d4c-b07ae2aaef2c.png)
![Screenshot 2022-11-15 at 14 09 42](https://user-images.githubusercontent.com/5357530/201941322-eebeb48f-fb0a-4ee0-a74a-4de48a36c6ce.png)
