### PR TITLE
Migrate Football To `Optional`

### DIFF
--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -10,7 +10,7 @@ import {
 	DottedLines,
 	StraightLines,
 } from '@guardian/source-react-components-development-kitchen';
-import { map, none, withDefault } from '@guardian/types';
+import { map, withDefault } from '@guardian/types';
 import { pillarToId, themeToPillar } from 'articleFormat';
 import Body from 'components/ArticleBody';
 import Epic from 'components/Epic';
@@ -41,6 +41,8 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
+import { Optional } from 'optional';
+import type { MatchScores } from 'football';
 
 // ----- Styles ----- //
 const backgroundStyles = (format: ArticleFormat): SerializedStyles => css`
@@ -105,11 +107,11 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 		  )
 		: null;
 
-	const matchScores = 'football' in item ? item.football : none;
+	const matchScores: Optional<MatchScores> = 'football' in item ? item.football : Optional.none();
 	return (
 		<main css={backgroundStyles(format)}>
 			<article className="js-article" css={BorderStyles}>
-				{maybeRender(matchScores, (scores) => (
+				{maybeRender(matchScores.toOption(), (scores) => (
 					<div id="js-football-scores">
 						<FootballScores
 							league={scores.league}

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -25,6 +25,7 @@ import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
+import type { MatchScores } from 'football';
 import { getFormat } from 'item';
 import type {
 	Explainer as ExplainerItem,
@@ -34,6 +35,7 @@ import type {
 	Standard as StandardItem,
 } from 'item';
 import { maybeRender, pipe } from 'lib';
+import { Optional } from 'optional';
 import type { FC, ReactNode } from 'react';
 import {
 	articleWidthStyles,
@@ -41,8 +43,6 @@ import {
 	lineStyles,
 	onwardStyles,
 } from 'styles';
-import { Optional } from 'optional';
-import type { MatchScores } from 'football';
 
 // ----- Styles ----- //
 const backgroundStyles = (format: ArticleFormat): SerializedStyles => css`
@@ -107,7 +107,8 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 		  )
 		: null;
 
-	const matchScores: Optional<MatchScores> = 'football' in item ? item.football : Optional.none();
+	const matchScores: Optional<MatchScores> =
+		'football' in item ? item.football : Optional.none();
 	return (
 		<main css={backgroundStyles(format)}>
 			<article className="js-article" css={BorderStyles}>

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -15,12 +15,14 @@ import HeaderImageCaption, {
 } from 'components/editions/headerImageCaption';
 import StarRating from 'components/editions/starRating';
 import Img from 'components/ImgAlt';
+import type { MatchScores } from 'football';
 import type { Image } from 'image';
 import type { Sizes } from 'image/sizes';
 import type { Item } from 'item';
 import { isPicture as checkIfPicture, getFormat } from 'item';
 import { maybeRender } from 'lib';
 import { MainMediaKind } from 'mainMedia';
+import { Optional } from 'optional';
 import type { FC } from 'react';
 import FootballScores from '../footballScores';
 import { wideImageWidth } from '../styles';
@@ -171,7 +173,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 	const isPicture = checkIfPicture(item.tags);
 	const iconColour = fill.editionsCameraIcon(format);
 	const iconBackgroundColour = background.editionsCameraIcon(format);
-	const matchScores = 'football' in item ? item.football : none;
+	const matchScores: Optional<MatchScores> = 'football' in item ? item.football : Optional.none();
 
 	return maybeRender(item.mainMedia, (media) => {
 		if (media.kind === MainMediaKind.Image) {
@@ -185,7 +187,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 					css={[getStyles(format, isPicture)]}
 					aria-labelledby={captionId}
 				>
-					{maybeRender(matchScores, (scores) => {
+					{maybeRender(matchScores.toOption(), (scores) => {
 						return (
 							<div css={footballWrapperStyles(false)}>
 								<FootballScores
@@ -229,7 +231,7 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 
 			return (
 				<>
-					{maybeRender(matchScores, (scores) => {
+					{maybeRender(matchScores.toOption(), (scores) => {
 						return (
 							<div css={footballWrapperStyles(true)}>
 								<FootballScores

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -173,7 +173,8 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 	const isPicture = checkIfPicture(item.tags);
 	const iconColour = fill.editionsCameraIcon(format);
 	const iconBackgroundColour = background.editionsCameraIcon(format);
-	const matchScores: Optional<MatchScores> = 'football' in item ? item.football : Optional.none();
+	const matchScores: Optional<MatchScores> =
+		'football' in item ? item.football : Optional.none();
 
 	return maybeRender(item.mainMedia, (media) => {
 		if (media.kind === MainMediaKind.Image) {

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -473,7 +473,7 @@ const cartoon: Item = {
 
 const matchReport: MatchReport = {
 	design: ArticleDesign.MatchReport,
-	football: some(matchScores),
+	football: Optional.some(matchScores),
 	...fields,
 	theme: ArticlePillar.Sport,
 	body: galleryBody,

--- a/apps-rendering/src/football.ts
+++ b/apps-rendering/src/football.ts
@@ -100,26 +100,33 @@ const parseTime = (time: unknown): Optional<string> => {
 	return Optional.some(`${date.getUTCHours()}:${date.getUTCMinutes()}`);
 };
 
-const parseMatchStatus = (status: string, time: string): Optional<MatchStatus> =>
+const parseMatchStatus = (
+	status: string,
+	time: string,
+): Optional<MatchStatus> =>
 	parseStatus(status).flatMap<MatchStatus>((s) => {
-			if (s === MatchStatusKind.KickOff) {
-				return parseTime(time).map((t) => ({ kind: s, time: t }));
-			}
+		if (s === MatchStatusKind.KickOff) {
+			return parseTime(time).map((t) => ({ kind: s, time: t }));
+		}
 
-			return Optional.some({ kind: s });
-		});
+		return Optional.some({ kind: s });
+	});
 
 const parseMatchScores = (football: FootballContent): Optional<MatchScores> => {
 	const maybeStadium = Optional.fromNullable(football.venue);
 	const maybeStatus = parseMatchStatus(football.status, football.kickOff);
 
-	return Optional.map2(maybeStadium, maybeStatus, (stadium: string, status: MatchStatus) => ({
-		league: football.competitionDisplayName,
-		stadium,
-		status,
-		homeTeam: football.homeTeam,
-		awayTeam: football.awayTeam,
-	}));
+	return Optional.map2(
+		maybeStadium,
+		maybeStatus,
+		(stadium: string, status: MatchStatus) => ({
+			league: football.competitionDisplayName,
+			stadium,
+			status,
+			homeTeam: football.homeTeam,
+			awayTeam: football.awayTeam,
+		}),
+	);
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -78,7 +78,7 @@ interface Fields extends ArticleFormat {
 interface MatchReport extends Fields {
 	design: ArticleDesign.MatchReport;
 	body: Body;
-	football: Option<MatchScores>;
+	football: Optional<MatchScores>;
 }
 
 interface ResizedRelatedContent extends RelatedContent {
@@ -539,9 +539,7 @@ const fromCapi =
 		} else if (isMatchReport(tags)) {
 			return {
 				design: ArticleDesign.MatchReport,
-				football: parseMatchScores(
-					fromNullable(request.footballContent),
-				),
+				football: Optional.fromNullable(request.footballContent).flatMap(parseMatchScores),
 				...itemFieldsWithBody(context, request),
 			};
 		}

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -539,7 +539,9 @@ const fromCapi =
 		} else if (isMatchReport(tags)) {
 			return {
 				design: ArticleDesign.MatchReport,
-				football: Optional.fromNullable(request.footballContent).flatMap(parseMatchScores),
+				football: Optional.fromNullable(
+					request.footballContent,
+				).flatMap(parseMatchScores),
 				...itemFieldsWithBody(context, request),
 			};
 		}


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages.

## Changes

- Migrated football parsing functions to `Optional`
- Updated `football` field in `Item` to use `Optional`
- Updated Apps and Editions components to use new football field
