### PR TITLE
Use h3 for `CardHeadline`

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -226,7 +226,7 @@ export const CardHeadline = ({
 		: palette.text.cardKicker;
 	return (
 		<>
-			<h4
+			<h3
 				css={[
 					format.theme === ArticleSpecial.Labs
 						? labTextStyles(size)
@@ -269,7 +269,7 @@ export const CardHeadline = ({
 						{headlineText}
 					</span>
 				</WithLink>
-			</h4>
+			</h3>
 			{!!byline && showByline && (
 				<Byline
 					text={byline}

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -80,7 +80,7 @@ export const LinkHeadline = ({
 	const palette = decidePalette(format);
 
 	return (
-		<h4 css={fontStyles(size)}>
+		<h3 css={fontStyles(size)}>
 			{!!kickerText && (
 				<Kicker
 					text={kickerText}
@@ -122,6 +122,6 @@ export const LinkHeadline = ({
 					)}
 				</>
 			)}
-		</h4>
+		</h3>
 	);
 };


### PR DESCRIPTION
## What does this change?

Use `h3` for `CardHeadline` instead of `h4`.

## Why?

Otherwise, we don’t have third-level headings and it means we have are not in sequentially descending order.

We should reach 96/100 on our Lighthouse Accessibility score.

Fixes #6315

## Screenshots (Lighthouse report)

<img width="903" alt="image" src="https://user-images.githubusercontent.com/76776/201953950-d6e8e2d2-6834-4f01-8a7e-754d3e27a3cc.png">

