### PR TITLE
a11y: Add a title to the `Back to homepage` SVG

### DIFF
--- a/dotcom-rendering/src/web/components/GuardianRoundel.tsx
+++ b/dotcom-rendering/src/web/components/GuardianRoundel.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 import { brand, neutral } from '@guardian/source-foundations';
 
+const title = 'Back to homepage';
+
 export const GuardianRoundel = () => {
 	return (
 		<div
@@ -9,8 +11,13 @@ export const GuardianRoundel = () => {
 				width: 42px;
 			`}
 		>
-			<a href="https://www.theguardian.com" data-link-name="nav2 : logo">
+			<a
+				href="https://www.theguardian.com"
+				data-link-name="nav2 : logo"
+				aria-label={title}
+			>
 				<svg viewBox="0 0 56 56">
+					<title>{title}</title>
 					<path
 						d="M28 0a28 28 0 1 0 28 28A28 28 0 0 0 28 0"
 						fill={neutral[100]}


### PR DESCRIPTION
## What does this change?

Adds a title to the SVG used by the "Back to hompage button"

We also add aria-label as the [docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title) recommend using `aria-labelledby` even when a title is set.

## Why?

Previously there was no hint telling screen readers what this button did! Also shows a label to users not using a screen reader on hover.

Fixes #5057 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/21217225/201959011-4b338db9-1ea3-442d-9b0d-6336c1d29793.png) | ![image](https://user-images.githubusercontent.com/21217225/201958941-66c9bc23-d42d-4d51-ac00-8bcdf41617a9.png) |


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
