### PR TITLE
Document `FetchCommentCounts`’s expected attribute `data-discussion-id`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -605,5 +605,13 @@ declare namespace JSX {
 		 * link is clicked.
 		 */
 		'data-link-name'?: string;
+
+		/**
+		 * Elements with this attribute will fetch their comment count on
+		 * the client-side.
+		 *
+		 * @see {@link ../src/web/components/FetchCommentCounts.importable.tsx}
+		 */
+		'data-discussion-id'?: string;
 	}
 }

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -268,7 +268,6 @@ export const Card = ({
 							// This a tag is initially rendered empty. It gets populated later
 							// after a fetch call is made to get all the counts for each Card
 							// on the page with a discussion (see FetchCommentCounts.tsx)
-							data-name="comment-count-marker"
 							data-discussion-id={discussionId}
 							data-format={JSON.stringify(format)}
 							data-is-dynamo={isDynamo ? 'true' : undefined}

--- a/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
@@ -44,7 +44,7 @@ type RenderedCountType = {
 function extractMarkers() {
 	const markers: MarkerType[] = [];
 	document
-		.querySelectorAll('[data-name="comment-count-marker"]')
+		.querySelectorAll('[data-discussion-id]')
 		.forEach((element: Element) => {
 			if (element instanceof HTMLElement) {
 				try {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Improve docs around the `FetchCommentCount` Island

## Why?

This pattern was introduced in #5091, but can be hard to reason about. @bryophyta and I were stumped with the actual inner workings of it.