### PR TITLE
Pf/a11y show more focus behaviour

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -11,7 +11,7 @@ import {
 	SvgCross,
 	SvgPlus,
 } from '@guardian/source-react-components';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { DCRContainerPalette, FEFrontCard } from 'src/types/front';
 import { enhanceCards } from '../../model/enhanceCards';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
@@ -71,6 +71,12 @@ export const ShowMore = ({
 		setExistingCardLinks(containerLinks);
 	}, []);
 
+	const moreCardsHeadingReference = useCallback((node: HTMLElement | null) => {
+		if (node !== null) {
+		  node.focus();
+		}
+	  }, []);
+
 	/** We only pass an actual URL to SWR when 'showMore' is true.
 	 * Toggling 'showMore' will trigger a re-render
 	 *   @see https://swr.vercel.app/docs/conditional-fetching#conditional
@@ -99,9 +105,11 @@ export const ShowMore = ({
 							`}
 						/>
 						<h4
+							ref={moreCardsHeadingReference}
 							css={css`
 								${visuallyHidden}
 							`}
+							tabIndex={-1}
 						>
 							More {containerTitle}
 						</h4>

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -71,11 +71,14 @@ export const ShowMore = ({
 		setExistingCardLinks(containerLinks);
 	}, []);
 
-	const moreCardsHeadingReference = useCallback((node: HTMLElement | null) => {
-		if (node !== null) {
-		  node.focus();
-		}
-	  }, []);
+	const moreCardsHeadingReference = useCallback(
+		(node: HTMLElement | null) => {
+			if (node !== null) {
+				node.focus();
+			}
+		},
+		[],
+	);
 
 	/** We only pass an actual URL to SWR when 'showMore' is true.
 	 * Toggling 'showMore' will trigger a re-render


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
