### PR TITLE
Be more leanient on where Storybook is ran from

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -30,6 +30,7 @@
     "cypress:run:e2e": "cypress run --browser chrome --spec 'cypress/e2e/**/*'",
     "cypress:run:percy": "percy exec -- cypress run --browser chrome --config specPattern='cypress/snapshot/**/*'",
     "unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
+    "storybook": "yarn --cwd .. storybook",
     "makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./scripts/webpack/webpack.config.js"
   },
   "bundlesize": [


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Allow `yarn storybook` to be ran from `dotcom-rendering/dotcom-rendering.`

## Why?

The current behaviour can be confusing, and we do not provide a helpful message for developers.

## Screenshots

<img width="455" alt="image" src="https://user-images.githubusercontent.com/76776/202147466-7263c192-da22-42f7-9121-5665c8ead2b3.png">
