### PR TITLE
Fix flakey `article.e2e.cy` AB tests

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -113,7 +113,13 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.scrollTo('bottom', { duration: 300 });
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+				.scrollIntoView({ duration: 100, timeout: 10000 })
+				.should(
+					'have.attr',
+					'data-gu-ready',
+					'true',
+				);
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-not-in-test]').should(
 				'be.visible',

--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -87,10 +87,13 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.scrollTo('bottom', { duration: 300 });
-			cy.get('[data-cy-ab-user-in-variant=ab-test-variant]').should(
-				'be.visible',
-			);
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+				.scrollIntoView({ duration: 100, timeout: 10000 })
+				.should(
+					'have.attr',
+					'data-gu-ready',
+					'true',
+				);
 
 			cy.get('[data-cy-ab-runnable-test=variant]').should('be.visible');
 

--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -87,13 +87,13 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+			cy.get('gu-island[name=MostViewedFooterData]')
 				.scrollIntoView({ duration: 100, timeout: 10000 })
-				.should(
-					'have.attr',
-					'data-gu-ready',
-					'true',
-				);
+				.should('have.attr', 'data-gu-ready', 'true');
+
+			cy.get('[data-cy-ab-user-in-variant=ab-test-variant]').should(
+				'be.visible',
+			);
 
 			cy.get('[data-cy-ab-runnable-test=variant]').should('be.visible');
 
@@ -113,13 +113,9 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+			cy.get('gu-island[name=MostViewedFooterData]')
 				.scrollIntoView({ duration: 100, timeout: 10000 })
-				.should(
-					'have.attr',
-					'data-gu-ready',
-					'true',
-				);
+				.should('have.attr', 'data-gu-ready', 'true');
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-not-in-test]').should(
 				'be.visible',


### PR DESCRIPTION
## What does this change?

The current `article.e2e.cy` AB tests are flakey.

This is because the tests are scrolling to the bottom of the page expecting to trigger the `MostViewedFooterData` island which is deferred until viewable.

I assume due to the instant scroll and layout shift the island does not always intersect the viewport and therefore does not render.

This PR scrolls to `MostViewedFooterData` directly and waits for it to be rendered via the `data-gu-ready` attribute. 

