### PR TITLE
Update braze-components dependency to v8.1.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.8.1",
-    "@guardian/braze-components": "^8.0.0",
+    "@guardian/braze-components": "^8.1.0",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.21.0",
     "@guardian/consent-management-platform": "10.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,10 +2813,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.0.0.tgz#b90f07746faafe2e587bb112c78dd2411f3a2998"
-  integrity sha512-hAJsfjio4VJ/qPGR+NTbgiLR+7mJetJZDExZ560XUUzMKpqVICsIL4S/l9HRqjAZ4G7r2SE6M4ONMfnPZUTwBQ==
+"@guardian/braze-components@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.0.tgz#25804cc2fbdb3ce31689f4a12b2c7b864b946db6"
+  integrity sha512-UMU62666vSE5Dlrd7BjZlOBYxmwyoLqomkzoWiUkC3GGUM2kCY/Phq81m+QfHpNgPT8rrHiO/LrfQI9DNNjGhw==
 
 "@guardian/browserslist-config@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## What does this change?
Updates braze-components repo to v8.1.0

## Why?
We have updated braze-components to fix two issues

1. Marketing colleagues asked for the ability to suppress payment icons next to the main CTA in braze banners
2. An accessibility fix to allow user to close a Braze banner by clicking on the keyboard ESC key

## Screenshots
None required for this PR

## Testing
We will deploy to DCR CODE and make sure the braze banner works as expected in the code environment