### PR TITLE
Refactor Ophan component event without action type to use the `Omit`

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/componentEventTracking.tsx
@@ -1,11 +1,6 @@
 import type { OphanComponent, OphanComponentEvent } from '@guardian/libs';
 import type { CurrentSignInGateABTest } from './types';
 
-type ABTestVariant = {
-	name: string;
-	variant: string;
-};
-
 const isServer = typeof window === 'undefined';
 
 export type ComponentEventParams = {
@@ -18,13 +13,6 @@ export type ComponentEventParams = {
 	visitId?: string;
 };
 
-type ComponentEventWithoutAction = {
-	component: OphanComponent;
-	value?: string;
-	id?: string;
-	abTest?: ABTestVariant;
-};
-
 const ophan = isServer ? undefined : window.guardian.ophan;
 
 // ophan helper methods
@@ -33,7 +21,7 @@ const submitComponentEventTracking = (componentEvent: OphanComponentEvent) => {
 };
 
 export const submitViewEventTracking = (
-	componentEvent: ComponentEventWithoutAction,
+	componentEvent: Omit<OphanComponentEvent, 'action'>,
 ) =>
 	submitComponentEventTracking({
 		...componentEvent,
@@ -41,7 +29,7 @@ export const submitViewEventTracking = (
 	});
 
 const submitClickEventTracking = (
-	componentEvent: ComponentEventWithoutAction,
+	componentEvent: Omit<OphanComponentEvent, 'action'>,
 ) =>
 	submitComponentEventTracking({
 		...componentEvent,


### PR DESCRIPTION
## What does this change?

Use the `Omit` type instead of a duplicated version of the type without the `action` key.

## Why?

Less code duplication and more reliance on `@guardian/libs`