### PR TITLE
Expand `useAB`

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -24,15 +24,17 @@ if (isChromatic()) {
 
 mockRESTCalls();
 
-setABTests(
-	new AB({
+setABTests({
+	api: new AB({
 		mvtMaxValue: 1_000_000,
 		mvtId: 1234,
 		pageIsSensitive: false,
 		abTestSwitches: {},
 		arrayOfTestObjects: [],
 	}),
-);
+	participations: {},
+	allRunnableTests: [],
+});
 
 // Add base css for the site
 let css = `${getFontsCss()}${resets.resetCSS}`;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -33,7 +33,6 @@ setABTests({
 		arrayOfTestObjects: [],
 	}),
 	participations: {},
-	allRunnableTests: [],
 });
 
 // Add base css for the site

--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -87,9 +87,11 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]')
-				.scrollIntoView({ duration: 100, timeout: 10000 })
-				.should('have.attr', 'data-gu-ready', 'true');
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 3000 })
+				.scrollIntoView({ duration: 100, timeout: 30000 })
+				.should('have.attr', 'data-gu-ready', 'true', {
+					timeout: 30000,
+				});
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-variant]').should(
 				'be.visible',
@@ -113,9 +115,11 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]')
-				.scrollIntoView({ duration: 100, timeout: 10000 })
-				.should('have.attr', 'data-gu-ready', 'true');
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 3000 })
+				.scrollIntoView({ duration: 100, timeout: 30000 })
+				.should('have.attr', 'data-gu-ready', 'true', {
+					timeout: 30000,
+				});
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-not-in-test]').should(
 				'be.visible',

--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -30,18 +30,18 @@ import { useAB } from '../lib/useAB';
 
 // Example usage of AB Tests
 // Used in the Cypress tests as smoke test of the AB tests framework integration
-const ABTestAPI = useAB();
+const ABTestAPI = useAB()?.api;
 
 // We can check if a user is in a variant, returns a boolean
 // ABTestTest being an ab test that was passed in via the ab test array
 const abTestDataAttr =
-    (ABTestAPI.isUserInVariant('AbTestTest', 'control') && 'ab-test-control') ||
-    (ABTestAPI.isUserInVariant('AbTestTest', 'variant') && 'ab-test-variant') ||
+    (ABTestAPI?.isUserInVariant('AbTestTest', 'control') && 'ab-test-control') ||
+    (ABTestAPI?.isUserInVariant('AbTestTest', 'variant') && 'ab-test-variant') ||
     'ab-test-not-in-test';
 
 // We can get the variant straight from a check for
 // whether the test is runnable
-const runnableTest = ABTestAPI.runnableTest(abTestTest);
+const runnableTest = ABTestAPI?.runnableTest(abTestTest);
 const variantFromRunnable =
     (runnableTest && runnableTest.variantToRun.id) || 'not-runnable';
 

--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export const CommercialMetrics = ({ enabled }: Props) => {
-	const ABTestAPI = useAB();
+	const ABTestAPI = useAB()?.api;
 	const adBlockerInUse = useAdBlockInUse();
 
 	useOnce(() => {

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -19,7 +19,7 @@ export const CoreVitals = () => {
 		window.location.hostname === 'preview.gutools.co.uk';
 	const sampling = 1 / 100;
 
-	const ABTestAPI = useAB();
+	const ABTestAPI = useAB()?.api;
 
 	// For these tests switch off sampling and collect metrics for 100% of views
 	const clientSideTestsToForceMetrics: ABTest[] = [

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -46,7 +46,7 @@ export const MostViewedFooterData = ({
 	const palette = decidePalette(format);
 	// Example usage of AB Tests
 	// Used in the Cypress tests as smoke test of the AB tests framework integration
-	const ABTestAPI = useAB();
+	const ABTestAPI = useAB()?.api;
 
 	const abTestCypressDataAttr =
 		(ABTestAPI?.isUserInVariant('AbTestTest', 'control') &&

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -61,7 +61,6 @@ export const SetABTests = ({
 	setABTests({
 		api: ab,
 		participations,
-		allRunnableTests,
 	});
 
 	ab.trackABTests(allRunnableTests);

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -5,6 +5,7 @@ import type { ABTestSwitches } from '../../model/enhance-switches';
 import { getOphanRecordFunction } from '../browser/ophan/ophan';
 import { tests } from '../experiments/ab-tests';
 import { getCypressSwitches } from '../experiments/cypress-switches';
+import { runnableTestsToParticipations } from '../experiments/lib/ab-participations';
 import { getForcedParticipationsFromUrl } from '../lib/getAbUrlHash';
 import { setABTests } from '../lib/useAB';
 
@@ -30,11 +31,17 @@ export const SetABTests = ({
 		// 0 is default and falsy here
 		console.log('There is no MVT ID set, see SetABTests.importable.tsx');
 	}
+
 	const ophanRecord = getOphanRecordFunction();
-	const windowHash = window.location.hash;
+
 	// Get the forced switches to use for when running within cypress
 	// Is empty object if not in cypress
 	const cypressAbSwitches = getCypressSwitches();
+
+	const allForcedTestVariants = {
+		...forcedTestVariants,
+		...getForcedParticipationsFromUrl(window.location.hash),
+	};
 
 	const ab = new AB({
 		mvtId,
@@ -45,17 +52,15 @@ export const SetABTests = ({
 		},
 		arrayOfTestObjects: tests,
 		ophanRecord,
-		forcedTestVariants: {
-			...forcedTestVariants,
-			...getForcedParticipationsFromUrl(windowHash),
-		},
+		forcedTestVariants: allForcedTestVariants,
 	});
 
 	const allRunnableTests = ab.allRunnableTests(tests);
+	const participations = runnableTestsToParticipations(allRunnableTests);
 
 	setABTests({
 		api: ab,
-		participations: {},
+		participations,
 		allRunnableTests,
 	});
 

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -51,7 +51,12 @@ export const SetABTests = ({
 			...getForcedParticipationsFromUrl(windowHash),
 		},
 	});
-	setABTests(ab);
+
+	setABTests({
+		api: ab,
+		participations: {},
+		allRunnableTests: [],
+	});
 
 	const allRunnableTests = ab.allRunnableTests(tests);
 	ab.trackABTests(allRunnableTests);

--- a/dotcom-rendering/src/web/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/web/components/SetABTests.importable.tsx
@@ -28,7 +28,6 @@ export const SetABTests = ({
 	);
 	if (!mvtId) {
 		// 0 is default and falsy here
-
 		console.log('There is no MVT ID set, see SetABTests.importable.tsx');
 	}
 	const ophanRecord = getOphanRecordFunction();
@@ -52,13 +51,14 @@ export const SetABTests = ({
 		},
 	});
 
+	const allRunnableTests = ab.allRunnableTests(tests);
+
 	setABTests({
 		api: ab,
 		participations: {},
-		allRunnableTests: [],
+		allRunnableTests,
 	});
 
-	const allRunnableTests = ab.allRunnableTests(tests);
 	ab.trackABTests(allRunnableTests);
 	ab.registerImpressionEvents(allRunnableTests);
 	ab.registerCompleteEvents(allRunnableTests);

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -94,7 +94,10 @@ export const YoutubeBlockComponent = ({
 		undefined,
 	);
 
-	const imaEnabled = !!useAB()?.isUserInVariant('IntegrateIMA', 'variant');
+	const imaEnabled = !!useAB()?.api.isUserInVariant(
+		'IntegrateIMA',
+		'variant',
+	);
 
 	useEffect(() => {
 		const defineConsentState = async () => {

--- a/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-localstorage.ts
@@ -1,5 +1,6 @@
 import type { Participations } from '@guardian/ab-core';
-import { isObject, isString, storage } from '@guardian/libs';
+import { storage } from '@guardian/libs';
+import { isParticipations } from './ab-participations';
 
 /**
  * These utils have been lifted from the equivalent Frontend file
@@ -7,17 +8,6 @@ import { isObject, isString, storage } from '@guardian/libs';
  */
 
 const participationsKey = 'gu.ab._participations';
-
-export const isParticipations = (
-	participations: unknown,
-): participations is Participations => {
-	if (!isObject(participations)) return false;
-	return Object.values(participations).some((participation) => {
-		if (!isObject(participation)) return false;
-		if (!isString(participation.variant)) return false;
-		return true;
-	});
-};
 
 // -------
 // Reading

--- a/dotcom-rendering/src/web/experiments/lib/ab-participations.test.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-participations.test.ts
@@ -1,4 +1,4 @@
-import { isParticipations } from './ab-localstorage';
+import { isParticipations } from './ab-participations';
 
 describe('isParticipations validation', () => {
 	test('Localstorage Participation data is validated correctly,', () => {

--- a/dotcom-rendering/src/web/experiments/lib/ab-participations.ts
+++ b/dotcom-rendering/src/web/experiments/lib/ab-participations.ts
@@ -1,0 +1,28 @@
+import type { Participations, Runnable } from '@guardian/ab-core';
+import { isObject, isString } from '@guardian/libs';
+
+const isParticipations = (
+	participations: unknown,
+): participations is Participations =>
+	isObject(participations) &&
+	Object.values(participations).every(
+		(participation) =>
+			isObject(participation) && isString(participation.variant),
+	);
+
+const runnableTestsToParticipations = (
+	runnableTests: readonly Runnable[],
+): Participations =>
+	runnableTests.reduce(
+		(participations: Participations, { id: testId, variantToRun }) => ({
+			...participations,
+			...{
+				[testId]: {
+					variant: variantToRun.id,
+				},
+			},
+		}),
+		{},
+	);
+
+export { isParticipations, runnableTestsToParticipations };

--- a/dotcom-rendering/src/web/lib/useAB.ts
+++ b/dotcom-rendering/src/web/lib/useAB.ts
@@ -1,11 +1,10 @@
-import type { ABTestAPI, Participations, Runnable } from '@guardian/ab-core';
+import type { ABTestAPI, Participations } from '@guardian/ab-core';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
 type ABTests = {
 	api: ABTestAPI;
 	participations: Participations;
-	allRunnableTests: [] | readonly Runnable[];
 };
 
 const apiPromise = new Promise<ABTests>(() => {});
@@ -24,10 +23,6 @@ export const useAB = (): ABTests | undefined => {
 	return data;
 };
 
-export const setABTests = ({
-	api,
-	participations,
-	allRunnableTests,
-}: ABTests): void => {
-	void mutate(key, { api, participations, allRunnableTests }, false);
+export const setABTests = ({ api, participations }: ABTests): void => {
+	void mutate(key, { api, participations }, false);
 };

--- a/dotcom-rendering/src/web/lib/useAB.ts
+++ b/dotcom-rendering/src/web/lib/useAB.ts
@@ -1,9 +1,15 @@
-import type { ABTestAPI } from '@guardian/ab-core';
+import type { ABTestAPI, Participations, Runnable } from '@guardian/ab-core';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
-const apiPromise = new Promise<ABTestAPI>(() => {});
-const key = 'ab-test-api';
+type ABTests = {
+	api: ABTestAPI;
+	participations: Participations;
+	allRunnableTests: [] | readonly Runnable[];
+};
+
+const apiPromise = new Promise<ABTests>(() => {});
+const key = 'ab-tests';
 
 /**
  * A hook which returns the AB Test Api when available,
@@ -13,13 +19,15 @@ const key = 'ab-test-api';
  * AB Core. As soon as the tests are available, all instances of
  * the useAB hook will render.
  */
-export const useAB = (): ABTestAPI | undefined => {
+export const useAB = (): ABTests | undefined => {
 	const { data } = useSWRImmutable(key, () => apiPromise);
-
 	return data;
 };
 
-export const setABTests = (api: ABTestAPI): void => {
-	// eslint-disable-next-line @typescript-eslint/no-floating-promises
-	mutate(key, api, false);
+export const setABTests = ({
+	api,
+	participations,
+	allRunnableTests,
+}: ABTests): void => {
+	void mutate(key, { api, participations, allRunnableTests }, false);
 };

--- a/dotcom-rendering/src/web/lib/useSignInGateSelector.ts
+++ b/dotcom-rendering/src/web/lib/useSignInGateSelector.ts
@@ -17,7 +17,7 @@ import { useAB } from './useAB';
 export const useSignInGateSelector = ():
 	| undefined
 	| [SignInGateComponent | null, CurrentSignInGateABTest | null] => {
-	const ab = useAB();
+	const ab = useAB()?.api;
 	if (!ab) return undefined;
 
 	const test: Runnable | null = ab.firstRunnableTest(signInGateTests);


### PR DESCRIPTION
## What does this change?

For an upcoming PR we wish to pass AB test participations to YoutubeAtom to add it to the ad targeting we send to Google Ad Manager and YouTube.

AB test participations are not currently available in DCR but it is possible to determine at the point `SetABTests.importable` instantiates the AB API and invokes `setABTests`.

This PR extends `setABTests` to take an object of shape:

```ts
type ABTests = {
  api: ABTestAPI;
  participations: Participations;
};
```

Any consumer of `useAB` can now access those properties.

## Why?

This will allow us to test new YouTube advertising integrations based on participation in ab tests.

