### PR TITLE
`parseIntOpt` To `Optional`

### DIFF
--- a/apps-rendering/src/embed.ts
+++ b/apps-rendering/src/embed.ts
@@ -2,9 +2,10 @@
 
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType';
-import { andThen, fromNullable, withDefault } from '@guardian/types';
+import { fromNullable, withDefault } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { parseIntOpt, pipe, resultFromNullable } from 'lib';
+import { Optional } from 'optional';
 import type { DocParser } from 'parserContext';
 import { Result } from 'result';
 
@@ -100,7 +101,9 @@ const youtubeUrl = (id: string): string => {
 const getNumericAttribute =
 	(attr: string) =>
 	(elem: Element): Option<number> =>
-		pipe(elem.getAttribute(attr), fromNullable, andThen(parseIntOpt));
+		Optional.fromNullable(elem.getAttribute(attr))
+			.flatMap(parseIntOpt)
+			.toOption();
 
 const getAttribute =
 	(attr: string) =>

--- a/apps-rendering/src/lib.ts
+++ b/apps-rendering/src/lib.ts
@@ -83,10 +83,18 @@ const resultFromNullable =
 	<A>(a: A | null | undefined): Result<E, A> =>
 		a === null || a === undefined ? Result.err(e) : Result.ok(a);
 
-const parseIntOpt = (int: string): Option<number> => {
-	const parsed = parseInt(int);
+/**
+ * Attempts to parse a `string` into an integer (`number`). Returns an
+ * {@linkcode Optional} `Some` if a valid number, and a `None` if not.
+ * Note: `NaN`s are considered invalid.
+ *
+ * @param str A `string` to be parsed
+ * @returns {Optional<number>} A valid number in a `Some`, or a `None`
+ */
+const parseIntOpt = (str: string): Optional<number> => {
+	const parsed = parseInt(str);
 
-	return isNaN(parsed) ? none : some(parsed);
+	return isNaN(parsed) ? Optional.none() : Optional.some(parsed);
 };
 
 const resultMap3 =


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages.

## Changes

- Updated `parseIntOpt` to return `Optional`
- Updated usage of `parseIntOpt`
- Added docs for `parseIntOpt`
