### PR TITLE
Feat: Add design tag to obituary articles

### DIFF
--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -136,6 +136,14 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
+		case ArticleDesign.Obituary:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/obituaries">Obituaries</TagLink>
+					</Tag>
+				</Margins>
+			);
 		default:
 			return null;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the design tag to obituary articles on dcr

## Why?
To align with editorial designs. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/202206655-96c8c723-876f-4e7c-87d9-5be199a581dd.png
[after]: https://user-images.githubusercontent.com/20416599/202207305-f1f67259-36a1-45ec-8b03-7a2d4057e3de.png


| Before      | After      |
|-------------|------------|
| ![before-web][] | ![after-web][] |

[before-web]: https://user-images.githubusercontent.com/20416599/202207394-6080e754-0087-44f6-8479-7143ce40705f.png
[after-web]: https://user-images.githubusercontent.com/20416599/202207326-f11f860d-a73a-4398-8ba4-d16f37d400ed.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
