### PR TITLE
a11y: Fix 2 labels refering 1 input in the More button of the navbar

### DIFF
--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -75,7 +75,6 @@ export const ShowMoreMenu = ({ display }: { display: ArticleDisplay }) => (
 			css={openExpandedMenuStyles(display)}
 			aria-label="Toggle main menu"
 			key="OpenExpandedMenuButton"
-			htmlFor={navInputCheckboxId}
 			data-link-name="nav2 : veggie-burger: show"
 			tabIndex={0}
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -115,7 +115,6 @@ export const VeggieBurgerMenu = ({ display }: Props) => {
 			css={veggieBurgerStyles(display)}
 			aria-label="Toggle main menu"
 			key="OpenExpandedMenuButton"
-			htmlFor={navInputCheckboxId}
 			data-link-name="nav2 : veggie-burger: show"
 			tabIndex={0}
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role -- we’re using this label for a CSS-only toggle

--- a/dotcom-rendering/src/web/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/web/components/Nav/Nav.tsx
@@ -228,6 +228,7 @@ export const Nav = ({
 					role="button"
 					aria-expanded="false"
 					aria-haspopup="true"
+					aria-label="Toggle main menu"
 				/>
 				<Pillars
 					display={format.display}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds aria-label straight to the checkbox used by the "More" button on the navbar instead of using labels.

In reality this won't actually improve accessibility as both labels had the same value, but it should stop this error from showing up in a11y testers.

## Why?

![image](https://user-images.githubusercontent.com/21217225/202430216-2010a638-d008-4ccf-8a5a-7af26064de5b.png)


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
