### PR TITLE
a11y: Add a maincontent anchor to Fronts

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -280,7 +280,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				</>
 			</div>
 
-			<main data-layout="FrontLayout">
+			<main data-layout="FrontLayout" id="maincontent">
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a `maincontent` ID to the main section of our fronts to allow our "Skip to main content" button to work

## Why?

We don't have any content marked as "maincontent" on a front so our "Skip to main content" button doesn't do anything!