### PR TITLE
Small text for headlines on 25perc cards without images

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.tsx
@@ -373,6 +373,12 @@ const Card75_ColumnOfCards25 = ({
 											? card.image
 											: undefined
 									}
+									headlineSize={
+										cardIndex === 0 ||
+										remaining.length === 2
+											? 'medium'
+											: 'small'
+									}
 									supportingContent={card.supportingContent}
 								/>
 							</LI>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This renders the headline with small font-size for 25perc cards without images.
This resolves https://github.com/guardian/dotcom-rendering/issues/6488
## Why?
Parity with frontend
## Screenshots

| frontend      | Before      | After      |
|-------------|-------------|------------|
| ![frontend][] | ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/202503267-9405b31e-08cb-4447-89ac-2e9cb74bd331.png
[after]: https://user-images.githubusercontent.com/110032454/202504541-33987def-b63e-4c9a-b957-6009e8649a13.png
[frontend]: https://user-images.githubusercontent.com/110032454/202504828-2e5db203-6a44-4af2-9567-dac75ec15446.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
