### PR TITLE
Cypress `article.e2e` flaky fixes

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -87,11 +87,9 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 3000 })
-				.scrollIntoView({ duration: 100, timeout: 30000 })
-				.should('have.attr', 'data-gu-ready', 'true', {
-					timeout: 30000,
-				});
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+				.scrollIntoView({ duration: 100 })
+				.should('have.attr', 'data-gu-ready', 'true');
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-variant]').should(
 				'be.visible',
@@ -115,11 +113,9 @@ describe('E2E Page rendering', function () {
 				'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			);
 
-			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 3000 })
-				.scrollIntoView({ duration: 100, timeout: 30000 })
-				.should('have.attr', 'data-gu-ready', 'true', {
-					timeout: 30000,
-				});
+			cy.get('gu-island[name=MostViewedFooterData]', { timeout: 30000 })
+				.scrollIntoView({ duration: 100 })
+				.should('have.attr', 'data-gu-ready', 'true');
 
 			cy.get('[data-cy-ab-user-in-variant=ab-test-not-in-test]').should(
 				'be.visible',


### PR DESCRIPTION
## What does this change?

After testing _lots_ of different combinations of scrolling this version is the least flaky so far.

In general however the Cypress commands `scrollTo` and `scrollIntoView` can be problematic:

https://github.com/cypress-io/cypress/issues/805
https://github.com/cypress-io/cypress/issues/3200
https://stackoverflow.com/questions/65035916/cypress-does-not-automatically-scroll

### Next steps

We should look at doing this test differently:

- moving AB API testing to unit tests
- moving AB API testing out of a `deferUntil="visible"` island like `MostViewedFooterData` which means no scrolling required
