### PR TITLE
Bump `atoms-rendering` to `23.10.0`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -62,7 +62,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
-    "@guardian/atoms-rendering": "^23.8.1",
+    "@guardian/atoms-rendering": "^23.10.0",
     "@guardian/braze-components": "^8.1.0",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.21.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -65,7 +65,7 @@
     "@guardian/atoms-rendering": "^23.10.0",
     "@guardian/braze-components": "^8.1.0",
     "@guardian/browserslist-config": "^2.0.3",
-    "@guardian/commercial-core": "^4.21.0",
+    "@guardian/commercial-core": "^4.24.0",
     "@guardian/consent-management-platform": "10.11.1",
     "@guardian/discussion-rendering": "^11.0.3",
     "@guardian/libs": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,10 +2806,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^23.8.1":
-  version "23.8.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.8.1.tgz#cd738ef65b67c2d6555952a10ae132c0bcfe4955"
-  integrity sha512-Z+HAoFZB2SMilWs90OLOcqrnkOmY9Xot7Arl6KjvEB5Au4fjzSTQmIxO8iV9j3igNwpQdGm2qp/364A0WpTo8A==
+"@guardian/atoms-rendering@^23.10.0":
+  version "23.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.10.0.tgz#4441773c40ab431386b71649245b7273e04a45ab"
+  integrity sha512-gbsoIsMEVYcsZksZGEXs/6yiVdi14e4KRwUEAXf2aWuBu6WS+47EIe7kxCLjKO2i1Ez8NZ9+F/lbipFeaDpLEw==
   dependencies:
     is-mobile "^3.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,10 +2823,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-2.0.3.tgz#1c8b832ab564b257f8146ca1b3183b7683026ec9"
   integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
 
-"@guardian/commercial-core@^4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.21.0.tgz#d6ad678a563bd82c3ed738bc4f77a0c7494a5120"
-  integrity sha512-OpME2iB6Dosvdu7MF8npzgIeRFOPWwdeSVNaUI3aB1wqU+FQh47cozGk1BASgCXlsUwhhGvQbx5vTBkDiptsgQ==
+"@guardian/commercial-core@^4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.24.0.tgz#4812d2a97f8b888092a4170624a0871742d83128"
+  integrity sha512-6ql4W6y0bx0GehSn7jNEkcn8DAoq3b/R9sfOCtbI952rouSaoKtIZcxKPK9PA9vSkWqkXF3hm9r/Ci2AKo+7gA==
 
 "@guardian/consent-management-platform@10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?

Bumps `atoms-rendering` to `23.10.0` to bring in this change: https://github.com/guardian/atoms-rendering/pull/489
