### PR TITLE
Update braze-components dependency to v8.1.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -63,7 +63,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/atoms-rendering": "^23.8.1",
-    "@guardian/braze-components": "^8.1.0",
+    "@guardian/braze-components": "^8.1.1",
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.21.0",
     "@guardian/consent-management-platform": "10.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,10 +2813,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.0.tgz#25804cc2fbdb3ce31689f4a12b2c7b864b946db6"
-  integrity sha512-UMU62666vSE5Dlrd7BjZlOBYxmwyoLqomkzoWiUkC3GGUM2kCY/Phq81m+QfHpNgPT8rrHiO/LrfQI9DNNjGhw==
+"@guardian/braze-components@^8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.1.tgz#7b265a7d2a2163df70238823e881950a6d43598d"
+  integrity sha512-4izZBDS9HXgEmf9hLBs0X3JdtgrdnGuFRCGhyJFodUPU+ZFXo2H4rOQlTBBsUhr5PurEZBDVU+9y6ZCe74ZWcg==
 
 "@guardian/browserslist-config@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## What does this change?
Updates braze-components dependency to v8.1.1

## Why?
We have updated braze-components to fix one issues
1. Fix an issue where short (single line) paragraphs in Braze Epic marketing messages were justified centrally, rather than to the left

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-11-17 at 15 37 05](https://user-images.githubusercontent.com/5357530/202724228-8561be2b-6b74-4dd4-9826-7cf940e83918.png) | ![Screenshot 2022-11-17 at 16 43 43](https://user-images.githubusercontent.com/5357530/202724330-7607ab7c-53d3-4e41-9b77-52514b801ee6.png) |
