### PR TITLE
Fix show more focus behaviour

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -68,7 +68,7 @@ export const ShowMore = ({
 	}, []);
 
 	/** We only pass an actual URL to SWR when 'showMore' is true.
-	 * Toggling 'showMore' will trigger a re-render
+	 * Toggling 'isOpen' will trigger a re-render
 	 *   @see https://swr.vercel.app/docs/conditional-fetching#conditional
 	 */
 	const url = isOpen

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -11,7 +11,7 @@ import {
 	SvgCross,
 	SvgPlus,
 } from '@guardian/source-react-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { DCRContainerPalette, FEFrontCard } from 'src/types/front';
 import { enhanceCards } from '../../model/enhanceCards';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
@@ -55,10 +55,6 @@ export const ShowMore = ({
 	const [existingCardLinks, setExistingCardLinks] = useState<string[]>([]);
 	const [isOpen, setIsOpen] = useState(false);
 
-	/**
-		@todo: Fix focus behaviour on expand/collapse: @see https://github.com/guardian/dotcom-rendering/issues/6343
-	*/
-
 	useOnce(() => {
 		const container = document.getElementById(containerId);
 		const containerLinks = Array.from(
@@ -87,6 +83,22 @@ export const ShowMore = ({
 		);
 
 	const showMoreContainerId = `show-more-${containerId}`;
+
+	useEffect(() => {
+		/**
+		 * Focus the first of the new cards when they're loaded in.
+		 * There's no need to check `isOpen` here because if `isOpen` is
+		 * `false` then `filteredData` will be `undefined`.
+		 * */
+		if (filteredData && filteredData.length > 0) {
+			const maybeFirstCard = document.querySelector(
+				`#${showMoreContainerId} [data-link-name="${filteredData[0].dataLinkName}"]`,
+			);
+			if (maybeFirstCard instanceof HTMLElement) {
+				maybeFirstCard.focus();
+			}
+		}
+	}, [filteredData, showMoreContainerId]);
 
 	return (
 		<>
@@ -165,6 +177,7 @@ export const ShowMore = ({
 					`}
 					aria-controls={showMoreContainerId}
 					aria-expanded={isOpen && !loading}
+					aria-describedby={`show-more-button-${containerId}-description`}
 					data-cy={`show-more-button-${containerId}`}
 				>
 					{decideButtonText({
@@ -173,6 +186,14 @@ export const ShowMore = ({
 						containerTitle,
 					})}
 				</Button>
+				<span
+					id={`show-more-button-${containerId}-description`}
+					css={css`
+						${visuallyHidden}
+					`}
+				>
+					Loads more stories and moves focus to first new story.
+				</span>
 				{error && (
 					<InlineError
 						cssOverrides={css`

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -90,7 +90,7 @@ export const ShowMore = ({
 		 * There's no need to check `isOpen` here because if `isOpen` is
 		 * `false` then `filteredData` will be `undefined`.
 		 * */
-		if (filteredData && filteredData.length > 0) {
+		if (filteredData?.length) {
 			const maybeFirstCard = document.querySelector(
 				`#${showMoreContainerId} [data-link-name="${filteredData[0].dataLinkName}"]`,
 			);

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -110,13 +110,6 @@ export const ShowMore = ({
 								height: ${space[3]}px;
 							`}
 						/>
-						<h4
-							css={css`
-								${visuallyHidden}
-							`}
-						>
-							More {containerTitle}
-						</h4>
 						<UL direction="row" wrapCards={true}>
 							{filteredData.map((card, cardIndex) => {
 								const columns = 3;


### PR DESCRIPTION
## What does this change?

Programmatically focuses the first new card in the 'show more' section, when that section is loaded.

## Why?

Because the new cards are rendered above the button itself. So with default tab behaviour keyboard users will need to tab backwards through the new cards to get to the beginning of the list. And it won't be obvious to screen reader users where they can find the new content.

Programmatically shifting focus is generally discouraged, but afaict is permissible when it's done in response to user interaction (here, clicking the 'show more' button). In addition, an aria description is added to the button to signal the behaviour to screen reader users.

Closes #6343