### PR TITLE
Install `common-rendering` as a dependecy of `apps-rendering`

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -40,6 +40,7 @@
     "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/bridget": "^2.0.0",
     "@guardian/cdk": "^47.3.3",
+    "@guardian/common-rendering": "file:../common-rendering",
     "@guardian/content-api-models": "^17.4.0",
     "@guardian/content-atom-model": "^3.4.0",
     "@guardian/discussion-rendering": "^10.1.1",

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1341,6 +1341,9 @@
     read-pkg-up "7.0.1"
     yargs "^17.5.1"
 
+"@guardian/common-rendering@file:../common-rendering":
+  version "1.0.0"
+
 "@guardian/content-api-models@^17.4.0":
   version "17.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/content-api-models/-/content-api-models-17.4.0.tgz#c8ab4000b7761a65018481bddadde950c76358b4"

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -1,28 +1,33 @@
 {
-	"name": "@guardian/common-rendering",
-	"version": "1.0.0",
-	"license": "Apache-2.0",
-	"scripts": {
-		"test": "jest"
-	},
-	"dependencies": {
-		"@emotion/react": "^11.4.1",
-		"@guardian/libs": "^9.0.1",
-		"@guardian/types": "^9.0.1",
-		"react": "^17.0.2"
-	},
-	"devDependencies": {
-		"@emotion/jest": "^11.3.0",
-		"@types/jest": "^27.4.0",
-		"@types/react-test-renderer": "^17.0.1",
-		"jest": "^26.6.3",
-		"react-test-renderer": "^17.0.1",
-		"ts-jest": "^26.5.3"
-	},
-	"jest": {
-		"preset": "ts-jest/presets/js-with-ts",
-		"transformIgnorePatterns": [
-			"node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
-		]
-	}
+  "name": "@guardian/common-rendering",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@guardian/types": "^9.0.1"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.4.1",
+    "@guardian/libs": "^9.0.1",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "@emotion/react": "11.4.1",
+    "@emotion/jest": "^11.3.0",
+    "@guardian/libs": "9.0.1",
+    "@types/jest": "^27.4.0",
+    "@types/react-test-renderer": "^17.0.1",
+    "jest": "^26.6.3",
+    "react": "17.0.2",
+    "react-test-renderer": "^17.0.1",
+    "ts-jest": "^26.5.3"
+  },
+  "jest": {
+    "preset": "ts-jest/presets/js-with-ts",
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,6 +2659,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
+"@emotion/react@11.4.1":
+  version "11.4.1"
+  resolved "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz#a1b0b767b5bad57515ffb0cad9349614d27f4d57"
+  integrity sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.0.2"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/react@^11.4.1":
   version "11.5.0"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.5.0.tgz#19b5771bbfbda5e8517e948a2d9064810f0022bd"
@@ -2708,6 +2721,11 @@
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.0.2":
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/sheet@^1.0.3":
   version "1.0.3"
@@ -2869,15 +2887,15 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
+"@guardian/libs@9.0.1", "@guardian/libs@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"
+  integrity sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw==
+
 "@guardian/libs@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
   integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
-
-"@guardian/libs@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"
-  integrity sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw==
 
 "@guardian/prettier@^1.0.0":
   version "1.0.0"
@@ -2920,7 +2938,7 @@
 
 "@guardian/types@^9.0.1":
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-9.0.1.tgz#a03682d9c2942560714f9c724a1cd7068f772a93"
+  resolved "https://registry.npmjs.org/@guardian/types/-/types-9.0.1.tgz#a03682d9c2942560714f9c724a1cd7068f772a93"
   integrity sha512-JTQe4giki1QYqE5bRkCbYWvelF2DtaQVlGmIbVwO8XWNc62TOQcBOUmqFb2EWpszWqkzBLEBB4rKKArgBZHTeA==
 
 "@hapi/hoek@^9.0.0":
@@ -17940,7 +17958,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^17.0.2:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
- install `common-rendering` as a dependency of `apps-rendering`
- turn `common-rendering` deps into `peerDependencies`

## Why?

currently, `apps-rendering` can use `common-rendering` because the DCR/CR workspace alongside AR hoists it into the `node_modules` in the root of the DCR/CR workspace.

because this also happens to be in the `node_modules` folder hierarchy for apps, AR finds it too. but this is just chance. 

this PR makes it a full dependency of AR, so that `apps-rendering` installs `common-rendering` like any other node package, meaning that CR and AR work with a single set of deps when AR is bundled (rather than a mishmash of AR's deps and DCR's deps)

co-authored with @joecowton1 

