### PR TITLE
Add stories for the HeaderTopBar, HeaderTopBarEditionsDropdown, Heade…

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
@@ -9,6 +9,8 @@ const articleUrl =
 const profileResponse =
 	'{"status":"ok","userProfile":{"userId":"102309223","displayName":"Guardian User","webUrl":"https://profile.theguardian.com/user/id/102309223","apiUrl":"https://discussion.guardianapis.com/discussion-api/profile/102309223","avatar":"https://avatar.guim.co.uk/user/102309223","secureAvatarUrl":"https://avatar.guim.co.uk/user/102309223","badge":[],"privateFields":{"canPostComment":true,"isPremoderated":false,"hasCommented":false}}}';
 
+const idapiIdentifiersResponse = `{ "id": "000000000", "brazeUuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "puzzleUuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }`;
+
 describe('Signed in readers', function () {
 	beforeEach(function () {
 		disableCMP();
@@ -27,13 +29,15 @@ describe('Signed in readers', function () {
 			// this commercial error from failing this test
 			return false;
 		});
+		cy.intercept('GET', '**/user/me/identifiers', idapiIdentifiersResponse);
 		// Mock call to 'profile/me'
 		cy.intercept(
 			'GET',
 			'**/profile/me?strict_sanctions_check=false',
 			profileResponse,
-		);
+		).as('profileMe');
 		cy.visit(`Article?url=${articleUrl}`);
+		cy.wait('@profileMe');
 		// This text is shown in the header for signed in users
 		cy.contains('My account');
 	});

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -98,6 +98,11 @@ cypress: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")
 	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress run --browser chrome --spec "cypress/e2e/**/*"'
 
+cypress-open: export NODE_ENV=production
+cypress-open: clear clean-dist install build
+	$(call log, "starting frontend PROD server for Cypress")
+	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress open --browser chrome'
+
 cypress-arm64: export NODE_ENV=production
 cypress-arm64: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")

--- a/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
+++ b/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
@@ -33,7 +33,7 @@ export const HeaderSingleFrontDoor = ({
 	idApiUrl,
 }: Props) => (
 	<div css={headerStyles}>
-		<Island deferUntil="idle">
+		<Island>
 			<HeaderTopBar
 				editionId={editionId}
 				dataLinkName="nav3 : topbar : edition-picker: toggle"

--- a/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { getCookie } from '@guardian/libs';
 import { brand, from, space } from '@guardian/source-foundations';
 import type { EditionId } from '../../types/edition';
 import { center } from '../lib/center';
@@ -16,6 +17,7 @@ interface HeaderTopBarProps {
 	mmaUrl?: string;
 	discussionApiUrl: string;
 	idApiUrl: string;
+	isSignedIn?: boolean;
 }
 
 const topBarStyles = css`
@@ -48,6 +50,9 @@ export const HeaderTopBar = ({
 	discussionApiUrl,
 	idApiUrl,
 }: HeaderTopBarProps) => {
+	const isServer = typeof window === 'undefined';
+	const isSignedIn =
+		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
 	return (
 		<div
 			css={css`
@@ -61,6 +66,7 @@ export const HeaderTopBar = ({
 					idUrl={idUrl ?? 'https://profile.theguardian.com'}
 					discussionApiUrl={discussionApiUrl}
 					idApiUrl={idApiUrl}
+					isSignedIn={isSignedIn}
 				/>
 				<SearchJobs />
 

--- a/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
@@ -1,0 +1,37 @@
+import { HeaderTopBar } from './HeaderTopBar.importable';
+
+export default {
+	component: HeaderTopBar,
+	title: 'Components/HeaderTopBar',
+};
+
+export const defaultStory = () => {
+	return (
+		<HeaderTopBar
+			editionId="UK"
+			dataLinkName="test"
+			idUrl="idurl"
+			mmaUrl="mmaUrl"
+			discussionApiUrl="discussionApiUrl"
+			idApiUrl="idApiUrl"
+		/>
+	);
+};
+
+defaultStory.story = { name: 'Header top bar signed out' };
+
+export const signedInStory = () => {
+	return (
+		<HeaderTopBar
+			editionId="UK"
+			dataLinkName="test"
+			idUrl="idurl"
+			mmaUrl="mmaUrl"
+			discussionApiUrl="discussionApiUrl"
+			idApiUrl="idApiUrl"
+			isSignedIn={true}
+		/>
+	);
+};
+
+signedInStory.story = { name: 'Header top bar signed in' };

--- a/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.stories.tsx
@@ -1,0 +1,16 @@
+import { HeaderTopBarEditionDropdown } from './HeaderTopBarEditionDropdown';
+
+export default {
+	component: HeaderTopBarEditionDropdown,
+	title: 'Components/HeaderTopBarEditionDropdown',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return <HeaderTopBarEditionDropdown editionId="UK" dataLinkName="test" />;
+};
+
+defaultStory.story = { name: 'default' };

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
@@ -1,0 +1,41 @@
+import { MyAccount } from './HeaderTopBarMyAccount';
+
+export default {
+	component: MyAccount,
+	title: 'Components/MyAccount',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return (
+		<MyAccount
+			mmaUrl="mmaUrl"
+			idApiUrl="idApiUrl"
+			idUrl="idUrl"
+			discussionApiUrl="discussionApiUrl"
+		/>
+	);
+};
+
+defaultStory.story = {
+	name: 'not signed in',
+};
+
+export const signedInStory = () => {
+	return (
+		<MyAccount
+			mmaUrl="mmaUrl"
+			idApiUrl="idApiUrl"
+			idUrl="idUrl"
+			discussionApiUrl="discussionApiUrl"
+			isSignedIn={true}
+		/>
+	);
+};
+
+signedInStory.story = {
+	name: 'signed in',
+};

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { getCookie, joinUrl } from '@guardian/libs';
+import { joinUrl } from '@guardian/libs';
 import { brand, from, neutral, textSans } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
@@ -20,10 +20,15 @@ interface MyAccountProps {
 	idUrl: string;
 	discussionApiUrl: string;
 	idApiUrl: string;
+	isSignedIn?: boolean;
 }
 
 const myAccountStyles = css`
 	display: flex;
+	align-items: center;
+	${from.tablet} {
+		align-items: stretch;
+	}
 	${from.desktop} {
 		:before {
 			content: '';
@@ -42,7 +47,7 @@ const myAccountLinkStyles = css`
 	color: ${neutral[100]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
-	padding: 7px 0;
+	padding: 0;
 
 	${from.tablet} {
 		padding: 7px 10px 0 5px;
@@ -201,11 +206,13 @@ const SignedInWithNotifications = ({
 const SignedIn = ({ idApiUrl, ...props }: MyAccountProps) => {
 	const { brazeCards } = useBraze(idApiUrl);
 	const [notifications, setNotifications] = useState<Notification[]>([]);
-
 	useEffect(() => {
 		if (brazeCards) {
 			const cards = brazeCards.getCardsForProfileBadge();
-			setNotifications(mapBrazeCardsToNotifications(cards));
+			const cardsToNotifications = mapBrazeCardsToNotifications(cards);
+			if (cardsToNotifications.length) {
+				setNotifications(cardsToNotifications);
+			}
 		}
 	}, [brazeCards]);
 
@@ -219,23 +226,18 @@ export const MyAccount = ({
 	idUrl,
 	discussionApiUrl,
 	idApiUrl,
-}: MyAccountProps) => {
-	const isServer = typeof window === 'undefined';
-	const isSignedIn =
-		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
-
-	return (
-		<div css={myAccountStyles}>
-			{isSignedIn ? (
-				<SignedIn
-					mmaUrl={mmaUrl}
-					idUrl={idUrl}
-					discussionApiUrl={discussionApiUrl}
-					idApiUrl={idApiUrl}
-				/>
-			) : (
-				<SignIn idUrl={idUrl} />
-			)}
-		</div>
-	);
-};
+	isSignedIn,
+}: MyAccountProps) => (
+	<div css={myAccountStyles}>
+		{isSignedIn ? (
+			<SignedIn
+				mmaUrl={mmaUrl}
+				idUrl={idUrl}
+				discussionApiUrl={discussionApiUrl}
+				idApiUrl={idApiUrl}
+			/>
+		) : (
+			<SignIn idUrl={idUrl} />
+		)}
+	</div>
+);

--- a/dotcom-rendering/src/web/components/HeaderTopBarSearch.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarSearch.stories.tsx
@@ -1,0 +1,16 @@
+import { Search } from './HeaderTopBarSearch';
+
+export default {
+	component: Search,
+	title: 'Components/HeaderTopBarSearch',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return <Search href="" dataLinkName="" />;
+};
+
+defaultStory.story = { name: 'Header top bar search' };

--- a/dotcom-rendering/src/web/lib/mockRESTCalls.ts
+++ b/dotcom-rendering/src/web/lib/mockRESTCalls.ts
@@ -262,5 +262,32 @@ export const mockRESTCalls = (): void => {
 				body: matchReport,
 			},
 			{ overwriteRoutes: false },
+		)
+
+		// Get user discussion api (used for myAccount dropdown)
+		.get(
+			/discussionApiUrl\/profile\/me\?strict_sanctions_check=false/,
+			{
+				status: 200,
+				body: {
+					status: 'ok',
+					userProfile: {
+						userId: '123',
+						displayName: 'Guardian User',
+						webUrl: 'https://profile.test-theguardian.com/user/id/123',
+						apiUrl: 'http://discussion.test-guardianapis.com/discussion-api/profile/123',
+						avatar: 'https://avatar.test-guimcode.co.uk/user/123',
+						secureAvatarUrl:
+							'https://avatar.test-guimcode.co.uk/user/123',
+						badge: [],
+						privateFields: {
+							canPostComment: true,
+							isPremoderated: false,
+							hasCommented: false,
+						},
+					},
+				},
+			},
+			{ overwriteRoutes: false },
 		);
 };


### PR DESCRIPTION
## What does this change?
Add stories for the HeaderTopBar, HeaderTopBarEditionsDropdown, HeaderTopBarMyAccount and HeaderTopBarSearch components

Move the logic for checking if a user is signed in higher up the component tree and prop drill through to the child components, making them self contained and easier to test.

Fix the vertical alignment of the my account dropdown on mobile breakpoints

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/2510683/203023591-56112d08-1684-4614-ba08-75664c411ae5.png) | ![after](https://user-images.githubusercontent.com/2510683/203023675-5f5527e8-de2c-49c7-b4b7-bec67908df0a.png) |



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
