### PR TITLE
Grid experiment

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardWrapper.tsx
@@ -25,8 +25,8 @@ const cardStyles = (
 	containerPalette?: DCRContainerPalette,
 ) => {
 	const baseCardStyles = css`
-		display: flex;
-		flex-direction: column;
+		display: block;
+		height: 100%;
 		justify-content: space-between;
 		width: 100%;
 		/* We absolutely position the faux link

--- a/dotcom-rendering/src/web/components/Card/components/Grid.test.ts
+++ b/dotcom-rendering/src/web/components/Card/components/Grid.test.ts
@@ -1,0 +1,40 @@
+import { getTemplateAreas } from './Grid';
+
+describe('getTemplateAreas returns correct grid-template-areas ', () => {
+	test('for 2 slices: [50%, 25%, 25%], [25%, 25%, 25%, 25%]', () => {
+		const percentages: CardPercentageType[][] = [
+			['50%', '25%', '25%'],
+			['25%', '25%', '25%', '25%'],
+		];
+		const expected = ['1 1 2 3', '4 5 6 7'];
+		expect(getTemplateAreas(percentages)).toStrictEqual(expected);
+	});
+	test('for 2 slices: [50%, 50%], [25%, 75%]', () => {
+		const per2: CardPercentageType[][] = [
+			['50%', '50%'],
+			['25%', '75%'],
+		];
+		const expected2 = ['1 1 2 2', '3 4 4 4'];
+		expect(getTemplateAreas(per2)).toStrictEqual(expected2);
+	});
+	test('for 3 slices: [100%], [25%, 25%, 50%], [75%, 25%]', () => {
+		const per3: CardPercentageType[][] = [
+			['100%'],
+			['25%', '25%', '50%'],
+			['75%', '25%'],
+		];
+		const expected3 = ['1 1 1 1', '2 3 4 4', '5 5 5 6'];
+		expect(getTemplateAreas(per3)).toStrictEqual(expected3);
+	});
+
+	test('for 3 slices: [66.666%, 33.333%], [33.333%, 66.666%], [25%, 25%, 50%]', () => {
+		const per4: CardPercentageType[][] = [
+			['66.666%', '33.333%'],
+			['33.333%', '66.666%'],
+			['25%', '25%', '50%'],
+		];
+		const expected4 = ['1 1 2', '3 4 4', '5 6 7 7'];
+
+		expect(getTemplateAreas(per4)).toStrictEqual(expected4);
+	});
+});

--- a/dotcom-rendering/src/web/components/Card/components/Grid.test.ts
+++ b/dotcom-rendering/src/web/components/Card/components/Grid.test.ts
@@ -6,35 +6,50 @@ describe('getTemplateAreas returns correct grid-template-areas ', () => {
 			['50%', '25%', '25%'],
 			['25%', '25%', '25%', '25%'],
 		];
-		const expected = ['1 1 2 3', '4 5 6 7'];
+		const expected = [
+			'card-1 card-1 card-2 card-3',
+			'card-4 card-5 card-6 card-7',
+		];
 		expect(getTemplateAreas(percentages)).toStrictEqual(expected);
 	});
+
 	test('for 2 slices: [50%, 50%], [25%, 75%]', () => {
-		const per2: CardPercentageType[][] = [
+		const percentages: CardPercentageType[][] = [
 			['50%', '50%'],
 			['25%', '75%'],
 		];
-		const expected2 = ['1 1 2 2', '3 4 4 4'];
-		expect(getTemplateAreas(per2)).toStrictEqual(expected2);
+		const expected = [
+			'card-1 card-1 card-2 card-2',
+			'card-3 card-4 card-4 card-4',
+		];
+		expect(getTemplateAreas(percentages)).toStrictEqual(expected);
 	});
+
 	test('for 3 slices: [100%], [25%, 25%, 50%], [75%, 25%]', () => {
-		const per3: CardPercentageType[][] = [
+		const percentages: CardPercentageType[][] = [
 			['100%'],
 			['25%', '25%', '50%'],
 			['75%', '25%'],
 		];
-		const expected3 = ['1 1 1 1', '2 3 4 4', '5 5 5 6'];
-		expect(getTemplateAreas(per3)).toStrictEqual(expected3);
+		const expected = [
+			'card-1 card-1 card-1 card-1',
+			'card-2 card-3 card-4 card-4',
+			'card-5 card-5 card-5 card-6',
+		];
+		expect(getTemplateAreas(percentages)).toStrictEqual(expected);
 	});
 
 	test('for 3 slices: [66.666%, 33.333%], [33.333%, 66.666%], [25%, 25%, 50%]', () => {
-		const per4: CardPercentageType[][] = [
+		const percentages: CardPercentageType[][] = [
 			['66.666%', '33.333%'],
 			['33.333%', '66.666%'],
 			['25%', '25%', '50%'],
 		];
-		const expected4 = ['1 1 2', '3 4 4', '5 6 7 7'];
-
-		expect(getTemplateAreas(per4)).toStrictEqual(expected4);
+		const expected = [
+			'card-1 card-1 card-2',
+			'card-3 card-4 card-4',
+			'card-5 card-6 card-7 card-7',
+		];
+		expect(getTemplateAreas(percentages)).toStrictEqual(expected);
 	});
 });

--- a/dotcom-rendering/src/web/components/Card/components/Grid.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/Grid.tsx
@@ -9,7 +9,7 @@ const splitGridAreas = (grid: GridElement[]): string[] => {
 			let index = 4;
 
 			while (index > 0) {
-				slice = slice.concat(grid[i].cardAreaValue);
+				slice = slice.concat('card-' + grid[i].cardAreaValue);
 				if (index !== 1) slice = slice.concat(' ');
 
 				i++;
@@ -21,7 +21,7 @@ const splitGridAreas = (grid: GridElement[]): string[] => {
 			let index = 3;
 
 			while (index > 0) {
-				slice = slice.concat(grid[i].cardAreaValue);
+				slice = slice.concat('card-' + grid[i].cardAreaValue);
 				if (index !== 1) slice = slice.concat(' ');
 				i++;
 				index--;

--- a/dotcom-rendering/src/web/components/Card/components/Grid.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/Grid.tsx
@@ -1,0 +1,118 @@
+const splitGridAreas = (grid: GridElement[]): string[] => {
+	const res: string[] = [];
+	let i = 0;
+
+	while (i < grid.length) {
+		let slice = '';
+
+		if (grid[i].totalNumberOfAreasInSlice === 4) {
+			let index = 4;
+
+			while (index > 0) {
+				slice = slice.concat(grid[i].cardAreaValue);
+				if (index !== 1) slice = slice.concat(' ');
+
+				i++;
+				index--;
+			}
+
+			res.push(slice);
+		} else {
+			let index = 3;
+
+			while (index > 0) {
+				slice = slice.concat(grid[i].cardAreaValue);
+				if (index !== 1) slice = slice.concat(' ');
+				i++;
+				index--;
+			}
+			res.push(slice);
+		}
+	}
+	return res;
+};
+
+type GridElement = {
+	cardAreaValue: string;
+	totalNumberOfAreasInSlice: number;
+};
+
+const SLICE_OF_4 = 4;
+const SLICE_OF_3 = 3;
+
+export const getTemplateAreas = (
+	percentages: CardPercentageType[][],
+): string[] => {
+	const grid: GridElement[] = [];
+	let cardArea = 1;
+
+	percentages.forEach((row) => {
+		row.forEach((percentage) => {
+			switch (percentage) {
+				case '25%': {
+					grid.push({
+						cardAreaValue: cardArea.toString(),
+						totalNumberOfAreasInSlice: SLICE_OF_4,
+					});
+					break;
+				}
+				case '33.333%': {
+					grid.push({
+						cardAreaValue: cardArea.toString(),
+						totalNumberOfAreasInSlice: SLICE_OF_3,
+					});
+					break;
+				}
+				case '50%': {
+					let areasInSlice = 2;
+					while (areasInSlice > 0) {
+						grid.push({
+							cardAreaValue: cardArea.toString(),
+							totalNumberOfAreasInSlice: SLICE_OF_4,
+						});
+						areasInSlice--;
+					}
+					break;
+				}
+				case '66.666%': {
+					let areasInSlice = 2;
+					while (areasInSlice > 0) {
+						grid.push({
+							cardAreaValue: cardArea.toString(),
+							totalNumberOfAreasInSlice: SLICE_OF_3,
+						});
+						areasInSlice--;
+					}
+					break;
+				}
+				case '75%': {
+					let areasInSlice = 3;
+					while (areasInSlice > 0) {
+						grid.push({
+							cardAreaValue: cardArea.toString(),
+							totalNumberOfAreasInSlice: SLICE_OF_4,
+						});
+						areasInSlice--;
+					}
+					break;
+				}
+				case '100%':
+					{
+						let areasInSlice = 4;
+						while (areasInSlice > 0) {
+							grid.push({
+								cardAreaValue: cardArea.toString(),
+								totalNumberOfAreasInSlice: SLICE_OF_4,
+							});
+							areasInSlice--;
+						}
+					}
+					break;
+			}
+
+			cardArea += 1;
+		});
+	});
+
+	return splitGridAreas(grid);
+};

--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
@@ -1,8 +1,9 @@
+import { css } from '@emotion/react';
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
-import { LI } from './Card/components/LI';
-import { UL } from './Card/components/UL';
+import { getTemplateAreas } from './Card/components/Grid';
 import { FrontCard } from './FrontCard';
+import { GridItem } from './GridItem';
 
 type Props = {
 	trails: TrailType[];
@@ -19,84 +20,83 @@ export const FixedMediumSlowVII = ({
 	const firstSlice = trails.slice(1, 3);
 	const secondSlice = trails.slice(3, 7);
 
+	const templateAreas = getTemplateAreas([
+		['50%', '25%', '25%'],
+		['25%', '25%', '25%', '25%'],
+	]);
+
 	return (
-		<>
-			<UL direction="row" padBottom={true}>
-				<LI
-					key={primary.url}
-					padSides={true}
-					showDivider={false}
-					percentage="50%"
-				>
-					<FrontCard
-						trail={primary}
-						format={primary.format}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						headlineSize="large"
-						imagePositionOnMobile="top"
-						imageSize="large"
-						supportingContent={primary.supportingContent}
-					/>
-				</LI>
-				{firstSlice.map((trail) => {
-					return (
-						<LI
-							key={trail.url}
-							padSides={true}
-							showDivider={true}
-							percentage="25%"
-						>
-							<FrontCard
-								trail={trail}
-								format={trail.format}
-								containerPalette={containerPalette}
-								showAge={showAge}
-								headlineSize="medium"
-								imagePositionOnMobile="left"
-								imageSize="medium"
-								trailText={
-									trail.supportingContent &&
-									trail.supportingContent.length > 0
-										? undefined
-										: trail.trailText
-								}
-								supportingContent={
-									trail.supportingContent &&
-									trail.supportingContent.length > 2
-										? trail.supportingContent.slice(0, 2)
-										: trail.supportingContent
-								}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-			<UL direction="row">
-				{secondSlice.map((trail, index) => {
-					return (
-						<LI
-							key={trail.url}
-							padSides={true}
-							showDivider={index > 0}
-						>
-							<FrontCard
-								trail={trail}
-								format={trail.format}
-								containerPalette={containerPalette}
-								showAge={showAge}
-								headlineSize="small"
-								supportingContent={
-									trail.supportingContent &&
-									trail.supportingContent.length > 2
-										? trail.supportingContent.slice(0, 2)
-										: trail.supportingContent
-								}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-		</>
+		<div
+			css={css`
+				display: grid;
+				gap: 12px;
+				grid-template-columns: repeat(4, 1fr);
+				grid-template-areas:
+					'${templateAreas[0]}'
+					'${templateAreas[1]}';
+			`}
+		>
+			<GridItem area="card-1">
+				<FrontCard
+					trail={primary}
+					format={primary.format}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					headlineSize="large"
+					imagePositionOnMobile="top"
+					imageSize="large"
+					supportingContent={primary.supportingContent}
+					// TODO: size="50%"
+				/>
+			</GridItem>
+			{firstSlice.map((trail, index) => {
+				return (
+					<GridItem area={'card-' + (index + 2).toString()}>
+						<FrontCard
+							trail={trail}
+							format={trail.format}
+							containerPalette={containerPalette}
+							showAge={showAge}
+							headlineSize="medium"
+							imagePositionOnMobile="left"
+							imageSize="medium"
+							trailText={
+								trail.supportingContent &&
+								trail.supportingContent.length > 0
+									? undefined
+									: trail.trailText
+							}
+							supportingContent={
+								trail.supportingContent &&
+								trail.supportingContent.length > 2
+									? trail.supportingContent.slice(0, 2)
+									: trail.supportingContent
+							}
+							// TODO: size="25%"
+						/>
+					</GridItem>
+				);
+			})}
+			{secondSlice.map((trail, index) => {
+				return (
+					<GridItem area={'card-' + (index + 4).toString()}>
+						<FrontCard
+							trail={trail}
+							format={trail.format}
+							containerPalette={containerPalette}
+							showAge={showAge}
+							headlineSize="small"
+							supportingContent={
+								trail.supportingContent &&
+								trail.supportingContent.length > 2
+									? trail.supportingContent.slice(0, 2)
+									: trail.supportingContent
+							}
+							// TODO: size="25%"
+						/>
+					</GridItem>
+				);
+			})}
+		</div>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Experiment: `FixedMediumSlowVII` using the grid

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/19683595/203027000-2dd89d83-1602-419a-9c90-03d39a2e608c.png">

TODO:
* Sublinks
* Responsiveness

Please ignore Chromatic diffs!


## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
