### PR TITLE
docs(dotenv): link to removal PR

### DIFF
--- a/dotcom-rendering/docs/architecture/028-dotenv.md
+++ b/dotcom-rendering/docs/architecture/028-dotenv.md
@@ -1,5 +1,6 @@
-> **Warning**
-> We no longer generate a `.env` file
+> **Warning**  
+> We no longer generate a `.env` file  
+> _See [dotcom-rendering#6468](https://github.com/guardian/dotcom-rendering/pull/6468)_
 
 # `.env` File
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Link the docs and the associated PR for removing `dotenv`.

## Why?

@OllysCoding suggested it in https://github.com/guardian/dotcom-rendering/pull/6468#discussion_r1026259589