### PR TITLE
Remove generation of dotenv step in CI

### DIFF
--- a/scripts/ci-dcr.sh
+++ b/scripts/ci-dcr.sh
@@ -45,9 +45,6 @@ else
 		#Code Validation
 		make validate-ci
 
-		# Generate .env file
-		make gen-dotenv-ci
-
 		# Cypress Tests
 		# see https://docs.cypress.io/guides/guides/continuous-integration.html#Advanced-setup
 		# apt-get install xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Stop trying to generate a `.env` file in CI.

## Why?

- #6468 

Our CI is currently broken 😵‍💫 