### PR TITLE
Increase ASG Capacity

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -24,8 +24,8 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 	stage: 'PROD',
 	recordPrefix: 'mobile-rendering',
 	asgCapacity: {
-		minimumInstances: 3,
-		maximumInstances: 12,
+		minimumInstances: 6,
+		maximumInstances: 24,
 	},
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
 	hostedZoneId: 'Z1EYB4AREPXE3B',


### PR DESCRIPTION
## Why?

We're regularly running at higher than the minimum number of instances due to CPU usage scaling us up. This risks us being unable to deploy if the number of instances running is more than half the maximum, as RiffRaff requires the capacity to double for a deploy.

## Changes

- Increase the minimum and maximum capacity on the ASG
