### PR TITLE
Skip article.e2e AB tests

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-1/article.e2e.cy.js
@@ -66,7 +66,8 @@ describe('E2E Page rendering', function () {
 		});
 	});
 
-	describe('AB Tests - Can modify page', function () {
+	// eslint-disable-next-line mocha/no-skipped-tests
+	describe.skip('AB Tests - Can modify page', function () {
 		beforeEach(function () {
 			mockApi();
 		});


### PR DESCRIPTION
## What does this change?

Skip `article.e2e` AB tests

## Why?

The current test is flakey and fails intermittently on GHA and more frequently on TeamCity.

We are using the `deferUntil="visible"` island `MostViewedFooterData` to assert on dummy control/variant attributes from the AB testing framework.

To invoke the island requires scrolling to it which is temperamental in Cypress.

### Next steps

We should look at doing this test differently:

- moving AB API testing to unit tests
- moving AB API testing out of a `deferUntil="visible"` island like `MostViewedFooterData` which means no scrolling required
