### PR TITLE
ShowMore button design tweaks

### DIFF
--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -152,7 +152,6 @@ export const ShowMore = ({
 				`}
 			>
 				<Button
-					priority="tertiary"
 					size="small"
 					icon={isOpen ? <SvgCross /> : <SvgPlus />}
 					isLoading={loading}
@@ -165,7 +164,8 @@ export const ShowMore = ({
 						background-color: ${neutral[7]};
 						border-color: ${neutral[7]};
 						&:hover {
-							color: ${neutral[7]};
+							background-color: ${neutral[46]};
+							border-color: ${neutral[46]};
 						}
 						${from.tablet} {
 							margin-left: 10px;

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -163,6 +163,7 @@ export const ShowMore = ({
 						margin-right: 10px;
 						color: ${neutral[100]};
 						background-color: ${neutral[7]};
+						border-color: ${neutral[7]};
 						&:hover {
 							color: ${neutral[7]};
 						}


### PR DESCRIPTION
## What does this change?

- Makes the border of the button match the background colour.
- Explicitly sets the hover state colours to match the design system.
- Removes the `priority` prop from the button (this pulled in styles from Source, but we're overwriting all of those styles here, so it's unnecessary now).


## Why?

For consistency, and in response to comments by @HarryFischer. Closes #6451.