### PR TITLE
refactor(grid): use the API directly

### DIFF
--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -157,7 +157,7 @@ const grid = {
 	 * breakpoint.
 	 */
 	mobileColumnGap,
-};
+} as const;
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/grid/grid.ts
+++ b/apps-rendering/src/grid/grid.ts
@@ -59,24 +59,6 @@ const container = `
     }
 `;
 
-// ----- Grid Item Styles ----- //
-
-const centreColumn = `
-    grid-column: centre-column-start / centre-column-end;
-`;
-
-const leftColumn = `
-    grid-column: left-column-start / left-column-end;
-`;
-
-const rightColumn = `
-    grid-column: right-column-start / right-column-end;
-`;
-
-const allColumns = `
-    grid-column: viewport-start / viewport-end;
-`;
-
 // ----- API ----- //
 
 /**
@@ -147,22 +129,22 @@ const grid = {
 		 * Place the element into the centre column. Available for all
 		 * breakpoints.
 		 */
-		centre: centreColumn,
+		centre: between('centre-column-start', 'centre-column-end'),
 		/**
 		 * Place the element into the left column. Available for `leftCol`
 		 * and above breakpoints.
 		 */
-		left: leftColumn,
+		left: between('left-column-start', 'left-column-end'),
 		/**
 		 * Place the element into the right column. Available for `desktop`
 		 * and above breakpoints.
 		 */
-		right: rightColumn,
+		right: between('right-column-start', 'right-column-end'),
 		/**
 		 * Ask the element to take up the entire width of the viewport.
 		 * Available for all breakpoints.
 		 */
-		all: allColumns,
+		all: between('viewport-start', 'viewport-end'),
 	},
 	between,
 	span,


### PR DESCRIPTION
## What does this change?

Use the `between` API directly in AR’s `grid`.

## Why?

The `between` method is typed, so it is safer to use than strings which depend on above.