### PR TITLE
Mobile sticky ad uses `getZIndex`

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -11,6 +11,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
+import { getZIndex } from '../lib/getZIndex';
 import { Island } from './Island';
 import { TopRightAdSlot } from './TopRightAdSlot.importable';
 
@@ -172,7 +173,7 @@ const mobileStickyAdStyles = css`
 	margin: 0 auto;
 	right: 0;
 	left: 0;
-	z-index: 1010;
+	${getZIndex('mobileSticky')}
 	${from.phablet} {
 		display: none;
 	}

--- a/dotcom-rendering/src/web/lib/getZIndex.test.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.test.tsx
@@ -2,13 +2,14 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 24;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 23;');
-		expect(getZIndex('banner')).toBe('z-index: 22;');
-		expect(getZIndex('dropdown')).toBe('z-index: 21;');
-		expect(getZIndex('burger')).toBe('z-index: 20;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 19;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 18;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 25;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 24;');
+		expect(getZIndex('banner')).toBe('z-index: 23;');
+		expect(getZIndex('dropdown')).toBe('z-index: 22;');
+		expect(getZIndex('burger')).toBe('z-index: 21;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 20;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 19;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 18;');
 		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 17;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 16;');
 		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/web/lib/getZIndex.tsx
+++ b/dotcom-rendering/src/web/lib/getZIndex.tsx
@@ -33,6 +33,9 @@ const indices = [
 	'expanded-veggie-menu-wrapper',
 	'expanded-veggie-menu',
 
+	// Mobile sticky appears below banners
+	'mobileSticky',
+
 	// Headers with sticky ads
 	'stickyAdWrapperLabsHeader',
 	'stickyAdWrapper',


### PR DESCRIPTION
## What does this change?

The mobile sticky advert used to have a very high z-index of `1010` - a hangover from Frontend. This causes the advert to appear above epics, which has a z-index computed via the `getZIndex` function.

Since `getZIndex` assigns z-indexes by keeping an ordered list of sticky components, we can use this to give the mobile sticky a z-index such that it appears higher than non-sticky article content but beneath epics.

## Why?

Prevent ads appearing above epics. It's worth noting this brings parity with Frontend, but a better long-term solution would be to not fill the slot until we know it'll be visible.

## Screenshots

In the second image the advert appears underneath the banner once it's dismissed.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/8000415/203103373-0de4b4e2-4d16-4866-8e9c-f738884bd501.png
[after]: https://user-images.githubusercontent.com/8000415/203103724-f28a2c7d-b1ea-4d57-8fd9-42182f1acbb4.png
