### PR TITLE
handle CalloutBlockElementV2 element type 

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -31,6 +31,9 @@
                         "$ref": "#/definitions/CalloutBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/CalloutBlockElementV2"
+                    },
+                    {
                         "$ref": "#/definitions/ChartAtomBlockElement"
                     },
                     {
@@ -1131,6 +1134,92 @@
                 "options",
                 "required",
                 "type"
+            ]
+        },
+        "CalloutBlockElementV2": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.CalloutBlockElementV2"
+                    ]
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "activeFrom": {
+                    "type": "number"
+                },
+                "activeTo": {
+                    "type": "number"
+                },
+                "displayOnSensitive": {
+                    "type": "boolean"
+                },
+                "formId": {
+                    "type": "number"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "tagName": {
+                    "type": "string"
+                },
+                "formFields": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CampaignFieldText"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldTextArea"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldFile"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldRadio"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldCheckbox"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldSelect"
+                            }
+                        ]
+                    }
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                },
+                "isNonCollapsible": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "activeFrom",
+                "calloutsUrl",
+                "description",
+                "displayOnSensitive",
+                "elementId",
+                "formFields",
+                "formId",
+                "id",
+                "isNonCollapsible",
+                "tagName",
+                "title"
             ]
         },
         "ChartAtomBlockElement": {
@@ -3567,6 +3656,9 @@
                             },
                             {
                                 "$ref": "#/definitions/CalloutBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/CalloutBlockElementV2"
                             },
                             {
                                 "$ref": "#/definitions/ChartAtomBlockElement"

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -1157,7 +1157,7 @@
                 "activeFrom": {
                     "type": "number"
                 },
-                "activeTo": {
+                "activeUntil": {
                     "type": "number"
                 },
                 "displayOnSensitive": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -68,7 +68,7 @@ export interface CalloutBlockElementV2 {
 	id: string;
 	calloutsUrl: string;
 	activeFrom: number;
-	activeTo?: number;
+	activeUntil?: number;
 	displayOnSensitive: boolean;
 	formId: number;
 	title: string;

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -62,6 +62,23 @@ export interface CalloutBlockElement {
 	role?: RoleType;
 }
 
+export interface CalloutBlockElementV2 {
+	_type: 'model.dotcomrendering.pageElements.CalloutBlockElementV2';
+	elementId: string;
+	id: string;
+	calloutsUrl: string;
+	activeFrom: number;
+	activeTo?: number;
+	displayOnSensitive: boolean;
+	formId: number;
+	title: string;
+	description: string;
+	tagName: string;
+	formFields: CampaignFieldType[];
+	role?: RoleType;
+	isNonCollapsible: boolean;
+}
+
 interface ChartAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
 	elementId: string;
@@ -574,6 +591,7 @@ export type CAPIElement =
 	| BlockquoteBlockElement
 	| CaptionBlockElement
 	| CalloutBlockElement
+	| CalloutBlockElementV2
 	| ChartAtomBlockElement
 	| CodeBlockElement
 	| CommentBlockElement

--- a/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
@@ -136,7 +136,6 @@ export const CalloutEmbedBlockComponent = ({
 	callout: CalloutBlockElement | CalloutBlockElementV2;
 	format: ArticleFormat;
 }) => {
-	console.log("I'm hit at CalloutEmbedBlockComponent");
 	let expandFormButtonRef: HTMLButtonElement | null = null;
 	let firstFieldElementRef: HTMLElement | null = null;
 	let lastElementRef: HTMLButtonElement | null = null;

--- a/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
@@ -136,6 +136,7 @@ export const CalloutEmbedBlockComponent = ({
 	callout: CalloutBlockElement | CalloutBlockElementV2;
 	format: ArticleFormat;
 }) => {
+	console.log("I'm hit at CalloutEmbedBlockComponent");
 	let expandFormButtonRef: HTMLButtonElement | null = null;
 	let firstFieldElementRef: HTMLElement | null = null;
 	let lastElementRef: HTMLButtonElement | null = null;

--- a/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
@@ -4,7 +4,10 @@ import { Button } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import MinusIcon from '../../static/icons/minus.svg';
 import PlusIcon from '../../static/icons/plus.svg';
-import { CalloutBlockElement } from '../../types/content';
+import type {
+	CalloutBlockElement,
+	CalloutBlockElementV2,
+} from '../../types/content';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { Form } from './Callout/Form';
@@ -130,7 +133,7 @@ export const CalloutEmbedBlockComponent = ({
 	callout,
 	format,
 }: {
-	callout: CalloutBlockElement;
+	callout: CalloutBlockElement | CalloutBlockElementV2;
 	format: ArticleFormat;
 }) => {
 	let expandFormButtonRef: HTMLButtonElement | null = null;

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -173,6 +173,7 @@ export const renderElement = ({
 			];
 
 		case 'model.dotcomrendering.pageElements.CalloutBlockElement':
+		case 'model.dotcomrendering.pageElements.CalloutBlockElementV2':
 			return [
 				true,
 				<Island deferUntil="visible">


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR is updating schema to support a new type `CalloutBlockElementV2`. This is a type that's being added to frontend as part of this PR https://github.com/guardian/frontend/pull/25703

For now, we are using this new type the same way the old type `CalloutBlockElement` is sued with component `CalloutEmbedBlockComponent`. In future PRs, a new component is craeted which will be used for the new type `CalloutBlockElementV2`

## Test
This branch was tested locally and in code using frontend from main https://github.com/guardian/frontend, and frontend from mk/add-capi-callout-element https://github.com/guardian/frontend/tree/mk/add-capi-callout-element to make sure that:
- it is backward compatible
- it works properly with the new `CalloutBlockElementV2` received in request

## Why?
This change is because a new element type has been added to CAPI `callout` and we want to support this type in DCR platform
