### PR TITLE
Core web vitals from own lib

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -67,6 +67,7 @@
     "@guardian/browserslist-config": "^2.0.3",
     "@guardian/commercial-core": "^4.25.0",
     "@guardian/consent-management-platform": "10.11.1",
+    "@guardian/core-web-vitals": "^1.0.0",
     "@guardian/discussion-rendering": "^11.0.3",
     "@guardian/libs": "^9.0.1",
     "@guardian/shimport": "^1.0.2",

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -1,9 +1,9 @@
 import type { ABTest } from '@guardian/ab-core';
 import {
 	bypassCoreWebVitalsSampling,
-	getCookie,
 	initCoreWebVitals,
-} from '@guardian/libs';
+} from '@guardian/core-web-vitals';
+import { getCookie } from '@guardian/libs';
 import { dcrJavascriptBundle } from '../../../scripts/webpack/bundles';
 import type { ServerSideTestNames } from '../../types/config';
 import { removePrebidA9Canada } from '../experiments/tests/remove-prebid-a9-canada';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2853,6 +2853,11 @@
   dependencies:
     "@guardian/libs" "^7.1.4"
 
+"@guardian/core-web-vitals@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-1.0.0.tgz#f5624eabbf7123f8a764c00674e640a10a80e2da"
+  integrity sha512-3WTUK6FmZpVUQGoc+hlAcuYx8yVKdYfpcP7HWkBmy1yaWV5yJ81HBxxoACwUeMrZrKLMlCMriPTC9CLhPgGGUQ==
+
 "@guardian/discussion-rendering@^11.0.3":
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-11.0.3.tgz#4e18a9e28a0d12a4dc61739b3877478c780b36a9"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use [`@guardian/core-web-vitals`](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fcore-web-vitals%401.0.0) directly.

## Why?

This package has been taken out of `@guardian/libs` as it has a peer dependency on Google’s web-vitals