### PR TITLE
Apps Rendering - Fix bottom padding on pull quotes. 

### DIFF
--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -81,7 +81,7 @@ const styles = (
 	return css`
 		${body.medium()}
 		overflow-wrap: break-word;
-		margin: 0 0 ${remSpace[3]};
+		margin: ${remSpace[3]} 0 ${remSpace[3]};
 		color: ${text.paragraph(format)};
 
 		${isEditions

--- a/dotcom-rendering/src/model/enhance-recipes.ts
+++ b/dotcom-rendering/src/model/enhance-recipes.ts
@@ -1,4 +1,4 @@
-const makeEmpty = (elements: CAPIElement[]): CAPIElement[] => {
+const applyArithmetic = (elements: CAPIElement[]): CAPIElement[] => {
 	// Loop over elements and check if a dot is in the TextBlockElement
 	const enhanced: CAPIElement[] = [];
 	elements.forEach((element) => {
@@ -13,10 +13,10 @@ const makeEmpty = (elements: CAPIElement[]): CAPIElement[] => {
 	return enhanced;
 };
 
-export const enhanceText = (blocks: Block[]): Block[] =>
+export const enhanceRecipes = (blocks: Block[]): Block[] =>
 	blocks.map((block: Block) => {
 		return {
 			...block,
-			elements: makeEmpty(block.elements),
+			elements: applyArithmetic(block.elements),
 		};
 	});

--- a/dotcom-rendering/src/model/enhance-recipes.ts
+++ b/dotcom-rendering/src/model/enhance-recipes.ts
@@ -1,22 +1,37 @@
 const applyArithmetic = (elements: CAPIElement[]): CAPIElement[] => {
 	// Loop over elements and check if a dot is in the TextBlockElement
 	const enhanced: CAPIElement[] = [];
+	// const reg = new RegExp('^[0-9]+$');
+
 	elements.forEach((element) => {
-		if (
-			element._type ===
-			'model.dotcomrendering.pageElements.TextBlockElement'
-		) {
-			element.html = '';
-			enhanced.push(element);
+		switch (element._type) {
+			case 'model.dotcomrendering.pageElements.TextBlockElement':
+				{
+					element.html = '';
+					enhanced.push(element);
+				}
+				break;
+			default:
+				enhanced.push(element);
 		}
 	});
 	return enhanced;
 };
 
-export const enhanceRecipes = (blocks: Block[]): Block[] =>
-	blocks.map((block: Block) => {
+export const enhanceRecipes = (
+	blocks: Block[],
+	format: CAPIFormat,
+): Block[] => {
+	const isRecipe = format.design === 'FeatureDesign';
+
+	if (!isRecipe) {
+		return blocks;
+	}
+
+	return blocks.map((block: Block) => {
 		return {
 			...block,
 			elements: applyArithmetic(block.elements),
 		};
 	});
+};

--- a/dotcom-rendering/src/model/enhance-text.ts
+++ b/dotcom-rendering/src/model/enhance-text.ts
@@ -1,0 +1,22 @@
+const makeEmpty = (elements: CAPIElement[]): CAPIElement[] => {
+	// Loop over elements and check if a dot is in the TextBlockElement
+	const enhanced: CAPIElement[] = [];
+	elements.forEach((element) => {
+		if (
+			element._type ===
+			'model.dotcomrendering.pageElements.TextBlockElement'
+		) {
+			element.html = '';
+			enhanced.push(element);
+		}
+	});
+	return enhanced;
+};
+
+export const enhanceText = (blocks: Block[]): Block[] =>
+	blocks.map((block: Block) => {
+		return {
+			...block,
+			elements: makeEmpty(block.elements),
+		};
+	});

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -7,7 +7,7 @@ import { enhanceH3s } from './enhance-H3s';
 import { enhanceImages } from './enhance-images';
 import { enhanceInteractiveContentsElements } from './enhance-interactive-contents-elements';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
-import { enhanceText } from './enhance-text';
+import { enhanceRecipes } from './enhance-recipes';
 import { enhanceTweets } from './enhance-tweets';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
@@ -87,8 +87,8 @@ class BlockEnhancer {
 		return this;
 	}
 
-	enhanceText() {
-		this.blocks = enhanceText(this.blocks);
+	enhanceRecipes() {
+		this.blocks = enhanceRecipes(this.blocks);
 		return this;
 	}
 }
@@ -112,6 +112,6 @@ export const enhanceBlocks = (
 		.enhanceNumberedLists()
 		.enhanceEmbeds()
 		.enhanceTweets()
-		.enhanceText()
+		.enhanceRecipes()
 		.enhanceNewsletterSignup().blocks;
 };

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -7,6 +7,7 @@ import { enhanceH3s } from './enhance-H3s';
 import { enhanceImages } from './enhance-images';
 import { enhanceInteractiveContentsElements } from './enhance-interactive-contents-elements';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
+import { enhanceText } from './enhance-text';
 import { enhanceTweets } from './enhance-tweets';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
@@ -85,6 +86,11 @@ class BlockEnhancer {
 		this.blocks = enhanceTweets(this.blocks);
 		return this;
 	}
+
+	enhanceText() {
+		this.blocks = enhanceText(this.blocks);
+		return this;
+	}
 }
 
 // IMPORTANT: the ordering of the enhancer is IMPORTANT to keep in mind
@@ -106,5 +112,6 @@ export const enhanceBlocks = (
 		.enhanceNumberedLists()
 		.enhanceEmbeds()
 		.enhanceTweets()
+		.enhanceText()
 		.enhanceNewsletterSignup().blocks;
 };

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -88,7 +88,7 @@ class BlockEnhancer {
 	}
 
 	enhanceRecipes() {
-		this.blocks = enhanceRecipes(this.blocks);
+		this.blocks = enhanceRecipes(this.blocks, this.format);
 		return this;
 	}
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

 This PR adds padding underneath pull quotes. Actually, it adds padding to the top of paragraph elements. But it has the effect of fixing padding on pull quotes. As far as I can see, this does not cause visual regressions elsewhere. 

Article with pull quote: https://www.theguardian.com/world/2022/nov/20/cop27-backfires-egypt-repression-climate-summit

## Why?

A user on the iOS app highlighted there was no padding underneath quotes. I believe this is a bug. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/102960825/203304028-673f6a11-2e88-44c9-a343-817f36789b12.png
[after]: https://user-images.githubusercontent.com/102960825/203303920-39994458-68c4-46f1-908e-93b21e261726.png
