### PR TITLE
add top padding

### DIFF
--- a/apps-rendering/src/components/Paragraph/index.tsx
+++ b/apps-rendering/src/components/Paragraph/index.tsx
@@ -81,7 +81,7 @@ const styles = (
 	return css`
 		${body.medium()}
 		overflow-wrap: break-word;
-		margin: 0 0 ${remSpace[3]};
+		margin: ${remSpace[3]} 0 ${remSpace[3]};
 		color: ${text.paragraph(format)};
 
 		${isEditions


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

 This PR adds padding underneath pull quotes. Actually, it adds padding to the top of paragraph elements. But it has the effect of fixing padding on pull quotes. As far as I can see, this does not cause visual regressions elsewhere. 

Article with pull quote: https://www.theguardian.com/world/2022/nov/20/cop27-backfires-egypt-repression-climate-summit

## Why?

A user on the iOS app highlighted there was no padding underneath quotes. I believe this is a bug. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/102960825/203304028-673f6a11-2e88-44c9-a343-817f36789b12.png
[after]: https://user-images.githubusercontent.com/102960825/203303920-39994458-68c4-46f1-908e-93b21e261726.png
