### PR TITLE
Add dynamo (dynamic/package) floating sub links and mobile styles

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -166,15 +166,17 @@ const lineStyles = (palette: Palette) => css`
 `;
 
 const dynamoLineStyles = (palette: Palette) => css`
-	padding-top: 1px;
-	:before {
-		display: block;
-		position: absolute;
-		top: 0;
-		left: 0;
-		content: '';
-		width: 100%;
-		border-top: 1px solid ${palette.border.cardSupporting};
+	${until.phablet} {
+		padding-top: 1px;
+		:before {
+			display: block;
+			position: absolute;
+			top: 0;
+			left: 0;
+			content: '';
+			width: 100%;
+			border-top: 1px solid ${palette.border.cardSupporting};
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -165,6 +165,19 @@ const lineStyles = (palette: Palette) => css`
 	}
 `;
 
+const dynamoLineStyles = (palette: Palette) => css`
+	padding-top: 1px;
+	:before {
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
+		content: '';
+		width: 100%;
+		border-top: 1px solid ${palette.border.cardSupporting};
+	}
+`;
+
 const WithLink = ({
 	linkTo,
 	children,
@@ -255,7 +268,9 @@ export const CardHeadline = ({
 							size: sizeOnMobile ?? size,
 							fontWeight: containerPalette ? 'bold' : 'regular',
 						}),
-					showLine && lineStyles(palette),
+					showLine && isDynamo
+						? dynamoLineStyles(palette)
+						: lineStyles(palette),
 				]}
 			>
 				<WithLink linkTo={linkTo}>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -175,7 +175,7 @@ const dynamoLineStyles = (palette: Palette) => css`
 			left: 0;
 			content: '';
 			width: 100%;
-			border-top: 1px solid ${palette.border.cardSupporting};
+			border-top: 1px solid ${palette.topBar.card};
 		}
 	}
 `;

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -168,34 +168,45 @@ const lineStyles = (palette: Palette) => css`
 const WithLink = ({
 	linkTo,
 	children,
+	isDynamo,
 }: {
 	linkTo?: string;
 	children: React.ReactNode;
+	isDynamo?: true;
 }) => {
 	if (linkTo) {
 		return (
 			<Link
 				href={linkTo}
-				cssOverrides={css`
-					/* See: https://css-tricks.com/nested-links/ */
-					${getZIndex('card-nested-link')}
-					/* The following styles turn off those provided by Link */
-					color: inherit;
-					text-decoration: none;
-					/* stylelint-disable-next-line property-disallowed-list */
-					font-family: inherit;
-					font-size: inherit;
-					line-height: inherit;
-					/* This css is used to remove any underline from the kicker but still
-					   have it applied to the headline when the kicker is hovered */
-					:hover {
+				cssOverrides={[
+					css`
+						/* See: https://css-tricks.com/nested-links/ */
+						${getZIndex('card-nested-link')}
+						/* The following styles turn off those provided by Link */
 						color: inherit;
 						text-decoration: none;
-						.show-underline {
-							text-decoration: underline;
+						/* stylelint-disable-next-line property-disallowed-list */
+						font-family: inherit;
+						font-size: inherit;
+						line-height: inherit;
+						/* This css is used to remove any underline from the kicker but still
+					   have it applied to the headline when the kicker is hovered */
+						:hover {
+							color: inherit;
+							text-decoration: none;
+							.show-underline {
+								text-decoration: underline;
+							}
 						}
-					}
-				`}
+					`,
+					isDynamo
+						? css`
+								font-weight: 800;
+						  `
+						: css`
+								font-weight: inherit;
+						  `,
+				]}
 			>
 				{children}
 			</Link>

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -47,6 +47,7 @@ export const Default = () => {
 		<SupportingContent
 			supportingContent={[aBasicLink]}
 			alignment="horizontal"
+			parentFormat={aBasicLink.format}
 		/>
 	);
 };
@@ -56,6 +57,7 @@ export const WithKicker = () => {
 		<SupportingContent
 			supportingContent={[{ ...aBasicLink, kickerText: 'Kicker text' }]}
 			alignment="horizontal"
+			parentFormat={aBasicLink.format}
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -71,19 +71,16 @@ const dynamoLiStyles = (palette: Palette) => css`
 		display: flex;
 		flex-direction: column;
 		flex: 1;
-		padding-top: 2px;
-		background-color: ${palette.background.article};
+		padding-top: 8px;
+		padding-bottom: 8px;
+		background-color: ${palette.background.card};
 		position: relative;
-		&:first-of-type {
-			margin-top: 0px;
-		}
-		margin-top: 8px;
 	}
 	${from.phablet} {
 		margin-left: 10px;
 		margin-bottom: 12px;
 		padding-top: 5px;
-		background-color: ${palette.background.article};
+		background-color: ${palette.background.card};
 		opacity: 0.9;
 		&:first-of-type {
 			margin-left: 0px;

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -65,27 +65,43 @@ const bottomMargin = css`
 `;
 
 const dynamoLiStyles = css`
-	margin-left: 10px;
-	margin-bottom: 12px;
-	padding-top: 5px;
-	background-color: rgba(237, 237, 237, 0.9);
-	&:first-of-type {
-		margin-left: 0px;
+	${from.phablet} {
+		margin-left: 10px;
+		margin-bottom: 12px;
+		padding-top: 5px;
+		background-color: rgba(237, 237, 237, 0.9);
+		&:first-of-type {
+			margin-left: 0px;
+		}
+		padding: 0.3125rem 0.3125rem 0.625rem;
+		max-width: 33%;
 	}
-	padding: 0.3125rem 0.3125rem 0.625rem;
 `;
 
 const dynamoWrapperStyles = css`
-	display: flex;
-	position: absolute;
-	justify-content: space-between;
-	bottom: 0;
-	right: 0;
-	margin-left: 5px;
-	margin-right: 5px;
-	flex-direction: column;
 	${from.phablet} {
+		display: flex;
+		position: absolute;
+		justify-content: space-between;
+		bottom: 0;
+		right: 0;
+		margin-left: 5px;
+		margin-right: 5px;
 		flex-direction: row;
+	}
+`;
+
+const dynamoLiStylesMobile = css`
+	${until.phablet} {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		padding-top: 2px;
+		position: relative;
+		&:first-of-type {
+			margin-top: 0px;
+		}
+		margin-top: 8px;
 	}
 `;
 
@@ -97,12 +113,22 @@ export const SupportingContent = ({
 }: Props) => {
 	return isDynamo ? (
 		<ul css={[dynamoWrapperStyles]}>
-			{supportingContent.map((subLink: DCRSupportingContent) => {
+			{supportingContent.map((subLink: DCRSupportingContent, index) => {
 				// The model has this property as optional but it is very likely
 				// to exist
 				if (!subLink.headline) return null;
+				const shouldPadLeft = index > 0 && alignment === 'horizontal';
 				return (
-					<li key={subLink.url} css={[dynamoLiStyles]}>
+					<li
+						key={subLink.url}
+						css={[
+							dynamoLiStyles,
+							dynamoLiStylesMobile,
+							shouldPadLeft && leftMargin,
+							index === supportingContent.length - 1 &&
+								bottomMargin,
+						]}
+					>
 						<CardHeadline
 							format={subLink.format}
 							size="tiny"

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -80,7 +80,6 @@ const dynamoLiStyles = (palette: Palette) => css`
 	${from.phablet} {
 		margin-left: 10px;
 		margin-bottom: 12px;
-		padding-top: 5px;
 		background-color: ${palette.background.card};
 		opacity: 0.9;
 		&:first-of-type {

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -64,13 +64,61 @@ const bottomMargin = css`
 	}
 `;
 
+const dynamoLiStyles = css`
+	margin-left: 10px;
+	margin-bottom: 12px;
+	padding-top: 5px;
+	background-color: rgba(237, 237, 237, 0.9);
+	&:first-of-type {
+		margin-left: 0px;
+	}
+	padding: 0.3125rem 0.3125rem 0.625rem;
+`;
+
+const dynamoWrapperStyles = css`
+	display: flex;
+	position: absolute;
+	justify-content: space-between;
+	bottom: 0;
+	right: 0;
+	margin-left: 5px;
+	margin-right: 5px;
+	flex-direction: column;
+	${from.phablet} {
+		flex-direction: row;
+	}
+`;
+
 export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
 	isDynamo,
 }: Props) => {
-	return (
+	return isDynamo ? (
+		<ul css={[dynamoWrapperStyles]}>
+			{supportingContent.map((subLink: DCRSupportingContent) => {
+				// The model has this property as optional but it is very likely
+				// to exist
+				if (!subLink.headline) return null;
+				return (
+					<li key={subLink.url} css={[dynamoLiStyles]}>
+						<CardHeadline
+							format={subLink.format}
+							size="tiny"
+							showSlash={false}
+							showLine={true}
+							linkTo={subLink.url}
+							containerPalette={containerPalette}
+							isDynamo={isDynamo}
+							headlineText={subLink.headline}
+							kickerText={subLink.kickerText}
+						/>
+					</li>
+				);
+			})}
+		</ul>
+	) : (
 		<ul css={[wrapperStyles, directionStyles(alignment)]}>
 			{supportingContent.map((subLink: DCRSupportingContent, index) => {
 				// The model has this property as optional but it is very likely

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -15,7 +15,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: true;
-	parentFormat: ArticleFormat;
+	parentFormat?: ArticleFormat;
 };
 
 const wrapperStyles = css`

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -4,6 +4,8 @@ import type {
 	DCRContainerPalette,
 	DCRSupportingContent,
 } from '../../types/front';
+import type { Palette } from '../../types/palette';
+import { decidePalette } from '../lib/decidePalette';
 import { CardHeadline } from './CardHeadline';
 
 type Alignment = 'vertical' | 'horizontal';
@@ -13,7 +15,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: true;
-	parentFormat?: ArticleFormat;
+	parentFormat: ArticleFormat;
 };
 
 const wrapperStyles = css`
@@ -64,16 +66,17 @@ const bottomMargin = css`
 	}
 `;
 
-const dynamoLiStyles = css`
+const dynamoLiStyles = (palette: Palette) => css`
 	${from.phablet} {
 		margin-left: 10px;
 		margin-bottom: 12px;
 		padding-top: 5px;
-		background-color: rgba(237, 237, 237, 0.9);
+		background-color: ${palette.background.article};
+		opacity: 0.9;
 		&:first-of-type {
 			margin-left: 0px;
 		}
-		padding: 0.3125rem 0.3125rem 0.625rem;
+		padding: 5px 5px 10px;
 		max-width: 33%;
 	}
 `;
@@ -110,7 +113,9 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
+	parentFormat,
 }: Props) => {
+	const palette = decidePalette(parentFormat, containerPalette);
 	return isDynamo ? (
 		<ul css={[dynamoWrapperStyles]}>
 			{supportingContent.map((subLink: DCRSupportingContent, index) => {
@@ -122,7 +127,7 @@ export const SupportingContent = ({
 					<li
 						key={subLink.url}
 						css={[
-							dynamoLiStyles,
+							dynamoLiStyles(palette),
 							dynamoLiStylesMobile,
 							shouldPadLeft && leftMargin,
 							index === supportingContent.length - 1 &&

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -15,7 +15,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: true;
-	parentFormat?: ArticleFormat;
+	parentFormat: ArticleFormat;
 };
 
 const wrapperStyles = css`

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -71,6 +71,7 @@ const dynamoLiStyles = (palette: Palette) => css`
 		display: flex;
 		flex-direction: column;
 		flex: 1;
+		padding-left: 5px;
 		padding-top: 8px;
 		padding-bottom: 8px;
 		background-color: ${palette.background.card};

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -72,8 +72,8 @@ const dynamoLiStyles = (palette: Palette) => css`
 		flex-direction: column;
 		flex: 1;
 		padding-left: 5px;
-		padding-top: 8px;
-		padding-bottom: 8px;
+		padding-top: 4px;
+		padding-bottom: 12px;
 		background-color: ${palette.background.card};
 		position: relative;
 	}

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -67,6 +67,18 @@ const bottomMargin = css`
 `;
 
 const dynamoLiStyles = (palette: Palette) => css`
+	${until.phablet} {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		padding-top: 2px;
+		background-color: ${palette.background.article};
+		position: relative;
+		&:first-of-type {
+			margin-top: 0px;
+		}
+		margin-top: 8px;
+	}
 	${from.phablet} {
 		margin-left: 10px;
 		margin-bottom: 12px;
@@ -78,6 +90,7 @@ const dynamoLiStyles = (palette: Palette) => css`
 		}
 		padding: 5px 5px 10px;
 		max-width: 33%;
+		border-top: 1px solid ${palette.topBar.card};
 	}
 `;
 
@@ -91,20 +104,6 @@ const dynamoWrapperStyles = css`
 		margin-left: 5px;
 		margin-right: 5px;
 		flex-direction: row;
-	}
-`;
-
-const dynamoLiStylesMobile = css`
-	${until.phablet} {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		padding-top: 2px;
-		position: relative;
-		&:first-of-type {
-			margin-top: 0px;
-		}
-		margin-top: 8px;
 	}
 `;
 
@@ -128,7 +127,6 @@ export const SupportingContent = ({
 						key={subLink.url}
 						css={[
 							dynamoLiStyles(palette),
-							dynamoLiStylesMobile,
 							shouldPadLeft && leftMargin,
 							index === supportingContent.length - 1 &&
 								bottomMargin,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This brings dynamo (dynamic/package) floating sub links to DCR.
## Why?
Parity with frontend.
This resolves https://github.com/guardian/dotcom-rendering/issues/5267
## Screenshots

| Frontend     | DCR      |
|-------------|------------|
| desktop      | desktop      |
| ![frontend][] | ![dcr][] |
| mobile      | mobile      |
| ![frontendmob][] | ![dcrmob][] |


[frontend]: https://user-images.githubusercontent.com/110032454/203533257-7ce188f8-a1d4-4c58-9113-d36059bce5a7.png
[dcr]: https://user-images.githubusercontent.com/110032454/203533318-cc95a427-5240-4ab6-be13-e4189681fb97.png
[frontendmob]: https://user-images.githubusercontent.com/110032454/203535419-fa093da9-e59c-4ac6-bd59-e4a4df87b776.png
[dcrmob]: https://user-images.githubusercontent.com/110032454/203567914-9f271d97-c10d-4ed6-bf1e-0420efc6654d.png
