### PR TITLE
Refactor `content` types

### DIFF
--- a/dotcom-rendering/fixtures/generated/images.ts
+++ b/dotcom-rendering/fixtures/generated/images.ts
@@ -11,6 +11,8 @@
  *    gen-fixtures.ts directly.
  */
 
+import type { ImageBlockElement } from '../../src/types/content';
+
 export const images: [
 	ImageBlockElement,
 	ImageBlockElement,

--- a/dotcom-rendering/fixtures/manual/calloutCampaign.ts
+++ b/dotcom-rendering/fixtures/manual/calloutCampaign.ts
@@ -1,3 +1,5 @@
+import type { CalloutBlockElement } from '../../src/types/content';
+
 export const calloutCampaign: CalloutBlockElement = {
 	_type: 'model.dotcomrendering.pageElements.CalloutBlockElement',
 	elementId: 'mockId',

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -153,7 +153,7 @@ interface BlockContributor {
 
 interface Block {
 	id: string;
-	elements: CAPIElement[];
+	elements: import('./src/types/content').CAPIElement[];
 	attributes: Attributes;
 	blockCreatedOn?: number;
 	blockCreatedOnDisplay?: string;

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -5,7 +5,6 @@ const root = path.resolve(__dirname, '..', '..');
 
 const program = TJS.getProgramFromFiles(
 	[
-		path.resolve(`${root}/src/lib/content.d.ts`),
 		path.resolve(`${root}/index.d.ts`),
 		path.resolve(`${root}/src/types/frontend.ts`),
 	],

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -201,11 +201,10 @@ try {
 					: 'unknown';
 
 				// Write the new fixture data
-				const contents = `${HEADER}export const images: ${type} = ${JSON.stringify(
-					images,
-					null,
-					4,
-				)}`;
+				const contents = `${HEADER}
+				import type { ImageBlockElement } from '../../src/types/content';
+
+				export const images: ${type} = ${JSON.stringify(images, null, 4)}`;
 				fs.writeFileSync(
 					`${root}/fixtures/generated/images.ts`,
 					contents,

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -1,5 +1,6 @@
 import type { Switches } from 'src/types/config';
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
+import type { CAPIElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import { enhance } from '../lib/enhance';
 import { AudioAtomBlockComponent } from './elements/AudioAtomBlockComponent';

--- a/dotcom-rendering/src/amp/components/MainMedia.tsx
+++ b/dotcom-rendering/src/amp/components/MainMedia.tsx
@@ -6,6 +6,11 @@ import {
 } from '@guardian/source-foundations';
 import React from 'react';
 import InfoIcon from '../../static/icons/info.svg';
+import type {
+	CAPIElement,
+	ImageBlockElement,
+	SrcSetItem,
+} from '../../types/content';
 import { bestFitImage, heightEstimate } from '../lib/image-fit';
 import { scrsetStringFromImagesSources } from '../lib/srcset-utils';
 import { YoutubeBlockComponentAMP } from './elements/YoutubeBlockComponentAMP';

--- a/dotcom-rendering/src/amp/components/elements/AudioAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/AudioAtomBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { AudioAtomBlockElement } from '../../../types/content';
 
 export const AudioAtomBlockComponent: React.FC<{
 	element: AudioAtomBlockElement;

--- a/dotcom-rendering/src/amp/components/elements/CommentBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/CommentBlockComponent.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { neutral, news, textSans } from '@guardian/source-foundations';
 import React from 'react';
+import type { CommentBlockElement } from '../../../types/content';
 
 const wrapper = css`
 	overflow: hidden;

--- a/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { ContentAtomBlockElement } from '../../../types/content';
 
 export const ContentAtomBlockComponent: React.FC<{
 	element: ContentAtomBlockElement;

--- a/dotcom-rendering/src/amp/components/elements/EmbedBlockComponentAMP.tsx
+++ b/dotcom-rendering/src/amp/components/elements/EmbedBlockComponentAMP.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { NotRenderableInDCR } from '../../../lib/errors/not-renderable-in-dcr';
+import type { EmbedBlockElement } from '../../../types/content';
 
 export const EmbedBlockComponentAMP: React.FC<{
 	element: EmbedBlockElement;

--- a/dotcom-rendering/src/amp/components/elements/GuVideoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/GuVideoBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { GuVideoBlockElement } from '../../../types/content';
 import { Caption } from '../Caption';
 
 export const GuVideoBlockComponent: React.FC<{

--- a/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
@@ -3,6 +3,7 @@ import { text, textSans } from '@guardian/source-foundations';
 import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import TriangleIcon from '../../../static/icons/triangle.svg';
+import type { ImageBlockElement, SrcSetItem } from '../../../types/content';
 import { bestFitImage, heightEstimate } from '../../lib/image-fit';
 
 const figureStyle = css`

--- a/dotcom-rendering/src/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/RichLinkBlockComponent.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source-foundations';
 import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
+import { RichLinkBlockElement } from '../../../types/content';
 
 const richLinkContainer = css`
 	float: left;

--- a/dotcom-rendering/src/amp/components/elements/SoundcloudBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/SoundcloudBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { SoundcloudBlockElement } from '../../../types/content';
 
 export const SoundcloudBlockComponent: React.FC<{
 	element: SoundcloudBlockElement;

--- a/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { TimelineEvent } from '@guardian/atoms-rendering/dist/types/types';
 import { brandAlt, neutral } from '@guardian/source-foundations';
 import React from 'react';
 import { Expandable } from '../Expandable';

--- a/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
@@ -3,6 +3,7 @@ import { body, neutral } from '@guardian/source-foundations';
 import { JSDOM } from 'jsdom';
 import React from 'react';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
+import type { TweetBlockElement } from '../../../types/content';
 
 const ListStyle = (iconColour: string) => css`
 	li {

--- a/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { VideoVimeoBlockElement } from '../../../types/content';
 import { getIdFromUrl } from '../../lib/get-video-id';
 import { Caption } from '../Caption';
 

--- a/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { VideoYoutubeBlockElement } from '../../../types/content';
 import { getIdFromUrl } from '../../lib/get-video-id';
 import { Caption } from '../Caption';
 

--- a/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponentAMP.tsx
+++ b/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponentAMP.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { constructQuery } from '../../../lib/querystring';
+import { YoutubeBlockElement } from '../../../types/content';
 import { Caption } from '../Caption';
 
 type EmbedConfig = {

--- a/dotcom-rendering/src/amp/lib/enhance.test.ts
+++ b/dotcom-rendering/src/amp/lib/enhance.test.ts
@@ -1,3 +1,4 @@
+import type { InteractiveAtomBlockElement } from '../../types/content';
 import { enhance } from './enhance';
 
 const getData = (): InteractiveAtomBlockElement => ({

--- a/dotcom-rendering/src/amp/lib/enhance.ts
+++ b/dotcom-rendering/src/amp/lib/enhance.ts
@@ -1,5 +1,6 @@
 import { minify } from 'html-minifier';
 import { sanitiseHTML } from '../../model/sanitise';
+import { CAPIElement } from '../../types/content';
 
 // We don't represent lists in InCopy, so things will just come across with bullet characters.
 // These may also be used for emphasis, so bullet characters don't mean list.

--- a/dotcom-rendering/src/amp/lib/find-adslots.test.ts
+++ b/dotcom-rendering/src/amp/lib/find-adslots.test.ts
@@ -1,3 +1,8 @@
+import type {
+	CAPIElement,
+	ImageBlockElement,
+	TextBlockElement,
+} from '../../types/content';
 import {
 	AD_LIMIT,
 	findAdSlots,

--- a/dotcom-rendering/src/amp/lib/find-adslots.ts
+++ b/dotcom-rendering/src/amp/lib/find-adslots.ts
@@ -17,6 +17,8 @@
  * around the ad and it can be placed.
  */
 
+import type { CAPIElement } from '../../types/content';
+
 interface ElementWithLength {
 	element: CAPIElement;
 	length: number;

--- a/dotcom-rendering/src/amp/lib/image-fit.test.ts
+++ b/dotcom-rendering/src/amp/lib/image-fit.test.ts
@@ -1,9 +1,10 @@
+import type { Image, ImageSource } from '../../types/content';
 import { bestFitImage, heightEstimate } from './image-fit';
 
 test('chooses smallest image that is still greater than column width', () => {
-	const images = [
+	const images: ImageSource[] = [
 		{
-			weighting: 'inline' as Weighting,
+			weighting: 'inline',
 			srcSet: [
 				{
 					src: 'https://i.guim.co.uk/img/media/d78248012632672db90b7cbd766e6a8383542fc0/0_316_4366_2619/master/4366.jpg?width=620&quality=85&auto=format&fit=max&s=dedab549648a105a71696cadab62715f',
@@ -20,7 +21,7 @@ test('chooses smallest image that is still greater than column width', () => {
 			],
 		},
 		{
-			weighting: 'thumbnail' as Weighting,
+			weighting: 'thumbnail',
 			srcSet: [
 				{
 					src: 'https://i.guim.co.uk/img/media/d78248012632672db90b7cbd766e6a8383542fc0/0_316_4366_2619/master/4366.jpg?width=140&quality=85&auto=format&fit=max&s=92dec489a4ea25b8ba80f8b260ca0bb9',
@@ -42,9 +43,9 @@ test('chooses smallest image that is still greater than column width', () => {
 });
 
 test('if no image is greater than column width, just return the biggest available', async () => {
-	const images = [
+	const images: ImageSource[] = [
 		{
-			weighting: 'thumbnail' as Weighting,
+			weighting: 'thumbnail',
 			srcSet: [
 				{
 					src: 'https://i.guim.co.uk/img/media/d78248012632672db90b7cbd766e6a8383542fc0/0_316_4366_2619/master/4366.jpg?width=140&quality=85&auto=format&fit=max&s=92dec489a4ea25b8ba80f8b260ca0bb9',

--- a/dotcom-rendering/src/amp/lib/image-fit.ts
+++ b/dotcom-rendering/src/amp/lib/image-fit.ts
@@ -1,3 +1,5 @@
+import type { Image, ImageSource, SrcSetItem } from '../../types/content';
+
 export const bestFitImage = (
 	images: ImageSource[],
 	containerWidth: number,

--- a/dotcom-rendering/src/amp/lib/scripts.ts
+++ b/dotcom-rendering/src/amp/lib/scripts.ts
@@ -1,3 +1,5 @@
+import type { CAPIElement } from '../../types/content';
+
 const notEmpty = (value: string | null): value is string => value !== null;
 const unique = (value: string | null, index: number, self: (string | null)[]) =>
 	value && self.indexOf(value) === index;

--- a/dotcom-rendering/src/amp/lib/srcset-utils.ts
+++ b/dotcom-rendering/src/amp/lib/srcset-utils.ts
@@ -1,3 +1,4 @@
+import type { ImageSource, SrcSetItem } from '../../types/content';
 import { bestFitImage } from './image-fit';
 
 const containerWidths: number[] = [600, 800, 1000, 1200, 1600];

--- a/dotcom-rendering/src/amp/types/ArticleModel.tsx
+++ b/dotcom-rendering/src/amp/types/ArticleModel.tsx
@@ -1,6 +1,7 @@
 import type { CommercialProperties } from '../../types/commercial';
-import type { EditionId } from '../../web/lib/edition';
+import type { CAPIElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
+import type { EditionId } from '../../web/lib/edition';
 
 // This is a subset of CAPIArticleType for use in AMP and as a result there needs to be parity between the types of shared fields.
 export interface ArticleModel {

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -667,6 +667,7 @@
             ]
         },
         "RoleType": {
+            "description": "Affects how an image is placed.\n\nAlso known as “weighting” in Composer, but we respect the CAPI naming.",
             "enum": [
                 "halfWidth",
                 "immersive",
@@ -1933,11 +1934,11 @@
             ]
         },
         "Weighting": {
+            "description": "This duplicate type is unfortunate, but the image sources come lowercase\nNote, 'richLink' is used internally but does not exist upstream.",
             "enum": [
                 "halfwidth",
                 "immersive",
                 "inline",
-                "richLink",
                 "showcase",
                 "supporting",
                 "thumbnail"
@@ -2582,7 +2583,16 @@
                     "type": "string"
                 },
                 "role": {
-                    "$ref": "#/definitions/Weighting"
+                    "enum": [
+                        "halfWidth",
+                        "immersive",
+                        "inline",
+                        "richLink",
+                        "showcase",
+                        "supporting",
+                        "thumbnail"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/model/enhance-H2s.ts
+++ b/dotcom-rendering/src/model/enhance-H2s.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import type { CAPIElement, SubheadingBlockElement } from '../types/content';
 import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 
 const shouldUseLegacyIDs = (elements: CAPIElement[]): boolean => {

--- a/dotcom-rendering/src/model/enhance-H3s.ts
+++ b/dotcom-rendering/src/model/enhance-H3s.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import type { CAPIElement, TextBlockElement } from '../types/content';
 import { sanitiseHTML } from './sanitise';
 
 /**

--- a/dotcom-rendering/src/model/enhance-blockquotes.ts
+++ b/dotcom-rendering/src/model/enhance-blockquotes.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import type { BlockquoteBlockElement, CAPIElement } from '../types/content';
 
 const isQuoted = (element: BlockquoteBlockElement): boolean => {
 	// A quoted blockquote: <blockquote class="quoted"><p>I think therefore I am</p></blockquote>

--- a/dotcom-rendering/src/model/enhance-dividers.ts
+++ b/dotcom-rendering/src/model/enhance-dividers.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import type { CAPIElement } from '../types/content';
 
 const isDinkus = (element: CAPIElement): boolean => {
 	// Classic dinkus do not trigger dropcaps

--- a/dotcom-rendering/src/model/enhance-dots.ts
+++ b/dotcom-rendering/src/model/enhance-dots.ts
@@ -1,3 +1,4 @@
+import type { CAPIElement } from '../types/content';
 import { transformDots } from './transformDots';
 
 const checkForDots = (elements: CAPIElement[]): CAPIElement[] => {

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import type { CAPIElement } from '../types/content';
 
 const addTitleToIframe = (elements: CAPIElement[]): CAPIElement[] => {
 	const enhanced: CAPIElement[] = [];

--- a/dotcom-rendering/src/model/enhance-images.test.ts
+++ b/dotcom-rendering/src/model/enhance-images.test.ts
@@ -3,6 +3,7 @@ import { PhotoEssay } from '../../fixtures/generated/articles/PhotoEssay';
 import { Standard as ExampleArticle } from '../../fixtures/generated/articles/Standard';
 import { images } from '../../fixtures/generated/images';
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { TextBlockElement } from '../types/content';
 import { enhanceImages } from './enhance-images';
 
 const image = {
@@ -518,14 +519,13 @@ describe('Enhance Images', () => {
 			);
 		});
 
-		// Need to ignore TS to check test works for other element types
 		it('will pass through other element types', () => {
 			const input: Block[] = [
 				{
 					...blockMetaData,
 					elements: [
 						{
-							// @ts-expect-error
+							// @ts-expect-error -- Need to ignore TS to check test works for other element types
 							_type: 'model.dotcomrendering.pageElements.model.dotcomrendering.pageElements.PullquoteBlockElement',
 							elementId: 'mockId',
 							html: '<p>A Pullquote</p>',

--- a/dotcom-rendering/src/model/enhance-images.ts
+++ b/dotcom-rendering/src/model/enhance-images.ts
@@ -1,4 +1,11 @@
 import { JSDOM } from 'jsdom';
+import type {
+	CAPIElement,
+	ImageBlockElement,
+	MultiImageBlockElement,
+	SubheadingBlockElement,
+	TextBlockElement,
+} from '../types/content';
 
 interface HalfWidthImageBlockElement extends ImageBlockElement {
 	role: 'halfWidth';

--- a/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
+++ b/dotcom-rendering/src/model/enhance-interactive-contents-elements.ts
@@ -1,3 +1,4 @@
+import type { CAPIElement, SubheadingBlockElement } from '../types/content';
 import { isLegacyTableOfContents } from './isLegacyTableOfContents';
 import { stripHTML } from './sanitise';
 

--- a/dotcom-rendering/src/model/enhance-numbered-lists.ts
+++ b/dotcom-rendering/src/model/enhance-numbered-lists.ts
@@ -1,4 +1,9 @@
 import { JSDOM } from 'jsdom';
+import type {
+	CAPIElement,
+	ImageBlockElement,
+	TextBlockElement,
+} from '../types/content';
 
 const isFalseH3 = (element: CAPIElement): boolean => {
 	if (!element) return false;

--- a/dotcom-rendering/src/model/enhance-tweets.ts
+++ b/dotcom-rendering/src/model/enhance-tweets.ts
@@ -1,3 +1,5 @@
+import { CAPIElement } from '../types/content';
+
 const removeTweetClass = (elements: CAPIElement[]): CAPIElement[] => {
 	const enhanced: CAPIElement[] = [];
 	elements.forEach((element) => {

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -1,3 +1,4 @@
+import { Newsletter } from '../types/content';
 import { enhanceBlockquotes } from './enhance-blockquotes';
 import { enhanceDividers } from './enhance-dividers';
 import { enhanceDots } from './enhance-dots';

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import type { TableOfContentsItem } from 'src/types/frontend';
+import { CAPIElement, SubheadingBlockElement } from '../types/content';
 
 const isH2 = (element: CAPIElement): element is SubheadingBlockElement => {
 	return (

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.test.ts
@@ -1,6 +1,7 @@
 import { Live as exampleLiveBlog } from '../../fixtures/generated/articles/Live';
 import { Quiz as exampleQuiz } from '../../fixtures/generated/articles/Quiz';
 import { Standard as exampleStandard } from '../../fixtures/generated/articles/Standard';
+import { Newsletter, NewsletterSignupBlockElement } from '../types/content';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
 const NEWSLETTER: Newsletter = {

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -1,4 +1,5 @@
 import { logger } from '../server/lib/logging';
+import type { CAPIElement, Newsletter } from '../types/content';
 
 type PlaceInArticle = {
 	position: number;

--- a/dotcom-rendering/src/model/isLegacyTableOfContents.ts
+++ b/dotcom-rendering/src/model/isLegacyTableOfContents.ts
@@ -1,3 +1,5 @@
+import { CAPIElement } from '../types/content';
+
 const scriptUrls = [
 	'https://interactive.guim.co.uk/page-enhancers/nav/boot.js',
 	'https://uploads.guim.co.uk/2019/03/20/boot.js',

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -1,5 +1,10 @@
 // -------------------------------------
 // Elements
+
+import type { PersonalityQuizAtom } from '@guardian/atoms-rendering';
+
+export type QuizAtomType = Parameters<typeof PersonalityQuizAtom>[0];
+
 // -------------------------------------
 interface ThirdPartyEmbeddedContent {
 	isThirdPartyTracking: boolean;
@@ -7,7 +12,7 @@ interface ThirdPartyEmbeddedContent {
 	sourceDomain?: string;
 }
 
-interface AudioAtomBlockElement {
+export interface AudioAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
 	elementId: string;
 	id: string;
@@ -24,7 +29,7 @@ interface AudioBlockElement {
 	elementId: string;
 }
 
-interface BlockquoteBlockElement {
+export interface BlockquoteBlockElement {
 	_type: 'model.dotcomrendering.pageElements.BlockquoteBlockElement';
 	elementId: string;
 	html: string;
@@ -42,7 +47,7 @@ interface CaptionBlockElement {
 	isOverlaid?: boolean;
 }
 
-interface CalloutBlockElement {
+export interface CalloutBlockElement {
 	_type: 'model.dotcomrendering.pageElements.CalloutBlockElement';
 	elementId: string;
 	id: string;
@@ -75,7 +80,7 @@ interface QuizAtomBlockElement {
 	quizType: 'personality' | 'knowledge';
 	id: string;
 	questions: QuestionType[];
-	resultBuckets: ResultBucketsType[];
+	resultBuckets: QuizAtomType['resultBuckets'];
 	resultGroups: {
 		id: string;
 		title: string;
@@ -92,7 +97,7 @@ interface CodeBlockElement {
 	language?: string;
 }
 
-interface CommentBlockElement {
+export interface CommentBlockElement {
 	_type: 'model.dotcomrendering.pageElements.CommentBlockElement';
 	elementId: string;
 	body: string;
@@ -104,7 +109,7 @@ interface CommentBlockElement {
 	role?: RoleType;
 }
 
-interface ContentAtomBlockElement {
+export interface ContentAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ContentAtomBlockElement';
 	elementId: string;
 	atomId: string;
@@ -117,13 +122,13 @@ interface DisclaimerBlockElement {
 	role?: RoleType;
 }
 
-interface DividerBlockElement {
+export interface DividerBlockElement {
 	_type: 'model.dotcomrendering.pageElements.DividerBlockElement';
 	size?: 'full' | 'partial';
 	spaceAbove?: 'tight' | 'loose';
 }
 
-interface DocumentBlockElement extends ThirdPartyEmbeddedContent {
+export interface DocumentBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.DocumentBlockElement';
 	elementId: string;
 	embedUrl: string;
@@ -133,7 +138,7 @@ interface DocumentBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface EmbedBlockElement extends ThirdPartyEmbeddedContent {
+export interface EmbedBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement';
 	elementId: string;
 	safe?: boolean;
@@ -178,7 +183,7 @@ interface GuideAtomBlockElement {
 	role?: RoleType;
 }
 
-interface GuVideoBlockElement {
+export interface GuVideoBlockElement {
 	_type: 'model.dotcomrendering.pageElements.GuVideoBlockElement';
 	elementId: string;
 	assets: VideoAssets[];
@@ -197,7 +202,7 @@ interface HighlightBlockElement {
 	html: string;
 }
 
-interface ImageBlockElement {
+export interface ImageBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ImageBlockElement';
 	elementId: string;
 	media: { allImages: Image[] };
@@ -215,7 +220,7 @@ interface ImageBlockElement {
 	isAvatar?: boolean;
 }
 
-interface InstagramBlockElement extends ThirdPartyEmbeddedContent {
+export interface InstagramBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.InstagramBlockElement';
 	elementId: string;
 	html: string;
@@ -224,7 +229,7 @@ interface InstagramBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface InteractiveAtomBlockElement {
+export interface InteractiveAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement';
 	elementId: string;
 	url: string;
@@ -254,7 +259,7 @@ interface ItemLinkBlockElement {
 	html: string;
 }
 
-interface MapBlockElement extends ThirdPartyEmbeddedContent {
+export interface MapBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.MapBlockElement';
 	elementId: string;
 	embedUrl: string;
@@ -279,7 +284,7 @@ interface MediaAtomBlockElement {
 	duration?: number;
 }
 
-interface MultiImageBlockElement {
+export interface MultiImageBlockElement {
 	_type: 'model.dotcomrendering.pageElements.MultiImageBlockElement';
 	elementId: string;
 	images: ImageBlockElement[];
@@ -287,7 +292,7 @@ interface MultiImageBlockElement {
 	role?: RoleType;
 }
 
-interface NewsletterSignupBlockElement {
+export interface NewsletterSignupBlockElement {
 	_type: 'model.dotcomrendering.pageElements.NewsletterSignupBlockElement';
 	newsletter: Newsletter;
 	elementId?: string;
@@ -301,7 +306,7 @@ interface NumberedTitleBlockElement {
 	format: CAPIFormat;
 }
 
-interface InteractiveContentsBlockElement {
+export interface InteractiveContentsBlockElement {
 	_type: 'model.dotcomrendering.pageElements.InteractiveContentsBlockElement';
 	elementId: string;
 	subheadingLinks: SubheadingBlockElement[];
@@ -340,16 +345,16 @@ interface QABlockElement {
 	role?: RoleType;
 }
 
-interface RichLinkBlockElement {
+export interface RichLinkBlockElement {
 	_type: 'model.dotcomrendering.pageElements.RichLinkBlockElement';
 	elementId: string;
 	url: string;
 	text: string;
 	prefix: string;
-	role?: Weighting;
+	role?: RoleType | 'richLink';
 }
 
-interface SoundcloudBlockElement extends ThirdPartyEmbeddedContent {
+export interface SoundcloudBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.SoundcloudBlockElement';
 	elementId: string;
 	html: string;
@@ -359,7 +364,7 @@ interface SoundcloudBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface SpotifyBlockElement extends ThirdPartyEmbeddedContent {
+export interface SpotifyBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.SpotifyBlockElement';
 	elementId: string;
 	embedUrl?: string;
@@ -377,13 +382,13 @@ interface StarRatingBlockElement {
 	size: RatingSizeType;
 }
 
-interface SubheadingBlockElement {
+export interface SubheadingBlockElement {
 	_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement';
 	elementId: string;
 	html: string;
 }
 
-interface TableBlockElement {
+export interface TableBlockElement {
 	_type: 'model.dotcomrendering.pageElements.TableBlockElement';
 	elementId: string;
 	isMandatory: boolean;
@@ -391,14 +396,14 @@ interface TableBlockElement {
 	role?: RoleType;
 }
 
-interface TextBlockElement {
+export interface TextBlockElement {
 	_type: 'model.dotcomrendering.pageElements.TextBlockElement';
 	elementId: string;
 	dropCap?: boolean;
 	html: string;
 }
 
-interface TimelineBlockElement {
+export interface TimelineBlockElement {
 	_type: 'model.dotcomrendering.pageElements.TimelineBlockElement';
 	elementId: string;
 	id: string;
@@ -408,7 +413,7 @@ interface TimelineBlockElement {
 	role?: RoleType;
 }
 
-interface TweetBlockElement extends ThirdPartyEmbeddedContent {
+export interface TweetBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.TweetBlockElement';
 	elementId: string;
 	html: string;
@@ -418,7 +423,7 @@ interface TweetBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface VineBlockElement extends ThirdPartyEmbeddedContent {
+export interface VineBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.VineBlockElement';
 	elementId: string;
 	url: string;
@@ -428,13 +433,13 @@ interface VineBlockElement extends ThirdPartyEmbeddedContent {
 	title: string;
 }
 
-interface VideoBlockElement extends ThirdPartyEmbeddedContent {
+export interface VideoBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.VideoBlockElement';
 	elementId: string;
 	role?: RoleType;
 }
 
-interface VideoFacebookBlockElement extends ThirdPartyEmbeddedContent {
+export interface VideoFacebookBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.VideoFacebookBlockElement';
 	elementId: string;
 	url: string;
@@ -445,7 +450,7 @@ interface VideoFacebookBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface VideoVimeoBlockElement extends ThirdPartyEmbeddedContent {
+export interface VideoVimeoBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement';
 	elementId: string;
 	embedUrl?: string;
@@ -459,7 +464,7 @@ interface VideoVimeoBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface VideoYoutubeBlockElement extends ThirdPartyEmbeddedContent {
+export interface VideoYoutubeBlockElement extends ThirdPartyEmbeddedContent {
 	_type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
 	elementId: string;
 	embedUrl?: string;
@@ -473,7 +478,7 @@ interface VideoYoutubeBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface YoutubeBlockElement {
+export interface YoutubeBlockElement {
 	_type: 'model.dotcomrendering.pageElements.YoutubeBlockElement';
 	elementId: string;
 	assetId: string;
@@ -544,7 +549,7 @@ interface WitnessTypeDataText extends WitnessTypeDataBase {
 	authorWitnessProfileUrl: string;
 }
 
-interface WitnessAssetType {
+export interface WitnessAssetType {
 	type: 'Image';
 	mimeType: 'image/jpeg';
 	file: string;
@@ -563,7 +568,7 @@ interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {
 		| WitnessTypeDataText;
 }
 
-type CAPIElement =
+export type CAPIElement =
 	| AudioAtomBlockElement
 	| AudioBlockElement
 	| BlockquoteBlockElement
@@ -618,19 +623,20 @@ type CAPIElement =
 // Misc
 // -------------------------------------
 
-type Weighting =
-	| 'inline'
-	| 'thumbnail'
-	| 'supporting'
-	| 'showcase'
-	| 'halfwidth'
-	| 'immersive'
-	| 'richLink'; // Note, 'richLink' is used internally but does not exist upstream.
+/**
+ * This duplicate type is unfortunate, but the image sources come lowercase
+ * Note, 'richLink' is used internally but does not exist upstream.
+ */
+type Weighting = Exclude<RoleType, 'halfWidth' | 'richLink'> | 'halfwidth';
 
-// aka weighting. RoleType affects how an image is placed. It is called weighting
-// in Composer but role in CAPI. We respect CAPI so we maintain this nomenclature
-// in DCR
-type RoleType =
+/**
+ * Affects how an image is placed.
+ *
+ * Also known as “weighting” in Composer, but we respect the CAPI naming.
+ *
+ * @see https://github.com/guardian/frontend/blob/0a32dba0/common/app/model/dotcomrendering/pageElements/Role.scala
+ */
+export type RoleType =
 	| 'immersive'
 	| 'supporting'
 	| 'showcase'
@@ -638,17 +644,17 @@ type RoleType =
 	| 'thumbnail'
 	| 'halfWidth';
 
-interface ImageSource {
+export interface ImageSource {
 	weighting: Weighting;
 	srcSet: SrcSetItem[];
 }
 
-interface SrcSetItem {
+export interface SrcSetItem {
 	src: string;
 	width: number;
 }
 
-interface Image {
+export interface Image {
 	index: number;
 	fields: {
 		height: string;
@@ -683,13 +689,13 @@ interface TimelineEvent {
 	toUnixDate?: number;
 }
 
-type RatingSizeType = 'large' | 'medium' | 'small';
+export type RatingSizeType = 'large' | 'medium' | 'small';
 
 // -------------------------------------
 // Callout Campaign
 // -------------------------------------
 
-type CampaignFieldType =
+export type CampaignFieldType =
 	| CampaignFieldText
 	| CampaignFieldTextArea
 	| CampaignFieldFile
@@ -707,19 +713,19 @@ interface CampaignField {
 	label: string;
 }
 
-interface CampaignFieldText extends CampaignField {
+export interface CampaignFieldText extends CampaignField {
 	type: 'text';
 }
 
-interface CampaignFieldTextArea extends CampaignField {
+export interface CampaignFieldTextArea extends CampaignField {
 	type: 'textarea';
 }
 
-interface CampaignFieldFile extends CampaignField {
+export interface CampaignFieldFile extends CampaignField {
 	type: 'file';
 }
 
-interface CampaignFieldRadio extends CampaignField {
+export interface CampaignFieldRadio extends CampaignField {
 	type: 'radio';
 	options: {
 		label: string;
@@ -727,7 +733,7 @@ interface CampaignFieldRadio extends CampaignField {
 	}[];
 }
 
-interface CampaignFieldCheckbox extends CampaignField {
+export interface CampaignFieldCheckbox extends CampaignField {
 	type: 'checkbox';
 	options: {
 		label: string;
@@ -735,7 +741,7 @@ interface CampaignFieldCheckbox extends CampaignField {
 	}[];
 }
 
-interface CampaignFieldSelect extends CampaignField {
+export interface CampaignFieldSelect extends CampaignField {
 	type: 'select';
 	options: {
 		label: string;
@@ -755,12 +761,6 @@ type AnswerType = {
 	answerBuckets: string[];
 };
 
-type QuizAtomResultBucketType = {
-	id: string;
-	title: string;
-	description: string;
-};
-
 type QuestionType = {
 	id: string;
 	text: string;
@@ -769,17 +769,11 @@ type QuestionType = {
 	imageAlt?: string;
 };
 
-type ResultBucketsType = {
-	id: string;
-	title: string;
-	description: string;
-};
-
 // -------------------------------------
 // Newsletter
 // -------------------------------------
 
-type Newsletter = {
+export type Newsletter = {
 	listId: number;
 	identityName: string;
 	name: string;

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -2,6 +2,7 @@ import type { EditionId } from '../web/lib/edition';
 import type { BadgeType } from './badge';
 import type { CommercialProperties } from './commercial';
 import type { ConfigType } from './config';
+import { CAPIElement, Newsletter } from './content';
 import type { FooterType } from './footer';
 import type { CAPIOnwards } from './onwards';
 import type { TagType } from './tag';

--- a/dotcom-rendering/src/web/components/ArticleHeadline.mocks.ts
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.mocks.ts
@@ -1,3 +1,5 @@
+import { CAPIElement } from '../../types/content';
+
 export const mainMediaElements: CAPIElement[] = [
 	{
 		role: 'showcase',

--- a/dotcom-rendering/src/web/components/Callout/CheckboxSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/CheckboxSelect.tsx
@@ -1,4 +1,5 @@
 import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
+import { CampaignFieldCheckbox } from '../../../types/content';
 import { FieldLabel } from './FieldLabel';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
+import { CampaignFieldType } from '../../../types/content';
 
 const fieldLabelStyles = css`
 	${textSans.medium({ fontWeight: 'bold' })}
@@ -15,7 +16,7 @@ const optionalTextStyles = css`
 	padding-left: 5px;
 `;
 
-export const FieldLabel = ({ formField }: { formField: CampaignField }) => (
+export const FieldLabel = ({ formField }: { formField: CampaignFieldType }) => (
 	<label css={fieldLabelStyles} htmlFor={formField.name}>
 		{formField.label}
 		{!formField.required && <span css={optionalTextStyles}>Optional</span>}

--- a/dotcom-rendering/src/web/components/Callout/FileUpload.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FileUpload.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space, text, textSans } from '@guardian/source-foundations';
 import { useState } from 'react';
+import { CampaignFieldFile } from '../../../types/content';
 import { stringifyFileBase64 } from '../../lib/stringifyFileBase64';
 import { FieldLabel } from './FieldLabel';
 

--- a/dotcom-rendering/src/web/components/Callout/Form.test.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.test.tsx
@@ -1,8 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
+import type {
+	CampaignFieldCheckbox,
+	CampaignFieldFile,
+	CampaignFieldRadio,
+	CampaignFieldSelect,
+	CampaignFieldText,
+	CampaignFieldTextArea,
+} from '../../../types/content';
 import { Form } from './Form';
 
-const textField = {
+const textField: CampaignFieldText = {
 	textSize: 50,
 	name: 'which_event_did_you_attend_and_when',
 	hideLabel: false,
@@ -10,9 +18,9 @@ const textField = {
 	id: '91884886',
 	type: 'text',
 	required: true,
-} as CampaignFieldText;
+};
 
-const textAreaField = {
+const textAreaField: CampaignFieldTextArea = {
 	name: 'share_your_experiences_here',
 	description: 'Please include as much detail as possible',
 	hideLabel: false,
@@ -20,18 +28,18 @@ const textAreaField = {
 	id: '91884874',
 	type: 'textarea',
 	required: true,
-} as CampaignFieldTextArea;
+};
 
-const fileField = {
+const fileField: CampaignFieldFile = {
 	name: 'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
 	hideLabel: false,
 	label: 'You can upload a photo here if you think it will add to your story',
 	id: '91884877',
 	type: 'file',
 	required: false,
-} as CampaignFieldFile;
+};
 
-const radioField = {
+const radioField: CampaignFieldRadio = {
 	name: 'can_we_publish_your_response',
 	options: [
 		{
@@ -52,9 +60,9 @@ const radioField = {
 	id: '91884878',
 	type: 'radio',
 	required: true,
-} as CampaignFieldRadio;
+};
 
-const checkboxField = {
+const checkboxField: CampaignFieldCheckbox = {
 	name: 'can_we_publish_your_response',
 	options: [
 		{
@@ -75,9 +83,9 @@ const checkboxField = {
 	id: '91884871',
 	type: 'checkbox',
 	required: true,
-} as CampaignFieldCheckbox;
+};
 
-const selectField = {
+const selectField: CampaignFieldSelect = {
 	name: 'do_you_have_anything_else_to_add',
 	hideLabel: false,
 	label: 'Do you have anything else to add?',
@@ -94,7 +102,7 @@ const selectField = {
 		},
 	],
 	required: false,
-} as CampaignFieldSelect;
+};
 
 describe('Callout from', () => {
 	it('should submit text input', () => {

--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { text, textSans } from '@guardian/source-foundations';
 import { Button, Link } from '@guardian/source-react-components';
 import { useState } from 'react';
+import { CampaignFieldType } from '../../../types/content';
 import { FileUpload } from './FileUpload';
 import { MultiSelect } from './MultiSelect';
 import { Select } from './Select';

--- a/dotcom-rendering/src/web/components/Callout/MultiSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/MultiSelect.tsx
@@ -1,3 +1,7 @@
+import type {
+	CampaignFieldCheckbox,
+	CampaignFieldRadio,
+} from '../../../types/content';
 import { CheckboxSelect } from './CheckboxSelect';
 import { RadioSelect } from './RadioSelect';
 

--- a/dotcom-rendering/src/web/components/Callout/RadioSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/RadioSelect.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { Radio, RadioGroup } from '@guardian/source-react-components';
+import type { CampaignFieldRadio } from '../../../types/content';
 import { FieldLabel } from './FieldLabel';
 
 type FieldProp = {

--- a/dotcom-rendering/src/web/components/Callout/Select.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Select.tsx
@@ -1,3 +1,4 @@
+import { CampaignFieldSelect } from '../../../types/content';
 import { FieldLabel } from './FieldLabel';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/Callout/TextArea.tsx
+++ b/dotcom-rendering/src/web/components/Callout/TextArea.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { TextArea as SourceTextArea } from '@guardian/source-react-components';
+import { CampaignFieldTextArea } from '../../../types/content';
 
 const textAreaStyles = css`
 	width: 100%;

--- a/dotcom-rendering/src/web/components/Callout/TextInput.tsx
+++ b/dotcom-rendering/src/web/components/Callout/TextInput.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { TextInput as SourceTextInput } from '@guardian/source-react-components';
+import { CampaignFieldText } from '../../../types/content';
 
 const textInputStyles = css`
 	margin-top: ${space[2]}px;

--- a/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/CalloutEmbedBlockComponent.importable.tsx
@@ -4,6 +4,7 @@ import { Button } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
 import MinusIcon from '../../static/icons/minus.svg';
 import PlusIcon from '../../static/icons/plus.svg';
+import { CalloutBlockElement } from '../../types/content';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { Form } from './Callout/Form';

--- a/dotcom-rendering/src/web/components/ClickToView.stories.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.stories.tsx
@@ -1,6 +1,18 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { textSans } from '@guardian/source-foundations';
+import type {
+	DocumentBlockElement,
+	EmbedBlockElement,
+	InstagramBlockElement,
+	MapBlockElement,
+	RoleType,
+	SoundcloudBlockElement,
+	SpotifyBlockElement,
+	TweetBlockElement,
+	VideoVimeoBlockElement,
+	VineBlockElement,
+} from '../../types/content';
 import { ClickToView } from './ClickToView';
 import { DocumentBlockComponent } from './DocumentBlockComponent.importable';
 import { EmbedBlockComponent } from './EmbedBlockComponent.importable';

--- a/dotcom-rendering/src/web/components/ClickToView.tsx
+++ b/dotcom-rendering/src/web/components/ClickToView.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source-foundations';
 import { Button, SvgCheckmark } from '@guardian/source-react-components';
 import { useState } from 'react';
+import type { RoleType } from '../../types/content';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/web/components/DocumentBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/DocumentBlockComponent.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { LinkButton } from '@guardian/source-react-components';
+import type { RoleType } from '../../types/content';
 import { ClickToView } from './ClickToView';
 
 const widthOverride = css`

--- a/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/EmbedBlockComponent.importable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { from, space, text, textSans } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
+import type { RoleType } from '../../types/content';
 import { ClickToView } from './ClickToView';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/Figure.tsx
+++ b/dotcom-rendering/src/web/components/Figure.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, space, until } from '@guardian/source-foundations';
+import type { CAPIElement, RoleType } from '../../types/content';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.mocks.ts
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.mocks.ts
@@ -1,3 +1,5 @@
+import type { ImageBlockElement } from '../../types/content';
+
 export const image: ImageBlockElement = {
 	role: 'inline',
 	elementId: 'mockId',

--- a/dotcom-rendering/src/web/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageBlockComponent.tsx
@@ -1,3 +1,4 @@
+import { ImageBlockElement } from '../../types/content';
 import { ImageComponent } from './ImageComponent';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/web/components/ImageComponent.tsx
@@ -8,6 +8,7 @@ import {
 	neutral,
 	until,
 } from '@guardian/source-foundations';
+import type { Image, ImageBlockElement, RoleType } from '../../types/content';
 import type { Palette } from '../../types/palette';
 import { decidePalette } from '../lib/decidePalette';
 import { Caption } from './Caption';

--- a/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { InstagramBlockElement } from '../../types/content';
 import { updateIframeHeight } from '../browser/updateIframeHeight';
 import { ClickToView } from './ClickToView';
 

--- a/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveBlockComponent.importable.tsx
@@ -3,6 +3,7 @@ import { ArticleSpecial } from '@guardian/libs';
 import { body, space, textSans } from '@guardian/source-foundations';
 import libDebounce from 'lodash.debounce';
 import { useRef, useState } from 'react';
+import { RoleType } from '../../types/content';
 import type { Palette } from '../../types/palette';
 import { interactiveLegacyFigureClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { decidePalette } from '../lib/decidePalette';

--- a/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.stories.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { NumberedList } from '../../../fixtures/generated/articles/NumberedList';
 import { enhanceInteractiveContentsElements } from '../../model/enhance-interactive-contents-elements';
+import { InteractiveContentsBlockElement } from '../../types/content';
 import { InteractiveContentsBlockComponent } from './InteractiveContentsBlockComponent';
 
 const interactiveContentsBlock = enhanceInteractiveContentsElements(

--- a/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/InteractiveContentsBlockComponent.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { SvgChevronDownSingle } from '@guardian/source-react-components';
 import { useCallback, useEffect, useState } from 'react';
+import type { SubheadingBlockElement } from '../../types/content';
 import { getZIndex } from '../lib/getZIndex';
 
 const liStyles = css`

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import type { Switches } from '../../types/config';
+import { CAPIElement } from '../../types/content';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
 

--- a/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/MapEmbedBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { RoleType } from '../../types/content';
 import { Caption } from './Caption';
 import { ClickToView } from './ClickToView';
 import { MaintainAspectRatio } from './MaintainAspectRatio';

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.mocks.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.mocks.tsx
@@ -1,3 +1,5 @@
+import { ImageBlockElement } from '../../types/content';
+
 export const fourImages: ImageBlockElement[] = [
 	{
 		role: 'halfWidth',

--- a/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/MultiImageBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
+import type { ImageBlockElement } from '../../types/content';
 import { Caption } from './Caption';
 import { GridItem } from './GridItem';
 import { ImageComponent } from './ImageComponent';

--- a/dotcom-rendering/src/web/components/PersonalityQuizAtomWrapper.importable.tsx
+++ b/dotcom-rendering/src/web/components/PersonalityQuizAtomWrapper.importable.tsx
@@ -1,36 +1,5 @@
 import { PersonalityQuizAtom } from '@guardian/atoms-rendering';
-import type { SharingUrlsType } from '@guardian/atoms-rendering/dist/types/types';
-
-// These types are duplicates of those defined in the atom file.
-type AnswerType = {
-	id: string;
-	text: string;
-	revealText?: string;
-	isCorrect: boolean;
-	answerBuckets: string[];
-};
-
-type QuestionType = {
-	id: string;
-	text: string;
-	answers: AnswerType[];
-	imageUrl?: string;
-	imageAlt?: string;
-};
-
-type ResultsBucket = {
-	id: string;
-	title: string;
-	description: string;
-};
-
-type QuizAtomType = {
-	id: string;
-	questions: QuestionType[];
-	resultBuckets: ResultsBucket[];
-	sharingUrls: SharingUrlsType;
-	theme: ArticleTheme;
-};
+import { QuizAtomType } from '../../types/content';
 
 export const PersonalityQuizAtomWrapper = (props: QuizAtomType) => {
 	return <PersonalityQuizAtom {...props} />;

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import React from 'react';
+import type { RoleType } from '../../types/content';
 
 /**
  * Working on this file? Checkout out 027-pictures.md & 029-signing-image-urls.md for background information & context

--- a/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/RichLinkComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import { RichLinkBlockElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import { decideFormat } from '../lib/decideFormat';
 import { useApi } from '../lib/useApi';

--- a/dotcom-rendering/src/web/components/SoundcloudBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/SoundcloudBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { unescapeData } from '../../lib/escapeData';
+import { SoundcloudBlockElement } from '../../types/content';
 
 const widthOverride = css`
 	iframe {
@@ -8,9 +9,11 @@ const widthOverride = css`
 	}
 `;
 
-export const SoundcloudBlockComponent: React.FC<{
+type Props = {
 	element: SoundcloudBlockElement;
-}> = ({ element }) => {
+};
+
+export const SoundcloudBlockComponent = ({ element }: Props) => {
 	return (
 		<div css={widthOverride}>
 			<div

--- a/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { RoleType } from '../../types/content';
 import { Caption } from './Caption';
 import { ClickToView } from './ClickToView';
 

--- a/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { Star } from '../../../static/icons/Star';
+import type { RatingSizeType } from '../../../types/content';
 
 const starWrapper = css`
 	display: inline-block;

--- a/dotcom-rendering/src/web/components/StarRatingBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/StarRatingBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { brandAltBackground } from '@guardian/source-foundations';
+import type { RatingSizeType } from '../../types/content';
 import { StarRating } from './StarRating/StarRating';
 
 type Props = {

--- a/dotcom-rendering/src/web/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TableBlockComponent.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { border, neutral, text, textSans } from '@guardian/source-foundations';
 import { unescapeData } from '../../lib/escapeData';
+import type { TableBlockElement } from '../../types/content';
 
 const tableEmbed = css`
 	.table--football {

--- a/dotcom-rendering/src/web/components/TweetBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/TweetBlockComponent.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { body, border } from '@guardian/source-foundations';
 import { useEffect } from 'react';
 import { unescapeData } from '../../lib/escapeData';
+import type { TweetBlockElement } from '../../types/content';
 
 type Props = {
 	element: TweetBlockElement;

--- a/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/UnsafeEmbedBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { RoleType } from '../../types/content';
 import { updateIframeHeight } from '../browser/updateIframeHeight';
 import { ClickToView } from './ClickToView';
 

--- a/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VideoFacebookBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { RoleType } from '../../types/content';
 import { Caption } from './Caption';
 import { ClickToView } from './ClickToView';
 import { MaintainAspectRatio } from './MaintainAspectRatio';

--- a/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/VineBlockComponent.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
+import type { RoleType, VineBlockElement } from '../../types/content';
 import { ClickToView } from './ClickToView';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 

--- a/dotcom-rendering/src/web/components/WitnessBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/web/components/WitnessBlockComponent.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { WitnessAssetType } from '../../types/content';
 import { decidePalette } from '../lib/decidePalette';
 import {
 	WitnessImageBlockComponent,

--- a/dotcom-rendering/src/web/components/WitnessBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/WitnessBlockComponent.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { body, headline, neutral, space } from '@guardian/source-foundations';
+import type { WitnessAssetType } from '../../types/content';
 import type { Palette } from '../../types/palette';
 
 // Wrapper Styles

--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -4,6 +4,7 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { body, neutral, space } from '@guardian/source-foundations';
 import { SvgAlertRound } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
+import type { RoleType } from '../../types/content';
 import { trackVideoInteraction } from '../browser/ga/ga';
 import { record } from '../browser/ophan/ophan';
 import { useAB } from '../lib/useAB';

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -13,6 +13,7 @@ import {
 } from '@guardian/source-foundations';
 import type { NavType } from '../../model/extract-nav';
 import type { Switches } from '../../types/config';
+import type { CAPIElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import {
 	adCollapseStyles,

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -13,6 +13,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { parse } from '../../lib/slot-machine-flags';
 import type { NavType } from '../../model/extract-nav';
+import type { ImageBlockElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';

--- a/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
+++ b/dotcom-rendering/src/web/layouts/headers/ImmersiveHeader.tsx
@@ -9,6 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { buildAdTargeting } from '../../../lib/ad-targeting';
 import type { NavType } from '../../../model/extract-nav';
+import type { ImageBlockElement } from '../../../types/content';
 import type { FEArticleType } from '../../../types/frontend';
 import type { Palette } from '../../../types/palette';
 import { ArticleHeadline } from '../../components/ArticleHeadline';
@@ -115,7 +116,6 @@ export const ImmersiveHeader = ({ CAPIArticle, NAV, format }: Props) => {
 	// TODO:
 	// 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
 	// 2) Otherwise, ensure slot only renders if `CAPIArticle.config.shouldHideReaderRevenue` equals false.
-
 	const mainMedia = CAPIArticle.mainMediaElements[0] as ImageBlockElement;
 	const captionText = decideCaption(mainMedia);
 

--- a/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/web/layouts/lib/interactiveLegacyStyling.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { from, until } from '@guardian/source-foundations';
+import type { RoleType } from '../../../types/content';
 import { center } from '../../lib/center';
 
 export const isInteractive = (design: ArticleDesign): boolean =>

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import type { Switches } from '../../types/config';
+import type { CAPIElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import {
 	adCollapseStyles,

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -8,6 +8,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
 import type { Switches } from '../../types/config';
+import type { CAPIElement, RoleType } from '../../types/content';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
 import { CalloutEmbedBlockComponent } from '../components/CalloutEmbedBlockComponent.importable';

--- a/dotcom-rendering/src/web/server/articleToHtml.tsx
+++ b/dotcom-rendering/src/web/server/articleToHtml.tsx
@@ -20,6 +20,7 @@ import { escapeData } from '../../lib/escapeData';
 import { extractGA } from '../../model/extract-ga';
 import { extractNAV } from '../../model/extract-nav';
 import { makeWindowGuardian } from '../../model/window-guardian';
+import type { CAPIElement } from '../../types/content';
 import type { FEArticleType } from '../../types/frontend';
 import type { TagType } from '../../types/tag';
 import { ArticlePage } from '../components/ArticlePage';


### PR DESCRIPTION
## What does this change?

Convert the ambient `content.d.ts` to an explicity `content.ts` from which types must be imported.

## Why?

Importing types explicitely is favourable as it makes refactor easier in the future.
