### PR TITLE
Update header notifications design

### DIFF
--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -194,7 +194,7 @@ const notificationBadgeStyles = (diameter: number) => css`
 	${textSans.xsmall()};
 	line-height: 1;
 
-	min-width: ${diameter}px;
+	width: ${diameter}px;
 	height: ${diameter}px;
 	border-radius: ${diameter}px;
 `;

--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -69,6 +69,11 @@ const ulStyles = css`
 	}
 `;
 
+const liStyles = css`
+	position: relative;
+	display: flex;
+`;
+
 const displayBlock = css`
 	display: block;
 `;
@@ -177,57 +182,49 @@ const buttonExpanded = css`
 	}
 `;
 
-const badgeDiameter = 20;
 const notificationColor = palette.error[400];
 
-const notificationBadgeStyles = css`
+const notificationBadgeStyles = (diameter: number) => css`
 	background-color: ${notificationColor};
 	color: ${palette.neutral[100]};
-	position: absolute;
-	top: 0;
-	left: 0;
-	min-width: ${badgeDiameter}px;
-	height: ${badgeDiameter}px;
-	border-radius: ${badgeDiameter / 2}px;
+	margin-top: 12px;
 	text-align: center;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: 0 5px;
+	${textSans.xsmall()};
+	line-height: 1;
+
+	min-width: ${diameter}px;
+	height: ${diameter}px;
+	border-radius: ${diameter / 2}px;
+`;
+
+const dropdownButtonNotificationBadgeStyles = css`
+	position: absolute;
+	top: 0;
+	left: 0;
 	margin-left: -10px;
 	margin-top: -3px;
 `;
 
-const notificationStyles = css`
+const notificationTextStyles = css`
 	${textSans.xxsmall()};
-	color: ${notificationColor};
 `;
 
-const redDotDiameter = 16;
-const redDotStyles = css`
-	background-color: ${notificationColor};
-	width: ${redDotDiameter}px;
-	height: ${redDotDiameter}px;
-	border-radius: ${redDotDiameter / 2}px;
-	position: absolute;
-	left: 5px;
-	top: 12px;
-`;
-
-const notificationCountStyles = css`
-	${textSans.xsmall()};
-	line-height: ${badgeDiameter}px;
-`;
-
-const NotificationBadge = ({ count }: { count: number }) => {
+const NotificationBadge = ({
+	cssOverrides,
+	diameter,
+}: {
+	cssOverrides?: SerializedStyles;
+	diameter: number;
+}) => {
 	return (
-		<div css={notificationBadgeStyles}>
-			<span css={notificationCountStyles}>{count + 0}</span>
+		<div css={[notificationBadgeStyles(diameter), cssOverrides]}>
+			<span>!</span>
 		</div>
 	);
 };
-
-const RedDot = () => <div css={redDotStyles} />;
 
 export const Dropdown = ({
 	id,
@@ -346,7 +343,12 @@ export const Dropdown = ({
 					>
 						{label}
 						{notificationCount > 0 && (
-							<NotificationBadge count={notificationCount} />
+							<NotificationBadge
+								cssOverrides={
+									dropdownButtonNotificationBadgeStyles
+								}
+								diameter={18}
+							/>
 						)}
 					</button>
 					<div css={isExpanded ? displayBlock : displayNone}>
@@ -358,12 +360,7 @@ export const Dropdown = ({
 								data-cy="dropdown-options"
 							>
 								{links.map((l, index) => (
-									<li
-										css={css`
-											position: relative;
-										`}
-										key={l.title}
-									>
+									<li css={liStyles} key={l.title}>
 										<a
 											href={l.url}
 											css={[
@@ -377,7 +374,9 @@ export const Dropdown = ({
 											{l.notifications?.map(
 												(notification) => (
 													<div
-														css={notificationStyles}
+														css={
+															notificationTextStyles
+														}
 													>
 														{notification}
 													</div>
@@ -386,7 +385,7 @@ export const Dropdown = ({
 										</a>
 
 										{!!l.notifications?.length && (
-											<RedDot />
+											<NotificationBadge diameter={22} />
 										)}
 									</li>
 								))}

--- a/dotcom-rendering/src/web/components/Dropdown.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.tsx
@@ -187,7 +187,6 @@ const notificationColor = palette.error[400];
 const notificationBadgeStyles = (diameter: number) => css`
 	background-color: ${notificationColor};
 	color: ${palette.neutral[100]};
-	margin-top: 12px;
 	text-align: center;
 	display: flex;
 	justify-content: center;
@@ -197,7 +196,7 @@ const notificationBadgeStyles = (diameter: number) => css`
 
 	min-width: ${diameter}px;
 	height: ${diameter}px;
-	border-radius: ${diameter / 2}px;
+	border-radius: ${diameter}px;
 `;
 
 const dropdownButtonNotificationBadgeStyles = css`
@@ -212,15 +211,9 @@ const notificationTextStyles = css`
 	${textSans.xxsmall()};
 `;
 
-const NotificationBadge = ({
-	cssOverrides,
-	diameter,
-}: {
-	cssOverrides?: SerializedStyles;
-	diameter: number;
-}) => {
+const NotificationBadge = ({ diameter }: { diameter: number }) => {
 	return (
-		<div css={[notificationBadgeStyles(diameter), cssOverrides]}>
+		<div css={notificationBadgeStyles(diameter)}>
 			<span>!</span>
 		</div>
 	);
@@ -343,12 +336,9 @@ export const Dropdown = ({
 					>
 						{label}
 						{notificationCount > 0 && (
-							<NotificationBadge
-								cssOverrides={
-									dropdownButtonNotificationBadgeStyles
-								}
-								diameter={18}
-							/>
+							<div css={dropdownButtonNotificationBadgeStyles}>
+								<NotificationBadge diameter={18} />
+							</div>
 						)}
 					</button>
 					<div css={isExpanded ? displayBlock : displayNone}>
@@ -385,7 +375,15 @@ export const Dropdown = ({
 										</a>
 
 										{!!l.notifications?.length && (
-											<NotificationBadge diameter={22} />
+											<div
+												css={css`
+													margin-top: 12px;
+												`}
+											>
+												<NotificationBadge
+													diameter={22}
+												/>
+											</div>
 										)}
 									</li>
 								))}


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/dotcom-rendering/pull/5241) added notifications to the "my account" dropdown component.

The design has changed -
1. No longer display the number of notifications in the badge, just a "!"
2. In the dropdown, move the badge to the right

<img width="284" alt="Screenshot 2022-11-23 at 08 23 18" src="https://user-images.githubusercontent.com/1513454/203500032-c8edf827-bebb-447c-b80b-36c85f1194ca.png">
