### PR TITLE
Read the S3 bucket for deployments from SSM

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -30,7 +30,7 @@ deployments:
   frontend-static:
     type: aws-s3
     parameters:
-      bucketSsmKey: /account/services/dotcom-static.bucket
+      bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
       publicReadAcl: false

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -23,14 +23,14 @@ deployments:
   rendering:
     type: autoscaling
     parameters:
-      bucket: aws-frontend-artifacts
+      bucketSsmKey: /account/services/dotcom-artifact.bucket
     dependencies:
       - frontend-static
       - frontend-cfn
   frontend-static:
     type: aws-s3
     parameters:
-      bucket: aws-frontend-static
+      bucketSsmKey: /account/services/dotcom-static.bucket
       cacheControl: public, max-age=315360000
       prefixStack: false
       publicReadAcl: false


### PR DESCRIPTION
## Why?

This change reads the S3 bucket name from SSM for the `frontend-static` and `rendering` deployments, resolving the deployment warning given by riff-raff:

<img width="830" alt="Screenshot 2022-11-23 at 14 35 07" src="https://user-images.githubusercontent.com/953792/203573643-fa2c09bc-84fc-4e56-a05c-f5d3710a5bc7.png">

## How to test?

Try deploying this to code!