### PR TITLE
Remove E2E test for the puzzles banner

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-2/banner.e2e.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-2/banner.e2e.cy.js
@@ -22,22 +22,4 @@ describe('The banner', function () {
 		cy.visit(`/Article?url=${articleUrl}`);
 		cy.wait('@rrBannerRequest');
 	});
-
-	it('requests the puzzles banner on puzzles pages', function () {
-		disableCMP();
-		optOutOfArticleCountConsent();
-		const articleUrl =
-			'https://www.theguardian.com/crosswords/crossword-blog/2021/mar/29/crossword-blog-is-it-ok-to-when-solving-puzzles';
-		const rrBannerUrl = 'https://contributions.guardianapis.com/puzzles';
-
-		cy.intercept(rrBannerUrl, (req) => {
-			expect(req.body).to.have.property('targeting');
-			expect(req.body).to.have.property('tracking');
-
-			req.reply({});
-		}).as('puzzlesBannerRequest');
-
-		cy.visit(`/Article?url=${articleUrl}`);
-		cy.wait('@puzzlesBannerRequest');
-	});
 });


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This removes the E2E Cypress test for the puzzles banner.

## Why?

We've turned this banner off via the switchboard, which has been causing this test to fail. While I think the code to load the banner should probably remain for the time being, I don't envision us turning it back on any time soon, so this test can be removed.
