### PR TITLE
Render Blockquotes in Editions

### DIFF
--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -262,9 +262,7 @@ const textElement =
 					children,
 				);
 			case 'BLOCKQUOTE':
-				return isEditions
-					? h('blockquote', { key }, children)
-					: h(Blockquote, { key, format }, children);
+				return h(Blockquote, { key, format }, children);
 			case 'STRONG':
 				return styledH(
 					'strong',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the conditional that renders blockquotes in the renderer so that editions will use the blockquote component from AR.

## Why?
Currently, blockquotes are a completely un-styled base HTML element and they need to be supported and styled when used.

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="560" alt="image" src="https://user-images.githubusercontent.com/99400613/203826055-1928273f-5148-425f-ae25-46e0b60585e3.png"> | <img width="563" alt="image" src="https://user-images.githubusercontent.com/99400613/203825903-ec7f37f3-e012-4316-bc88-7b9e0126afca.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
