### PR TITLE
Fix: correct Obituary typo

### DIFF
--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -140,7 +140,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 			return (
 				<Margins format={format}>
 					<Tag format={format}>
-						<TagLink href="/tone/obituaries">Obituaries</TagLink>
+						<TagLink href="/tone/obituaries">Obituary</TagLink>
 					</Tag>
 				</Margins>
 			);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes a typo `Obituaries` > `Obituary`
