### PR TITLE
Fix: Obituary Typo

### DIFF
--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -140,7 +140,7 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 			return (
 				<Margins format={format}>
 					<Tag format={format}>
-						<TagLink href="/tone/obituaries">Obituaries</TagLink>
+						<TagLink href="/tone/obituaries">Obituary</TagLink>
 					</Tag>
 				</Margins>
 			);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes typo `Obituaries` becomes `Obituary`

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/203833178-a205264b-76c8-4dad-8335-21bf4d8fd25a.png
[after]: https://user-images.githubusercontent.com/20416599/203833306-7cf8b0f6-6d69-4016-98c3-e1f4468ff281.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
