### PR TITLE
feat: redirect article and fronts

### DIFF
--- a/dotcom-rendering/src/server/dev-server.ts
+++ b/dotcom-rendering/src/server/dev-server.ts
@@ -10,6 +10,11 @@ import {
 	renderKeyEvents,
 } from '../web/server';
 
+/** article URLs contain a part that looks like “2022/nov/25” */
+const ARTICLE_URL = /\/\d{4}\/[a-z]{3}\/\d{2}\//;
+/** fronts are a series of lowercase strings, dashes and forward slashes */
+const FRONT_URL = /^\/[a-z-/]+/;
+
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
 // for more info
 export const devServer = () => {
@@ -33,8 +38,27 @@ export const devServer = () => {
 				return renderFront(req, res);
 			case '/FrontJSON':
 				return renderFrontJson(req, res);
-			default:
+			default: {
+				if (req.url.match(ARTICLE_URL)) {
+					const url = new URL(
+						req.url,
+						'https://www.theguardian.com/',
+					).toString();
+					console.info('redirecting to Article:', url);
+					return res.redirect(`/Article?url=${url}`);
+				}
+
+				if (req.url.match(FRONT_URL)) {
+					const url = new URL(
+						req.url,
+						'https://www.theguardian.com/',
+					).toString();
+					console.info('redirecting to Front:', url);
+					return res.redirect(`/Front?url=${url}`);
+				}
+
 				next();
+			}
 		}
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

When running the dev server, catch routes that match Front or Article urls and redirect them to an endpoint that will actually render them.

- `/uk` &rarr; `/Front?url=https://www.theguardian.com/uk`
- `/money/2016/may/26/ticket-touts-review-licensing-enforcement` &rarr; `/Article?url=https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement`

## Why?

We know these can be rendered by DCR, so make navigation between them easier.

One further step would be to catch any incoming URL and replace it with a DCR rendered one, to prevent leaving the dev server and jumping into PROD