### PR TITLE
Fix LinkedIn embeds

### DIFF
--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -106,7 +106,7 @@ const buildCsp = (
 			? 'https://platform.twitter.com https://cdn.syndication.twimg.com'
 			: ''
 	};
-    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com ${
+    frame-src https://www.theguardian.com https://www.scribd.com https://www.google.com https://webstories.theguardian.com https://www.linkedin.com ${
 		thirdPartyEmbed.instagram ? 'https://www.instagram.com' : ''
 	} https://www.facebook.com https://www.tiktok.com https://interactive.guim.co.uk ${
 		thirdPartyEmbed.spotify ? 'https://open.spotify.com' : ''


### PR DESCRIPTION
## What does this change?

- adds `https://www.linkedin.com` to `frame-src`

## Why?

- To fix LinkedIn embeds in articles (e.g https://mobile.guardianapis.com/uk/rendered-items/technology/2022/nov/22/twitter-elon-musk-staff-tech)

