### PR TITLE
Fix H2s on Immersives in darkmode

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -43,7 +43,7 @@
     "@guardian/atoms-rendering": "^23.7.2",
     "@guardian/bridget": "^2.0.0",
     "@guardian/cdk": "^47.3.3",
-    "@guardian/common-rendering": "file:../common-rendering",
+    "@guardian/common-rendering": "./../common-rendering",
     "@guardian/content-api-models": "^17.4.0",
     "@guardian/content-atom-model": "^3.4.0",
     "@guardian/discussion-rendering": "^10.1.1",

--- a/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
@@ -1,19 +1,27 @@
 // ----- Imports ----- //
 
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette/text';
+import type { ArticleFormat } from '@guardian/libs';
 import { headline } from '@guardian/source-foundations';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 import type { DefaultProps } from './HeadingTwo.defaults';
 import DefaultHeadingTwo from './HeadingTwo.defaults';
 
 // ----- Component ----- //
 
-const styles = css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'light' })}
+
+	${darkModeCss`
+		color: ${text.headingTwoDark(format)};
+	`}
 `;
 
 const ImmersiveHeadingTwo: FC<DefaultProps> = (props) => (
-	<DefaultHeadingTwo {...props} css={styles} />
+	<DefaultHeadingTwo {...props} css={styles(props.format)} />
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
+++ b/apps-rendering/src/components/HeadingTwo/ImmersiveHeadingTwo.tsx
@@ -12,16 +12,24 @@ import DefaultHeadingTwo from './HeadingTwo.defaults';
 
 // ----- Component ----- //
 
-const styles = (format: ArticleFormat): SerializedStyles => css`
+const styles = (
+	format: ArticleFormat,
+	isEditions: boolean,
+): SerializedStyles => css`
 	${headline.medium({ fontWeight: 'light' })}
 
-	${darkModeCss`
+	${isEditions
+		? null
+		: darkModeCss`
 		color: ${text.headingTwoDark(format)};
 	`}
 `;
 
 const ImmersiveHeadingTwo: FC<DefaultProps> = (props) => (
-	<DefaultHeadingTwo {...props} css={styles(props.format)} />
+	<DefaultHeadingTwo
+		{...props}
+		css={styles(props.format, props.isEditions)}
+	/>
 );
 
 // ----- Exports ----- //

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1495,7 +1495,7 @@
     read-pkg-up "7.0.1"
     yargs "^17.5.1"
 
-"@guardian/common-rendering@file:../common-rendering":
+"@guardian/common-rendering@./../common-rendering":
   version "1.0.0"
   dependencies:
     "@guardian/types" "^9.0.1"

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -1161,6 +1161,10 @@ const tableOfContentsTitleDark = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
+const headingTwoDark = (_format: ArticleFormat): string => {
+	return neutral[86];
+};
+
 // ----- API ----- //
 
 const text = {
@@ -1234,6 +1238,7 @@ const text = {
 	galleryDark,
 	tableOfContentsTitle,
 	tableOfContentsTitleDark,
+	headingTwoDark,
 };
 
 // ----- Exports ----- //


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds styles for H2s on Immersive articles in darkmode, except for editions articles
- Removes `file:` prefix for the dependency `@guardian/common-rendering`. This was preventing yarn picking up changes made to this package
  - cc @joecowton1 @sndrs 

## Why?

- Fixes #6585

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/204276448-7d9c234e-a47c-405e-82a3-7c48560d212b.png
[after]: https://user-images.githubusercontent.com/705427/204276451-55bbdcef-c7e1-426f-bf4b-65efde58835d.png

### Editions in darkmode

![Screen Shot 2022-11-28 at 12 21 20](https://user-images.githubusercontent.com/705427/204276546-1ccc91b0-b246-4cba-9978-a353e49aa500.png)


