### PR TITLE
Refactor abTest usage

### DIFF
--- a/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/YoutubeBlockComponent.importable.tsx
@@ -96,8 +96,9 @@ export const YoutubeBlockComponent = ({
 	);
 
 	const abTests = useAB();
+	const abTestsApi = abTests?.api;
 	const imaEnabled =
-		abTests?.api.isUserInVariant('IntegrateIma', 'variant') ?? false;
+		abTestsApi?.isUserInVariant('IntegrateIma', 'variant') ?? false;
 	const abTestParticipations = abTests?.participations ?? {};
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

As part of the work to separate Storybook instances, we were seeing a number of TS. errors in Chromatic around the `isUserInVariant` possibly being undefined.

https://www.chromatic.com/setup?appId=637e40d1bc73bf3f604394b9

This PR refactors this code to bring it into line with other instances of `useAB()` and fix those errors. See docs [here](https://github.com/guardian/dotcom-rendering/blob/f57dce2fac84c4379140b4f7e056ff888f5046fe/dotcom-rendering/docs/development/ab-testing-in-dcr.md#L33)
