### PR TITLE
feat: Add dynamo sublink styling

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -459,7 +459,7 @@ export const Card = ({
 			) : (
 				<></>
 			)}
-			{isOpinion && (
+			{isOpinion && !isDynamo && (
 				<CommentFooter
 					hasSublinks={hasSublinks}
 					displayAge={displayAge}

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -139,7 +139,7 @@ const DecideFooter = ({
 		displayAge,
 		displayLines: false,
 	});
-	// Note. Opinion cards always show the lines at the botom of the card (in CommentFooter)
+	// Note. Opinion cards always show the lines at the bottom of the card (in CommentFooter)
 };
 
 const CommentFooter = ({

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -117,6 +117,15 @@ const decideIfAgeShouldShow = ({
 	return false;
 };
 
+type RenderFooter = ({
+	displayAge,
+	displayLines,
+}: {
+	displayAge: boolean;
+	displayLines: boolean;
+	// eslint-disable-next-line @typescript-eslint/ban-types -- this signature is adequate
+}) => JSX.Element;
+
 const DecideFooter = ({
 	isOpinion,
 	hasSublinks,
@@ -126,7 +135,7 @@ const DecideFooter = ({
 	isOpinion: boolean;
 	hasSublinks?: boolean;
 	displayAge: boolean;
-	renderFooter: Function;
+	renderFooter: RenderFooter;
 }) => {
 	if (isOpinion && !hasSublinks) {
 		// Opinion cards without sublinks render the entire footer, including lines,
@@ -151,7 +160,7 @@ const CommentFooter = ({
 	hasSublinks?: boolean;
 	palette: Palette;
 	displayAge: boolean;
-	renderFooter: Function;
+	renderFooter: RenderFooter;
 }) => {
 	return hasSublinks ? (
 		// For opinion cards with sublinks there is already a footer rendered inside that

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -152,6 +152,27 @@ const labTextStyles = (size: SmallHeadlineSize) => {
 	}
 };
 
+const cssOverrides = css`
+	/* See: https://css-tricks.com/nested-links/ */
+	${getZIndex('card-nested-link')}
+	/* The following styles turn off those provided by Link */
+	color: inherit;
+	text-decoration: none;
+	/* stylelint-disable-next-line property-disallowed-list */
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	/* This css is used to remove any underline from the kicker but still
+have it applied to the headline when the kicker is hovered */
+	:hover {
+		color: inherit;
+		text-decoration: none;
+		.show-underline {
+			text-decoration: underline;
+		}
+	}
+`;
+
 const lineStyles = (palette: Palette) => css`
 	padding-top: 1px;
 	:before {
@@ -165,37 +186,28 @@ const lineStyles = (palette: Palette) => css`
 	}
 `;
 
+const dynamoStyles = css`
+	display: block;
+	font-weight: 800;
+	padding: 5px;
+`;
+
 const WithLink = ({
 	linkTo,
 	children,
+	isDynamo,
 }: {
 	linkTo?: string;
 	children: React.ReactNode;
+	isDynamo?: true;
 }) => {
 	if (linkTo) {
 		return (
 			<Link
 				href={linkTo}
-				cssOverrides={css`
-					/* See: https://css-tricks.com/nested-links/ */
-					${getZIndex('card-nested-link')}
-					/* The following styles turn off those provided by Link */
-					color: inherit;
-					text-decoration: none;
-					/* stylelint-disable-next-line property-disallowed-list */
-					font-family: inherit;
-					font-size: inherit;
-					line-height: inherit;
-					/* This css is used to remove any underline from the kicker but still
-					   have it applied to the headline when the kicker is hovered */
-					:hover {
-						color: inherit;
-						text-decoration: none;
-						.show-underline {
-							text-decoration: underline;
-						}
-					}
-				`}
+				cssOverrides={
+					isDynamo ? [cssOverrides, dynamoStyles] : cssOverrides
+				}
 			>
 				{children}
 			</Link>
@@ -244,10 +256,10 @@ export const CardHeadline = ({
 							size: sizeOnMobile ?? size,
 							fontWeight: containerPalette ? 'bold' : 'regular',
 						}),
-					showLine && lineStyles(palette),
+					showLine && !isDynamo && lineStyles(palette),
 				]}
 			>
-				<WithLink linkTo={linkTo}>
+				<WithLink linkTo={linkTo} isDynamo={isDynamo}>
 					{!!kickerText && (
 						<Kicker
 							text={kickerText}

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -47,6 +47,7 @@ export const Default = () => {
 		<SupportingContent
 			supportingContent={[aBasicLink]}
 			alignment="horizontal"
+			parentFormat={aBasicLink.format}
 		/>
 	);
 };
@@ -56,6 +57,7 @@ export const WithKicker = () => {
 		<SupportingContent
 			supportingContent={[{ ...aBasicLink, kickerText: 'Kicker text' }]}
 			alignment="horizontal"
+			parentFormat={aBasicLink.format}
 		/>
 	);
 };

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -31,7 +31,7 @@ const directionStyles = (alignment: Alignment) => {
 		case 'horizontal':
 			return css`
 				flex-direction: column;
-				${from.phablet} {
+				${from.tablet} {
 					flex-direction: row;
 				}
 			`;
@@ -48,7 +48,7 @@ const dynamoStyles = css`
 	width: 100%;
 	margin: 0;
 
-	${from.phablet} {
+	${from.tablet} {
 		padding: 0 5px 5px;
 		flex-direction: row;
 		position: absolute;
@@ -63,7 +63,7 @@ const liStyles = css`
 	padding-top: 2px;
 	position: relative;
 	margin-top: 8px;
-	${from.phablet} {
+	${from.tablet} {
 		margin-bottom: 4px;
 	}
 `;
@@ -82,7 +82,7 @@ const leftMargin = css`
 `;
 
 const bottomMargin = css`
-	${until.phablet} {
+	${until.tablet} {
 		margin-bottom: 8px;
 	}
 `;

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, neutral, until } from '@guardian/source-foundations';
 import type {
 	DCRContainerPalette,
 	DCRSupportingContent,
 } from '../../types/front';
+import { decidePalette } from '../lib/decidePalette';
+import { transparentColour } from '../lib/transparentColour';
 import { CardHeadline } from './CardHeadline';
 
 type Alignment = 'vertical' | 'horizontal';
@@ -13,7 +15,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: true;
-	parentFormat?: ArticleFormat;
+	parentFormat: ArticleFormat;
 };
 
 const wrapperStyles = css`
@@ -40,6 +42,20 @@ const directionStyles = (alignment: Alignment) => {
 	}
 };
 
+const dynamoStyles = css`
+	flex-direction: column;
+	column-gap: 5px;
+	width: 100%;
+	margin: 0;
+
+	${from.phablet} {
+		padding: 0 5px 5px;
+		flex-direction: row;
+		position: absolute;
+		bottom: 0;
+	}
+`;
+
 const liStyles = css`
 	display: flex;
 	flex-direction: column;
@@ -50,6 +66,13 @@ const liStyles = css`
 	${from.phablet} {
 		margin-bottom: 4px;
 	}
+`;
+
+const dynamoLiStyles = css`
+	background-color: ${transparentColour(neutral[97], 0.875)};
+	border-top: 1px solid;
+	flex-grow: 1;
+	margin: 0;
 `;
 
 const leftMargin = css`
@@ -69,10 +92,16 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
+	parentFormat,
 }: Props) => {
 	return (
-		<ul css={[wrapperStyles, directionStyles(alignment)]}>
-			{supportingContent.map((subLink: DCRSupportingContent, index) => {
+		<ul
+			css={[
+				wrapperStyles,
+				isDynamo ? dynamoStyles : directionStyles(alignment),
+			]}
+		>
+			{supportingContent.map((subLink, index) => {
 				// The model has this property as optional but it is very likely
 				// to exist
 				if (!subLink.headline) return null;
@@ -81,7 +110,17 @@ export const SupportingContent = ({
 					<li
 						key={subLink.url}
 						css={[
-							liStyles,
+							isDynamo
+								? [
+										dynamoLiStyles,
+										css`
+											border-color: ${decidePalette(
+												parentFormat,
+												containerPalette,
+											).topBar.card};
+										`,
+								  ]
+								: liStyles,
 							shouldPadLeft && leftMargin,
 							index === supportingContent.length - 1 &&
 								bottomMargin,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Handle Dynamo sublinks so they look identical to frontend.

The sublinks float on top of the main image from phablet breakpoints and stack vertically, with a full-width red line below tablet.

This also adjust the breakpoint at which to stack from phablet (660) to tablet (740).

## Why?

Fixes #5267

Duplicate of #6552 

## Screenshots

| Frontend            | DCR      |
|-----------------|------------|
| ![fe mobile][]     |    ![dcr mobile][] |
| ![fe phablet][]    |    ![dcr phablet][] |
| ![fe tablet][]       |    ![dcr tablet][] |
| ![fe desktop][]   |    ![dcr desktop][] |
| ![fe leftCol][]     |    ![dcr leftCol][] |

[fe mobile]: https://user-images.githubusercontent.com/76776/204519813-6a757f7b-fc5a-4b79-b536-d0c32de79733.png
[fe phablet]: https://user-images.githubusercontent.com/76776/204520242-7dbdb73a-13f0-4ab3-b53e-65aeac396ec3.png
[fe tablet]: https://user-images.githubusercontent.com/76776/204520314-3f9019ed-6c35-4da4-979b-eabe62750d1d.png
[fe desktop]: https://user-images.githubusercontent.com/76776/204520448-ab73cf89-2697-47cd-a57c-de2c6b861444.png
[fe leftCol]: https://user-images.githubusercontent.com/76776/204520542-2ebdb797-8ecf-4a2e-8db7-45c8d123c77c.png

[dcr mobile]: https://user-images.githubusercontent.com/76776/204519383-047242ed-0339-4371-b49a-1fdcaa402182.png
[dcr phablet]: https://user-images.githubusercontent.com/76776/204521796-913ed9d6-664a-46a4-96a6-479216791b94.png
[dcr tablet]: https://user-images.githubusercontent.com/76776/204521647-7a4049e6-e80e-4204-950f-46d5658dea8b.png
[dcr desktop]: https://user-images.githubusercontent.com/76776/204517810-9b15e021-4167-4de3-b0ba-5cb99988877a.png
[dcr leftCol]: https://user-images.githubusercontent.com/76776/204517716-c2eda9c7-fd58-4fb4-b534-2d20a37254a8.png
