### PR TITLE
import and use the insertNewsletterIntoItem function

### DIFF
--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -23,6 +23,7 @@ import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { csp } from 'server/csp';
 import { pageFonts } from 'styles';
+import { insertNewsletterIntoItem } from '../newsletter';
 
 // ----- Types ----- //
 
@@ -151,7 +152,10 @@ function render(
 	getAssetLocation: (assetName: string) => string,
 	page: Option<string>,
 ): Page {
-	const item = fromCapi({ docParser, salt: imageSalt })(request, page);
+	const item = insertNewsletterIntoItem(
+		fromCapi({ docParser, salt: imageSalt })(request, page),
+	);
+
 	const clientScript = map(getAssetLocation)(scriptName(item));
 	const thirdPartyEmbeds = getThirdPartyEmbeds(request.content);
 	const body = renderBody(item, request);

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -5,6 +5,7 @@ import { CacheProvider } from '@emotion/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import type { EmotionCritical } from '@emotion/server/create-instance';
 import type { RenderingRequest } from '@guardian/apps-rendering-api-models/renderingRequest';
+import { pipe } from '@guardian/common-rendering/src/lib';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { background, resets } from '@guardian/source-foundations';
@@ -152,8 +153,9 @@ function render(
 	getAssetLocation: (assetName: string) => string,
 	page: Option<string>,
 ): Page {
-	const item = insertNewsletterIntoItem(
+	const item = pipe(
 		fromCapi({ docParser, salt: imageSalt })(request, page),
+		insertNewsletterIntoItem,
 	);
 
 	const clientScript = map(getAssetLocation)(scriptName(item));


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Enables the function to insert the newsletter signup components into articles with the `promotedNewsletter` property. These components are hidden by default and will only be displayed for users with Apps using the latest release of Bridget(2.0.0).

## Why?
The feature has just gone out for iOS beta testing in version 11.22-18558. It will need the feature enabled on the web layer. 

**If AR has a beta release channel, this branch could be released to beta instead of being merged into main if that would be preferable**.

## Screenshots

| Before(no component)      | After (Prod - component hidden)    | After (Beta - component visible)
|-------------|------------|------------|
| <img width="308" alt="Screenshot 2022-11-29 at 11 56 01" src="https://user-images.githubusercontent.com/30567854/204522920-b93c4405-550b-40c7-b0a4-7ae176da28fd.png">| <img width="308" alt="Screenshot 2022-11-29 at 11 56 01" src="https://user-images.githubusercontent.com/30567854/204522920-b93c4405-550b-40c7-b0a4-7ae176da28fd.png">| <img width="308" alt="Screenshot 2022-11-29 at 11 56 15" src="https://user-images.githubusercontent.com/30567854/204523030-21d1524f-066d-41d2-a182-ab6d5e75c942.png">




