### PR TITLE
use default for storybooks build folder:

### DIFF
--- a/storybooks/package.json
+++ b/storybooks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Global storybook that composes the repo's individual project storybooks",
   "scripts": {
-    "build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook --static-dir ../dotcom-rendering/src/static -o ../storybook-static",
+    "build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook --static-dir ../dotcom-rendering/src/static",
     "storybook": "node --max-old-space-size=4096 $(yarn bin)/start-storybook --static-dir ../dotcom-rendering/src/static -p 6006"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Uses the default path for the storybook build folder to test asset loading in chromatic - these files will be now be automatically picked up.
