### PR TITLE
Revert removing fonts from CR preview-head.html

### DIFF
--- a/common-rendering/.storybook/preview-head.html
+++ b/common-rendering/.storybook/preview-head.html
@@ -12,6 +12,118 @@
 <script defer="" src="/js/curl-with-js-and-domReady.js"></script>
 
 <style>
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: 400;
+		src: url('/fonts/GuardianTextEgyptian-Reg.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: 400;
+		font-style: italic;
+		src: url('/fonts/GuardianTextEgyptian-RegItalic.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: 700;
+		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: 700;
+		font-style: italic;
+		src: url('/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: bold;
+		src: url('/fonts/GuardianTextEgyptian-Bold.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Egyptian Web';
+		font-weight: bold;
+		font-style: italic;
+		src: url('/fonts/GuardianTextEgyptian-BoldItalic.ttf');
+	}
+
+	@font-face {
+		font-family: 'Guardian Text Sans Web';
+		font-weight: 400;
+		src: url('/fonts/GuardianTextSans-Regular.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Sans Web';
+		font-weight: 400;
+		font-style: italic;
+		src: url('/fonts/GuardianTextSans-RegularItalic.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Sans Web';
+		font-weight: 700;
+		src: url('/fonts/GuardianTextSans-Bold.ttf');
+	}
+	@font-face {
+		font-family: 'Guardian Text Sans Web';
+		font-weight: 700;
+		font-style: italic;
+		src: url('/fonts/GuardianTextSans-BoldItalic.ttf');
+	}
+
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 300;
+		src: url('/fonts/GHGuardianHeadline-Light.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 300;
+		font-style: italic;
+		src: url('/fonts/GHGuardianHeadline-LightItalic.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 400;
+		src: url('/fonts/GHGuardianHeadline-Regular.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 400;
+		font-style: italic;
+		src: url('/fonts/GHGuardianHeadline-RegularItalic.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 500;
+		src: url('/fonts/GHGuardianHeadline-Medium.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 500;
+		font-style: italic;
+		src: url('/fonts/GHGuardianHeadline-MediumItalic.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 600;
+		src: url('/fonts/GHGuardianHeadline-Semibold.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 600;
+		font-style: italic;
+		src: url('/fonts/GHGuardianHeadline-SemiboldItalic.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 700;
+		src: url('/fonts/GHGuardianHeadline-Bold.ttf');
+	}
+	@font-face {
+		font-family: 'GH Guardian Headline';
+		font-weight: 700;
+		font-style: italic;
+		src: url('/fonts/GHGuardianHeadline-BoldItalic.ttf');
+	}
 	body {
 		margin: 0;
 		font-family: 'Guardian Text Egyptian Web';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Reinstates fonts that we'd removed erroneously from common-rendering storybook `preview-head.html` file.

Storybook recommends fonts are specified here in order to preload them:  https://www.chromatic.com/docs/resource-loading#solution-a-preload-fonts
