### PR TITLE
Remove recipeEnhancer from enhanceBlocks

### DIFF
--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -8,7 +8,10 @@ import { enhanceH3s } from './enhance-H3s';
 import { enhanceImages } from './enhance-images';
 import { enhanceInteractiveContentsElements } from './enhance-interactive-contents-elements';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
-import { enhanceRecipes } from './enhance-recipes';
+/**
+ * Removing this enhancer temporarily because it's causing a bug in production
+ */
+// import { enhanceRecipes } from './enhance-recipes';
 import { enhanceTweets } from './enhance-tweets';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
 
@@ -86,10 +89,13 @@ class BlockEnhancer {
 		return this;
 	}
 
-	enhanceRecipes(isRecipe: boolean) {
-		if (isRecipe) this.blocks = enhanceRecipes(this.blocks);
-		return this;
-	}
+	/**
+	 * Removing this enhancer temporarily because it's causing a bug in production
+	 */
+	// enhanceRecipes(isRecipe: boolean) {
+	// 	if (isRecipe) this.blocks = enhanceRecipes(this.blocks);
+	// 	return this;
+	// }
 }
 
 type Options = {
@@ -107,17 +113,22 @@ export const enhanceBlocks = (
 ): Block[] => {
 	const { isRecipe = false, promotedNewsletter } = options ?? {};
 
-	return new BlockEnhancer(blocks, format, { isRecipe, promotedNewsletter })
-		.enhanceDividers()
-		.enhanceH3s()
-		.enhanceH2s()
-		.enhanceInteractiveContentsElements()
-		.enhanceBlockquotes()
-		.enhanceDots()
-		.enhanceImages()
-		.enhanceNumberedLists()
-		.enhanceEmbeds()
-		.enhanceTweets()
-		.enhanceRecipes(isRecipe)
-		.enhanceNewsletterSignup().blocks;
+	return (
+		new BlockEnhancer(blocks, format, { isRecipe, promotedNewsletter })
+			.enhanceDividers()
+			.enhanceH3s()
+			.enhanceH2s()
+			.enhanceInteractiveContentsElements()
+			.enhanceBlockquotes()
+			.enhanceDots()
+			.enhanceImages()
+			.enhanceNumberedLists()
+			.enhanceEmbeds()
+			.enhanceTweets()
+			/**
+			 * Removing this enhancer temporarily because it's causing a bug in production
+			 */
+			// .enhanceRecipes(isRecipe)
+			.enhanceNewsletterSignup().blocks
+	);
 };


### PR DESCRIPTION
The recipeEnhancer is causing a bug in production when it edits certain links in recipe pages:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/37048459/204811474-34a77fbe-7ba0-4348-9c17-60b5e43e102d.png">

Removing it from enhanceBlocks provides a quick fix, but the enhancer code should either be fixed or removed in future PRs, depending on plans for it moving forwards. The enhancer was introduced in #6562.

cc. @mxdvl @tkgnm 