### PR TITLE
Remove Chromatic workflow for composed storybook page

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -68,12 +68,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           autoAcceptChanges: main
           workingDir: dotcom-rendering
-
-      - name: Chromatic - DCR Repo All
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: storybooks
-          exitOnceUploaded: true
-          onlyChanged: '!(main)' # only turbosnap on non-main branches


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes the workflow config that pushes the composed storybook to chromatic. Removing this also removes confusion around having two chromatic instances with the same name `dotcom-rendering` and `dotcom_rendering`.

## Why?

The composed storybook is only useful locally currently, if we wish to host to we'll need to setup something similar to CSNX where we use gh pages to host the composed storybook, and AWS Amplify to host the individual storybooks.

Composing chromatic instances is, in our experience, so slow as to be unworkable.

