### PR TITLE
Header design amends

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-4/signedin.cy.js
@@ -9,6 +9,8 @@ const articleUrl =
 const profileResponse =
 	'{"status":"ok","userProfile":{"userId":"102309223","displayName":"Guardian User","webUrl":"https://profile.theguardian.com/user/id/102309223","apiUrl":"https://discussion.guardianapis.com/discussion-api/profile/102309223","avatar":"https://avatar.guim.co.uk/user/102309223","secureAvatarUrl":"https://avatar.guim.co.uk/user/102309223","badge":[],"privateFields":{"canPostComment":true,"isPremoderated":false,"hasCommented":false}}}';
 
+const idapiIdentifiersResponse = `{ "id": "000000000", "brazeUuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "puzzleUuid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "googleTagId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }`;
+
 describe('Signed in readers', function () {
 	beforeEach(function () {
 		disableCMP();
@@ -27,13 +29,15 @@ describe('Signed in readers', function () {
 			// this commercial error from failing this test
 			return false;
 		});
+		cy.intercept('GET', '**/user/me/identifiers', idapiIdentifiersResponse);
 		// Mock call to 'profile/me'
 		cy.intercept(
 			'GET',
 			'**/profile/me?strict_sanctions_check=false',
 			profileResponse,
-		);
+		).as('profileMe');
 		cy.visit(`Article?url=${articleUrl}`);
+		cy.wait('@profileMe');
 		// This text is shown in the header for signed in users
 		cy.contains('My account');
 	});

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -98,6 +98,11 @@ cypress: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")
 	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress run --browser chrome --spec "cypress/e2e/**/*"'
 
+cypress-open: export NODE_ENV=production
+cypress-open: clear clean-dist install build
+	$(call log, "starting frontend PROD server for Cypress")
+	@DISABLE_LOGGING_AND_METRICS=true start-server-and-test 'node dist/frontend.server.js' 9000 'cypress open --browser chrome'
+
 cypress-arm64: export NODE_ENV=production
 cypress-arm64: clear clean-dist install build
 	$(call log, "starting frontend PROD server for Cypress")

--- a/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.stories.tsx
@@ -28,22 +28,6 @@ export const defaultStory = () => {
 			contributionsServiceUrl="https://contributions.guardianapis.com"
 			idApiUrl="https://idapi.theguardian.com"
 		/>
-
-		/*
-		<Header
-			editionId={front.editionId}
-			idUrl={front.config.idUrl}
-			mmaUrl={front.config.mmaUrl}
-			supporterCTA={
-				front.nav.readerRevenueLinks.header.supporter
-			}
-			discussionApiUrl={front.config.discussionApiUrl}
-			urls={front.nav.readerRevenueLinks.header}
-			remoteHeader={!!front.config.switches.remoteHeader}
-			contributionsServiceUrl="https://contributions.guardianapis.com" // TODO: Pass this in
-			idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
-		/>
-		*/
 	);
 };
 defaultStory.story = { name: 'default' };

--- a/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
+++ b/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
@@ -33,7 +33,7 @@ export const HeaderSingleFrontDoor = ({
 	idApiUrl,
 }: Props) => (
 	<div css={headerStyles}>
-		<Island deferUntil="idle">
+		<Island>
 			<HeaderTopBar
 				editionId={editionId}
 				dataLinkName="nav3 : topbar : edition-picker: toggle"

--- a/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
@@ -32,7 +32,7 @@ const topBarStyles = css`
 		padding-left: 15px;
 	}
 	${from.desktop} {
-		height: 2.5rem;
+		height: 2.1875rem;
 		justify-content: flex-end;
 		padding-right: ${space[5]}px;
 	}

--- a/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { getCookie } from '@guardian/libs';
 import { brand, from, space } from '@guardian/source-foundations';
 import type { EditionId } from '../lib/edition';
 import { center } from '../lib/center';
@@ -48,6 +49,9 @@ export const HeaderTopBar = ({
 	discussionApiUrl,
 	idApiUrl,
 }: HeaderTopBarProps) => {
+	const isServer = typeof window === 'undefined';
+	const isSignedIn =
+		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
 	return (
 		<div
 			css={css`
@@ -61,6 +65,7 @@ export const HeaderTopBar = ({
 					idUrl={idUrl ?? 'https://profile.theguardian.com'}
 					discussionApiUrl={discussionApiUrl}
 					idApiUrl={idApiUrl}
+					isSignedIn={isSignedIn}
 				/>
 				<SearchJobs />
 

--- a/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
@@ -21,7 +21,7 @@ interface HeaderTopBarProps {
 
 const topBarStyles = css`
 	display: flex;
-	height: 1.9rem;
+	height: 30px;
 	background-color: ${brand[300]};
 	box-sizing: border-box;
 	padding-left: 10px;
@@ -32,7 +32,7 @@ const topBarStyles = css`
 		padding-left: 15px;
 	}
 	${from.desktop} {
-		height: 2.1875rem;
+		height: 35px;
 		justify-content: flex-end;
 		padding-right: ${space[5]}px;
 	}

--- a/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
@@ -1,0 +1,21 @@
+import { HeaderTopBar } from './HeaderTopBar.importable';
+
+export default {
+	component: HeaderTopBar,
+	title: 'Components/HeaderTopBar',
+};
+
+export const defaultStory = () => {
+	return (
+		<HeaderTopBar
+			editionId="UK"
+			dataLinkName="test"
+			idUrl="idurl"
+			mmaUrl="mmaUrl"
+			discussionApiUrl="discussionApiUrl"
+			idApiUrl="idApiUrl"
+		/>
+	);
+};
+
+defaultStory.story = { name: 'Header top bar signed out' };

--- a/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.stories.tsx
@@ -1,0 +1,16 @@
+import { HeaderTopBarEditionDropdown } from './HeaderTopBarEditionDropdown';
+
+export default {
+	component: HeaderTopBarEditionDropdown,
+	title: 'Components/HeaderTopBarEditionDropdown',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return <HeaderTopBarEditionDropdown editionId="UK" dataLinkName="test" />;
+};
+
+defaultStory.story = { name: 'default' };

--- a/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
@@ -65,19 +65,16 @@ export const HeaderTopBarEditionDropdown = ({
 
 	return (
 		<div css={editionDropdownStyles}>
-			<div
-				css={css`
-					padding-top: 7px;
+			<Dropdown
+				label={activeLink.title}
+				links={linksToDisplay}
+				id="edition"
+				dataLinkName={dataLinkName}
+				cssOverrides={css`
+					${dropDownOverrides};
+					padding-top: 6px;
 				`}
-			>
-				<Dropdown
-					label={activeLink.title}
-					links={linksToDisplay}
-					id="edition"
-					dataLinkName={dataLinkName}
-					cssOverrides={dropDownOverrides}
-				/>
-			</div>
+			/>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.stories.tsx
@@ -1,0 +1,41 @@
+import { MyAccount } from './HeaderTopBarMyAccount';
+
+export default {
+	component: MyAccount,
+	title: 'Components/MyAccount',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return (
+		<MyAccount
+			mmaUrl="mmaUrl"
+			idApiUrl="idApiUrl"
+			idUrl="idUrl"
+			discussionApiUrl="discussionApiUrl"
+		/>
+	);
+};
+
+defaultStory.story = {
+	name: 'not signed in',
+};
+
+export const signedInStory = () => {
+	return (
+		<MyAccount
+			mmaUrl="mmaUrl"
+			idApiUrl="idApiUrl"
+			idUrl="idUrl"
+			discussionApiUrl="discussionApiUrl"
+			isSignedIn={true}
+		/>
+	);
+};
+
+signedInStory.story = {
+	name: 'signed in',
+};

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
@@ -40,17 +40,23 @@ const myAccountStyles = css`
 
 const myAccountLinkStyles = css`
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	height: fit-content;
 	position: relative;
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSans.medium()};
+	font-size: 1rem;
+	line-height: 1;
 	color: ${neutral[100]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
 	padding: 0;
 
 	${from.tablet} {
-		padding: 7px 10px 0 5px;
+		padding: 7px 10px 7px 6px;
+	}
+
+	${from.desktop} {
+		font-weight: bold;
 	}
 
 	:hover,
@@ -63,7 +69,7 @@ const myAccountLinkStyles = css`
 		float: left;
 		height: 18px;
 		width: 18px;
-		margin: 3px 4px 0 0;
+		margin: 0 4px 0 0;
 	}
 	${getZIndex('myAccountDropdown')}
 `;
@@ -141,7 +147,7 @@ export const dropDownOverrides = css`
 	color: ${neutral[100]};
 	padding-right: 0;
 
-	font-weight: bold;
+	font-size: 1rem;
 
 	&:not(ul):hover {
 		color: ${neutral[100]};
@@ -150,6 +156,10 @@ export const dropDownOverrides = css`
 
 	${from.tablet} {
 		right: 0;
+	}
+
+	${from.desktop} {
+		font-weight: bold;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarMyAccount.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { getCookie, joinUrl } from '@guardian/libs';
+import { joinUrl } from '@guardian/libs';
 import { brand, from, neutral, textSans } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
@@ -20,10 +20,15 @@ interface MyAccountProps {
 	idUrl: string;
 	discussionApiUrl: string;
 	idApiUrl: string;
+	isSignedIn?: boolean;
 }
 
 const myAccountStyles = css`
 	display: flex;
+	align-items: center;
+	${from.tablet} {
+		align-items: stretch;
+	}
 	${from.desktop} {
 		:before {
 			content: '';
@@ -42,7 +47,7 @@ const myAccountLinkStyles = css`
 	color: ${neutral[100]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
-	padding: 7px 0;
+	padding: 0;
 
 	${from.tablet} {
 		padding: 7px 10px 0 5px;
@@ -201,11 +206,13 @@ const SignedInWithNotifications = ({
 const SignedIn = ({ idApiUrl, ...props }: MyAccountProps) => {
 	const { brazeCards } = useBraze(idApiUrl);
 	const [notifications, setNotifications] = useState<Notification[]>([]);
-
 	useEffect(() => {
 		if (brazeCards) {
 			const cards = brazeCards.getCardsForProfileBadge();
-			setNotifications(mapBrazeCardsToNotifications(cards));
+			const cardsToNotifications = mapBrazeCardsToNotifications(cards);
+			if (cardsToNotifications.length) {
+				setNotifications(cardsToNotifications);
+			}
 		}
 	}, [brazeCards]);
 
@@ -219,23 +226,18 @@ export const MyAccount = ({
 	idUrl,
 	discussionApiUrl,
 	idApiUrl,
-}: MyAccountProps) => {
-	const isServer = typeof window === 'undefined';
-	const isSignedIn =
-		!isServer && !!getCookie({ name: 'GU_U', shouldMemoize: true });
-
-	return (
-		<div css={myAccountStyles}>
-			{isSignedIn ? (
-				<SignedIn
-					mmaUrl={mmaUrl}
-					idUrl={idUrl}
-					discussionApiUrl={discussionApiUrl}
-					idApiUrl={idApiUrl}
-				/>
-			) : (
-				<SignIn idUrl={idUrl} />
-			)}
-		</div>
-	);
-};
+	isSignedIn,
+}: MyAccountProps) => (
+	<div css={myAccountStyles}>
+		{isSignedIn ? (
+			<SignedIn
+				mmaUrl={mmaUrl}
+				idUrl={idUrl}
+				discussionApiUrl={discussionApiUrl}
+				idApiUrl={idApiUrl}
+			/>
+		) : (
+			<SignIn idUrl={idUrl} />
+		)}
+	</div>
+);

--- a/dotcom-rendering/src/web/components/HeaderTopBarPrintSubscriptions.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarPrintSubscriptions.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
-import { brand, brandAlt, from, textSans } from '@guardian/source-foundations';
+import { brandAlt, from, textSans } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import NewspaperIcon from '../../static/icons/newspaper.svg';
-import type { EditionId } from '../lib/edition';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
+import type { EditionId } from '../lib/edition';
 
 interface PrintSubscriptionsProps {
 	editionId: EditionId;
@@ -12,26 +12,25 @@ interface PrintSubscriptionsProps {
 const printSubscriptionStyles = css`
 	display: none;
 
-	:before {
-		content: '';
-		border-left: 1px solid ${brand[600]};
-		height: 24px;
-	}
-
 	${from.desktop} {
 		display: flex;
 	}
 `;
 
 const linkStyles = css`
+	display: flex;
+	align-items: center;
 	${textSans.medium({ fontWeight: 'bold' })};
+	font-size: 1rem;
+	height: fit-content;
+	line-height: 1;
 	color: ${brandAlt[400]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
 	padding: 7px 0;
 
 	${from.tablet} {
-		padding: 7px 10px 7px 5px;
+		padding: 7px 10px 7px 6px;
 	}
 
 	:hover,
@@ -44,7 +43,7 @@ const linkStyles = css`
 		float: left;
 		height: 18px;
 		width: 18px;
-		margin: 3px 4px 0 0;
+		margin: 0 4px 0 0;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/HeaderTopBarSearch.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarSearch.stories.tsx
@@ -1,0 +1,16 @@
+import { Search } from './HeaderTopBarSearch';
+
+export default {
+	component: Search,
+	title: 'Components/HeaderTopBarSearch',
+	parameters: {
+		backgrounds: { default: 'dark' },
+		layout: 'centered',
+	},
+};
+
+export const defaultStory = () => {
+	return <Search href="" dataLinkName="" />;
+};
+
+defaultStory.story = { name: 'Header top bar search' };

--- a/dotcom-rendering/src/web/components/HeaderTopBarSearch.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarSearch.tsx
@@ -9,14 +9,19 @@ interface SearchProps {
 }
 
 const searchLinkStyles = css`
+	display: flex;
+	align-items: center;
 	${textSans.medium({ fontWeight: 'bold' })};
+	line-height: 1;
+	font-size: 1rem;
+	height: fit-content;
 	color: ${neutral[100]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
 	padding: 7px 0;
 
 	${from.tablet} {
-		padding: 7px 10px 7px 5px;
+		padding: 7px 10px 7px 6px;
 	}
 
 	:hover,
@@ -29,7 +34,7 @@ const searchLinkStyles = css`
 		float: left;
 		height: 18px;
 		width: 18px;
-		margin: 3px 4px 0 0;
+		margin: 0 4px 0 0;
 	}
 	${getZIndex('searchHeaderLink')}
 `;

--- a/dotcom-rendering/src/web/components/HeaderTopBarSearchJobs.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarSearchJobs.tsx
@@ -3,13 +3,15 @@ import { brand, from, neutral, textSans } from '@guardian/source-foundations';
 
 const searchLinkStyles = css`
 	${textSans.medium({ fontWeight: 'bold' })};
+	font-size: 1rem;
+	line-height: 1;
 	color: ${neutral[100]};
 	transition: color 80ms ease-out;
 	text-decoration: none;
 	padding: 7px 0;
 
 	${from.tablet} {
-		padding: 7px 10px 7px 5px;
+		padding: 8px 10px 7px 6px;
 	}
 
 	:hover,

--- a/dotcom-rendering/src/web/components/Logo.tsx
+++ b/dotcom-rendering/src/web/components/Logo.tsx
@@ -15,7 +15,7 @@ import { getZIndex } from '../lib/getZIndex';
 
 const linkStyles = css`
 	float: right;
-	margin-top: 10px;
+	margin-top: 6px;
 	margin-right: 54px;
 	margin-bottom: 10px;
 	width: 146px;
@@ -28,7 +28,6 @@ const linkStyles = css`
 		margin-right: 20px;
 	}
 	${from.tablet} {
-		margin-top: 8px;
 		width: 224px;
 	}
 	${from.desktop} {

--- a/dotcom-rendering/src/web/lib/mockRESTCalls.ts
+++ b/dotcom-rendering/src/web/lib/mockRESTCalls.ts
@@ -262,5 +262,32 @@ export const mockRESTCalls = (): void => {
 				body: matchReport,
 			},
 			{ overwriteRoutes: false },
+		)
+
+		// Get user discussion api (used for myAccount dropdown)
+		.get(
+			/discussionApiUrl\/profile\/me\?strict_sanctions_check=false/,
+			{
+				status: 200,
+				body: {
+					status: 'ok',
+					userProfile: {
+						userId: '123',
+						displayName: 'Guardian User',
+						webUrl: 'https://profile.test-theguardian.com/user/id/123',
+						apiUrl: 'http://discussion.test-guardianapis.com/discussion-api/profile/123',
+						avatar: 'https://avatar.test-guimcode.co.uk/user/123',
+						secureAvatarUrl:
+							'https://avatar.test-guimcode.co.uk/user/123',
+						badge: [],
+						privateFields: {
+							canPostComment: true,
+							isPremoderated: false,
+							hasCommented: false,
+						},
+					},
+				},
+			},
+			{ overwriteRoutes: false },
 		);
 };


### PR DESCRIPTION
## What does this change?
Design amends following the release of the new header.

## Screenshots

### vertical centering and font weight at mobile breakpoint
| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/2510683/204565406-c7cdc9b2-8543-4e38-a42d-4f6904637f3d.png) | ![after](https://user-images.githubusercontent.com/2510683/204783256-ab55f40a-4099-4f4e-b49a-022928e1bef6.png) |

### various desktop amends
<img width="968" alt="Screenshot 2022-11-30 at 11 22 04" src="https://user-images.githubusercontent.com/2510683/204833180-0fce469d-f1f4-4740-a96a-ab5d84510ac6.png">