### PR TITLE
Up node memory limit from 2G to 8G for dev server

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -81,12 +81,12 @@ run-ci: stop build-ci start-ci
 
 # dev #########################################
 
-dev: export NODE_ENV=development
+dev: export NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8192'
 dev: clear clean-dist install
 	$(call log, "starting DEV server")
 	@SKIP_LEGACY=true webpack serve --config ./scripts/webpack/webpack.config.js
 
-dev-legacy: export NODE_ENV=development
+dev-legacy: export NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8192'
 dev-legacy: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./scripts/webpack/webpack.config.js


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
