### PR TITLE
Remove static path from common rendering storybook script

### DIFF
--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "@guardian/common-rendering",
-  "version": "1.0.0",
-  "license": "Apache-2.0",
-  "scripts": {
-    "test": "jest",
-    "storybook": "start-storybook -p 4001 --static-dir ../dotcom-rendering/src/static",
-    "build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook"
-  },
-  "dependencies": {
-    "@babel/core": "^7.0.0",
-    "@emotion/react": "^11.4.1",
-    "@guardian/libs": "^9.0.1",
-    "@guardian/source-foundations": "^7.0.1",
-    "@guardian/source-react-components": "^9.0.0",
-    "@guardian/types": "^9.0.1",
-    "babel-loader": "^8.2.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
-  },
-  "devDependencies": {
-    "@emotion/jest": "^11.3.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/addon-knobs": "^6.4.0",
-    "@storybook/addons": "^6.4.0",
-    "@storybook/api": "^6.4.0",
-    "@storybook/builder-webpack5": "^6.4.0",
-    "@storybook/components": "^6.4.0",
-    "@storybook/core-events": "^6.4.0",
-    "@storybook/manager-webpack5": "^6.4.0",
-    "@storybook/react": "^6.4.0",
-    "@storybook/theming": "^6.4.0",
-    "@types/jest": "^27.4.0",
-    "@types/react-test-renderer": "^17.0.1",
-    "jest": "^26.6.3",
-    "react-test-renderer": "^17.0.1",
-    "require-from-string": "^2.0.2",
-    "ts-jest": "^26.5.3",
-    "tslib": "^2.4.0"
-  },
-  "jest": {
-    "preset": "ts-jest/presets/js-with-ts",
-    "transformIgnorePatterns": [
-      "node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
-    ]
-  }
+	"name": "@guardian/common-rendering",
+	"version": "1.0.0",
+	"license": "Apache-2.0",
+	"scripts": {
+		"test": "jest",
+		"storybook": "start-storybook -p 4001",
+		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook"
+	},
+	"dependencies": {
+		"@babel/core": "^7.0.0",
+		"@emotion/react": "^11.4.1",
+		"@guardian/libs": "^9.0.1",
+		"@guardian/source-foundations": "^7.0.1",
+		"@guardian/source-react-components": "^9.0.0",
+		"@guardian/types": "^9.0.1",
+		"babel-loader": "^8.2.5",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2"
+	},
+	"devDependencies": {
+		"@emotion/jest": "^11.3.0",
+		"@storybook/addon-essentials": "^6.4.0",
+		"@storybook/addon-knobs": "^6.4.0",
+		"@storybook/addons": "^6.4.0",
+		"@storybook/api": "^6.4.0",
+		"@storybook/builder-webpack5": "^6.4.0",
+		"@storybook/components": "^6.4.0",
+		"@storybook/core-events": "^6.4.0",
+		"@storybook/manager-webpack5": "^6.4.0",
+		"@storybook/react": "^6.4.0",
+		"@storybook/theming": "^6.4.0",
+		"@types/jest": "^27.4.0",
+		"@types/react-test-renderer": "^17.0.1",
+		"jest": "^26.6.3",
+		"react-test-renderer": "^17.0.1",
+		"require-from-string": "^2.0.2",
+		"ts-jest": "^26.5.3",
+		"tslib": "^2.4.0"
+	},
+	"jest": {
+		"preset": "ts-jest/presets/js-with-ts",
+		"transformIgnorePatterns": [
+			"node_modules/(?!(@guardian/source-foundations|@guardian/types|@guardian/libs)/)"
+		]
+	}
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes the `--static-dir` path from the Common Rendering Storybook script.

## Why?

If we are to separate the projects at a later date, we don't want to rely on serving assets from another project. 

