### PR TITLE
Fix Express production server error handler

### DIFF
--- a/dotcom-rendering/src/server/prod-server.ts
+++ b/dotcom-rendering/src/server/prod-server.ts
@@ -116,7 +116,10 @@ export const prodServer = (): void => {
 		}
 	});
 
-	const handleError: ErrorRequestHandler = (e, _, res) => {
+	// All params to error handlers must be declared for express to identify them as error middleware
+	// https://expressjs.com/en/api.html#:~:text=Error%2Dhandling%20middleware%20always,see%3A%20Error%20handling
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- all params to error handlers must be declared
+	const handleError: ErrorRequestHandler = (e, _req, res, _next) => {
 		const message =
 			e instanceof Error ? e.stack ?? 'Unknown stack' : 'Unknown error';
 		res.status(500).send(`<pre>${message}</pre>`);


### PR DESCRIPTION
## What does this change?

When running a prod build and Cypress tests locally I noticed the following repeated error in the server terminal output:

```
TypeError: res.status is not a function
    at handleError (/Users/[user]/code/dotcom-rendering/dotcom-rendering/dist/frontend.server.js:10400:256)
    at Layer.handle [as handle_request] (/Users/[user]/code/dotcom-rendering/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/[user]/code/dotcom-rendering/node_modules/express/lib/router/index.js:323:13)
    at /Users/[user]/code/dotcom-rendering/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Users/[user]/code/dotcom-rendering/node_modules/express/lib/router/index.js:341:12)
    at next (/Users/[user]/code/dotcom-rendering/node_modules/express/lib/router/index.js:275:10)
    at SendStream.error (/Users/[user]/code/dotcom-rendering/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (events.js:400:28)
    at SendStream.error (/Users/[user]/code/dotcom-rendering/node_modules/send/index.js:270:17)
    at SendStream.onStatError (/Users/[user]/code/dotcom-rendering/node_modules/send/index.js:421:12)
```

This is caused by not declaring all parameters to the `handleError` function in `prod-server.ts` which means Express will not recognise the function as an error handler as per the docs:

https://expressjs.com/en/api.html#:~:text=Error%2Dhandling%20middleware%20always,see%3A%20Error%20handling

## Why

- fix production error handling
- potentially consuming memory / disk logs in production.



