### PR TITLE
Ad labels refactor

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -203,18 +203,17 @@ const mobileStickyAdStyles = css`
 		stroke-width: 2;
 		text-align: center;
 	}
-	.ad-slot__label {
-		font-size: 0.75rem;
-		line-height: 1.25rem;
+	.ad-slot:not[data-label-show='true']::before {
+		content: '';
+		display: block;
+		height: ${labelHeight}px;
+		visibility: hidden;
+	}
+	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
+		content: 'Advertisement';
+		display: block;
 		position: relative;
-		height: 1.5rem;
-		background-color: ${neutral[97]};
-		padding: 0 0.5rem;
-		border-top: 0.0625rem solid ${border.secondary};
-		color: ${neutral[60]};
-		text-align: left;
-		box-sizing: border-box;
-		${textSans.xxsmall()};
+		${adSlotLabelStyles}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -80,6 +80,16 @@ export const labelStyles = css`
 		position: relative;
 		${adSlotLabelStyles}
 	}
+
+	.ad-slot__adtest-cookie-clear-link {
+		${textSans.xxsmall()};
+		text-align: left;
+		position: absolute;
+		right: 3px;
+		top: -22px;
+		padding: 0;
+		border: 0;
+	}
 `;
 
 export const adCollapseStyles = css`

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -209,7 +209,7 @@ const mobileStickyAdStyles = css`
 		height: ${labelHeight}px;
 		visibility: hidden;
 	}
-	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
+	.ad-slot[data-label-show='true']::before {
 		content: 'Advertisement';
 		display: block;
 		position: relative;

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -9,6 +9,7 @@ import {
 	space,
 	text,
 	textSans,
+	until,
 } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { Island } from './Island';
@@ -56,6 +57,23 @@ const outOfPageStyles = css`
 `;
 
 export const labelStyles = css`
+	.ad-slot__label,
+	.ad-slot__scroll {
+		${adSlotLabelStyles}
+		position: relative;
+		&.visible {
+			visibility: initial;
+		}
+		&.hidden {
+			visibility: hidden;
+		}
+		&.ad-slot__label--toggle {
+			margin: 0 auto;
+			${until.tablet} {
+				display: none;
+			}
+		}
+	}
 	.ad-slot__close-button {
 		display: none;
 	}
@@ -203,7 +221,7 @@ const mobileStickyAdStyles = css`
 		stroke-width: 0;
 		text-align: center;
 	}
-	.ad-slot--mobile-sticky .ad-slot__close-button {
+	.ad-slot--mobile-sticky .ad-slot__label .ad-slot__close-button {
 		display: block;
 	}
 	.ad-slot__close-button__x {
@@ -213,6 +231,21 @@ const mobileStickyAdStyles = css`
 		stroke-width: 2;
 		text-align: center;
 	}
+
+	.ad-slot__label {
+		font-size: 0.75rem;
+		line-height: 1.25rem;
+		position: relative;
+		height: 1.5rem;
+		background-color: ${neutral[97]};
+		padding: 0 0.5rem;
+		border-top: 0.0625rem solid ${border.secondary};
+		color: ${neutral[60]};
+		text-align: left;
+		box-sizing: border-box;
+		${textSans.xxsmall()};
+	}
+
 	.ad-slot:not[data-label-show='true']::before {
 		content: '';
 		display: block;

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -39,7 +39,7 @@ type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
-const adSlotLabelStyles = css`
+export const adSlotLabelStyles = css`
 	${textSans.xxsmall()};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -75,7 +75,7 @@ export const labelStyles = css`
 	}
 
 	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
-		content: 'Advertisement';
+		content: attr(ad-label-text);
 		display: block;
 		position: relative;
 		${adSlotLabelStyles}

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -177,7 +177,7 @@ const mobileStickyAdStyles = css`
 		display: none;
 		position: absolute;
 		right: 3px;
-		top: 3px;
+		top: -21px;
 		padding: 0;
 		border: 0;
 		height: 21px;

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -40,7 +40,7 @@ type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
-export const adSlotLabelStyles = css`
+export const individualLabelCSS = css`
 	${textSans.xxsmall()};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
@@ -59,7 +59,7 @@ const outOfPageStyles = css`
 export const labelStyles = css`
 	.ad-slot__label,
 	.ad-slot__scroll {
-		${adSlotLabelStyles}
+		${individualLabelCSS}
 		position: relative;
 		&.visible {
 			visibility: initial;
@@ -82,7 +82,7 @@ export const labelStyles = css`
 		position: fixed;
 		bottom: 0;
 		width: 100%;
-		${adSlotLabelStyles}
+		${individualLabelCSS}
 	}
 
 	.ad-slot:not[data-label-show='true']::before {
@@ -96,7 +96,7 @@ export const labelStyles = css`
 		content: attr(ad-label-text);
 		display: block;
 		position: relative;
-		${adSlotLabelStyles}
+		${individualLabelCSS}
 	}
 
 	.ad-slot__adtest-cookie-clear-link {
@@ -256,7 +256,7 @@ const mobileStickyAdStyles = css`
 		content: 'Advertisement';
 		display: block;
 		position: relative;
-		${adSlotLabelStyles}
+		${individualLabelCSS}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -39,6 +39,18 @@ type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
+const adSlotLabelStyles = css`
+	${textSans.xxsmall()};
+	height: ${labelHeight}px;
+	max-height: ${labelHeight}px;
+	background-color: ${neutral[97]};
+	padding: 0 8px;
+	border-top: 1px solid ${border.secondary};
+	color: ${text.supporting};
+	text-align: left;
+	box-sizing: border-box;
+`;
+
 const outOfPageStyles = css`
 	height: 0;
 `;
@@ -52,6 +64,7 @@ export const labelStyles = css`
 		position: fixed;
 		bottom: 0;
 		width: 100%;
+		${adSlotLabelStyles}
 	}
 
 	.ad-slot:not[data-label-show='true']::before {
@@ -61,19 +74,11 @@ export const labelStyles = css`
 		visibility: hidden;
 	}
 
-	.ad-slot[data-label-show='true']::before {
+	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
 		content: 'Advertisement';
-		${textSans.xxsmall()};
-		position: relative;
-		height: ${labelHeight}px;
-		max-height: ${labelHeight}px;
-		background-color: ${neutral[97]};
-		padding: 0 8px;
-		border-top: 1px solid ${border.secondary};
-		color: ${text.supporting};
-		text-align: left;
-		box-sizing: border-box;
 		display: block;
+		position: relative;
+		${adSlotLabelStyles}
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -193,7 +193,7 @@ const mobileStickyAdStyles = css`
 		stroke-width: 0;
 		text-align: center;
 	}
-	.ad-slot--mobile-sticky .ad-slot__label .ad-slot__close-button {
+	.ad-slot--mobile-sticky .ad-slot__close-button {
 		display: block;
 	}
 	.ad-slot__close-button__x {

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -9,7 +9,6 @@ import {
 	space,
 	text,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { Island } from './Island';
@@ -40,41 +39,11 @@ type Props = InlineProps | NonInlineProps;
 
 export const labelHeight = 24;
 
-const adSlotLabelStyles = css`
-	${textSans.xxsmall()};
-	position: relative;
-	height: ${labelHeight}px;
-	max-height: ${labelHeight}px;
-	background-color: ${neutral[97]};
-	padding: 0 8px;
-	border-top: 1px solid ${border.secondary};
-	color: ${text.supporting};
-	text-align: left;
-	box-sizing: border-box;
-	&.visible {
-		visibility: initial;
-	}
-	&.hidden {
-		visibility: hidden;
-	}
-	&.ad-slot__label--toggle {
-		margin: 0 auto;
-		${until.tablet} {
-			display: none;
-		}
-	}
-`;
-
 const outOfPageStyles = css`
 	height: 0;
 `;
 
 export const labelStyles = css`
-	.ad-slot__label,
-	.ad-slot__scroll {
-		${adSlotLabelStyles}
-	}
-
 	.ad-slot__close-button {
 		display: none;
 	}
@@ -83,6 +52,28 @@ export const labelStyles = css`
 		position: fixed;
 		bottom: 0;
 		width: 100%;
+	}
+
+	.ad-slot:not[data-label-show='true']::before {
+		content: '';
+		display: block;
+		height: ${labelHeight}px;
+		visibility: hidden;
+	}
+
+	.ad-slot[data-label-show='true']::before {
+		content: 'Advertisement';
+		${textSans.xxsmall()};
+		position: relative;
+		height: ${labelHeight}px;
+		max-height: ${labelHeight}px;
+		background-color: ${neutral[97]};
+		padding: 0 8px;
+		border-top: 1px solid ${border.secondary};
+		color: ${text.supporting};
+		text-align: left;
+		box-sizing: border-box;
+		display: block;
 	}
 `;
 
@@ -224,17 +215,6 @@ const mobileStickyAdStyles = css`
 
 const adStyles = [labelStyles, fluidAdStyles];
 
-const AdSlotLabelToggled = () => (
-	<div
-		className={['ad-slot__label', 'ad-slot__label--toggle', 'hidden'].join(
-			' ',
-		)}
-		css={adSlotLabelStyles}
-	>
-		Advertisement
-	</div>
-);
-
 export const AdSlot = ({
 	position,
 	display,
@@ -248,21 +228,23 @@ export const AdSlot = ({
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div
-							id="dfp-ad--right"
-							className={[
-								'js-ad-slot',
-								'ad-slot',
-								'ad-slot--right',
-								'ad-slot--mpu-banner-ad',
-								'ad-slot--rendered',
-								'js-sticky-mpu',
-							].join(' ')}
-							css={adStyles}
-							data-link-name="ad slot right"
-							data-name="right"
-							aria-hidden="true"
-						/>
+						<div css={[adStyles]}>
+							<div
+								id="dfp-ad--right"
+								className={[
+									'js-ad-slot',
+									'ad-slot',
+									'ad-slot--right',
+									'ad-slot--mpu-banner-ad',
+									'ad-slot--rendered',
+									'js-sticky-mpu',
+								].join(' ')}
+								css={adStyles}
+								data-link-name="ad slot right"
+								data-name="right"
+								aria-hidden="true"
+							/>
+						</div>
 					);
 				}
 				case ArticleDisplay.Standard: {
@@ -281,10 +263,13 @@ export const AdSlot = ({
 		case 'comments': {
 			return (
 				<div
-					css={css`
-						position: static;
-						height: 100%;
-					`}
+					css={[
+						css`
+							position: static;
+							height: 100%;
+						`,
+						adStyles,
+					]}
 				>
 					<div
 						id="dfp-ad--comments"
@@ -321,42 +306,40 @@ export const AdSlot = ({
 				min-width: 728px;
 			`;
 			return (
-				<>
-					<div
-						id="dfp-ad--top-above-nav"
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							'ad-slot--top-above-nav',
-							'ad-slot--mpu-banner-ad',
-							'ad-slot--rendered',
-						].join(' ')}
-						css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
-						data-link-name="ad slot top-above-nav"
-						data-name="top-above-nav"
-						aria-hidden="true"
-					>
-						<AdSlotLabelToggled />
-					</div>
-				</>
+				<div
+					id="dfp-ad--top-above-nav"
+					className={[
+						'js-ad-slot',
+						'ad-slot',
+						'ad-slot--top-above-nav',
+						'ad-slot--mpu-banner-ad',
+						'ad-slot--rendered',
+					].join(' ')}
+					css={[adStyles, fluidFullWidthAdStyles, adSlotAboveNav]}
+					data-link-name="ad slot top-above-nav"
+					data-name="top-above-nav"
+					aria-hidden="true"
+				></div>
 			);
 		}
 		case 'mostpop': {
 			return (
-				<div
-					id="dfp-ad--mostpop"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--mostpop',
-						'ad-slot--mpu-banner-ad',
-						'ad-slot--rendered',
-					].join(' ')}
-					css={[adStyles, mostPopAdStyles]}
-					data-link-name="ad slot mostpop"
-					data-name="mostpop"
-					aria-hidden="true"
-				/>
+				<div css={[adStyles]}>
+					<div
+						id="dfp-ad--mostpop"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--mostpop',
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[adStyles, mostPopAdStyles]}
+						data-link-name="ad slot mostpop"
+						data-name="mostpop"
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'merchandising-high': {

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -3,8 +3,8 @@ import { adSizes } from '@guardian/commercial-core';
 import { ArticleDesign } from '@guardian/libs';
 import { from, neutral, space, until } from '@guardian/source-foundations';
 import {
-	adSlotLabelStyles,
 	carrotAdStyles,
+	individualLabelCSS,
 	labelHeight,
 	labelStyles,
 } from './AdSlot';
@@ -123,7 +123,7 @@ const adStyles = css`
 			right: 0px;
 			border: 0;
 			display: block;
-			${adSlotLabelStyles}
+			${individualLabelCSS}
 		}
 
 		/* liveblogs ads have different background colours due the darker page background */

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -1,16 +1,13 @@
 import { css } from '@emotion/react';
 import { adSizes } from '@guardian/commercial-core';
 import { ArticleDesign } from '@guardian/libs';
+import { from, neutral, space, until } from '@guardian/source-foundations';
 import {
-	border,
-	from,
-	neutral,
-	space,
-	text,
-	textSans,
-	until,
-} from '@guardian/source-foundations';
-import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
+	adSlotLabelStyles,
+	carrotAdStyles,
+	labelHeight,
+	labelStyles,
+} from './AdSlot';
 
 type Props = {
 	format: ArticleFormat;
@@ -124,17 +121,9 @@ const adStyles = css`
 			top: 0px;
 			left: 0px;
 			right: 0px;
-			${textSans.xxsmall()};
-			height: ${labelHeight}px;
-			max-height: ${labelHeight}px;
-			background-color: ${neutral[97]};
-			padding: 0 8px;
 			border: 0;
-			border-top: 1px solid ${border.secondary};
-			color: ${text.supporting};
-			text-align: left;
-			box-sizing: border-box;
 			display: block;
+			${adSlotLabelStyles}
 		}
 
 		/* liveblogs ads have different background colours due the darker page background */

--- a/dotcom-rendering/src/web/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/web/components/ArticleContainer.tsx
@@ -1,7 +1,15 @@
 import { css } from '@emotion/react';
 import { adSizes } from '@guardian/commercial-core';
 import { ArticleDesign } from '@guardian/libs';
-import { from, neutral, space, until } from '@guardian/source-foundations';
+import {
+	border,
+	from,
+	neutral,
+	space,
+	text,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
 import { carrotAdStyles, labelHeight, labelStyles } from './AdSlot';
 
 type Props = {
@@ -110,6 +118,25 @@ const adStyles = css`
 			}
 		}
 
+		.ad-slot--interscroller[data-label-show='true']::before {
+			content: 'Advertisement';
+			position: absolute;
+			top: 0px;
+			left: 0px;
+			right: 0px;
+			${textSans.xxsmall()};
+			height: ${labelHeight}px;
+			max-height: ${labelHeight}px;
+			background-color: ${neutral[97]};
+			padding: 0 8px;
+			border: 0;
+			border-top: 1px solid ${border.secondary};
+			color: ${text.supporting};
+			text-align: left;
+			box-sizing: border-box;
+			display: block;
+		}
+
 		/* liveblogs ads have different background colours due the darker page background */
 		.ad-slot--liveblog-inline {
 			/* outstreamMobile is the ad with the smallest height that we serve for mobile
@@ -120,10 +147,6 @@ const adStyles = css`
 			}
 
 			background-color: ${neutral[93]};
-			.ad-slot__label {
-				color: ${neutral[46]};
-				border-top-color: ${neutral[86]};
-			}
 		}
 	}
 

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -2,7 +2,7 @@ import { css, Global } from '@emotion/react';
 import { TOP_ABOVE_NAV_HEIGHT } from '@guardian/commercial-core/dist/esm/constants';
 import type { ArticleDisplay } from '@guardian/libs';
 import { border, neutral, space } from '@guardian/source-foundations';
-import { AdSlot, labelHeight } from './AdSlot';
+import { AdSlot, labelHeight, labelStyles } from './AdSlot';
 import { Hide } from './Hide';
 
 type Props = {
@@ -57,7 +57,10 @@ export const HeaderAdSlot = ({ display }: Props) => (
 			`}
 		/>
 		<Hide when="below" breakpoint="tablet">
-			<div css={[headerAdWrapper]} className="top-banner-ad-container">
+			<div
+				css={[headerAdWrapper, labelStyles]}
+				className="top-banner-ad-container"
+			>
 				<AdSlot position="top-above-nav" display={display} />
 			</div>
 		</Hide>

--- a/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
+++ b/dotcom-rendering/src/web/components/TopRightAdSlot.importable.tsx
@@ -19,10 +19,13 @@ export const TopRightAdSlot = ({
 	return (
 		<div
 			id="top-right-ad-slot"
-			css={css`
-				position: static;
-				height: ${MOSTVIEWED_STICKY_HEIGHT}px;
-			`}
+			css={[
+				css`
+					position: static;
+					height: ${MOSTVIEWED_STICKY_HEIGHT}px;
+				`,
+				adStyles,
+			]}
 		>
 			<div
 				id="dfp-ad--right"


### PR DESCRIPTION
## What does this change?
Supports the change to the ad label rendering in frontend. Adds new styles to the ad slots in DCR to use CSS pseudo :before elements to display ad labels.

## Why?
Currently the ad label rendering logic has a few edge cases and creates divs for the ad labels. Some need to be toggled on and off, with different styling in different places. This change to the ad label rendering moves the logic to the stylesheet, and reduces code complexity.

Note: In this PR, I've kept some of the old styling so that when we deploy this PR, there is minimal disruption to the site while we wait for the corresponding update to frontend to deploy to the live site. These styles can then be removed in a later PR.