### PR TITLE
feat: add HeaderTopBarSearchCapi

### DIFF
--- a/dotcom-rendering/src/web/components/Header.tsx
+++ b/dotcom-rendering/src/web/components/Header.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { brand } from '@guardian/source-foundations';
-import type { EditionId } from '../lib/edition';
 import { center } from '../lib/center';
+import type { EditionId } from '../lib/edition';
 import { EditionDropdown } from './EditionDropdown.importable';
 import { HeaderSingleFrontDoor } from './HeaderSingleFrontDoor';
 import { Hide } from './Hide';
@@ -33,6 +33,7 @@ type Props = {
 	idApiUrl: string;
 	headerTopBarSwitch: boolean;
 	isInEuropeTest: boolean;
+	headerTopBarSearchCapiSwitch: boolean;
 };
 
 export const Header = ({
@@ -47,6 +48,7 @@ export const Header = ({
 	idApiUrl,
 	isInEuropeTest,
 	headerTopBarSwitch,
+	headerTopBarSearchCapiSwitch,
 }: Props) => {
 	return headerTopBarSwitch ? (
 		<HeaderSingleFrontDoor
@@ -58,6 +60,7 @@ export const Header = ({
 			remoteHeader={remoteHeader}
 			contributionsServiceUrl={contributionsServiceUrl}
 			idApiUrl={idApiUrl}
+			headerTopBarSearchCapiSwitch={headerTopBarSearchCapiSwitch}
 		/>
 	) : (
 		<div css={center}>

--- a/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.stories.tsx
@@ -27,6 +27,7 @@ export const defaultStory = () => {
 			remoteHeader={false}
 			contributionsServiceUrl="https://contributions.guardianapis.com"
 			idApiUrl="https://idapi.theguardian.com"
+			headerTopBarSearchCapiSwitch={false}
 		/>
 
 		/*

--- a/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
+++ b/dotcom-rendering/src/web/components/HeaderSingleFrontDoor.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { brand } from '@guardian/source-foundations';
-import type { EditionId } from '../lib/edition';
 import { center } from '../lib/center';
+import type { EditionId } from '../lib/edition';
 import { HeaderTopBar } from './HeaderTopBar.importable';
 import { Island } from './Island';
 import { Logo } from './Logo';
@@ -20,6 +20,7 @@ type Props = {
 	remoteHeader: boolean;
 	contributionsServiceUrl: string;
 	idApiUrl: string;
+	headerTopBarSearchCapiSwitch: boolean;
 };
 
 export const HeaderSingleFrontDoor = ({
@@ -31,6 +32,7 @@ export const HeaderSingleFrontDoor = ({
 	remoteHeader,
 	contributionsServiceUrl,
 	idApiUrl,
+	headerTopBarSearchCapiSwitch,
 }: Props) => (
 	<div css={headerStyles}>
 		<Island deferUntil="idle">
@@ -41,6 +43,7 @@ export const HeaderSingleFrontDoor = ({
 				mmaUrl={mmaUrl}
 				discussionApiUrl={discussionApiUrl}
 				idApiUrl={idApiUrl}
+				headerTopBarSearchCapiSwitch={headerTopBarSearchCapiSwitch}
 			/>
 		</Island>
 		<div

--- a/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.importable.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/react';
 import { brand, from, space } from '@guardian/source-foundations';
-import type { EditionId } from '../lib/edition';
 import { center } from '../lib/center';
+import type { EditionId } from '../lib/edition';
 import { HeaderTopBarEditionDropdown } from './HeaderTopBarEditionDropdown';
 import { MyAccount } from './HeaderTopBarMyAccount';
 import { HeaderTopBarPrintSubscriptions } from './HeaderTopBarPrintSubscriptions';
 import { Search } from './HeaderTopBarSearch';
+import { HeaderTopBarSearchCapi } from './HeaderTopBarSearchCapi';
 import { SearchJobs } from './HeaderTopBarSearchJobs';
 import { Hide } from './Hide';
 
@@ -16,6 +17,7 @@ interface HeaderTopBarProps {
 	mmaUrl?: string;
 	discussionApiUrl: string;
 	idApiUrl: string;
+	headerTopBarSearchCapiSwitch: boolean;
 }
 
 const topBarStyles = css`
@@ -47,6 +49,7 @@ export const HeaderTopBar = ({
 	mmaUrl,
 	discussionApiUrl,
 	idApiUrl,
+	headerTopBarSearchCapiSwitch,
 }: HeaderTopBarProps) => {
 	return (
 		<div
@@ -64,10 +67,13 @@ export const HeaderTopBar = ({
 				/>
 				<SearchJobs />
 
-				<Search
-					href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
-					dataLinkName="nav3 : search"
-				/>
+				{!headerTopBarSearchCapiSwitch && (
+					<Search
+						href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+						dataLinkName="nav3 : search"
+					/>
+				)}
+				{headerTopBarSearchCapiSwitch && <HeaderTopBarSearchCapi />}
 				<Hide when="below" breakpoint="desktop">
 					<HeaderTopBarEditionDropdown
 						editionId={editionId}

--- a/dotcom-rendering/src/web/components/HeaderTopBarSearchCapi.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarSearchCapi.tsx
@@ -1,0 +1,211 @@
+import { css } from '@emotion/react';
+import {
+	brand,
+	brandAlt,
+	from,
+	neutral,
+	textSans,
+} from '@guardian/source-foundations';
+import { useEffect, useRef, useState } from 'react';
+import SearchIcon from '../../static/icons/search.svg';
+import { getZIndex } from '../lib/getZIndex';
+import { useApi } from '../lib/useApi';
+
+const searchLinkStyles = css`
+	${textSans.medium({ fontWeight: 'bold' })};
+	color: ${neutral[100]};
+	transition: color 80ms ease-out;
+	text-decoration: none;
+	padding: 7px 0;
+	background: none;
+	border: none;
+
+	${from.tablet} {
+		padding: 7px 10px 7px 5px;
+	}
+
+	:hover,
+	:focus {
+		text-decoration: underline;
+	}
+
+	svg {
+		fill: currentColor;
+		float: left;
+		height: 18px;
+		width: 18px;
+		margin: 3px 4px 0 0;
+	}
+	${getZIndex('searchHeaderLink')}
+`;
+
+const linkTablet = css`
+	display: none;
+	position: relative;
+
+	:before {
+		content: '';
+		border-left: 1px solid ${brand[600]};
+		height: 24px;
+	}
+
+	${from.desktop} {
+		display: flex;
+	}
+`;
+
+export const HeaderTopBarSearchCapi = () => {
+	const [isSearchVisible, setIsSearchVisible] = useState(false);
+	const [q, setQ] = useState<string>();
+	const qRef = useRef<HTMLInputElement>(null);
+	const { data } = useApi<{
+		response: { results: { webTitle: string; webUrl: string }[] };
+	}>(
+		q
+			? `https://content.guardianapis.com/search?api-key=d1280925-708c-4940-9162-0952ac6e728f&q=${q}`
+			: undefined,
+	);
+
+	const formRef = useRef<HTMLFormElement>(null);
+
+	// Hide search if you click anywhere outside of search when it's shown
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (
+				!formRef.current?.contains(event.target as Node) &&
+				isSearchVisible
+			) {
+				setQ(undefined);
+				setIsSearchVisible(false);
+			}
+		}
+
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [formRef, isSearchVisible]);
+
+	// Hide search if you press escape and it's show
+	useEffect(() => {
+		const hideSearch = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				setQ(undefined);
+				setIsSearchVisible(false);
+			}
+		};
+		document.addEventListener('keydown', hideSearch, false);
+		return () => {
+			document.removeEventListener('keydown', hideSearch, false);
+		};
+	}, []);
+
+	// Focus the input element when we show search
+	useEffect(() => {
+		if (isSearchVisible) {
+			qRef.current?.focus();
+		}
+	}, [isSearchVisible]);
+
+	return (
+		<>
+			<div css={linkTablet}>
+				<a
+					href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+					type="button"
+					css={searchLinkStyles}
+					data-link-name="nav3 : search"
+					onClick={(event) => {
+						event.preventDefault();
+
+						// toggle search
+						if (isSearchVisible) {
+							setQ(undefined);
+							setIsSearchVisible(false);
+						} else {
+							setIsSearchVisible(true);
+						}
+
+						return false;
+					}}
+				>
+					<SearchIcon />
+					<>Search</>
+				</a>
+			</div>
+			{isSearchVisible && (
+				<form
+					css={css`
+						position: absolute;
+						background: ${brand[400]};
+						z-index: 1000;
+						right: 0;
+						width: 50%;
+						top: 40px;
+					`}
+					onSubmit={(event) => {
+						event.preventDefault();
+						setQ(qRef.current?.value);
+					}}
+					ref={formRef}
+				>
+					<input
+						name="q"
+						type="text"
+						css={css`
+							border: 2px solid ${neutral[46]};
+							font-size: 1.0625rem;
+							padding: 0px 8px;
+							width: 100%;
+							line-height: 1.35;
+							height: 44px;
+						`}
+						ref={qRef}
+						autoComplete="off"
+					/>
+					{data && data.response.results.length == 0 && (
+						<p
+							css={css`
+								${textSans.medium()};
+								padding: 1rem 25px;
+								color: ${neutral[100]};
+
+								:hover {
+									color: ${brandAlt[400]};
+								}
+							`}
+						>
+							There are no results
+						</p>
+					)}
+
+					{data && data.response.results.length > 0 && (
+						<ul>
+							{data.response.results.map((result) => {
+								return (
+									<li>
+										<a
+											href={result.webUrl}
+											css={css`
+												${textSans.medium()};
+												color: ${neutral[100]};
+												display: block;
+												padding: 1rem 25px;
+
+												:hover {
+													color: ${brandAlt[400]};
+												}
+											`}
+										>
+											{result.webTitle}
+										</a>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</form>
+			)}
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -361,6 +361,10 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									!!CAPIArticle.config.switches.headerTopNav
 								}
 								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!CAPIArticle.config.switches
+										.headerTopBarSearchCapiSwitch
+								}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -223,6 +223,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								!!front.config.switches.headerTopNav
 							}
 							isInEuropeTest={isInEuropeTest}
+							headerTopBarSearchCapiSwitch={
+								!!front.config.switches
+									.headerTopBarSearchCapiSwitch
+							}
 						/>
 					</Section>
 					<Section

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -240,6 +240,10 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 								!!CAPIArticle.config.switches.headerTopNav
 							}
 							isInEuropeTest={isInEuropeTest}
+							headerTopBarSearchCapiSwitch={
+								!!CAPIArticle.config.switches
+									.headerTopBarSearchCapiSwitch
+							}
 						/>
 					</Section>
 				</div>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -296,6 +296,10 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									!!CAPIArticle.config.switches.headerTopNav
 								}
 								isInEuropeTest={isInEuropeTest}
+								headerTopBarSearchCapiSwitch={
+									!!CAPIArticle.config.switches
+										.headerTopBarSearchCapiSwitch
+								}
 							/>
 						</Section>
 					</div>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -351,6 +351,10 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								!!CAPIArticle.config.switches.headerTopNav
 							}
 							isInEuropeTest={isInEuropeTest}
+							headerTopBarSearchCapiSwitch={
+								!!CAPIArticle.config.switches
+									.headerTopBarSearchCapiSwitch
+							}
 						/>
 					</Section>
 

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -255,6 +255,10 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							!!CAPIArticle.config.switches.headerTopNav
 						}
 						isInEuropeTest={isInEuropeTest}
+						headerTopBarSearchCapiSwitch={
+							!!CAPIArticle.config.switches
+								.headerTopBarSearchCapiSwitch
+						}
 					/>
 				</Section>
 

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -306,6 +306,10 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 											.headerTopNav
 									}
 									isInEuropeTest={isInEuropeTest}
+									headerTopBarSearchCapiSwitch={
+										!!CAPIArticle.config.switches
+											.headerTopBarSearchCapiSwitch
+									}
 								/>
 							</Section>
 							<Section

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -401,6 +401,10 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								headerTopBarSwitch={
 									!!CAPIArticle.config.switches.headerTopNav
 								}
+								headerTopBarSearchCapiSwitch={
+									!!CAPIArticle.config.switches
+										.headerTopBarSearchCapiSwitch
+								}
 							/>
 						</Section>
 					)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This is a proof of concept and a starting point to start discussing with design, UX etc.

Adds a UI for search in the header using CAPI.

## Why?
Part of delivering search would start with working out what people want to use search for. Currently we send people offsite making it impossible to start tracking what terms people are searching which would help inform how we go about search.

It a step in the direction of being able to track search. Where we do this still needs to be thought about.

This data would ave to be supplemented with qualitative research.

### huh?

**Why `HeaderTopBarSearchCapi` and not `HeaderTopBarCapiSearch`?**
This is to keep the file similarly named to `HeaderTopBarSearch`. This might be removed as an abstraction and keep in `HeaderTopBar` going forward, so is even more of a non-issue.

**That CSS is a mess**
It might be, I haven't quite got a grip on how much css is reusable or not, so any suggestions there would be much appriciated.

**Accessibility** 
This is a POC to work with other disciplines and will not be put live until we make it way more accessible.

**Where's your frontend switch?**
Coming up.

**13 files for a test?!**
[Prop drilling](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/architecture/021-react-portals.md) [by design](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/architecture/018-react-context-api.md)

## Screenshots

https://user-images.githubusercontent.com/31692/205045966-c3472cf9-1d15-4ee9-8208-84da945274c5.mov

## TODO
- [ ] Somehow get CAPI API key into component 
