### PR TITLE
Update Snyk org to guardian-dotcom-n2y

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -37,7 +37,7 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --file=yarn.lock --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
+                  args: --org=guardian-dotcom-n2y --project-name=${{ github.repository }} --file=yarn.lock --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
                   command: test
 
             - name: Upload result to GitHub Code Scanning
@@ -53,5 +53,5 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --file=dotcom-rendering/yarn.lock --dev=true --prune-repeated-subdependencies
+                  args: --org=guardian-dotcom-n2y --project-name=${{ github.repository }} --file=dotcom-rendering/yarn.lock --dev=true --prune-repeated-subdependencies
                   command: monitor


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Uses the `guardian-dotcom-n2y` or to be consistent with the rest of our repos.

We might want to standardise this to use [the DevX action](https://github.com/guardian/.github/blob/main/.github/workflows/sbt-node-snyk.yml) as a secondary step.
