### PR TITLE
Yarn script to run percy tests in a real browser

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -28,6 +28,7 @@
 		"cypress:run": "cypress run --browser chrome",
 		"cypress:open:e2e": "cypress open --e2e --browser chrome",
 		"cypress:run:e2e": "cypress run --browser chrome --spec 'cypress/e2e/**/*'",
+		"cypress:open:percy": "percy exec -- cypress open --e2e --browser chrome --config specPattern='cypress/snapshot/**/*'",
 		"cypress:run:percy": "percy exec -- cypress run --browser chrome --config specPattern='cypress/snapshot/**/*'",
 		"unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
 		"storybook": "start-storybook -p 4002 --static-dir ./src/static",


### PR DESCRIPTION
## What does this change?

Adds a yarn script to run percy tests in a real browser: `yarn cypress:open:percy`.

## Why?

It's helpful to see what the browser is doing when debugging test failures.