### PR TITLE
feat: add mock promoted newsletter if article contains newsletter tag

### DIFF
--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -224,16 +224,16 @@ const getMockPromotedNewsletter = (
 	content: Content,
 ): Newsletter | undefined => {
 	const newsletterTagPrefix = 'campaign/email/';
-	const hasNewsletterTag = tagsOfType(TagType.CAMPAIGN)(content.tags).some(
+	const newsletterTag = tagsOfType(TagType.CAMPAIGN)(content.tags).find(
 		(campaignTag) => campaignTag.id.startsWith(newsletterTagPrefix),
 	);
 
-	if (hasNewsletterTag) {
+	if (newsletterTag) {
 		return {
 			description: 'Test newsletter',
 			frequency: 'test',
 			identityName: 'invalid',
-			name: 'Test newsletter',
+			name: `Test: ${newsletterTag.id}`,
 			successDescription: 'test',
 			theme: 'news',
 		};

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -1,5 +1,6 @@
 // ----- Imports ----- //
 
+import type { Newsletter } from '@guardian/apps-rendering-api-models/newsletter';
 import type { BlockElement } from '@guardian/content-api-models/v1/blockElement';
 import type { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime';
 import type { Content } from '@guardian/content-api-models/v1/content';
@@ -18,7 +19,6 @@ import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import { parseVideo } from 'video';
-import { Newsletter } from '@guardian/apps-rendering-api-models/newsletter';
 
 // ----- Lookups ----- //
 

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -215,6 +215,11 @@ const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
 const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
 	pipe(date, fromNullable, andThen(capiDateTimeToDate));
 
+/**
+ * Return a mock `Newsletter` if `content` contains a newsletter tag
+ * @param content the content to check for presence of a newsletter tag
+ * @returns a mock `Newsletter`, or `undefined` if `content` does not include a newsletter tag
+ */
 const getMockPromotedNewsletter = (
 	content: Content,
 ): Newsletter | undefined => {

--- a/apps-rendering/src/capi.ts
+++ b/apps-rendering/src/capi.ts
@@ -18,6 +18,7 @@ import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import { parseVideo } from 'video';
+import { Newsletter } from '@guardian/apps-rendering-api-models/newsletter';
 
 // ----- Lookups ----- //
 
@@ -214,6 +215,26 @@ const capiDateTimeToDate = (date: CapiDateTime): Option<Date> =>
 const maybeCapiDate = (date: CapiDateTime | undefined): Option<Date> =>
 	pipe(date, fromNullable, andThen(capiDateTimeToDate));
 
+const getMockPromotedNewsletter = (
+	content: Content,
+): Newsletter | undefined => {
+	const newsletterTagPrefix = 'campaign/email/';
+	const hasNewsletterTag = tagsOfType(TagType.CAMPAIGN)(content.tags).some(
+		(campaignTag) => campaignTag.id.startsWith(newsletterTagPrefix),
+	);
+
+	if (hasNewsletterTag) {
+		return {
+			description: 'Test newsletter',
+			frequency: 'test',
+			identityName: 'invalid',
+			name: 'Test newsletter',
+			successDescription: 'test',
+			theme: 'news',
+		};
+	}
+};
+
 // ----- Exports ----- //
 
 export {
@@ -235,4 +256,5 @@ export {
 	articleMainImage,
 	checkForThirdPartyEmbed,
 	requiresInlineStyles,
+	getMockPromotedNewsletter,
 };

--- a/apps-rendering/src/server/server.ts
+++ b/apps-rendering/src/server/server.ts
@@ -17,7 +17,7 @@ import {
 	some,
 	withDefault,
 } from '@guardian/types';
-import { capiEndpoint } from 'capi';
+import { capiEndpoint, getMockPromotedNewsletter } from 'capi';
 import compression from 'compression';
 import type {
 	Response as ExpressResponse,
@@ -352,6 +352,7 @@ async function serveArticleGet(
 					relatedContent,
 					footballContent: resultToNullable(footballContent),
 					edition,
+					promotedNewsletter: getMockPromotedNewsletter(content),
 				};
 
 				const richLinkDetails = req.query.richlink === '';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Adds a mock promoted newsletter to the `RenderingRequest` when running the dev server. The mock newsletter is invalid and stub data only. We do not fetch data from the Newsletters API

## Why?

- To facilitate testing newsletters functionality locally