### PR TITLE
Upgrade braze-components

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
 		"@guardian/ab-core": "^2.0.0",
 		"@guardian/ab-react": "^2.0.1",
 		"@guardian/atoms-rendering": "^24.0.0",
-		"@guardian/braze-components": "^8.1.1",
+		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^4.25.0",
 		"@guardian/consent-management-platform": "10.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,10 +2951,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.1.tgz#7b265a7d2a2163df70238823e881950a6d43598d"
-  integrity sha512-4izZBDS9HXgEmf9hLBs0X3JdtgrdnGuFRCGhyJFodUPU+ZFXo2H4rOQlTBBsUhr5PurEZBDVU+9y6ZCe74ZWcg==
+"@guardian/braze-components@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
+  integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
 "@guardian/browserslist-config@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
includes a [fix for bold text](https://github.com/guardian/braze-components/pull/378) in braze epics