### PR TITLE
feat: custom CAPI key

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -23,3 +23,4 @@ jobs:
         run: scripts/ci-deno.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAPI_KEY: ${{ secrets.CAPI_KEY }}

--- a/scripts/ci-deno.sh
+++ b/scripts/ci-deno.sh
@@ -16,4 +16,5 @@ deno run \
 	--no-check=remote \
 	--allow-net \
 	--allow-env="GITHUB_TOKEN" \
+	--allow-env="CAPI_KEY" \
 	scripts/deno/iframe-titles.ts

--- a/scripts/deno/iframe-titles.ts
+++ b/scripts/deno/iframe-titles.ts
@@ -7,7 +7,7 @@ import {
 import { octokit } from './github.ts';
 
 const searchParams = new URLSearchParams({
-	'api-key': 'test',
+	'api-key': Deno.env.get('CAPI_KEY') ?? 'test',
 	'query-fields': 'body',
 	q: 'iframe',
 	'show-fields': 'body',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add a custom key for the `iframe-titles` scheduled script for usage tracking purposes, with extremely low rate limits.

## Why?

The `test` key is generic. Having a specific key means we can track and revoke its usage.