### PR TITLE
fix: determine if article is recipe before feature check

### DIFF
--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -520,6 +520,11 @@ const fromCapi =
 				design: ArticleDesign.Interview,
 				...itemFieldsWithBody(context, request),
 			};
+		} else if (isRecipe(tags)) {
+			return {
+				design: ArticleDesign.Recipe,
+				...itemFieldsWithBody(context, request),
+			};
 		} else if (isFeature(tags)) {
 			return {
 				design: ArticleDesign.Feature,
@@ -527,11 +532,6 @@ const fromCapi =
 			};
 		} else if (isLive(tags)) {
 			return fromCapiLiveBlog(context)(request, page);
-		} else if (isRecipe(tags)) {
-			return {
-				design: ArticleDesign.Recipe,
-				...itemFieldsWithBody(context, request),
-			};
 		} else if (isQuiz(tags)) {
 			return {
 				design: ArticleDesign.Quiz,


### PR DESCRIPTION
## What does this change?

- Moves the `isRecipe` check above `isFeature`, so recipe wins when an article has the correct tags for recipes

## Why?

- Many recipes are also features, so they were being classified as features when recipe should win