### PR TITLE
Add new `exclusion` ad slot to all pages

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -476,6 +476,16 @@ export const AdSlot = ({
 				/>
 			);
 		}
+		case 'exclusion': {
+			return (
+				<div
+					id={'dfp-ad--exclusion'}
+					className={['js-ad-slot', 'ad-slot'].join(' ')}
+					data-name="exclusion"
+					aria-hidden="true"
+				/>
+			);
+		}
 		default:
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -483,6 +483,7 @@ export const AdSlot = ({
 					className={['js-ad-slot', 'ad-slot'].join(' ')}
 					data-name="exclusion"
 					aria-hidden="true"
+					data-label="false"
 				/>
 			);
 		}

--- a/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/web/components/HeaderAdSlot.tsx
@@ -33,6 +33,15 @@ const headerAdWrapper = css`
 
 export const HeaderAdSlot = ({ display }: Props) => (
 	<div css={headerWrapper}>
+		{/*
+			This is a special type of ad which, when filled, blocks
+			all other ads on the page. This allows us to run "exclusion
+			campaigns" against certain breaking news pages. Exclusion
+			ads are used for consentless advertising only. They are
+			ignored by GAM, which has a different mechanism to achieve
+			the same thing.
+		 */}
+		<AdSlot position="exclusion" />
 		<Global
 			styles={css`
 				/**


### PR DESCRIPTION
## What does this change?

Adds a new `exclusion` ad slot to the header of the page, just before `top-above-nav`.

## Why?

AdOps would like to be able to target _exclusion_ campaigns against certain breaking news pages in order to disable Opt Out advertising on those pages.

To get this working, Opt Out have asked us to introduce a new `exclusion` ad slot. When it is filled, Opt Out's new logic will magically prevent all other ads making their way onto the page.

URL targeting will determine whether or not this slot is filled. Something like the following:

<img width="866" alt="Screenshot 2022-12-02 at 12 45 54" src="https://user-images.githubusercontent.com/7423751/205296049-ce18668e-66ef-4f8e-bcab-447ab7fe9b81.png">

The new `exclusion` slot isn't visible to the user and will be ignored by GAM.

## Next steps

1) ~~Replicate this change on frontend so it works on non-DCR rendered pages (like fronts)~~ Update: https://github.com/guardian/frontend/pull/25732

2) ~~Configure the `exclusion` ad slot in the [Opt Out console](https://dashboard.optoutadvertising.com/adslottags/publisher/33)~~ Update: done!

![Screenshot 2022-12-02 at 13 59 45](https://user-images.githubusercontent.com/7423751/205309736-903f2db8-c020-4490-93f8-05832a45cda4.png)

3) We _might_ need to add some logic [around here](https://github.com/guardian/frontend/blob/0d2568f996e1f0fc5068f6217169b34c501d7a97/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts#L31-L34) to tidy up empty ad slots, but this also may just work

## Screenshots

Here is a sample request to Opt Out with the `exclusion` ad slot in place:

![Screenshot 2022-12-01 at 16 58 10](https://user-images.githubusercontent.com/7423751/205278627-75ecace8-e014-456d-b459-3752e095d60f.png)
