### PR TITLE
Add AB test for outstream on desktop inline2+ on liveblogs

### DIFF
--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
+import { liveblogDesktopOutstream } from './tests/liveblog-desktop-outstream';
 import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	consentlessAds,
 	integrateIma,
 	removePrebidA9Canada,
+	liveblogDesktopOutstream,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
+++ b/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
@@ -7,7 +7,7 @@ export const liveblogDesktopOutstream: ABTest = {
 	author: 'Jake Lee Kennedy',
 	description:
 		'Test the impact of enabling outstream on inline2+ on liveblogs on desktop',
-	audience: 95 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Opt in',
 	successMeasure: 'No significant impact to CWV',

--- a/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
+++ b/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
 
 export const liveblogDesktopOutstream: ABTest = {
 	id: 'LiveblogDesktopOutstream',
@@ -13,7 +14,7 @@ export const liveblogDesktopOutstream: ABTest = {
 	successMeasure: 'No significant impact to CWV',
 	canRun: () => true,
 	variants: [
-		{ id: 'control', test: (): void => {} },
-		{ id: 'variant', test: (): void => {} },
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant', test: bypassMetricsSampling },
 	],
 };

--- a/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
+++ b/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const liveblogDesktopOutstream: ABTest = {
+	id: 'IntegrateIma',
+	start: '2022-12-02',
+	expiry: '2023-01-31',
+	author: 'Jake Lee Kennedy',
+	description:
+		'Test the impact of enabling outstream on inline2+ on liveblogs on desktop',
+	audience: 95 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No significant impact to CWV',
+	canRun: () => true,
+	variants: [
+		{ id: 'control', test: (): void => {} },
+		{ id: 'variant', test: (): void => {} },
+	],
+};

--- a/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
+++ b/dotcom-rendering/src/web/experiments/tests/liveblog-desktop-outstream.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
 export const liveblogDesktopOutstream: ABTest = {
-	id: 'IntegrateIma',
+	id: 'LiveblogDesktopOutstream',
 	start: '2022-12-02',
 	expiry: '2023-01-31',
 	author: 'Jake Lee Kennedy',

--- a/dotcom-rendering/src/web/experiments/utils.ts
+++ b/dotcom-rendering/src/web/experiments/utils.ts
@@ -1,0 +1,7 @@
+import { bypassCommercialMetricsSampling } from '@guardian/commercial-core';
+import { bypassCoreWebVitalsSampling } from '@guardian/libs';
+
+export const bypassMetricsSampling = (): void => {
+	void bypassCommercialMetricsSampling();
+	void bypassCoreWebVitalsSampling();
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add an AB test for adding outstream site to desktop inline2+ on liveblogs

Frontend PR: https://github.com/guardian/frontend/pull/25729

