### PR TITLE
Error on eslint ban-types React.FC and friends

### DIFF
--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -169,11 +169,25 @@ module.exports = {
 					'warn',
 					{
 						types: {
+							// Why? Using explicit return types for React results in types that are often too wide,
+							// as expressed in Kent C Dodd’s article How to write a React Component in TypeScript.
+							// We don't include `JSX.Element` here as that is
+							// see: https://kentcdodds.com/blog/how-to-write-a-react-component-in-typescript
+							// pr: https://github.com/guardian/dotcom-rendering/pull/5192
 							'JSX.Element': 'Prefer type inference',
 							'EmotionJSX.Element': 'Prefer type inference',
+						},
+					},
+				],
+				'@typescript-eslint/ban-types': [
+					'error',
+					{
+						types: {
+							// Why? See this: https://github.com/facebook/create-react-app/pull/8177
+							// pr: https://github.com/guardian/dotcom-rendering/pull/5622
 							'React.StatelessComponent':
 								'Please use const MyThing = ({foo, bar}: Props) instead',
-							'React.FunctionalComponent':
+							'React.FunctionComponent':
 								'Please use const MyThing = ({foo, bar}: Props) instead',
 							'React.SC':
 								'Please use const MyThing = ({foo, bar}: Props) instead',

--- a/dotcom-rendering/__mocks__/svgMock.tsx
+++ b/dotcom-rendering/__mocks__/svgMock.tsx
@@ -1,3 +1,3 @@
-const SVG: React.FC = () => null;
+const SVG = () => null;
 
 module.exports = SVG;

--- a/dotcom-rendering/docs/contributing/code-style.md
+++ b/dotcom-rendering/docs/contributing/code-style.md
@@ -221,3 +221,5 @@ const MyLink = ({ isActive }) => (
     <a className={cx({ [activeLink]: isActive }, link)}>Click Me</a>
 );
 ```
+
+### Don't use React.FC or equivalent

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
 		"@guardian/ab-core": "^2.0.0",
 		"@guardian/ab-react": "^2.0.1",
 		"@guardian/atoms-rendering": "^24.0.0",
-		"@guardian/braze-components": "^8.1.1",
+		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^4.25.0",
 		"@guardian/consent-management-platform": "10.11.1",

--- a/dotcom-rendering/src/amp/components/AdConsent.tsx
+++ b/dotcom-rendering/src/amp/components/AdConsent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { JsonScript } from './JsonScript';
 
 const sourcepointDomain = 'sourcepoint.theguardian.com';
@@ -56,7 +55,7 @@ const clientConfigAus = {
 	},
 };
 
-export const AdConsent: React.FC = () => {
+export const AdConsent = () => {
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code

--- a/dotcom-rendering/src/amp/components/AmpExperiment.tsx
+++ b/dotcom-rendering/src/amp/components/AmpExperiment.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import type { AmpExperiments } from '../server/ampExperimentCache';
 
-export const AmpExperimentComponent: React.FC<{
+type Props = {
 	experimentsData?: AmpExperiments;
-}> = ({ experimentsData }) => {
+};
+export const AmpExperimentComponent = ({ experimentsData }: Props) => {
 	return (
 		<amp-experiment>
 			<script

--- a/dotcom-rendering/src/amp/components/Analytics.tsx
+++ b/dotcom-rendering/src/amp/components/Analytics.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export interface AnalyticsModel {
 	gaTracker: string;
 	title: string;
@@ -12,9 +10,11 @@ export interface AnalyticsModel {
 	ipsosSectionName: string;
 }
 
-export const Analytics: React.FC<{
+type Props = {
 	analytics: AnalyticsModel;
-}> = ({
+};
+
+export const Analytics = ({
 	analytics: {
 		gaTracker,
 		comscoreID,
@@ -26,7 +26,7 @@ export const Analytics: React.FC<{
 		domain,
 		ipsosSectionName,
 	},
-}) => {
+}: Props) => {
 	const scripts: string[] = [
 		`<amp-analytics config="https://ophan.theguardian.com/amp.json" data-credentials="include" ></amp-analytics>`,
 		`<amp-analytics data-block-on-consent type="googleanalytics" id="google-analytics">

--- a/dotcom-rendering/src/amp/components/AnalyticsIframe.tsx
+++ b/dotcom-rendering/src/amp/components/AnalyticsIframe.tsx
@@ -1,10 +1,11 @@
 import { ClassNames } from '@emotion/react';
-import React from 'react';
 
 const prebidImg =
 	'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
-export const AnalyticsIframe: React.FC<{ url: string }> = ({ url }) => {
+type Props = { url: string };
+
+export const AnalyticsIframe = ({ url }: Props) => {
 	return (
 		<ClassNames>
 			{({ css }) => {

--- a/dotcom-rendering/src/amp/components/Blocks.tsx
+++ b/dotcom-rendering/src/amp/components/Blocks.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/react';
 import { neutral, text, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../lib/pillars';
 import type { CommercialProperties } from '../../types/commercial';
 import type { Switches } from '../../types/config';
-import { EditionId } from '../../web/lib/edition';
-
+import type { EditionId } from '../../web/lib/edition';
 import { blockLink } from '../lib/block-link';
 import { findBlockAdSlots } from '../lib/find-adslots';
 import { Elements } from './Elements';
@@ -61,9 +59,7 @@ const clearBoth = css`
 	clear: both;
 `;
 
-// TODO ad handling (currently done in elements, which is wrong, so let's lift
-// that out and have an Ad element type we match against
-export const Blocks: React.FunctionComponent<{
+type Props = {
 	blocks: Block[];
 	pillar: ArticleTheme;
 	editionId: EditionId;
@@ -74,7 +70,11 @@ export const Blocks: React.FunctionComponent<{
 	url: string;
 	shouldHideAds: boolean;
 	adTargeting: AdTargeting;
-}> = ({
+};
+
+// TODO ad handling (currently done in elements, which is wrong, so let's lift
+// that out and have an Ad element type we match against
+export const Blocks = ({
 	blocks,
 	pillar,
 	editionId,
@@ -85,7 +85,7 @@ export const Blocks: React.FunctionComponent<{
 	url,
 	shouldHideAds,
 	adTargeting,
-}) => {
+}: Props) => {
 	// TODO add last updated for blocks to show here
 	const liveBlogBlocks = blocks.map((block) => {
 		return (

--- a/dotcom-rendering/src/amp/components/BodyArticle.tsx
+++ b/dotcom-rendering/src/amp/components/BodyArticle.tsx
@@ -101,10 +101,12 @@ const adStyle = css`
 	}
 `;
 
-export const Body: React.FC<{
+type Props = {
 	data: ArticleModel;
 	config: ConfigType;
-}> = ({ data, config }) => {
+};
+
+export const Body = ({ data, config }: Props) => {
 	const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: data.isAdFreeUser,

--- a/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
+++ b/dotcom-rendering/src/amp/components/BodyLiveblog.tsx
@@ -5,7 +5,6 @@ import {
 	news,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import { getSharingUrls } from '../../lib/sharing-urls';
 import RefreshIcon from '../../static/icons/refresh.svg';
@@ -75,14 +74,16 @@ const updateButtonStyle = css`
 	}
 `;
 
+type Props = {
+	data: ArticleModel;
+	config: ConfigType;
+};
+
 // Note, it is possible for liveblog updates to lack styling if a style change
 // to any block content is deployed between a user loading a live blog and the
 // updates happening. This happens because we don't include new styles on block
 // updates, but only on initial page load.
-export const Body: React.FC<{
-	data: ArticleModel;
-	config: ConfigType;
-}> = ({ data, config }) => {
+export const Body = ({ data, config }: Props) => {
 	const adTargeting: AdTargeting = buildAdTargeting({
 		isAdFreeUser: data.isAdFreeUser,
 		isSensitive: config.isSensitive,

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -108,7 +108,6 @@ export const Elements = (
 	pillar: ArticleTheme,
 	isImmersive: boolean,
 	adTargeting?: AdTargeting,
-	// eslint-disable-next-line @typescript-eslint/ban-types -- the type signature is helpful
 ): JSX.Element[] => {
 	const cleanedElements = enhance(elements);
 	const output = cleanedElements.map((element) => {
@@ -149,12 +148,7 @@ export const Elements = (
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
-				return (
-					<ContentAtomBlockComponent
-						key={element.elementId}
-						element={element}
-					/>
-				);
+				return <ContentAtomBlockComponent key={element.elementId} />;
 			case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
 				return (
 					<DisclaimerBlockComponent
@@ -358,7 +352,6 @@ export const Elements = (
 	});
 
 	return output.filter(
-		// eslint-disable-next-line @typescript-eslint/ban-types -- it’s a type predicate
 		(el: JSX.Element | null): el is JSX.Element => el !== null,
 	);
 };

--- a/dotcom-rendering/src/amp/components/Epic.tsx
+++ b/dotcom-rendering/src/amp/components/Epic.tsx
@@ -11,7 +11,6 @@ import {
 	neutral,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import {
 	MoustacheSection,
 	MoustacheTemplate,
@@ -347,7 +346,11 @@ const reminderWrapperStyle = css`
 	}
 `;
 
-export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
+type Props = {
+	webURL: string;
+};
+
+export const Epic = ({ webURL }: Props) => {
 	const supportDotcomComponentsUrl =
 		process.env.GU_STAGE === 'PROD'
 			? 'https://contributions.guardianapis.com'

--- a/dotcom-rendering/src/amp/components/Expandable.tsx
+++ b/dotcom-rendering/src/amp/components/Expandable.tsx
@@ -168,7 +168,7 @@ const imageStyle = css`
 	}
 `;
 
-export const Expandable: React.FC<{
+type Props = {
 	id: string;
 	type: string;
 	title: string;
@@ -176,7 +176,17 @@ export const Expandable: React.FC<{
 	credit?: string;
 	pillar: ArticleTheme;
 	children: React.ReactNode;
-}> = ({ id, type, title, img, children, credit, pillar }) => (
+};
+
+export const Expandable = ({
+	id,
+	type,
+	title,
+	img,
+	children,
+	credit,
+	pillar,
+}: Props) => (
 	<aside css={wrapper(pillar)}>
 		<div css={headers}>
 			<span css={[headerStyle, pillarColour(pillar)]}>{type}</span>

--- a/dotcom-rendering/src/amp/components/Footer.tsx
+++ b/dotcom-rendering/src/amp/components/Footer.tsx
@@ -6,7 +6,6 @@ import {
 	neutral,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import type { Link } from '../../lib/footer-links';
 import {
 	footerLinksNew,
@@ -137,10 +136,12 @@ const supportLink = css`
 
 const year = new Date().getFullYear();
 
-const FooterLinks: React.FC<{
+type FooterLinksProps = {
 	links: Link[][];
 	nav: NavType;
-}> = ({ links, nav }) => {
+};
+
+const FooterLinks = ({ links, nav }: FooterLinksProps) => {
 	const linkGroups = links.map((linkGroup) => {
 		const ls = linkGroup
 			.filter((l) => isOnPlatform(l, LinkPlatform.Amp))
@@ -177,7 +178,9 @@ const FooterLinks: React.FC<{
 	);
 };
 
-export const Footer: React.FC<{ nav: NavType }> = ({ nav }) => {
+type FooterProps = { nav: NavType };
+
+export const Footer = ({ nav }: FooterProps) => {
 	const { group } = useContentABTestGroup();
 	return (
 		<footer data-content-test-group={group} css={footer}>

--- a/dotcom-rendering/src/amp/components/Header.tsx
+++ b/dotcom-rendering/src/amp/components/Header.tsx
@@ -10,7 +10,6 @@ import {
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { SvgGuardianBestWebsiteLogo } from '@guardian/source-react-components';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../lib/pillars';
 import type { NavType, PillarType } from '../../model/extract-nav';
 import { ReaderRevenueButton } from './ReaderRevenueButton';
@@ -197,10 +196,12 @@ const pillarLinks = (pillars: PillarType[], guardianBaseURL: string) => (
 	</nav>
 );
 
-export const Header: React.FC<{
+type Props = {
 	nav: NavType;
 	guardianBaseURL: string;
-}> = ({ nav, guardianBaseURL }) => (
+};
+
+export const Header = ({ nav, guardianBaseURL }: Props) => (
 	<header css={headerStyles}>
 		<div css={row}>
 			<ReaderRevenueButton

--- a/dotcom-rendering/src/amp/components/JsonScript.tsx
+++ b/dotcom-rendering/src/amp/components/JsonScript.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+type Props = { o: any };
 
-export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
+export const JsonScript = ({ o }: Props) => {
 	const JSONString: string = JSON.stringify(o);
 	return (
 		<script

--- a/dotcom-rendering/src/amp/components/KeyEvents.tsx
+++ b/dotcom-rendering/src/amp/components/KeyEvents.tsx
@@ -5,7 +5,6 @@ import {
 	sport,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import DownArrow from '../../static/icons/down-arrow.svg';
 import { blockLink } from '../lib/block-link';
 
@@ -65,10 +64,12 @@ const listStyle = css`
 	padding: 0.375rem 0.625rem;
 `;
 
-export const KeyEvents: React.FunctionComponent<{
+type Props = {
 	events: Block[];
 	url: string;
-}> = ({ events, url }) => {
+};
+
+export const KeyEvents = ({ events, url }: Props) => {
 	if (!events || events.length < 1) {
 		return null;
 	}

--- a/dotcom-rendering/src/amp/components/MainMedia.tsx
+++ b/dotcom-rendering/src/amp/components/MainMedia.tsx
@@ -4,7 +4,6 @@ import {
 	textSans,
 	visuallyHidden,
 } from '@guardian/source-foundations';
-import React from 'react';
 import InfoIcon from '../../static/icons/info.svg';
 import type {
 	CAPIElement,
@@ -154,11 +153,13 @@ const asComponent = (
 	}
 };
 
-export const MainMedia: React.FC<{
+type Props = {
 	element: CAPIElement;
 	pillar: ArticleTheme;
 	adTargeting?: any;
-}> = ({ element, pillar, adTargeting }) => {
+};
+
+export const MainMedia = ({ element, pillar, adTargeting }: Props) => {
 	return (
 		<div css={expanded}>{asComponent(element, pillar, adTargeting)}</div>
 	);

--- a/dotcom-rendering/src/amp/components/Onward.tsx
+++ b/dotcom-rendering/src/amp/components/Onward.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import React from 'react';
 import type { TagType } from '../../types/tag';
 import { OnwardContainer } from './OnwardContainer';
 
@@ -44,21 +43,23 @@ const sectionHasMostViewed = (sectionID: string): boolean => {
 	return allowed.has(sectionID);
 };
 
-export const Onward: React.FC<{
+type Props = {
 	pageID: string;
 	sectionID?: string;
 	hasStoryPackage: boolean;
 	hasRelated: boolean;
 	seriesTags: TagType[];
 	guardianBaseURL: string;
-}> = ({
+};
+
+export const Onward = ({
 	pageID,
 	sectionID,
 	hasStoryPackage,
 	hasRelated,
 	seriesTags,
 	guardianBaseURL,
-}) => {
+}: Props) => {
 	const ampBaseURL = 'https://amp.theguardian.com';
 
 	const container = (path: string, componentName: string) => (

--- a/dotcom-rendering/src/amp/components/Pagination.tsx
+++ b/dotcom-rendering/src/amp/components/Pagination.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import ChevronLeftDouble from '../../static/icons/chevron-left-double.svg';
 import ChevronLeftSingle from '../../static/icons/chevron-left-single.svg';
 import ChevronRightDouble from '../../static/icons/chevron-right-double.svg';
@@ -45,10 +44,12 @@ const marginRightStyle = css`
 	margin-right: 5px;
 `;
 
-export const Pagination: React.FunctionComponent<{
+type Props = {
 	pagination?: Pagination;
 	guardianURL: string;
-}> = ({ pagination, guardianURL }) => {
+};
+
+export const Pagination = ({ pagination, guardianURL }: Props) => {
 	if (!pagination) {
 		return null;
 	}

--- a/dotcom-rendering/src/amp/components/ReaderRevenueButton.tsx
+++ b/dotcom-rendering/src/amp/components/ReaderRevenueButton.tsx
@@ -5,7 +5,6 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import React from 'react';
 import type { NavType } from '../../model/extract-nav';
 import ArrowRight from '../../static/icons/arrow-right.svg';
 
@@ -72,13 +71,21 @@ const rightAlignedIcon = css`
 	top: 0;
 `;
 
-export const ReaderRevenueButton: React.FunctionComponent<{
+type Props = {
 	nav: NavType;
 	linkLabel: string;
 	rrLink: ReaderRevenuePosition;
 	rrCategory: ReaderRevenueCategory;
 	rightAlignIcon?: boolean;
-}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon }) => {
+};
+
+export const ReaderRevenueButton = ({
+	nav,
+	linkLabel,
+	rrLink,
+	rrCategory,
+	rightAlignIcon,
+}: Props) => {
 	const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
 	if (url === '') {

--- a/dotcom-rendering/src/amp/components/ShareIcons.tsx
+++ b/dotcom-rendering/src/amp/components/ShareIcons.tsx
@@ -67,7 +67,7 @@ interface ShareListItemType {
 	mobileOnly: boolean;
 }
 
-export const ShareIcons: React.FC<{
+type Props = {
 	sharingUrls: {
 		[K in SharePlatform]?: {
 			url: string;
@@ -76,7 +76,9 @@ export const ShareIcons: React.FC<{
 	};
 	displayIcons: SharePlatform[];
 	pillar: ArticleTheme;
-}> = ({ sharingUrls, displayIcons, pillar }) => {
+};
+
+export const ShareIcons = ({ sharingUrls, displayIcons, pillar }: Props) => {
 	const icons: { [K in SharePlatform]?: React.ComponentType } = {
 		facebook: FacebookIcon,
 		twitter: TwitterIconPadded,

--- a/dotcom-rendering/src/amp/components/ShowMoreButton.tsx
+++ b/dotcom-rendering/src/amp/components/ShowMoreButton.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import PlusIcon from '../../static/icons/plus.svg';
 
 const showMore = css`
@@ -37,7 +36,7 @@ const showMore = css`
 	}
 `;
 
-export const ShowMoreButton: React.FC = () => (
+export const ShowMoreButton = () => (
 	<div css={showMore} aria-label="Show more">
 		<PlusIcon />
 		Show more

--- a/dotcom-rendering/src/amp/components/Sidebar.tsx
+++ b/dotcom-rendering/src/amp/components/Sidebar.tsx
@@ -6,11 +6,9 @@ import {
 	neutral,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
-import type { NavType } from '../../model/extract-nav';
 
-export const Sidebar: React.FC<{ nav: NavType }> = () => {
+export const Sidebar = () => {
 	// this next line is necessary cos react has a 'template' object with no 'type' property.
 	// By saying 'as {}' we can pretend we're not adding the 'type' property and thus avoid unhappy type errors
 	const props = { type: 'amp-mustache' } as { [key: string]: any };

--- a/dotcom-rendering/src/amp/components/StarRating.tsx
+++ b/dotcom-rendering/src/amp/components/StarRating.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { brandAlt } from '@guardian/source-foundations';
-import React from 'react';
 import { Star } from '../../static/icons/Star';
 
 const ratingsWrapper = css`
@@ -24,10 +23,12 @@ const smallSize = css`
 	}
 `;
 
-export const StarRating: React.FC<{
+type Props = {
 	rating: number;
 	size: string;
-}> = ({ rating, size }) => {
+};
+
+export const StarRating = ({ rating, size }: Props) => {
 	const sizeClass = size === 'large' ? largeSize : smallSize;
 	const stars = (n: number) => {
 		return Array(5)

--- a/dotcom-rendering/src/amp/components/SubMeta.tsx
+++ b/dotcom-rendering/src/amp/components/SubMeta.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { body, neutral, text, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../lib/pillars';
 import type { BaseLinkType } from '../../model/extract-nav';
 import CommentIcon from '../../static/icons/comment.svg';
@@ -108,7 +107,7 @@ const shareIcons = css`
 	padding-bottom: 30px;
 `;
 
-export const SubMeta: React.FC<{
+type Props = {
 	pillar: ArticleTheme;
 	sections: BaseLinkType[];
 	keywords: BaseLinkType[];
@@ -121,7 +120,9 @@ export const SubMeta: React.FC<{
 	pageID: string;
 	isCommentable: boolean;
 	guardianBaseURL: string;
-}> = ({
+};
+
+export const SubMeta = ({
 	pillar,
 	sections,
 	keywords,
@@ -129,7 +130,7 @@ export const SubMeta: React.FC<{
 	pageID,
 	isCommentable,
 	guardianBaseURL,
-}) => {
+}: Props) => {
 	const sectionListItems = sections.map((link) => (
 		<li css={itemStyle} key={link.url}>
 			<a

--- a/dotcom-rendering/src/amp/components/elements/AudioAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/AudioAtomBlockComponent.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import type { AudioAtomBlockElement } from '../../../types/content';
 
-export const AudioAtomBlockComponent: React.FC<{
+type Props = {
 	element: AudioAtomBlockElement;
-}> = ({ element }) => {
+};
+
+export const AudioAtomBlockComponent = ({ element }: Props) => {
 	return (
 		<amp-audio src={element.trackUrl} title={element.kicker}>
 			<div fallback="">

--- a/dotcom-rendering/src/amp/components/elements/CommentBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/CommentBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral, news, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import type { CommentBlockElement } from '../../../types/content';
 
 const wrapper = css`
@@ -38,9 +37,11 @@ const bodyCSS = css`
 	}
 `;
 
-export const CommentBlockComponent: React.FC<{
+type Props = {
 	element: CommentBlockElement;
-}> = ({ element }) => (
+};
+
+export const CommentBlockComponent = ({ element }: Props) => (
 	<div css={wrapper}>
 		<amp-img
 			class={avatar}

--- a/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ContentAtomBlockComponent.tsx
@@ -1,8 +1,3 @@
-import type React from 'react';
-import { ContentAtomBlockElement } from '../../../types/content';
-
-export const ContentAtomBlockComponent: React.FC<{
-	element: ContentAtomBlockElement;
-}> = () => {
+export const ContentAtomBlockComponent = () => {
 	return null;
 };

--- a/dotcom-rendering/src/amp/components/elements/DisclaimerBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/DisclaimerBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 
 const style = (pillar: ArticleTheme) => css`
@@ -11,10 +10,12 @@ const style = (pillar: ArticleTheme) => css`
 	}
 `;
 
-export const DisclaimerBlockComponent: React.FC<{
+type Props = {
 	html: string;
 	pillar: ArticleTheme;
-}> = ({ html, pillar }) => (
+};
+
+export const DisclaimerBlockComponent = ({ html, pillar }: Props) => (
 	<span
 		css={style(pillar)}
 		dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/amp/components/elements/EmbedBlockComponentAMP.tsx
+++ b/dotcom-rendering/src/amp/components/elements/EmbedBlockComponentAMP.tsx
@@ -1,10 +1,11 @@
-import type React from 'react';
 import { NotRenderableInDCR } from '../../../lib/errors/not-renderable-in-dcr';
 import type { EmbedBlockElement } from '../../../types/content';
 
-export const EmbedBlockComponentAMP: React.FC<{
+type Props = {
 	element: EmbedBlockElement;
-}> = ({ element }) => {
+};
+
+export const EmbedBlockComponentAMP = ({ element }: Props) => {
 	if (element.isMandatory) {
 		throw new NotRenderableInDCR();
 	}

--- a/dotcom-rendering/src/amp/components/elements/GuVideoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/GuVideoBlockComponent.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import type { GuVideoBlockElement } from '../../../types/content';
 import { Caption } from '../Caption';
 
-export const GuVideoBlockComponent: React.FC<{
+type Props = {
 	element: GuVideoBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => {
+};
+
+export const GuVideoBlockComponent = ({ element, pillar }: Props) => {
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>
 			<amp-video controls="" width="16" height="9" layout="responsive">

--- a/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/ImageBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { text, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import TriangleIcon from '../../../static/icons/triangle.svg';
 import type { ImageBlockElement, SrcSetItem } from '../../../types/content';
@@ -17,10 +16,12 @@ const captionStyle = css`
 	color: ${text.supporting};
 `;
 
-export const ImageBlockComponent: React.FC<{
+type Props = {
 	element: ImageBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => {
+};
+
+export const ImageBlockComponent = ({ element, pillar }: Props) => {
 	const containerWidth = 600;
 	const image: SrcSetItem = bestFitImage(
 		element.imageSources,

--- a/dotcom-rendering/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
@@ -1,5 +1,4 @@
 import { ClassNames } from '@emotion/react';
-import React from 'react';
 import { ShowMoreButton } from '../ShowMoreButton';
 
 // We look in the html field of the atom for a hint for the height of the atom
@@ -45,11 +44,17 @@ const getHeight = (html?: string): number => {
 	return defaultInteractiveAtomHeight;
 };
 
-export const InteractiveAtomBlockComponent: React.FunctionComponent<{
+type Props = {
 	url: string;
 	html?: string;
 	placeholderUrl?: string;
-}> = ({ url, placeholderUrl, html }) => {
+};
+
+export const InteractiveAtomBlockComponent = ({
+	url,
+	placeholderUrl,
+	html,
+}: Props) => {
 	// On Dot Com, Interactive Atoms are sometimes used to modify the page
 	// around them. CSS, JS but no HTML can exist in an atom, and because we just
 	// add it to the page, it can modify the world around it.

--- a/dotcom-rendering/src/amp/components/elements/InteractiveBlockComponentAMP.tsx
+++ b/dotcom-rendering/src/amp/components/elements/InteractiveBlockComponentAMP.tsx
@@ -1,12 +1,13 @@
 import { ClassNames } from '@emotion/react';
-import React from 'react';
 import { NotRenderableInDCR } from '../../../lib/errors/not-renderable-in-dcr';
 import { ShowMoreButton } from '../ShowMoreButton';
 
-export const InteractiveBlockComponentAMP: React.FunctionComponent<{
+type Props = {
 	url?: string;
 	isMandatory?: boolean;
-}> = ({ url, isMandatory }) => {
+};
+
+export const InteractiveBlockComponentAMP = ({ url, isMandatory }: Props) => {
 	// If this element is mandatory, we don't know if we can render it properly, so we have to
 	// throw an error and chuck the whole page out of AMP. You're barred son.
 	if (isMandatory) {

--- a/dotcom-rendering/src/amp/components/elements/PullquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/PullquoteBlockComponent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { body, neutral } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import Quote from '../../../static/icons/quote.svg';
 
@@ -17,10 +16,12 @@ const styles = (pillar: ArticleTheme) => css`
 	}
 `;
 
-export const PullquoteBlockComponent: React.FC<{
+type Props = {
 	html?: string;
 	pillar: ArticleTheme;
-}> = ({ html, pillar }) => {
+};
+
+export const PullquoteBlockComponent = ({ html, pillar }: Props) => {
 	if (!html) return <></>;
 	return (
 		<aside css={styles(pillar)}>

--- a/dotcom-rendering/src/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/RichLinkBlockComponent.tsx
@@ -5,9 +5,8 @@ import {
 	text,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
-import { RichLinkBlockElement } from '../../../types/content';
+import type { RichLinkBlockElement } from '../../../types/content';
 
 const richLinkContainer = css`
 	float: left;
@@ -42,10 +41,12 @@ const richLink = css`
 	}
 `;
 
-export const RichLinkBlockComponent: React.FC<{
+type Props = {
 	element: RichLinkBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => (
+};
+
+export const RichLinkBlockComponent = ({ element, pillar }: Props) => (
 	<aside css={richLinkContainer}>
 		<a css={[richLink, pillarColour(pillar)]} href={element.url}>
 			{element.text}

--- a/dotcom-rendering/src/amp/components/elements/SoundcloudBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/SoundcloudBlockComponent.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import type { SoundcloudBlockElement } from '../../../types/content';
 
-export const SoundcloudBlockComponent: React.FC<{
+type Props = {
 	element: SoundcloudBlockElement;
-}> = ({ element }) => {
+};
+
+export const SoundcloudBlockComponent = ({ element }: Props) => {
 	return element.isTrack ? (
 		<amp-soundcloud
 			height="300"

--- a/dotcom-rendering/src/amp/components/elements/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/SubheadingBlockComponent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleSpecial as Special } from '@guardian/libs';
 import { headline, neutral, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 
 const style = (pillar: ArticleTheme) => css`
@@ -38,11 +37,17 @@ const subHeadingStyleLabs = css`
 	}
 `;
 
-export const SubheadingBlockComponent: React.FC<{
+type Props = {
 	html: string;
 	pillar: ArticleTheme;
 	isImmersive: boolean;
-}> = ({ html, pillar, isImmersive }) => (
+};
+
+export const SubheadingBlockComponent = ({
+	html,
+	pillar,
+	isImmersive,
+}: Props) => (
 	<span
 		css={
 			pillar === Special.Labs

--- a/dotcom-rendering/src/amp/components/elements/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TextBlockComponent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleSpecial } from '@guardian/libs';
 import { body, neutral, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import sanitise from 'sanitize-html';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 
@@ -71,10 +70,12 @@ const textStyleLabs = css`
 	}
 `;
 
-export const TextBlockComponent: React.FC<{
+type Props = {
 	html: string;
 	pillar: ArticleTheme;
-}> = ({ html, pillar }) => (
+};
+
+export const TextBlockComponent = ({ html, pillar }: Props) => (
 	<span
 		css={
 			pillar === ArticleSpecial.Labs

--- a/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import type { TimelineEvent } from '@guardian/atoms-rendering/dist/types/types';
 import { brandAlt, neutral } from '@guardian/source-foundations';
-import React from 'react';
 import { Expandable } from '../Expandable';
 
 const eventsWrapper = css`
@@ -37,13 +36,21 @@ const headingStyle = css`
 	font-weight: bold;
 `;
 
-export const TimelineBlockComponent: React.FC<{
+type Props = {
 	id: string;
 	title: string;
 	description?: string;
 	events: TimelineEvent[];
 	pillar: ArticleTheme;
-}> = ({ id, title, description, events, pillar }) => (
+};
+
+export const TimelineBlockComponent = ({
+	id,
+	title,
+	description,
+	events,
+	pillar,
+}: Props) => (
 	<Expandable id={id} type="Timeline" title={title} pillar={pillar}>
 		{description || ''}
 		<ul css={eventsWrapper}>

--- a/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/TwitterBlockComponent.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { body, neutral } from '@guardian/source-foundations';
 import { JSDOM } from 'jsdom';
-import React from 'react';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import type { TweetBlockElement } from '../../../types/content';
 
@@ -72,10 +71,12 @@ const makeFallback = (html: string): string | null => {
 	return q.innerHTML;
 };
 
-export const TwitterBlockComponent: React.FC<{
+type Props = {
 	element: TweetBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => {
+};
+
+export const TwitterBlockComponent = ({ element, pillar }: Props) => {
 	const fallbackHTML = makeFallback(element.html);
 
 	return (

--- a/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoVimeoBlockComponent.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { VideoVimeoBlockElement } from '../../../types/content';
+import type { VideoVimeoBlockElement } from '../../../types/content';
 import { getIdFromUrl } from '../../lib/get-video-id';
 import { Caption } from '../Caption';
 
-export const VideoVimeoBlockComponent: React.FC<{
+type Props = {
 	element: VideoVimeoBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => {
+};
+
+export const VideoVimeoBlockComponent = ({ element, pillar }: Props) => {
 	// This is a hack as `url` is coming through as `""` from the embed.ly oembed endpoint
 	// which is used in composer.
 	// see: https://github.com/guardian/dotcom-rendering/issues/4057

--- a/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/dotcom-rendering/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
 import type { VideoYoutubeBlockElement } from '../../../types/content';
 import { getIdFromUrl } from '../../lib/get-video-id';
 import { Caption } from '../Caption';
 
-export const VideoYoutubeBlockComponent: React.FC<{
+type Props = {
 	element: VideoYoutubeBlockElement;
 	pillar: ArticleTheme;
-}> = ({ element, pillar }) => {
+};
+
+export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const youtubeId = getIdFromUrl(
 		element.originalUrl || element.url,
 		'^[a-zA-Z0-9_-]{11}$', // Alpha numeric, underscores and hyphens, exactly 11 numbers long

--- a/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponentAMP.tsx
+++ b/dotcom-rendering/src/amp/components/elements/YoutubeBlockComponentAMP.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { constructQuery } from '../../../lib/querystring';
-import { YoutubeBlockElement } from '../../../types/content';
+import type { YoutubeBlockElement } from '../../../types/content';
 import { Caption } from '../Caption';
 
 type EmbedConfig = {
@@ -40,11 +39,17 @@ const buildEmbedConfig = (adTargeting: AdTargeting): EmbedConfig => {
 	}
 };
 
-export const YoutubeBlockComponentAMP: React.FC<{
+type Props = {
 	element: YoutubeBlockElement;
 	pillar: ArticleTheme;
 	adTargeting?: AdTargeting;
-}> = ({ element, pillar, adTargeting }) => {
+};
+
+export const YoutubeBlockComponentAMP = ({
+	element,
+	pillar,
+	adTargeting,
+}: Props) => {
 	// https://www.ampproject.org/docs/reference/components/amp-youtube
 	// https://developers.google.com/youtube/player_parameters
 	const attributes: { [key: string]: any } = {

--- a/dotcom-rendering/src/amp/components/moustache.tsx
+++ b/dotcom-rendering/src/amp/components/moustache.tsx
@@ -21,7 +21,9 @@ export const MoustacheSection = ({
 	</>
 );
 
-export const MoustacheVariable: React.FC<{ name: string }> = ({ name }) => (
+type Props = { name: string };
+
+export const MoustacheVariable = ({ name }: Props) => (
 	<>{moustacheVariable(name)}</>
 );
 

--- a/dotcom-rendering/src/amp/components/topMeta/Branding.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/Branding.tsx
@@ -37,10 +37,12 @@ const brandingLogoStyle = css`
 	padding: 10px 0;
 `;
 
-export const Branding: React.FC<{
+type BrandingProps = {
 	branding: BrandingType;
 	pillar: ArticleTheme;
-}> = ({ branding, pillar }) => {
+};
+
+export const Branding = ({ branding, pillar }: BrandingProps) => {
 	const { logo, sponsorName } = branding;
 
 	return (
@@ -65,10 +67,15 @@ export const Branding: React.FC<{
 	);
 };
 
-export const BrandingRegionContainer: React.FC<{
+type BrandingRegionContainerProps = {
 	children: (branding: BrandingType) => React.ReactNode;
 	commercialProperties: CommercialProperties;
-}> = ({ children, commercialProperties }) => (
+};
+
+export const BrandingRegionContainer = ({
+	children,
+	commercialProperties,
+}: BrandingRegionContainerProps) => (
 	<>
 		{Object.keys(commercialProperties)
 			.filter(isEditionId)

--- a/dotcom-rendering/src/amp/components/topMeta/PaidForBand.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/PaidForBand.tsx
@@ -6,7 +6,6 @@ import {
 	neutral,
 	textSans,
 } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import ArrowRightIcon from '../../../static/icons/arrow-right.svg';
 import LabsLogo from '../../../static/logos/the-guardian-labs.svg';
@@ -107,7 +106,7 @@ const iconStyle = css`
 	height: 20px;
 `;
 
-export const PaidForBand: React.FC = () => (
+export const PaidForBand = () => (
 	<header css={headerStyle}>
 		<div css={metaStyle}>
 			<span>Paid content</span>

--- a/dotcom-rendering/src/amp/components/topMeta/SeriesLink.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/SeriesLink.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
-import React from 'react';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 import type { TagType } from '../../../types/tag';
 
@@ -13,22 +12,24 @@ const seriesStyle = (pillar: ArticleTheme) => css`
 	display: block;
 `;
 
-// Returns a series link if possible, and attempt to return a section link as a fallback if provided
-export const SeriesLink: React.FunctionComponent<{
+type Props = {
 	baseURL: string;
 	tags: TagType[];
 	fallbackToSection: boolean;
 	sectionLabel?: string; // required for fallback only
 	sectionUrl?: string; // required for fallback only
 	pillar: ArticleTheme;
-}> = ({
+};
+
+// Returns a series link if possible, and attempt to return a section link as a fallback if provided
+export const SeriesLink = ({
 	baseURL,
 	tags,
 	fallbackToSection,
 	sectionLabel,
 	sectionUrl,
 	pillar,
-}) => {
+}: Props) => {
 	const tag = tags.find((t) => t.type === 'Blog' || t.type === 'Series');
 
 	if (!tag && !fallbackToSection) {

--- a/dotcom-rendering/src/amp/components/topMeta/Standfirst.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/Standfirst.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import type { ArticleTheme } from '@guardian/libs';
 import { ArticleSpecial } from '@guardian/libs';
 import { headline, neutral, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
 
 const ListStyle = (iconColour: string) => css`
@@ -64,10 +63,12 @@ const labsStyle = css`
 	}
 `;
 
-export const Standfirst: React.FunctionComponent<{
+type Props = {
 	text: string;
 	pillar: ArticleTheme;
-}> = ({ text, pillar }) => {
+};
+
+export const Standfirst = ({ text, pillar }: Props) => {
 	return (
 		<div
 			data-print-layout="hide"

--- a/dotcom-rendering/src/amp/components/topMeta/TopMeta.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMeta.tsx
@@ -1,17 +1,17 @@
 import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
-import React from 'react';
 import type { ArticleModel } from '../../types/ArticleModel';
 import { TopMetaAnalysis } from './TopMetaAnalysis';
 import { TopMetaNews } from './TopMetaNews';
 import { TopMetaOpinion } from './TopMetaOpinion';
 import { TopMetaPaidContent } from './TopMetaPaidContent';
 
-export const TopMeta: React.FunctionComponent<{
+type Props = {
 	data: ArticleModel;
 	design: ArticleDesign;
 	pillar: ArticleTheme;
 	adTargeting?: AdTargeting;
-}> = ({ data, design, pillar, adTargeting }) => {
+};
+export const TopMeta = ({ data, design, pillar, adTargeting }: Props) => {
 	if (pillar === ArticleSpecial.Labs)
 		return <TopMetaPaidContent articleData={data} pillar={pillar} />;
 	switch (design) {

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaAnalysis.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaAnalysis.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { headline, neutral, until } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
-import React from 'react';
 import { getAgeWarning } from '../../../lib/age-warning';
 import { getSoleContributor } from '../../../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
@@ -66,10 +65,12 @@ const starRatingWrapper = css`
 	margin: 0 0 6px -10px;
 `;
 
-const Headline: React.FC<{
+type HeadlineProps = {
 	headlineText: string;
 	starRating?: number;
-}> = ({ headlineText, starRating }) => {
+};
+
+const Headline = ({ headlineText, starRating }: HeadlineProps) => {
 	return (
 		<div>
 			<h1 css={[headerStyle, underlinedStyles]}>{curly(headlineText)}</h1>
@@ -83,11 +84,17 @@ const Headline: React.FC<{
 	);
 };
 
-export const TopMetaAnalysis: React.FC<{
+type Props = {
 	articleData: ArticleModel;
 	adTargeting?: AdTargeting;
 	pillar: ArticleTheme;
-}> = ({ articleData, adTargeting, pillar }) => {
+};
+
+export const TopMetaAnalysis = ({
+	articleData,
+	adTargeting,
+	pillar,
+}: Props) => {
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaExtras.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaExtras.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral, text, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import {
 	neutralBorder,
 	pillarMap,
@@ -67,14 +66,20 @@ const twitterIcon = css`
 	width: 12px;
 `;
 
-const WebPublicationDate: React.FC<{
+type WebPublicationDateProps = {
 	date: string;
-}> = ({ date }) => <div css={metaStyle}>{date}</div>;
+};
 
-const AgeWarning: React.FC<{
+const WebPublicationDate = ({ date }: WebPublicationDateProps) => (
+	<div css={metaStyle}>{date}</div>
+);
+
+type AgeWarningProps = {
 	warning?: string;
 	pillar: ArticleTheme;
-}> = ({ warning, pillar }) => {
+};
+
+const AgeWarning = ({ warning, pillar }: AgeWarningProps) => {
 	if (!warning) {
 		return null;
 	}
@@ -86,9 +91,11 @@ const AgeWarning: React.FC<{
 	);
 };
 
-const TwitterHandle: React.FC<{
+type TwitterHandleProps = {
 	handle?: string;
-}> = ({ handle }) => {
+};
+
+const TwitterHandle = ({ handle }: TwitterHandleProps) => {
 	if (!handle) {
 		return null;
 	}
@@ -100,19 +107,21 @@ const TwitterHandle: React.FC<{
 	);
 };
 
-export const TopMetaExtras: React.FC<{
+type TopMetaExtrasProps = {
 	sharingUrls: SharingURLs;
 	pillar: ArticleTheme;
 	webPublicationDate: string;
 	ageWarning?: string;
 	twitterHandle?: string;
-}> = ({
+};
+
+export const TopMetaExtras = ({
 	sharingUrls,
 	pillar,
 	webPublicationDate,
 	ageWarning,
 	twitterHandle,
-}) => (
+}: TopMetaExtrasProps) => (
 	<div css={metaExtras}>
 		<TwitterHandle handle={twitterHandle} />
 		<WebPublicationDate date={webPublicationDate} />

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { headline, neutral } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
-import React from 'react';
 import { getAgeWarning } from '../../../lib/age-warning';
 import { getSoleContributor } from '../../../lib/byline';
 import { neutralBorder, pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
@@ -80,11 +79,13 @@ const fullWidth = css`
 	margin: 0 -10px;
 `;
 
-const Headline: React.FC<{
+type HeadlineProps = {
 	headlineText: string;
 	standfirst: string;
 	pillar: ArticleTheme;
-}> = ({ headlineText, pillar, standfirst }) => {
+};
+
+const Headline = ({ headlineText, pillar, standfirst }: HeadlineProps) => {
 	return (
 		<div css={fullWidth}>
 			<h1 css={headerStyle(pillar)}>{curly(headlineText)}</h1>
@@ -98,10 +99,15 @@ const Headline: React.FC<{
 	);
 };
 
-export const TopMetaLiveblog: React.FC<{
+type TopMetaLiveblogProps = {
 	articleData: ArticleModel;
 	pillar: ArticleTheme;
-}> = ({ articleData, pillar }) => (
+};
+
+export const TopMetaLiveblog = ({
+	articleData,
+	pillar,
+}: TopMetaLiveblogProps) => (
 	<header>
 		<Headline
 			headlineText={articleData.headline}

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaNews.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { headline, neutral } from '@guardian/source-foundations';
 import { string as curly } from 'curlyquotes';
-import React from 'react';
 import { getAgeWarning } from '../../../lib/age-warning';
 import { getSoleContributor } from '../../../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
@@ -40,10 +39,12 @@ const starRatingWrapper = css`
 	margin: 0 0 6px -10px;
 `;
 
-const Headline: React.FC<{
+type HeadlineProps = {
 	headlineText: string;
 	starRating?: number;
-}> = ({ headlineText, starRating }) => {
+};
+
+const Headline = ({ headlineText, starRating }: HeadlineProps) => {
 	return (
 		<div>
 			<h1 css={headerStyle}>{curly(headlineText)}</h1>
@@ -57,11 +58,17 @@ const Headline: React.FC<{
 	);
 };
 
-export const TopMetaNews: React.FC<{
+type TopMetaNewsProps = {
 	articleData: ArticleModel;
 	adTargeting?: AdTargeting;
 	pillar: ArticleTheme;
-}> = ({ articleData, adTargeting, pillar }) => {
+};
+
+export const TopMetaNews = ({
+	articleData,
+	adTargeting,
+	pillar,
+}: TopMetaNewsProps) => {
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { headline, neutral } from '@guardian/source-foundations';
-import React from 'react';
 import { getAgeWarning } from '../../../lib/age-warning';
 import { getSoleContributor } from '../../../lib/byline';
 import { pillarPalette_DO_NOT_USE } from '../../../lib/pillars';
@@ -61,10 +60,12 @@ const bottomPadding = css`
 	padding-bottom: 72px;
 `;
 
-const BylineMeta: React.FunctionComponent<{
+type BylineMetaProps = {
 	articleData: ArticleModel;
 	pillar: ArticleTheme;
-}> = ({ articleData, pillar }) => {
+};
+
+const BylineMeta = ({ articleData, pillar }: BylineMetaProps) => {
 	const contributorTag = articleData.tags.find(
 		(t) => t.type === 'Contributor',
 	);
@@ -106,10 +107,15 @@ const BylineMeta: React.FunctionComponent<{
 	);
 };
 
-export const TopMetaOpinion: React.FC<{
+type TopMetaOpinionProps = {
 	articleData: ArticleModel;
 	pillar: ArticleTheme;
-}> = ({ articleData, pillar }) => {
+};
+
+export const TopMetaOpinion = ({
+	articleData,
+	pillar,
+}: TopMetaOpinionProps) => {
 	return (
 		<header>
 			{articleData.mainMediaElements.map((element, i) => (

--- a/dotcom-rendering/src/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/dotcom-rendering/src/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { body, neutral, text, textSans } from '@guardian/source-foundations';
-import React from 'react';
 import { getAgeWarning } from '../../../lib/age-warning';
 import { getSoleContributor } from '../../../lib/byline';
 import { getSharingUrls } from '../../../lib/sharing-urls';
@@ -50,9 +49,11 @@ const paidForLogoStyle = css`
 	margin-bottom: 12px;
 `;
 
-const PaidForByLogo: React.FC<{
+type PaidForByLogoProps = {
 	branding: Branding;
-}> = ({ branding }) => {
+};
+
+const PaidForByLogo = ({ branding }: PaidForByLogoProps) => {
 	const { logo, sponsorName } = branding;
 
 	return (
@@ -75,14 +76,23 @@ const PaidForByLogo: React.FC<{
 	);
 };
 
-const Headline: React.FC<{
+type HeadlineProps = {
 	headlineText: string;
-}> = ({ headlineText }) => <h1 css={headerStyle}>{headlineText}</h1>;
+};
 
-export const TopMetaPaidContent: React.FC<{
+const Headline = ({ headlineText }: HeadlineProps) => (
+	<h1 css={headerStyle}>{headlineText}</h1>
+);
+
+type TopMetaPaidContentProps = {
 	articleData: ArticleModel;
 	pillar: ArticleTheme;
-}> = ({ articleData, pillar }) => (
+};
+
+export const TopMetaPaidContent = ({
+	articleData,
+	pillar,
+}: TopMetaPaidContentProps) => (
 	<header>
 		<PaidForBand />
 

--- a/dotcom-rendering/src/amp/pages/Article.tsx
+++ b/dotcom-rendering/src/amp/pages/Article.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral } from '@guardian/source-foundations';
-import React from 'react';
 import type { NavType } from '../../model/extract-nav';
 import type { ConfigType } from '../../types/config';
 import { AdConsent } from '../components/AdConsent';
@@ -30,10 +29,12 @@ const backgroundColour = css`
 	background-color: ${neutral[97]};
 `;
 
-const Body: React.FunctionComponent<{
+type BodyProps = {
 	data: ArticleModel;
 	config: ConfigType;
-}> = ({ data, config }) => {
+};
+
+const Body = ({ data, config }: BodyProps) => {
 	const { format } = data;
 
 	if (
@@ -45,21 +46,23 @@ const Body: React.FunctionComponent<{
 	return <BodyArticle data={data} config={config} />;
 };
 
-export const Article: React.FC<{
+type ArticleProps = {
 	experimentsData?: AmpExperiments;
 	nav: NavType;
 	articleData: ArticleModel;
 	config: ConfigType;
 	analytics: AnalyticsModel;
 	permutive: PermutiveModel;
-}> = ({
+};
+
+export const Article = ({
 	nav,
 	articleData,
 	config,
 	analytics,
 	experimentsData,
 	permutive: { projectId, apiKey, payload },
-}) => {
+}: ArticleProps) => {
 	return (
 		<ContentABTestProvider
 			switches={config.switches}
@@ -97,7 +100,7 @@ export const Article: React.FC<{
 
 			{/* The sidebar has to live here unfortunately to be valid AMP
             but note the click handler lives in the Header. */}
-			<Sidebar key="sidebar" nav={nav} />
+			<Sidebar key="sidebar" />
 		</ContentABTestProvider>
 	);
 };

--- a/dotcom-rendering/src/web/components/Avatar.tsx
+++ b/dotcom-rendering/src/web/components/Avatar.tsx
@@ -15,12 +15,19 @@ const backgroundStyles = (palette: Palette) =>
 		background-color: ${palette.background.avatar};
 	`;
 
-export const Avatar: React.FC<{
+type Props = {
 	imageSrc: string;
 	imageAlt: string;
 	format: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
-}> = ({ imageSrc, imageAlt, format, containerPalette }) => {
+};
+
+export const Avatar = ({
+	imageSrc,
+	imageAlt,
+	format,
+	containerPalette,
+}: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
 		<img

--- a/dotcom-rendering/src/web/components/BackToTop.tsx
+++ b/dotcom-rendering/src/web/components/BackToTop.tsx
@@ -56,7 +56,7 @@ const textStyles = css`
 	padding-right: 5px;
 `;
 
-export const BackToTop: React.FC = () => (
+export const BackToTop = () => (
 	<a css={link} href="#top">
 		<span css={textStyles}>Back to top</span>
 		<span css={iconContainer} className="icon-container">

--- a/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/BlockquoteBlockComponent.tsx
@@ -12,11 +12,7 @@ type Props = {
 	quoted?: boolean;
 };
 
-export const BlockquoteBlockComponent: React.FC<Props> = ({
-	html,
-	palette,
-	quoted,
-}: Props) => (
+export const BlockquoteBlockComponent = ({ html, palette, quoted }: Props) => (
 	<ClassNames>
 		{({ css }) => {
 			const baseBlockquoteStyles = css`

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -123,7 +123,6 @@ type RenderFooter = ({
 }: {
 	displayAge: boolean;
 	displayLines: boolean;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- this signature is adequate
 }) => JSX.Element;
 
 const DecideFooter = ({

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -343,7 +343,7 @@ type CarouselCardProps = {
 	branding?: Branding;
 };
 
-const CarouselCard: React.FC<CarouselCardProps> = ({
+const CarouselCard = ({
 	format,
 	linkTo,
 	imageUrl,
@@ -394,14 +394,14 @@ type HeaderAndNavProps = {
 	goToIndex: (newIndex: number) => void;
 };
 
-const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
+const HeaderAndNav = ({
 	heading,
 	trails,
 	palette,
 	index,
 	isCuratedContent,
 	goToIndex,
-}) => (
+}: HeaderAndNavProps) => (
 	<div>
 		<Title
 			title={heading}

--- a/dotcom-rendering/src/web/components/ContributorAvatar.tsx
+++ b/dotcom-rendering/src/web/components/ContributorAvatar.tsx
@@ -9,9 +9,11 @@ const imageStyles = css`
 	}
 `;
 
-export const ContributorAvatar: React.FC<{
+type Props = {
 	imageSrc: string;
 	imageAlt: string;
-}> = ({ imageSrc, imageAlt }) => {
+};
+
+export const ContributorAvatar = ({ imageSrc, imageAlt }: Props) => {
 	return <img src={imageSrc} alt={imageAlt} css={imageStyles} />;
 };

--- a/dotcom-rendering/src/web/components/Dateline.tsx
+++ b/dotcom-rendering/src/web/components/Dateline.tsx
@@ -39,11 +39,17 @@ const standfirstColouring = (palette: Palette) => css`
 // At the moment the 'First published on' / 'Last modified on' is passed through on
 // the secondaryDateline (this will be refactored). The current logic checks if the primary
 // date is in the secondary to avoid duplicate dates being shown
-export const Dateline: React.FC<{
+type Props = {
 	primaryDateline: string;
 	secondaryDateline: string;
 	format: ArticleFormat;
-}> = ({ primaryDateline, secondaryDateline, format }) => {
+};
+
+export const Dateline = ({
+	primaryDateline,
+	secondaryDateline,
+	format,
+}: Props) => {
 	const palette = decidePalette(format);
 
 	if (secondaryDateline && !secondaryDateline.includes(primaryDateline)) {

--- a/dotcom-rendering/src/web/components/DisclaimerBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/DisclaimerBlockComponent.tsx
@@ -11,9 +11,11 @@ const disclaimerStyles = css`
 	margin-bottom: 16px;
 `;
 
-export const DisclaimerBlockComponent: React.FC<{
+type Props = {
 	html: string;
-}> = ({ html }) => (
+};
+
+export const DisclaimerBlockComponent = ({ html }: Props) => (
 	<footer
 		css={disclaimerStyles}
 		data-cy="affiliate-disclaimer"

--- a/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
+++ b/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
@@ -29,11 +29,17 @@ const editionDropdown = css`
 	}
 `;
 
-export const EditionDropdown: React.FC<{
+type Props = {
 	editionId: EditionId;
 	dataLinkName: string;
 	isInEuropeTest: boolean;
-}> = ({ editionId, dataLinkName, isInEuropeTest }) => {
+};
+
+export const EditionDropdown = ({
+	editionId,
+	dataLinkName,
+	isInEuropeTest,
+}: Props) => {
 	const links = [
 		{
 			id: 'uk',

--- a/dotcom-rendering/src/web/components/Footer.stories.tsx
+++ b/dotcom-rendering/src/web/components/Footer.stories.tsx
@@ -10,7 +10,6 @@ import {
 import { Standard } from '../../../fixtures/generated/articles/Standard';
 import { extractNAV } from '../../model/extract-nav';
 import { editionList } from '../lib/edition';
-
 import { Footer } from './Footer';
 import { Section } from './Section';
 

--- a/dotcom-rendering/src/web/components/HighlightBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/HighlightBlockComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
 	html: string;
 };
 
-export const HighlightBlockComponent: React.FC<Props> = ({ html }: Props) => (
+export const HighlightBlockComponent = ({ html }: Props) => (
 	<ClassNames>
 		{({ css }) => {
 			const {

--- a/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/web/components/InstagramBlockComponent.importable.tsx
@@ -12,11 +12,16 @@ const fullWidthStyles = css`
  * called to be size correctly.
  * src/web/browser/embedIframe/embedIframe.ts
  */
-export const InstagramBlockComponent: React.FC<{
+type Props = {
 	element: InstagramBlockElement;
 	index: number;
 	isMainMedia: boolean;
-}> = ({ element, index, isMainMedia }) => {
+};
+export const InstagramBlockComponent = ({
+	element,
+	index,
+	isMainMedia,
+}: Props) => {
 	return (
 		<ClickToView
 			role={element.role}

--- a/dotcom-rendering/src/web/components/Lazy.tsx
+++ b/dotcom-rendering/src/web/components/Lazy.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { useIsInView } from '../lib/useIsInView';
 
 type Props = {
-	// eslint-disable-next-line @typescript-eslint/ban-types -- we want to coerce children
 	children: JSX.Element;
 	margin: number;
 	disableFlexStyles?: boolean;

--- a/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlogEpic.importable.tsx
@@ -52,7 +52,8 @@ const useCountryCode = () => {
 const useEpic = ({ url, name }: { url: string; name: string }) => {
 	// Using state here to store the Epic component that gets imported allows
 	// us to render it with React (instead of inserting it into the dom manually)
-	const [Epic, setEpic] = useState<React.FC<{ [key: string]: unknown }>>();
+	const [Epic, setEpic] =
+		useState<React.ElementType<{ [key: string]: unknown }>>();
 
 	useEffect(() => {
 		setAutomat();

--- a/dotcom-rendering/src/web/components/MainMedia.tsx
+++ b/dotcom-rendering/src/web/components/MainMedia.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import { until } from '@guardian/source-foundations';
 import type { Switches } from '../../types/config';
-import { CAPIElement } from '../../types/content';
+import type { CAPIElement } from '../../types/content';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
 
@@ -68,7 +68,7 @@ const chooseWrapper = (format: ArticleFormat) => {
 	}
 };
 
-export const MainMedia: React.FC<{
+type Props = {
 	format: ArticleFormat;
 	elements: CAPIElement[];
 	hideCaption?: boolean;
@@ -81,7 +81,9 @@ export const MainMedia: React.FC<{
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: Switches;
-}> = ({
+};
+
+export const MainMedia = ({
 	elements,
 	format,
 	hideCaption,
@@ -94,7 +96,7 @@ export const MainMedia: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	switches,
-}) => {
+}: Props) => {
 	return (
 		<div css={[mainMedia, chooseWrapper(format)]}>
 			{elements.map((element, index) => (

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -211,12 +211,19 @@ const editionsSwitch = css`
 	}
 `;
 
-export const Columns: React.FC<{
+type Props = {
 	editionId: EditionId;
 	format: ArticleFormat;
 	nav: NavType;
 	headerTopBarSwitch: boolean;
-}> = ({ format, nav, editionId, headerTopBarSwitch }) => {
+};
+
+export const Columns = ({
+	format,
+	nav,
+	editionId,
+	headerTopBarSwitch,
+}: Props) => {
 	const activeEdition = getEditionFromId(editionId);
 	const remainingEditions = getRemainingEditions(activeEdition.editionId);
 	return (

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -7,8 +7,7 @@ import {
 	until,
 } from '@guardian/source-foundations';
 import type { NavType } from '../../../../model/extract-nav';
-import { EditionId } from '../../../lib/edition';
-
+import type { EditionId } from '../../../lib/edition';
 import { getZIndex } from '../../../lib/getZIndex';
 import { navInputCheckboxId } from '../config';
 import { Columns } from './Columns';
@@ -105,12 +104,19 @@ const mainMenuStyles = css`
 	}
 `;
 
-export const ExpandedMenu: React.FC<{
+type Props = {
 	editionId: EditionId;
 	format: ArticleFormat;
 	nav: NavType;
 	headerTopBarSwitch: boolean;
-}> = ({ format, nav, editionId, headerTopBarSwitch }) => {
+};
+
+export const ExpandedMenu = ({
+	format,
+	nav,
+	editionId,
+	headerTopBarSwitch,
+}: Props) => {
 	return (
 		<div id="expanded-menu-root">
 			<ShowMoreMenu display={format.display} />

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx
@@ -189,10 +189,12 @@ const shareIconStyles = css`
 	width: 28px;
 `;
 
-export const MoreColumn: React.FC<{
+type Props = {
 	column: LinkType;
 	brandExtensions: LinkType[];
-}> = ({ column, brandExtensions }) => {
+};
+
+export const MoreColumn = ({ column, brandExtensions }: Props) => {
 	const subNavId = `${column.title.toLowerCase()}Links`;
 	// Add the brand extensions to 'more' on mobile.
 	const moreColumn = {

--- a/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -8,9 +8,8 @@ import {
 } from '@guardian/source-foundations';
 import { useEffect, useState } from 'react';
 import type { LinkType } from '../../../../model/extract-nav';
-
 import { addTrackingCodesToUrl } from '../../../lib/acquisitions';
-import { EditionId } from '../../../lib/edition';
+import type { EditionId } from '../../../lib/edition';
 
 const hideDesktop = css`
 	${from.desktop} {
@@ -70,11 +69,17 @@ const mainMenuLinkStyle = css`
 	}
 `;
 
-export const ReaderRevenueLinks: React.FC<{
+type Props = {
 	readerRevenueLinks: ReaderRevenuePositions;
 	editionId: EditionId;
 	headerTopBarSwitch: boolean;
-}> = ({ readerRevenueLinks, editionId, headerTopBarSwitch }) => {
+};
+
+export const ReaderRevenueLinks = ({
+	readerRevenueLinks,
+	editionId,
+	headerTopBarSwitch,
+}: Props) => {
 	const [pageViewId, setPageViewId] = useState('');
 	const [referrerUrl, setReferrerUrl] = useState('');
 	useEffect(() => {

--- a/dotcom-rendering/src/web/components/Pillars.tsx
+++ b/dotcom-rendering/src/web/components/Pillars.tsx
@@ -237,21 +237,23 @@ const forceUnderline = css`
 const isNotLastPillar = (i: number, noOfPillars: number): boolean =>
 	i !== noOfPillars - 1;
 
-export const Pillars: React.FC<{
+type Props = {
 	display: ArticleDisplay;
 	isTopNav?: boolean;
 	pillars: PillarType[];
 	pillar: ArticleTheme;
 	showLastPillarDivider?: boolean;
 	dataLinkName: string;
-}> = ({
+};
+
+export const Pillars = ({
 	display,
 	isTopNav,
 	pillars,
 	pillar,
 	showLastPillarDivider = true,
 	dataLinkName,
-}) => (
+}: Props) => (
 	<ul data-testid="pillar-list" css={pillarsStyles(display)}>
 		{pillars.map((p, i) => {
 			const isSelected = p.pillar === pillar;

--- a/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/PullQuoteBlockComponent.tsx
@@ -139,13 +139,21 @@ function decideFont(role: string) {
 	`;
 }
 
-export const PullQuoteBlockComponent: React.FC<{
+type Props = {
 	html?: string;
 	palette: Palette;
 	format: ArticleFormat;
 	role: string;
 	attribution?: string;
-}> = ({ html, palette, format, attribution, role }) => {
+};
+
+export const PullQuoteBlockComponent = ({
+	html,
+	palette,
+	format,
+	attribution,
+	role,
+}: Props) => {
 	if (!html) return <></>;
 
 	if (format.theme === ArticleSpecial.SpecialReportAlt)

--- a/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/web/components/ReaderRevenueLinks.importable.tsx
@@ -19,7 +19,6 @@ import type {
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import ArrowRightIcon from '../../static/icons/arrow-right.svg';
-import type { EditionId } from '../lib/edition';
 import type { OphanRecordFunction } from '../browser/ophan/ophan';
 import {
 	getOphanRecordFunction,
@@ -33,6 +32,7 @@ import {
 	MODULES_VERSION,
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
+import type { EditionId } from '../lib/edition';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
 import { useIsInView } from '../lib/useIsInView';
@@ -155,15 +155,29 @@ const subMessageStyles = css`
 	margin: 5px 0;
 `;
 
-const ReaderRevenueLinksRemote: React.FC<{
+type SupportHeaderType = React.ElementType<
+	ModuleData['props'] & {
+		submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+	}
+>;
+
+type ReaderRevenueLinksRemoteProps = {
 	countryCode: string;
 	pageViewId: string;
 	contributionsServiceUrl: string;
 	ophanRecord: OphanRecordFunction;
-}> = ({ countryCode, pageViewId, contributionsServiceUrl, ophanRecord }) => {
+};
+
+const ReaderRevenueLinksRemote = ({
+	countryCode,
+	pageViewId,
+	contributionsServiceUrl,
+	ophanRecord,
+}: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
-	const [SupportHeader, setSupportHeader] = useState<React.FC | null>(null);
+	const [SupportHeader, setSupportHeader] =
+		useState<SupportHeaderType | null>(null);
 
 	useOnce((): void => {
 		setAutomat();
@@ -199,9 +213,13 @@ const ReaderRevenueLinksRemote: React.FC<{
 
 				return window
 					.guardianPolyfilledImport(module.url)
-					.then((headerModule: { [key: string]: JSX.Element }) => {
-						setSupportHeader(() => headerModule[module.name]);
-					});
+					.then(
+						(headerModule: {
+							[key: string]: SupportHeaderType;
+						}) => {
+							setSupportHeader(() => headerModule[module.name]);
+						},
+					);
 			})
 			.catch((error) => {
 				const msg = `Error importing RR header links: ${String(error)}`;
@@ -219,7 +237,6 @@ const ReaderRevenueLinksRemote: React.FC<{
 			<div css={headerStyles}>
 				{}
 				<SupportHeader
-					// @ts-expect-error
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
 					) => submitComponentEvent(componentEvent, ophanRecord)}
@@ -232,7 +249,7 @@ const ReaderRevenueLinksRemote: React.FC<{
 	return null;
 };
 
-const ReaderRevenueLinksNative: React.FC<{
+type ReaderRevenueLinksNativeProps = {
 	editionId: EditionId;
 	dataLinkNamePrefix: string;
 	inHeader: boolean;
@@ -243,14 +260,16 @@ const ReaderRevenueLinksNative: React.FC<{
 	};
 	ophanRecord: OphanRecordFunction;
 	pageViewId: string;
-}> = ({
+};
+
+const ReaderRevenueLinksNative = ({
 	editionId,
 	dataLinkNamePrefix,
 	inHeader,
 	urls,
 	ophanRecord,
 	pageViewId,
-}) => {
+}: ReaderRevenueLinksNativeProps) => {
 	const hideSupportMessaging = shouldHideSupportMessaging();
 
 	// Only the header component is in the AB test

--- a/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd.importable.tsx
@@ -104,7 +104,9 @@ export const SlotBodyEnd = ({
 	const [countryCode, setCountryCode] = useState<string>();
 	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
-	const [SelectedEpic, setSelectedEpic] = useState<React.FC | null>(null);
+	const [SelectedEpic, setSelectedEpic] = useState<React.ElementType | null>(
+		null,
+	);
 	const [asyncArticleCount, setAsyncArticleCount] =
 		useState<Promise<WeeklyArticleHistory | undefined>>();
 

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.stories.tsx
@@ -1,4 +1,4 @@
-import type { CommonEndOfArticleComponentProps as BrazeEpicProps } from '@guardian/braze-components';
+import type { BrazeEndOfArticleComponent } from '@guardian/braze-components';
 import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
 
@@ -17,7 +17,7 @@ export const BrazeEpicComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -95,7 +95,7 @@ export const BrazeEpicWithReminderComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -173,7 +173,7 @@ export const BrazeEpicSpecialHeaderComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -249,7 +249,7 @@ export const BrazeUKNewsletterEpicComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -314,7 +314,7 @@ export const BrazeUSNewsletterEpicComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -379,7 +379,7 @@ export const BrazeAUNewsletterEpicComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -444,7 +444,7 @@ export const BrazeDownToEarthNewsletterEpicComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeEpicProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { CommonEndOfArticleComponentProps } from '@guardian/braze-components/end-of-article';
+import type { BrazeEndOfArticleComponent } from '@guardian/braze-components/end-of-article';
 import type {
 	BrazeArticleContext,
 	BrazeMessagesInterface,
@@ -75,7 +75,7 @@ export const canShowBrazeEpic = async (
 type InnerProps = {
 	meta: Meta;
 	countryCode: string;
-	BrazeComponent: React.FC<CommonEndOfArticleComponentProps>;
+	BrazeComponent: typeof BrazeEndOfArticleComponent;
 	idApiUrl: string;
 };
 
@@ -145,7 +145,7 @@ const BrazeEpicWithSatisfiedDependencies = ({
 
 export const MaybeBrazeEpic = ({ meta, countryCode, idApiUrl }: EpicConfig) => {
 	const [BrazeComponent, setBrazeComponent] =
-		useState<React.FC<CommonEndOfArticleComponentProps>>();
+		useState<typeof BrazeEndOfArticleComponent>();
 
 	useEffect(() => {
 		import(

--- a/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -42,6 +42,8 @@ type EpicProps = {
 	// Also anything specified by support-dotcom-components
 };
 
+type EpicType = React.ElementType<EpicProps>;
+
 const wrapperMargins = css`
 	margin: 18px 0;
 	clear: both;
@@ -152,7 +154,7 @@ export const ReaderRevenueEpic = ({
 	hasConsentForArticleCount,
 	stage,
 }: EpicConfig) => {
-	const [Epic, setEpic] = useState<React.FC<EpicProps>>();
+	const [Epic, setEpic] = useState<EpicType>();
 
 	const openCmp = () => {
 		cmp.showPrivacyManager();
@@ -166,7 +168,7 @@ export const ReaderRevenueEpic = ({
 
 		window
 			.guardianPolyfilledImport(module.url)
-			.then((epicModule: { ContributionsEpic: React.FC<EpicProps> }) => {
+			.then((epicModule: { ContributionsEpic: EpicType }) => {
 				modulePerf.end();
 				setEpic(() => epicModule.ContributionsEpic); // useState requires functions to be wrapped
 			})

--- a/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
@@ -36,10 +36,12 @@ const determineSize = (size: RatingSizeType) => {
 	}
 };
 
-export const StarRating: React.FC<{
+type Props = {
 	rating: number;
 	size: RatingSizeType;
-}> = ({ rating, size }) => (
+};
+
+export const StarRating = ({ rating, size }: Props) => (
 	<div css={determineSize(size)}>
 		<div css={starWrapper}>
 			<Star starId={`${size}1`} isEmpty={rating < 1} />

--- a/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner.importable.tsx
@@ -53,7 +53,7 @@ type Props = {
 
 type RRBannerConfig = {
 	id: string;
-	BannerComponent: React.FC<BannerProps>;
+	BannerComponent: typeof ReaderRevenueBanner;
 	canShowFn: CanShowFunctionType<BannerProps>;
 	isEnabled: boolean;
 };
@@ -226,7 +226,7 @@ export const StickyBottomBanner = ({
 
 	const asyncCountryCode = getLocaleCode();
 	const isSignedIn = !!getCookie({ name: 'GU_U', shouldMemoize: true });
-	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
+	const [SelectedBanner, setSelectedBanner] = useState<MaybeFC | null>(null);
 	const [asyncArticleCounts, setAsyncArticleCounts] =
 		useState<Promise<ArticleCounts | undefined>>();
 	const signInGateWillShow = useSignInGateWillShow({

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -1,4 +1,4 @@
-import type { CommonBannerComponentProps as BrazeBannerProps } from '@guardian/braze-components';
+import type { BrazeBannerComponent as BrazeBannerComponentType } from '@guardian/braze-components';
 import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
 
@@ -17,7 +17,7 @@ export const BrazeBannerComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeBannerProps>>();
+		useState<typeof BrazeBannerComponentType>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -87,7 +87,7 @@ export const BrazeAppBannerComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeBannerProps>>();
+		useState<typeof BrazeBannerComponentType>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')
@@ -148,7 +148,7 @@ export const BrazeDigitalSubscriberAppBannerComponent = (
 	args: BrazeMessageProps & { componentName: string },
 ): ReactElement => {
 	const [BrazeMessage, setBrazeMessage] =
-		useState<React.FC<BrazeBannerProps>>();
+		useState<typeof BrazeBannerComponentType>();
 
 	useEffect(() => {
 		import('@guardian/braze-components')

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { CommonBannerComponentProps } from '@guardian/braze-components/banner';
+import type { BrazeBannerComponent } from '@guardian/braze-components/banner';
 import type {
 	BrazeArticleContext,
 	BrazeMessagesInterface,
@@ -82,7 +82,7 @@ export const canShowBrazeBanner = async (
 
 type InnerProps = {
 	meta: Meta;
-	BrazeComponent: React.FC<CommonBannerComponentProps>;
+	BrazeComponent: typeof BrazeBannerComponent;
 };
 
 const BrazeBannerWithSatisfiedDependencies = ({
@@ -120,7 +120,7 @@ const BrazeBannerWithSatisfiedDependencies = ({
 
 export const BrazeBanner = ({ meta }: Props) => {
 	const [BrazeComponent, setBrazeComponent] =
-		useState<React.FC<CommonBannerComponentProps>>();
+		useState<typeof BrazeBannerComponent>();
 
 	useEffect(() => {
 		import(

--- a/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -313,7 +313,7 @@ const RemoteBanner = ({
 	module,
 	fetchEmail,
 }: RemoteBannerProps) => {
-	const [Banner, setBanner] = useState<React.FC>();
+	const [Banner, setBanner] = useState<React.ElementType>();
 
 	const [hasBeenSeen, setNode] = useIsInView({
 		threshold: 0,
@@ -365,7 +365,6 @@ const RemoteBanner = ({
 				{}
 				<Banner
 					{...module.props}
-					// @ts-expect-error
 					submitComponentEvent={submitComponentEvent}
 					fetchEmail={fetchEmail}
 				/>

--- a/dotcom-rendering/src/web/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/SubheadingBlockComponent.tsx
@@ -1,9 +1,9 @@
 import { unwrapHtml } from '../../model/unwrapHtml';
 import { RewrappedComponent } from './RewrappedComponent';
 
-export const SubheadingBlockComponent: React.FC<{ html: string }> = ({
-	html,
-}) => {
+type Props = { html: string };
+
+export const SubheadingBlockComponent = ({ html }: Props) => {
 	const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
 		fixes: [{ prefix: '<h2>', suffix: '</h2>' }],
 		html,

--- a/dotcom-rendering/src/web/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/web/components/SupportTheG.importable.tsx
@@ -19,7 +19,6 @@ import type {
 } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import ArrowRightIcon from '../../static/icons/arrow-right.svg';
-import type { EditionId } from '../lib/edition';
 import type { OphanRecordFunction } from '../browser/ophan/ophan';
 import {
 	getOphanRecordFunction,
@@ -33,6 +32,7 @@ import {
 	MODULES_VERSION,
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
+import type { EditionId } from '../lib/edition';
 import { getLocaleCode } from '../lib/getCountryCode';
 import { setAutomat } from '../lib/setAutomat';
 import { useIsInView } from '../lib/useIsInView';
@@ -155,15 +155,23 @@ const subMessageStyles = css`
 	margin: 5px 0;
 `;
 
-const ReaderRevenueLinksRemote: React.FC<{
+type ReaderRevenueLinksRemoteProps = {
 	countryCode: string;
 	pageViewId: string;
 	contributionsServiceUrl: string;
 	ophanRecord: OphanRecordFunction;
-}> = ({ countryCode, pageViewId, contributionsServiceUrl, ophanRecord }) => {
+};
+
+const ReaderRevenueLinksRemote = ({
+	countryCode,
+	pageViewId,
+	contributionsServiceUrl,
+	ophanRecord,
+}: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
-	const [SupportHeader, setSupportHeader] = useState<React.FC | null>(null);
+	const [SupportHeader, setSupportHeader] =
+		useState<React.ElementType | null>(null);
 
 	useOnce((): void => {
 		setAutomat();
@@ -199,9 +207,13 @@ const ReaderRevenueLinksRemote: React.FC<{
 
 				return window
 					.guardianPolyfilledImport(module.url)
-					.then((headerModule: { [key: string]: JSX.Element }) => {
-						setSupportHeader(() => headerModule[module.name]);
-					});
+					.then(
+						(headerModule: {
+							[key: string]: React.ElementType;
+						}) => {
+							setSupportHeader(() => headerModule[module.name]);
+						},
+					);
 			})
 			.catch((error) => {
 				const msg = `Error importing RR header links: ${String(error)}`;
@@ -219,7 +231,6 @@ const ReaderRevenueLinksRemote: React.FC<{
 			<div css={headerStyles}>
 				{}
 				<SupportHeader
-					// @ts-expect-error
 					submitComponentEvent={(
 						componentEvent: OphanComponentEvent,
 					) => submitComponentEvent(componentEvent, ophanRecord)}
@@ -232,7 +243,7 @@ const ReaderRevenueLinksRemote: React.FC<{
 	return null;
 };
 
-const ReaderRevenueLinksNative: React.FC<{
+type ReaderRevenueLinksNativeProps = {
 	editionId: EditionId;
 	dataLinkNamePrefix: string;
 	inHeader: boolean;
@@ -243,14 +254,16 @@ const ReaderRevenueLinksNative: React.FC<{
 	};
 	ophanRecord: OphanRecordFunction;
 	pageViewId: string;
-}> = ({
+};
+
+const ReaderRevenueLinksNative = ({
 	editionId,
 	dataLinkNamePrefix,
 	inHeader,
 	urls,
 	ophanRecord,
 	pageViewId,
-}) => {
+}: ReaderRevenueLinksNativeProps) => {
 	const hideSupportMessaging = shouldHideSupportMessaging();
 
 	// Only the header component is in the AB test

--- a/dotcom-rendering/src/web/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/web/components/TableBlockComponent.tsx
@@ -38,9 +38,11 @@ const tableEmbed = css`
 	margin-bottom: 16px;
 `;
 
-export const TableBlockComponent: React.FC<{
+type Props = {
 	element: TableBlockElement;
-}> = ({ element }) => {
+};
+
+export const TableBlockComponent = ({ element }: Props) => {
 	return (
 		<div
 			css={tableEmbed}

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -42,7 +42,7 @@ interface Props {
 	format: ArticleFormat;
 }
 
-const Renderer: React.FC<{
+type RendererProps = {
 	format: ArticleFormat;
 	elements: CAPIElement[];
 	host?: string;
@@ -52,7 +52,9 @@ const Renderer: React.FC<{
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
 	switches: Switches;
-}> = ({
+};
+
+const Renderer = ({
 	format,
 	elements,
 	host,
@@ -62,7 +64,7 @@ const Renderer: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	switches,
-}) => {
+}: RendererProps) => {
 	// const cleanedElements = elements.map(element =>
 	//     'html' in element ? { ...element, html: clean(element.html) } : element,
 	// );

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -27,7 +27,7 @@ const adStylesDynamic = css`
 	${adCollapseStyles}
 `;
 
-export const ArticleRenderer: React.FC<{
+type Props = {
 	format: ArticleFormat;
 	elements: CAPIElement[];
 	adTargeting?: AdTargeting;
@@ -45,7 +45,9 @@ export const ArticleRenderer: React.FC<{
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
-}> = ({
+};
+
+export const ArticleRenderer = ({
 	format,
 	elements,
 	adTargeting,
@@ -63,7 +65,7 @@ export const ArticleRenderer: React.FC<{
 	isAdFreeUser,
 	isSensitive,
 	isDev,
-}) => {
+}: Props) => {
 	const renderedElements = elements.map((element, index) => {
 		return (
 			<RenderArticleElement

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -1,79 +1,79 @@
 import type {
-  Callback,
-  CMP,
-  ConsentState,
-  VendorName,
-} from "@guardian/consent-management-platform/dist/types";
-import type { WeeklyArticleHistory } from "@guardian/support-dotcom-components/dist/dotcom/src/types";
-import type { WindowGuardianConfig } from "./src/model/window-guardian";
-import type { OphanRecordFunction } from "./src/web/browser/ophan/ophan";
-import type { DailyArticleHistory } from "./src/web/lib/dailyArticleCount";
-import type { ReaderRevenueDevUtils } from "./src/web/lib/readerRevenueDevUtils";
+	Callback,
+	CMP,
+	ConsentState,
+	VendorName,
+} from '@guardian/consent-management-platform/dist/types';
+import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
+import type { WindowGuardianConfig } from './src/model/window-guardian';
+import type { OphanRecordFunction } from './src/web/browser/ophan/ophan';
+import type { DailyArticleHistory } from './src/web/lib/dailyArticleCount';
+import type { ReaderRevenueDevUtils } from './src/web/lib/readerRevenueDevUtils';
 
 declare global {
-  /* ~ Here, declare things that go in the global namespace, or augment
+	/* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
-  interface Window {
-    guardian: {
-      mustardCut: boolean;
-      polyfilled: boolean;
-      onPolyfilled: () => void;
-      queue: Array<() => void>;
-      config: WindowGuardianConfig;
-      ophan?: {
-        setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
-        trackComponentAttention: (
-          name: string,
-          el: Element,
-          visiblityThreshold: number,
-        ) => void;
-        record: OphanRecordFunction;
-        viewId: string;
-        pageViewId: string;
-      };
-      modules: {
-        sentry: {
-          reportError: (error: Error, feature: string) => void;
-        };
-      };
-      // TODO expose as type from Automat client lib
-      automat: {
-        react: any;
-        emotionReact: any;
-        emotionReactJsxRuntime: any;
-      };
-      readerRevenue: ReaderRevenueDevUtils;
-      gaPath: string;
-      weeklyArticleCount: WeeklyArticleHistory | undefined;
-      dailyArticleCount: DailyArticleHistory | undefined;
-      GAData: GADataType;
-    };
-    GoogleAnalyticsObject: string;
-    ga: UniversalAnalytics.ga | null;
-    /**
-     * ES6 module import, possibly polyfilled depending on the current
-     * browser. There are three categories:
-     *
-     * 1. Full support out of the box
-     * 2. ES6 module support but not dynamic modules
-     * 3. No module support
-     *
-     * This gives support across all 3 cases.
-     */
-    guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
-    Cypress: any; // for checking if running within cypress
-    guCmpHotFix: {
-      initialised?: boolean;
-      cmp: CMP;
-      onConsentChange: (fn: Callback) => void;
-      getConsentFor: (
-        vendor: VendorName,
-        consent: ConsentState,
-      ) => boolean;
-    };
-    mockLiveUpdate: (data: LiveUpdateType) => void;
-  }
+	interface Window {
+		guardian: {
+			mustardCut: boolean;
+			polyfilled: boolean;
+			onPolyfilled: () => void;
+			queue: Array<() => void>;
+			config: WindowGuardianConfig;
+			ophan?: {
+				setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
+				trackComponentAttention: (
+					name: string,
+					el: Element,
+					visiblityThreshold: number,
+				) => void;
+				record: OphanRecordFunction;
+				viewId: string;
+				pageViewId: string;
+			};
+			modules: {
+				sentry: {
+					reportError: (error: Error, feature: string) => void;
+				};
+			};
+			// TODO expose as type from Automat client lib
+			automat: {
+				react: any;
+				emotionReact: any;
+				emotionReactJsxRuntime: any;
+			};
+			readerRevenue: ReaderRevenueDevUtils;
+			gaPath: string;
+			weeklyArticleCount: WeeklyArticleHistory | undefined;
+			dailyArticleCount: DailyArticleHistory | undefined;
+			GAData: GADataType;
+		};
+		GoogleAnalyticsObject: string;
+		ga: UniversalAnalytics.ga | null;
+		/**
+		 * ES6 module import, possibly polyfilled depending on the current
+		 * browser. There are three categories:
+		 *
+		 * 1. Full support out of the box
+		 * 2. ES6 module support but not dynamic modules
+		 * 3. No module support
+		 *
+		 * This gives support across all 3 cases.
+		 */
+		guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
+		Cypress: any; // for checking if running within cypress
+		guCmpHotFix: {
+			initialised?: boolean;
+			cmp: CMP;
+			onConsentChange: (fn: Callback) => void;
+			getConsentFor: (
+				vendor: VendorName,
+				consent: ConsentState,
+			) => boolean;
+		};
+		mockLiveUpdate: (data: LiveUpdateType) => void;
+	}
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
 export {};

--- a/dotcom-rendering/window.guardian.d.ts
+++ b/dotcom-rendering/window.guardian.d.ts
@@ -1,79 +1,79 @@
 import type {
-	Callback,
-	CMP,
-	ConsentState,
-	VendorName,
-} from '@guardian/consent-management-platform/dist/types';
-import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import type { WindowGuardianConfig } from './src/model/window-guardian';
-import type { OphanRecordFunction } from './src/web/browser/ophan/ophan';
-import type { DailyArticleHistory } from './src/web/lib/dailyArticleCount';
-import type { ReaderRevenueDevUtils } from './src/web/lib/readerRevenueDevUtils';
+  Callback,
+  CMP,
+  ConsentState,
+  VendorName,
+} from "@guardian/consent-management-platform/dist/types";
+import type { WeeklyArticleHistory } from "@guardian/support-dotcom-components/dist/dotcom/src/types";
+import type { WindowGuardianConfig } from "./src/model/window-guardian";
+import type { OphanRecordFunction } from "./src/web/browser/ophan/ophan";
+import type { DailyArticleHistory } from "./src/web/lib/dailyArticleCount";
+import type { ReaderRevenueDevUtils } from "./src/web/lib/readerRevenueDevUtils";
 
 declare global {
-	/* ~ Here, declare things that go in the global namespace, or augment
+  /* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
-	interface Window {
-		guardian: {
-			mustardCut: boolean;
-			polyfilled: boolean;
-			onPolyfilled: () => void;
-			queue: Array<() => void>;
-			config: WindowGuardianConfig;
-			ophan?: {
-				setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
-				trackComponentAttention: (
-					name: string,
-					el: Element,
-					visiblityThreshold: number,
-				) => void;
-				record: OphanRecordFunction;
-				viewId: string;
-				pageViewId: string;
-			};
-			modules: {
-				sentry: {
-					reportError: (error: Error, feature: string) => void;
-				};
-			};
-			// TODO expose as type from Automat client lib
-			automat: {
-				react: any;
-				emotionReact: any;
-				emotionReactJsxRuntime: any;
-			};
-			readerRevenue: ReaderRevenueDevUtils;
-			gaPath: string;
-			weeklyArticleCount: WeeklyArticleHistory | undefined;
-			dailyArticleCount: DailyArticleHistory | undefined;
-			GAData: GADataType;
-		};
-		GoogleAnalyticsObject: string;
-		ga: UniversalAnalytics.ga | null;
-		/**
-		 * ES6 module import, possibly polyfilled depending on the current
-		 * browser. There are three categories:
-		 *
-		 * 1. Full support out of the box
-		 * 2. ES6 module support but not dynamic modules
-		 * 3. No module support
-		 *
-		 * This gives support across all 3 cases.
-		 */
-		guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
-		Cypress: any; // for checking if running within cypress
-		guCmpHotFix: {
-			initialised?: boolean;
-			cmp: CMP;
-			onConsentChange: (fn: Callback) => void;
-			getConsentFor: (
-				vendor: VendorName,
-				consent: ConsentState,
-			) => boolean;
-		};
-		mockLiveUpdate: (data: LiveUpdateType) => void;
-	}
+  interface Window {
+    guardian: {
+      mustardCut: boolean;
+      polyfilled: boolean;
+      onPolyfilled: () => void;
+      queue: Array<() => void>;
+      config: WindowGuardianConfig;
+      ophan?: {
+        setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
+        trackComponentAttention: (
+          name: string,
+          el: Element,
+          visiblityThreshold: number,
+        ) => void;
+        record: OphanRecordFunction;
+        viewId: string;
+        pageViewId: string;
+      };
+      modules: {
+        sentry: {
+          reportError: (error: Error, feature: string) => void;
+        };
+      };
+      // TODO expose as type from Automat client lib
+      automat: {
+        react: any;
+        emotionReact: any;
+        emotionReactJsxRuntime: any;
+      };
+      readerRevenue: ReaderRevenueDevUtils;
+      gaPath: string;
+      weeklyArticleCount: WeeklyArticleHistory | undefined;
+      dailyArticleCount: DailyArticleHistory | undefined;
+      GAData: GADataType;
+    };
+    GoogleAnalyticsObject: string;
+    ga: UniversalAnalytics.ga | null;
+    /**
+     * ES6 module import, possibly polyfilled depending on the current
+     * browser. There are three categories:
+     *
+     * 1. Full support out of the box
+     * 2. ES6 module support but not dynamic modules
+     * 3. No module support
+     *
+     * This gives support across all 3 cases.
+     */
+    guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
+    Cypress: any; // for checking if running within cypress
+    guCmpHotFix: {
+      initialised?: boolean;
+      cmp: CMP;
+      onConsentChange: (fn: Callback) => void;
+      getConsentFor: (
+        vendor: VendorName,
+        consent: ConsentState,
+      ) => boolean;
+    };
+    mockLiveUpdate: (data: LiveUpdateType) => void;
+  }
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
 export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,10 +2951,10 @@
   dependencies:
     is-mobile "^3.1.1"
 
-"@guardian/braze-components@^8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.1.tgz#7b265a7d2a2163df70238823e881950a6d43598d"
-  integrity sha512-4izZBDS9HXgEmf9hLBs0X3JdtgrdnGuFRCGhyJFodUPU+ZFXo2H4rOQlTBBsUhr5PurEZBDVU+9y6ZCe74ZWcg==
+"@guardian/braze-components@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-8.1.3.tgz#47adc4892716904a62afa62da66f31eae059d56b"
+  integrity sha512-Tol4O7A3ErmzgCd9YtkajJUfCps/1RCNXhtaUBwgT8u0OUPRmfk4jjD7cS3nok5gDTEUVemKwT2yysx1CxfWaw==
 
 "@guardian/browserslist-config@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## Why?
This errors on using `React.FC` and friends as per [this PR](https://github.com/guardian/dotcom-rendering/pull/5622).

It was inspired by [@bryophyta's issue](https://github.com/orgs/guardian/projects/8/views/4) where it felt like linting the recommendation and co-locating the reason why we have it would be more useful to engineers in the future.

- remove all references to `React.FC`
- if there is only one component in the directory, move those to `type Props` and reference it on the arguments to the component
- if there are more than 1 component, move those props to `type {ComponentName}Props`
- when using `useState()` for async components:
  - and we know the component type, we use `useState<typeof ComponentName>(null)`
  - when we know the props, but not the component, use `useState<React.ElementType<Props>>(null)`
  - when we don't know anything, we use useState<React.ElementType>(null)
  
  This is because `React.ElementType` is the most basic Element type, so we can and shouldn't infer anything about it. It would be nice to know what elements we were pulling in async, but that might be another PR

This is also mostly necessary as we pull in components async from Braze / commercial core - having those types published somewhere would be very useful.

---

I would have looked at the other banned-types, but those felt problematic. `JSX.Element` for example has legitimate uses, like typing `children`. It feels like we might have outright ban it, but we actually only want to ban certain uses of it e.g. when used to loosen the return types of a method.