### PR TITLE
Layout Story Refactor

### DIFF
--- a/apps-rendering/src/articleFormat.test.ts
+++ b/apps-rendering/src/articleFormat.test.ts
@@ -1,0 +1,18 @@
+// ----- Imports ----- //
+
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { formatToString } from 'articleFormat';
+
+// ----- Tests ----- //
+
+describe('formatToString', () => {
+    it('creates a string describing ArticleFormat', () => {
+        const format = formatToString({
+            design: ArticleDesign.Standard,
+            display: ArticleDisplay.Immersive,
+            theme: ArticlePillar.Culture,
+        });
+
+        expect(format).toBe('Design: Standard, Display: Immersive, Theme: Culture');
+    });
+});

--- a/apps-rendering/src/articleFormat.ts
+++ b/apps-rendering/src/articleFormat.ts
@@ -4,7 +4,7 @@
 
 // ----- Imports ----- //
 
-import type { ArticleTheme } from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleFormat, ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { Optional } from 'optional';
 
@@ -109,6 +109,124 @@ const themeToPillar = (theme: ArticleTheme): ArticlePillar => {
 	}
 };
 
+/**
+ * Creates a string representation of {@linkcode ArticleDesign}. Useful for
+ * logging, storybook UI etc.
+ * 
+ * @param design An {@linkcode ArticleDesign}
+ * @returns A string representation of `ArticleDesign`
+ */
+const designToString = (design: ArticleDesign): string => {
+	switch (design) {
+		case ArticleDesign.Standard:
+			return 'Standard';
+		case ArticleDesign.Gallery:
+			return 'Gallery';
+		case ArticleDesign.Audio:
+			return 'Audio';
+		case ArticleDesign.Video:
+			return 'Video';
+		case ArticleDesign.Review:
+			return 'Review';
+		case ArticleDesign.Analysis:
+			return 'Analysis';
+		case ArticleDesign.Explainer:
+			return 'Explainer';
+		case ArticleDesign.Comment:
+			return 'Comment';
+		case ArticleDesign.Letter:
+			return 'Letter';
+		case ArticleDesign.Feature:
+			return 'Feature';
+		case ArticleDesign.LiveBlog:
+			return 'Liveblog';
+		case ArticleDesign.DeadBlog:
+			return 'Deadblog';
+		case ArticleDesign.Recipe:
+			return 'Recipe';
+		case ArticleDesign.MatchReport:
+			return 'Match Report';
+		case ArticleDesign.Interview:
+			return 'Interview';
+		case ArticleDesign.Editorial:
+			return 'Editorial';
+		case ArticleDesign.Quiz:
+			return 'Quiz';
+		case ArticleDesign.Interactive:
+			return 'Interactive';
+		case ArticleDesign.PhotoEssay:
+			return 'Photo Essay';
+		case ArticleDesign.PrintShop:
+			return 'Print Shop';
+		case ArticleDesign.Obituary:
+			return 'Obituary';
+		case ArticleDesign.Correction:
+			return 'Correction';
+		case ArticleDesign.FullPageInteractive:
+			return 'Full Page Interactive';
+		case ArticleDesign.NewsletterSignup:
+			return 'Newsletter Signup';
+	}
+}
+
+/**
+ * Creates a string representation of {@linkcode ArticleDisplay}. Useful for
+ * logging, storybook UI etc.
+ * 
+ * @param display An {@linkcode ArticleDisplay}
+ * @returns A string representation of `ArticleDisplay`
+ */
+const displayToString = (display: ArticleDisplay): string => {
+	switch (display) {
+		case ArticleDisplay.Standard:
+			return 'Standard';
+		case ArticleDisplay.Immersive:
+			return 'Immersive';
+		case ArticleDisplay.Showcase:
+			return 'Showcase';
+		case ArticleDisplay.NumberedList:
+			return 'Numbered List';
+	}
+}
+
+/**
+ * Creates a string representation of {@linkcode ArticleTheme}. Useful for
+ * logging, storybook UI etc.
+ * 
+ * @param theme An {@linkcode ArticleTheme}
+ * @returns A string representation of `ArticleTheme`
+ */
+const themeToString = (theme: ArticleTheme): string => {
+	switch (theme) {
+		case ArticlePillar.News:
+			return 'News';
+		case ArticlePillar.Opinion:
+			return 'Opinion';
+		case ArticlePillar.Sport:
+			return 'Sport';
+		case ArticlePillar.Culture:
+			return 'Culture';
+		case ArticlePillar.Lifestyle:
+			return 'Lifestyle';
+		case ArticleSpecial.Labs:
+			return 'Labs';
+		case ArticleSpecial.SpecialReport:
+			return 'Special Report';
+		case ArticleSpecial.SpecialReportAlt:
+			return 'Special Report Alt';
+	}
+}
+
+/**
+ * Creates a string representation of {@linkcode ArticleFormat}. Useful for
+ * logging, storybook UI etc.
+ * 
+ * @param format An {@linkcode ArticleFormat}
+ * @returns A string representation of `ArticleFormat`
+ */
+const formatToString = (format: ArticleFormat): string =>
+	`Design: ${designToString(format.design)}, Display: ${displayToString(format.display)}, Theme: ${themeToString(format.theme)}`;
+
 // ----- Exports ----- //
 
-export { getPillarFromId, getPillarOrElseNews, pillarToId, themeToPillar };
+export { formatToString, getPillarFromId, getPillarOrElseNews, pillarToId, themeToPillar };

--- a/apps-rendering/src/articleFormat.ts
+++ b/apps-rendering/src/articleFormat.ts
@@ -4,8 +4,13 @@
 
 // ----- Imports ----- //
 
-import { ArticleDesign, ArticleDisplay, ArticleFormat, ArticleTheme } from '@guardian/libs';
-import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { Optional } from 'optional';
 
 // ----- Functions ----- //
@@ -112,7 +117,7 @@ const themeToPillar = (theme: ArticleTheme): ArticlePillar => {
 /**
  * Creates a string representation of {@linkcode ArticleDesign}. Useful for
  * logging, storybook UI etc.
- * 
+ *
  * @param design An {@linkcode ArticleDesign}
  * @returns A string representation of `ArticleDesign`
  */
@@ -167,12 +172,12 @@ const designToString = (design: ArticleDesign): string => {
 		case ArticleDesign.NewsletterSignup:
 			return 'Newsletter Signup';
 	}
-}
+};
 
 /**
  * Creates a string representation of {@linkcode ArticleDisplay}. Useful for
  * logging, storybook UI etc.
- * 
+ *
  * @param display An {@linkcode ArticleDisplay}
  * @returns A string representation of `ArticleDisplay`
  */
@@ -187,12 +192,12 @@ const displayToString = (display: ArticleDisplay): string => {
 		case ArticleDisplay.NumberedList:
 			return 'Numbered List';
 	}
-}
+};
 
 /**
  * Creates a string representation of {@linkcode ArticleTheme}. Useful for
  * logging, storybook UI etc.
- * 
+ *
  * @param theme An {@linkcode ArticleTheme}
  * @returns A string representation of `ArticleTheme`
  */
@@ -215,18 +220,26 @@ const themeToString = (theme: ArticleTheme): string => {
 		case ArticleSpecial.SpecialReportAlt:
 			return 'Special Report Alt';
 	}
-}
+};
 
 /**
  * Creates a string representation of {@linkcode ArticleFormat}. Useful for
  * logging, storybook UI etc.
- * 
+ *
  * @param format An {@linkcode ArticleFormat}
  * @returns A string representation of `ArticleFormat`
  */
 const formatToString = (format: ArticleFormat): string =>
-	`Design: ${designToString(format.design)}, Display: ${displayToString(format.display)}, Theme: ${themeToString(format.theme)}`;
+	`Design: ${designToString(format.design)}, Display: ${displayToString(
+		format.display,
+	)}, Theme: ${themeToString(format.theme)}`;
 
 // ----- Exports ----- //
 
-export { formatToString, getPillarFromId, getPillarOrElseNews, pillarToId, themeToPillar };
+export {
+	formatToString,
+	getPillarFromId,
+	getPillarOrElseNews,
+	pillarToId,
+	themeToPillar,
+};

--- a/apps-rendering/src/articleFormat.ts
+++ b/apps-rendering/src/articleFormat.ts
@@ -229,10 +229,12 @@ const themeToString = (theme: ArticleTheme): string => {
  * @param format An {@linkcode ArticleFormat}
  * @returns A string representation of `ArticleFormat`
  */
-const formatToString = (format: ArticleFormat): string =>
-	`Design: ${designToString(format.design)}, Display: ${displayToString(
-		format.display,
-	)}, Theme: ${themeToString(format.theme)}`;
+const formatToString = ({ design, display, theme }: ArticleFormat): string =>
+	[
+		`Design: ${designToString(design)}`,
+		`Display: ${displayToString(display)}`,
+		`Theme: ${themeToString(theme)}`,
+	].join(', ');
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -5,6 +5,7 @@ import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { none, some, withDefault } from '@guardian/types';
+import { formatToString } from 'articleFormat';
 import AnalysisLayout from 'components/Layout/AnalysisLayout';
 import Comment from 'components/Layout/CommentLayout';
 import Standard from 'components/Layout/StandardLayout';
@@ -61,7 +62,7 @@ export const Article = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Article.story = { name: 'Article' };
+Article.story = { name: formatToString(article) };
 
 export const Review = (): React.ReactNode => {
 	return (
@@ -73,7 +74,7 @@ export const Review = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Review.story = { name: 'Review' };
+Review.story = { name: formatToString(review) };
 
 export const MatchReport = (): React.ReactNode => {
 	return (
@@ -85,7 +86,7 @@ export const MatchReport = (): React.ReactNode => {
 		</Standard>
 	);
 };
-MatchReport.story = { name: 'Match Report' };
+MatchReport.story = { name: formatToString(matchReport) };
 
 export const PrintShop = (): React.ReactNode => {
 	return (
@@ -97,7 +98,7 @@ export const PrintShop = (): React.ReactNode => {
 		</Standard>
 	);
 };
-PrintShop.story = { name: 'PrintShop' };
+PrintShop.story = { name: formatToString(printShop) };
 
 export const PhotoEssay = (): React.ReactNode => {
 	return (
@@ -109,7 +110,7 @@ export const PhotoEssay = (): React.ReactNode => {
 		</Standard>
 	);
 };
-PhotoEssay.story = { name: 'Photo Essay' };
+PhotoEssay.story = { name: formatToString(photoEssay) };
 
 export const Feature = (): React.ReactNode => {
 	return (
@@ -121,7 +122,7 @@ export const Feature = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Feature.story = { name: 'Feature' };
+Feature.story = { name: formatToString(feature) };
 
 export const Interview = (): React.ReactNode => {
 	return (
@@ -133,7 +134,7 @@ export const Interview = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Interview.story = { name: 'Interview' };
+Interview.story = { name: formatToString(interview) };
 
 export const Quiz = (): React.ReactNode => {
 	return (
@@ -145,7 +146,7 @@ export const Quiz = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Quiz.story = { name: 'Quiz' };
+Quiz.story = { name: formatToString(quiz) };
 
 export const Recipe = (): React.ReactNode => {
 	return (
@@ -157,7 +158,7 @@ export const Recipe = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Recipe.story = { name: 'Recipe' };
+Recipe.story = { name: formatToString(recipe) };
 
 export const CommentItem = (): React.ReactNode => {
 	return (
@@ -169,7 +170,7 @@ export const CommentItem = (): React.ReactNode => {
 		</Comment>
 	);
 };
-CommentItem.story = { name: 'Comment' };
+CommentItem.story = { name: formatToString(comment) };
 
 export const Letter = (): React.ReactNode => {
 	return (
@@ -181,7 +182,7 @@ export const Letter = (): React.ReactNode => {
 		</LetterLayout>
 	);
 };
-Letter.story = { name: 'Letter' };
+Letter.story = { name: formatToString(letter) };
 
 export const Editorial = (): React.ReactNode => {
 	return (
@@ -193,7 +194,7 @@ export const Editorial = (): React.ReactNode => {
 		</Comment>
 	);
 };
-Editorial.story = { name: 'Editorial' };
+Editorial.story = { name: formatToString(editorial) };
 
 export const Analysis = (): React.ReactNode => {
 	return (
@@ -205,7 +206,7 @@ export const Analysis = (): React.ReactNode => {
 		</AnalysisLayout>
 	);
 };
-Analysis.story = { name: 'Analysis' };
+Analysis.story = { name: formatToString(analysis) };
 
 export const Explainer = (): React.ReactNode => {
 	return (
@@ -217,18 +218,17 @@ export const Explainer = (): React.ReactNode => {
 		</Standard>
 	);
 };
-Explainer.story = { name: 'Explainer' };
+Explainer.story = { name: formatToString(explainer) };
 
 export const LiveBlog = (): ReactElement => (
 	<Live
 		item={{
 			...live,
-			display: ArticleDisplay.Standard,
 			edition: Edition.US,
 		}}
 	/>
 );
-LiveBlog.story = { name: 'LiveBlog ' };
+LiveBlog.story = { name: formatToString(live) };
 
 export const DeadBlog = (): ReactElement => (
 	<Live
@@ -239,7 +239,7 @@ export const DeadBlog = (): ReactElement => (
 		}}
 	/>
 );
-DeadBlog.story = { name: 'DeadBlog ' };
+DeadBlog.story = { name: formatToString(deadBlog) };
 
 export const NewsletterSignup = (): ReactElement => (
 	<NewsletterSignUpLayout item={newsletterSignUp}>
@@ -249,21 +249,7 @@ export const NewsletterSignup = (): ReactElement => (
 		)}
 	</NewsletterSignUpLayout>
 );
-NewsletterSignup.story = { name: 'NewsletterSignup' };
-export const Immersive = (): ReactElement => (
-	<ImmersiveLayout
-		item={{
-			...immersive,
-			edition: Edition.UK,
-		}}
-	>
-		{renderAll(
-			formatFromItem(immersive, none),
-			Result.partition(immersive.body).oks,
-		)}
-	</ImmersiveLayout>
-);
-Immersive.story = { name: 'Immersive ' };
+NewsletterSignup.story = { name: formatToString(newsletterSignUp) };
 
 export const Gallery = (): ReactElement => (
 	<GalleryLayout
@@ -278,10 +264,25 @@ export const Gallery = (): ReactElement => (
 		)}
 	</GalleryLayout>
 );
-Gallery.story = { name: 'Gallery ' };
+Gallery.story = { name: formatToString(gallery) };
+
+export const Immersive = (): ReactElement => (
+	<ImmersiveLayout
+		item={{
+			...immersive,
+			edition: Edition.UK,
+		}}
+	>
+		{renderAll(
+			formatFromItem(immersive, none),
+			Result.partition(immersive.body).oks,
+		)}
+	</ImmersiveLayout>
+);
+Immersive.story = { name: formatToString(immersive) };
 
 export default {
-	title: 'AR/Layouts/Standard',
+	title: 'AR/Layout',
 	parameters: {
 		layout: 'fullscreen',
 		chromatic: {


### PR DESCRIPTION
## Why?

To make what each of the layout stories represent clearer. See the screenshot for details on how this will look. It's similar to the approach taken by DCR (FYI @guardian/dotcom-platform ), and I think we can probably start to expand these stories to cover every format variation as is the case there.

## Changes

- Added `formatToString`
- Added tests for `articleFormat`
- Refactored layout story names
- Swapped order of gallery and immersive stories

## Screenshots

![storybook](https://user-images.githubusercontent.com/53781962/205666366-6f907c36-38cb-455c-b563-10f2d0a40e48.jpg)
