### PR TITLE
Duplicate `common-rendering` code inside `dotcom-rendering`

### DIFF
--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -41,6 +41,7 @@ export type Palette = {
 		carouselTitle: Colour;
 		calloutHeading: Colour;
 		pullQuote: Colour;
+		pagination: Colour;
 		pullQuoteAttribution: Colour;
 		dropCap: Colour;
 		blockquote: Colour;
@@ -51,6 +52,7 @@ export type Palette = {
 		shareCountUntilDesktop: Colour;
 		cricketScoreboardLink: Colour;
 		keyEvent: Colour;
+		keyEventFromDesktop: Colour;
 		keyEventTime: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
@@ -130,6 +132,7 @@ export type Palette = {
 		keyEvent: Colour;
 		filterButton: Colour;
 		secondary: Colour;
+		pagination: Colour;
 	};
 	topBar: {
 		card: Colour;
@@ -140,6 +143,7 @@ export type Palette = {
 		keyEventLink: Colour;
 		keyEventBullet: Colour;
 		summaryEventBullet: Colour;
+		pagination: Colour;
 	};
 };
 

--- a/dotcom-rendering/src/web/components/Accordion.stories.tsx
+++ b/dotcom-rendering/src/web/components/Accordion.stories.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { body, breakpoints, from, space } from '@guardian/source-foundations';
+import { Accordion } from './Accordion';
+
+const textStyle = css`
+	${body.medium({ lineHeight: 'loose' })};
+	margin-bottom: ${space[3]}px;
+`;
+
+const hideAboveTablet: SerializedStyles = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const adviceColourAboveTablet: SerializedStyles = css`
+	display: none;
+	${from.desktop} {
+		display: block;
+		color: red;
+		font-size: 18px;
+		width: 300px;
+		margin: 0 auto;
+		margin-top: ${space[12]}px;
+	}
+`;
+
+const accordionContent = (
+	<>
+		<p css={[textStyle, adviceColourAboveTablet]}>
+			There's a trick to viewing this - you need to switch the storybook
+			viewport to mobile, phablet or tablet in order to see the accordion.
+		</p>
+		<p css={[textStyle, hideAboveTablet]}>
+			Vaccine passports enjoy substantial support across Europe, a YouGov
+			survey suggests, as a fourth wave of infections prompts a growing
+			number of countries to impose tougher restrictions on people who
+			have not been fully vaccinated.
+		</p>
+		<p css={[textStyle, hideAboveTablet]}>
+			The annual YouGov-Cambridge Globalism Project suggests majorities in
+			all 10 European countries surveyed back compulsory vaccine passes
+			for large events, while in most, more people favour than oppose
+			their use in cafes, restaurants and gyms.
+		</p>
+	</>
+);
+
+export default {
+	component: Accordion,
+	title: 'Components/Accordion',
+	parameters: {
+		backgrounds: {
+			default: 'grey',
+			values: [{ name: 'grey', value: 'lightgrey' }],
+		},
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.tablet],
+		},
+	},
+};
+
+export const Default = () => (
+	<Accordion accordionTitle="Live feed" context="keyEvents">
+		{accordionContent}
+	</Accordion>
+);

--- a/dotcom-rendering/src/web/components/Accordion.tsx
+++ b/dotcom-rendering/src/web/components/Accordion.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import {
+	background,
+	focusHalo,
+	from,
+	headline,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
+import {
+	SvgChevronDownSingle,
+	SvgChevronUpSingle,
+} from '@guardian/source-react-components';
+
+interface Props {
+	children: React.ReactNode;
+	accordionTitle: string;
+	context: 'keyEvents' | 'liveFeed';
+}
+
+const detailsStyles: SerializedStyles = css`
+	&:not([open]) .is-on,
+	&[open] .is-off {
+		display: none;
+	}
+	summary::-webkit-details-marker {
+		display: none;
+	}
+`;
+
+const titleRowStyles = css`
+	cursor: pointer;
+	position: relative;
+	display: block;
+	align-items: center;
+	border-top: ${neutral[86]} 1px solid;
+	background-color: ${neutral[100]};
+	padding: ${space[2]}px ${space[2]}px ${space[2]}px ${space[3]}px;
+	&:focus {
+		${focusHalo};
+	}
+	path {
+		fill: ${neutral[46]};
+	}
+	svg {
+		height: 2rem;
+	}
+
+	${from.phablet} {
+		padding: ${space[2]}px ${space[4]}px ${space[2]}px ${space[5]}px;
+	}
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const titleStyle = css`
+	${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
+	color: ${neutral[7]};
+`;
+
+const arrowPosition: SerializedStyles = css`
+	position: absolute;
+	right: ${space[1]}px;
+	top: ${space[1]}px;
+
+	${from.phablet} {
+		right: ${space[4]}px;
+	}
+`;
+
+const backgroundColour = (
+	context: 'keyEvents' | 'liveFeed',
+): SerializedStyles => {
+	if (context === 'keyEvents') {
+		return css`
+			background-color: ${background.primary};
+			${from.desktop} {
+				background-color: transparent;
+			}
+		`;
+	}
+	return css`
+		background-color: ${neutral[97]};
+		${from.desktop} {
+			background-color: transparent;
+		}
+	`;
+};
+
+const paddingBody: SerializedStyles = css`
+	padding: ${space[3]}px;
+	${from.mobileLandscape} {
+		padding: ${space[3]}px ${space[5]}px;
+	}
+	${from.desktop} {
+		padding: 0;
+	}
+`;
+
+export const Accordion = ({ children, accordionTitle, context }: Props) => {
+	return (
+		<details open={true} css={detailsStyles}>
+			<summary css={titleRowStyles}>
+				<h2 css={titleStyle}>{accordionTitle}</h2>
+				<span className="is-off" css={arrowPosition}>
+					<SvgChevronDownSingle />
+				</span>
+				<span className="is-on" css={arrowPosition}>
+					<SvgChevronUpSingle />
+				</span>
+			</summary>
+			<div css={[backgroundColour(context), paddingBody]}>{children}</div>
+		</details>
+	);
+};

--- a/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleMeta.stories.tsx
@@ -5,10 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import {
-	getAllThemes,
-	getThemeNameAsString,
-} from '../../../../common-rendering/src/fixtures/article';
+import { getAllThemes, getThemeNameAsString } from '../lib/format';
 import { ArticleMeta } from './ArticleMeta';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleTitle.stories.tsx
@@ -5,10 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import {
-	getAllThemes,
-	getThemeNameAsString,
-} from '../../../../common-rendering/src/fixtures/article';
+import { getAllThemes, getThemeNameAsString } from '../lib/format';
 import { ArticleTitle } from './ArticleTitle';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/web/components/FirstPublished.stories.tsx
+++ b/dotcom-rendering/src/web/components/FirstPublished.stories.tsx
@@ -1,0 +1,64 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { FirstPublished } from './FirstPublished';
+
+export default {
+	component: FirstPublished,
+	title: 'Components/FirstPublished',
+};
+
+export const Default = () => (
+	<FirstPublished
+		firstPublished={1613763003000}
+		blockId="#block-60300f5f8f08ad21ea60071e"
+		isPinnedPost={false}
+		isOriginalPinnedPost={false}
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+	/>
+);
+
+export const WithFirstPublishedDisplay = () => (
+	<FirstPublished
+		firstPublished={1613763003000}
+		firstPublishedDisplay={'99:99'}
+		blockId="#block-60300f5f8f08ad21ea60071e"
+		isPinnedPost={false}
+		isOriginalPinnedPost={false}
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+	/>
+);
+
+export const PinnedPost = () => (
+	<FirstPublished
+		firstPublished={1613763003000}
+		blockId="#block-60300f5f8f08ad21ea60071e"
+		isPinnedPost={true}
+		isOriginalPinnedPost={false}
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+	/>
+);
+
+export const OriginalPinnedPost = () => (
+	<FirstPublished
+		firstPublished={1613763003000}
+		blockId="#block-60300f5f8f08ad21ea60071e"
+		isPinnedPost={false}
+		isOriginalPinnedPost={true}
+		format={{
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: ArticlePillar.News,
+		}}
+	/>
+);

--- a/dotcom-rendering/src/web/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/web/components/FirstPublished.tsx
@@ -1,0 +1,120 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { joinUrl, timeAgo } from '@guardian/libs';
+import { neutral, space, textSans } from '@guardian/source-foundations';
+import { SvgPinned } from '@guardian/source-react-components';
+import { decidePalette } from '../lib/decidePalette';
+
+const fallbackDate = (date: Date) =>
+	[date.getHours(), date.getMinutes()]
+		.map((time) => time.toString().padStart(2, '0'))
+		.join('.');
+
+type Props = {
+	firstPublished: number;
+	firstPublishedDisplay?: string;
+	blockId: string;
+	isPinnedPost: boolean;
+	isOriginalPinnedPost: boolean;
+	format: ArticleFormat;
+	host?: string;
+	pageId?: string;
+};
+
+const FirstPublished = ({
+	firstPublished,
+	firstPublishedDisplay,
+	blockId,
+	isPinnedPost,
+	isOriginalPinnedPost,
+	format,
+	host,
+	pageId,
+}: Props) => {
+	const baseHref = host && pageId ? joinUrl(host, pageId) : '';
+	const { border } = decidePalette(format);
+	const publishedDate = new Date(firstPublished);
+	return (
+		<div
+			css={css`
+				display: flex;
+			`}
+		>
+			<a
+				href={`${baseHref}?page=with:block-${blockId}#block-${blockId}`}
+				data-ignore="global-link-styling"
+				css={css`
+					${textSans.xxsmall({ fontWeight: 'bold' })}
+					margin-bottom: ${space[1]}px;
+					display: flex;
+					width: fit-content;
+					flex-direction: row;
+					text-decoration: none;
+
+					:hover {
+						filter: brightness(30%);
+					}
+				`}
+			>
+				{!isPinnedPost && (
+					<time
+						dateTime={publishedDate.toISOString()}
+						data-relativeformat="med"
+						css={css`
+							color: ${neutral[46]};
+							font-weight: bold;
+							margin-right: ${space[2]}px;
+						`}
+					>
+						{timeAgo(firstPublished)}
+					</time>
+				)}
+				<span
+					css={css`
+						${textSans.xxsmall()};
+						color: ${neutral[46]};
+					`}
+				>
+					{firstPublishedDisplay ?? fallbackDate(publishedDate)}
+				</span>
+			</a>
+			{isOriginalPinnedPost && (
+				<a
+					href={`${baseHref}#pinned-post`}
+					data-ignore="global-link-styling"
+					css={css`
+						${textSans.xxsmall({ fontWeight: 'bold' })}
+						margin-bottom: ${space[1]}px;
+						text-decoration: none;
+						display: flex;
+
+						:hover {
+							span {
+								height: 16px;
+								width: 16px;
+							}
+						}
+					`}
+				>
+					<span
+						css={css`
+							width: 14px;
+							height: 14px;
+							border-radius: 50%;
+							background-color: ${border.liveBlock};
+							align-self: center;
+							margin-left: ${space[2]}px;
+							svg {
+								fill: ${neutral[100]};
+							}
+						`}
+					>
+						<SvgPinned />
+					</span>
+				</a>
+			)}
+		</div>
+	);
+};
+
+export { FirstPublished };

--- a/dotcom-rendering/src/web/components/KeyEvents.stories.tsx
+++ b/dotcom-rendering/src/web/components/KeyEvents.stories.tsx
@@ -1,0 +1,78 @@
+import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import { getAllThemes, getThemeNameAsString } from '../lib/format';
+import { KeyEvents } from './KeyEvents';
+import type { KeyEvent } from './KeyEvents';
+
+const events: KeyEvent[] = [
+	{
+		date: new Date(1 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(2 * 60 * 1000),
+		text: 'Ben Maher goes into the gold medal sport in the equestrian jumps',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(3 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(5 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(9 * 60 * 1000),
+		text: 'Jodie Williams qualifies for the 400m final',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(15 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(20 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+	{
+		date: new Date(35 * 60 * 1000),
+		text: 'Gold for Uganda',
+		url: 'https://www.theguardian.com/environment/2021/sep/01/opec-member-urges-oil-producers-to-focus-more-on-renewable-energy',
+	},
+];
+
+export default {
+	component: KeyEvents,
+	title: 'Components/KeyEvents',
+};
+
+export const Default = () => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			flex-wrap: wrap;
+		`}
+	>
+		{getAllThemes({
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+		}).map((format) => (
+			<div
+				css={css`
+					flex-grow: 1;
+				`}
+			>
+				<div>{getThemeNameAsString(format)}</div>
+				<KeyEvents keyEvents={events} format={format} />
+			</div>
+		))}
+	</div>
+);

--- a/dotcom-rendering/src/web/components/KeyEvents.tsx
+++ b/dotcom-rendering/src/web/components/KeyEvents.tsx
@@ -1,0 +1,161 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { timeAgo } from '@guardian/libs';
+import { from, neutral, space, textSans } from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
+import { decidePalette } from '../lib/decidePalette';
+import { Accordion } from './Accordion';
+
+export type KeyEvent = {
+	date: Date;
+	text: string;
+	url: string;
+};
+
+type KeyEventsProps = {
+	keyEvents: KeyEvent[];
+	format: ArticleFormat;
+};
+
+type ListItemProps = {
+	keyEvent: KeyEvent;
+	format: ArticleFormat;
+};
+
+const keyEventWrapperStyles = (hideMobile: boolean): SerializedStyles => css`
+	width: 100%;
+
+	${hideMobile &&
+	css`
+		display: none;
+	`}
+
+	${from.desktop} {
+		display: block;
+		border-top: 1px solid ${neutral[86]};
+		padding-top: ${space[2]}px;
+	}
+`;
+
+const listStyles = (format: ArticleFormat) => css`
+	background-color: ${decidePalette(format).background.keyEvent};
+
+	${from.desktop} {
+		background-color: ${decidePalette(format).background
+			.keyEventFromDesktop};
+	}
+`;
+
+const linkStyles = css`
+	position: initial;
+	text-decoration: none;
+
+	&:hover::before {
+		background-color: ${neutral[0]};
+	}
+
+	&::before {
+		content: '';
+		display: block;
+		position: absolute;
+		left: -5px;
+		height: 9px;
+		width: 9px;
+		border-radius: 50%;
+		background-color: ${neutral[46]};
+	}
+`;
+
+const listItemStyles = css`
+	padding-bottom: ${space[3]}px;
+	border-left: 1px solid ${neutral[86]};
+	position: relative;
+	transform: translateY(-1px);
+	margin-left: ${space[1]}px;
+
+	&:last-child {
+		border-left-color: transparent;
+	}
+`;
+
+const timeTextWrapperStyles: SerializedStyles = css`
+	margin-left: 0.5rem;
+`;
+
+const textStyles = (format: ArticleFormat): SerializedStyles => css`
+	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
+	color: ${decidePalette(format).text.keyEvent};
+	display: block;
+	text-decoration: none;
+	transform: translateY(-2px);
+
+	&:hover {
+		color: currentColor;
+		text-decoration: underline;
+	}
+
+	${from.desktop} {
+		color: ${decidePalette(format).text.keyEventFromDesktop};
+
+		&:hover {
+			color: currentColor;
+			text-decoration: underline;
+		}
+	}
+`;
+
+const timeStyles = css`
+	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
+	color: ${neutral[7]};
+	display: block;
+	transform: translateY(-4px);
+`;
+
+const ListItem = ({ keyEvent, format }: ListItemProps) => (
+	<li css={listItemStyles}>
+		<Link priority="secondary" css={linkStyles} href={keyEvent.url}>
+			<div css={timeTextWrapperStyles}>
+				<time
+					dateTime={keyEvent.date.toISOString()}
+					data-relativeformat="med"
+					title={`${keyEvent.date.toLocaleDateString('en-GB', {
+						hour: '2-digit',
+						minute: '2-digit',
+						weekday: 'long',
+						year: 'numeric',
+						month: 'long',
+						day: 'numeric',
+						timeZoneName: 'long',
+					})}`}
+					css={timeStyles}
+				>
+					{timeAgo(keyEvent.date.getTime())}
+				</time>
+				<span css={textStyles(format)}>{keyEvent.text}</span>
+			</div>
+		</Link>
+	</li>
+);
+
+export const KeyEvents = ({ keyEvents, format }: KeyEventsProps) => (
+	<nav
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- this is superior
+		tabIndex={0}
+		id="keyevents"
+		css={keyEventWrapperStyles(keyEvents.length === 0)}
+		aria-label="Key Events"
+	>
+		<Accordion accordionTitle="Key events" context="keyEvents">
+			<ul css={listStyles(format)}>
+				{keyEvents.slice(0, 7).map((event, index) => (
+					<ListItem
+						key={`${event.url}${index}`}
+						keyEvent={event}
+						format={format}
+					/>
+				))}
+			</ul>
+		</Accordion>
+	</nav>
+);

--- a/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
+++ b/dotcom-rendering/src/web/components/KeyEventsContainer.tsx
@@ -1,6 +1,5 @@
-import type { KeyEvent } from '@guardian/common-rendering/src/components/keyEvents';
-// eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
-import KeyEvents from '@guardian/common-rendering/src/components/keyEvents';
+import type { KeyEvent } from './KeyEvents';
+import { KeyEvents } from './KeyEvents';
 
 type Props = {
 	keyEvents: Block[];
@@ -37,11 +36,5 @@ export const KeyEventsContainer = ({
 			};
 		});
 
-	return (
-		<KeyEvents
-			format={format}
-			keyEvents={transformedKeyEvents}
-			supportsDarkMode={false}
-		/>
-	);
+	return <KeyEvents format={format} keyEvents={transformedKeyEvents} />;
 };

--- a/dotcom-rendering/src/web/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlock.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
-// eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
-import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { Switches } from '../../types/config';
 import { RenderArticleElement } from '../lib/renderElement';
 import { LastUpdated } from './LastUpdated';
+import { LiveBlockContainer } from './LiveBlockContainer';
 import { ShareIcons } from './ShareIcons';
 
 type Props = {
@@ -58,7 +57,6 @@ export const LiveBlock = ({
 			isLiveUpdate={isLiveUpdate}
 			contributors={block.contributors}
 			isPinnedPost={isPinnedPost}
-			supportsDarkMode={false}
 			format={format}
 			isOriginalPinnedPost={isOriginalPinnedPost}
 			host={host}

--- a/dotcom-rendering/src/web/components/LiveBlockContainer.tsx
+++ b/dotcom-rendering/src/web/components/LiveBlockContainer.tsx
@@ -1,0 +1,197 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { isString } from '@guardian/libs';
+import {
+	body,
+	from,
+	headline,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
+import { decidePalette } from '../lib/decidePalette';
+import { FirstPublished } from './FirstPublished';
+
+type BlockContributor = {
+	name: string;
+	imageUrl?: string;
+	largeImageUrl?: string;
+};
+
+type Props = {
+	id: string;
+	children: React.ReactNode;
+	format: ArticleFormat;
+	blockTitle?: string;
+	blockFirstPublished?: number;
+	blockFirstPublishedDisplay?: string;
+	blockId: string;
+	isLiveUpdate?: boolean;
+	contributors?: BlockContributor[];
+	isPinnedPost: boolean;
+	isOriginalPinnedPost?: boolean;
+	host?: string;
+	pageId?: string;
+};
+
+const LEFT_MARGIN_DESKTOP = 60;
+const SIDE_MARGIN = space[5];
+const SIDE_MARGIN_MOBILE = 10;
+
+const Header = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<header
+			css={css`
+				padding-right: ${space[3]}px;
+				display: flex;
+				flex-direction: column;
+			`}
+		>
+			{children}
+		</header>
+	);
+};
+
+const BlockTitle = ({ title }: { title: string }) => {
+	return (
+		<h2
+			css={css`
+				${headline.xxsmall({ fontWeight: 'bold' })}
+				margin-bottom: ${space[2]}px;
+			`}
+		>
+			{title}
+		</h2>
+	);
+};
+
+const BlockByline = ({
+	name,
+	format,
+	imageUrl,
+}: {
+	name: string;
+	format: ArticleFormat;
+	imageUrl?: string;
+}) => {
+	const palette = decidePalette(format);
+	return (
+		<div
+			css={css`
+				display: flex;
+				flex-direction: row;
+				padding-bottom: ${space[1]}px;
+			`}
+		>
+			{!!imageUrl && (
+				<div
+					css={css`
+						height: ${space[9]}px;
+						width: ${space[9]}px;
+					`}
+				>
+					<img
+						src={imageUrl}
+						alt={name}
+						css={css`
+							border-radius: 100%;
+							display: block;
+							width: 100%;
+							height: 100%;
+							object-fit: cover;
+							background-color: ${palette.background.avatar};
+						`}
+					/>
+				</div>
+			)}
+			<span
+				css={css`
+					${body.medium()}
+					display: flex;
+					align-items: center;
+					padding-left: ${imageUrl ? space[1] : 0}px;
+				`}
+			>
+				{name}
+			</span>
+		</div>
+	);
+};
+
+export const LiveBlockContainer = ({
+	id,
+	children,
+	format,
+	blockTitle,
+	blockFirstPublished,
+	blockFirstPublishedDisplay,
+	blockId,
+	isLiveUpdate,
+	contributors,
+	isPinnedPost,
+	isOriginalPinnedPost = false,
+	host,
+	pageId,
+}: Props) => {
+	const palette = decidePalette(format);
+	return (
+		<article
+			/**
+			 * Pinned posts are not the cannonical source for a post, they're a copy. Only the *true* post
+			 * should get the id. This will prevent two elements on the page having the same id.
+			 * */
+			id={!isPinnedPost ? `block-${id}` : undefined}
+			key={id}
+			/**
+			 *   Classnames
+			 *   ----------
+			 * - 'block' is used by Spacefinder as a possible candidate before which it can insert an inline ad
+			 * - 'pending' is used to mark blocks that have been inserted as part of a live update. We use this
+			 *    to animate the reveal as well as for enhancing twitter embeds
+			 */
+			className={['block', isLiveUpdate && 'pending']
+				.filter(isString)
+				.join(' ')}
+			css={css`
+				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
+				box-sizing: border-box;
+				margin-bottom: ${space[3]}px;
+				background: ${neutral[100]};
+				${!isPinnedPost &&
+				`border-top: 1px solid ${palette.border.liveBlock};
+				border-bottom: 1px solid ${neutral[86]};`}
+				${from.tablet} {
+					padding: ${space[2]}px ${SIDE_MARGIN}px;
+					padding-left: ${LEFT_MARGIN_DESKTOP}px;
+				}
+			`}
+		>
+			<Header>
+				{!!blockFirstPublished && (
+					<FirstPublished
+						firstPublished={blockFirstPublished}
+						firstPublishedDisplay={blockFirstPublishedDisplay}
+						blockId={blockId}
+						isPinnedPost={isPinnedPost}
+						isOriginalPinnedPost={isOriginalPinnedPost}
+						format={format}
+						host={host}
+						pageId={pageId}
+					/>
+				)}
+				{blockTitle ? <BlockTitle title={blockTitle} /> : null}
+				{contributors?.map((contributor) => (
+					<BlockByline
+						name={contributor.name}
+						imageUrl={
+							contributor.largeImageUrl
+								? contributor.largeImageUrl
+								: contributor.imageUrl
+						}
+						format={format}
+					/>
+				))}
+			</Header>
+			{children}
+		</article>
+	);
+};

--- a/dotcom-rendering/src/web/components/Pagination.stories.tsx
+++ b/dotcom-rendering/src/web/components/Pagination.stories.tsx
@@ -1,0 +1,42 @@
+import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
+import { getAllThemes } from '../lib/format';
+import { Pagination } from './Pagination';
+
+export default {
+	component: Pagination,
+	title: 'Components/Pagination',
+	parameters: {
+		layout: 'padded',
+		chromatic: { viewports: [breakpoints.mobile, breakpoints.wide] },
+	},
+};
+
+const formats = getAllThemes({
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+});
+
+export const notFirstPage = () => (
+	<>
+		{formats.map((format) => (
+			<Pagination currentPage={2} totalPages={6} format={format} />
+		))}
+	</>
+);
+
+notFirstPage.story = {
+	name: 'Not first page',
+};
+
+export const firstPageStory = () => (
+	<>
+		{formats.map((format) => (
+			<Pagination currentPage={1} totalPages={4} format={format} />
+		))}
+	</>
+);
+
+firstPageStory.story = {
+	name: 'First page',
+};

--- a/dotcom-rendering/src/web/components/Pagination.tsx
+++ b/dotcom-rendering/src/web/components/Pagination.tsx
@@ -1,0 +1,200 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { space, textSans, until } from '@guardian/source-foundations';
+import {
+	Hide,
+	LinkButton,
+	SvgChevronLeftDouble,
+	SvgChevronLeftSingle,
+	SvgChevronRightDouble,
+	SvgChevronRightSingle,
+} from '@guardian/source-react-components';
+import { decidePalette } from '../lib/decidePalette';
+
+type Props = {
+	currentPage: number;
+	totalPages: number;
+	newest?: string;
+	newer?: string;
+	oldest?: string;
+	older?: string;
+	format: ArticleFormat;
+};
+
+const NavWrapper = ({ children }: { children: React.ReactNode }) => (
+	<nav
+		// Used to scroll the page to this point when using permalinks
+		id="liveblog-navigation"
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			padding-top: ${space[1]}px;
+			padding-bottom: ${space[4]}px;
+		`}
+	>
+		{children}
+	</nav>
+);
+
+const FlexSection = ({
+	hide = false,
+	children,
+}: {
+	hide?: boolean;
+	children: React.ReactNode;
+}) => (
+	<section
+		css={css`
+			display: flex;
+			align-items: center;
+			visibility: ${hide ? 'hidden' : 'visible'};
+		`}
+	>
+		{children}
+	</section>
+);
+
+const Bold = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			font-weight: bold;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Position = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			${textSans.small()}
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Of = () => <span>&nbsp;of&nbsp;</span>;
+
+const Space = () => (
+	<div
+		css={css`
+			${until.phablet} {
+				width: ${space[2]}px;
+			}
+			width: ${space[4]}px;
+		`}
+	/>
+);
+
+const decidePaginationCss = (format: ArticleFormat): SerializedStyles => css`
+	color: ${decidePalette(format).text.pagination};
+	border: 1px solid ${decidePalette(format).border.pagination};
+	:hover {
+		border: 1px solid ${decidePalette(format).hover.pagination};
+	}
+`;
+
+export const Pagination = ({
+	currentPage,
+	totalPages,
+	oldest,
+	older,
+	newest,
+	newer,
+	format,
+}: Props) => {
+	const cssOverrides = decidePaginationCss(format);
+
+	return (
+		<NavWrapper>
+			<FlexSection hide={currentPage === 1}>
+				<Hide above="phablet">
+					<LinkButton
+						size="small"
+						priority="tertiary"
+						icon={<SvgChevronLeftDouble />}
+						iconSide="left"
+						hideLabel={true}
+						href={newest}
+						cssOverrides={cssOverrides}
+					>
+						Newest
+					</LinkButton>
+				</Hide>
+				<Hide below="phablet">
+					<LinkButton
+						size="small"
+						priority="tertiary"
+						icon={<SvgChevronLeftDouble />}
+						iconSide="left"
+						href={newest}
+						cssOverrides={cssOverrides}
+					>
+						Newest
+					</LinkButton>
+				</Hide>
+				<Space />
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronLeftSingle />}
+					hideLabel={true}
+					href={newer}
+					cssOverrides={cssOverrides}
+				>
+					Previous
+				</LinkButton>
+			</FlexSection>
+			<FlexSection>
+				<Position>
+					<Bold>{currentPage}</Bold>
+					<Of />
+					<Bold>{totalPages}</Bold>
+				</Position>
+			</FlexSection>
+			<FlexSection hide={currentPage === totalPages}>
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronRightSingle />}
+					hideLabel={true}
+					href={older}
+					cssOverrides={cssOverrides}
+				>
+					Next
+				</LinkButton>
+				<Space />
+				<Hide above="phablet">
+					<LinkButton
+						size="small"
+						priority="tertiary"
+						icon={<SvgChevronRightDouble />}
+						iconSide="right"
+						href={oldest}
+						hideLabel={true}
+						cssOverrides={cssOverrides}
+					>
+						Oldest
+					</LinkButton>
+				</Hide>
+				<Hide below="phablet">
+					<LinkButton
+						size="small"
+						priority="tertiary"
+						icon={<SvgChevronRightDouble />}
+						iconSide="right"
+						href={oldest}
+						cssOverrides={cssOverrides}
+					>
+						Oldest
+					</LinkButton>
+				</Hide>
+			</FlexSection>
+		</NavWrapper>
+	);
+};

--- a/dotcom-rendering/src/web/components/SubMeta.stories.tsx
+++ b/dotcom-rendering/src/web/components/SubMeta.stories.tsx
@@ -5,10 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import {
-	getAllThemes,
-	getThemeNameAsString,
-} from '../../../../common-rendering/src/fixtures/article';
+import { getAllThemes, getThemeNameAsString } from '../lib/format';
 import { SubMeta } from './SubMeta';
 
 export default {

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1,8 +1,4 @@
 import { css } from '@emotion/react';
-// eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
-import Accordion from '@guardian/common-rendering/src/components/accordion';
-// eslint-disable-next-line import/no-extraneous-dependencies -- it’s a yarn workspace
-import { Pagination } from '@guardian/common-rendering/src/components/Pagination';
 import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
@@ -20,6 +16,7 @@ import { StraightLines } from '@guardian/source-react-components-development-kit
 import { buildAdTargeting } from '../../lib/ad-targeting';
 import type { NavType } from '../../model/extract-nav';
 import type { FEArticleType } from '../../types/frontend';
+import { Accordion } from '../components/Accordion';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
@@ -48,6 +45,7 @@ import { MostViewedFooterData } from '../components/MostViewedFooterData.importa
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { Nav } from '../components/Nav/Nav';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { Pagination } from '../components/Pagination';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
 import { Standfirst } from '../components/Standfirst';
@@ -840,7 +838,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
-														supportsDarkMode={false}
 													/>
 												)}
 												<ArticleBody
@@ -948,7 +945,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
-														supportsDarkMode={false}
 													/>
 												)}
 												<StraightLines
@@ -980,7 +976,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										</div>
 									) : (
 										<Accordion
-											supportsDarkMode={false}
 											accordionTitle="Live feed"
 											context="liveFeed"
 										>
@@ -1003,7 +998,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
-														supportsDarkMode={false}
 													/>
 												)}
 												<ArticleBody
@@ -1111,7 +1105,6 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 														newer={pagination.newer}
 														older={pagination.older}
 														format={format}
-														supportsDarkMode={false}
 													/>
 												)}
 												<StraightLines

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -503,6 +503,27 @@ const textKeyEvent = (format: ArticleFormat): string => {
 	}
 };
 
+const textKeyEventFromDesktop = ({ theme }: ArticleFormat) => {
+	switch (theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
+};
+
 const textStandfirstLink = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
 	if (format.design === ArticleDesign.DeadBlog) {
@@ -1526,6 +1547,27 @@ const textRichLink = (format: ArticleFormat): string => {
 	}
 };
 
+const textPagination = (format: ArticleFormat) => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
+};
+
 const hoverStandfirstLink = (format: ArticleFormat): string => {
 	return textStandfirstLink(format);
 };
@@ -1612,6 +1654,10 @@ const borderSecondary = (format: ArticleFormat) => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt)
 		return transparentColour(neutral[60], 0.3);
 
+	return neutral[86];
+};
+
+const borderPagination = () => {
 	return neutral[86];
 };
 
@@ -1953,6 +1999,27 @@ const hoverSummaryEventBullet = (format: ArticleFormat): string => {
 	}
 };
 
+const hoverPagination = (format: ArticleFormat) => {
+	switch (format.theme) {
+		case ArticlePillar.News:
+			return news[400];
+		case ArticlePillar.Lifestyle:
+			return lifestyle[300];
+		case ArticlePillar.Sport:
+			return sport[300];
+		case ArticlePillar.Culture:
+			return culture[300];
+		case ArticlePillar.Opinion:
+			return opinion[300];
+		case ArticleSpecial.Labs:
+			return labs[300];
+		case ArticleSpecial.SpecialReport:
+			return specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return news[400];
+	}
+};
+
 export const decidePalette = (
 	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
@@ -1998,6 +2065,7 @@ export const decidePalette = (
 			disclaimerLink: textDisclaimerLink(format),
 			signInLink: textSignInLink(format),
 			richLink: textRichLink(format),
+			pagination: textPagination(format),
 			pullQuote: textPullQuote(format),
 			pullQuoteAttribution: textPullQuoteAttribution(format),
 			witnessIcon: textWitnessIcon(format),
@@ -2014,6 +2082,7 @@ export const decidePalette = (
 			shareCountUntilDesktop: textShareCountUntilDesktop(format),
 			cricketScoreboardLink: textCricketScoreboardLink(),
 			keyEvent: textKeyEvent(format),
+			keyEventFromDesktop: textKeyEventFromDesktop(format),
 			keyEventTime: textKeyEventTime(),
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),
@@ -2093,6 +2162,7 @@ export const decidePalette = (
 			keyEvent: borderKeyEvent(),
 			filterButton: borderFilterButton(),
 			secondary: borderSecondary(format),
+			pagination: borderPagination(),
 		},
 		topBar: {
 			card: overrides?.topBar.card ?? topBarCard(format),
@@ -2103,6 +2173,7 @@ export const decidePalette = (
 			keyEventLink: hoverKeyEventLink(format),
 			keyEventBullet: hoverKeyEventBullet(),
 			summaryEventBullet: hoverSummaryEventBullet(format),
+			pagination: hoverPagination(format),
 		},
 	};
 };

--- a/dotcom-rendering/src/web/lib/format.ts
+++ b/dotcom-rendering/src/web/lib/format.ts
@@ -1,0 +1,30 @@
+import { ArticlePillar, ArticleSpecial, isString } from '@guardian/libs';
+
+export const getThemeNameAsString = (format: ArticleFormat): string => {
+	const themeName =
+		ArticlePillar[format.theme] ?? ArticleSpecial[format.theme];
+	if (!themeName) throw new Error('Unknown theme');
+	return themeName;
+};
+
+/**
+ * We need a type guard because TypeScript enums are (confusingly)
+ * returning both strings and numbers.
+ */
+const isTheme = (theme: string | ArticleTheme): theme is ArticleTheme =>
+	!isString(theme);
+
+export const getAllThemes = ({
+	display,
+	design,
+}: {
+	display: ArticleDisplay;
+	design: ArticleDesign;
+}): Array<ArticleFormat> =>
+	Object.values({ ...ArticlePillar, ...ArticleSpecial })
+		.filter(isTheme)
+		.map((theme) => ({
+			theme,
+			display,
+			design,
+		}));


### PR DESCRIPTION
## What does this change?

Extract the `LiveContainer` components out of common-rendering directly into `dotcom-rendering`

Also extract theme helpers.

## Why?

The maintenance burden of this shared library is high for minimal benefits in sharing a single implementation between AR & DCR, so the components have been duplicated in DCR.