### PR TITLE
Remove ad-slot__label styles

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -9,7 +9,6 @@ import {
 	space,
 	text,
 	textSans,
-	until,
 } from '@guardian/source-foundations';
 import { getZIndex } from '../lib/getZIndex';
 import { Island } from './Island';
@@ -57,7 +56,6 @@ const outOfPageStyles = css`
 `;
 
 export const labelStyles = css`
-	.ad-slot__label,
 	.ad-slot__scroll {
 		${individualLabelCSS}
 		position: relative;
@@ -66,12 +64,6 @@ export const labelStyles = css`
 		}
 		&.hidden {
 			visibility: hidden;
-		}
-		&.ad-slot__label--toggle {
-			margin: 0 auto;
-			${until.tablet} {
-				display: none;
-			}
 		}
 	}
 	.ad-slot__close-button {
@@ -221,7 +213,7 @@ const mobileStickyAdStyles = css`
 		stroke-width: 0;
 		text-align: center;
 	}
-	.ad-slot--mobile-sticky .ad-slot__label .ad-slot__close-button {
+	.ad-slot--mobile-sticky .ad-slot__close-button {
 		display: block;
 	}
 	.ad-slot__close-button__x {
@@ -230,20 +222,6 @@ const mobileStickyAdStyles = css`
 		stroke-linecap: round;
 		stroke-width: 2;
 		text-align: center;
-	}
-
-	.ad-slot__label {
-		font-size: 0.75rem;
-		line-height: 1.25rem;
-		position: relative;
-		height: 1.5rem;
-		background-color: ${neutral[97]};
-		padding: 0 0.5rem;
-		border-top: 0.0625rem solid ${border.secondary};
-		color: ${neutral[60]};
-		text-align: left;
-		box-sizing: border-box;
-		${textSans.xxsmall()};
 	}
 
 	.ad-slot:not[data-label-show='true']::before {


### PR DESCRIPTION
## What does this change?
Now that the new ad labelling method is live, we no longer need these styles in DCR to support the ad-slot__label div