### PR TITLE
Handle headline quotes on Cards

### DIFF
--- a/dotcom-rendering/fixtures/generated/articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/articles/Analysis.ts
@@ -1461,6 +1461,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Micheál Martin becomes Irish taoiseach in historic coalition',
 				shortUrl: 'https://www.theguardian.com/p/e79et',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/jun/26/irish-government-to-be-formed-after-greens-vote-yes-to-coalition',
@@ -1486,6 +1487,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Ireland to form new government after Green party votes for coalition',
 				shortUrl: 'https://www.theguardian.com/p/e7572',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/jun/15/fine-gael-fianna-fail-and-greens-agree-deal-to-form-irish-coalition',
@@ -1511,6 +1513,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Fine Gael, Fianna Fáil and Greens agree deal to form Irish coalition',
 				shortUrl: 'https://www.theguardian.com/p/e49gh',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/may/26/irish-taoiseach-leo-varadkar-denies-picnic-with-friends-was-covid-19-rule-breach',
@@ -1536,6 +1539,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Irish taoiseach Leo Varadkar denies picnic with friends was Covid-19 rule breach',
 				shortUrl: 'https://www.theguardian.com/p/evan3',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/apr/14/ireland-fine-gael-fianna-fail-close-forming-coalition-government',
@@ -1561,6 +1565,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Ireland’s Fine Gael and Fianna Fáil close to forming coalition government',
 				shortUrl: 'https://www.theguardian.com/p/dk7xx',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/feb/24/micheal-martin-faces-a-battle-of-conscience-to-form-irish-government',
@@ -1586,6 +1591,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Micheál Martin faces a battle of conscience to form Irish government',
 				shortUrl: 'https://www.theguardian.com/p/dayh8',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/feb/20/irish-parliament-set-for-stalemate-in-attempt-to-form-new-government',
@@ -1611,6 +1617,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Varadkar resigns as Irish government enters stalemate',
 				shortUrl: 'https://www.theguardian.com/p/dayq6',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2020/feb/17/fine-gael-fianna-fail-coalition-unthinkable-says-sinn-fein-leader-mary-lou-mcdonald',
@@ -1636,6 +1643,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Varadkar prepares to go into opposition as deadlock continues',
 				shortUrl: 'https://www.theguardian.com/p/da75n',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/commentisfree/2020/feb/16/even-as-ireland-economy-booms-sinn-fein-win-is-bitter-cry-for-equality',
@@ -1660,6 +1668,7 @@ export const Analysis: FEArticleType = {
 				headline:
 					'Ireland’s shock poll result was a vote against the success of globalisation',
 				shortUrl: 'https://www.theguardian.com/p/d9kx7',
+				showQuotedHeadline: false,
 			},
 		],
 	},

--- a/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/articles/NumberedList.ts
@@ -1738,6 +1738,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'EU deal will force iPhones to use USB-C charger by 2024',
 				shortUrl: 'https://www.theguardian.com/p/ytt7j',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/world/2022/oct/04/eu-votes-to-force-all-phones-to-use-same-charger-by-2024',
@@ -1762,6 +1763,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'EU votes to force all phones to use same charger by 2024',
 				shortUrl: 'https://www.theguardian.com/p/mcnx4',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/uk-news/2021/aug/09/vodaphone-to-reintroduce-roaming-fees-for-uk-customers-in-europe',
@@ -1787,6 +1789,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Vodafone to reintroduce roaming fees for UK customers in Europe',
 				shortUrl: 'https://www.theguardian.com/p/teezg',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2020/apr/23/bug-leaves-iphones-vulnerable-hackers-stealing-email-contents',
@@ -1812,6 +1815,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Bug leaves iPhones vulnerable to hackers stealing email contents',
 				shortUrl: 'https://www.theguardian.com/p/dyyea',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2020/feb/24/mate-xs-huawei-launches-latest-version-of-folding-smartphone',
@@ -1837,6 +1841,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Mate Xs: Huawei launches latest version of folding smartphone',
 				shortUrl: 'https://www.theguardian.com/p/dap9k',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2020/feb/11/samsung-launches-galaxy-s20-range-with-up-to-100x-zoom-camera',
@@ -1862,6 +1867,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Samsung launches Galaxy S20 range with up to 100x zoom camera',
 				shortUrl: 'https://www.theguardian.com/p/d9ve7',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2020/feb/11/samsung-galaxy-z-flip-folding-screen-flip-phone-launches',
@@ -1887,6 +1893,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Samsung Galaxy Z Flip: folding-screen flip-phone launches',
 				shortUrl: 'https://www.theguardian.com/p/d9xdb',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2019/oct/21/google-eye-detection-pixel-4-smartphone-unlock',
@@ -1912,6 +1919,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Google to add eye detection to Pixel 4 after privacy concerns',
 				shortUrl: 'https://www.theguardian.com/p/chhfd',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2019/oct/02/microsoft-launches-surface-pro-x-and-previews-folding-phone',
@@ -1937,6 +1945,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Microsoft launches Surface Pro X and previews folding phone',
 				shortUrl: 'https://www.theguardian.com/p/cechh',
+				showQuotedHeadline: false,
 			},
 			{
 				url: 'https://www.theguardian.com/technology/2019/aug/07/samsung-galaxy-note-10-launch-big-screens-and-stylus-air-gestures',
@@ -1962,6 +1971,7 @@ export const NumberedList: FEArticleType = {
 				headline:
 					'Samsung Galaxy Note 10 launch: big screens and stylus air gestures',
 				shortUrl: 'https://www.theguardian.com/p/c4chq',
+				showQuotedHeadline: false,
 			},
 		],
 	},

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -34,6 +34,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@1',
+		showQuotedHeadline: true,
 
 		supportingContent: [
 			{
@@ -83,6 +84,7 @@ export const trails: [
 		mediaType: 'Video',
 		mediaDuration: 378,
 		dataLinkName: 'news | group-0 | card-@2',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -98,6 +100,7 @@ export const trails: [
 		},
 		kickerText: 'Live',
 		dataLinkName: 'news | group-0 | card-@3',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -112,6 +115,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@4',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -126,6 +130,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@5',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -141,6 +146,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@6',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -157,6 +163,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@7',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -172,6 +179,7 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@8',
+		showQuotedHeadline: false,
 	},
 
 	{
@@ -189,6 +197,7 @@ export const trails: [
 		headline:
 			'UK Covid live: England lockdown to be eased in stages, says PM, amid reports of nationwide mass testing',
 		dataLinkName: 'news | group-0 | card-@9',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -205,6 +214,7 @@ export const trails: [
 		headline:
 			'UK to infect up to 90 healthy volunteers with Covid in world first trial',
 		dataLinkName: 'news | group-0 | card-@10',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -221,6 +231,7 @@ export const trails: [
 		headline:
 			'Scottish government inadequately prepared for Covid, says watchdog',
 		dataLinkName: 'news | group-0 | card-@11',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -237,6 +248,7 @@ export const trails: [
 		headline:
 			'‘Encouraging’ signs for Covid vaccine as over-80s deaths fall in England',
 		dataLinkName: 'news | group-0 | card-@12',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -253,6 +265,7 @@ export const trails: [
 		headline:
 			'Contact tracing alone has little impact on curbing Covid spread, report finds',
 		dataLinkName: 'news | group-0 | card-@1',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -269,6 +282,7 @@ export const trails: [
 		headline:
 			'Ethnicity and poverty are Covid risk factors, new Oxford modelling tool shows',
 		dataLinkName: 'news | group-0 | card-@13',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -285,6 +299,7 @@ export const trails: [
 		headline:
 			'UK Covid: 799 more deaths and 10,625 new cases reported; Scottish schools in phased return from Monday – as it happened',
 		dataLinkName: 'news | group-0 | card-@14',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -301,6 +316,7 @@ export const trails: [
 		headline:
 			'QCovid: how improved algorithm can identify more higher-risk adults',
 		dataLinkName: 'news | group-0 | card-@1',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -315,5 +331,6 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@15',
+		showQuotedHeadline: false,
 	},
 ];

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4301,6 +4301,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "showQuotedHeadline": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -192,6 +192,7 @@ export const enhanceCards = (
 			showByline: faciaCard.properties.showByline,
 			snapData: enhanceSnaps(faciaCard.enriched),
 			isBoosted: faciaCard.display.isBoosted,
+			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
 			avatarUrl:
 				faciaCard.properties.maybeContent?.tags.tags &&
 				faciaCard.properties.image?.type === 'Cutout'

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3045,6 +3045,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "showQuotedHeadline": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -235,6 +235,7 @@ export type DCRFrontCard = {
 	format: ArticleFormat;
 	url: string;
 	headline: string;
+	showQuotedHeadline: boolean;
 	trailText?: string;
 	starRating?: number;
 	webPublicationDate?: string;

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -22,6 +22,7 @@ interface BaseTrailType {
 	branding?: Branding;
 	isSnap?: boolean;
 	snapData?: DCRSnapType;
+	showQuotedHeadline?: boolean;
 }
 
 export interface TrailType extends BaseTrailType {

--- a/dotcom-rendering/src/web/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.stories.tsx
@@ -54,6 +54,7 @@ const trails: TrailType[] = [
 			'UK Covid live: England lockdown to be eased in stages, says PM, amid reports of nationwide mass testing',
 		shortUrl: 'https://gu.com/p/gekj6',
 		dataLinkName: 'news | group-2 | card-@1',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -72,6 +73,7 @@ const trails: TrailType[] = [
 			'UK to infect up to 90 healthy volunteers with Covid in world first trial',
 		shortUrl: 'https://gu.com/p/gey5n',
 		dataLinkName: 'news | group-2 | card-@2',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -90,6 +92,7 @@ const trails: TrailType[] = [
 			'Scottish government inadequately prepared for Covid, says watchdog',
 		shortUrl: 'https://gu.com/p/gey2h',
 		dataLinkName: 'news | group-1 | card-@3',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -108,6 +111,7 @@ const trails: TrailType[] = [
 			'‘Encouraging’ signs for Covid vaccine as over-80s deaths fall in England',
 		shortUrl: 'https://gu.com/p/g94y7',
 		dataLinkName: 'news | group-0 | card-@4',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -126,6 +130,7 @@ const trails: TrailType[] = [
 			'Contact tracing alone has little impact on curbing Covid spread, report finds',
 		shortUrl: 'https://gu.com/p/geeq2',
 		dataLinkName: 'news | group-0 | card-@5',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -144,6 +149,7 @@ const trails: TrailType[] = [
 			'Ethnicity and poverty are Covid risk factors, new Oxford modelling tool shows',
 		shortUrl: 'https://gu.com/p/gee2t',
 		dataLinkName: 'news | group-0 | card-@6',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -162,6 +168,7 @@ const trails: TrailType[] = [
 			'UK Covid: 799 more deaths and 10,625 new cases reported; Scottish schools in phased return from Monday – as it happened',
 		shortUrl: 'https://gu.com/p/geczb',
 		dataLinkName: 'news | group-0 | card-@7',
+		showQuotedHeadline: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -180,6 +187,7 @@ const trails: TrailType[] = [
 			'QCovid: how improved algorithm can identify more higher-risk adults',
 		shortUrl: 'https://gu.com/p/gefev',
 		dataLinkName: 'news | group-0 | card-@8',
+		showQuotedHeadline: false,
 	},
 ];
 

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -32,6 +32,7 @@ export const FrontCard = (props: Props) => {
 		byline: trail.byline,
 		showByline: trail.showByline,
 		showQuotes:
+			!!trail.showQuotedHeadline ||
 			trail.format.design === ArticleDesign.Comment ||
 			trail.format.design === ArticleDesign.Letter,
 		webPublicationDate: trail.webPublicationDate,

--- a/dotcom-rendering/src/web/components/MostViewed.mocks.ts
+++ b/dotcom-rendering/src/web/components/MostViewed.mocks.ts
@@ -18,6 +18,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
@@ -34,6 +35,7 @@ export const mockTab1: CAPITrailTabType = {
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			ageWarning: '1 year old',
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/sport/2019/sep/15/ashes-cricket-series-drawn-england-beat-australia-fifth-test',
@@ -50,6 +52,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'sport',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/uk-news/2019/sep/15/boris-johnson-bonkers-plan-for-15bn-pound-bridge-derided-by-engineers',
@@ -66,6 +69,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'culture',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/politics/2019/sep/15/five-things-we-learned-from-david-cameron-memoir-boris-johnson-michael-gove-referendum',
@@ -82,6 +86,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'lifestyle',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 			ageWarning: '4 months old',
 		},
 		{
@@ -99,6 +104,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/lifeandstyle/2019/sep/15/how-six-weddings-in-one-year-made-me-love-being-single',
@@ -115,6 +121,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/fashion/2019/sep/15/joani-johnson-model-fenty-career-began-at-65-ageing-interview',
@@ -131,6 +138,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/fashion/2019/sep/15/victoria-beckham-announces-launch-of-own-makeup-brand',
@@ -147,6 +155,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/commentisfree/2019/sep/15/government-boris-johnson-incredible-hulk-sam-gyimah',
@@ -163,6 +172,7 @@ export const mockTab1: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 	],
 };
@@ -185,6 +195,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/15/aphex-twin-review-printworks-london-electronic-music',
@@ -201,6 +212,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/13/100-best-albums-of-the-21st-century',
@@ -216,6 +228,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/14/missy-elliott-interview-beyonce-vmas-katy-perry-misdemeanor',
@@ -232,6 +245,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'culture',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/14/beatles-paul-mccartney-ringo-starr-reunite-record-john-lennon-song',
@@ -248,6 +262,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/15/on-my-radar-gruff-rhys-interview',
@@ -263,6 +278,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/13/sam-smith-on-being-non-binary-im-changing-my-pronouns-to-theythem',
@@ -279,6 +295,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/15/pixies-beneath-the-eyrie-review',
@@ -295,6 +312,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/14/emeli-sande-interview-life-on-a-plate-i-loved-spaghetti-so-much',
@@ -311,6 +329,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 		{
 			url: 'https://www.theguardian.com/music/2019/sep/15/joyce-didonato-interview-agrippina-royal-opera-house',
@@ -327,6 +346,7 @@ export const mockTab2: CAPITrailTabType = {
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
+			showQuotedHeadline: false,
 		},
 	],
 };


### PR DESCRIPTION
## What does this change?

Some headlines start with “I ” or “We ”, and then get separated from the following line, so this prevents these small words from hanging on their own.

## Why?

This data comes from the pressed page, and we need to pass it through to Cards.

Resolves #4710 
Resolves #6443

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/205707686-12954d18-cfbe-4c3a-9073-9588ba981995.png
[after]: https://user-images.githubusercontent.com/76776/205707623-57625414-39b3-4616-9dc2-2c0f0abb0fb5.png
