### PR TITLE
Make the first space in a headline non-breaking when following a short word

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -216,6 +216,9 @@ const WithLink = ({
 	return <>{children}</>;
 };
 
+/** Matches headlines starting with short words of 1 to 3 letters followed by a space */
+const isFirstWordShort = /^(\w{1,3}) \b/;
+
 export const CardHeadline = ({
 	headlineText,
 	format,
@@ -236,6 +239,9 @@ export const CardHeadline = ({
 	const kickerColour = isDynamo
 		? palette.text.dynamoKicker
 		: palette.text.cardKicker;
+	const cleanHeadLineText = headlineText.match(isFirstWordShort)
+		? headlineText.replace(' ', ' ') // from regular to non-breaking space
+		: headlineText;
 	return (
 		<>
 			<h3
@@ -278,7 +284,7 @@ export const CardHeadline = ({
 						`}
 						className="show-underline"
 					>
-						{headlineText}
+						{cleanHeadLineText}
 					</span>
 				</WithLink>
 			</h3>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Some headlines start with “I ” or “We ”, and then get separated from the following line, so this prevents these small words from hanging on their own.

## Why?

It looks better, generally.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/205710328-87642ff7-fa92-41a5-b02b-f6fd9fadafb1.png
[after]: https://user-images.githubusercontent.com/76776/205710401-152a7f67-da04-4cf8-b8a7-2f0fbef11611.png
