### PR TITLE
lower LatencyAlarmThreshold to 0.2

### DIFF
--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -32,7 +32,11 @@ Parameters:
   LatencyAlarmThreshold:
     Type: String
     Description: (Optional) Latency Threshold in seconds
-    Default: '0.5'
+    # This sits at 0.1 seconds lower that of our ArticleStack in frontend - which calls this service.
+    # This will allow this service to scale up first and be ready for if ArticleStack needs to get larger.
+    # This might actually alleviate the pressure on ArticleStack avoiding it needing to scale up.
+    # ArticleStack LatencyAlarmThreshold: https://github.com/guardian/platform/blob/main/provisioning/cloudformation/frontend.yaml#L118
+    Default: '0.4'
   LatencyAlarmPeriod:
     Type: String
     Description: (Optional) Duration in seconds over which the latency is applied

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -36,7 +36,7 @@ Parameters:
     # This will allow this service to scale up first and be ready for if ArticleStack needs to get larger.
     # This might actually alleviate the pressure on ArticleStack avoiding it needing to scale up.
     # ArticleStack LatencyAlarmThreshold: https://github.com/guardian/platform/blob/main/provisioning/cloudformation/frontend.yaml#L118
-    Default: '0.4'
+    Default: '0.2'
   LatencyAlarmPeriod:
     Type: String
     Description: (Optional) Duration in seconds over which the latency is applied

--- a/dotcom-rendering/cloudformation.yml
+++ b/dotcom-rendering/cloudformation.yml
@@ -32,7 +32,7 @@ Parameters:
   LatencyAlarmThreshold:
     Type: String
     Description: (Optional) Latency Threshold in seconds
-    # This sits at 0.1 seconds lower that of our ArticleStack in frontend - which calls this service.
+    # This sits at 0.3 seconds lower that of our ArticleStack in frontend - which calls this service.
     # This will allow this service to scale up first and be ready for if ArticleStack needs to get larger.
     # This might actually alleviate the pressure on ArticleStack avoiding it needing to scale up.
     # ArticleStack LatencyAlarmThreshold: https://github.com/guardian/platform/blob/main/provisioning/cloudformation/frontend.yaml#L118


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This sets the `LatencyAlarmThreshold` to `0.2` less than the `ArticleStack.LatencyAlarmThreshold`.

This value has been chosen because the latency of DCR usually sits way below 0.1, buts starts to become troublesome at about `0.15-0.20`, meaning that `RenderingStack` will nearly always be in a `Low` scaling state. You can see this in the graph below. 

When looking through the stats, it seems our
1. request count goes up
1. `RenderingStack.Latency` latency goes up
1. `ArticleStack.Latency` > `0.5`
1. We scale `ArticleStack`
1. This raises `RenderingStack`'s latency, eventually > `0.5`
1. We then scale `RenderingStack`

We might be able to avoid this if we scale rendering before we scale `ArticleStack`. This tries to do this. i.e. 
1. request count goes up
1. `RenderingStack.Latency` latency goes up
1. This raises `RenderingStack`'s latency, eventually > `0.2`
2. 1. We then scale `RenderingStack`
1. Hopefully `ArticleStack` stays good

This was also tested by raising the instance count of `RenderingStack` when in alert mode, which dropped the latency almost immediately. See the graph below (for colours in Graph 2 and 3, the green colour is our rendering ELB stats).

<img width="1214" alt="Screenshot 2022-12-05 at 21 37 08" src="https://user-images.githubusercontent.com/31692/205748057-1d332ed3-0ee8-4985-9f4b-d8d34184bd6a.png">

While this change feels sensible as a chain of events, it could indicate that our response time on DCR has been on a [downward trend over a prolonged time](https://en.wikipedia.org/wiki/Gradualism), and we might need to investigate if there are any big offenders in our callstack.

It also indicates that we have created systems that have side effects on other services (request => article => CAPI => DCR => response) and should be mindful of the complexity this creates in debugging and maintenance, and also might have us have another thought on how we might make this a single I/O operation per request to reduce this complexity. 
