### PR TITLE
fix(cwv): import from @guardian/core-web-vitals

### DIFF
--- a/dotcom-rendering/src/web/experiments/utils.ts
+++ b/dotcom-rendering/src/web/experiments/utils.ts
@@ -1,5 +1,5 @@
 import { bypassCommercialMetricsSampling } from '@guardian/commercial-core';
-import { bypassCoreWebVitalsSampling } from '@guardian/libs';
+import { bypassCoreWebVitalsSampling } from '@guardian/core-web-vitals';
 
 export const bypassMetricsSampling = (): void => {
 	void bypassCommercialMetricsSampling();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Import from the right package

## Why?

Otherwise it won’t work. `main` is currently broken 