### PR TITLE
Remove Prebid AMP AB test and use Pubmatic

### DIFF
--- a/dotcom-rendering/src/amp/components/Ad.tsx
+++ b/dotcom-rendering/src/amp/components/Ad.tsx
@@ -4,7 +4,6 @@ import { EditionId } from '../../web/lib/edition';
 import { adJson, stringify } from '../lib/ad-json';
 import type { RTCParameters } from '../lib/real-time-config';
 import { realTimeConfig } from '../lib/real-time-config';
-import { useContentABTestGroup } from './ContentABTest';
 
 // Largest size first
 const inlineSizes = [
@@ -28,9 +27,6 @@ const ampData = (section: string, contentType: string): string => {
 	return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
-const relevantYieldURLPrefix =
-	'https://guardian-pbs.relevant-digital.com/openrtb2/amp';
-
 const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	const adTargetingMapped: AdTargetParam[] = [];
 
@@ -49,76 +45,24 @@ const mapAdTargeting = (adTargeting: AdTargeting): AdTargetParam[] => {
 	return adTargetingMapped;
 };
 
-// Variants for the Prebid server test
-// Assign each variant 4 groups e.g. 33.3% of content types each
-const variants = {
-	'relevant-yield': new Set<number>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-	pubmatic: new Set<number>([]),
-};
-
-// Determine participation in a variant from group
-const isInVariant = (
-	variantName: 'relevant-yield' | 'pubmatic',
-	group: number | undefined,
-) => group !== undefined && variants[variantName].has(group);
-
-const useRealTimeConfig = (
+const pubmaticRealTimeConfig = (
 	usePrebid: boolean,
 	usePermutive: boolean,
 	useAmazon: boolean,
-	{ tagId, profileId, pubId }: RTCParameters,
+	{ profileId, pubId }: RTCParameters,
 ): string => {
-	const { group } = useContentABTestGroup();
-
-	// Relevant Yield variant
-	if (isInVariant('relevant-yield', group)) {
-		const relevantYieldURL = [
-			`${relevantYieldURLPrefix}?tag_id=${tagId}`,
-			'w=ATTR(width)',
-			'h=ATTR(height)',
-			'ow=ATTR(data-override-width)',
-			'oh=ATTR(data-override-height)',
-			'ms=ATTR(data-multi-size)',
-			'slot=ATTR(data-slot)',
-			'targeting=TGT',
-			'curl=CANONICAL_URL',
-			'timeout=TIMEOUT',
-			'adcid=ADCID',
-			'purl=HREF',
-			'gdpr_consent=CONSENT_STRING',
-			'tgt_pfx=rv',
-			'dummy_param=ATTR(data-amp-slot-index)',
-		].join('&');
-
-		return realTimeConfig({
-			url: usePrebid ? relevantYieldURL : undefined,
-			usePermutive,
-			useAmazon,
-		});
-	}
-
-	// Pubmatic variant
-	if (isInVariant('pubmatic', group)) {
-		const pubmaticConfig = {
-			openwrap: {
-				PROFILE_ID: profileId,
-				PUB_ID: pubId,
-			},
-		};
-
-		return realTimeConfig({
-			vendors: usePrebid ? pubmaticConfig : {},
-			usePermutive,
-			useAmazon,
-			timeoutMillis: 1000,
-		});
-	}
-
-	// Not in test - dont't run Prebid
+	const pubmaticConfig = {
+		openwrap: {
+			PROFILE_ID: profileId,
+			PUB_ID: pubId,
+		},
+	};
 
 	return realTimeConfig({
+		vendors: usePrebid ? pubmaticConfig : {},
 		usePermutive,
 		useAmazon,
+		timeoutMillis: 1000,
 	});
 };
 
@@ -158,7 +102,7 @@ export const Ad = ({
 	// Secondary ad sizes
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
-	const rtcConfig = useRealTimeConfig(
+	const rtcConfig = pubmaticRealTimeConfig(
 		usePrebid,
 		usePermutive,
 		useAmazon,

--- a/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
+++ b/dotcom-rendering/src/amp/components/RegionalAd.test.tsx
@@ -5,14 +5,6 @@ import { RegionalAd } from './RegionalAd';
 describe('RegionalAd', () => {
 	const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
 
-	const ukRelevantYieldURL =
-		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
-	const usRelevantYieldURL =
-		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cb381a577cd525aeef3f_6214caacb52b565527aeef39&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
-	const auRelevantYieldURL =
-		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
-	const intRelevantYieldURL =
-		'https://guardian-pbs.relevant-digital.com/openrtb2/amp?tag_id=6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&tgt_pfx=rv&dummy_param=ATTR(data-amp-slot-index)';
 	const apsVendorObj = {
 		aps: { PUB_ID: '3722', PARAMS: { amp: '1' } },
 	};
@@ -42,7 +34,7 @@ describe('RegionalAd', () => {
 		},
 	};
 
-	it('with no ab test running rtc-config contains just a permutive URL when `usePermutive` and `usePrebid` flags are set to true', () => {
+	it('rtc-config contains just a permutive URL and prebid object when `usePermutive` and `usePrebid` flags are set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -90,9 +82,14 @@ describe('RegionalAd', () => {
 		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
+
+		expect(ukRtcAttribute.vendors).toEqual(ukPubmaticVendorObj);
+		expect(usRtcAttribute.vendors).toEqual(usPubmaticVendorObj);
+		expect(auRtcAttribute.vendors).toEqual(auPubmaticVendorObj);
+		expect(intRtcAttribute.vendors).toEqual(intPubmaticVendorObj);
 	});
 
-	it('with no ab test running rtc-config contains just no prebid URL when `usePermutive` is false and `usePrebid` is true', () => {
+	it('rtc-config contains just a prebid object when `usePrebid` is true and other flags are false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -136,13 +133,13 @@ describe('RegionalAd', () => {
 			ampAdElement[3].getAttribute('rtc-config') || '{}',
 		);
 
-		expect(ukRtcAttribute.urls).toEqual([]);
-		expect(usRtcAttribute.urls).toEqual([]);
-		expect(auRtcAttribute.urls).toEqual([]);
-		expect(intRtcAttribute.urls).toEqual([]);
+		expect(ukRtcAttribute.vendors).toEqual(ukPubmaticVendorObj);
+		expect(usRtcAttribute.vendors).toEqual(usPubmaticVendorObj);
+		expect(auRtcAttribute.vendors).toEqual(auPubmaticVendorObj);
+		expect(intRtcAttribute.vendors).toEqual(intPubmaticVendorObj);
 	});
 
-	it('with no ab test running rtc-config contains just the permutive URL when `usePermutive` is true and `usePrebid` is false', () => {
+	it('rtc-config contains just the permutive URL when `usePermutive` is true and other flags are false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -192,57 +189,7 @@ describe('RegionalAd', () => {
 		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
 	});
 
-	it('with no ab test running rtc-config contains no URLs when `usePermutive` and `usePrebid` flags are both set to false', () => {
-		const { container } = render(
-			<ContentABTestProvider pageId="" switches={{}}>
-				<RegionalAd
-					editionId="UK"
-					section=""
-					contentType=""
-					config={{
-						usePrebid: false,
-						usePermutive: false,
-						useAmazon: false,
-					}}
-					commercialProperties={{
-						UK: { adTargeting: [] },
-						US: { adTargeting: [] },
-						AU: { adTargeting: [] },
-						INT: { adTargeting: [] },
-						EUR: { adTargeting: [] },
-					}}
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
-				/>
-			</ContentABTestProvider>,
-		);
-
-		const ampAdElement = container.querySelectorAll('amp-ad');
-
-		expect(ampAdElement).not.toBeNull();
-
-		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[0].getAttribute('rtc-config') || '{}',
-		);
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[1].getAttribute('rtc-config') || '{}',
-		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[2].getAttribute('rtc-config') || '{}',
-		);
-		const intRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
-
-		expect(ukRtcAttribute.urls).toHaveLength(0);
-		expect(usRtcAttribute.urls).toHaveLength(0);
-		expect(auRtcAttribute.urls).toHaveLength(0);
-		expect(intRtcAttribute.urls).toHaveLength(0);
-	});
-
-	it('with no ab test running rtc-config contains the correct vendor config when `useAmazon` is set to true', () => {
+	it('rtc-config contains the correct vendor config when just `useAmazon` flag is set to true', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -292,7 +239,7 @@ describe('RegionalAd', () => {
 		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
 	});
 
-	it('with no ab test running rtc-config contains no vendor config when `useAmazon` is set to false', () => {
+	it('rtc-config contains no vendor config when all flags are set to false', () => {
 		const { container } = render(
 			<ContentABTestProvider pageId="" switches={{}}>
 				<RegionalAd
@@ -340,136 +287,5 @@ describe('RegionalAd', () => {
 		expect(usRtcAttribute.vendors).toEqual({});
 		expect(auRtcAttribute.vendors).toEqual({});
 		expect(intRtcAttribute.vendors).toEqual({});
-	});
-
-	it('with ab test running and in relevant yield variant, rtc-config contains permutive and relevant yield URLs when `usePermutive` and `usePrebid` flags are set to true', () => {
-		const { container } = render(
-			<ContentABTestProvider
-				pageId="food/2022/feb/15/air-fryers-miraculous-kitchen-must-have-or-just-a-load-of-hot-air"
-				switches={{ ampContentAbTesting: true }}
-			>
-				<RegionalAd
-					editionId="UK"
-					section=""
-					contentType=""
-					config={{
-						usePrebid: true,
-						usePermutive: true,
-						useAmazon: true,
-					}}
-					commercialProperties={{
-						UK: { adTargeting: [] },
-						US: { adTargeting: [] },
-						AU: { adTargeting: [] },
-						INT: { adTargeting: [] },
-						EUR: { adTargeting: [] },
-					}}
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
-				/>
-			</ContentABTestProvider>,
-		);
-
-		const ampAdElement = container.querySelectorAll('amp-ad');
-
-		expect(ampAdElement).not.toBeNull();
-
-		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[0].getAttribute('rtc-config') || '{}',
-		);
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[1].getAttribute('rtc-config') || '{}',
-		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[2].getAttribute('rtc-config') || '{}',
-		);
-		const intRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
-
-		expect(ukRtcAttribute.urls).toEqual([ukRelevantYieldURL, permutiveURL]);
-		expect(usRtcAttribute.urls).toEqual([usRelevantYieldURL, permutiveURL]);
-		expect(auRtcAttribute.urls).toEqual([auRelevantYieldURL, permutiveURL]);
-		expect(intRtcAttribute.urls).toEqual([
-			intRelevantYieldURL,
-			permutiveURL,
-		]);
-
-		expect(ukRtcAttribute.vendors).toEqual(apsVendorObj);
-		expect(usRtcAttribute.vendors).toEqual(apsVendorObj);
-		expect(auRtcAttribute.vendors).toEqual(apsVendorObj);
-		expect(intRtcAttribute.vendors).toEqual(apsVendorObj);
-	});
-
-	it.skip('with ab test running and in Pubmatic variant, rtc-config contains Permutive UR and Pubmatic vendor when `usePermutive` and `usePrebid` flags are set to true', () => {
-		const { container } = render(
-			<ContentABTestProvider
-				pageId="money/2004/may/13/homeimprovements"
-				switches={{ ampContentAbTesting: true }}
-			>
-				<RegionalAd
-					editionId="UK"
-					section=""
-					contentType=""
-					config={{
-						usePrebid: true,
-						usePermutive: true,
-						useAmazon: true,
-					}}
-					commercialProperties={{
-						UK: { adTargeting: [] },
-						US: { adTargeting: [] },
-						AU: { adTargeting: [] },
-						INT: { adTargeting: [] },
-						EUR: { adTargeting: [] },
-					}}
-					adTargeting={{
-						customParams: { sens: 'f', urlkw: [] },
-						adUnit: '',
-					}}
-				/>
-			</ContentABTestProvider>,
-		);
-
-		const ampAdElement = container.querySelectorAll('amp-ad');
-
-		expect(ampAdElement).not.toBeNull();
-
-		const ukRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[0].getAttribute('rtc-config') || '{}',
-		);
-		const usRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[1].getAttribute('rtc-config') || '{}',
-		);
-		const auRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[2].getAttribute('rtc-config') || '{}',
-		);
-		const intRtcAttribute: Record<string, unknown> = JSON.parse(
-			ampAdElement[3].getAttribute('rtc-config') || '{}',
-		);
-
-		expect(ukRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(usRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(auRtcAttribute.urls).toEqual([permutiveURL]);
-		expect(intRtcAttribute.urls).toEqual([permutiveURL]);
-
-		expect(ukRtcAttribute.vendors).toEqual({
-			...ukPubmaticVendorObj,
-			...apsVendorObj,
-		});
-		expect(usRtcAttribute.vendors).toEqual({
-			...usPubmaticVendorObj,
-			...apsVendorObj,
-		});
-		expect(auRtcAttribute.vendors).toEqual({
-			...auPubmaticVendorObj,
-			...apsVendorObj,
-		});
-		expect(intRtcAttribute.vendors).toEqual({
-			...intPubmaticVendorObj,
-			...apsVendorObj,
-		});
 	});
 });

--- a/dotcom-rendering/src/amp/lib/real-time-config.ts
+++ b/dotcom-rendering/src/amp/lib/real-time-config.ts
@@ -18,41 +18,15 @@ type AdType =
  * These can be computed from the Config type above
  */
 export type RTCParameters = {
-	tagId: string;
 	profileId: string;
 	pubId: string;
-};
-
-/**
- * Determine the Relevant Yield tag id that is used to look up a given stored bid request
- */
-const getTagId = (adType: AdType): string => {
-	if (adType.isSticky || adType.adRegion === 'INT') {
-		return '6214ca56243f4ff4f5aeef36_6214c723c70856442e4d79f2';
-	}
-
-	if (adType.adRegion === 'UK') {
-		return '6214ca675cf18e70cbaeef37_6214c9a4b73a6613d4aeef2f';
-	}
-
-	if (adType.adRegion === 'US') {
-		return '6214cb381a577cd525aeef3f_6214caacb52b565527aeef39';
-	}
-
-	// ad region is AU
-	return '6214cbe6a24103508faeef45_6214cb50aac9c1160daeef40';
 };
 
 /**
  * Determine the pub id and profile id required by Pubmatic to construct an RTC vendor
  *
  */
-const getPubAndProfileIds = (
-	adType: AdType,
-): {
-	pubId: string;
-	profileId: string;
-} => {
+export const getRTCParameters = (adType: AdType): RTCParameters => {
 	if (
 		adType.isSticky ||
 		adType.adRegion === 'UK' ||
@@ -71,14 +45,6 @@ const getPubAndProfileIds = (
 	// ad region is US
 	return { profileId: '6696', pubId: '157206' };
 };
-
-/**
- * Compute the full set of RTC parameters from a given ad type
- */
-export const getRTCParameters = (adType: AdType): RTCParameters => ({
-	tagId: getTagId(adType),
-	...getPubAndProfileIds(adType),
-});
 
 const permutiveURL = 'amp-script:permutiveCachedTargeting.ct';
 


### PR DESCRIPTION
## What does this change?

This PR removes the Prebid content-based AB test (see #4110 for the initial setup of the framework). We keep the Pubmatic variant as the default behaviour and remove Relevant Yield. This allows us to clean up the required configuration and removes the need for a `useRealtimeConfig` hook, since we know longer need to access the React context to check participation.

The unit tests are also cleaned up to remove mention of the AB test and to ensure we only test the now-default behaviour.

## Why?

This test has finally concluded!
