### PR TITLE
Fix `HeaderTopBar.stories` TypeScript error

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBar.stories.tsx
@@ -14,6 +14,7 @@ export const defaultStory = () => {
 			mmaUrl="mmaUrl"
 			discussionApiUrl="discussionApiUrl"
 			idApiUrl="idApiUrl"
+			headerTopBarSearchCapiSwitch={false}
 		/>
 	);
 };


### PR DESCRIPTION
## What does this change?

A TypeScript error in `HeaderTopBar.stories` has crept in to main which is blocking PRs.

