### PR TITLE
No incremental `tsc` build

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -18,7 +18,7 @@
 		"prettier:check": "prettier . --check --cache",
 		"prettier:fix": "prettier . --write --cache",
 		"lintstats": "yarn lint --format node_modules/eslint-stats/byError.js",
-		"tsc": "tsc --incremental",
+		"tsc": "tsc",
 		"test": "jest --maxWorkers=50%",
 		"test:watch": "jest --watch --maxWorkers=25%",
 		"test:ci": "jest --runInBand",


### PR DESCRIPTION
this feature causes a lot of issues for developers, including inconsistent results between local and CI.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Reverts #6548

## Why?

Lots of issues locally raised by fellow developers, such as @tjmw, @joecowton1, @bryophyta.