### PR TITLE
Feat: add design tag to review

### DIFF
--- a/apps-rendering/src/components/DesignTag/index.tsx
+++ b/apps-rendering/src/components/DesignTag/index.tsx
@@ -59,6 +59,12 @@ const DesignTag: FC<Props> = ({ format }) => {
 					<span css={designTagStyles(format)}>Obituary</span>
 				</div>
 			);
+		case ArticleDesign.Review:
+			return (
+				<div css={designTagWrapper}>
+					<span css={designTagStyles(format)}>Review</span>
+				</div>
+			);
 		case ArticleDesign.Interview:
 			return <span css={designTagStyles(format)}>Interview</span>;
 		default:

--- a/apps-rendering/src/components/Headline/ReviewHeadline.tsx
+++ b/apps-rendering/src/components/Headline/ReviewHeadline.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, headline } from '@guardian/source-foundations';
-import StarRating from 'components/StarRating';
 import type { Item } from 'item';
 import { defaultStyles } from './Headline.defaults';
 
@@ -19,7 +18,6 @@ interface Props {
 const ReviewHeadline: React.FC<Props> = ({ item }) => (
 	<h1 css={css(defaultStyles(item), reviewStyles)}>
 		<span>{item.headline}</span>
-		<StarRating item={item} />
 	</h1>
 );
 

--- a/apps-rendering/src/components/Standfirst/ReviewStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ReviewStandfirst.tsx
@@ -1,11 +1,15 @@
 import { css } from '@emotion/react';
 import { headline } from '@guardian/source-foundations';
+import StarRating from 'components/StarRating';
 import type { Item } from 'item';
 import { getFormat } from 'item';
 import DefaultStandfirst, { defaultStyles } from './Standfirst.defaults';
 
 const reviewStyles = css`
 	${headline.xxsmall({ fontWeight: 'light' })}
+	p:first-of-type {
+		padding-top: 0;
+	}
 `;
 
 interface Props {
@@ -13,10 +17,13 @@ interface Props {
 }
 
 const ReviewStandfirst: React.FC<Props> = ({ item }) => (
-	<DefaultStandfirst
-		item={item}
-		css={css(defaultStyles(getFormat(item)), reviewStyles)}
-	/>
+	<>
+		<StarRating item={item} />
+		<DefaultStandfirst
+			item={item}
+			css={css(defaultStyles(getFormat(item)), reviewStyles)}
+		/>
+	</>
 );
 
 export default ReviewStandfirst;

--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -144,6 +144,14 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
+		case ArticleDesign.Review:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/reviews">Review</TagLink>
+					</Tag>
+				</Margins>
+			);
 		default:
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/web/components/StarRating/StarRating.tsx
@@ -27,7 +27,7 @@ const determineSize = (size: RatingSizeType) => {
 			`;
 		case 'large':
 			return css`
-				padding: 2px;
+				padding: 2px 1px 2px 2px;
 				svg {
 					width: 20px;
 					height: 20px;

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -271,8 +271,8 @@ const stretchLines = css`
 `;
 
 const starWrapper = css`
-	margin-bottom: 18px;
-	margin-top: 6px;
+	margin-top: 18px;
+	margin-bottom: 6px;
 	background-color: ${brandAltBackground.primary};
 	display: inline-block;
 
@@ -557,6 +557,8 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									}
 								/>
 							</div>
+						</GridItem>
+						<GridItem area="standfirst">
 							{CAPIArticle.starRating ||
 							CAPIArticle.starRating === 0 ? (
 								<div css={starWrapper}>
@@ -568,8 +570,6 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							) : (
 								<></>
 							)}
-						</GridItem>
-						<GridItem area="standfirst">
 							<Standfirst
 								format={format}
 								standfirst={CAPIArticle.standfirst}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -284,9 +284,6 @@ const starWrapper = css`
 		padding-left: 0px;
 		margin-left: -0px;
 	}
-
-	padding-left: 10px;
-	margin-left: -10px;
 `;
 
 interface Props {

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -10,6 +10,7 @@ import {
 	from,
 	labs,
 	neutral,
+	space,
 	until,
 } from '@guardian/source-foundations';
 import { StraightLines } from '@guardian/source-react-components-development-kitchen';
@@ -271,8 +272,7 @@ const stretchLines = css`
 `;
 
 const starWrapper = css`
-	margin-top: 18px;
-	margin-bottom: 6px;
+	margin-top: ${space[4]}px;
 	background-color: ${brandAltBackground.primary};
 	display: inline-block;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the design tag to review articles on dcr

## Why?
Aligns with editorial designs

# DotCom Rendering
## Screenshots - with stars

| Before     | After     |
|-------------|------------|
| ![before-web][] | ![after-web][] |

[after-web]: https://user-images.githubusercontent.com/20416599/206164151-4b32291f-5fd7-4a23-ab5c-e816f837e660.png
[before-web]: https://user-images.githubusercontent.com/20416599/206164486-a6ff53df-f511-4f4f-bd52-879d9b9a6f72.png

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/20416599/206163900-084083ba-b738-47e6-a47a-ad8e409d4674.png
[after]: https://user-images.githubusercontent.com/20416599/206163913-66b4cc14-96dc-4671-9b67-77651784fbb3.png

## Screenshots - no stars

| Before     | After     |
|-------------|------------|
| ![before-web-2][] | ![after-web-2][] |

[before-web-2]: https://user-images.githubusercontent.com/20416599/206164286-60d6460c-0e82-4f56-8b81-4ec125d15a5f.png
[after-web-2]: https://user-images.githubusercontent.com/20416599/206164295-32eb99ae-739b-46fd-9170-e037cb4340a5.png


| Before      | After      |
|-------------|------------|
| ![before-2][] | ![after-2][] |

[after-2]: https://user-images.githubusercontent.com/20416599/206163943-e9a10a51-8baf-4c2a-aec9-b32f4ad22a91.png
[before-2]: https://user-images.githubusercontent.com/20416599/206163951-50b927d3-4de4-47f5-9c2a-404d43a6153a.png

# Apps Rendering

## Screenshots - with stars

| Before     | After     |
|-------------|------------|
| ![before-app][] | ![after-app][] |

[after-app]: https://user-images.githubusercontent.com/20416599/206220595-22ce7811-3b09-4162-94ff-bb8f1bff9c1f.png
[before-app]: https://user-images.githubusercontent.com/20416599/206220581-91eff01c-4e80-4cbc-bb0f-1e6c74216fd3.png
## Screenshots - no stars

| Before     | After     |
|-------------|------------|
| ![before-app-2][] | ![after-app-2][] |

[before-app-2]: https://user-images.githubusercontent.com/20416599/206220558-3d12f232-9ef3-49eb-a944-1c4781cc5079.png
[after-app-2]: https://user-images.githubusercontent.com/20416599/206220586-4ade5e09-fc54-48bd-abf3-db8c29e2497d.png
