### PR TITLE
Spike: billboard adverts in merchandising slots

### DIFF
--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -370,43 +370,61 @@ export const AdSlot = ({
 		case 'merchandising-high': {
 			return (
 				<div
-					id="dfp-ad--merchandising-high"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--merchandising-high',
-					].join(' ')}
 					css={[
-						merchandisingAdStyles,
+						css`
+							display: flex;
+							justify-content: center;
+						`,
 						adStyles,
-						fluidFullWidthAdStyles,
 					]}
-					data-link-name="ad slot merchandising-high"
-					data-name="merchandising-high"
-					aria-hidden="true"
-					data-label="false"
-				/>
+				>
+					<div
+						id="dfp-ad--merchandising-high"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--merchandising-high',
+						].join(' ')}
+						css={[
+							merchandisingAdStyles,
+							adStyles,
+							fluidFullWidthAdStyles,
+						]}
+						data-link-name="ad slot merchandising-high"
+						data-name="merchandising-high"
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'merchandising': {
 			return (
 				<div
-					id="dfp-ad--merchandising"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--merchandising',
-					].join(' ')}
 					css={[
-						merchandisingAdStyles,
+						css`
+							display: flex;
+							justify-content: center;
+						`,
 						adStyles,
-						fluidFullWidthAdStyles,
 					]}
-					data-link-name="ad slot merchandising"
-					data-name="merchandising"
-					aria-hidden="true"
-					data-label="false"
-				/>
+				>
+					<div
+						id="dfp-ad--merchandising"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--merchandising',
+						].join(' ')}
+						css={[
+							merchandisingAdStyles,
+							adStyles,
+							fluidFullWidthAdStyles,
+						]}
+						data-link-name="ad slot merchandising"
+						data-name="merchandising"
+						aria-hidden="true"
+					/>
+				</div>
 			);
 		}
 		case 'survey': {

--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
+import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
 import { liveblogDesktopOutstream } from './tests/liveblog-desktop-outstream';
@@ -25,4 +26,5 @@ export const tests: ABTest[] = [
 	removePrebidA9Canada,
 	liveblogDesktopOutstream,
 	teadsCookieless,
+	billboardsInMerch,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/billboards-in-merch.ts
+++ b/dotcom-rendering/src/web/experiments/tests/billboards-in-merch.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const billboardsInMerch: ABTest = {
+	id: 'BillboardsInMerch',
+	author: '@commercial-dev',
+	start: '2022-12-07',
+	expiry: '2023-02-31',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in only',
+	successMeasure:
+		'Test the commercial impact of showing billboard adverts in merchandising slots',
+	description:
+		'Show billboard adverts in merchandising slots to browsers in the variant',
+	variants: [
+		// TODO Bypass metrics sampling once we increase audience size
+		{ id: 'control', test: (): void => {} },
+		// TODO Bypass metrics sampling once we increase audience size
+		{ id: 'variant', test: (): void => {} },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

This PR adds some corresponding logic to DCR that is required by https://github.com/guardian/frontend/pull/25750.

This is three changes:
- Add a copy of the AB test definition to DCR, in the usual way.
- Wrap the merchandising units in containers that have `display: flex` and our label styles. This ensures that when a billboard is placed in a slot, we get a centred advert. This has no effect on fluid adverts placed in merchandising slots.
- Remove the `data-label="false"` attributes from the merch slots. As far as I can tell, this attribute had no effect, as the client doesn't apply labels to these units as the contents are fluid. Now we might want billboards to appear, we need to remove these attributes to ensure proper labelling. Again, this shouldn't have an effect on the merch units as they stand now.

## Why?

This is a spike into displaying billboard (that's `970x250` sized display ads) into the merchandising units on the site. These units typically contain fluid-sized commercial templates that display in-house promotions and marketing. Allowing billboards would present an opportunity to further monetise these slots via Google's OMP and our own direct campaigns.


## Screenshots

`merchandising-high` and `merchandising` slots.

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/8000415/206233309-95181da8-658e-4e56-937e-2f2be0285fa3.png
[before2]: https://user-images.githubusercontent.com/8000415/206233356-1ad6f151-211c-40d0-9298-f8c25f2d2997.png
[after]: https://user-images.githubusercontent.com/8000415/206232735-f0c304d9-e592-4926-8f19-27e4d1526b82.png
[after2]: https://user-images.githubusercontent.com/8000415/206232837-08a87779-2f8e-4c3c-85a5-b7e374bcf3fd.png
