### PR TITLE
Remove `Result`s From Body

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -184,7 +184,7 @@ type BodyElement =
 
 type Elements = BlockElement[] | undefined;
 
-type Body = Array<Result<string, BodyElement>>;
+type Body = Array<BodyElement>;
 
 // ----- Functions ----- //
 

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -184,7 +184,7 @@ type BodyElement =
 
 type Elements = BlockElement[] | undefined;
 
-type Body = Array<BodyElement>;
+type Body = BodyElement[];
 
 // ----- Functions ----- //
 

--- a/apps-rendering/src/components/ArticleBody/index.tsx
+++ b/apps-rendering/src/components/ArticleBody/index.tsx
@@ -2,13 +2,16 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { background, neutral, remSpace } from '@guardian/source-foundations';
-import type { FC, ReactNode } from 'react';
+import { BodyElement } from 'bodyElement';
+import type { FC } from 'react';
+import { render } from 'renderer';
 import { darkModeCss } from 'styles';
 
 interface ArticleBodyProps {
 	className?: SerializedStyles[];
-	children: ReactNode[];
-	format: ArticleFormat;
+	shouldHideAdverts: boolean,
+	format: ArticleFormat,
+	body: BodyElement[],
 }
 
 const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
@@ -41,7 +44,7 @@ const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     }
 `;
 
-const ArticleBody: FC<ArticleBodyProps> = ({ className, children, format }) => {
+const ArticleBody: FC<ArticleBodyProps> = ({ className, format, body, shouldHideAdverts }) => {
 	const classNames = className ? className : [];
 	return (
 		<div
@@ -51,7 +54,7 @@ const ArticleBody: FC<ArticleBodyProps> = ({ className, children, format }) => {
 				...classNames,
 			]}
 		>
-			{children}
+			{render(shouldHideAdverts, format, body)}
 		</div>
 	);
 };

--- a/apps-rendering/src/components/ArticleBody/index.tsx
+++ b/apps-rendering/src/components/ArticleBody/index.tsx
@@ -2,16 +2,16 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { background, neutral, remSpace } from '@guardian/source-foundations';
-import { BodyElement } from 'bodyElement';
+import type { BodyElement } from 'bodyElement';
 import type { FC } from 'react';
 import { render } from 'renderer';
 import { darkModeCss } from 'styles';
 
 interface ArticleBodyProps {
 	className?: SerializedStyles[];
-	shouldHideAdverts: boolean,
-	format: ArticleFormat,
-	body: BodyElement[],
+	shouldHideAdverts: boolean;
+	format: ArticleFormat;
+	body: BodyElement[];
 }
 
 const ArticleBodyStyles = (format: ArticleFormat): SerializedStyles => css`
@@ -44,7 +44,12 @@ const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
     }
 `;
 
-const ArticleBody: FC<ArticleBodyProps> = ({ className, format, body, shouldHideAdverts }) => {
+const ArticleBody: FC<ArticleBodyProps> = ({
+	className,
+	format,
+	body,
+	shouldHideAdverts,
+}) => {
 	const classNames = className ? className : [];
 	return (
 		<div

--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -20,7 +20,7 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type { Analysis } from 'item';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -47,10 +47,9 @@ const BorderStyles = css`
 
 interface Props {
 	item: Analysis;
-	children: ReactNode[];
 }
 
-const AnalysisLayout: FC<Props> = ({ item, children }) => (
+const AnalysisLayout: FC<Props> = ({ item }) => (
 	<>
 		<main css={backgroundStyles(item)}>
 			<article css={BorderStyles}>
@@ -70,9 +69,12 @@ const AnalysisLayout: FC<Props> = ({ item, children }) => (
 						<Logo item={item} />
 					</section>
 				</header>
-				<ArticleBody className={[articleWidthStyles]} format={item}>
-					{children}
-				</ArticleBody>
+				<ArticleBody
+					className={[articleWidthStyles]}
+					format={item}
+					body={item.body}
+					shouldHideAdverts={item.shouldHideAdverts}
+				/>
 				<section css={articleWidthStyles}>
 					<Tags item={item} />
 				</section>

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -24,7 +24,7 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type { Comment as CommentItem, Editorial } from 'item';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -71,10 +71,9 @@ const commentLineStylePosition = css`
 
 interface Props {
 	item: CommentItem | Editorial;
-	children: ReactNode[];
 }
 
-const CommentLayout: FC<Props> = ({ item, children }) => (
+const CommentLayout: FC<Props> = ({ item }) => (
 	<main css={[Styles, DarkStyles]}>
 		<article css={BorderStyles}>
 			<header>
@@ -109,9 +108,12 @@ const CommentLayout: FC<Props> = ({ item, children }) => (
 					<Logo item={item} />
 				</section>
 			</header>
-			<ArticleBody className={[articleWidthStyles]} format={item}>
-				{children}
-			</ArticleBody>
+			<ArticleBody
+					className={[articleWidthStyles]}
+					format={item}
+					body={item.body}
+					shouldHideAdverts={item.shouldHideAdverts}
+				/>
 			<section css={articleWidthStyles}>
 				<Tags item={item} />
 			</section>

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -109,11 +109,11 @@ const CommentLayout: FC<Props> = ({ item }) => (
 				</section>
 			</header>
 			<ArticleBody
-					className={[articleWidthStyles]}
-					format={item}
-					body={item.body}
-					shouldHideAdverts={item.shouldHideAdverts}
-				/>
+				className={[articleWidthStyles]}
+				format={item}
+				body={item.body}
+				shouldHideAdverts={item.shouldHideAdverts}
+			/>
 			<section css={articleWidthStyles}>
 				<Tags item={item} />
 			</section>

--- a/apps-rendering/src/components/Layout/GalleryLayout.tsx
+++ b/apps-rendering/src/components/Layout/GalleryLayout.tsx
@@ -17,9 +17,10 @@ import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { grid } from 'grid/grid';
-import type { Item } from 'item';
+import type { Gallery } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
+import { render } from 'renderer';
 import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
@@ -47,10 +48,10 @@ const logoStyles = css`
 `;
 
 type Props = {
-	item: Item;
+	item: Gallery;
 };
 
-const GalleryLayout: FC<Props> = ({ item, children }) => {
+const GalleryLayout: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	return (
@@ -72,7 +73,7 @@ const GalleryLayout: FC<Props> = ({ item, children }) => {
 							<Logo item={item} />
 						</div>
 					</header>
-					{children}
+					{render(item.shouldHideAdverts, format, item.body)}
 					<Tags item={item} />
 				</article>
 			</main>

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -20,9 +20,10 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { grid } from 'grid/grid';
 import LeftCentreBorder from 'grid/LeftCentreBorder';
-import type { Item } from 'item';
+import type { DeadBlog, Item, LiveBlog } from 'item';
 import { getFormat } from 'item';
 import type { FC } from 'react';
+import { render } from 'renderer';
 import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
@@ -82,10 +83,10 @@ const logoStyles = css`
 `;
 
 type Props = {
-	item: Item;
+	item: Exclude<Item, LiveBlog | DeadBlog>;
 };
 
-const ImmersiveLayout: FC<Props> = ({ item, children }) => {
+const ImmersiveLayout: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	return (
@@ -111,7 +112,13 @@ const ImmersiveLayout: FC<Props> = ({ item, children }) => {
 							<Logo item={item} />
 						</div>
 						<Metadata item={item} />
-						<div css={bodyStyles}>{children}</div>
+						<div css={bodyStyles}>
+							{render(
+								item.shouldHideAdverts,
+								format,
+								item.body,
+							)}
+						</div>
 						<Tags item={item} />
 					</div>
 				</article>

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -113,11 +113,7 @@ const ImmersiveLayout: FC<Props> = ({ item }) => {
 						</div>
 						<Metadata item={item} />
 						<div css={bodyStyles}>
-							{render(
-								item.shouldHideAdverts,
-								format,
-								item.body,
-							)}
+							{render(item.shouldHideAdverts, format, item.body)}
 						</div>
 						<Tags item={item} />
 					</div>

--- a/apps-rendering/src/components/Layout/InteractiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/InteractiveLayout.tsx
@@ -1,19 +1,21 @@
 // ----- Imports ----- //
 
-import type { ArticleFormat } from '@guardian/libs';
 import Footer from 'components/Footer';
-import type { FC, ReactNode } from 'react';
+import { getFormat, Interactive } from 'item';
+import type { FC } from 'react';
+import { renderWithoutStyles } from 'renderer';
 
 // ----- Component ----- //
 
 interface Props {
-	children: ReactNode[];
-	item: ArticleFormat;
+	item: Interactive;
 }
 
-const InteractiveLayout: FC<Props> = ({ children, item }) => (
+const InteractiveLayout: FC<Props> = ({ item }) => (
 	<main>
-		<article>{children}</article>
+		<article>
+			{renderWithoutStyles(getFormat(item), item.body)}
+		</article>
 		<Footer isCcpa={false} format={item} />
 	</main>
 );

--- a/apps-rendering/src/components/Layout/InteractiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/InteractiveLayout.tsx
@@ -1,7 +1,8 @@
 // ----- Imports ----- //
 
 import Footer from 'components/Footer';
-import { getFormat, Interactive } from 'item';
+import type { Interactive } from 'item';
+import { getFormat } from 'item';
 import type { FC } from 'react';
 import { renderWithoutStyles } from 'renderer';
 
@@ -13,9 +14,7 @@ interface Props {
 
 const InteractiveLayout: FC<Props> = ({ item }) => (
 	<main>
-		<article>
-			{renderWithoutStyles(getFormat(item), item.body)}
-		</article>
+		<article>{renderWithoutStyles(getFormat(item), item.body)}</article>
 		<Footer isCcpa={false} format={item} />
 	</main>
 );

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/source-foundations';
 import { DottedLines } from '@guardian/source-react-components-development-kitchen';
 import { map, withDefault } from '@guardian/types';
-import Body from 'components/ArticleBody';
+import ArticleBody from 'components/ArticleBody';
 import Footer from 'components/Footer';
 import Headline from 'components/Headline';
 import Logo from 'components/LabsLogo';
@@ -18,10 +18,10 @@ import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
-import { getFormat } from 'item';
+import { DeadBlog, getFormat, LiveBlog } from 'item';
 import type { Item } from 'item';
 import { pipe } from 'lib';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -52,11 +52,10 @@ const BorderStyles = css`
 // ----- Component ----- //
 
 interface Props {
-	item: Item;
-	children: ReactNode[];
+	item: Exclude<Item, LiveBlog | DeadBlog>;
 }
 
-const LabsLayout: FC<Props> = ({ item, children }) => {
+const LabsLayout: FC<Props> = ({ item }) => {
 	return (
 		<main css={[Styles, DarkStyles]}>
 			<article css={BorderStyles}>
@@ -82,9 +81,12 @@ const LabsLayout: FC<Props> = ({ item, children }) => {
 						)}
 					</section>
 				</header>
-				<Body className={[articleWidthStyles]} format={item}>
-					{children}
-				</Body>
+				<ArticleBody
+					className={[articleWidthStyles]}
+					format={item}
+					body={item.body}
+					shouldHideAdverts={item.shouldHideAdverts}
+				/>
 			</article>
 			<section css={onwardStyles}>
 				<RelatedContent item={item} />

--- a/apps-rendering/src/components/Layout/LabsLayout.tsx
+++ b/apps-rendering/src/components/Layout/LabsLayout.tsx
@@ -18,8 +18,8 @@ import Metadata from 'components/Metadata';
 import RelatedContent from 'components/RelatedContent';
 import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
-import { DeadBlog, getFormat, LiveBlog } from 'item';
-import type { Item } from 'item';
+import { getFormat } from 'item';
+import type { DeadBlog, Item, LiveBlog } from 'item';
 import { pipe } from 'lib';
 import type { FC } from 'react';
 import {

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -2,9 +2,6 @@
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { breakpoints } from '@guardian/source-foundations';
 import { formatToString } from 'articleFormat';
-import AnalysisLayout from './AnalysisLayout';
-import CommentLayout from './CommentLayout';
-import StandardLayout from './StandardLayout';
 import {
 	analysis,
 	article,
@@ -26,11 +23,14 @@ import {
 } from 'fixtures/item';
 import { deadBlog, live } from 'fixtures/live';
 import type { ReactElement } from 'react';
+import AnalysisLayout from './AnalysisLayout';
+import CommentLayout from './CommentLayout';
 import GalleryLayout from './GalleryLayout';
 import ImmersiveLayout from './ImmersiveLayout';
 import LetterLayout from './LetterLayout';
 import LiveLayout from './LiveLayout';
 import NewsletterSignUpLayout from './NewsletterSignUpLayout';
+import StandardLayout from './StandardLayout';
 
 // ----- Stories ----- //
 
@@ -40,19 +40,27 @@ Standard.story = { name: formatToString(article) };
 export const Review = (): ReactElement => <StandardLayout item={review} />;
 Review.story = { name: formatToString(review) };
 
-export const MatchReport = (): ReactElement => <StandardLayout item={matchReport} />;
+export const MatchReport = (): ReactElement => (
+	<StandardLayout item={matchReport} />
+);
 MatchReport.story = { name: formatToString(matchReport) };
 
-export const PrintShop = (): ReactElement => <StandardLayout item={printShop} />;
+export const PrintShop = (): ReactElement => (
+	<StandardLayout item={printShop} />
+);
 PrintShop.story = { name: formatToString(printShop) };
 
-export const PhotoEssay = (): ReactElement => <StandardLayout item={photoEssay} />;
+export const PhotoEssay = (): ReactElement => (
+	<StandardLayout item={photoEssay} />
+);
 PhotoEssay.story = { name: formatToString(photoEssay) };
 
 export const Feature = (): ReactElement => <StandardLayout item={feature} />;
 Feature.story = { name: formatToString(feature) };
 
-export const Interview = (): ReactElement => <StandardLayout item={interview} />;
+export const Interview = (): ReactElement => (
+	<StandardLayout item={interview} />
+);
 Interview.story = { name: formatToString(interview) };
 
 export const Quiz = (): ReactElement => <StandardLayout item={quiz} />;
@@ -73,7 +81,9 @@ Editorial.story = { name: formatToString(editorial) };
 export const Analysis = (): ReactElement => <AnalysisLayout item={analysis} />;
 Analysis.story = { name: formatToString(analysis) };
 
-export const Explainer = (): ReactElement => <StandardLayout item={explainer} />;
+export const Explainer = (): ReactElement => (
+	<StandardLayout item={explainer} />
+);
 Explainer.story = { name: formatToString(explainer) };
 
 export const LiveBlog = (): ReactElement => (
@@ -125,7 +135,9 @@ NewsletterSignupFallback.story = {
 export const Gallery = (): ReactElement => <GalleryLayout item={gallery} />;
 Gallery.story = { name: formatToString(gallery) };
 
-export const Immersive = (): ReactElement => <ImmersiveLayout item={immersive} />;
+export const Immersive = (): ReactElement => (
+	<ImmersiveLayout item={immersive} />
+);
 Immersive.story = { name: formatToString(immersive) };
 
 export default {

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -1,14 +1,10 @@
 // ----- Imports ----- //
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
-import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDisplay } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import type { Option } from '@guardian/types';
-import { none, some, withDefault } from '@guardian/types';
 import { formatToString } from 'articleFormat';
-import AnalysisLayout from 'components/Layout/AnalysisLayout';
-import Comment from 'components/Layout/CommentLayout';
-import Standard from 'components/Layout/StandardLayout';
+import AnalysisLayout from './AnalysisLayout';
+import CommentLayout from './CommentLayout';
+import StandardLayout from './StandardLayout';
 import {
 	analysis,
 	article,
@@ -29,199 +25,59 @@ import {
 	review,
 } from 'fixtures/item';
 import { deadBlog, live } from 'fixtures/live';
-import type { Item } from 'item';
 import type { ReactElement } from 'react';
-import { renderAll } from 'renderer';
-import { Result } from 'result';
 import GalleryLayout from './GalleryLayout';
 import ImmersiveLayout from './ImmersiveLayout';
 import LetterLayout from './LetterLayout';
-import Live from './LiveLayout';
+import LiveLayout from './LiveLayout';
 import NewsletterSignUpLayout from './NewsletterSignUpLayout';
-
-// ----- Functions ----- //
-
-const formatFromItem = (
-	item: Item,
-	forceDisplay: Option<ArticleDisplay>,
-): ArticleFormat => ({
-	theme: item.theme,
-	design: item.design,
-	display: withDefault(item.display)(forceDisplay),
-});
 
 // ----- Stories ----- //
 
-export const Article = (): React.ReactNode => {
-	return (
-		<Standard item={article}>
-			{renderAll(
-				formatFromItem(article, some(ArticleDisplay.Standard)),
-				Result.partition(article.body).oks,
-			)}
-		</Standard>
-	);
-};
-Article.story = { name: formatToString(article) };
+export const Standard = (): ReactElement => <StandardLayout item={article} />;
+Standard.story = { name: formatToString(article) };
 
-export const Review = (): React.ReactNode => {
-	return (
-		<Standard item={review}>
-			{renderAll(
-				formatFromItem(review, some(ArticleDisplay.Standard)),
-				Result.partition(review.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Review = (): ReactElement => <StandardLayout item={review} />;
 Review.story = { name: formatToString(review) };
 
-export const MatchReport = (): React.ReactNode => {
-	return (
-		<Standard item={matchReport}>
-			{renderAll(
-				formatFromItem(matchReport, some(ArticleDisplay.Standard)),
-				Result.partition(matchReport.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const MatchReport = (): ReactElement => <StandardLayout item={matchReport} />;
 MatchReport.story = { name: formatToString(matchReport) };
 
-export const PrintShop = (): React.ReactNode => {
-	return (
-		<Standard item={printShop}>
-			{renderAll(
-				formatFromItem(printShop, some(ArticleDisplay.Standard)),
-				Result.partition(printShop.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const PrintShop = (): ReactElement => <StandardLayout item={printShop} />;
 PrintShop.story = { name: formatToString(printShop) };
 
-export const PhotoEssay = (): React.ReactNode => {
-	return (
-		<Standard item={photoEssay}>
-			{renderAll(
-				formatFromItem(photoEssay, some(ArticleDisplay.Standard)),
-				Result.partition(photoEssay.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const PhotoEssay = (): ReactElement => <StandardLayout item={photoEssay} />;
 PhotoEssay.story = { name: formatToString(photoEssay) };
 
-export const Feature = (): React.ReactNode => {
-	return (
-		<Standard item={feature}>
-			{renderAll(
-				formatFromItem(feature, some(ArticleDisplay.Standard)),
-				Result.partition(feature.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Feature = (): ReactElement => <StandardLayout item={feature} />;
 Feature.story = { name: formatToString(feature) };
 
-export const Interview = (): React.ReactNode => {
-	return (
-		<Standard item={interview}>
-			{renderAll(
-				formatFromItem(interview, some(ArticleDisplay.Standard)),
-				Result.partition(interview.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Interview = (): ReactElement => <StandardLayout item={interview} />;
 Interview.story = { name: formatToString(interview) };
 
-export const Quiz = (): React.ReactNode => {
-	return (
-		<Standard item={quiz}>
-			{renderAll(
-				formatFromItem(quiz, some(ArticleDisplay.Standard)),
-				Result.partition(quiz.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Quiz = (): ReactElement => <StandardLayout item={quiz} />;
 Quiz.story = { name: formatToString(quiz) };
 
-export const Recipe = (): React.ReactNode => {
-	return (
-		<Standard item={recipe}>
-			{renderAll(
-				formatFromItem(recipe, some(ArticleDisplay.Standard)),
-				Result.partition(recipe.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Recipe = (): ReactElement => <StandardLayout item={recipe} />;
 Recipe.story = { name: formatToString(recipe) };
 
-export const CommentItem = (): React.ReactNode => {
-	return (
-		<Comment item={comment}>
-			{renderAll(
-				formatFromItem(comment, some(ArticleDisplay.Standard)),
-				Result.partition(comment.body).oks,
-			)}
-		</Comment>
-	);
-};
-CommentItem.story = { name: formatToString(comment) };
+export const Comment = (): ReactElement => <CommentLayout item={comment} />;
+Comment.story = { name: formatToString(comment) };
 
-export const Letter = (): React.ReactNode => {
-	return (
-		<LetterLayout item={letter}>
-			{renderAll(
-				formatFromItem(letter, some(ArticleDisplay.Standard)),
-				Result.partition(letter.body).oks,
-			)}
-		</LetterLayout>
-	);
-};
+export const Letter = (): ReactElement => <LetterLayout item={letter} />;
 Letter.story = { name: formatToString(letter) };
 
-export const Editorial = (): React.ReactNode => {
-	return (
-		<Comment item={editorial}>
-			{renderAll(
-				formatFromItem(editorial, some(ArticleDisplay.Standard)),
-				Result.partition(editorial.body).oks,
-			)}
-		</Comment>
-	);
-};
+export const Editorial = (): ReactElement => <CommentLayout item={editorial} />;
 Editorial.story = { name: formatToString(editorial) };
 
-export const Analysis = (): React.ReactNode => {
-	return (
-		<AnalysisLayout item={analysis}>
-			{renderAll(
-				formatFromItem(analysis, some(ArticleDisplay.Standard)),
-				Result.partition(analysis.body).oks,
-			)}
-		</AnalysisLayout>
-	);
-};
+export const Analysis = (): ReactElement => <AnalysisLayout item={analysis} />;
 Analysis.story = { name: formatToString(analysis) };
 
-export const Explainer = (): React.ReactNode => {
-	return (
-		<Standard item={explainer}>
-			{renderAll(
-				formatFromItem(explainer, some(ArticleDisplay.Standard)),
-				Result.partition(explainer.body).oks,
-			)}
-		</Standard>
-	);
-};
+export const Explainer = (): ReactElement => <StandardLayout item={explainer} />;
 Explainer.story = { name: formatToString(explainer) };
 
 export const LiveBlog = (): ReactElement => (
-	<Live
+	<LiveLayout
 		item={{
 			...live,
 			edition: Edition.US,
@@ -231,10 +87,9 @@ export const LiveBlog = (): ReactElement => (
 LiveBlog.story = { name: formatToString(live) };
 
 export const DeadBlog = (): ReactElement => (
-	<Live
+	<LiveLayout
 		item={{
 			...deadBlog,
-			display: ArticleDisplay.Standard,
 			edition: Edition.AU,
 		}}
 	/>
@@ -248,12 +103,7 @@ export const NewsletterSignup = (): ReactElement => (
 			display:block !important;
 		}`}
 		</style>
-		<NewsletterSignUpLayout item={newsletterSignUp}>
-			{renderAll(
-				formatFromItem(newsletterSignUp, some(ArticleDisplay.Standard)),
-				Result.partition(newsletterSignUp.body).oks,
-			)}
-		</NewsletterSignUpLayout>
+		<NewsletterSignUpLayout item={newsletterSignUp} />
 	</>
 );
 NewsletterSignup.story = { name: formatToString(newsletterSignUp) };
@@ -265,46 +115,17 @@ export const NewsletterSignupFallback = (): ReactElement => (
 			display:block !important;
 		}`}
 		</style>
-		<NewsletterSignUpLayout item={newsletterSignUp}>
-			{renderAll(
-				formatFromItem(newsletterSignUp, some(ArticleDisplay.Standard)),
-				Result.partition(newsletterSignUp.body).oks,
-			)}
-		</NewsletterSignUpLayout>
+		<NewsletterSignUpLayout item={newsletterSignUp} />
 	</>
 );
 NewsletterSignupFallback.story = {
 	name: `${formatToString(newsletterSignUp)} (form component not supported)`,
 };
 
-export const Gallery = (): ReactElement => (
-	<GalleryLayout
-		item={{
-			...gallery,
-			edition: Edition.UK,
-		}}
-	>
-		{renderAll(
-			formatFromItem(gallery, none),
-			Result.partition(gallery.body).oks,
-		)}
-	</GalleryLayout>
-);
+export const Gallery = (): ReactElement => <GalleryLayout item={gallery} />;
 Gallery.story = { name: formatToString(gallery) };
 
-export const Immersive = (): ReactElement => (
-	<ImmersiveLayout
-		item={{
-			...immersive,
-			edition: Edition.UK,
-		}}
-	>
-		{renderAll(
-			formatFromItem(immersive, none),
-			Result.partition(immersive.body).oks,
-		)}
-	</ImmersiveLayout>
-);
+export const Immersive = (): ReactElement => <ImmersiveLayout item={immersive} />;
 Immersive.story = { name: formatToString(immersive) };
 
 export default {

--- a/apps-rendering/src/components/Layout/LetterLayout.tsx
+++ b/apps-rendering/src/components/Layout/LetterLayout.tsx
@@ -93,11 +93,11 @@ const LetterLayout: FC<Props> = ({ item }) => (
 				</section>
 			</header>
 			<ArticleBody
-					className={[articleWidthStyles]}
-					format={item}
-					body={item.body}
-					shouldHideAdverts={item.shouldHideAdverts}
-				/>
+				className={[articleWidthStyles]}
+				format={item}
+				body={item.body}
+				shouldHideAdverts={item.shouldHideAdverts}
+			/>
 			<section css={articleWidthStyles}>
 				<Tags item={item} />
 			</section>

--- a/apps-rendering/src/components/Layout/LetterLayout.tsx
+++ b/apps-rendering/src/components/Layout/LetterLayout.tsx
@@ -24,7 +24,7 @@ import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import { getFormat } from 'item';
 import type { Letter as LetterItem } from 'item';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -58,10 +58,9 @@ const linePosition = css`
 
 interface Props {
 	item: LetterItem;
-	children: ReactNode[];
 }
 
-const LetterLayout: FC<Props> = ({ item, children }) => (
+const LetterLayout: FC<Props> = ({ item }) => (
 	<main css={[Styles, DarkStyles]}>
 		<article css={BorderStyles}>
 			<header>
@@ -93,9 +92,12 @@ const LetterLayout: FC<Props> = ({ item, children }) => (
 					<Logo item={item} />
 				</section>
 			</header>
-			<ArticleBody className={[articleWidthStyles]} format={item}>
-				{children}
-			</ArticleBody>
+			<ArticleBody
+					className={[articleWidthStyles]}
+					format={item}
+					body={item.body}
+					shouldHideAdverts={item.shouldHideAdverts}
+				/>
 			<section css={articleWidthStyles}>
 				<Tags item={item} />
 			</section>

--- a/apps-rendering/src/components/Layout/NewsletterSignUpLayout.tsx
+++ b/apps-rendering/src/components/Layout/NewsletterSignUpLayout.tsx
@@ -21,8 +21,8 @@ import RelatedContent from 'components/RelatedContent';
 import Standfirst from 'components/Standfirst';
 import { grid } from 'grid/grid';
 import { getFormat } from 'item';
-import type { Item } from 'item';
-import type { FC, ReactNode } from 'react';
+import type { NewsletterSignup } from 'item';
+import type { FC } from 'react';
 import { darkModeCss, onwardStyles } from 'styles';
 import InPageNewsletterSignup from '../InPageNewsletterSignup';
 
@@ -83,12 +83,12 @@ const detailBlockStyles = css`
 `;
 
 // ----- Component ----- //
+
 interface Props {
-	item: Item;
-	children: ReactNode[];
+	item: NewsletterSignup;
 }
 
-const NewsletterSignUpLayout: FC<Props> = ({ item, children }) => {
+const NewsletterSignUpLayout: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 
 	return (
@@ -128,14 +128,20 @@ const NewsletterSignUpLayout: FC<Props> = ({ item, children }) => {
 							newsletter={newsletter}
 							format={getFormat(item)}
 							fallbackContent={
-								<ArticleBody format={item}>
-									{children}
-								</ArticleBody>
+								<ArticleBody
+									format={item}
+									body={item.body}
+									shouldHideAdverts={item.shouldHideAdverts}
+								/>
 							}
 						/>
 					))}
 					{item.promotedNewsletter.kind === OptionKind.None && (
-						<ArticleBody format={item}>{children}</ArticleBody>
+						<ArticleBody
+							format={item}
+							body={item.body}
+							shouldHideAdverts={item.shouldHideAdverts}
+						/>
 					)}
 				</section>
 			</article>

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -26,8 +26,23 @@ import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import type { MatchScores } from 'football';
-import { getFormat, PhotoEssay, PrintShop } from 'item';
-import type { Correction, Explainer, Feature, Interactive, Interview, Item, MatchReport, Obituary, Quiz, Recipe, Review, Standard } from 'item';
+import { getFormat } from 'item';
+import type {
+	Correction,
+	Explainer,
+	Feature,
+	Interactive,
+	Interview,
+	Item,
+	MatchReport,
+	Obituary,
+	PhotoEssay,
+	PrintShop,
+	Quiz,
+	Recipe,
+	Review,
+	Standard,
+} from 'item';
 import { maybeRender, pipe } from 'lib';
 import { Optional } from 'optional';
 import type { FC } from 'react';
@@ -69,19 +84,19 @@ const decideLines = (
 
 interface Props {
 	item:
-		Feature |
-		Explainer |
-		Review |
-		Standard |
-		Interactive |
-		Quiz |
-		MatchReport |
-		Obituary |
-		Correction |
-		Interview |
-		Recipe |
-		PrintShop |
-		PhotoEssay;
+		| Feature
+		| Explainer
+		| Review
+		| Standard
+		| Interactive
+		| Quiz
+		| MatchReport
+		| Obituary
+		| Correction
+		| Interview
+		| Recipe
+		| PrintShop
+		| PhotoEssay;
 }
 
 const StandardLayout: FC<Props> = ({ item }) => {

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/source-react-components-development-kitchen';
 import { map, withDefault } from '@guardian/types';
 import { pillarToId, themeToPillar } from 'articleFormat';
-import Body from 'components/ArticleBody';
+import ArticleBody from 'components/ArticleBody';
 import DesignTag from 'components/DesignTag';
 import Epic from 'components/Epic';
 import FootballScores from 'components/FootballScores';
@@ -26,17 +26,11 @@ import Series from 'components/Series';
 import Standfirst from 'components/Standfirst';
 import Tags from 'components/Tags';
 import type { MatchScores } from 'football';
-import { getFormat } from 'item';
-import type {
-	Explainer as ExplainerItem,
-	Item,
-	MatchReport as MatchReportItem,
-	Review as ReviewItem,
-	Standard as StandardItem,
-} from 'item';
+import { getFormat, PhotoEssay, PrintShop } from 'item';
+import type { Correction, Explainer, Feature, Interactive, Interview, Item, MatchReport, Obituary, Quiz, Recipe, Review, Standard } from 'item';
 import { maybeRender, pipe } from 'lib';
 import { Optional } from 'optional';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import {
 	articleWidthStyles,
 	darkModeCss,
@@ -74,11 +68,23 @@ const decideLines = (
 };
 
 interface Props {
-	item: StandardItem | ReviewItem | MatchReportItem | ExplainerItem;
-	children: ReactNode[];
+	item:
+		Feature |
+		Explainer |
+		Review |
+		Standard |
+		Interactive |
+		Quiz |
+		MatchReport |
+		Obituary |
+		Correction |
+		Interview |
+		Recipe |
+		PrintShop |
+		PhotoEssay;
 }
 
-const StandardLayout: FC<Props> = ({ item, children }) => {
+const StandardLayout: FC<Props> = ({ item }) => {
 	const format = getFormat(item);
 	// client side code won't render an Epic if there's an element with this id
 	const epicContainer = item.shouldHideReaderRevenue ? null : (
@@ -143,9 +149,12 @@ const StandardLayout: FC<Props> = ({ item, children }) => {
 						<Logo item={item} />
 					</section>
 				</header>
-				<Body className={[articleWidthStyles]} format={item}>
-					{children}
-				</Body>
+				<ArticleBody
+					className={[articleWidthStyles]}
+					format={item}
+					body={item.body}
+					shouldHideAdverts={item.shouldHideAdverts}
+				/>
 				{epicContainer}
 				<section className="js-tags" css={articleWidthStyles}>
 					<Tags item={item} />

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -2,10 +2,7 @@
 
 import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import type { ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/source-foundations';
-import { getAdPlaceholderInserter } from 'ads';
-import type { BodyElement } from 'bodyElement';
 import CommentLayout from 'components/Layout/CommentLayout';
 import GalleryLayout from 'components/Layout/GalleryLayout';
 import InteractiveLayout from 'components/Layout/InteractiveLayout';
@@ -13,29 +10,16 @@ import LabsLayout from 'components/Layout/LabsLayout';
 import LiveLayout from 'components/Layout/LiveLayout';
 import StandardLayout from 'components/Layout/StandardLayout';
 import type { Item } from 'item';
-import type { FC, ReactNode } from 'react';
-import { renderAll, renderAllWithoutStyles } from 'renderer';
-import { Result } from 'result';
+import type { FC } from 'react';
 import AnalysisLayout from './AnalysisLayout';
 import ImmersiveLayout from './ImmersiveLayout';
 import LetterLayout from './LetterLayout';
 import NewsletterSignUpLayout from './NewsletterSignUpLayout';
 
-// ----- Functions ----- //
-
-const renderWithAds =
-	(shouldHide: boolean) =>
-	(format: ArticleFormat, elements: BodyElement[]): ReactNode[] =>
-		getAdPlaceholderInserter(shouldHide)(
-			renderAll(format, elements),
-			format,
-		);
-
 // ----- Component ----- //
 
 interface Props {
 	item: Item;
-	shouldHideAds: boolean;
 }
 
 const notImplemented = (
@@ -48,7 +32,7 @@ const notImplemented = (
 	</p>
 );
 
-const Layout: FC<Props> = ({ item, shouldHideAds }) => {
+const Layout: FC<Props> = ({ item }) => {
 	if (
 		item.design === ArticleDesign.LiveBlog ||
 		item.design === ArticleDesign.DeadBlog
@@ -56,50 +40,37 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 		return <LiveLayout item={item} />;
 	}
 
-	const body = Result.partition(item.body).oks;
-	const render = renderWithAds(shouldHideAds);
-
 	if (item.theme === ArticleSpecial.Labs) {
-		return <LabsLayout item={item}>{render(item, body)}</LabsLayout>;
+		return <LabsLayout item={item} />;
 	}
 
 	if (
 		item.design === ArticleDesign.Interactive &&
 		item.display === ArticleDisplay.Immersive
 	) {
-		return (
-			<InteractiveLayout item={item}>
-				{renderAllWithoutStyles(item, body)}
-			</InteractiveLayout>
-		);
+		return <InteractiveLayout item={item} />;
 	}
 
 	if (
 		item.design === ArticleDesign.Comment ||
 		item.design === ArticleDesign.Editorial
 	) {
-		return <CommentLayout item={item}>{render(item, body)}</CommentLayout>;
+		return <CommentLayout item={item} />;
 	}
 
 	if (item.design === ArticleDesign.Letter) {
-		return <LetterLayout item={item}>{render(item, body)}</LetterLayout>;
+		return <LetterLayout item={item} />;
 	}
 	if (item.design === ArticleDesign.Analysis) {
-		return (
-			<AnalysisLayout item={item}>{render(item, body)}</AnalysisLayout>
-		);
+		return <AnalysisLayout item={item} />;
 	}
 
 	if (item.design === ArticleDesign.Gallery) {
-		return <GalleryLayout item={item}>{render(item, body)}</GalleryLayout>;
+		return <GalleryLayout item={item} />;
 	}
 
 	if (item.design === ArticleDesign.NewsletterSignup) {
-		return (
-			<NewsletterSignUpLayout item={item}>
-				{render(item, body)}
-			</NewsletterSignUpLayout>
-		);
+		return <NewsletterSignUpLayout item={item} />;
 	}
 
 	if (
@@ -116,16 +87,10 @@ const Layout: FC<Props> = ({ item, shouldHideAds }) => {
 		item.design === ArticleDesign.Recipe
 	) {
 		if (item.display === ArticleDisplay.Immersive) {
-			return (
-				<ImmersiveLayout item={item}>
-					{render(item, body)}
-				</ImmersiveLayout>
-			);
+			return <ImmersiveLayout item={item} />;
 		}
 
-		return (
-			<StandardLayout item={item}>{render(item, body)}</StandardLayout>
-		);
+		return <StandardLayout item={item} />;
 	}
 
 	return notImplemented;

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -10,8 +10,7 @@ import { datetimeFormat, timestampFormat } from 'datetime';
 import { pipe } from 'lib';
 import type { LiveBlock as LiveBlockType } from 'liveBlock';
 import type { FC } from 'react';
-import { renderAll } from 'renderer';
-import { Result } from 'result';
+import { renderElements } from 'renderer';
 
 // ----- Functions ----- //
 
@@ -58,7 +57,7 @@ const LiveBlock: FC<LiveBlockProps> = ({
 			supportsDarkMode={true}
 			contributors={block.contributors.map(contributorToBlockContributor)}
 		>
-			{renderAll(format, Result.partition(block.body).oks)}
+			{renderElements(format, block.body)}
 
 			<footer
 				css={css`

--- a/apps-rendering/src/components/editions/layout/index.tsx
+++ b/apps-rendering/src/components/editions/layout/index.tsx
@@ -14,8 +14,7 @@ import {
 import type { Item } from 'item';
 import { isPicture } from 'item';
 import type { FC } from 'react';
-import { renderEditionsAll } from 'renderer';
-import { Result } from 'result';
+import { renderEditionsElements } from 'renderer';
 import Header from '../header';
 import {
 	articleMarginStyles,
@@ -214,10 +213,7 @@ const Layout: FC<Props> = ({ item }) => {
 							className={'body-content'}
 							css={bodyStyles(item)}
 						>
-							{renderEditionsAll(
-								item,
-								Result.partition(item.body).oks,
-							)}
+							{renderEditionsElements(item, item.body)}
 						</section>
 					</div>
 				</article>

--- a/apps-rendering/src/fixtures/galleryBody.ts
+++ b/apps-rendering/src/fixtures/galleryBody.ts
@@ -1,7 +1,6 @@
 import type { Body } from 'bodyElement';
 import { ImageSubtype } from 'image/image';
 import { Optional } from 'optional';
-import { Result } from 'result';
 
 const captionFragment = (headline: string, body: string): DocumentFragment => {
 	const frag = new DocumentFragment();
@@ -14,7 +13,7 @@ const captionFragment = (headline: string, body: string): DocumentFragment => {
 };
 
 export const galleryBody: Body = [
-	Result.ok({
+	{
 		kind: 1,
 		src: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3',
 		srcset: 'https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=140&quality=85&fit=bounds&s=c125868b875fa9ec4a8ce180360836e0 140w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=500&quality=85&fit=bounds&s=b4c08994b6aad3ffcea8e242793755f3 500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1000&quality=85&fit=bounds&s=dde3e8a919521443e8b0f5fba726fb24 1000w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=1500&quality=85&fit=bounds&s=3b57ebd649babc411c89f62a27bd800a 1500w, https://i.guim.co.uk/img/media/2232f7bb9c21692cae8f499c70fde2c599f07b1e/0_0_5699_3799/master/5699.jpg?width=2000&quality=85&fit=bounds&s=d0d5bfe2a9ce9000f6d8afc8b864fe92 2000w',
@@ -40,8 +39,8 @@ export const galleryBody: Body = [
 		},
 		role: 0,
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
-	}),
-	Result.ok({
+	},
+	{
 		kind: 1,
 		src: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063',
 		srcset: 'https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=140&quality=85&fit=bounds&s=00a782574440af9727bf87616b94d572 140w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=500&quality=85&fit=bounds&s=6b5da882eaec6ebf16644dedbb902063 500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1000&quality=85&fit=bounds&s=d4b61df8dc308483ca3b92c7da5de42e 1000w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=1500&quality=85&fit=bounds&s=b9a3f3096a28cadaef022bbbf5322c56 1500w, https://i.guim.co.uk/img/media/00a3f00503f26ab688f32c7b5acaa60fc2e7755f/0_0_5472_3648/master/5472.jpg?width=2000&quality=85&fit=bounds&s=c476519c6a377a16d963a8cf9888713a 2000w',
@@ -67,8 +66,8 @@ export const galleryBody: Body = [
 		},
 		role: 0,
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
-	}),
-	Result.ok({
+	},
+	{
 		kind: 1,
 		src: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c',
 		srcset: 'https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=140&quality=85&fit=bounds&s=7231bc978677afa567b999de7645602a 140w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=500&quality=85&fit=bounds&s=d824f8198249e9b1b119070023b1850c 500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1000&quality=85&fit=bounds&s=cdeb3b040ff85ccebaa83f54643c87cb 1000w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=1500&quality=85&fit=bounds&s=61bde3db8713dfa8ab6c9d94d3b53d3e 1500w, https://i.guim.co.uk/img/media/0673ebd6b05c437c792a24c375b3be3204fe8283/0_0_4482_2988/master/4482.jpg?width=2000&quality=85&fit=bounds&s=fe5d0c455c7a8bf71082086f9b24e934 2000w',
@@ -97,8 +96,8 @@ export const galleryBody: Body = [
 		},
 		role: 0,
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
-	}),
-	Result.ok({
+	},
+	{
 		kind: 1,
 		src: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867',
 		srcset: 'https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=140&quality=85&fit=bounds&s=dc30181295bcbe657a051d55966d119a 140w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=500&quality=85&fit=bounds&s=3f341f45e1c1ce8c8c0f28d07cdf6867 500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1000&quality=85&fit=bounds&s=59187d1926376734fedf391885c21c75 1000w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=1500&quality=85&fit=bounds&s=31b6374d30517dca65cbb0d7c0454535 1500w, https://i.guim.co.uk/img/media/300a7451bd9b52d2a7ec7466619c7108ecba43a7/0_0_3600_2400/master/3600.jpg?width=2000&quality=85&fit=bounds&s=15e40dc6afcdbfefe241ddb4748c8ac5 2000w',
@@ -127,5 +126,5 @@ export const galleryBody: Body = [
 		},
 		role: 0,
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
-	}),
+	},
 ];

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -25,10 +25,12 @@ import type {
 	Editorial,
 	Explainer,
 	Feature,
+	Gallery,
 	Interview,
 	Item,
 	Letter,
 	MatchReport,
+	NewsletterSignup,
 	PhotoEssay,
 	PrintShop,
 	Quiz,
@@ -40,9 +42,7 @@ import type { LiveBlock } from 'liveBlock';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
-import type { Outline } from 'outline';
 import { fromBodyElements } from 'outline';
-import { Result } from 'result';
 import { galleryBody } from './galleryBody';
 import { partialNewsletterItem } from './newsletterSignUpContent';
 import { relatedContent } from './relatedContent';
@@ -175,16 +175,16 @@ const mainMedia: Option<MainMedia> = {
 const doc = docFixture();
 
 const body: Body = [
-	Result.ok({
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.HeadingTwo,
 		id: Optional.some('who-qualifies-for-student-loan-forgiveness'),
 		doc: h2ElementWithSub(),
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Image,
 		src: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d',
 		srcset: 'https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=140&quality=85&fit=bounds&s=978ea68731deea77a6ec549b36f5e32b 140w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=500&quality=85&fit=bounds&s=8c34202360927c9ececb6f241c57859d 500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1000&quality=85&fit=bounds&s=8d92ccc42745c327145fa3bcd7aea0c1 1000w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=1500&quality=85&fit=bounds&s=f677266ce93d0c51eb6a7a5c0162ed89 1500w, https://i.guim.co.uk/img/media/8cbb56d2c2df876a9f3255bf99da6034eaac9fa8/0_307_2000_2500/master/2000.jpg?width=2000&quality=85&fit=bounds&s=90415465f0f60ef29d5067933e7df697 2000w',
@@ -207,54 +207,54 @@ const body: Body = [
 		},
 		role: ArticleElementRole.Standard,
 		imageSubtype: Optional.some(ImageSubtype.Jpeg),
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.HeadingTwo,
 		id: Optional.some('how-the-student-debt-crisis-started'),
 		doc: elementFixture('h2', 'How the student debt crisis started?'),
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.GuideAtom,
 		html: "<p>Queen's consent is a little-known procedure whereby the government asks the monarch's permission for parliament to be able to debate laws that affect her. Unlike royal assent, which is a formality that takes place at the end of the process of drafting a bill, Queen's consent takes place before parliament is permitted to debate the legislation.</p><p>Consent has to be sought for any legislation affecting either the royal prerogative – fundamental powers of state, such as the ability to declare war – or the assets of the crown, such as the royal palaces. Buckingham Palace says the procedure also covers assets that the monarch owns privately, such as the estates of Sandringham and Balmoral.</p><p>If parliamentary lawyers decide that a bill requires consent, a government minister writes to the Queen formally requesting her permission for parliament to debate it. A copy of the bill is sent to the Queen's private lawyers, who have 14 days to consider it and to advise her.</p><p>If the Queen grants her consent, parliament can debate the legislation and the process is formally signified in Hansard, the record of parliamentary debates. If the Queen withholds consent, the bill cannot proceed and parliament is in effect banned from debating it.&nbsp,</p><p>The royal household claims consent has only ever been withheld on the advice of government ministers.</p>",
 		title: "What is Queen's consent?",
 		id: '575888ee-9973-4256-9a96-bad4b9c65d81',
 		image: undefined,
 		credit: undefined,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.HeadingTwo,
 		id: Optional.some('what-student-debt-looks-like-today'),
 		doc: elementFixture('h2', 'What student debt looks like today?'),
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Pullquote,
 		quote: 'Why should the crown be allowed to carry on with a feudal system just because they want to?',
 		attribution: { kind: 0, value: 'Jane Giddins' },
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc,
-	}),
+	},
 ];
 
 const pinnedBlock: LiveBlock = {
@@ -264,10 +264,10 @@ const pinnedBlock: LiveBlock = {
 	firstPublished: new Date('2021-11-02T10:20:20Z'),
 	lastModified: new Date('2021-11-02T11:13:13Z'),
 	body: [
-		Result.ok({
+		{
 			kind: ElementKind.Text,
 			doc,
-		}),
+		},
 	],
 	contributors: [],
 	isPinned: true,
@@ -400,6 +400,7 @@ const fields = {
 	webUrl: '',
 	promotedNewsletter: none,
 	edition: Edition.UK,
+	shouldHideAdverts: false,
 };
 
 const article: Standard = {
@@ -413,14 +414,10 @@ const articleWithStandfirstLink: Item = {
 	standfirst: standfirstWithLink,
 };
 
-const outlineFromItem = (body: Body): Outline => {
-	const elements = Result.partition(body).oks;
-	return fromBodyElements(elements);
-};
 const analysis: Analysis = {
 	design: ArticleDesign.Analysis,
 	...fields,
-	outline: outlineFromItem(fields.body),
+	outline: fromBodyElements(fields.body),
 };
 
 const feature: Feature = {
@@ -514,10 +511,10 @@ const quiz: Quiz = {
 const explainer: Explainer = {
 	design: ArticleDesign.Explainer,
 	...fields,
-	outline: outlineFromItem(fields.body),
+	outline: fromBodyElements(fields.body),
 };
 
-const newsletterSignUp: Standard = {
+const newsletterSignUp: NewsletterSignup = {
 	...fields,
 	design: ArticleDesign.NewsletterSignup,
 	...partialNewsletterItem,
@@ -529,14 +526,10 @@ const immersive: Standard = {
 	display: ArticleDisplay.Immersive,
 };
 
-const gallery: Standard = {
+const gallery: Gallery = {
 	design: ArticleDesign.Gallery,
 	...fields,
-	body: body.filter(
-		(element) =>
-			element.isErr() ||
-			(element.isOk() && element.value.kind === ElementKind.Image),
-	),
+	body: body.filter((element) => element.kind === ElementKind.Image),
 };
 
 // ----- Exports ----- //

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -267,6 +267,7 @@ const fields = {
 	webUrl: '',
 	edition: Edition.UK,
 	promotedNewsletter: none,
+	shouldHideAdverts: false,
 };
 
 const pinnedBlock: LiveBlock = {

--- a/apps-rendering/src/fixtures/newsletterSignUpContent.ts
+++ b/apps-rendering/src/fixtures/newsletterSignUpContent.ts
@@ -9,11 +9,10 @@ import { ElementKind } from 'bodyElement';
 import { parse } from 'client/parser';
 import { EmbedKind } from 'embed';
 import { ImageSubtype } from 'image/image';
-import type { Standard } from 'item';
+import type { NewsletterSignup } from 'item';
 import { MainMediaKind } from 'mainMedia';
 import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
-import { Result } from 'result';
 
 const parser = new DOMParser();
 const parseHtml = (html: string): Option<DocumentFragment> =>
@@ -64,13 +63,13 @@ const newsletterStandfirst = parseHtml(
 	`<p>Style with substance: smart fashion writing and inspiring shopping galleries from the Guardian</p>`,
 );
 const newsletterBody: Body = [
-	Result.ok({
+	{
 		kind: ElementKind.Text,
 		doc: docFixture(
 			'A weekly hit of style with substance. Smart fashion writing and inspiring shopping galleries delivered straight to your inbox. Sign up for our Friday email for the best of the week in style, brought to you with expertise, humour and irreverence.',
 		),
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Embed,
 		embed: {
 			kind: EmbedKind.EmailSignup,
@@ -81,16 +80,16 @@ const newsletterBody: Body = [
 			source: none,
 			sourceDomain: none,
 		},
-	}),
-	Result.ok({
+	},
+	{
 		kind: ElementKind.Text,
 		doc: docFixture(
 			'<strong><a href="https://www.theguardian.com/email-newsletters">Explore all our newsletters:</a></strong><a href="https://www.theguardian.com/email-newsletters"> whether you love film, football, fashion or food, we’ve got something for you</a>',
 		),
-	}),
+	},
 ];
 
-export const partialNewsletterItem: Partial<Standard> = {
+export const partialNewsletterItem: Partial<NewsletterSignup> = {
 	headline: newsletterHeadline,
 	standfirst: newsletterStandfirst,
 	mainMedia: newsletterMainMedia,

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -14,7 +14,7 @@ import { JSDOM } from 'jsdom';
 import { Content } from '@guardian/content-api-models/v1/content';
 import { articleContentWith } from 'helperTest';
 import { EmbedKind, Spotify, YouTube } from 'embed';
-import { Result } from 'result';
+import { Optional } from 'optional';
 
 const articleContent = {
 	id: '',
@@ -189,8 +189,7 @@ const f = (content: Content) =>
 	);
 
 const getFirstBody = (item: Review | Standard) =>
-	item.body[0]
-		.toOptional()
+	Optional.fromNullable(item.body[0])
 		.withDefault({
 			kind: ElementKind.Interactive,
 			url: '',
@@ -351,8 +350,7 @@ describe('interactive elements', () => {
 			},
 		};
 		const item = f(articleContentWith(interactiveElement)) as Standard;
-		const element = item.body[0]
-			.toOptional()
+		const element = Optional.fromNullable(item.body[0])
 			.withDefault({
 				kind: ElementKind.RichLink,
 				url: '',
@@ -370,8 +368,7 @@ describe('interactive elements', () => {
 			},
 		};
 		const item = f(articleContentWith(interactiveElement)) as Standard;
-		const element = item.body[0]
-			.toOptional()
+		const element = Optional.fromNullable(item.body[0])
 			.withDefault({
 				kind: ElementKind.RichLink,
 				url: '',
@@ -592,17 +589,17 @@ describe('audio elements', () => {
 			},
 		};
 		const item = f(articleContentWith(audioElement)) as Standard;
-		const embed = item.body[0]
+		const embed = Optional.fromNullable(item.body[0])
 			.flatMap<Spotify>((element) =>
 				element.kind === ElementKind.Embed &&
 				element.embed.kind === EmbedKind.Spotify
-					? Result.ok(element.embed)
-					: Result.err('Not an audio embed'),
+					? Optional.some(element.embed)
+					: Optional.none(),
 			)
 		
-		expect(embed.isOk()).toBe(true);
+		expect(embed.isSome()).toBe(true);
 		
-		if (embed.isOk()) {
+		if (embed.isSome()) {
 			expect(embed.value.src).toContain('https://open.spotify.com/embed/track/');
 			expect(embed.value.width).toBe(300);
 			expect(embed.value.height).not.toBe(380);
@@ -661,17 +658,17 @@ describe('video elements', () => {
 			},
 		};
 		const item = f(articleContentWith(videoElement)) as Standard;
-		const embed = item.body[0]
+		const embed = Optional.fromNullable(item.body[0])
 			.flatMap<YouTube>((element) =>
 				element.kind === ElementKind.Embed &&
 				element.embed.kind === EmbedKind.YouTube
-					? Result.ok(element.embed)
-					: Result.err('Not a YouTube embed'),
+					? Optional.some(element.embed)
+					: Optional.none(),
 			);
 		
-		expect(embed.isOk()).toBe(true);
+		expect(embed.isSome()).toBe(true);
 		
-		if (embed.isOk()) {
+		if (embed.isSome()) {
 			expect(embed.value.id).toBe('mockVideoId');
 			expect(embed.value.width).toBe(460);
 			expect(embed.value.height).toBe(259);

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -21,8 +21,7 @@ import {
 import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { getPillarFromId } from 'articleFormat';
-import type { Body } from 'bodyElement';
-import { parseElements } from 'bodyElement';
+import { BodyElement, parseElements } from 'bodyElement';
 import { getReport } from 'campaign';
 import type { Logo } from 'capi';
 import {
@@ -74,11 +73,12 @@ interface Fields extends ArticleFormat {
 	webUrl: string;
 	edition: Edition;
 	promotedNewsletter: Option<Newsletter>;
+	shouldHideAdverts: boolean;
 }
 
 interface MatchReport extends Fields {
 	design: ArticleDesign.MatchReport;
-	body: Body;
+	body: BodyElement[];
 	football: Optional<MatchScores>;
 }
 
@@ -102,93 +102,117 @@ interface DeadBlog extends Fields {
 
 interface Review extends Fields {
 	design: ArticleDesign.Review;
-	body: Body;
+	body: BodyElement[];
 	starRating: Option<number>;
 }
 
 interface Comment extends Fields {
 	design: ArticleDesign.Comment;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Letter extends Fields {
 	design: ArticleDesign.Letter;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Editorial extends Fields {
 	design: ArticleDesign.Editorial;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Interactive extends Fields {
 	design: ArticleDesign.Interactive;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Obituary extends Fields {
 	design: ArticleDesign.Obituary;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Correction extends Fields {
 	design: ArticleDesign.Correction;
-	body: Body;
+	body: BodyElement[];
 }
 interface Interview extends Fields {
 	design: ArticleDesign.Interview;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Quiz extends Fields {
 	design: ArticleDesign.Quiz;
-	body: Body;
+	body: BodyElement[];
 }
 interface Recipe extends Fields {
 	design: ArticleDesign.Recipe;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Feature extends Fields {
 	design: ArticleDesign.Feature;
-	body: Body;
+	body: BodyElement[];
 }
 interface PhotoEssay extends Fields {
 	design: ArticleDesign.PhotoEssay;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface PrintShop extends Fields {
 	design: ArticleDesign.PrintShop;
-	body: Body;
+	body: BodyElement[];
 }
 
 interface Analysis extends Fields {
 	design: ArticleDesign.Analysis;
-	body: Body;
+	body: BodyElement[];
 	outline: Outline;
 }
 
 interface Explainer extends Fields {
 	design: ArticleDesign.Explainer;
-	body: Body;
+	body: BodyElement[];
 	outline: Outline;
 }
-// Catch-all for other Designs for now. As coverage of Designs increases,
-// this will likely be split out into each ArticleDesign type.
+
+interface Gallery extends Fields {
+	design: ArticleDesign.Gallery;
+	body: BodyElement[];
+}
+
+interface Audio extends Fields {
+	design: ArticleDesign.Audio;
+	body: BodyElement[];
+}
+
+interface Video extends Fields {
+	design: ArticleDesign.Video;
+	body: BodyElement[];
+}
+
 interface Standard extends Fields {
-	design: Exclude<
-		ArticleDesign,
-		| ArticleDesign.LiveBlog
-		| ArticleDesign.DeadBlog
-		| ArticleDesign.Review
-		| ArticleDesign.Comment
-		| ArticleDesign.Letter
-		| ArticleDesign.Editorial
-		| ArticleDesign.Analysis
-		| ArticleDesign.Explainer
-	>;
-	body: Body;
+	design: ArticleDesign.Standard;
+	body: BodyElement[];
+}
+
+interface NewsletterSignup extends Fields {
+	design: ArticleDesign.NewsletterSignup;
+	body: BodyElement[];
+}
+
+interface PhotoEssay extends Fields {
+	design: ArticleDesign.PhotoEssay;
+	body: BodyElement[];
+}
+
+interface PrintShop extends Fields {
+	design: ArticleDesign.PrintShop;
+	body: BodyElement[];
+}
+
+interface FullPageInteractive extends Fields {
+	design: ArticleDesign.FullPageInteractive;
+	body: BodyElement[];
 }
 
 type Item =
@@ -205,13 +229,21 @@ type Item =
 	| Correction
 	| Interview
 	| Analysis
-	| Explainer;
+	| Explainer
+	| Gallery
+	| Audio
+	| Video
+	| Recipe
+	| Feature
+	| Quiz
+	| NewsletterSignup
+	| PhotoEssay
+	| PrintShop
+	| FullPageInteractive;
 
 // ----- Convenience Types ----- //
 
 type ItemFields = Omit<Fields, 'design'>;
-
-type ItemFieldsWithBody = ItemFields & { body: Body };
 
 // ----- Functions ----- //
 
@@ -276,7 +308,7 @@ const getBranding = ({
 		? none
 		: fromNullable(branding);
 
-const itemFields = (
+const parseItemFields = (
 	context: Context,
 	request: RenderingRequest,
 ): ItemFields => {
@@ -326,30 +358,23 @@ const itemFields = (
 		webUrl: content.webUrl,
 		edition: Optional.fromNullable(request.edition).withDefault(Edition.UK),
 		promotedNewsletter: fromNullable(request.promotedNewsletter),
+		shouldHideAdverts: request.content.fields?.shouldHideAdverts ?? false,
 	};
 };
 
-const outlineFromItem = (item: ItemFieldsWithBody): Outline => {
-	const elements = Result.partition(item.body).oks;
-	return fromBodyElements(elements);
-};
-
-const itemFieldsWithBody = (
+const parseBody = (
 	context: Context,
 	request: RenderingRequest,
-): ItemFieldsWithBody => {
+): BodyElement[] => {
 	const { content } = request;
 	const body = content.blocks?.body ?? [];
 	const atoms = content.atoms;
 	const campaigns = request.campaigns ?? [];
 	const elements = [...body].shift()?.elements;
 
-	return {
-		...itemFields(context, request),
-		body: elements
-			? parseElements(context, campaigns, atoms)(elements)
-			: [],
-	};
+	return elements !== undefined
+		? Result.partition(parseElements(context, campaigns, atoms)(elements)).oks
+		: [];
 };
 
 const hasSomeTag =
@@ -409,6 +434,7 @@ const fromCapiLiveBlog =
 	(
 		request: RenderingRequest,
 		blockId: Option<string>,
+		itemFields: ItemFields,
 	): LiveBlog | DeadBlog => {
 		const { content, campaigns } = request;
 		const body = content.blocks?.body ?? [];
@@ -430,7 +456,7 @@ const fromCapiLiveBlog =
 			blocks: parsedBlocks,
 			pagedBlocks,
 			totalBodyBlocks: content.blocks?.totalBodyBlocks ?? body.length,
-			...itemFields(context, request),
+			...itemFields,
 		};
 	};
 
@@ -439,13 +465,21 @@ const fromCapi =
 	(request: RenderingRequest, page: Option<string>): Item => {
 		const { content } = request;
 		const { tags, fields } = content;
+		const itemFields = parseItemFields(context, request);
+
+		if (isLive(tags)) {
+			return fromCapiLiveBlog(context)(request, page, itemFields);
+		}
+
+		const body = parseBody(context, request);
 
 		// These checks aim for parity with the CAPI Scala client:
 		// https://github.com/guardian/content-api-scala-client/blob/9e249bcef47cc048da483b3453c10dd7d2e9565d/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
 		if (isInteractive(content)) {
 			return {
 				design: ArticleDesign.Interactive,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 			// This isn't accurate, picture pieces look different to galleries.
 			// This is to prevent accidentally breaking Editions until we have
@@ -453,94 +487,105 @@ const fromCapi =
 		} else if (isGallery(tags) || isPicture(tags)) {
 			return {
 				design: ArticleDesign.Gallery,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isAudio(tags)) {
 			return {
 				design: ArticleDesign.Audio,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isVideo(tags)) {
 			return {
 				design: ArticleDesign.Video,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isReview(tags)) {
 			return {
 				design: ArticleDesign.Review,
 				starRating: fromNullable(fields?.starRating),
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isAnalysis(tags)) {
-			const item = itemFieldsWithBody(context, request);
 			return {
 				design: ArticleDesign.Analysis,
-				...item,
-				outline: outlineFromItem(item),
+				outline: fromBodyElements(body),
+				body,
+				...itemFields,
 			};
 		} else if (isExplainer(tags)) {
-			const item = itemFieldsWithBody(context, request);
 			return {
 				design: ArticleDesign.Explainer,
-				...item,
-				outline: outlineFromItem(item),
+				outline: fromBodyElements(body),
+				body,
+				...itemFields,
 			};
 		} else if (isCorrection(tags)) {
 			return {
 				design: ArticleDesign.Correction,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isLetter(tags)) {
 			return {
 				design: ArticleDesign.Letter,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isObituary(tags)) {
 			return {
 				design: ArticleDesign.Obituary,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isGuardianView(tags)) {
 			return {
 				design: ArticleDesign.Editorial,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isComment(tags)) {
-			const item = itemFieldsWithBody(context, request);
 			return {
 				design: ArticleDesign.Comment,
-				...item,
+				body,
+				...itemFields,
 				theme:
-					item.theme === ArticlePillar.News
+					itemFields.theme === ArticlePillar.News
 						? ArticlePillar.Opinion
-						: item.theme,
+						: itemFields.theme,
 			};
 		} else if (isInterview(tags)) {
 			return {
 				design: ArticleDesign.Interview,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isRecipe(tags)) {
 			return {
 				design: ArticleDesign.Recipe,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isFeature(tags)) {
 			return {
 				design: ArticleDesign.Feature,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
-		} else if (isLive(tags)) {
-			return fromCapiLiveBlog(context)(request, page);
 		} else if (isQuiz(tags)) {
 			return {
 				design: ArticleDesign.Quiz,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		} else if (isLabs(tags)) {
 			return {
 				design: ArticleDesign.Standard,
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 				theme: ArticleSpecial.Labs,
 			};
 		} else if (isMatchReport(tags)) {
@@ -549,13 +594,15 @@ const fromCapi =
 				football: Optional.fromNullable(
 					request.footballContent,
 				).flatMap(parseMatchScores),
-				...itemFieldsWithBody(context, request),
+				body,
+				...itemFields,
 			};
 		}
 
 		return {
 			design: ArticleDesign.Standard,
-			...itemFieldsWithBody(context, request),
+			body,
+			...itemFields,
 		};
 	};
 
@@ -580,6 +627,13 @@ export {
 	Feature,
 	PrintShop,
 	Explainer,
+	Gallery,
+	Audio,
+	Video,
+	Interactive,
+	NewsletterSignup,
+	Obituary,
+	Correction,
 	fromCapi,
 	fromCapiLiveBlog,
 	getFormat,

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -21,7 +21,8 @@ import {
 import { andThen, fromNullable, map, none, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
 import { getPillarFromId } from 'articleFormat';
-import { BodyElement, parseElements } from 'bodyElement';
+import type { BodyElement } from 'bodyElement';
+import { parseElements } from 'bodyElement';
 import { getReport } from 'campaign';
 import type { Logo } from 'capi';
 import {
@@ -373,7 +374,8 @@ const parseBody = (
 	const elements = [...body].shift()?.elements;
 
 	return elements !== undefined
-		? Result.partition(parseElements(context, campaigns, atoms)(elements)).oks
+		? Result.partition(parseElements(context, campaigns, atoms)(elements))
+				.oks
 		: [];
 };
 

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -63,7 +63,7 @@ const parse =
 			title: block.title ?? '',
 			firstPublished: firstPublishedDate.value,
 			lastModified: lastModifiedDate.value,
-			body: parseElements(context, campaigns)(block.elements),
+			body: Result.partition(parseElements(context, campaigns)(block.elements)).oks,
 			contributors: tagsToContributors(
 				contributorTags(block.contributors, tags),
 				context,

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -63,7 +63,9 @@ const parse =
 			title: block.title ?? '',
 			firstPublished: firstPublishedDate.value,
 			lastModified: lastModifiedDate.value,
-			body: Result.partition(parseElements(context, campaigns)(block.elements)).oks,
+			body: Result.partition(
+				parseElements(context, campaigns)(block.elements),
+			).oks,
 			contributors: tagsToContributors(
 				contributorTags(block.contributors, tags),
 				context,

--- a/apps-rendering/src/newsletter.test.ts
+++ b/apps-rendering/src/newsletter.test.ts
@@ -7,7 +7,6 @@ import type { Body, BodyElement } from 'bodyElement';
 import { ElementKind } from 'bodyElementKind';
 import type { DeadBlog, Quiz, Standard } from 'item';
 import { Optional } from 'optional';
-import { Result } from 'result';
 import { quiz, article } from 'fixtures/item';
 import { deadBlog } from 'fixtures/live';
 import { insertNewsletterIntoItem } from './newsletter';
@@ -31,75 +30,77 @@ const makeTextElementNode = (html: string, outerTag = 'p'): Node => {
 	return doc.firstChild!;
 };
 
-const makeParagraphResult = (html: string): Result<string, BodyElement> =>
-	Result.ok({
+const makeParagraph = (html: string): BodyElement =>
+	({
 		kind: ElementKind.Text,
 		doc: makeTextElementNode(html),
 	});
-const makeHeadingResult = (
+
+const makeHeading = (
 	html: string,
 	id: string,
-): Result<string, BodyElement> =>
-	Result.ok({
+): BodyElement =>
+	({
 		kind: ElementKind.HeadingTwo,
 		id: Optional.some(id),
 		doc: makeTextElementNode(html, 'h2'),
 	});
-const makePullquoteResult = (): Result<string, BodyElement> =>
-	Result.ok({
+
+const makePullquote = (): BodyElement =>
+	({
 		kind: ElementKind.Pullquote,
 		quote: 'Why should the crown be allowed to carry on with a feudal system just because they want to?',
 		attribution: { kind: 0, value: 'Jane Giddins' },
 	});
 
 const makeBodyWithPlaceToInsert = (): Body => [
-	makeParagraphResult('Introductory paragraph.'),
-	makeHeadingResult('first subheading', 'first-subheading'),
-	makeParagraphResult('Another paragraph.'),
-	makeHeadingResult('Another heading', 'another-heading'),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makeHeadingResult('Another heading', 'another-heading'),
-	makeParagraphResult('Another paragraph.'),
-	makePullquoteResult(),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
+	makeParagraph('Introductory paragraph.'),
+	makeHeading('first subheading', 'first-subheading'),
+	makeParagraph('Another paragraph.'),
+	makeHeading('Another heading', 'another-heading'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeHeading('Another heading', 'another-heading'),
+	makeParagraph('Another paragraph.'),
+	makePullquote(),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
 ];
 
 const makeBodyWithNoPlacesToInsert = (): Body => [
-	makeParagraphResult('Introductory paragraph.'),
-	makeHeadingResult('first subheading', 'first-subheading'),
-	makeParagraphResult('Another paragraph.'),
-	makeHeadingResult('Another heading', 'another-heading'),
-	makeParagraphResult('Another paragraph.'),
-	makeHeadingResult('Another heading', 'another-heading'),
-	makeParagraphResult('Another paragraph.'),
-	makePullquoteResult(),
+	makeParagraph('Introductory paragraph.'),
+	makeHeading('first subheading', 'first-subheading'),
+	makeParagraph('Another paragraph.'),
+	makeHeading('Another heading', 'another-heading'),
+	makeParagraph('Another paragraph.'),
+	makeHeading('Another heading', 'another-heading'),
+	makeParagraph('Another paragraph.'),
+	makePullquote(),
 ];
 
 const makeBodyWithNoPlacesToInsertInTheTargetZone = (): Body => [
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makePullquoteResult(),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
-	makeParagraphResult('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makePullquote(),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
+	makeParagraph('Another paragraph.'),
 ];
 
 describe('Insert Newsletter Signups', () => {
@@ -141,9 +142,7 @@ describe('Insert Newsletter Signups', () => {
 		}) as Standard;
 
 		const insertedElement = newItem.body.find(
-			(result) =>
-				result.isOk() &&
-				result.value.kind === ElementKind.NewsletterSignUp,
+			(element) => element.kind === ElementKind.NewsletterSignUp,
 		);
 		expect(insertedElement).toBeTruthy();
 	});

--- a/apps-rendering/src/newsletter.ts
+++ b/apps-rendering/src/newsletter.ts
@@ -28,20 +28,13 @@ type ElementCategoryAndIndex = {
 
 // ----- pure functions ---//
 
-function categoriseElement(
-	result: Result<string, BodyElement>,
-): ElementCategory {
-	if (!result.isOk()) {
-		// using result.isErr does not convince the compiler that result.value exists
-		return ElementCategory.Error;
-	}
-
-	switch (result.value.kind) {
+function categoriseElement(element: BodyElement): ElementCategory {
+	switch (element.kind) {
 		case ElementKind.HeadingThree:
 		case ElementKind.HeadingTwo:
 			return ElementCategory.Heading;
 		case ElementKind.Text: {
-			const { doc } = result.value;
+			const { doc } = element;
 			if (doc.textContent?.trim().length === 0) {
 				return ElementCategory.WhiteSpace;
 			}
@@ -203,7 +196,7 @@ function insertNewsletterIntoBody(
 		(insertIndex) => {
 			return Result.ok([
 				...body.slice(0, insertIndex),
-				Result.ok(newsletterSignUp),
+				newsletterSignUp,
 				...body.slice(insertIndex),
 			]);
 		},

--- a/apps-rendering/src/renderer.test.ts
+++ b/apps-rendering/src/renderer.test.ts
@@ -23,10 +23,10 @@ import { EmbedTracksType } from '@guardian/content-api-models/v1/embedTracksType
 import { ArticleElementRole } from '@guardian/libs';
 import {
 	mockFormat,
-	renderEditions,
-	renderElement,
+	mockRenderEditions,
+	mockRenderElement,
 	renderTextElement,
-	renderWithoutStyles,
+	mockRenderWithoutStyles,
 	textElements,
 } from 'testsHelper';
 import { Optional } from 'optional';
@@ -218,11 +218,11 @@ const audioAtom = (): BodyElement => ({
 });
 
 const renderTextElementWithoutStyles = compose(
-	renderWithoutStyles,
+	mockRenderWithoutStyles,
 	textElements,
 );
 
-const renderCaptionElement = compose(renderElement, imageElement);
+const renderCaptionElement = compose(mockRenderElement, imageElement);
 
 const getHtml = (node: ReactNode): string =>
 	isValidElement(node) ? renderToStaticMarkup(node) : '';
@@ -284,7 +284,7 @@ describe('Transforms text nodes', () => {
 
 describe('Renders different types of elements', () => {
 	test('ElementKind.Image', () => {
-		const nodes = renderElement(imageElement());
+		const nodes = mockRenderElement(imageElement());
 		const bodyImage = nodes.flat()[0];
 		expect(getHtml(bodyImage)).toContain('img');
 		expect(getHtml(bodyImage)).toContain('figcaption');
@@ -293,27 +293,27 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Image with thumbnail role', () => {
-		const nodes = renderElement(imageElementWithRole());
+		const nodes = mockRenderElement(imageElementWithRole());
 		const bodyImage = nodes.flat()[0];
 		expect(getHtml(bodyImage)).toContain('img');
 	});
 
 	test('ElementKind.Pullquote', () => {
-		const nodes = renderElement(pullquoteElement());
+		const nodes = mockRenderElement(pullquoteElement());
 		const pullquote = nodes.flat()[0];
 		expect(getHtml(pullquote)).toContain('quote');
 		expect(getHtml(pullquote)).not.toContain('attribution');
 	});
 
 	test('ElementKind.Pullquote with attribution', () => {
-		const nodes = renderElement(pullquoteWithAttributionElement());
+		const nodes = mockRenderElement(pullquoteWithAttributionElement());
 		const pullquote = nodes.flat()[0];
 		expect(getHtml(pullquote)).toContain('attribution');
 		expect(getHtml(pullquote)).toContain('quote');
 	});
 
 	test('ElementKind.RichLink', () => {
-		const nodes = renderElement(richLinkElement());
+		const nodes = mockRenderElement(richLinkElement());
 		const richLink = nodes.flat()[0];
 		expect(getHtml(richLink)).toContain(
 			'<h1>this links to a related article</h1>',
@@ -322,7 +322,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Interactive', () => {
-		const nodes = renderElement(interactiveElement());
+		const nodes = mockRenderElement(interactiveElement());
 		const interactive = nodes.flat()[0];
 		expect(getHtml(interactive)).toContain('iframe');
 		expect(getHtml(interactive)).toContain('src="https://theguardian.com"');
@@ -330,13 +330,13 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Tweet', () => {
-		const nodes = renderElement(tweetElement());
+		const nodes = mockRenderElement(tweetElement());
 		const tweet = nodes.flat()[0];
 		expect(getHtml(tweet)).toContain('twitter-tweet');
 	});
 
 	test('ElementKind.Instagram', () => {
-		const nodes = renderElement(instagramElement());
+		const nodes = mockRenderElement(instagramElement());
 		const instagram = nodes.flat()[0];
 		expect(getHtml(instagram)).toBe(
 			'<iframe src="https://www.instagram.com/p/embedId/embed" height="830" title="&lt;blockquote&gt;Instagram&lt;/blockquote&gt;"></iframe>',
@@ -344,7 +344,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Embed', () => {
-		const nodes = renderElement(embedElement);
+		const nodes = mockRenderElement(embedElement);
 		const embed = nodes.flat()[0];
 		expect(getHtml(embed)).toContain(
 			'<iframe srcDoc="&lt;section&gt;Embed&lt;/section&gt;" title="Embed" height="322"></iframe>',
@@ -352,7 +352,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Audio', () => {
-		const nodes = renderElement(audioElement);
+		const nodes = mockRenderElement(audioElement);
 		const audio = nodes.flat()[0];
 		expect(getHtml(audio)).toContain(
 			'src="https://www.spotify.com/" sandbox="allow-scripts" height="300" width="500" title="Audio element"',
@@ -360,7 +360,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.Video', () => {
-		const nodes = renderElement(videoElement);
+		const nodes = mockRenderElement(videoElement);
 		const video = nodes.flat()[0];
 		expect(getHtml(video)).toContain(
 			'src="https://www.youtube-nocookie.com/embed/mockYoutubeId?wmode=opaque&amp;feature=oembed" height="300" width="500" allowfullscreen="" title="Video element"',
@@ -368,7 +368,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.LiveEvent', () => {
-		const nodes = renderElement(liveEventElement());
+		const nodes = mockRenderElement(liveEventElement());
 		const liveEvent = nodes.flat()[0];
 		expect(getHtml(liveEvent)).toContain(
 			'<h1>this links to a live event</h1>',
@@ -376,7 +376,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.InteractiveAtom', () => {
-		const nodes = renderElement(atomElement());
+		const nodes = mockRenderElement(atomElement());
 		const atom = nodes.flat()[0];
 		expect(getHtml(atom)).toContain('main { background: yellow; }');
 		expect(getHtml(atom)).toContain('console.log(&#x27;init&#x27;)');
@@ -384,34 +384,34 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.ExplainerAtom', () => {
-		const nodes = renderElement(explainerElement());
+		const nodes = mockRenderElement(explainerElement());
 		const explainer = nodes.flat()[0];
 		expect(getHtml(explainer)).toContain('<main>Explainer content</main>');
 	});
 
 	test('ElementKind.GuideAtom', () => {
-		const nodes = renderElement(guideElement());
+		const nodes = mockRenderElement(guideElement());
 		const guide = nodes.flat()[0];
 		expect(getHtml(guide)).toContain('<main>Guide content</main>');
 		testHandlers(guide);
 	});
 
 	test('ElementKind.QandaAtom', () => {
-		const nodes = renderElement(qandaElement());
+		const nodes = mockRenderElement(qandaElement());
 		const qanda = nodes.flat()[0];
 		expect(getHtml(qanda)).toContain('<main>QandA content</main>');
 		testHandlers(qanda);
 	});
 
 	test('ElementKind.ProfileAtom', () => {
-		const nodes = renderElement(profileElement());
+		const nodes = mockRenderElement(profileElement());
 		const profile = nodes.flat()[0];
 		expect(getHtml(profile)).toContain('<main>Profile content</main>');
 		testHandlers(profile);
 	});
 
 	test('ElementKind.TimelineAtom', () => {
-		const nodes = renderElement(timelineElement());
+		const nodes = mockRenderElement(timelineElement());
 		const timeline = nodes.flat()[0];
 		expect(getHtml(timeline)).toContain(
 			'<p>Swedish prosecutors announce they are <a href="https://www.theguardian.com/media/2019/may/13/sweden-reopens-case-against-julian-assange">reopening an investigation into a rape allegation</a> against Julian Assange.</p><p><br></p>',
@@ -420,7 +420,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.ChartAtom', () => {
-		const nodes = renderElement(chartElement());
+		const nodes = mockRenderElement(chartElement());
 		const chart = nodes.flat()[0];
 		expect(getHtml(chart)).toContain(
 			'srcDoc="&lt;main&gt;Chart content&lt;/main&gt;"',
@@ -428,7 +428,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.KnowledgeQuizAtom', () => {
-		const nodes = renderElement(knowledgeQuizAtom());
+		const nodes = mockRenderElement(knowledgeQuizAtom());
 		const quiz = nodes.flat()[0];
 		const html = getHtml(quiz);
 		expect(html).toContain('<div class="js-quiz">');
@@ -438,7 +438,7 @@ describe('Renders different types of elements', () => {
 	});
 
 	test('ElementKind.AudioAtom', () => {
-		const nodes = renderElement(audioAtom());
+		const nodes = mockRenderElement(audioAtom());
 		const audio = nodes.flat()[0];
 		const html = getHtml(audio);
 		expect(html).toContain(
@@ -483,7 +483,7 @@ describe('Renders different types of elements', () => {
 
 describe('Renders different types of Editions elements', () => {
 	test('ElementKind.Image', () => {
-		const nodes = renderEditions(imageElement());
+		const nodes = mockRenderEditions(imageElement());
 		const bodyImage = nodes.flat()[0];
 		expect(getHtml(bodyImage)).toContain('img');
 		expect(getHtml(bodyImage)).toContain('figcaption');
@@ -492,40 +492,40 @@ describe('Renders different types of Editions elements', () => {
 	});
 
 	test('ElementKind.Image with thumbnail role', () => {
-		const nodes = renderEditions(imageElementWithRole());
+		const nodes = mockRenderEditions(imageElementWithRole());
 		const bodyImage = nodes.flat()[0];
 		expect(getHtml(bodyImage)).toContain('img');
 	});
 
 	test('ElementKind.Pullquote', () => {
-		const nodes = renderEditions(pullquoteElement());
+		const nodes = mockRenderEditions(pullquoteElement());
 		const pullquote = nodes.flat()[0];
 		expect(getHtml(pullquote)).toContain('quote');
 		expect(getHtml(pullquote)).not.toContain('attribution');
 	});
 
 	test('ElementKind.Pullquote with attribution', () => {
-		const nodes = renderEditions(pullquoteWithAttributionElement());
+		const nodes = mockRenderEditions(pullquoteWithAttributionElement());
 		const pullquote = nodes.flat()[0];
 		expect(getHtml(pullquote)).toContain('attribution');
 		expect(getHtml(pullquote)).toContain('quote');
 	});
 
 	test('ElementKind.Tweet', () => {
-		const nodes = renderEditions(tweetElement());
+		const nodes = mockRenderEditions(tweetElement());
 		const tweet = nodes.flat()[0];
 		expect(getHtml(tweet)).toContain('twitter-tweet');
 	});
 
 	test('ElementKind.Embed', () => {
-		const nodes = renderEditions(embedElement);
+		const nodes = mockRenderEditions(embedElement);
 		const embed = nodes.flat()[0];
 		// Editions shouldn't render generic embeds
 		expect(getHtml(embed)).toBeNull;
 	});
 
 	test('ElementKind.Video', () => {
-		const nodes = renderEditions(videoElement);
+		const nodes = mockRenderEditions(videoElement);
 		const video = nodes.flat()[0];
 		expect(getHtml(video)).toContain(
 			'src="https://www.youtube-nocookie.com/embed/mockYoutubeId?wmode=opaque&amp;feature=oembed" height="300" width="500" allowfullscreen="" title="Video element"',
@@ -533,7 +533,7 @@ describe('Renders different types of Editions elements', () => {
 	});
 
 	test('ElementKind.LiveEvent', () => {
-		const nodes = renderEditions(liveEventElement());
+		const nodes = mockRenderEditions(liveEventElement());
 		const liveEvent = nodes.flat()[0];
 		expect(getHtml(liveEvent)).toContain(
 			'<h1>this links to a live event</h1>',

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -27,6 +27,7 @@ import {
 	withDefault,
 } from '@guardian/types';
 import type { Option } from '@guardian/types';
+import { getAdPlaceholderInserter } from 'ads';
 import { themeToPillar } from 'articleFormat';
 import { ElementKind } from 'bodyElement';
 import type {
@@ -73,7 +74,6 @@ import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { Result } from 'result';
 import { backgroundColor, darkModeCss } from 'styles';
-import { getAdPlaceholderInserter } from 'ads';
 
 // ----- Renderer ----- //
 

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -73,6 +73,7 @@ import { createElement as h } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import { Result } from 'result';
 import { backgroundColor, darkModeCss } from 'styles';
+import { getAdPlaceholderInserter } from 'ads';
 
 // ----- Renderer ----- //
 
@@ -608,7 +609,7 @@ const audioAtomRenderer = (
 	);
 };
 
-const render =
+const renderElement =
 	(format: ArticleFormat, excludeStyles = false) =>
 	(element: BodyElement, key: number): ReactNode => {
 		switch (element.kind) {
@@ -745,27 +746,37 @@ const renderEditions =
 		}
 	};
 
-const renderAll = (
+const renderElements = (
 	format: ArticleFormat,
 	elements: BodyElement[],
-): ReactNode[] => elements.map(render(format));
+): ReactNode[] => elements.map(renderElement(format));
 
-const renderEditionsAll = (
+const renderEditionsElements = (
 	format: ArticleFormat,
 	elements: BodyElement[],
 ): ReactNode[] => elements.map(renderEditions(format));
 
-const renderAllWithoutStyles = (
+const renderWithoutStyles = (
 	format: ArticleFormat,
 	elements: BodyElement[],
-): ReactNode[] => elements.map(render(format, true));
+): ReactNode[] => elements.map(renderElement(format, true));
+
+const render = (
+	shouldHideAdverts: boolean,
+	format: ArticleFormat,
+	elements: BodyElement[],
+): ReactNode[] =>
+	getAdPlaceholderInserter(shouldHideAdverts)(
+		renderElements(format, elements),
+		format,
+	);
 
 // ----- Exports ----- //
 
 export {
-	renderAll,
-	renderEditionsAll,
-	renderAllWithoutStyles,
+	renderElements,
+	renderEditionsElements,
+	renderWithoutStyles,
 	renderText,
 	textElement as renderTextElement,
 	standfirstText as renderStandfirstText,
@@ -773,4 +784,5 @@ export {
 	transformHref,
 	plainTextElement,
 	shouldShowDropCap,
+	render,
 };

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -47,7 +47,7 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 		{ scripts: [], styles: [] },
 	);
 
-const getElements = (item: Item): Array<BodyElement> =>
+const getElements = (item: Item): BodyElement[] =>
 	item.design === ArticleDesign.LiveBlog ||
 	item.design === ArticleDesign.DeadBlog
 		? item.blocks.flatMap((block) => block.body)

--- a/apps-rendering/src/server/csp.ts
+++ b/apps-rendering/src/server/csp.ts
@@ -8,7 +8,6 @@ import { ElementKind } from 'bodyElement';
 import type { ThirdPartyEmbeds } from 'capi';
 import type { Item } from 'item';
 import { compose, pipe } from 'lib';
-import { Result } from 'result';
 
 // ----- Types ----- //
 
@@ -48,16 +47,13 @@ const extractInteractiveAssets = (elements: BodyElement[]): Assets =>
 		{ scripts: [], styles: [] },
 	);
 
-const getElements = (item: Item): Array<Result<string, BodyElement>> =>
+const getElements = (item: Item): Array<BodyElement> =>
 	item.design === ArticleDesign.LiveBlog ||
 	item.design === ArticleDesign.DeadBlog
 		? item.blocks.flatMap((block) => block.body)
 		: item.body;
 
-const getValidElements = (item: Item): BodyElement[] =>
-	Result.partition(getElements(item)).oks;
-
-const interactiveAssets = compose(extractInteractiveAssets, getValidElements);
+const interactiveAssets = compose(extractInteractiveAssets, getElements);
 
 const assetHashes = (assets: string[]): string =>
 	assets.map((asset) => `'sha256-${assetHash(asset)}'`).join(' ');

--- a/apps-rendering/src/server/page.tsx
+++ b/apps-rendering/src/server/page.tsx
@@ -52,9 +52,6 @@ const scriptName = ({ design, display }: ArticleFormat): Option<string> => {
 	}
 };
 
-const shouldHideAds = (request: RenderingRequest): boolean =>
-	request.content.fields?.shouldHideAdverts ?? false;
-
 const styles = (format: ArticleFormat): string => `
     ${pageFonts}
 	${resets.resetCSS}
@@ -119,7 +116,7 @@ const renderBody = (item: Item, request: RenderingRequest): EmotionCritical =>
 	emotionServer.extractCritical(
 		renderToString(
 			<CacheProvider value={emotionCache}>
-				<Layout item={item} shouldHideAds={shouldHideAds(request)} />
+				<Layout item={item} />
 			</CacheProvider>,
 		),
 	);

--- a/apps-rendering/src/testsHelper.ts
+++ b/apps-rendering/src/testsHelper.ts
@@ -5,7 +5,11 @@ import { flattenTextElement } from 'bodyElement';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
 import type { ReactNode } from 'react';
-import { renderEditionsElements, renderElements, renderWithoutStyles } from 'renderer';
+import {
+	renderEditionsElements,
+	renderElements,
+	renderWithoutStyles,
+} from 'renderer';
 
 const mockFormat: ArticleFormat = {
 	theme: ArticlePillar.News,

--- a/apps-rendering/src/testsHelper.ts
+++ b/apps-rendering/src/testsHelper.ts
@@ -5,7 +5,7 @@ import { flattenTextElement } from 'bodyElement';
 import { JSDOM } from 'jsdom';
 import { compose } from 'lib';
 import type { ReactNode } from 'react';
-import { renderAll, renderAllWithoutStyles, renderEditionsAll } from 'renderer';
+import { renderEditionsElements, renderElements, renderWithoutStyles } from 'renderer';
 
 const mockFormat: ArticleFormat = {
 	theme: ArticlePillar.News,
@@ -23,30 +23,30 @@ const textElements = (nodes: string[]): BodyElement[] => {
 	return flattenTextElement(frag);
 };
 
-const renderElement = (element: BodyElement): ReactNode[] =>
-	renderAll(mockFormat, [element]);
+const mockRenderElement = (element: BodyElement): ReactNode[] =>
+	renderElements(mockFormat, [element]);
 
-const renderElements = (elements: BodyElement[]): ReactNode[] =>
-	renderAll(mockFormat, elements);
+const mockRenderElements = (elements: BodyElement[]): ReactNode[] =>
+	renderElements(mockFormat, elements);
 
-const renderWithoutStyles = (elements: BodyElement[]): ReactNode[] =>
-	renderAllWithoutStyles(mockFormat, elements);
+const mockRenderWithoutStyles = (elements: BodyElement[]): ReactNode[] =>
+	renderWithoutStyles(mockFormat, elements);
 
-const renderEditions = (element: BodyElement): ReactNode[] =>
-	renderEditionsAll(mockFormat, [element]);
+const mockRenderEditions = (element: BodyElement): ReactNode[] =>
+	renderEditionsElements(mockFormat, [element]);
 
-const renderParagraphs = compose(renderElements, generateParas);
+const renderParagraphs = compose(mockRenderElements, generateParas);
 
-const renderTextElement = compose(renderElements, textElements);
+const renderTextElement = compose(mockRenderElements, textElements);
 
 export {
 	mockFormat,
 	generateParas,
 	textElements,
-	renderElement,
-	renderElements,
-	renderWithoutStyles,
-	renderEditions,
+	mockRenderElement,
+	mockRenderElements,
+	mockRenderWithoutStyles,
+	mockRenderEditions,
 	renderParagraphs,
 	renderTextElement,
 };


### PR DESCRIPTION
## Why?

These `Result`s are not needed in the rendering layer, and therefore capturing them in `Item` and having to deal with them in the rendering code introduces unnecessary complexity.

The core change in this PR is changing the type of `Body` on `Item` from `Array<Result<string, BodyElement>>` to `BodyElement[]`. Some related changes include:

- Moving `shouldHideAdverts` onto the `Item` type
- Adding the remaining `Design`s as separate sub-types of `Item`

Taken together, these changes allow us to make the following simplifications:

- Layout components no longer take the rendered body as `children`, they can instead render the body directly, simplifying the component API.
- Layout stories are simpler to write, which allows for more automation of stories in the future.
- Fixtures and tests no longer have to manage `Result`s when working with the `Body`, they can use `BodyElement` directly.
- The `Item` sub-types are more consistent, and layouts can be more specific about which ones they accept.

Hopefully this will result in changes becoming easier to make, particularly those involving tests, fixtures and stories.

## Changes

- Make `Body` an array of `BodyElement`
- Moved `shouldHideAdverts` onto `Item`
- Added separate `Item`s for each `Design`
- Parse `Body` and `ItemFields` separately
- Moved ad placeholder call into `renderer.ts`
- Refactored names of render functions and mock render functions
- Moved body rendering into `ArticleBody` component
- Updated layouts to use new `ArticleBody` and render functions
- Updated layouts to use more specific `Item` sub-types
- Simplified layout stories
- Updated tests to handle new `Body` and render functions
- Updated fixtures to handle new `Body`
