### PR TITLE
Add `NoCarrotAdsNearNewsletterSignupBlocks` test

### DIFF
--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -8,6 +8,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from './tests/newsletter-merch-unit-test';
+import { noCarrotAdsNearNewsletterSignupBlocks } from './tests/no-carrot-ads-near-newsletter-signup-blocks';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 import { teadsCookieless } from './tests/teads-cookieless';
@@ -25,4 +26,5 @@ export const tests: ABTest[] = [
 	liveblogDesktopOutstream,
 	teadsCookieless,
 	billboardsInMerch,
+	noCarrotAdsNearNewsletterSignupBlocks,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/no-carrot-ads-near-newsletter-signup-blocks.ts
+++ b/dotcom-rendering/src/web/experiments/tests/no-carrot-ads-near-newsletter-signup-blocks.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
+
+export const noCarrotAdsNearNewsletterSignupBlocks: ABTest = {
+	id: 'NoCarrotAdsNearNewsletterSignupBlocks',
+	author: '@commercial-dev',
+	start: '2022-12-08',
+	expiry: '2023-02-01',
+	audience: 10 / 100,
+	audienceOffset: 35 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Making the change does not lead to a significant reduction in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Test the impact of preventing spacefinder from positioning carrot ads near newsletter signup blocks',
+	variants: [
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant', test: bypassMetricsSampling },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

Introduces an A/B test in DCR which can be used to measure the impact of this change: https://github.com/guardian/frontend/pull/25756

## Why?

The test definition must exist in both frontend and DCR