### PR TITLE
Add a 0% test to share with teads

### DIFF
--- a/dotcom-rendering/src/web/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -10,6 +10,7 @@ import {
 import { removePrebidA9Canada } from './tests/remove-prebid-a9-canada';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { teadsCookieless } from './tests/teads-cookieless';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -23,4 +24,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	removePrebidA9Canada,
 	liveblogDesktopOutstream,
+	teadsCookieless,
 ];

--- a/dotcom-rendering/src/web/experiments/tests/teads-cookieless.ts
+++ b/dotcom-rendering/src/web/experiments/tests/teads-cookieless.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+import { bypassMetricsSampling } from '../utils';
+
+export const teadsCookieless: ABTest = {
+	id: 'TeadsCookieless',
+	start: '2022-12-07',
+	expiry: '2023-12-31',
+	author: 'Jake Lee Kennedy',
+	description: 'Test the impact of enabling the Teads cookieless tag',
+	audience: 0,
+	audienceOffset: 5 / 100,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No significant impact to UX',
+	canRun: () => true,
+	variants: [
+		{ id: 'control', test: () => bypassMetricsSampling },
+		{ id: 'variant', test: () => bypassMetricsSampling },
+	],
+};


### PR DESCRIPTION
## What does this change?
Adds Teads Cookieless tag 0% AB test, the tag is not working as expected, we need to share a link with Teads so that the can assist.
