### PR TITLE
MostViewedRightItem shouldn't pass `link` prop

### DIFF
--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { border, headline, text } from '@guardian/source-foundations';
+import { border, headline, neutral, text } from '@guardian/source-foundations';
 import type { TrailType } from '../../types/trails';
 import { useHover } from '../lib/useHover';
 import { AgeWarning } from './AgeWarning';
@@ -35,6 +35,14 @@ const linkTagStyles = css`
 	&:link,
 	&:active {
 		color: ${text.anchorSecondary};
+	}
+
+	&:visited h3 {
+		color: ${neutral[46]}
+	}
+
+	&:hover h3 {
+		text-decoration: underline;
 	}
 `;
 

--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { border, headline, neutral, text } from '@guardian/source-foundations';
+import { border, headline, text } from '@guardian/source-foundations';
 import type { TrailType } from '../../types/trails';
 import { useHover } from '../lib/useHover';
 import { AgeWarning } from './AgeWarning';
@@ -67,12 +67,6 @@ type Props = {
 export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 	const [hoverRef, isHovered] = useHover<HTMLAnchorElement>();
 
-	const linkProps = {
-		to: trail.url,
-		visitedColour: neutral[46],
-		preventFocus: true,
-	};
-
 	return (
 		<li
 			css={listItemStyles}
@@ -96,7 +90,6 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 								format={trail.format}
 								size="small"
 								showUnderline={isHovered}
-								link={linkProps}
 								kickerText="Live"
 								showSlash={false}
 								byline={
@@ -109,7 +102,6 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 								format={trail.format}
 								size="small"
 								showUnderline={isHovered}
-								link={linkProps}
 								byline={
 									trail.showByline ? trail.byline : undefined
 								}

--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -38,7 +38,7 @@ const linkTagStyles = css`
 	}
 
 	&:visited h3 {
-		color: ${neutral[46]}
+		color: ${neutral[46]};
 	}
 
 	&:hover h3 {


### PR DESCRIPTION
`MostViewedRightItem` wraps `LinkHeader` in an `<a>` tag, so it shouldn't pass a `link` prop to `LinkHeader`, because if it does then we will have an `<a>` tag inside an `<a>` tag. 

This [is invalid HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#properties)

It was also causing Jest to throw a warning when re-running tests for MostViewedRightItem:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/37048459/206509217-344e175c-606a-4a3f-b266-e1993e6df7c4.png">

## Screenshots

| Before      | After      |
|-------------|------------|
|<img width="1389" alt="image" src="https://user-images.githubusercontent.com/37048459/206503185-7e685276-b21d-4d7b-86b3-01db82c301a0.png">  Two `<a>` tags|<img width="1329" alt="image" src="https://user-images.githubusercontent.com/37048459/206507881-342197e6-b84b-4f58-a0a2-eb6a0561804f.png">One `<a>` tag |
| <img width="388" alt="image" src="https://user-images.githubusercontent.com/37048459/206507643-0240c2a2-d755-489b-914f-3449212e678b.png">Custom hover and visited styling | <img width="381" alt="image" src="https://user-images.githubusercontent.com/37048459/206507526-519dd163-324c-410a-b3f4-f3b10232dfc4.png"> Custom styling replicated in this PR|


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

## Further issues

If this PR is accepted, then the only uses of the `link` prop will be in stories for the LinkHeader component. I'd suggest we should create an issue to refactor this component when we get the chance, to remove the `link` prop entirely, or else create a more general-purpose wrapper component for card-type links. (Could build on the patterns used for `Card.tsx`)
