### PR TITLE
Prevent Repeated Config Lookup

### DIFF
--- a/apps-rendering/src/server/ssmConfig.ts
+++ b/apps-rendering/src/server/ssmConfig.ts
@@ -1,6 +1,5 @@
 import type { Option } from '@guardian/types';
-import { map, none, some, withDefault } from '@guardian/types';
-import { pipe } from 'lib';
+import { none, OptionKind, some } from '@guardian/types';
 import { App, Stack, Stage } from './appIdentity';
 import { ssm } from './aws';
 
@@ -44,11 +43,11 @@ async function getState(): Promise<Config> {
 }
 
 async function fetchConfig(): Promise<Config> {
-	return pipe(
-		state,
-		map((s) => Promise.resolve(s)),
-		withDefault(getState()),
-	);
+	if (state.kind === OptionKind.Some) {
+		return Promise.resolve(state.value);
+	}
+
+	return getState();
 }
 
 export async function getConfigValue(


### PR DESCRIPTION
## Why?

I think the `fetchConfig` function is meant to work like this: if `state` is populated, return its cached value, else call SSM via the `getState` function. `getState` is **not** meant to be called **unless** `state` is empty. However it looks like at the moment it's being called every time to provide the fallback, even when `state` is populated.

This change tweaks the code to make sure `getState` is only called when `state` is empty.
