### PR TITLE
Add support for description in containers

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,5 +1,5 @@
 import type { DCRCollectionType, FECollectionType } from '../types/front';
-import { EditionId } from '../web/lib/edition';
+import type { EditionId } from '../web/lib/edition';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
@@ -19,13 +19,15 @@ export const enhanceCollections = (
 	pageId: string,
 ): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection) => {
-		const { id, displayName, collectionType, hasMore } = collection;
+		const { id, displayName, collectionType, hasMore, description } =
+			collection;
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
 		);
 		return {
 			id,
 			displayName,
+			description,
 			collectionType,
 			containerPalette,
 			grouped: groupCards(

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -467,6 +467,9 @@
                             "displayName": {
                                 "type": "string"
                             },
+                            "description": {
+                                "type": "string"
+                            },
                             "curated": {
                                 "type": "array",
                                 "items": {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -282,6 +282,7 @@ type FECollectionConfigType = {
 export type FECollectionType = {
 	id: string;
 	displayName: string;
+	description?: string;
 	curated: FEFrontCard[];
 	backfill: FEFrontCard[];
 	treats: FEFrontCard[];
@@ -302,6 +303,7 @@ export type FECollectionType = {
 export type DCRCollectionType = {
 	id: string;
 	displayName: string;
+	description?: string;
 	collectionType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	grouped: DCRGroupedTrails;

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -379,6 +379,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							<Section
 								key={collection.id}
 								title={collection.displayName}
+								description={collection.description}
 								showTopBorder={index > 0}
 								padContent={false}
 								centralBorder="partial"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for descriptions configured in fronts tool

## Why?

Parity

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/206734015-fd70217a-ec1e-476f-a7f7-28ce5f440f3d.png
[after]: https://user-images.githubusercontent.com/9575458/206733958-acd42090-e1bb-430e-8a63-9eef1bc72284.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
