### PR TITLE
Add href to containers

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,5 +1,5 @@
 import type { DCRCollectionType, FECollectionType } from '../types/front';
-import { EditionId } from '../web/lib/edition';
+import type { EditionId } from '../web/lib/edition';
 import { decideContainerPalette } from './decideContainerPalette';
 import { enhanceCards } from './enhanceCards';
 import { enhanceTreats } from './enhanceTreats';
@@ -19,7 +19,7 @@ export const enhanceCollections = (
 	pageId: string,
 ): DCRCollectionType[] => {
 	return collections.filter(isSupported).map((collection) => {
-		const { id, displayName, collectionType, hasMore } = collection;
+		const { id, displayName, collectionType, hasMore, href } = collection;
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
 		);
@@ -27,6 +27,7 @@ export const enhanceCollections = (
 			id,
 			displayName,
 			collectionType,
+			href,
 			containerPalette,
 			grouped: groupCards(
 				collectionType,


### PR DESCRIPTION
Closes #6430

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Passes the href through to front containers

## Why?

Parity

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/206738560-e4d38159-2b41-4bd3-8c8d-fe971f0d0809.png
[after]: https://user-images.githubusercontent.com/9575458/206738519-7ae654ee-ed5f-4da3-8dab-bbbf4b50fc2b.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
