### PR TITLE
Migrate `standfirst` To `Optional`

### DIFF
--- a/apps-rendering/src/components/MainMediaCaption/MainMediaCaption.stories.tsx
+++ b/apps-rendering/src/components/MainMediaCaption/MainMediaCaption.stories.tsx
@@ -10,7 +10,7 @@ import MainMediaCaption from '.';
 
 const Default: FC = () => (
 	<MainMediaCaption
-		caption={parseHtml('A caption')}
+		caption={parseHtml('A caption').toOption()}
 		credit={some('By a person')}
 		format={{
 			design: ArticleDesign.Standard,

--- a/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
@@ -7,7 +7,7 @@ import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, remSpace } from '@guardian/source-foundations';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
-import { Optional } from 'optional';
+import type { Optional } from 'optional';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';
 

--- a/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/GalleryStandfirst.tsx
@@ -5,9 +5,9 @@ import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, remSpace } from '@guardian/source-foundations';
-import type { Option } from '@guardian/types';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
+import { Optional } from 'optional';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';
 
@@ -34,12 +34,12 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 type Props = {
-	standfirst: Option<DocumentFragment>;
+	standfirst: Optional<DocumentFragment>;
 	format: ArticleFormat;
 };
 
 const GalleryStandfirst: React.FC<Props> = ({ standfirst, format }) =>
-	maybeRender(standfirst, (standfirstDoc) => (
+	maybeRender(standfirst.toOption(), (standfirstDoc) => (
 		<div css={styles(format)}>
 			{renderStandfirstText(standfirstDoc, format)}
 		</div>

--- a/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
@@ -9,6 +9,7 @@ import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
+import { Optional } from 'optional';
 import type { ReactNode } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -72,7 +73,7 @@ const styles = (format: ArticleFormat): SerializedStyles => css`
 `;
 
 type Props = {
-	standfirst: Option<DocumentFragment>;
+	standfirst: Optional<DocumentFragment>;
 	byline: string;
 	bylineHtml: Option<DocumentFragment>;
 	format: ArticleFormat;
@@ -84,7 +85,7 @@ const ImmersiveStandfirst: React.FC<Props> = ({
 	byline,
 	bylineHtml,
 }) =>
-	maybeRender(standfirst, (standfirstDoc) => (
+	maybeRender(standfirst.toOption(), (standfirstDoc) => (
 		<div css={styles(format)}>
 			{renderContent(standfirstDoc, format, byline, bylineHtml)}
 		</div>

--- a/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
+++ b/apps-rendering/src/components/Standfirst/ImmersiveStandfirst.tsx
@@ -9,7 +9,7 @@ import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
-import { Optional } from 'optional';
+import type { Optional } from 'optional';
 import type { ReactNode } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -7,11 +7,10 @@ import {
 } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { headline, remSpace } from '@guardian/source-foundations';
-import { map, withDefault } from '@guardian/types';
 import type { Item } from 'item';
 import { getFormat } from 'item';
-import { pipe } from 'lib';
-import type { FC, ReactElement } from 'react';
+import { maybeRender } from 'lib';
+import type { FC } from 'react';
 import { renderStandfirstText } from 'renderer';
 import { darkModeCss } from 'styles';
 
@@ -58,14 +57,11 @@ interface Props {
 }
 
 const DefaultStandfirst: FC<Props> = ({ item, className }) =>
-	pipe(
-		item.standfirst,
-		map((standfirst) => (
+	maybeRender(item.standfirst.toOption(), (standfirst) => (
 			<div className={className}>
 				{renderStandfirstText(standfirst, getFormat(item))}
 			</div>
-		)),
-		withDefault<ReactElement | null>(null),
+		),
 	);
 
 export default DefaultStandfirst;

--- a/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
+++ b/apps-rendering/src/components/Standfirst/Standfirst.defaults.tsx
@@ -58,10 +58,9 @@ interface Props {
 
 const DefaultStandfirst: FC<Props> = ({ item, className }) =>
 	maybeRender(item.standfirst.toOption(), (standfirst) => (
-			<div className={className}>
-				{renderStandfirstText(standfirst, getFormat(item))}
-			</div>
-		),
-	);
+		<div className={className}>
+			{renderStandfirstText(standfirst, getFormat(item))}
+		</div>
+	));
 
 export default DefaultStandfirst;

--- a/apps-rendering/src/components/editions/standfirst/index.tsx
+++ b/apps-rendering/src/components/editions/standfirst/index.tsx
@@ -137,7 +137,7 @@ interface Props {
 const isEditions = true;
 
 const Standfirst: FC<Props> = ({ item, shareIcon }) => {
-	return maybeRender(item.standfirst, (standfirst) => (
+	return maybeRender(item.standfirst.toOption(), (standfirst) => (
 		<div css={getStyles(item)}>
 			<div css={textContainerStyles}>
 				{renderStandfirstText(standfirst, item, isEditions)}

--- a/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
@@ -1,10 +1,10 @@
 // ----- Imports ----- //
 import { ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
-import type { Option } from '@guardian/types';
 import { withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { analysis, article, comment, media } from 'fixtures/item';
+import { Optional } from 'optional';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from '.';
@@ -14,9 +14,9 @@ import Standfirst from '.';
 const parser = new DOMParser();
 const parseStandfirst = parse(parser);
 
-const standfirst: Option<DocumentFragment> = parseStandfirst(
+const standfirst: Optional<DocumentFragment> = parseStandfirst(
 	'<p>The Mexican capital was founded by Aztecs on an island in a vast lake. No wonder water flows through so many of its unbuilt projects</p>',
-).toOption();
+).toOptional();
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
+++ b/apps-rendering/src/components/editions/standfirst/standfirst.stories.tsx
@@ -4,7 +4,7 @@ import { neutral } from '@guardian/source-foundations';
 import { withKnobs } from '@storybook/addon-knobs';
 import { parse } from 'client/parser';
 import { analysis, article, comment, media } from 'fixtures/item';
-import { Optional } from 'optional';
+import type { Optional } from 'optional';
 import type { ReactElement } from 'react';
 import { selectPillar } from 'storybookHelpers';
 import Standfirst from '.';

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -68,7 +68,9 @@ const bylineHtml = parseHtml(
 	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
 ).toOption();
 
-const captionDocFragment = parseHtml('<em>Jane Smith</em> Editor of things').toOption();
+const captionDocFragment = parseHtml(
+	'<em>Jane Smith</em> Editor of things',
+).toOption();
 
 const docFixture = (): Node => {
 	const doc = new DocumentFragment();

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -50,11 +50,8 @@ import { relatedContent } from './relatedContent';
 // ----- Fixture ----- //
 
 const parser = new DOMParser();
-const parseHtml = (html: string): Option<DocumentFragment> =>
-	parse(parser)(html).either<Option<DocumentFragment>>(
-		(_err) => none,
-		(doc) => some(doc),
-	);
+const parseHtml = (html: string): Optional<DocumentFragment> =>
+	parse(parser)(html).toOptional();
 
 const headline =
 	'Reclaimed lakes and giant airports: how Mexico City might have looked';
@@ -69,9 +66,9 @@ const standfirstWithLink = parseHtml(
 
 const bylineHtml = parseHtml(
 	'<a href="https://theguardian.com">Jane Smith</a> Editor of things',
-);
+).toOption();
 
-const captionDocFragment = parseHtml('<em>Jane Smith</em> Editor of things');
+const captionDocFragment = parseHtml('<em>Jane Smith</em> Editor of things').toOption();
 
 const docFixture = (): Node => {
 	const doc = new DocumentFragment();

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -24,9 +24,9 @@ const parseHtml = parse(parser);
 const headline =
 	'Covid live: Brazil health minister who shook hands with maskless Boris Johnson at UN tests positive';
 
-const standfirst: Option<DocumentFragment> = parseHtml(
+const standfirst: Optional<DocumentFragment> = parseHtml(
 	'<p><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ae7e58f08b228c9498279#block-614ae7e58f08b228c9498279">Marcelo Quiroga tests positive</a> at UN general assembly in New York; <a href="x-gu://item/mobile.guardianapis.com/uk/items/world/live/2021/sep/22/coronavirus-live-news-brazil-health-minister-tests-positive-at-un-india-urges-uk-to-resolve-quarantine-dispute?page=with:block-614ad64b8f087b5c6fb4a8dc#block-614ad64b8f087b5c6fb4a8dc">Australia tourism minister says</a> on track to reopen borders ‘by Christmas’</p>\n<ul>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/2021/sep/22/calculated-risk-ardern-gambles-as-new-zealand-covid-restrictions-eased">Ardern gambles as New Zealand Covid restrictions eased</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/australia-news/2021/sep/22/riot-police-on-melbourne-streets-to-prevent-third-day-of-protests">Riot police on Melbourne streets to prevent third day of protests</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/global-development/2021/sep/21/argentina-to-lift-almost-all-covid-restrictions-as-cases-and-deaths-fall">Argentina to lift almost all Covid restrictions as cases and deaths fall</a></li>\n <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/education/2021/sep/21/more-than-100000-pupils-off-school-in-england-last-week-amid-covid-surge">‘High alert’ warning as more than 100,000 pupils in England miss school</a></li>\n</ul>',
-).toOption();
+).toOptional();
 
 const bylineHtml: Option<DocumentFragment> = parseHtml(
 	'<a href="https://theguardian.com">Tom Ambrose</a> (now); <a href="https://theguardian.com">Miranda Bryant</a> and <a href="https://theguardian.com">Helen Sullivan</a> (earlier)',

--- a/apps-rendering/src/fixtures/newsletterSignUpContent.ts
+++ b/apps-rendering/src/fixtures/newsletterSignUpContent.ts
@@ -18,7 +18,9 @@ const parser = new DOMParser();
 const parseHtml = (html: string): Optional<DocumentFragment> =>
 	parse(parser)(html).toOptional();
 
-const captionDocFragment = parseHtml('Fashion Statement Email image').toOption();
+const captionDocFragment = parseHtml(
+	'Fashion Statement Email image',
+).toOption();
 
 const newsletterMainMedia: Option<MainMedia> = {
 	kind: OptionKind.Some,

--- a/apps-rendering/src/fixtures/newsletterSignUpContent.ts
+++ b/apps-rendering/src/fixtures/newsletterSignUpContent.ts
@@ -15,13 +15,10 @@ import type { MainMedia } from 'mainMedia';
 import { Optional } from 'optional';
 
 const parser = new DOMParser();
-const parseHtml = (html: string): Option<DocumentFragment> =>
-	parse(parser)(html).either<Option<DocumentFragment>>(
-		(_err) => none,
-		(doc) => some(doc),
-	);
+const parseHtml = (html: string): Optional<DocumentFragment> =>
+	parse(parser)(html).toOptional();
 
-const captionDocFragment = parseHtml('Fashion Statement Email image');
+const captionDocFragment = parseHtml('Fashion Statement Email image').toOption();
 
 const newsletterMainMedia: Option<MainMedia> = {
 	kind: OptionKind.Some,

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -322,8 +322,9 @@ const parseItemFields = (
 		),
 		display: getDisplay(content),
 		headline: content.fields?.headline ?? '',
-		standfirst: Optional.fromNullable(content.fields?.standfirst)
-			.map(context.docParser),
+		standfirst: Optional.fromNullable(content.fields?.standfirst).map(
+			context.docParser,
+		),
 		byline: content.fields?.byline ?? '',
 		bylineHtml: pipe(
 			content.fields?.bylineHtml,

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -56,7 +56,7 @@ import { Result } from 'result';
 
 interface Fields extends ArticleFormat {
 	headline: string;
-	standfirst: Option<DocumentFragment>;
+	standfirst: Optional<DocumentFragment>;
 	byline: string;
 	bylineHtml: Option<DocumentFragment>;
 	publishDate: Option<Date>;
@@ -322,11 +322,8 @@ const parseItemFields = (
 		),
 		display: getDisplay(content),
 		headline: content.fields?.headline ?? '',
-		standfirst: pipe(
-			content.fields?.standfirst,
-			fromNullable,
-			map(context.docParser),
-		),
+		standfirst: Optional.fromNullable(content.fields?.standfirst)
+			.map(context.docParser),
 		byline: content.fields?.byline ?? '',
 		bylineHtml: pipe(
 			content.fields?.bylineHtml,


### PR DESCRIPTION
## Why?

Migrating `Option` to `Optional` in small stages.

## Changes

- Migrate `standfirst` field in `Item` to `Optional`
