### PR TITLE
Pass description to front html template

### DIFF
--- a/dotcom-rendering/src/web/server/frontToHtml.tsx
+++ b/dotcom-rendering/src/web/server/frontToHtml.tsx
@@ -146,6 +146,7 @@ export const frontToHtml = ({ front }: Props): string => {
 		css: extractedCss,
 		html,
 		title,
+		description: front.pressedPage.seoData.description,
 		windowGuardian,
 		gaPath,
 		keywords,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Passes description through to HTML template

## Why?

Parity

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/206757381-29dd8476-5f2d-4216-95c8-54257677a244.png
[after]: https://user-images.githubusercontent.com/9575458/206757295-e915fae3-4644-4878-b1e6-84b580d27dd0.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
