### PR TITLE
Fix: FixedSmallSlow1 sublinks

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowI.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowI.tsx
@@ -1,8 +1,8 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { Card100Media75 } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -21,16 +21,10 @@ export const FixedSmallSlowI = ({
 		<UL>
 			{firstSlice100.map((card) => (
 				<LI padSides={true} key={card.url}>
-					<FrontCard
+					<Card100Media75
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						imagePosition="right"
-						imagePositionOnMobile="top"
-						imageSize="jumbo"
-						headlineSize="huge"
-						headlineSizeOnMobile="large"
-						trailText={card.trailText}
 					/>
 				</LI>
 			))}


### PR DESCRIPTION
This adds sublinks to the card, taking advantage of the wrapper element's sublink display logic.

Closes #6696 as part of #6691.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

It displays the single card in FixedSlowSmallI using `Card100Media75` instead of `FrontCard`. 


## Why?

The new element has the same configuration as the original, but it also adds the right sublink behaviour for this container (checked against Frontend)

## Screenshots

Frontend (left) and DCR (right) match now
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/37048459/207068432-01763a55-128c-4164-b4df-0708e349b1df.png">


## Additional issues

While working on this I noticed that the trail text for the new card doesn't follow the same rules as on Frontend. However, I've checked the way Frontend vs DCR renders other cards which are currently using `Card100Media75` and there's a discrepancy there, too. Given that the discrepancy is more widespread, I'm going to open a separate PR for this (issue #6763)