### PR TITLE
Fix: FixedSlowSmallVThird Sublinks

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVThird.tsx
@@ -1,5 +1,6 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { Card25Media25Tall } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -29,12 +30,10 @@ export const FixedSmallSlowVThird = ({
 						containerPalette={containerPalette}
 						percentage="25%"
 					>
-						<FrontCard
+						<Card25Media25Tall
 							trail={trail}
-							starRating={trail.starRating}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							supportingContent={trail.supportingContent}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Uses `Card25Media25Tall` instead of `FrontCard` for the first two columns. This preserves the existing behaviour, but adds the correct sublink behaviour (in relation to Frontend).

Closes #6697 as part of #6691.

## Chromatic diffs

Frontend only renders up to 2 sublinks on the first two cards on this component, so the Chromatic change is expected.

## Screenshots

### One sublink (Frontend | DCR)
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/37048459/207099751-fbdded50-5137-4b08-8c71-71863828b8f2.png">


### Two sublinks (Frontend | DCR)
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/37048459/207085974-f3f22ae0-4af3-4f53-845e-45c9a6144b21.png">


