### PR TITLE
Only relative paths in module imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
     ],
     "git.branchProtection": [
         "main"
-    ]
+	],
+	"javascript.preferences.importModuleSpecifier": "relative"
 }

--- a/dotcom-rendering/.eslintrc.js
+++ b/dotcom-rendering/.eslintrc.js
@@ -135,6 +135,18 @@ module.exports = {
 			// https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md#options
 			{ packageDir: ['..', '.'] },
 		],
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: ['src/*'],
+						message:
+							'Paths starting with “src/” are forbidden. Please use a relative path instead',
+					},
+				],
+			},
+		],
 
 		'id-denylist': ['error', 'whitelist', 'whiteList', 'WHITELIST'],
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -452,7 +452,7 @@ interface BaseTrailType {
 	commentCount?: number;
 	starRating?: number;
 	linkText?: string;
-	branding?: import('src/types/branding').Branding;
+	branding?: import('./src/types/branding').Branding;
 	isSnap?: boolean;
 	snapData?: import('./src/types/front').DCRSnapType;
 }

--- a/dotcom-rendering/src/amp/components/Elements.tsx
+++ b/dotcom-rendering/src/amp/components/Elements.tsx
@@ -1,5 +1,5 @@
-import type { Switches } from 'src/types/config';
 import { NotRenderableInDCR } from '../../lib/errors/not-renderable-in-dcr';
+import type { Switches } from '../../types/config';
 import type { CAPIElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import { enhance } from '../lib/enhance';

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
-import type { TableOfContentsItem } from 'src/types/frontend';
-import { CAPIElement, SubheadingBlockElement } from '../types/content';
+import type { CAPIElement, SubheadingBlockElement } from '../types/content';
+import type { TableOfContentsItem } from '../types/frontend';
 
 const isH2 = (element: CAPIElement): element is SubheadingBlockElement => {
 	return (

--- a/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.test.ts
@@ -1,4 +1,4 @@
-import type { ServerSideTests } from 'src/types/config';
+import type { ServerSideTests } from '../../../types/config';
 import { abTestPayload } from './ophan';
 
 describe('abTestPayload', () => {

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -6,7 +6,7 @@ import type {
 	OphanComponentEvent,
 } from '@guardian/libs';
 import { log } from '@guardian/libs';
-import type { ServerSideTests } from 'src/types/config';
+import type { ServerSideTests } from '../../../types/config';
 
 export type OphanRecordFunction = (
 	event: { [key: string]: any },

--- a/dotcom-rendering/src/web/components/Callout/CheckboxSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/CheckboxSelect.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
-import type { CampaignFieldCheckbox } from 'src/types/content';
+import type { CampaignFieldCheckbox } from '../../../types/content';
 
 type Props = {
 	formField: CampaignFieldCheckbox;

--- a/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FieldLabel.tsx
@@ -4,7 +4,7 @@ import {
 	textSans,
 	visuallyHidden,
 } from '@guardian/source-foundations';
-import type { CampaignFieldType } from 'src/types/content';
+import type { CampaignFieldType } from '../../../types/content';
 
 const fieldLabelStyles = css`
 	${textSans.medium({ fontWeight: 'bold' })}

--- a/dotcom-rendering/src/web/components/Callout/MultiSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/MultiSelect.tsx
@@ -1,7 +1,7 @@
 import type {
 	CampaignFieldCheckbox,
 	CampaignFieldRadio,
-} from 'src/types/content';
+} from '../../../types/content';
 import { CheckboxSelect } from './CheckboxSelect';
 import { RadioSelect } from './RadioSelect';
 

--- a/dotcom-rendering/src/web/components/Callout/RadioSelect.tsx
+++ b/dotcom-rendering/src/web/components/Callout/RadioSelect.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { Radio, RadioGroup } from '@guardian/source-react-components';
-import type { CampaignFieldRadio } from 'src/types/content';
+import type { CampaignFieldRadio } from '../../../types/content';
 import { FieldLabel } from './FieldLabel';
 
 type FieldProp = {

--- a/dotcom-rendering/src/web/components/Callout/Select.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Select.tsx
@@ -1,5 +1,5 @@
 import { Select as SourceSelect } from '@guardian/source-react-components';
-import type { CampaignFieldSelect } from 'src/types/content';
+import type { CampaignFieldSelect } from '../../../types/content';
 
 type Props = {
 	validationErrors?: { [key in string]: string };

--- a/dotcom-rendering/src/web/components/Callout/TextArea.tsx
+++ b/dotcom-rendering/src/web/components/Callout/TextArea.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { TextArea as SourceTextArea } from '@guardian/source-react-components';
-import type { CampaignFieldTextArea } from 'src/types/content';
+import type { CampaignFieldTextArea } from '../../../types/content';
 
 const textAreaStyles = css`
 	width: 100%;

--- a/dotcom-rendering/src/web/components/Callout/TextInput.tsx
+++ b/dotcom-rendering/src/web/components/Callout/TextInput.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
 import { TextInput as SourceTextInput } from '@guardian/source-react-components';
-import type { CampaignFieldText } from 'src/types/content';
+import type { CampaignFieldText } from '../../../types/content';
 
 const textInputStyles = css`
 	margin-top: ${space[2]}px;

--- a/dotcom-rendering/src/web/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/LI.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import type { DCRContainerPalette } from 'src/types/front';
+import type { DCRContainerPalette } from '../../../../types/front';
 import { verticalDivider } from '../../../lib/verticalDivider';
 import { verticalDividerWithBottomOffset } from '../../../lib/verticalDividerWithBottomOffset';
 

--- a/dotcom-rendering/src/web/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/UL.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source-foundations';
-import type { DCRContainerPalette } from 'src/types/front';
+import type { DCRContainerPalette } from '../../../../types/front';
 import { verticalDivider } from '../../../lib/verticalDivider';
 
 type Direction = 'row' | 'column' | 'row-reverse';

--- a/dotcom-rendering/src/web/components/DiscussionWhenSignedIn.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionWhenSignedIn.tsx
@@ -1,5 +1,5 @@
 import { joinUrl } from '@guardian/libs';
-import type { Props as DiscussionProps } from 'src/web/components/Discussion';
+import type { Props as DiscussionProps } from '../../web/components/Discussion';
 import { useApi } from '../lib/useApi';
 import { Discussion } from './Discussion';
 

--- a/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicPackage.stories.tsx
@@ -1,6 +1,6 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { DCRGroupedTrails } from 'src/types/front';
 import { trails } from '../../../fixtures/manual/trails';
+import type { DCRGroupedTrails } from '../../types/front';
 import { DynamicPackage } from './DynamicPackage';
 import { Section } from './Section';
 

--- a/dotcom-rendering/src/web/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlow.tsx
@@ -1,5 +1,5 @@
-import type { TrailType } from 'src/types/trails';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
+import type { TrailType } from '../../types/trails';
 import {
 	Card25Media25Tall,
 	Card50Media50,

--- a/dotcom-rendering/src/web/components/MiniCard.tsx
+++ b/dotcom-rendering/src/web/components/MiniCard.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { body, breakpoints } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
-import type { DCRContainerPalette } from 'src/types/front';
-import type { TrailType } from 'src/types/trails';
+import type { DCRContainerPalette } from '../../types/front';
 import type { ContainerOverrides } from '../../types/palette';
+import type { TrailType } from '../../types/trails';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
 import { generateSources } from './Picture';
 

--- a/dotcom-rendering/src/web/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/web/components/ShowMore.importable.tsx
@@ -12,8 +12,8 @@ import {
 	SvgPlus,
 } from '@guardian/source-react-components';
 import { useEffect, useState } from 'react';
-import type { DCRContainerPalette, FEFrontCard } from 'src/types/front';
 import { enhanceCards } from '../../model/enhanceCards';
+import type { DCRContainerPalette, FEFrontCard } from '../../types/front';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { useApi } from '../lib/useApi';
 import { useOnce } from '../lib/useOnce';

--- a/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
-import type { TableOfContentsItem } from 'src/types/frontend';
+import type { TableOfContentsItem } from '../../types/frontend';
 import { TableOfContents } from './TableOfContents';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {

--- a/dotcom-rendering/src/web/components/TableOfContents.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.tsx
@@ -4,7 +4,7 @@ import {
 	SvgChevronDownSingle,
 	SvgChevronUpSingle,
 } from '@guardian/source-react-components';
-import type { TableOfContentsItem } from 'src/types/frontend';
+import type { TableOfContentsItem } from '../../types/frontend';
 
 interface Props {
 	tableOfContents: TableOfContentsItem[];

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.test.ts
@@ -1,4 +1,4 @@
-import type { CAPIElement } from 'src/types/content';
+import type { CAPIElement } from '../../types/content';
 import { calculateBlockSize, shouldDisplayAd } from './liveblogAdSlots';
 
 describe('calculateBlockSize', () => {

--- a/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
+++ b/dotcom-rendering/src/web/lib/liveblogAdSlots.ts
@@ -1,4 +1,4 @@
-import type { CAPIElement } from 'src/types/content';
+import type { CAPIElement } from '../../types/content';
 
 /**
  * Maximum number of inline ads to display on the page.

--- a/dotcom-rendering/src/web/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/web/lib/verticalDivider.ts
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { border, from } from '@guardian/source-foundations';
-import type { DCRContainerPalette } from 'src/types/front';
+import type { DCRContainerPalette } from '../../types/front';
 import { decideContainerOverrides } from './decideContainerOverrides';
 
 export const verticalDivider = (

--- a/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
+++ b/dotcom-rendering/src/web/lib/verticalDividerWithBottomOffset.ts
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { border, from } from '@guardian/source-foundations';
-import type { DCRContainerPalette } from 'src/types/front';
+import type { DCRContainerPalette } from '../../types/front';
 import { decideContainerOverrides } from './decideContainerOverrides';
 
 export function verticalDividerWithBottomOffset(

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -1,20 +1,20 @@
 {
-  "extends": "@guardian/tsconfig/tsconfig.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./",
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "@emotion/react",
-    "lib": ["esnext", "es2015", "dom"],
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "paths": {
-      /* Aliases should also be added to the webpack, babel and jest configurations */
-      "*": ["node_modules/@types/*", "*"] // Make sure that yarn linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
-    },
-    "preserveConstEnums": true
-  },
-  "exclude": ["cypress", "./cypress.config.js"]
+	"extends": "@guardian/tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"baseUrl": "./",
+		"forceConsistentCasingInFileNames": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "@emotion/react",
+		"lib": ["esnext", "es2015", "dom"],
+		"noEmit": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"paths": {
+			/* Aliases should also be added to the webpack, babel and jest configurations */
+			"*": ["node_modules/@types/*", "*"] // Make sure that yarn linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
+		},
+		"preserveConstEnums": true
+	},
+	"exclude": ["cypress", "./cypress.config.js"]
 }


### PR DESCRIPTION
## What does this change?

Prevent usage of non-relative paths, such as those starting with 'src/'.

## Why?

Part of #5863
