### PR TITLE
Remove unused Card100 component and fix Card100Media75 trail text logic

### DIFF
--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -59,7 +59,7 @@ export const Card100Media75 = ({
 			trailText={
 				// Only show trail text if there is no supportContent
 				trail.supportingContent === undefined ||
-				trail.supportingContent.length === 3
+				trail.supportingContent.length !== 3
 					? trail.trailText
 					: undefined
 			}

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -59,7 +59,7 @@ export const Card100Media75 = ({
 			trailText={
 				// Only show trail text if there is no supportContent
 				trail.supportingContent === undefined ||
-				trail.supportingContent.length === 0
+				trail.supportingContent.length === 3
 					? trail.trailText
 					: undefined
 			}

--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -22,39 +22,6 @@ import {
  * ' ' | '_'      => text / trail / supporting content
  */
 
-/* .___________________________________.
- * |         ##########################|
- * |         ###########(^)>###########|
- * |         ###########(_)############|
- * |         ##########################|
- * |_________##########################|
- */
-export const Card100 = ({
-	cards,
-	containerPalette,
-	showAge,
-}: {
-	cards: TrailType[];
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-}) => {
-	const card100 = cards.slice(0, 1);
-
-	return (
-		<UL>
-			{card100.map((trail) => (
-				<LI padSides={true}>
-					<Card100Media75
-						trail={trail}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				</LI>
-			))}
-		</UL>
-	);
-};
-
 /* ._________________._________________.
  * |#################|#################|
  * |#################|#################|


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

1. It shows the `trailText` on `Card100Media75` unless there are exactly 3 sublinks for that card.
2. It also removes `Card100` from `dynamicSlices.tsx`, because it was not used, and was _almost_ identical to `Card100PictureRight`, which is used. Given the (near) redundancy, it seems sensible to remove the code unless it's being used.

## Why?

Parity with Frontend for `DynamicFast` and `FixedSlowSmall-I`; see screenshots in #6763 

## Screenshots

Before (Frontend) | After (DCR, this PR)
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/37048459/207113623-17b05e87-7c4d-48f9-88bb-cd217aacfc0a.png">
