### PR TITLE
Check readText function exists in dev-index

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -356,6 +356,7 @@
 				if (document.visibilityState !== 'visible') return;
 				if (!navigator?.clipboard) return;
 				if (!document.hasFocus()) return;
+				if (typeof navigator.clipboard.readText !== 'function') return;
 
 				navigator.clipboard.readText().then((text) => {
 					const guurl = [


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Check if the readText function exists

## Why?

Sometimes it doesn't exist in firefox, and this breaks other parts of the dev-server index
