### PR TITLE
fix(zip): remove AR before zipping

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -128,6 +128,7 @@
 		"@types/react-google-recaptcha": "^2.1.5",
 		"@types/react-test-renderer": "18.0.0",
 		"@types/response-time": "^2.3.4",
+		"@types/rimraf": "^3.0.2",
 		"@types/sanitize-html": "^2.6.0",
 		"@types/twitter-for-web": "^0.0.2",
 		"@types/uuid": "^8.3.4",

--- a/dotcom-rendering/scripts/deploy/build-riffraff-bundle.js
+++ b/dotcom-rendering/scripts/deploy/build-riffraff-bundle.js
@@ -1,9 +1,9 @@
 const { promisify } = require('util');
 const writeFile = promisify(require('fs').writeFile);
-
-const execa = require('execa');
-const path = require('path');
 const cpy = require('cpy');
+const execa = require('execa');
+const rimraf = require('rimraf');
+const path = require('path');
 const { warn, log } = require('../env/log');
 
 const target = path.resolve(__dirname, '../..', 'target');
@@ -79,6 +79,11 @@ const zipBundle = () => {
 	});
 };
 
+const removeAR = () => {
+	log(' - removing ../apps-rendering');
+	return new Promise((resolve) => rimraf('../apps-rendering', resolve));
+};
+
 const createBuildConfig = () => {
 	log(' - creating build.json');
 	const buildConfig = {
@@ -97,6 +102,7 @@ const createBuildConfig = () => {
 };
 
 Promise.all([copyCfn(), copyStatic(), copyDist(), copyRiffRaff()])
+	.then(removeAR)
 	.then(zipBundle)
 	.then(createBuildConfig)
 	.catch((err) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,6 +5592,14 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/sanitize-html@^2.6.0":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.6.2.tgz#9c47960841b9def1e4c9dfebaaab010a3f6e97b9"


### PR DESCRIPTION
Fixes #6767 

## What does this change?

Remove apps-rendering folder before zipping artefact

## Why?

DCR does not need AR’s contents or its node_modules for its PROD artefact.

This reduces the zipped artefact bundle from ~720MB to ~280MB (less than 40% of original size)


## Next steps

- [ ] Audit needed packages for PROD, currently still 1.3GB are shipped in the artefact. We probably only need `pm2` and a handful of other things.
- [ ] Discuss with DevX wether we expect the base image to start at 4.4GB. This seems somewhat high.
- [ ] Make sure we get alerts above certain levels. Report if disk usage at startup is over 80%?
- [ ] Investigate why we are currently using `t4g.small`, min: 9, max: 36. The goal would be to scale vertically instead of horizontally. (Not directly related to this issue but somewhat related and something we should look into at some point.)
