### PR TITLE
feat: Add support for "Breaking news" toggle

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -113,6 +113,12 @@ const decideImage = (trail: FEFrontCard) => {
 	return trail.properties.maybeContent?.trail.trailPicture?.allImages[0].url;
 };
 
+const decideKicker = (trail: FEFrontCard) => {
+	return trail.properties.isBreaking
+		? 'Breaking news'
+		: trail.header.kicker?.item?.properties.kickerText;
+};
+
 const enhanceTags = (tags: FETagType[]): TagType[] => {
 	return tags.map(({ properties }) => {
 		const {
@@ -181,7 +187,7 @@ export const enhanceCards = (
 				  ).toISOString()
 				: undefined,
 			image: decideImage(faciaCard),
-			kickerText: faciaCard.header.kicker?.item?.properties.kickerText,
+			kickerText: decideKicker(faciaCard),
 			supportingContent: faciaCard.supportingContent
 				? enhanceSupportingContent(
 						faciaCard.supportingContent,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for the "Breaking news" card config toggle

## Why?

Fixes #6444 

## Screenshots

| Frontend      | DCR      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/207314508-f4f64a28-6666-4f72-9056-e9f9e06eb6d2.png

[after]: https://user-images.githubusercontent.com/21217225/207314355-87ea5887-86ff-4899-826a-e6ff31e3eb27.png

(interestingly Frontend is showing trailText whilst DCR isn't, but pretty sure thats unrelated to this PR)