### PR TITLE
Add Readme to generated stories

### DIFF
--- a/dotcom-rendering/.storybook/main.js
+++ b/dotcom-rendering/.storybook/main.js
@@ -17,7 +17,11 @@ module.exports = {
 	core: {
 		builder: 'webpack5',
 	},
-	stories: ['../src/**/*.stories.@(tsx)', '../stories/**/*.stories.@(tsx)'],
+	stories: [
+		'../src/**/*.stories.@(tsx)',
+		'../stories/**/*.stories.@(tsx)',
+		'../stories/**/*.stories.@(jsx)',
+	],
 	staticDirs: ['../src/static'],
 	addons: [
 		'@storybook/addon-essentials',

--- a/dotcom-rendering/scripts/gen-stories/get-stories.js
+++ b/dotcom-rendering/scripts/gen-stories/get-stories.js
@@ -28,6 +28,8 @@ const STORIES_PATH = path.resolve(
 );
 const LAYOUT_STORIES_FILE = path.resolve(STORIES_PATH, 'Layout.stories.tsx');
 const CARD_STORIES_FILE = path.resolve(STORIES_PATH, 'Card.stories.tsx');
+const README_FILE = (componentName) =>
+	path.resolve(STORIES_PATH, `${componentName}Readme.stories.jsx`);
 
 const CARD_TEMPLATE_HEADER = `
 /*
@@ -67,6 +69,36 @@ export default {
 		},
 	},
 };
+`;
+
+const README_TEMPLATE = (componentName) => `
+import { css } from '@emotion/react';
+
+const ReadMe = () => (
+	<section css={css\`
+		padding: 1rem;
+		& h1, p{
+			margin-bottom: 0.5rem;
+		}
+		\`}>
+		<h1 css={css\`font-size: 1.5em; font-weight: 400;\`}>Readme</h1>
+		<p>
+			The stories in this directory are automatically generated.
+		</p>
+		<p>
+			To add new format variations to test, please edit the list in \`get-stories.js\`.
+		</p>
+	</section>
+);
+
+// eslint-disable-next-line import/no-default-export
+export default {
+	title: 'Components/${componentName}/Format Variations',
+	component: ReadMe,
+	chromatic: { disableSnapshot: true },
+};
+
+export const Readme = () => <ReadMe />;
 `;
 
 const notNumber = (value) => {
@@ -164,11 +196,17 @@ const saveStories = () => {
 		`[scripts/gen-stories] Saved layout stories to ${LAYOUT_STORIES_FILE}!`,
 	);
 
+	writeFileSync(README_FILE('Layout'), README_TEMPLATE('Layout'));
+	success(`[scripts/gen-stories] Saved Readme ${README_FILE('Card')}!`);
+
 	const cardContents = generateCardStories();
 	writeFileSync(CARD_STORIES_FILE, cardContents);
 	success(
 		`[scripts/gen-stories] Saved layout stories to ${CARD_STORIES_FILE}!`,
 	);
+
+	writeFileSync(README_FILE('Card'), README_TEMPLATE('Card'));
+	success(`[scripts/gen-stories] Saved Readme ${README_FILE('Card')}!`);
 };
 
 const checkStories = () => {

--- a/dotcom-rendering/stories/generated/CardReadme.stories.jsx
+++ b/dotcom-rendering/stories/generated/CardReadme.stories.jsx
@@ -1,0 +1,28 @@
+
+import { css } from '@emotion/react';
+
+const ReadMe = () => (
+	<section css={css`
+		padding: 1rem;
+		& h1, p{
+			margin-bottom: 0.5rem;
+		}
+		`}>
+		<h1 css={css`font-size: 1.5em; font-weight: 400;`}>Readme</h1>
+		<p>
+			The stories in this directory are automatically generated.
+		</p>
+		<p>
+			To add new format variations to test, please edit the list in `get-stories.js`.
+		</p>
+	</section>
+);
+
+// eslint-disable-next-line import/no-default-export
+export default {
+	title: 'Components/Card/Format Variations',
+	component: ReadMe,
+	chromatic: { disableSnapshot: true },
+};
+
+export const Readme = () => <ReadMe />;

--- a/dotcom-rendering/stories/generated/LayoutReadme.stories.jsx
+++ b/dotcom-rendering/stories/generated/LayoutReadme.stories.jsx
@@ -1,0 +1,28 @@
+
+import { css } from '@emotion/react';
+
+const ReadMe = () => (
+	<section css={css`
+		padding: 1rem;
+		& h1, p{
+			margin-bottom: 0.5rem;
+		}
+		`}>
+		<h1 css={css`font-size: 1.5em; font-weight: 400;`}>Readme</h1>
+		<p>
+			The stories in this directory are automatically generated.
+		</p>
+		<p>
+			To add new format variations to test, please edit the list in `get-stories.js`.
+		</p>
+	</section>
+);
+
+// eslint-disable-next-line import/no-default-export
+export default {
+	title: 'Components/Layout/Format Variations',
+	component: ReadMe,
+	chromatic: { disableSnapshot: true },
+};
+
+export const Readme = () => <ReadMe />;


### PR DESCRIPTION
Generates Readme stories that sit alongside generated stories, to highlight that they are generated and to indicate how to add/edit generated stories.