### PR TITLE
fix: typescript errors in HeaderTopBarEdition dropdown

### DIFF
--- a/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
@@ -28,7 +28,13 @@ export const HeaderTopBarEditionDropdown = ({
 	dataLinkName,
 	isInEuropeTest,
 }: HeaderTopBarEditionDropdownProps) => {
-	const links: [HeaderLink, HeaderLink, HeaderLink, HeaderLink] = [
+	const links: [
+		HeaderLink,
+		HeaderLink,
+		HeaderLink,
+		HeaderLink,
+		...HeaderLink[],
+	] = [
 		{
 			id: 'uk',
 			url: '/preference/edition/uk',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Fixes typescript errors in HeaderTopBarEdition

## Why?

#6719 was slightly out of date with main when it was merged so this wasn't noticed

