### PR TITLE
More consistent use of `DropdownLinkType`

### DIFF
--- a/dotcom-rendering/src/types/header.ts
+++ b/dotcom-rendering/src/types/header.ts
@@ -1,7 +1,0 @@
-export type HeaderLink = {
-	id: string;
-	url: string;
-	title: string;
-	isActive?: boolean;
-	dataLinkName: string;
-};

--- a/dotcom-rendering/src/web/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { brandBackground } from '@guardian/source-foundations';
-import { HeaderLink } from '../../types/header';
+import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
 const Header = ({ children }: { children: React.ReactNode }) => (
@@ -33,7 +33,12 @@ const Nav = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-const links: [HeaderLink, HeaderLink, HeaderLink, HeaderLink] = [
+const links: [
+	DropdownLinkType,
+	DropdownLinkType,
+	DropdownLinkType,
+	DropdownLinkType,
+] = [
 	{
 		id: 'uk',
 		url: '/preference/edition/uk',

--- a/dotcom-rendering/src/web/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/web/components/Dropdown.test.tsx
@@ -1,8 +1,13 @@
 import { fireEvent, render } from '@testing-library/react';
-import { HeaderLink } from '../../types/header';
+import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
-const links: [HeaderLink, HeaderLink, HeaderLink, HeaderLink] = [
+const links: [
+	DropdownLinkType,
+	DropdownLinkType,
+	DropdownLinkType,
+	DropdownLinkType,
+] = [
 	{
 		id: 'uk',
 		url: '/preference/edition/uk',

--- a/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
+++ b/dotcom-rendering/src/web/components/EditionDropdown.importable.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { brand, from } from '@guardian/source-foundations';
-import { HeaderLink } from '../../types/header';
 import type { EditionId } from '../lib/edition';
 import { getZIndex } from '../lib/getZIndex';
+import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
 const editionDropdown = css`
@@ -41,7 +41,7 @@ export const EditionDropdown = ({
 	dataLinkName,
 	isInEuropeTest,
 }: Props) => {
-	const links: [HeaderLink, ...HeaderLink[]] = [
+	const links: [DropdownLinkType, ...DropdownLinkType[]] = [
 		{
 			id: 'uk',
 			url: '/preference/edition/uk',

--- a/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/web/components/HeaderTopBarEditionDropdown.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { brand } from '@guardian/source-foundations';
-import { HeaderLink } from '../../types/header';
 import type { EditionId } from '../lib/edition';
 import { getZIndex } from '../lib/getZIndex';
+import type { DropdownLinkType } from './Dropdown';
 import { Dropdown } from './Dropdown';
 import { dropDownOverrides } from './HeaderTopBarMyAccount';
 
@@ -28,38 +28,30 @@ export const HeaderTopBarEditionDropdown = ({
 	dataLinkName,
 	isInEuropeTest,
 }: HeaderTopBarEditionDropdownProps) => {
-	const links: [
-		HeaderLink,
-		HeaderLink,
-		HeaderLink,
-		HeaderLink,
-		...HeaderLink[],
-	] = [
-		{
-			id: 'uk',
-			url: '/preference/edition/uk',
-			isActive: editionId === 'UK',
-			title: 'UK edition',
-			dataLinkName: 'nav3 : topbar : edition-picker: UK',
-		},
+	const ukEdition: DropdownLinkType = {
+		id: 'uk',
+		url: '/preference/edition/uk',
+		title: 'UK edition',
+		dataLinkName: 'nav3 : topbar : edition-picker: UK',
+	};
+
+	const links: DropdownLinkType[] = [
+		ukEdition,
 		{
 			id: 'us',
 			url: '/preference/edition/us',
-			isActive: editionId === 'US',
 			title: 'US edition',
 			dataLinkName: 'nav3 : topbar : edition-picker: US',
 		},
 		{
 			id: 'au',
 			url: '/preference/edition/au',
-			isActive: editionId === 'AU',
 			title: 'Australia edition',
 			dataLinkName: 'nav3 : topbar : edition-picker: AU',
 		},
 		{
 			id: 'int',
 			url: '/preference/edition/int',
-			isActive: editionId === 'INT',
 			title: 'International edition',
 			dataLinkName: 'nav3 : topbar : edition-picker: INT',
 		},
@@ -68,20 +60,28 @@ export const HeaderTopBarEditionDropdown = ({
 					{
 						id: 'eur',
 						url: '/preference/edition/eur',
-						isActive: editionId === 'EUR',
 						title: 'Europe edition',
 						dataLinkName: 'nav3 : topbar : edition-picker: EUR',
 					},
 			  ]
 			: []),
-	];
+	].map((link) =>
+		link.id.toUpperCase() === editionId
+			? { ...link, isActive: true }
+			: link,
+	);
 
 	// Find active link, default to UK
-	const activeLink = links.find((link) => link.isActive) || links[0];
+	const activeLink = links.find(({ isActive }) => isActive) ?? {
+		...ukEdition,
+		isActive: true,
+	};
 
 	// Remove the active link and add it back to the top of the list
-	const linksToDisplay = links.filter((link) => !link.isActive);
-	linksToDisplay.unshift(activeLink);
+	const linksToDisplay = [
+		activeLink,
+		...links.filter(({ isActive }) => !isActive),
+	];
 
 	return (
 		<div css={editionDropdownStyles}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove the `HeaderLink` type in favour of the more generic `DropdownLinkType`.

Refactor some logic to avoid mutations.

## Why?

We want to reduce type profileration if we can.

Follow-up on #6785 and #6609 