### PR TITLE
fix: typo in headerTopBarSearchCapi

### DIFF
--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -356,7 +356,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!CAPIArticle.config.switches
-										.headerTopBarSearchCapiSwitch
+										.headerTopBarSearchCapi
 								}
 							/>
 						</Section>

--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -217,8 +217,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							idApiUrl="https://idapi.theguardian.com/" // TODO: read this from somewhere as in other layouts
 							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
-								!!front.config.switches
-									.headerTopBarSearchCapiSwitch
+								!!front.config.switches.headerTopBarSearchCapi
 							}
 						/>
 					</Section>

--- a/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FullPageInteractiveLayout.tsx
@@ -233,7 +233,7 @@ const NavHeader = ({ CAPIArticle, NAV, format }: Props) => {
 							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!CAPIArticle.config.switches
-									.headerTopBarSearchCapiSwitch
+									.headerTopBarSearchCapi
 							}
 						/>
 					</Section>

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -291,7 +291,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!CAPIArticle.config.switches
-										.headerTopBarSearchCapiSwitch
+										.headerTopBarSearchCapi
 								}
 							/>
 						</Section>

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -346,7 +346,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							isInEuropeTest={isInEuropeTest}
 							headerTopBarSearchCapiSwitch={
 								!!CAPIArticle.config.switches
-									.headerTopBarSearchCapiSwitch
+									.headerTopBarSearchCapi
 							}
 						/>
 					</Section>

--- a/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/NewsletterSignupLayout.tsx
@@ -270,8 +270,7 @@ export const NewsletterSignupLayout = ({ CAPIArticle, NAV, format }: Props) => {
 						idApiUrl={CAPIArticle.config.idApiUrl}
 						isInEuropeTest={isInEuropeTest}
 						headerTopBarSearchCapiSwitch={
-							!!CAPIArticle.config.switches
-								.headerTopBarSearchCapiSwitch
+							!!CAPIArticle.config.switches.headerTopBarSearchCapi
 						}
 					/>
 				</Section>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -300,7 +300,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isInEuropeTest={isInEuropeTest}
 									headerTopBarSearchCapiSwitch={
 										!!CAPIArticle.config.switches
-											.headerTopBarSearchCapiSwitch
+											.headerTopBarSearchCapi
 									}
 								/>
 							</Section>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -396,7 +396,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								isInEuropeTest={isInEuropeTest}
 								headerTopBarSearchCapiSwitch={
 									!!CAPIArticle.config.switches
-										.headerTopBarSearchCapiSwitch
+										.headerTopBarSearchCapi
 								}
 							/>
 						</Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
`Switch` is added when in the app. It's just called `headerTopBarSearchCapi` from Frontend.

## Why?
To make the search switch work.