### PR TITLE
Add a Deadline component

### DIFF
--- a/apps-rendering/src/components/Deadline/index.test.ts
+++ b/apps-rendering/src/components/Deadline/index.test.ts
@@ -1,0 +1,28 @@
+import { getDeadlineText } from './index';
+
+describe('getDeadlineText', () => {
+	test('Returns null if deadline date is > 7 days away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 12, 24, 0, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe(undefined);
+	});
+	test('Rounds days if deadline date is < 30 days away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 8, 0, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Open for 7 more days');
+	});
+	test('Is singular if deadline date is 1 day away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 2, 2, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Open for 1 more day');
+	});
+	test('Is today if deadline date is <24 hours', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 1, 2, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Closing today');
+	});
+});

--- a/apps-rendering/src/components/Deadline/index.tsx
+++ b/apps-rendering/src/components/Deadline/index.tsx
@@ -1,0 +1,55 @@
+import { SvgClock } from '@guardian/source-react-components';
+import { isValidDate } from 'date';
+import type { FC } from 'react';
+import { highlight } from './styles';
+
+const Highlight: FC = ({ children }) => {
+	return <span css={highlight}>{children}</span>;
+};
+
+function getDaysBetween(first: Date, second: Date): number {
+	const ONE_DAY = 1000 * 3600 * 24;
+	return (second.getTime() - first.getTime()) / ONE_DAY;
+}
+
+export const getDeadlineText = (
+	date1: Date,
+	date2: Date,
+): string | undefined => {
+	const maxDays = 7;
+	const daysBetween = getDaysBetween(date1, date2);
+	if (daysBetween <= 0 || daysBetween > maxDays) return;
+	if (daysBetween <= 1) return 'Closing today';
+	if (Math.round(daysBetween) === 1) return 'Open for 1 more day';
+	return `Open for ${Math.round(daysBetween)} more days`;
+};
+
+function formatOptionalDate(date: number | undefined): Date | undefined {
+	if (date === undefined) return undefined;
+	const d = new Date(date);
+	if (!isValidDate(d)) return undefined;
+	return d;
+}
+
+function isCalloutActive(until?: number): boolean {
+	const untilDate = formatOptionalDate(until);
+	const now = new Date();
+
+	return untilDate === undefined || untilDate > now;
+}
+
+const DeadlineDate: FC<{ until?: number }> = ({ until }) => {
+	const untilDate = formatOptionalDate(until);
+	if (!untilDate) return null;
+	const now = new Date();
+	const deadlineText = getDeadlineText(now, untilDate);
+	if (!deadlineText) return null;
+	return (
+		<Highlight>
+			<SvgClock size="xsmall" />
+			{deadlineText}
+		</Highlight>
+	);
+};
+
+export { Highlight, DeadlineDate, isCalloutActive };

--- a/apps-rendering/src/components/Deadline/styles.ts
+++ b/apps-rendering/src/components/Deadline/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+import {
+	brandAlt,
+	neutral,
+	remSpace,
+	textSans,
+} from '@guardian/source-foundations';
+import { darkModeCss } from 'styles';
+
+export const highlight = css`
+	${textSans.xsmall()}
+	color: ${neutral[7]};
+	display: flex;
+	align-items: center;
+	padding: 0 ${remSpace[1]};
+	background: ${brandAlt[400]};
+	${darkModeCss`
+		background: ${brandAlt[200]};
+	`}
+`;


### PR DESCRIPTION
This PR is one of several that make up the Callout work that Editorial Experience is working on.
It has been split out to reduce the size of the PR's, and make it more easily understandable.

1. **Add a deadline component (this PR)**
2. [Replace the FileInput](https://github.com/guardian/dotcom-rendering/pull/6791)
3. [Create the new callout component](https://github.com/guardian/dotcom-rendering/pull/6800)
4. [Hydrate the new callout component](https://github.com/guardian/dotcom-rendering/pull/6802)
5. [Use the new callout component, and remove the old one](https://github.com/guardian/dotcom-rendering/pull/6805)

## What does this change?
Add a Deadline Component, which takes a deadline and calculates the number of days between the current time and the deadline. 
Note: This component isn't used until PR 3, when we add the new component

If the deadline is less than 7 days away, it renders some text warning that the deadline is approaching.
## Screenshots
<img width="168" alt="image" src="https://user-images.githubusercontent.com/26366706/207888681-654fceaa-c968-4f91-9ea9-ca203123dff7.png">
