### PR TITLE
Hydrate new callout component

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -56,7 +56,7 @@
 		"@guardian/renditions": "^0.2.0",
 		"@guardian/source-foundations": "^7.0.1",
 		"@guardian/source-react-components": "^9.0.0",
-		"@guardian/source-react-components-development-kitchen": "6.0.2",
+		"@guardian/source-react-components-development-kitchen": "8.1.0",
 		"@guardian/types": "^9.0.1",
 		"@storybook/addon-knobs": "^6.4.0",
 		"@storybook/addons": "^6.4.0",

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -36,6 +36,7 @@ import { createElement as h } from 'react';
 import ReactDOM from 'react-dom';
 import { logger } from '../logger';
 import { hydrate as hydrateAtoms } from './atoms';
+import { callouts } from './callouts';
 import { initSignupForms } from './newsletterSignupForm';
 
 // ----- Run ----- //
@@ -238,107 +239,6 @@ function footerInit(): void {
 		.catch((error) => {
 			logger.error(error);
 		});
-}
-
-type FormData = Record<string, string>;
-
-function submit(body: FormData, form: Element): void {
-	fetch(
-		'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
-		{
-			method: 'POST',
-			body: JSON.stringify(body),
-		},
-	)
-		.then(() => {
-			const message = document.createElement('p');
-			message.textContent = 'Thank you for your contribution';
-			if (form.firstChild) {
-				form.replaceChild(message, form.firstChild);
-			}
-		})
-		.catch(() => {
-			const errorPlaceholder = form.querySelector('.js-error-message');
-			if (errorPlaceholder) {
-				errorPlaceholder.textContent =
-					'Sorry, there was a problem submitting your form. Please try again later.';
-			}
-		});
-}
-
-function readFile(file: Blob): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		setTimeout(reject, 30000);
-
-		reader.addEventListener('load', () => {
-			if (reader.result) {
-				const fileAsBase64 = reader.result
-					.toString()
-					.split(';base64,')[1];
-				resolve(fileAsBase64);
-			}
-		});
-
-		reader.addEventListener('error', () => {
-			reject();
-		});
-
-		reader.readAsDataURL(file);
-	});
-}
-
-function callouts(): void {
-	const callouts = Array.from(document.querySelectorAll('.js-callout'));
-	callouts.forEach((callout) => {
-		const buttons = Array.from(
-			callout.querySelectorAll('.js-callout-expand'),
-		);
-		buttons.forEach((button) => {
-			button.addEventListener('click', () => {
-				callout.toggleAttribute('open');
-			});
-		});
-
-		const form = callout.querySelector('form');
-		if (!form) return;
-		form.addEventListener(
-			'submit',
-			// eslint-disable-next-line @typescript-eslint/no-misused-promises -- use async function
-			async (e): Promise<void> => {
-				try {
-					e.preventDefault();
-					const elements = form.getElementsByTagName('input');
-					const data = Array.from(elements).reduce(
-						async (o: Promise<FormData>, elem) => {
-							const acc = await o;
-							const { type, checked, name, value, files } = elem;
-							if (type === 'radio') {
-								if (checked) {
-									acc[name] = value;
-								}
-							} else if (type === 'file' && files?.length) {
-								acc[name] = await readFile(files[0]);
-							} else if (value) {
-								acc[name] = value;
-							}
-							return Promise.resolve(acc);
-						},
-						Promise.resolve({}),
-					);
-
-					submit(await data, form);
-				} catch (e) {
-					const errorPlaceholder =
-						form.querySelector('.js-error-message');
-					if (errorPlaceholder) {
-						errorPlaceholder.textContent =
-							'There was a problem with the file you uploaded above. We accept images and pdfs up to 6MB';
-					}
-				}
-			},
-		);
-	});
 }
 
 function hasSeenCards(): void {

--- a/apps-rendering/src/client/callouts.ts
+++ b/apps-rendering/src/client/callouts.ts
@@ -1,0 +1,209 @@
+import type { FormField } from '@guardian/apps-rendering-api-models/formField';
+import type { FormOption } from '@guardian/apps-rendering-api-models/formOption';
+import { ArticlePillar, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
+import { withDefault } from '@guardian/types';
+import { ElementKind } from 'bodyElementKind';
+import { pipe, resultFromNullable } from 'lib';
+import {
+	andThen,
+	arrayParser,
+	booleanParser,
+	documentFragmentParser,
+	fieldParser,
+	map,
+	map2,
+	map7,
+	maybe,
+	numberParser,
+	parse,
+	stringParser,
+	succeed,
+} from 'parser';
+import type { Parser } from 'parser';
+import { createElement as h } from 'react';
+import ReactDOM from 'react-dom';
+import { Result } from 'result';
+import CalloutComponent from '../components/Callout';
+
+// **** Hydration **** \\
+
+type Callout = {
+	kind: ElementKind.Callout;
+	isNonCollapsible: boolean;
+	heading: string;
+	formId: number;
+	formFields: FormField[];
+	name: string;
+	description?: DocumentFragment;
+	activeUntil?: number;
+};
+
+interface ArticleFormatProps {
+	theme: ArticleTheme;
+}
+interface CalloutProps {
+	callout: Callout;
+	format: ArticleFormatProps;
+}
+
+const makeFormOption = (label: string, value: string): FormOption => ({
+	label,
+	value,
+});
+
+const makeFormFields = (
+	id: string,
+	label: string,
+	name: string,
+	type: string,
+	mandatory: boolean,
+	options: FormOption[],
+	description?: string,
+): FormField => ({
+	id,
+	label,
+	name,
+	type,
+	mandatory,
+	options,
+	description,
+});
+
+const makeCalloutProps = (
+	callout: Callout,
+	format: ArticleFormatProps,
+): CalloutProps => ({
+	callout,
+	format,
+});
+
+const makeCallout = (
+	heading: string,
+	formId: number,
+	formFields: FormField[],
+	isNonCollapsible: boolean,
+	name: string,
+	description?: DocumentFragment,
+	activeUntil?: number,
+): Callout => ({
+	kind: ElementKind.Callout,
+	heading,
+	formId,
+	formFields,
+	isNonCollapsible,
+	name,
+	description,
+	activeUntil,
+});
+
+const makeArticleFormat = (theme: ArticleTheme): ArticleFormatProps => ({
+	theme,
+});
+
+const themeParser: Parser<ArticleTheme> = pipe(
+	numberParser,
+	andThen((num) => {
+		switch (num) {
+			case ArticlePillar.News:
+			case ArticlePillar.Opinion:
+			case ArticlePillar.Sport:
+			case ArticlePillar.Culture:
+			case ArticlePillar.Lifestyle:
+			case ArticleSpecial.SpecialReport:
+			case ArticleSpecial.Labs:
+				return succeed(num);
+			default:
+				return fail(
+					`I was not able to parse '${num}' as a valid theme`,
+				);
+		}
+	}),
+);
+
+const formatParser: Parser<ArticleFormatProps> = map(makeArticleFormat)(
+	fieldParser('theme', themeParser),
+);
+
+const aOrUndefinedParser = <A>(aParser: Parser<A>): Parser<A | undefined> =>
+	pipe(maybe(aParser), map(withDefault<A | undefined>(undefined)));
+
+const optionParser: Parser<FormOption> = map2(makeFormOption)(
+	fieldParser('label', stringParser),
+	fieldParser('value', stringParser),
+);
+
+const formFieldsParser: Parser<FormField> = map7(makeFormFields)(
+	fieldParser('id', stringParser),
+	fieldParser('label', stringParser),
+	fieldParser('name', stringParser),
+	fieldParser('type', stringParser),
+	fieldParser('mandatory', booleanParser),
+	fieldParser('options', arrayParser(optionParser)),
+	aOrUndefinedParser(fieldParser('description', stringParser)),
+);
+
+const calloutParser: Parser<Callout> = map7(makeCallout)(
+	fieldParser('heading', stringParser),
+	fieldParser('formId', numberParser),
+	fieldParser('formFields', arrayParser(formFieldsParser)),
+	fieldParser('isNonCollapsible', booleanParser),
+	fieldParser('name', stringParser),
+	fieldParser('description', documentFragmentParser),
+	aOrUndefinedParser(fieldParser('activeUntil', numberParser)),
+);
+
+const calloutPropsParser: Parser<CalloutProps> = map2(makeCalloutProps)(
+	fieldParser('callout', calloutParser),
+	fieldParser('format', formatParser),
+);
+
+const parseCalloutProps = (
+	rawProps: string | undefined | null,
+): Result<string, CalloutProps> =>
+	pipe(
+		rawProps,
+		resultFromNullable(
+			'The callout did not have an accompanying element containing props',
+		),
+	)
+		.flatMap((p) =>
+			Result.fromUnsafe(
+				(): unknown => JSON.parse(p.replace(/&quot;/g, '"')),
+				'The props for the callout are not valid JSON',
+			),
+		)
+		.flatMap(parse(calloutPropsParser));
+
+function hydrateCallout(callout: Element): void {
+	const rawProps = document
+		.querySelector('.js-callout-props')
+		?.getAttribute('hydrationprops');
+	const parsedProps = parseCalloutProps(rawProps);
+
+	if (parsedProps.isOk()) {
+		const calloutProps = parsedProps.value;
+
+		ReactDOM.render(
+			h(CalloutComponent, {
+				...calloutProps.callout,
+				format: calloutProps.format as ArticleFormat,
+			}),
+			callout,
+		);
+	}
+
+	if (parsedProps.isErr()) {
+		console.error(parsedProps.error);
+	}
+}
+
+function callouts(): void {
+	const calloutForms = Array.from(document.querySelectorAll('.js-callout'));
+	if (!calloutForms.length) {
+		return;
+	}
+	calloutForms.forEach(hydrateCallout);
+}
+
+export { callouts };

--- a/apps-rendering/src/components/Callout/Callout.stories.tsx
+++ b/apps-rendering/src/components/Callout/Callout.stories.tsx
@@ -1,0 +1,113 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import fetchMock from 'fetch-mock';
+import { campaignDescription, mockCampaign } from 'fixtures/campaign';
+import type { ReactElement } from 'react';
+import Callout from '.';
+
+const mockFormat: ArticleFormat = {
+	theme: ArticlePillar.News,
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+};
+
+const futureDate = new Date();
+futureDate.setDate(futureDate.getDate() + 2);
+const pastDate = new Date();
+pastDate.setDate(pastDate.getDate() - 1);
+
+const callout = (): ReactElement => {
+	fetchMock
+		.restore()
+		.post(
+			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			{
+				status: 201,
+				body: null,
+			},
+		);
+	return (
+		<Callout
+			name={mockCampaign.name}
+			heading={mockCampaign.fields.callout}
+			formId={mockCampaign.fields.formId}
+			formFields={mockCampaign.fields.formFields}
+			format={mockFormat}
+			isNonCollapsible={false}
+			activeUntil={futureDate.getTime()}
+			description={campaignDescription}
+		/>
+	);
+};
+
+const closedCallout = (): ReactElement => (
+	<Callout
+		name={mockCampaign.name}
+		heading={mockCampaign.fields.callout}
+		formId={mockCampaign.fields.formId}
+		formFields={mockCampaign.fields.formFields}
+		format={mockFormat}
+		isNonCollapsible={true}
+		activeUntil={pastDate.getTime()}
+		description={campaignDescription}
+	/>
+);
+const nonCollapsableCallout = (): ReactElement => {
+	fetchMock
+		.restore()
+		.post(
+			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			{
+				status: 201,
+				body: null,
+			},
+		);
+	return (
+		<Callout
+			isNonCollapsible={true}
+			name={mockCampaign.name}
+			heading={mockCampaign.fields.callout}
+			formId={mockCampaign.fields.formId}
+			formFields={mockCampaign.fields.formFields}
+			format={mockFormat}
+			activeUntil={futureDate.getTime()}
+			description={campaignDescription}
+		/>
+	);
+};
+
+const calloutWithFormFailure = (): ReactElement => {
+	fetchMock
+		.restore()
+		.post(
+			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			{
+				status: 400,
+				body: null,
+			},
+		);
+	return (
+		<Callout
+			isNonCollapsible={true}
+			name={mockCampaign.name}
+			heading={mockCampaign.fields.callout}
+			formId={mockCampaign.fields.formId}
+			formFields={mockCampaign.fields.formFields}
+			format={mockFormat}
+			activeUntil={futureDate.getTime()}
+			description={campaignDescription}
+		/>
+	);
+};
+
+export default {
+	component: callout,
+	title: 'AR/Callout',
+};
+
+export {
+	callout,
+	closedCallout,
+	nonCollapsableCallout,
+	calloutWithFormFailure,
+};

--- a/apps-rendering/src/components/Callout/calloutBlock.tsx
+++ b/apps-rendering/src/components/Callout/calloutBlock.tsx
@@ -1,0 +1,44 @@
+// import {renderToString, renderToStaticMarkup} from 'react-dom/server';
+import type { FormField } from '@guardian/apps-rendering-api-models/formField';
+import type { ArticleFormat } from '@guardian/libs';
+import type { FC, ReactElement } from 'react';
+import { renderCalloutDescriptionText } from 'renderer';
+import CalloutForm from './calloutForm';
+import {
+	calloutContainerStyles,
+	calloutDescription,
+	calloutHeadingText,
+	calloutTitle,
+} from './styles';
+
+export interface CalloutBlockProps {
+	formId: number;
+	heading: string;
+	name: string;
+	formFields: FormField[];
+	format: ArticleFormat;
+	description?: DocumentFragment;
+	isTabbable?: boolean;
+}
+
+const CalloutBlock: FC<CalloutBlockProps> = ({
+	formId,
+	heading,
+	name,
+	formFields,
+	format,
+	description,
+}): ReactElement => (
+	<div css={calloutContainerStyles(format)}>
+		<div css={calloutTitle(format)}>{heading}</div>
+		<h4 css={calloutHeadingText}>{name}</h4>
+		{description && (
+			<div css={calloutDescription}>
+				{renderCalloutDescriptionText(format, description)}
+			</div>
+		)}
+		<CalloutForm id={formId} fields={formFields} format={format} />
+	</div>
+);
+
+export default CalloutBlock;

--- a/apps-rendering/src/components/Callout/calloutForm.tsx
+++ b/apps-rendering/src/components/Callout/calloutForm.tsx
@@ -1,0 +1,186 @@
+import type { FormField as FormFieldType } from '@guardian/apps-rendering-api-models/formField';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	Button,
+	InlineError,
+	InlineSuccess,
+	Link,
+} from '@guardian/source-react-components';
+import { useState } from 'react';
+import type { FC } from 'react';
+import { ContactText, Disclaimer, FormField } from './formFields';
+import { ShareLink } from './shareLink';
+import { calloutForm, calloutSubmitButton } from './styles';
+
+export interface CalloutFormProps {
+	format: ArticleFormat;
+	id: number;
+	fields: FormFieldType[];
+	disableInputs?: boolean;
+}
+
+type SubmitDataType = Record<string, string | string[]>;
+export type FormDataType = { [key in string]: undefined | string | string[] };
+export type ValidationErrors = { [key in string]: string };
+
+const CALLOUT_URL =
+	'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit';
+
+const CalloutForm: FC<CalloutFormProps> = ({ id, fields, format }) => {
+	const [formData, setFormData] = useState<FormDataType>({});
+	const [validationErrors, setValidationErrors] = useState<ValidationErrors>(
+		{},
+	);
+	const [submissionError, setSubmissionError] = useState<string>('');
+	const [submissionSuccess, setSubmissionSuccess] = useState<boolean>(false);
+
+	const setFieldInFormData = (
+		id: string,
+		data: string | string[] | undefined,
+	): void => {
+		const currentErrors = validationErrors;
+		currentErrors[id] = '';
+		setValidationErrors(currentErrors);
+
+		setFormData({
+			...formData,
+			[id]: data,
+		});
+	};
+
+	const validateForm = (): boolean => {
+		const errors: ValidationErrors = {};
+		let isValid = true;
+		fields.forEach((field: FormFieldType) => {
+			if (field.mandatory && !formData[field.id]) {
+				errors[field.id] = 'This field is required';
+				isValid = false;
+			}
+			if (field.type === 'email' && formData[field.id]) {
+				const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+				if (!emailRegex.test(formData[field.id] as string)) {
+					errors[field.id] = 'Please enter a valid email address';
+					isValid = false;
+				}
+			}
+			if (
+				['number', 'phone'].includes(field.type) &&
+				formData[field.id]
+			) {
+				const numberRegex = /^[0-9]+$/;
+				if (!numberRegex.test(formData[field.id] as string)) {
+					errors[field.id] = 'Please enter a valid number';
+					isValid = false;
+				}
+			}
+			return isValid;
+		});
+		setValidationErrors(errors);
+		return Object.keys(errors).length === 0;
+	};
+
+	const onSubmit = async (formData: FormDataType): Promise<void> => {
+		// Reset error for new submission attempt
+		setSubmissionError('');
+		const isValid = validateForm();
+		if (!isValid) return;
+
+		// need to add prefix `field_` to all keys in form (as is required by formstack api)
+		const formDataWithFieldPrefix = Object.keys(formData).reduce(
+			(acc, cur): SubmitDataType => ({
+				...acc,
+				[`field_${cur}`]: formData[cur],
+			}),
+			{},
+		);
+
+		return fetch(CALLOUT_URL, {
+			method: 'POST',
+			body: JSON.stringify({
+				formId: id,
+				...formDataWithFieldPrefix,
+			}),
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+		})
+			.then((res) => {
+				if (res.ok) {
+					setSubmissionSuccess(true);
+				} else {
+					setSubmissionError(
+						'Sorry, there was a problem submitting your form. Please try again later.',
+					);
+				}
+			})
+			.catch(() => {
+				setSubmissionError(
+					'Sorry, there was a problem submitting your form. Please try again later.',
+				);
+			});
+	};
+
+	return (
+		<div className="js-callout" css={calloutForm}>
+			{submissionSuccess ? (
+				<InlineSuccess>
+					Thank you, your story has been submitted successfully. One
+					of our journalists will be in touch if we wish to take your
+					submission further.
+				</InlineSuccess>
+			) : (
+				<form
+					method="post"
+					onSubmit={async (e): Promise<void> => {
+						e.preventDefault();
+						await onSubmit(formData);
+					}}
+					noValidate
+				>
+					<ShareLink format={format} />
+					<Disclaimer />
+					<input name="formId" type="hidden" value={id} />
+					<div className="js-callout__inputs">
+						{fields.map((field, i) => (
+							<FormField
+								key={i}
+								formId={id}
+								formField={field}
+								formData={formData}
+								setFieldInFormData={setFieldInFormData}
+								format={format}
+								validationErrors={validationErrors}
+							/>
+						))}
+						<div>
+							<ContactText />
+							{submissionError && (
+								<InlineError>
+									<>
+										Something went wrong. Please try again
+										or contact{' '}
+										<Link
+											href="mailto:customer.help@theguardian.com"
+											target="_blank"
+										>
+											customer.help@theguardian.com
+										</Link>
+									</>
+								</InlineError>
+							)}
+						</div>
+						<Button
+							css={calloutSubmitButton(format)}
+							type="submit"
+							priority="primary"
+						>
+							Submit
+						</Button>
+					</div>
+				</form>
+			)}
+		</div>
+	);
+};
+
+export default CalloutForm;

--- a/apps-rendering/src/components/Callout/formFields.tsx
+++ b/apps-rendering/src/components/Callout/formFields.tsx
@@ -1,0 +1,183 @@
+import { css } from '@emotion/react';
+import type { FormField as formFieldType } from '@guardian/apps-rendering-api-models/formField';
+import type { ArticleFormat } from '@guardian/libs';
+import { remSpace, textSans } from '@guardian/source-foundations';
+import {
+	Option,
+	Select,
+	TextArea,
+	TextInput,
+} from '@guardian/source-react-components';
+import { FileInput } from '@guardian/source-react-components-development-kitchen';
+import CheckboxInput from 'components/CheckboxInput';
+import RadioInput from 'components/RadioInput';
+import type { FC, ReactElement } from 'react';
+import { logger } from '../../logger';
+import type { FormDataType, ValidationErrors } from './calloutForm';
+import { fieldInput, textarea } from './styles';
+
+const infoStyles = css`
+	${textSans.small()};
+	margin-bottom: ${remSpace[4]};
+`;
+
+export const Disclaimer: FC = () => {
+	return (
+		<div css={infoStyles}>
+			You must be 18 or over to fill in this form. Only the Guardian can
+			see your contributions and one of our journalists may contact you to
+			discuss further. For more information please see our{' '}
+			<a href="https://www.theguardian.com/help/terms-of-service">
+				terms of service
+			</a>{' '}
+			and{' '}
+			<a href="https://www.theguardian.com/help/privacy-policy">
+				privacy policy
+			</a>
+			.
+		</div>
+	);
+};
+
+export const ContactText = (): ReactElement => (
+	<div css={infoStyles}>
+		One of our journalists will be in contact before we publish your
+		information, so please do leave contact details.
+	</div>
+);
+
+type FormFieldProp = {
+	formId: number;
+	formField: formFieldType;
+	formData: FormDataType;
+	setFieldInFormData: (
+		id: string,
+		data: string | string[] | undefined,
+	) => void;
+	format: ArticleFormat;
+	validationErrors: ValidationErrors;
+};
+
+export const FormField: FC<FormFieldProp> = ({
+	formId,
+	formField,
+	formData,
+	setFieldInFormData,
+	format,
+	validationErrors,
+}) => {
+	const { type, label, description, mandatory, options, id } = formField;
+	const name = `field_${type}_${id}`;
+	const fieldValue =
+		formField.id in formData ? (formData[formField.id] as string) : '';
+	const fieldError = validationErrors[formField.id];
+
+	const selectOptions = options.map(({ value, label }) => {
+		return (
+			<Option key={value} value={value}>
+				{label}
+			</Option>
+		);
+	});
+	if (!fieldValue || !mandatory)
+		selectOptions.unshift(
+			<Option value="">Please select an option</Option>,
+		);
+
+	switch (type) {
+		case 'text':
+		case 'number':
+		case 'phone':
+		case 'email':
+			return (
+				<TextInput
+					name={name}
+					type={type === 'phone' ? 'tel' : type}
+					label={label}
+					optional={!mandatory}
+					cssOverrides={fieldInput}
+					supporting={description}
+					value={fieldValue}
+					onChange={(e): void =>
+						setFieldInFormData(formField.id, e.target.value)
+					}
+					error={fieldError}
+				/>
+			);
+		case 'textarea':
+			return (
+				<TextArea
+					name={name}
+					label={label}
+					cssOverrides={textarea(!!fieldError)}
+					optional={!mandatory}
+					value={fieldValue}
+					supporting={description}
+					onChange={(e): void =>
+						setFieldInFormData(formField.id, e.target.value)
+					}
+					error={fieldError}
+				/>
+			);
+		case 'file':
+			return (
+				<FileInput
+					label={label}
+					optional={!mandatory}
+					supporting={description}
+					error={fieldError}
+					onUpload={(file: string | undefined): void =>
+						setFieldInFormData(formField.id, file)
+					}
+					cssOverrides={fieldInput}
+				/>
+			);
+		case 'radio':
+			return (
+				<RadioInput
+					formField={formField}
+					selected={
+						id in formData ? (formData[id] as string) : undefined
+					}
+					setFieldInFormData={setFieldInFormData}
+					error={fieldError}
+				/>
+			);
+		case 'checkbox':
+			return (
+				<CheckboxInput
+					formField={formField}
+					selectedCheckboxes={
+						id in formData ? (formData[id] as string[]) : []
+					}
+					setFieldInFormData={setFieldInFormData}
+					cssOverrides={fieldInput}
+					error={fieldError}
+				/>
+			);
+		case 'select':
+			return (
+				<Select
+					label={label}
+					supporting={description}
+					optional={!mandatory}
+					id={name}
+					cssOverrides={fieldInput}
+					key={name}
+					name={name}
+					value={fieldValue}
+					onChange={(e): void =>
+						setFieldInFormData(formField.id, e.target.value)
+					}
+					error={fieldError}
+				>
+					{selectOptions}
+				</Select>
+			);
+		default:
+			logger.error(
+				`Invalid field ${type} provided for callout ${formId}`,
+			);
+			return null;
+	}
+};

--- a/apps-rendering/src/components/Callout/index.tsx
+++ b/apps-rendering/src/components/Callout/index.tsx
@@ -1,0 +1,128 @@
+import { css, ThemeProvider } from '@emotion/react';
+import type { FormField } from '@guardian/apps-rendering-api-models/formField';
+import type { ArticleFormat } from '@guardian/libs';
+import { remSpace } from '@guardian/source-foundations';
+import { ExpandingWrapper } from '@guardian/source-react-components-development-kitchen';
+import { isElement } from 'lib';
+import type { FC, ReactElement } from 'react';
+import { createElement as h } from 'react';
+import { DeadlineDate, Highlight, isCalloutActive } from '../Deadline/index';
+import CalloutBlock from './calloutBlock';
+import { getTheme } from './theme';
+
+export interface CalloutProps {
+	heading: string;
+	formId: number;
+	formFields: FormField[];
+	format: ArticleFormat;
+	description?: DocumentFragment;
+	isNonCollapsible: boolean;
+	activeUntil?: number;
+	name: string;
+}
+
+const Callout: FC<CalloutProps> = ({
+	heading,
+	description,
+	formId,
+	formFields,
+	format,
+	isNonCollapsible,
+	activeUntil,
+	name,
+}): ReactElement => {
+	const isActive = isCalloutActive(activeUntil);
+
+	if (!isActive && isNonCollapsible) {
+		return (
+			<Highlight>
+				This form has been deactivated and is closed to any further
+				submissions.
+			</Highlight>
+		);
+	} else if (!isActive && !isNonCollapsible) {
+		return <></>;
+	}
+	return (
+		<aside className="js-callout">
+			{isNonCollapsible ? (
+				<ThemeProvider theme={getTheme(format)}>
+					<CalloutBlock
+						formId={formId}
+						heading={heading}
+						name={name}
+						formFields={formFields}
+						format={format}
+						description={description}
+					/>
+					<span
+						css={css`
+							position: absolute;
+							right: 0;
+							margin-top: -${remSpace[6]};
+						`}
+					>
+						<DeadlineDate until={activeUntil} />
+					</span>
+				</ThemeProvider>
+			) : (
+				<ThemeProvider theme={getTheme(format)}>
+					<ExpandingWrapper
+						renderExtra={(): ReactElement => (
+							<DeadlineDate until={activeUntil} />
+						)}
+						name={`${name} form`}
+					>
+						<CalloutBlock
+							formId={formId}
+							heading={heading}
+							name={name}
+							formFields={formFields}
+							format={format}
+							description={description}
+						/>
+					</ExpandingWrapper>
+				</ThemeProvider>
+			)}
+		</aside>
+	);
+};
+
+const CalloutWithHydrationProps: FC<CalloutProps> = ({
+	format,
+	...calloutProps
+}): ReactElement => {
+	const getStringFromNodes = (nodes: NodeListOf<ChildNode>): string =>
+		Array.from(nodes)
+			.map((node) => {
+				return isElement(node) ? node.outerHTML : node.textContent;
+			})
+			.join('');
+
+	const description = calloutProps.description;
+	const stringDescription = description
+		? getStringFromNodes(description.childNodes)
+		: '';
+
+	const serverSideProps = JSON.stringify({
+		callout: {
+			...calloutProps,
+			description: stringDescription,
+		},
+		format,
+	});
+
+	return h(
+		'div',
+		{
+			hydrationprops: serverSideProps,
+			className: 'js-callout-props',
+		},
+		Callout({
+			...calloutProps,
+			format,
+		}),
+	);
+};
+
+export default CalloutWithHydrationProps;

--- a/apps-rendering/src/components/Callout/shareLink.tsx
+++ b/apps-rendering/src/components/Callout/shareLink.tsx
@@ -1,0 +1,44 @@
+import type { ArticleFormat } from '@guardian/libs';
+import { Button, SvgShareCallout } from '@guardian/source-react-components';
+import { useState } from 'react';
+import type { FC } from 'react';
+import { calloutShare, calloutSharelink } from './styles';
+
+export const ShareLink: FC<{ format: ArticleFormat }> = ({ format }) => {
+	const [isCopied, setIsCopied] = useState(false);
+
+	const onShare = async (): Promise<void> => {
+		const url = window.location.href;
+		if ('share' in navigator) {
+			navigator
+				.share({
+					title: 'Share this callout',
+					url,
+				})
+				.catch(console.error);
+		} else if ('clipboard' in navigator) {
+			const nav: Navigator = navigator;
+			await nav.clipboard.writeText(url);
+			setIsCopied(true);
+			setTimeout(() => setIsCopied(false), 2000);
+		}
+	};
+	if (typeof window === 'undefined' || typeof navigator === 'undefined')
+		return <></>;
+
+	return (
+		<span css={calloutShare}>
+			<SvgShareCallout size="medium" />
+			Know others that are affected?
+			<Button
+				size="xsmall"
+				priority="subdued"
+				onClick={onShare}
+				css={calloutSharelink(format)}
+			>
+				Please share this callout
+			</Button>
+			{isCopied && <em> Link copied to clipboard</em>}
+		</span>
+	);
+};

--- a/apps-rendering/src/components/Callout/styles.ts
+++ b/apps-rendering/src/components/Callout/styles.ts
@@ -1,0 +1,116 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	body,
+	error,
+	headline,
+	neutral,
+	remSpace,
+	until,
+} from '@guardian/source-foundations';
+import { darkModeCss } from 'styles';
+
+// Callout block styles
+export const calloutContainerStyles = (
+	format: ArticleFormat,
+): SerializedStyles => css`
+	padding-bottom: ${remSpace[12]};
+	background: ${neutral[97]};
+	color: ${neutral[7]};
+	a {
+		color: ${text.calloutPrimary(format)};
+	}
+
+	${darkModeCss`
+		background: ${neutral[20]};
+		color: ${neutral[86]};
+		a {
+			color: ${neutral[86]};
+	`}
+`;
+
+export const calloutTitle = (format: ArticleFormat): SerializedStyles => css`
+	${headline.xxsmall({ fontWeight: 'bold' })};
+	color: ${text.calloutPrimary(format)};
+
+	${darkModeCss`
+		color: ${text.calloutPrimaryDark(format)};
+	`}
+`;
+
+export const calloutHeadingText = css`
+	${headline.xxsmall()}
+`;
+
+export const calloutDescription = css`
+	${body.medium()}
+	padding: ${remSpace[3]} 0;
+`;
+
+// Callout Form Styles
+export const calloutForm = css`
+	margin: ${remSpace[2]};
+`;
+
+export const calloutSubmitButton = (
+	format: ArticleFormat,
+): SerializedStyles => css`
+	background: ${text.calloutPrimary(format)};
+	color: ${neutral[100]};
+	margin-top: ${remSpace[2]};
+	${darkModeCss`
+		background: ${neutral[86]};
+		color: ${neutral[7]};
+	`}
+
+	${until.mobileLandscape} {
+		width: 100%;
+		justify-content: center;
+	}
+`;
+
+// Callout Share Link Styles
+export const calloutShare = css`
+	display: inline-flex;
+	align-items: center;
+	padding-right: ${remSpace[2]};
+	padding-bottom: ${remSpace[2]};
+	color: ${neutral[7]};
+	font-family: GuardianTextSans;
+	${darkModeCss`
+		color: ${neutral[86]};
+	`}
+`;
+export const calloutSharelink = (
+	format: ArticleFormat,
+): SerializedStyles => css`
+	padding: 0 ${remSpace[2]};
+	font-weight: normal;
+	color: ${text.calloutPrimary(format)};
+	${darkModeCss`
+		color: ${neutral[86]};
+	`}
+`;
+
+// Form fields
+export const fieldInput = css`
+	margin-bottom: ${remSpace[4]};
+`;
+
+export const textarea = (hasError: boolean): SerializedStyles => css`
+	// Source textarea doesn't have theming
+	${fieldInput}
+	border:  ${hasError
+		? `4px solid ${error[400]}`
+		: `2px solid${neutral[46]}`};
+
+	background-color: ${neutral[100]};
+	color: ${neutral[7]};
+	${darkModeCss`
+		background-color: ${neutral[7]};
+		color: ${neutral[97]};
+		border:  ${hasError ? `4px solid ${error[500]}` : `2px solid${neutral[46]}`};
+	`}
+`;

--- a/apps-rendering/src/components/Callout/theme.ts
+++ b/apps-rendering/src/components/Callout/theme.ts
@@ -1,0 +1,116 @@
+import type { Theme } from '@emotion/react';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	brand,
+	error,
+	focus,
+	neutral,
+	success,
+} from '@guardian/source-foundations';
+import {
+	fileInputDarkTheme,
+	fileInputThemeDefault,
+} from '@guardian/source-react-components-development-kitchen';
+
+const labelDarkTheme = {
+	textLabel: neutral[97],
+	textOptional: neutral[60],
+	textSupporting: neutral[60],
+	textError: error[500],
+	textSuccess: success[500],
+};
+
+const checkboxDarkTheme = {
+	border: neutral[60],
+	borderHover: brand[500],
+	borderChecked: brand[500],
+	borderError: error[500],
+	backgroundChecked: brand[500],
+	textLabel: neutral[97],
+	textLabelSupporting: neutral[60],
+	textIndeterminate: neutral[60],
+};
+
+const textInputDarkTheme = {
+	textUserInput: neutral[97],
+	textLabel: neutral[97],
+	textLabelOptional: neutral[46],
+	textLabelSupporting: neutral[46],
+	textError: neutral[97],
+	textSuccess: success[400],
+	backgroundInput: neutral[7],
+	border: neutral[46],
+	borderActive: focus[400],
+	borderError: error[500],
+	borderSuccess: success[500],
+};
+
+const selectDarkTheme = {
+	textUserInput: neutral[97],
+	textLabel: neutral[97],
+	textLabelOptional: neutral[46],
+	textLabelSupporting: neutral[46],
+	textError: neutral[97],
+	textSuccess: success[500],
+	backgroundInput: neutral[7],
+	border: neutral[46],
+	borderActive: focus[400],
+	borderError: error[500],
+	borderSuccess: success[500],
+};
+
+const radioDarkTheme = {
+	borderHover: focus[400],
+	border: neutral[46],
+	backgroundChecked: focus[400],
+	textLabel: neutral[97],
+	textLabelSupporting: neutral[60],
+	borderError: error[500],
+};
+
+const expandingWrapperDarkTheme = {
+	border: neutral[60],
+	expandBackground: neutral[86],
+	expandText: neutral[7],
+	collapseBackground: neutral[10],
+	collapseText: neutral[86],
+};
+const userFeedbackDarkTheme = {
+	textError: error[500],
+};
+
+export const darkTheme = {
+	label: labelDarkTheme,
+	checkbox: checkboxDarkTheme,
+	textInput: textInputDarkTheme,
+	select: selectDarkTheme,
+	radio: radioDarkTheme,
+	expander: expandingWrapperDarkTheme,
+	userFeedback: userFeedbackDarkTheme,
+	...fileInputDarkTheme,
+};
+
+type LightThemeType = {
+	fileInput: {
+		text: string;
+		supporting: string;
+		primary: string;
+		error: string;
+	};
+};
+
+export const lightThemeOverrides = (format: ArticleFormat): LightThemeType => ({
+	fileInput: {
+		...fileInputThemeDefault.fileInput,
+		primary: text.calloutPrimary(format),
+	},
+});
+
+const getPrefersDark = (): boolean => {
+	if (typeof window === 'undefined') return false;
+	return window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+export const getTheme = (format: ArticleFormat): Theme =>
+	getPrefersDark() ? darkTheme : lightThemeOverrides(format);

--- a/apps-rendering/src/components/CalloutForm/index.tsx
+++ b/apps-rendering/src/components/CalloutForm/index.tsx
@@ -22,7 +22,6 @@ import {
 	TextInput,
 } from '@guardian/source-react-components';
 import FileInput from 'components/FileInput';
-import RadioInput from 'components/RadioInput';
 import type { FC, ReactElement } from 'react';
 import { plainTextElement } from 'renderer';
 import { darkModeCss } from 'styles';
@@ -176,15 +175,17 @@ const renderField = ({
 					label={label}
 				/>
 			);
-		case 'radio':
-			return (
-				<RadioInput
-					cssOverrides={input}
-					options={options}
-					name={name}
-					label={label}
-				/>
-			);
+		// We have repurposed the RadioInput for the new callout form.
+		// We can comment this because the old calloutForm (this one) is never used anyway.
+		// case 'radio':
+		// 	return (
+		// 		<RadioInput
+		// 			cssOverrides={input}
+		// 			options={options}
+		// 			name={name}
+		// 			label={label}
+		// 		/>
+		// 	);
 		default:
 			return null;
 	}

--- a/apps-rendering/src/components/CheckboxInput/index.tsx
+++ b/apps-rendering/src/components/CheckboxInput/index.tsx
@@ -1,0 +1,70 @@
+import type { SerializedStyles } from '@emotion/react';
+import type { FormField } from '@guardian/apps-rendering-api-models/formField';
+import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
+import type { ReactElement } from 'react';
+
+interface CheckboxInputProps {
+	formField: FormField;
+	selectedCheckboxes: string[];
+	setFieldInFormData: (
+		id: string,
+		data: string | string[] | undefined,
+	) => void;
+	error?: string;
+	cssOverrides?: SerializedStyles;
+}
+
+const CheckboxInput = ({
+	formField,
+	selectedCheckboxes,
+	setFieldInFormData,
+	error,
+	cssOverrides,
+}: CheckboxInputProps): ReactElement => {
+	const { label, name, options, description, id } = formField;
+	return (
+		<CheckboxGroup
+			id={name}
+			label={label}
+			name={name}
+			supporting={description}
+			cssOverrides={cssOverrides}
+			error={error}
+		>
+			{options.map((option) => {
+				const isCheckboxChecked = !!selectedCheckboxes.find(
+					(v: string) => v === option.value,
+				);
+
+				const filterOutCheckboxFromArray = (): string[] =>
+					selectedCheckboxes.filter(
+						(v: string) => v !== option.value,
+					);
+
+				const addCheckboxToArray = (): string[] => [
+					...selectedCheckboxes,
+					option.value,
+				];
+
+				return (
+					<Checkbox
+						label={option.label}
+						value={option.value}
+						key={option.value}
+						checked={isCheckboxChecked}
+						onChange={(): void =>
+							setFieldInFormData(
+								id,
+								isCheckboxChecked
+									? filterOutCheckboxFromArray()
+									: addCheckboxToArray(),
+							)
+						}
+					/>
+				);
+			})}
+		</CheckboxGroup>
+	);
+};
+
+export default CheckboxInput;

--- a/apps-rendering/src/components/Deadline/index.test.ts
+++ b/apps-rendering/src/components/Deadline/index.test.ts
@@ -1,0 +1,28 @@
+import { getDeadlineText } from './index';
+
+describe('getCloseText', () => {
+	test('Returns null if deadline date is > 7 days away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 12, 24, 0, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe(undefined);
+	});
+	test('Rounds days if deadline date is < 30 days away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 8, 0, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Open for 7 more days');
+	});
+	test('Is singular if deadline date is 1 day away', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 2, 2, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Open for 1 more day');
+	});
+	test('Is today if deadline date is <24 hours', () => {
+		const date1 = new Date(2022, 11, 1, 0, 0, 0);
+		const date2 = new Date(2022, 11, 1, 2, 0, 0);
+
+		expect(getDeadlineText(date1, date2)).toBe('Closing today');
+	});
+});

--- a/apps-rendering/src/components/Deadline/index.tsx
+++ b/apps-rendering/src/components/Deadline/index.tsx
@@ -1,0 +1,55 @@
+import { SvgClock } from '@guardian/source-react-components';
+import { isValidDate } from 'date';
+import type { FC } from 'react';
+import { highlight } from './styles';
+
+const Highlight: FC = ({ children }) => {
+	return <span css={highlight}>{children}</span>;
+};
+
+function getDaysBetween(first: Date, second: Date): number {
+	const ONE_DAY = 1000 * 3600 * 24;
+	return (second.getTime() - first.getTime()) / ONE_DAY;
+}
+
+export const getDeadlineText = (
+	date1: Date,
+	date2: Date,
+): string | undefined => {
+	const maxDays = 7;
+	const daysBetween = getDaysBetween(date1, date2);
+	if (daysBetween <= 0 || daysBetween > maxDays) return;
+	if (daysBetween <= 1) return 'Closing today';
+	if (Math.round(daysBetween) === 1) return 'Open for 1 more day';
+	return `Open for ${Math.round(daysBetween)} more days`;
+};
+
+function formatOptionalDate(date: number | undefined): Date | undefined {
+	if (date === undefined) return undefined;
+	const d = new Date(date);
+	if (!isValidDate(d)) return undefined;
+	return d;
+}
+
+function isCalloutActive(until?: number): boolean {
+	const untilDate = formatOptionalDate(until);
+	const now = new Date();
+
+	return untilDate === undefined || untilDate > now;
+}
+
+const DeadlineDate: FC<{ until?: number }> = ({ until }) => {
+	const untilDate = formatOptionalDate(until);
+	if (!untilDate) return null;
+	const now = new Date();
+	const deadlineText = getDeadlineText(now, untilDate);
+	if (!deadlineText) return null;
+	return (
+		<Highlight>
+			<SvgClock size="xsmall" />
+			{deadlineText}
+		</Highlight>
+	);
+};
+
+export { Highlight, DeadlineDate, isCalloutActive };

--- a/apps-rendering/src/components/Deadline/styles.ts
+++ b/apps-rendering/src/components/Deadline/styles.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+import { brandAlt, neutral, remSpace } from '@guardian/source-foundations';
+import { darkModeCss } from 'styles';
+
+export const highlight = css`
+	color: ${neutral[7]};
+	display: flex;
+	align-items: center;
+	padding: 0 ${remSpace[1]};
+	font-family: GuardianTextSans;
+	background: ${brandAlt[400]};
+	${darkModeCss`
+		background: ${brandAlt[200]};
+	`}
+`;

--- a/apps-rendering/src/components/RadioInput/index.tsx
+++ b/apps-rendering/src/components/RadioInput/index.tsx
@@ -1,45 +1,46 @@
 import type { SerializedStyles } from '@emotion/react';
-import { css } from '@emotion/react';
-import type { FormOption } from '@guardian/apps-rendering-api-models/formOption';
-import { remSpace, textSans } from '@guardian/source-foundations';
+import type { FormField } from '@guardian/apps-rendering-api-models/formField';
 import { Radio, RadioGroup } from '@guardian/source-react-components';
 import type { ReactElement } from 'react';
 
 interface RadioInputProps {
-	name: string;
-	label: string;
-	options: FormOption[];
-	cssOverrides: SerializedStyles;
+	formField: FormField;
+	selected?: string;
+	setFieldInFormData: (id: string, data: string | undefined) => void;
+	error?: string;
+	cssOverrides?: SerializedStyles;
 }
 
-const radioStyles = css`
-	margin-bottom: ${remSpace[4]};
-`;
-
-const labelStyles = css`
-	${textSans.medium({ fontWeight: 'bold' })};
-`;
-
-const RadioInput = (props: RadioInputProps): ReactElement => (
-	<label css={labelStyles}>
-		{props.label}
+const RadioInput = ({
+	formField,
+	selected,
+	setFieldInFormData,
+	error,
+	cssOverrides,
+}: RadioInputProps): ReactElement => {
+	const { name, options, id, label, description } = formField;
+	return (
 		<RadioGroup
-			name={props.name}
+			defaultChecked
+			name={name}
 			orientation="horizontal"
-			cssOverrides={radioStyles}
+			cssOverrides={cssOverrides}
+			label={label}
+			supporting={description}
+			id={name}
+			error={error}
 		>
-			{props.options.map(({ value, label }) => {
-				return (
-					<Radio
-						key={value}
-						value={value}
-						label={label}
-						cssOverrides={props.cssOverrides}
-					/>
-				);
-			})}
+			{options.map((option) => (
+				<Radio
+					key={option.value}
+					value={option.value}
+					label={option.label}
+					checked={selected === option.value}
+					onChange={(): void => setFieldInFormData(id, option.value)}
+				/>
+			))}
 		</RadioGroup>
-	</label>
-);
+	);
+};
 
 export default RadioInput;

--- a/apps-rendering/src/fixtures/campaign.ts
+++ b/apps-rendering/src/fixtures/campaign.ts
@@ -1,0 +1,137 @@
+import { parse } from 'client/parser';
+
+const mockCampaign = {
+	id: '1fc53dab-1c76-4258-8194-b4b3d8399052',
+	name: 'CALLOUT: ghost flights',
+	priority: 0,
+	displayOnSensitive: false,
+	fields: {
+		callout: 'Share your experiences',
+		formId: 4711223,
+		tagName: 'callout-ghost-flights',
+		description:
+			'<p>If you have been affected or have any information, we\'d like to hear from you. You can get in touch by filling in the form below or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447766780300">clicking here&nbsp;</a>or\n adding the contact +44(0)7766780300. Only the Guardian can see your \ncontributions and one of our journalists may contact you to discuss \nfurther.&nbsp;If you’re having trouble using the form, click&nbsp;<a href="https://guardiannewsandmedia.formstack.com/forms/facebook_whatsapp_and_instagram_outage">here</a>.<br></p>',
+		formFields: [
+			{
+				id: '121575455',
+				label: 'Name',
+				name: 'name',
+				description: 'Or your nickname',
+				type: 'text',
+				mandatory: true,
+				options: [],
+			},
+			{
+				id: '121sd5455',
+				label: 'Phone number',
+				name: 'phone',
+				type: 'phone',
+				mandatory: false,
+				options: [],
+			},
+			{
+				id: '121575575',
+				label: 'Email',
+				name: 'email',
+				type: 'email',
+				mandatory: false,
+				options: [],
+			},
+			{
+				id: '121575458',
+				label: 'Share your experiences of ghost flights during the pandemic',
+				name: 'share_your_experiences_of_ghost_flights_during_the_pandemic',
+				description: 'Include as much detail as possible.',
+				type: 'textarea',
+				mandatory: true,
+				options: [],
+			},
+			{
+				id: '121575460',
+				label: 'If you are happy to, please upload a photo of yourself',
+				name: 'if_you_are_happy_to_please_upload_a_photo_of_yourself',
+				type: 'file',
+				mandatory: true,
+				options: [],
+			},
+			{
+				id: '121575461',
+				label: 'Can we publish your response?',
+				name: 'can_we_publish_your_response',
+				type: 'select',
+				mandatory: true,
+				options: [
+					{
+						label: 'Yes, entirely',
+						value: 'Yes, entirely',
+					},
+					{
+						label: 'Yes, but contact me first',
+						value: 'Yes, but contact me first',
+					},
+					{
+						label: 'Yes, but please keep me anonymous',
+						value: 'Yes, but please keep me anonymous',
+					},
+					{
+						label: 'No, this is information only',
+						value: 'No, this is information only',
+					},
+				],
+			},
+			{
+				id: '121575463451',
+				label: 'Do you like the guardian?',
+				name: 'do_you_like_the_guardian',
+				description: 'say yes',
+				type: 'radio',
+				mandatory: true,
+				options: [
+					{
+						label: 'Yes',
+						value: 'yes',
+					},
+					{
+						label: 'No',
+						value: 'no',
+					},
+				],
+			},
+			{
+				id: '121575463675',
+				label: 'What colours do you like?',
+				name: 'liked_colours',
+				type: 'checkbox',
+				mandatory: true,
+				options: [
+					{
+						label: 'Blue',
+						value: 'blue',
+					},
+					{
+						label: 'Red',
+						value: 'red',
+					},
+					{
+						label: 'Yellow',
+						value: 'yellow',
+					},
+				],
+			},
+		],
+		formUrl:
+			'https://guardiannewsandmedia.formstack.com/forms/ghost_flights',
+	},
+};
+
+const parser = new DOMParser();
+const parseHtml = (html: string): DocumentFragment | undefined =>
+	parse(parser)(html).either<DocumentFragment | undefined>(
+		(_err) => undefined,
+		(doc) => doc,
+	);
+const campaignDescription: DocumentFragment | undefined = parseHtml(
+	mockCampaign.fields.description,
+);
+
+export { mockCampaign, campaignDescription };

--- a/apps-rendering/src/parser.ts
+++ b/apps-rendering/src/parser.ts
@@ -114,6 +114,29 @@ const dateParser: Parser<Date> = parser((a) => {
 });
 
 /**
+ * Parses a string to a Document Fragment.
+ */
+const documentFragmentParser: Parser<DocumentFragment> = parser((a) => {
+	if (typeof a === 'string') {
+		const domParser = new DOMParser();
+		try {
+			const frag = new DocumentFragment();
+			const docNodes = domParser.parseFromString(a, 'text/html').body
+				.childNodes;
+			Array.from(docNodes).forEach((node) => {
+				return frag.appendChild(node);
+			});
+			return Result.ok(frag);
+		} catch (e) {
+			return Result.err(
+				`Can't transform ${String(a)} into a DocumentFragment`,
+			);
+		}
+	}
+	return Result.err(`Can't transform ${String(a)} into a DocumentFragment`);
+});
+
+/**
  * Makes the value handled by the given parser optional. **Note:** This
  * will effectively absorb any failure to parse the value, converting it to
  * a `None` instead.
@@ -692,6 +715,7 @@ export {
 	numberParser,
 	booleanParser,
 	dateParser,
+	documentFragmentParser,
 	maybe,
 	fieldParser,
 	indexParser,

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -320,6 +320,33 @@ const borderFromFormat = (format: ArticleFormat): string => {
 		: 'none';
 };
 
+const calloutDescriptionTextElement =
+	(format: ArticleFormat) =>
+	(node: Node, key: number): ReactNode => {
+		const children = Array.from(node.childNodes).map(
+			calloutDescriptionTextElement(format),
+		);
+		switch (node.nodeName) {
+			case 'P':
+				return h('p', { key }, children);
+			case 'STRONG':
+				return styledH(
+					'strong',
+					{ css: { fontWeight: 'bold' }, key },
+					children,
+				);
+			case 'A': {
+				const url = withDefault('')(getHref(node));
+				const href = url.startsWith('profile/')
+					? `https://www.theguardian.com/${url}`
+					: url;
+				return styledH('a', { key, href }, children);
+			}
+			default:
+				return textElement(format)(node, key);
+		}
+	};
+
 const standfirstTextElement =
 	(format: ArticleFormat) =>
 	(node: Node, key: number): ReactNode => {
@@ -382,6 +409,18 @@ const standfirstText = (
 		? nodes.filter(editionsStandfirstFilter)
 		: nodes;
 	return filteredNodes.map(standfirstTextElement(format));
+};
+
+const calloutDescriptionText = (
+	format: ArticleFormat,
+	doc?: DocumentFragment,
+): ReactNode[] => {
+	if (!doc) return [];
+	const nodes = Array.from(doc.childNodes);
+	const filteredNodes = nodes.filter(
+		(node) => !['A'].includes(node.nodeName),
+	);
+	return filteredNodes.map(calloutDescriptionTextElement(format));
 };
 
 const Tweet = (props: {
@@ -780,6 +819,7 @@ export {
 	renderText,
 	textElement as renderTextElement,
 	standfirstText as renderStandfirstText,
+	calloutDescriptionText as renderCalloutDescriptionText,
 	getHref,
 	transformHref,
 	plainTextElement,

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -2545,10 +2545,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-6.0.2.tgz#8db9316238774cfdc89b465f9f6550c6f3012af5"
-  integrity sha512-KEr16EjdFQaDd2u4LNp2ZXeWT6yf80QOI8ps1PgHqbNjHlvzuOwBQV5asY1EWf1+sj7mH1Lj/d1MjI5qn0jUMg==
+"@guardian/source-react-components-development-kitchen@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-8.1.0.tgz#9784720a9487b6b56fb20f8131c4bb313d9d1aa1"
+  integrity sha512-F6APcZQBqqujSUDo7sA3zDVGqcPT9TSqjhsHExtRU902MLL3EngaU4u9UFb3P/BQsdP6gefmUnMsCM1CsxKvOw==
 
 "@guardian/source-react-components@^9.0.0":
   version "9.1.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This change hydrates the updated Callout. This is needed as the callout relies on JS.

## Why?
This PR is one of several that make up the Callout work that Editorial Experience is working on.
It has been split out to reduce the size of the PR's, and make it more easily understandable.

## Screen