### PR TITLE
feat(enhanceCards): use replacement images

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -104,7 +104,10 @@ const decideAvatarUrl = (
 };
 
 const decideImage = (trail: FEFrontCard) => {
-	if (trail.type === 'LinkSnap') {
+	if (
+		trail.type === 'LinkSnap' ||
+		trail.properties.image?.type === 'Replace'
+	) {
 		return trail.properties.image?.item.imageSrc;
 	}
 

--- a/dotcom-rendering/src/web/components/Picture.tsx
+++ b/dotcom-rendering/src/web/components/Picture.tsx
@@ -179,6 +179,10 @@ const generateImageURL = ({
 	resolution: 'low' | 'high';
 }): string => {
 	const url = new URL(master);
+
+	// In CODE, we do not generate optimised replacement images
+	if (url.hostname === 's3-eu-west-1.amazonaws.com') return url.href;
+
 	const service = url.hostname.split('.')[0] ?? '';
 
 	const params = new URLSearchParams({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

If these images are specified in the Fronts tool, they should be served instead of the article’s main picture.

To get this behaviour in CODE environment, we need to keep S3 media URLs as-is.

## Why?

Resolves #6661 

## Screenshots

| Frontend      | DCR       |
|-------------|------------|
| ![fe-1][] | ![dcr-1][] |
| ![fe-2][] | ![dcr-2][] |

[fe-1]: https://user-images.githubusercontent.com/76776/208415588-30dc39e0-0840-44f5-8489-453149bdefa0.png
[dcr-1]: https://user-images.githubusercontent.com/76776/208415486-52f771fa-6411-45d2-997f-3c089918fb65.png


[fe-2]: https://user-images.githubusercontent.com/76776/208424888-415ce886-2300-4c7e-b71a-ec0d1febe523.png
[dcr-2]: https://user-images.githubusercontent.com/76776/208424852-70dda5ab-f1af-484f-bdc5-67896f7556b8.png
