### PR TITLE
Enable SWC browser variant AB test

### DIFF
--- a/dotcom-rendering/scripts/webpack/bundles.js
+++ b/dotcom-rendering/scripts/webpack/bundles.js
@@ -6,7 +6,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = false;
+const BUILD_VARIANT = true;
 
 /**
  * Server-side test names for `dcr-javascript-bundle`.

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
@@ -1,0 +1,63 @@
+import { isSentryEnabled } from './init';
+
+// Stubbed to prevent parsing of __webpack_public_path__
+jest.mock('./loadSentry', () => ({ loadSentry: jest.fn() }));
+
+describe('Load Sentry when it passes loading conditions', () => {
+	it('does NOT load Sentry when enableSentryReporting switch is false', () => {
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: false,
+				isInBrowserVariantTest: true,
+				randomCentile: 99,
+			}),
+		).toEqual(false);
+	});
+	it('does NOT load Sentry when in development environment', () => {
+		expect(
+			isSentryEnabled({
+				isDev: true,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: true,
+				randomCentile: 1,
+			}),
+		).toEqual(false);
+	});
+	it('does load Sentry when the user is in the browser bundle variant test', () => {
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: true,
+				randomCentile: 1,
+			}),
+		).toEqual(true);
+	});
+	it('does load Sentry for 1% of users', () => {
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: false,
+				randomCentile: 1,
+			}),
+		).toEqual(false);
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: false,
+				randomCentile: 99,
+			}),
+		).toEqual(false);
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: false,
+				randomCentile: 100,
+			}),
+		).toEqual(true);
+	});
+});

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
@@ -3,8 +3,8 @@ import { isSentryEnabled } from './init';
 // Stubbed to prevent parsing of __webpack_public_path__
 jest.mock('./loadSentry', () => ({ loadSentry: jest.fn() }));
 
-describe('Load Sentry when it passes loading conditions', () => {
-	it('does NOT load Sentry when enableSentryReporting switch is false', () => {
+describe('Enable Sentry when it passes loading conditions', () => {
+	it('does NOT enable Sentry when enableSentryReporting switch is false', () => {
 		expect(
 			isSentryEnabled({
 				isDev: false,
@@ -14,7 +14,7 @@ describe('Load Sentry when it passes loading conditions', () => {
 			}),
 		).toEqual(false);
 	});
-	it('does NOT load Sentry when in development environment', () => {
+	it('does NOT enable Sentry when in development environment', () => {
 		expect(
 			isSentryEnabled({
 				isDev: true,
@@ -24,7 +24,7 @@ describe('Load Sentry when it passes loading conditions', () => {
 			}),
 		).toEqual(false);
 	});
-	it('does load Sentry when the user is in the browser bundle variant test', () => {
+	it('does enable Sentry when the user is in the browser bundle variant test', () => {
 		expect(
 			isSentryEnabled({
 				isDev: false,
@@ -34,7 +34,7 @@ describe('Load Sentry when it passes loading conditions', () => {
 			}),
 		).toEqual(true);
 	});
-	it('does load Sentry for 1% of users', () => {
+	it('does enable Sentry for 1% of users', () => {
 		expect(
 			isSentryEnabled({
 				isDev: false,

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.ts
@@ -1,102 +1,63 @@
-import '../webpackPublicPath';
-import { isAdBlockInUse } from '@guardian/commercial-core';
 import {
 	BUILD_VARIANT,
 	dcrJavascriptBundle,
 } from '../../../../scripts/webpack/bundles';
 import { startup } from '../startup';
+import { loadSentry } from './loadSentry';
 
-const init = async (): Promise<void> => {
-	// We don't send errors on the dev server, or if the enableSentryReporting switch is off.
-	const {
-		switches: { enableSentryReporting },
-		isDev,
-	} = window.guardian.config;
-	const sentryDisabled = isDev || !enableSentryReporting;
+type IsSentryEnabled = {
+	enableSentryReporting: boolean;
+	isDev: boolean;
+	isInBrowserVariantTest: boolean;
+	randomCentile: number;
+};
+
+const isSentryEnabled = ({
+	enableSentryReporting,
+	isDev,
+	isInBrowserVariantTest,
+	randomCentile,
+}: IsSentryEnabled): boolean => {
+	// We don't send errors on the dev server, or if the enableSentryReporting switch is off
+	if (isDev || !enableSentryReporting) return false;
+	// We want to log all errors for users in the bundle variant AB test regardless of
+	// the sample rate. Please ensure that the test sample rate is low.
+	if (isInBrowserVariantTest) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that
 	// happen but if we used sampleRate to do this we'd be needlessly downloading
-	// Sentry 99% of the time. So instead we just do some basic math here
-	// and use that to prevent the Sentry script from ever loading.
-	const randomCentile = Math.floor(Math.random() * 100) + 1; // A number between 1 - 100
-	// We want to log all errors for users in the bundle variant AB test
-	// Please ensure that the test sample rate is low
+	// Sentry 99% of the time. So instead we just do some math here and use that
+	// to prevent the Sentry script from ever loading.
+	if (randomCentile <= 99) return false;
+	return true;
+};
+
+const stubSentry = () => {
+	window.guardian.modules.sentry.reportError = (error) => {
+		console.error(error);
+	};
+};
+
+const init = (): Promise<void> => {
+	const config = window.guardian.config;
+	const enableSentryReporting = config.switches.enableSentryReporting ?? false;
+	const isDev = config.isDev;
 	const isInBrowserVariantTest =
 		BUILD_VARIANT &&
-		window.guardian.config.tests[dcrJavascriptBundle('Variant')] ===
-			'variant';
-	const doNotLoadSentry =
-		(randomCentile <= 99 || sentryDisabled) && !isInBrowserVariantTest;
-
-	if (doNotLoadSentry) {
-		// 99% of the time we don't want to remotely log errors with Sentry and so
-		// we just console them out
-		window.guardian.modules.sentry.reportError = (error) => {
-			console.error(error);
-		};
-		return; // Don't initialise Sentry
-	}
-	// The other 1% of the time (randomCentile === 100) we continue
-	try {
-		// Downloading and initiliasing Sentry is asynchronous so we need a way
-		// to ensure injection only happens once and to capture any other errors that
-		// might happen while this script is loading
-		let injected = false;
-		const queue: Error[] = [];
-
-		// Function that gets called when an error happens before Sentry is ready
-		const injectSentry = async (error?: Error) => {
-			// Remember this error for later
-			if (error) queue.push(error);
-
-			// Only inject once
-			if (injected) {
-				return;
-			}
-			injected = true;
-
-			// Make this call blocking. We are queing errors while we wait for this code to run
-			// so we won't miss any and by waiting here we ensure we will never make calls we
-			// expect to be blocked
-			const adBlockInUse: boolean = await isAdBlockInUse();
-			if (adBlockInUse) {
-				// Ad Blockers prevent calls to Sentry from working so don't try to load the lib
-				return;
-			}
-
-			// Load sentry.ts
-			const { reportError } = await import(
-				/* webpackChunkName: "sentry" */ './sentry'
-			);
-
-			// Sentry takes over control of the window.onerror and
-			// window.onunhandledrejection listeners but we need to
-			// manually redefine our own custom error reporting function
-			window.guardian.modules.sentry.reportError = reportError;
-
-			// Now that we have the real reportError function available,
-			// send any queued errors
-			while (queue.length) {
-				const queuedError = queue.shift();
-				if (queuedError) reportError(queuedError);
-			}
-		};
-
-		// This is how we lazy load Sentry. We setup custom functions and
-		// listeners to inject Sentry when an error happens
-		window.onerror = (message, url, line, column, error) =>
-			injectSentry(error);
-		window.onunhandledrejection = (event: undefined | { reason?: any }) =>
-			event && injectSentry(event.reason);
-		window.guardian.modules.sentry.reportError = (error) => {
-			injectSentry(error).catch((e) =>
-				console.error(`injectSentry - error: ${String(e)}`),
-			);
-		};
-	} catch {
-		// We failed to setup Sentry :(
-	}
+		config.tests[dcrJavascriptBundle('Variant')] === 'variant';
+	// Generate a number between 1 - 100
+	const randomCentile = Math.floor(Math.random() * 100) + 1;
+	const canLoadSentry = isSentryEnabled({
+		enableSentryReporting,
+		isDev,
+		isInBrowserVariantTest,
+		randomCentile,
+	});
+	canLoadSentry ? loadSentry() : stubSentry();
+	return Promise.resolve();
 };
 
 startup('sentryLoader', null, init);
+
+export { isSentryEnabled };

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.ts
@@ -40,13 +40,10 @@ const stubSentry = () => {
 };
 
 const init = (): Promise<void> => {
-	const config = window.guardian.config;
-	const enableSentryReporting =
-		config.switches.enableSentryReporting ?? false;
-	const isDev = config.isDev;
+	const { switches, isDev, tests } = window.guardian.config;
+	const enableSentryReporting = !!switches.enableSentryReporting;
 	const isInBrowserVariantTest =
-		BUILD_VARIANT &&
-		config.tests[dcrJavascriptBundle('Variant')] === 'variant';
+		BUILD_VARIANT && tests[dcrJavascriptBundle('Variant')] === 'variant';
 	// Generate a number between 1 - 100
 	const randomCentile = Math.floor(Math.random() * 100) + 1;
 	const canLoadSentry = isSentryEnabled({

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.ts
@@ -41,7 +41,8 @@ const stubSentry = () => {
 
 const init = (): Promise<void> => {
 	const config = window.guardian.config;
-	const enableSentryReporting = config.switches.enableSentryReporting ?? false;
+	const enableSentryReporting =
+		config.switches.enableSentryReporting ?? false;
 	const isDev = config.isDev;
 	const isInBrowserVariantTest =
 		BUILD_VARIANT &&

--- a/dotcom-rendering/src/web/browser/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/loadSentry.ts
@@ -1,0 +1,66 @@
+import '../webpackPublicPath';
+import { isAdBlockInUse } from '@guardian/commercial-core';
+
+const loadSentry = (): void => {
+	try {
+		// Downloading and initiliasing Sentry is asynchronous so we need a way
+		// to ensure injection only happens once and to capture any other errors that
+		// might happen while this script is loading
+		let injected = false;
+		const queue: Error[] = [];
+
+		// Function that gets called when an error happens before Sentry is ready
+		const injectSentry = async (error?: Error) => {
+			// Remember this error for later
+			if (error) queue.push(error);
+
+			// Only inject once
+			if (injected) {
+				return;
+			}
+			injected = true;
+
+			// Make this call blocking. We are queing errors while we wait for this code to run
+			// so we won't miss any and by waiting here we ensure we will never make calls we
+			// expect to be blocked
+			const adBlockInUse: boolean = await isAdBlockInUse();
+			if (adBlockInUse) {
+				// Ad Blockers prevent calls to Sentry from working so don't try to load the lib
+				return;
+			}
+
+			// Load sentry.ts
+			const { reportError } = await import(
+				/* webpackChunkName: "sentry" */ './sentry'
+			);
+
+			// Sentry takes over control of the window.onerror and
+			// window.onunhandledrejection listeners but we need to
+			// manually redefine our own custom error reporting function
+			window.guardian.modules.sentry.reportError = reportError;
+
+			// Now that we have the real reportError function available,
+			// send any queued errors
+			while (queue.length) {
+				const queuedError = queue.shift();
+				if (queuedError) reportError(queuedError);
+			}
+		};
+
+		// This is how we lazy load Sentry. We setup custom functions and
+		// listeners to inject Sentry when an error happens
+		window.onerror = (message, url, line, column, error) =>
+			injectSentry(error);
+		window.onunhandledrejection = (event: undefined | { reason?: any }) =>
+			event && injectSentry(event.reason);
+		window.guardian.modules.sentry.reportError = (error) => {
+			injectSentry(error).catch((e) =>
+				console.error(`injectSentry - error: ${String(e)}`),
+			);
+		};
+	} catch {
+		// We failed to setup Sentry :(
+	}
+};
+
+export { loadSentry };

--- a/dotcom-rendering/src/web/browser/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/loadSentry.ts
@@ -23,6 +23,8 @@ const loadSentry = (): void => {
 			// Make this call blocking. We are queing errors while we wait for this code to run
 			// so we won't miss any and by waiting here we ensure we will never make calls we
 			// expect to be blocked
+			// Ad blocker detection can be expensive so it is checked here rather than in init
+			// to avoid blocking of the init flow
 			const adBlockInUse: boolean = await isAdBlockInUse();
 			if (adBlockInUse) {
 				// Ad Blockers prevent calls to Sentry from working so don't try to load the lib

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,7 +2901,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-2.0.3.tgz#1c8b832ab564b257f8146ca1b3183b7683026ec9"
   integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
 
-"@guardian/commercial-core@^5.0.0":
+"@guardian/commercial-core@^5.1.3":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.1.3.tgz#f7e845d8ae6e8ee6eaaf51fcce3400d94db81a59"
   integrity sha512-B7Sa7O0zHHP3jN36XdGHOZ9fAgjEMfRYuRURqX+ziiJE8+lmr7rkLX3MLgbYUJCIUfhagNkj559JZDXTLQoZ6g==


### PR DESCRIPTION
## What does this change?

Following #6578 :

- enables building and serving the SWC browser variant as an AB test
- bypass Sentry sampling if the user in the browser variant
- refactor Sentry loading as per #6829 

## Why?

To assess any impact of the SWC browser build on web vitals and Sentry errors against baseline

