### PR TITLE
Refactor Storybook static directories

### DIFF
--- a/dotcom-rendering/.storybook/main.js
+++ b/dotcom-rendering/.storybook/main.js
@@ -18,6 +18,7 @@ module.exports = {
 		builder: 'webpack5',
 	},
 	stories: ['../src/**/*.stories.@(tsx)', '../stories/**/*.stories.@(tsx)'],
+	staticDirs: ['../src/static'],
 	addons: [
 		'@storybook/addon-essentials',
 		'storybook-addon-turbo-build',

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -32,8 +32,8 @@
 		"cypress:open:percy": "percy exec -- cypress open --e2e --browser electron --config specPattern='cypress/snapshot/**/*'",
 		"cypress:run:percy": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'",
 		"unused-exports": "yarn ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
-		"storybook": "start-storybook -p 4002 --static-dir ./src/static",
-		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook --static-dir ./src/static",
+		"storybook": "start-storybook -p 4002",
+		"build-storybook": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
 		"makeBuild": "NODE_ENV=production CI_ENV=github webpack --config ./scripts/webpack/webpack.config.js"
 	},
 	"bundlesize": [


### PR DESCRIPTION
## What does this change?

Remove [deprecated](https://storybook.js.org/docs/react/configure/images-and-assets#%EF%B8%8F-deprecated-serving-static-files-via-storybook-cli) CLI option [in favour of the recommended config](https://storybook.js.org/docs/react/configure/images-and-assets#serving-static-files-via-storybook-configuration).

## Why?

Duplicate of #5929, which is not longer up-to-date with `main` 😢 

## Screenshots

The icons still work, see camera below:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/76776/208468343-c19daec8-8ae5-44ba-8cc7-7f8eb383be28.png">
