### PR TITLE
Support SVG images on Fronts

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -307,7 +307,7 @@ type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
 
-type CardImageType = 'mainMedia' | 'avatar';
+type CardImageType = 'mainMedia' | 'avatar' | 'crossword';
 
 type SmallHeadlineSize =
 	| 'tiny'

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4291,6 +4291,9 @@
                 "isSnap": {
                     "type": "boolean"
                 },
+                "isCrossword": {
+                    "type": "boolean"
+                },
                 "snapData": {
                     "type": "object",
                     "properties": {

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -113,6 +113,10 @@ const decideImage = (trail: FEFrontCard) => {
 
 	if (trail.display.imageHide) return undefined;
 
+	if (trail.properties.isCrossword && trail.properties.maybeContentId) {
+		return `https://api.nextgen.guardianapps.co.uk/${trail.properties.maybeContentId}.svg`;
+	}
+
 	return trail.properties.maybeContent?.trail.trailPicture?.allImages[0]?.url;
 };
 
@@ -208,6 +212,7 @@ export const enhanceCards = (
 			showByline: faciaCard.properties.showByline,
 			snapData: enhanceSnaps(faciaCard.enriched),
 			isBoosted: faciaCard.display.isBoosted,
+			isCrossword: faciaCard.properties.isCrossword,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
 			avatarUrl:
 				faciaCard.properties.maybeContent?.tags.tags &&

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3038,6 +3038,9 @@
                 "isSnap": {
                     "type": "boolean"
                 },
+                "isCrossword": {
+                    "type": "boolean"
+                },
                 "snapData": {
                     "type": "object",
                     "properties": {

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -21,6 +21,7 @@ interface BaseTrailType {
 	linkText?: string;
 	branding?: Branding;
 	isSnap?: boolean;
+	isCrossword?: boolean;
 	snapData?: DCRSnapType;
 	showQuotedHeadline?: boolean;
 }

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -50,6 +50,7 @@ export type Props = {
 	imagePositionOnMobile?: ImagePositionType;
 	/** Size is ignored when position = 'top' because in that case the image flows based on width */
 	imageSize?: ImageSizeType;
+	isCrossword?: boolean;
 	trailText?: string;
 	avatarUrl?: string;
 	showClock?: boolean;
@@ -180,12 +181,17 @@ const CommentFooter = ({
 const getImage = ({
 	imageUrl,
 	avatarUrl,
+	isCrossword,
 }: {
 	imageUrl?: string;
 	avatarUrl?: string;
+	isCrossword?: boolean;
 }): { type: CardImageType; src: string } | undefined => {
 	if (avatarUrl) return { type: 'avatar', src: avatarUrl };
-	if (imageUrl) return { type: 'mainMedia', src: imageUrl };
+	if (imageUrl) {
+		const type = isCrossword ? 'crossword' : 'mainMedia';
+		return { type, src: imageUrl };
+	}
 	return undefined;
 };
 
@@ -237,6 +243,7 @@ export const Card = ({
 	showAge = false,
 	discussionId,
 	isDynamo,
+	isCrossword,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 
@@ -324,6 +331,7 @@ export const Card = ({
 	const image = getImage({
 		imageUrl,
 		avatarUrl,
+		isCrossword,
 	});
 
 	return (
@@ -351,7 +359,7 @@ export const Card = ({
 						imagePosition={imagePosition}
 						imagePositionOnMobile={imagePositionOnMobile}
 					>
-						{image.type === 'avatar' ? (
+						{image.type === 'avatar' && (
 							<AvatarContainer
 								imageSize={imageSize}
 								imagePosition={imagePosition}
@@ -363,12 +371,16 @@ export const Card = ({
 									format={format}
 								/>
 							</AvatarContainer>
-						) : (
+						)}
+						{image.type === 'mainMedia' && (
 							<CardPicture
 								master={image.src}
 								imageSize={imageSize}
 								alt=""
 							/>
+						)}
+						{image.type === 'crossword' && (
+							<img src={image.src} alt="" />
 						)}
 					</ImageWrapper>
 				)}

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -41,6 +41,7 @@ export const FrontCard = (props: Props) => {
 		showSlash: true,
 		showClock: false,
 		imageUrl: trail.image,
+		isCrossword: trail.isCrossword,
 		mediaType: trail.mediaType,
 		mediaDuration: trail.mediaDuration,
 		starRating: trail.starRating,


### PR DESCRIPTION
## What does this change?

Adds SVG images on cards for crossword pages.

The image does not use the `Picture` component, as there’s only one source for the SVG, because it does not need to change depending on the viewport width and resolution.

## Why?

Resolves #6236 

## Screenshots

| Frontend      | DCR      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/208474329-cb2a607f-7cab-48fa-a5d1-6f250bd507b6.png
[after]: https://user-images.githubusercontent.com/76776/208482091-96c7f7d8-1070-4801-9df6-b191cb52b2da.png


