### PR TITLE
Refactor font functions signatures

### DIFF
--- a/dotcom-rendering/src/lib/fonts-css.ts
+++ b/dotcom-rendering/src/lib/fonts-css.ts
@@ -247,17 +247,10 @@ const fontList: FontDisplay[] = [
 	},
 ];
 
-const assetsUrl = (path: string): string =>
+const assetsUrl = (path: string) =>
 	`https://assets.guim.co.uk/static/frontend/${path}`;
 
-const template: (_: FontDisplay) => string = ({
-	family,
-	woff2,
-	woff,
-	ttf,
-	weight,
-	style,
-}) => `
+const template = ({ family, woff2, woff, ttf, weight, style }: FontDisplay) => `
     @font-face {
         font-family: "${family}";
         src: url(${assetsUrl(woff2)}) format("woff2"),
@@ -269,7 +262,7 @@ const template: (_: FontDisplay) => string = ({
     }
 `;
 
-const getStyleString: () => string = () => {
+const getStyleString = () => {
 	return fontList.reduce(
 		(styleString, font) => `${styleString}${template(font)}`,
 		'',


### PR DESCRIPTION
## What does this change?

Refactor `fonts-css.ts` type signatures.

> **Note**
> It might be beneficial to have more code generation, [like in search-rendering](https://github.com/mxdvl/search-rendering/blob/974db91faadff4a592ab4467045c191c05007907/src/fonts.ts)

## Why?

They can be inferred. Pass-by refactor whilst looking at why fonts sometimes fail to load on Chromatic. Makes @jamesgorrie [happy with lean PRs](https://github.com/guardian/dotcom-rendering/pull/6814#pullrequestreview-1224102024)