### PR TITLE
chore(deps): bump @guardian/core-web-vitals

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -75,7 +75,7 @@
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^5.0.0",
 		"@guardian/consent-management-platform": "11.0.0",
-		"@guardian/core-web-vitals": "^1.0.0",
+		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/discussion-rendering": "^11.0.3",
 		"@guardian/eslint-config": "^2.0.3",
 		"@guardian/eslint-config-typescript": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,10 +2980,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-11.0.0.tgz#240083bbe4e8c4c22410cfa4c867b608e7c0e92f"
   integrity sha512-j97gI5NbhVLXy1s8465lyT/w/nU3K+HewkfHIQ/NLOvzBS2mmcgB6A6sRXsKCOYRt4W8eNoTX5xgAdemFgvLAw==
 
-"@guardian/core-web-vitals@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-1.0.0.tgz#f5624eabbf7123f8a764c00674e640a10a80e2da"
-  integrity sha512-3WTUK6FmZpVUQGoc+hlAcuYx8yVKdYfpcP7HWkBmy1yaWV5yJ81HBxxoACwUeMrZrKLMlCMriPTC9CLhPgGGUQ==
+"@guardian/core-web-vitals@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-2.0.1.tgz#b04f12ff36f66db800a68b81b65eedfc86289211"
+  integrity sha512-xm5oDtRBu37KPmiT61z+E/Wz3HHifayJjVMwd/nfLxNRd1eFOVmplaeTDtygGKy4KjIwX90R5j/Sjs9apTVnLA==
 
 "@guardian/discussion-rendering@^11.0.3":
   version "11.0.3"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bump `@guardian/core-web-vitals` to v2

## Why?

Keep things up to date, and [in line with frontend](https://github.com/guardian/frontend/pull/25788).