### PR TITLE
Remove @guardian/ab-react

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,6 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^2.0.0",
-		"@guardian/ab-react": "^2.0.1",
 		"@guardian/atoms-rendering": "^24.0.0",
 		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,11 +2946,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/ab-react@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
-  integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
-
 "@guardian/atoms-rendering@^24.0.0":
   version "24.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-24.0.0.tgz#1c07557cfab11f27b256756fe0c566756ade1223"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove [@guardian/ab-react](https://github.com/guardian/ab-testing/tree/main/packages/ab-react)

## Why?

We no longer use this dependency, since #4200