### PR TITLE
Fix metric sampling for teads cookieless test

### DIFF
--- a/dotcom-rendering/src/web/experiments/tests/teads-cookieless.ts
+++ b/dotcom-rendering/src/web/experiments/tests/teads-cookieless.ts
@@ -13,7 +13,7 @@ export const teadsCookieless: ABTest = {
 	successMeasure: 'No significant impact to UX',
 	canRun: () => true,
 	variants: [
-		{ id: 'control', test: () => bypassMetricsSampling },
-		{ id: 'variant', test: () => bypassMetricsSampling },
+		{ id: 'control', test: bypassMetricsSampling },
+		{ id: 'variant', test: bypassMetricsSampling },
 	],
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
bypassMetricsSampling needs to be called, not just returned :)

Is there a way typescript could have saved me?


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
