### PR TITLE
Add total-blocking-time to Lighthouse assertions

### DIFF
--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -41,6 +41,10 @@ module.exports = {
 				{
 					matchingUrlPattern: 'http://localhost:9000/Article?.+',
 					assertions: {
+						'total-blocking-time': [
+							'warn',
+							{ maxNumericValue: 219 }
+						],
 						'categories:accessibility': [
 							'error',
 							{ minScore: 0.97 },
@@ -50,6 +54,10 @@ module.exports = {
 				{
 					matchingUrlPattern: 'http://localhost:9000/Front?.+',
 					assertions: {
+						'total-blocking-time': [
+							'warn',
+							{ maxNumericValue: 716 }
+						],
 						'categories:accessibility': [
 							'warn',
 							{ minScore: 0.97 },


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds budget assertions for Total Blocking Time to our Lighthouse config.

## Why?
It's being collected anyway as part of the Lighthouse CI action, and it will be useful to surface it more clearly. See issue [#6322](https://github.com/guardian/dotcom-rendering/issues/6322)

## Budgets
I'm not sure what our budget should be for this metric. I picked the current values from some recent Lighthouse runs, but it looks like there's actually quite a bit of variance, at least between different runs. (The assertions are made against the median values from 10 runs.) Given that it's not a blocking CI action, we could just merge it and see what sort of numbers come up, then set a floor based on that. (Unless anyone, e.g. @mxdvl, has a more principled way of setting a budget here?) 