### PR TITLE
FixedMediumFastXII sublinks: Use Card25Media25 for top row

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
@@ -1,5 +1,6 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import { Card25Media25 } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
@@ -25,7 +26,7 @@ export const FixedMediumFastXII = ({
 				{firstSlice25.map((trail) => {
 					return (
 						<LI key={trail.url} padSides={true} percentage="25%">
-							<FrontCard
+							<Card25Media25
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces the `<FrontCard>` component with a `<Card25Media25>` component in the top row.


## Why?
To match the sublink behaviour of Frontend. Closes #6701 


## Screenshots

**nb.** There are differences between these two screenshots in how the rows are rendered when they aren't full, and also in the rendering of the contributor photos, replacement images etc. These are separate issues, not related to sublinks. I think that the former is an intended change (it's a widespread one in DCR, anyway.) I'm assuming that the latter will be covered by #6392, but we should check.

| Frontend     | DCR (this PR)      |
|-------------|------------|
| <img width="460" alt="image" src="https://user-images.githubusercontent.com/37048459/209983652-e150ea73-5e9d-440c-8622-ce0eab1c3cd5.png"> | <img width="466" alt="image" src="https://user-images.githubusercontent.com/37048459/209983609-e6a92ca7-0d73-421a-a5de-aabe42c1bcca.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
