### PR TITLE
Bump atoms rendering to 25.0.3

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -42,7 +42,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/apps-rendering-api-models": "3.1.0",
-		"@guardian/atoms-rendering": "^23.7.2",
+		"@guardian/atoms-rendering": "^25.0.3",
 		"@guardian/bridget": "^2.0.0",
 		"@guardian/cdk": "^47.3.3",
 		"@guardian/common-rendering": "./../common-rendering",

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -2398,10 +2398,10 @@
     node-int64 "^0.4.0"
     thrift "^0.15.0"
 
-"@guardian/atoms-rendering@^23.7.2":
-  version "23.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-23.8.0.tgz#232eee050de29956d78357f92f3817f3300c5c53"
-  integrity sha512-zsbTWimqz2Ivm6GROUrUSgsc1XFEYUlVlyTOlHo1aBO2ZqN1MnZN3O4XhHnE1FivrDZhQmykRUZVO0a3kUoHYA==
+"@guardian/atoms-rendering@^25.0.3":
+  version "25.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.0.3.tgz#27ec39cc4737a5c09404e482f68a36bb82595b8a"
+  integrity sha512-Uh9Z12GUZbyT9guMCH92TVfSfhMVQT9luKxDsOalzlFwMVkrTAoDqqdzLAhJ8c6IX7SKaMXz76ZtDHZeskptQg==
   dependencies:
     is-mobile "^3.1.1"
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^2.0.0",
-		"@guardian/atoms-rendering": "^24.0.0",
+		"@guardian/atoms-rendering": "^25.0.3",
 		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,10 +2946,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/atoms-rendering@^24.0.0":
-  version "24.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-24.0.0.tgz#1c07557cfab11f27b256756fe0c566756ade1223"
-  integrity sha512-pB8Z3D/ag1lji+clwNsjjo3Yj3Ge8UoknM9WD4G7vZFPFWv31VLnv//MTx985v4iN0NAylWmtP/ePhTCzq6eJQ==
+"@guardian/atoms-rendering@^25.0.3":
+  version "25.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.0.3.tgz#27ec39cc4737a5c09404e482f68a36bb82595b8a"
+  integrity sha512-Uh9Z12GUZbyT9guMCH92TVfSfhMVQT9luKxDsOalzlFwMVkrTAoDqqdzLAhJ8c6IX7SKaMXz76ZtDHZeskptQg==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps Atoms-Rendering to version 25.0.3 in both DCR and AR

## Why?

We've made some recent updates to TS and Eslint rules and want to make sure the fixes work.

See the changelog here: https://github.com/guardian/atoms-rendering/blob/main/CHANGELOG.md

