### PR TITLE
Disable CMP for liveblog epic test

### DIFF
--- a/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
+++ b/dotcom-rendering/cypress/e2e/parallel-3/epic.interactivity.cy.js
@@ -3,7 +3,7 @@
 import { storage } from '@guardian/libs';
 import { mockApi } from '../../lib/mocks';
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
-import { cmpIframe } from '../../lib/cmpIframe';
+import { disableCMP } from '../../lib/disableCMP.js';
 
 const blogUrl =
 	'https://www.theguardian.com/australia-news/live/2022/feb/22/australia-news-live-updates-scott-morrison-nsw-trains-coronavirus-covid-omicron-weather';
@@ -19,6 +19,7 @@ const stubUpdates = () => {
 
 describe('Epics', function () {
 	beforeEach(function () {
+		disableCMP();
 		setLocalBaseUrl();
 		mockApi();
 	});
@@ -27,7 +28,6 @@ describe('Epics', function () {
 		stubUpdates();
 		storage.local.set('gu.geo.override', 'GB');
 		cy.visit(`/Article?url=${blogUrl}?live=true&force-liveblog-epic=true`);
-		cmpIframe().contains('Yes, I’m happy').click();
 
 		// Wait for hydration of the Epic
 		cy.get('gu-island[name=LiveBlogEpic]')


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

The liveblog epic cypress test now disables the CMP rather than accepts cookies after page load. This mimics the behaviour of similar cypress tests.

## Why?

There is an AB test running that changes that the text on the cookie banner. This means that the cypress test will periodically fail when the browser is opted in the variant of the AB test.

