### PR TITLE
Fixed small slow vmpu sublinks

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -1,7 +1,7 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
-import { Card25Media25Tall, CardDefault } from '../lib/cardWrappers';
+import { Card33Media33Tall, CardDefault } from '../lib/cardWrappers';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -26,7 +26,7 @@ export const FixedSmallSlowVMPU = ({
 		<UL direction="row">
 			{firstSlice33.map((trail) => (
 				<LI percentage="33.333%" padSides={true} key={trail.url}>
-					<Card25Media25Tall
+					<Card33Media33Tall
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -265,6 +265,46 @@ export const Card25Media25Tall = ({
 };
 
 /**
+ * ┏━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
+ * ┃▒▒▒▒▒▒▒▒▒▒▒▒┃           66%          ┊
+ * ┃▒▒▒▒▒▒▒▒▒▒▒▒┃        Remaining       ┊
+ * ┃            ┃                        ┊
+ * ┗━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
+ * Card designed to take up 33% of the container, with media that takes up 33%
+ *
+ * Options:
+ *  - Medium headline (medium on mobile)
+ *  - Small image on the top (left on mobile)
+ *  - Trail text when there is no supporting content
+ *  - Up to 2 supporting content items, always aligned vertical
+ */
+export const Card33Media33Tall = ({
+	trail,
+	showAge,
+	containerPalette,
+}: TrailProps) => {
+	return (
+		<FrontCard
+			trail={trail}
+			containerPalette={containerPalette}
+			showAge={showAge}
+			imagePosition="top"
+			imagePositionOnMobile="left"
+			imageSize="small"
+			headlineSize="medium"
+			headlineSizeOnMobile="medium"
+			trailText={
+				trail.supportingContent === undefined ||
+				trail.supportingContent.length === 0
+					? trail.trailText
+					: undefined
+			}
+			supportingContent={trail.supportingContent?.slice(0, 2)}
+		/>
+	);
+};
+
+/**
  * ┏━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
  * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃        50%       ┊
  * ┃▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃     Remaining    ┊


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces the `<FrontCard>` component with a `<Card33Media33Tall>` & `<CardDefault>`.
## Why?
To match the sublink behaviour of Frontend. Closes #6694
## Screenshots

| Frontend     | DCR (this PR)      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/210806343-175f3a62-2886-41a1-a917-9120292d916b.png
[after]: https://user-images.githubusercontent.com/110032454/210806454-b7451f20-3ed2-42d2-8051-090bb53e53fd.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
