### PR TITLE
AR: Fix pull quote padding on dark mode 

### DIFF
--- a/apps-rendering/src/components/ArticleBody/index.tsx
+++ b/apps-rendering/src/components/ArticleBody/index.tsx
@@ -40,7 +40,6 @@ const ArticleBodyDarkStyles: SerializedStyles = darkModeCss`
 
     p:last-child {
         margin-bottom: 0;
-        padding-bottom: 1em;
     }
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

 This PR fixes the amount of space underneath pull quotes without a citation on dark mode. 

## Why?

 In a recent PR https://github.com/guardian/dotcom-rendering/pull/6546 I fixed the margin underneath pull quotes by adding some space to the bottom. This fixed pull quotes with a citation, but unfortunately then added **too much** margin underneath pull quotes without a citation on dark mode only. This fixes that. 

 In order to do this I've had to edit the dark mode css on the "Article Body" file. I'm a little confused as to why dark mode would change things such as margin/padding. Any clarification here would be great incase I've broken something. I'm also conscious that we don't have visual regression testing for dark mode. 

Just to be clear, this is **not a bug on light mode** - pull quotes look absolutely fine with/without a citation on light mode. 

## Screenshots

The top row shows a pull quote **without a citation**. The bottom row shows a pull quote **with a citation**.

| Before      | After (no difference on citation quote)     |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[after]: https://user-images.githubusercontent.com/102960825/211038767-685aa820-f9b8-406d-9445-228b7dc06ce5.png
[before]: https://user-images.githubusercontent.com/102960825/211038819-1757e735-c6b6-4cf4-abd4-2994387f26c7.png
[after2]: https://user-images.githubusercontent.com/102960825/211038855-8cda3491-74a6-4c9e-bb69-7081b9aab6f9.png
[before2]: https://user-images.githubusercontent.com/102960825/211039069-38520975-0785-4729-b6e0-dfe14424d2e7.png


