### PR TITLE
AR: Fix padding under block quotes

### DIFF
--- a/apps-rendering/src/components/Blockquote/index.tsx
+++ b/apps-rendering/src/components/Blockquote/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 const styles = (format: ArticleFormat): SerializedStyles => css`
 	font-style: italic;
 	position: relative;
-	margin: ${remSpace[4]} 0 ${remSpace[9]} 0;
+	margin: ${remSpace[4]} 0 ${remSpace[4]} 0;
 
 	> svg {
 		width: 18px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This reduces the amount of padding under block quotes on AR.

## Why?

There is far more padding under block quotes on AR than there is on DCR. I'm assuming this is a visual bug, will need sign off from design. 

## Screenshots

| Before     | After     |
|-------------|------------|
| ![before][] | ![dark][] |

[before]: https://user-images.githubusercontent.com/102960825/211060751-bdf8b556-3171-4db2-b76a-1b206eaa32a1.png
[dark]: https://user-images.githubusercontent.com/102960825/211060798-ef7b9aec-eac6-41db-a63c-d122e4987d97.png