### PR TITLE
Reimplement the callout element

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -12,7 +12,7 @@ import type { Option } from '@guardian/types';
 import { fromNullable } from '@guardian/types';
 import { parseAtom } from 'atoms';
 import { ElementKind } from 'bodyElementKind';
-// import { getCallout } from 'campaign';
+import { getCallout } from 'campaign';
 import { formatDate } from 'date';
 import { parseAudio, parseGeneric, parseInstagram, parseVideo } from 'embed';
 import type { Embed } from 'embed';
@@ -344,45 +344,40 @@ const parse =
 			}
 
 			case ElementType.CALLOUT: {
-				/* Temporarily remove the callout implementation.
-				    This will be re-implemented after the A/B test in DCR is complete */
-				return Result.err(
-					'Callouts have not been implemented in Apps Rendering',
-				);
-				// const {
-				// 	campaignId: campaignId,
-				// 	isNonCollapsible: isNonCollapsible,
-				// } = element.calloutTypeData ?? {};
-				// if (
-				// 	campaignId === undefined ||
-				// 	campaignId === '' ||
-				// 	isNonCollapsible === undefined
-				// ) {
-				// 	return Result.err(
-				// 		'No valid campaignId or isNonCollapsible field on calloutTypeData',
-				// 	);
-				// }
+				const {
+					campaignId: campaignId,
+					isNonCollapsible: isNonCollapsible,
+				} = element.calloutTypeData ?? {};
+				if (
+					campaignId === undefined ||
+					campaignId === '' ||
+					isNonCollapsible === undefined
+				) {
+					return Result.err(
+						'No valid campaignId or isNonCollapsible field on calloutTypeData',
+					);
+				}
 
-				// return getCallout(campaignId, campaigns)
-				// 	.map(({ callout, name, activeUntil }) =>
-				// 		Result.ok<string, Callout>({
-				// 			kind: ElementKind.Callout,
-				// 			isNonCollapsible,
-				// 			heading: callout.callout,
-				// 			formFields: callout.formFields,
-				// 			formId: callout.formId,
-				// 			description: context.docParser(
-				// 				callout.description ?? '',
-				// 			),
-				// 			name: name,
-				// 			activeUntil: activeUntil,
-				// 		}),
-				// 	)
-				// 	.withDefault(
-				// 		Result.err<string, Callout>(
-				// 			'This piece contains a callout but no matching campaign',
-				// 		),
-				// 	);
+				return getCallout(campaignId, campaigns)
+					.map(({ callout, name, activeUntil }) =>
+						Result.ok<string, Callout>({
+							kind: ElementKind.Callout,
+							isNonCollapsible,
+							heading: callout.callout,
+							formFields: callout.formFields,
+							formId: callout.formId,
+							description: context.docParser(
+								callout.description ?? '',
+							),
+							name: name,
+							activeUntil: activeUntil,
+						}),
+					)
+					.withDefault(
+						Result.err<string, Callout>(
+							'This piece contains a callout but no matching campaign',
+						),
+					);
 			}
 
 			case ElementType.EMBED: {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR reimplements the callout element that was temporarily removed in https://github.com/guardian/dotcom-rendering/commit/a307c7d0e123e861964e37fe3e5f94408e7edb3d

## Why?
The callout element was temporarily removed as we wanted to do an A/B test in DCR. AR doesn't support this so it was temporarily removed until we'd completed the test.