### PR TITLE
Make `outline` Field Required

### DIFF
--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -69,7 +69,7 @@ const AnalysisLayout: FC<Props> = ({ item }) => (
 						<Metadata item={item} />
 						<Logo item={item} />
 					</section>
-					{!!item.outline?.length && (
+					{item.outline.length > 0 && (
 						<section css={[articleWidthStyles]}>
 							<TableOfContents
 								format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -108,7 +108,7 @@ const CommentLayout: FC<Props> = ({ item }) => (
 				<section css={articleWidthStyles}>
 					<Logo item={item} />
 				</section>
-				{!!item.outline?.length && (
+				{item.outline.length > 0 && (
 					<section css={articleWidthStyles}>
 						<TableOfContents
 							format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -113,7 +113,7 @@ const ImmersiveLayout: FC<Props> = ({ item }) => {
 						</div>
 						<Metadata item={item} />
 						<div css={bodyStyles}>
-							{!!item.outline?.length && (
+							{item.outline.length > 0 && (
 								<section>
 									<TableOfContents
 										format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -165,7 +165,7 @@ const StandardLayout: FC<Props> = ({ item }) => {
 						<Logo item={item} />
 					</section>
 
-					{!!item.outline?.length && (
+					{item.outline.length > 0 && (
 						<section css={articleWidthStyles}>
 							<TableOfContents
 								format={getFormat(item)}

--- a/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,7 +1,6 @@
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { explainer } from 'fixtures/item';
-import type { Outline } from 'outline';
 import type { ReactElement } from 'react';
 import TableOfContents from '.';
 
@@ -12,7 +11,7 @@ const format: ArticleFormat = {
 };
 
 const Default = (): ReactElement => (
-	<TableOfContents outline={explainer.outline as Outline} format={format} />
+	<TableOfContents outline={explainer.outline} format={format} />
 );
 
 export default {

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -400,6 +400,7 @@ const fields = {
 	promotedNewsletter: none,
 	edition: Edition.UK,
 	shouldHideAdverts: false,
+	outline: [],
 };
 
 const article: Standard = {

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -268,6 +268,7 @@ const fields = {
 	edition: Edition.UK,
 	promotedNewsletter: none,
 	shouldHideAdverts: false,
+	outline: [],
 };
 
 const pinnedBlock: LiveBlock = {

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -75,7 +75,7 @@ interface Fields extends ArticleFormat {
 	edition: Edition;
 	promotedNewsletter: Option<Newsletter>;
 	shouldHideAdverts: boolean;
-	outline?: Outline;
+	outline: Outline;
 }
 
 interface MatchReport extends Fields {
@@ -360,7 +360,7 @@ const parseItemFields = (
 		shouldHideAdverts: request.content.fields?.shouldHideAdverts ?? false,
 		outline: request.content.fields?.showTableOfContents
 			? fromBodyElements(body)
-			: undefined,
+			: [],
 	};
 };
 


### PR DESCRIPTION
## Why?

Currently the outline field has three possible states:

1. Populated list
2. Empty list
3. `undefined`

We consider 2) and 3) functionally the same, and handle them in the same way: don't render anything. Therefore we could reduce this field to two possible states - 1) and 2) - and remove some complexity.

This PR removes the possibility of this field being `undefined`, and uses empty list to represent the "empty" case.

## Changes

- Made empty list the "empty" case for outline
- Updated components to use `> 0` check for rendering
- Removed type cast
