### PR TITLE
Use `en-GB` For Paris

### DIFF
--- a/apps-rendering/src/datetime.ts
+++ b/apps-rendering/src/datetime.ts
@@ -56,7 +56,7 @@ const formatters = {
 		[Edition.UK]: timeFormatter('Europe/London', 'en-GB'),
 		[Edition.US]: timeFormatter('America/New_York', 'en-US'),
 		[Edition.AU]: timeFormatter('Australia/Sydney', 'en-AU'),
-		[Edition.EUROPE]: timeFormatter('Europe/Paris', 'en-FR'),
+		[Edition.EUROPE]: timeFormatter('Europe/Paris', 'en-GB'),
 		[Edition.INTERNATIONAL]: timeFormatter('Europe/London', 'en-GB'),
 	},
 };


### PR DESCRIPTION
## Why?

### TL;DR

`en-FR` is not a recognised locale, so the `Intl` library falls back to `en`. `en` doesn't provide timezone abbreviations for `Europe/Paris`, so uses GMT offsets for formatting. Using `en-GB` instead provides CET/CEST timezone abbreviations for `Europe/Paris`.

| Before | After |
| - | - |
| ![datetime-before] | ![datetime-after] |

[datetime-before]: https://user-images.githubusercontent.com/53781962/211335624-bfe889f7-1521-4b98-acbc-8f400756a7ec.jpg
[datetime-after]: https://user-images.githubusercontent.com/53781962/211335634-d568498e-923d-467f-b4e8-3ba5ee32b853.jpg

### Explanation

In order to format a date and/or time you need two pieces of information: a timezone, typically represented by a city, and a locale. Loosely speaking a locale could be thought of as a combination of region and language. The timezone tells you what offset from UTC to use, and the locale tells you how the formatted output should look, including language, order, timezone abbreviation (BST/EDT/AEDT) and so on.

Each locale only supports a subset of the list of timezone abbreviations (`en-GB` supports BST, `en-US` supports EDT, `en-AU` supports AEDT, etc.). These abbreviations correspond to timezones understood by the locale (`en-GB` understands `Europe/London`, `en-US` understands `America/Los_Angeles`, `en-AU` understands `Australia/Sydney`, etc.). For everything else, the formatter falls back to a UTC/GMT offset like UTC+1/GMT+1, UTC-5/GMT-5 etc. I think this is because the average person in a given locale is not expected to know the large list of worldwide timezone abbreviations, and is instead assumed to only recognise those that are commonly seen in that locale.

There is a finite list of locales defined by the `Intl` library/runtime, and `en-FR` does not appear to be in that list. In this situation the library attempts to fall back to one that is recognised (possibly the runtime default?), which on my machine is being reported as `en`. You can test this using the `resolvedOptions` [^1] method on an instance of `DateTimeFormat`. The `en` locale does not provide a timezone abbreviation for `Europe/Paris`, so is falling back to a GMT offset (GMT+1 or GMT+2, depending on whether daylight saving is in effect).

**Note:** `en` seems to provide abbreviations for the American timezones, so it may have some similarity to `en-US`.

We have decided we want to use CET/CEST for Europe, so we instead need to use a locale that provides this timezone abbreviation. `en-GB` works for this purpose.

More information in this discussion, particularly the section "A Note On Locales": https://github.com/guardian/dotcom-rendering/discussions/5068

## Changes

- Use `en-GB` to format Paris timezone

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
