### PR TITLE
Only build the browser variant if in production mode

### DIFF
--- a/dotcom-rendering/scripts/webpack/webpack.config.js
+++ b/dotcom-rendering/scripts/webpack/webpack.config.js
@@ -131,7 +131,9 @@ module.exports = [
 			sessionId,
 		}),
 	),
-	...(BUILD_VARIANT
+	// Only build the variant if in production mode
+	// Use `make build` or remove the PROD check temporarily to build the variant in development
+	...(PROD && BUILD_VARIANT
 		? [
 				merge(
 					commonConfigs({


### PR DESCRIPTION
## What does this change?

Adds a check to the webpack config to only build the browser variant if in production mode.

This is to prevent the variant building (and time cost) for all developers when they most likely will not test it locally.

If anyone wishes to test the variant locally they can run the production `make build` or remove the check temporarily.

## Why?

Improve local build times when `BUILD_VARIANT = true` in `bundles.js`

