### PR TITLE
Callouts : add flag and 0% AB test

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { between, body, headline, space } from '@guardian/source-foundations';
-import type { Switches } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import type { Palette } from '../../types/palette';
 import type { TagType } from '../../types/tag';
 import { ArticleRenderer } from '../lib/ArticleRenderer';
@@ -41,6 +41,7 @@ type Props = {
 	availableTopics?: Topic[];
 	selectedTopics?: Topic[];
 	isInLiveblogAdSlotTest?: boolean;
+	abTests?: ServerSideTests;
 };
 
 const globalH2Styles = (display: ArticleDisplay) => css`
@@ -139,6 +140,7 @@ export const ArticleBody = ({
 	selectedTopics,
 	keywordIds,
 	isInLiveblogAdSlotTest = false,
+	abTests,
 }: Props) => {
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const palette = decidePalette(format);
@@ -227,6 +229,7 @@ export const ArticleBody = ({
 				isDev={isDev}
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
+				abTests={abTests}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -601,6 +601,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 										keywordIds={
 											CAPIArticle.config.keywordIds
 										}
+										abTests={CAPIArticle.config.abTests}
 									/>
 									{showBodyEndSlot && (
 										<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -643,6 +643,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									isPreview={CAPIArticle.config.isPreview}
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -557,6 +557,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
 									keywordIds={CAPIArticle.config.keywordIds}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{showBodyEndSlot && (
 									<Island clientOnly={true}>

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -673,6 +673,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 									idUrl={CAPIArticle.config.idUrl || ''}
 									isDev={!!CAPIArticle.config.isDev}
 									keywordIds={CAPIArticle.config.keywordIds}
+									abTests={CAPIArticle.config.abTests}
 								/>
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (

--- a/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/web/lib/ArticleRenderer.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
-import type { Switches } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import type { CAPIElement } from '../../types/content';
 import type { TagType } from '../../types/tag';
 import {
@@ -45,6 +45,7 @@ type Props = {
 	isDev: boolean;
 	isAdFreeUser: boolean;
 	isSensitive: boolean;
+	abTests?: ServerSideTests;
 };
 
 export const ArticleRenderer = ({
@@ -65,6 +66,7 @@ export const ArticleRenderer = ({
 	isAdFreeUser,
 	isSensitive,
 	isDev,
+	abTests,
 }: Props) => {
 	const renderedElements = elements.map((element, index) => {
 		return (
@@ -83,6 +85,7 @@ export const ArticleRenderer = ({
 				isAdFreeUser={isAdFreeUser}
 				isSensitive={isSensitive}
 				switches={switches}
+				abTests={abTests}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -7,7 +7,7 @@ import {
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { getSharingUrls } from '../../lib/sharing-urls';
-import type { Switches } from '../../types/config';
+import type { ServerSideTests, Switches } from '../../types/config';
 import type { CAPIElement, RoleType } from '../../types/content';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
@@ -83,6 +83,7 @@ type Props = {
 	isSensitive: boolean;
 	switches: Switches;
 	isPinnedPost?: boolean;
+	abTests?: ServerSideTests;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -137,6 +138,7 @@ export const renderElement = ({
 	switches,
 	isSensitive,
 	isPinnedPost,
+	abTests,
 }: Props) => {
 	const palette = decidePalette(format);
 
@@ -181,10 +183,16 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.CalloutBlockElementV2':
-			if (switches.callouts) {
+			if (
+				switches.callouts &&
+				abTests?.calloutElementsVariant === 'variant'
+			) {
 				return (
 					<Island deferUntil="visible">
-						<CalloutBlockComponent callout={element} format={format} />
+						<CalloutBlockComponent
+							callout={element}
+							format={format}
+						/>
 					</Island>
 				);
 			}
@@ -783,6 +791,7 @@ export const RenderArticleElement = ({
 	isSensitive,
 	switches,
 	isPinnedPost,
+	abTests,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -802,6 +811,7 @@ export const RenderArticleElement = ({
 		isSensitive,
 		switches,
 		isPinnedPost,
+		abTests,
 	});
 
 	const needsFigure = !bareElements.has(element._type);

--- a/dotcom-rendering/src/web/lib/renderElement.tsx
+++ b/dotcom-rendering/src/web/lib/renderElement.tsx
@@ -181,11 +181,15 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.CalloutBlockElementV2':
-			return (
-				<Island deferUntil="visible">
-					<CalloutBlockComponent callout={element} format={format} />
-				</Island>
-			);
+			if (switches.callouts) {
+				return (
+					<Island deferUntil="visible">
+						<CalloutBlockComponent callout={element} format={format} />
+					</Island>
+				);
+			}
+			return null;
+
 		case 'model.dotcomrendering.pageElements.CaptionBlockElement':
 			return (
 				<CaptionBlockComponent


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR places the new callout block component behind a feature flag. It also places it behind a 0% AB that will allow editorial to test the feature before the hard launch. 
## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
