### PR TITLE
Do not show author's avatar in 2nd column `fixed/small/slow-V-mpu`

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallSlowVMPU.tsx
@@ -1,7 +1,7 @@
 import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
-import { Card33Media33Tall, CardDefault } from '../lib/cardWrappers';
+import { Card33Media33Tall, CardDefaultNoAvatar } from '../lib/cardWrappers';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -42,7 +42,7 @@ export const FixedSmallSlowVMPU = ({
 				<UL direction="column">
 					{remaining.map((trail) => (
 						<LI key={trail.url}>
-							<CardDefault
+							<CardDefaultNoAvatar
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -275,7 +275,7 @@ export const Card25Media25Tall = ({
  * Options:
  *  - Medium headline (medium on mobile)
  *  - Small image on the top (left on mobile)
- *  - Trail text when there is no supporting content
+ *  - Trail text when there is no supporting content or avatar
  *  - Up to 2 supporting content items, always aligned vertical
  */
 export const Card33Media33Tall = ({
@@ -294,8 +294,9 @@ export const Card33Media33Tall = ({
 			headlineSize="medium"
 			headlineSizeOnMobile="medium"
 			trailText={
-				trail.supportingContent === undefined ||
-				trail.supportingContent.length === 0
+				trail.avatarUrl === undefined &&
+				(trail.supportingContent === undefined ||
+					trail.supportingContent.length === 0)
 					? trail.trailText
 					: undefined
 			}

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -475,6 +475,37 @@ export const CardDefault = ({
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
+ * ┃                  ┃  Any% Remaining  ┊
+ * ┗━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
+ * Card designed to take up any width of container, with no media and no avatar
+ *
+ * Options:
+ *  - Small headline (small on mobile)
+ *  - No image / media
+ *  - No trail text
+ *  - No supporting content
+ *  - No avatar
+ */
+export const CardDefaultNoAvatar = ({
+	trail,
+	showAge,
+	containerPalette,
+}: TrailProps) => {
+	return (
+		<FrontCard
+			trail={trail}
+			containerPalette={containerPalette}
+			showAge={showAge}
+			imageUrl={undefined}
+			headlineSize="small"
+			headlineSizeOnMobile="small"
+			avatarUrl={undefined}
+		/>
+	);
+};
+
+/**
+ * ┏━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
  * ┃ ▒▒▒▒             ┃  Any% Remaining  ┊
  * ┗━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
  * Card designed to take up any width of container, with small left media


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes https://github.com/guardian/dotcom-rendering/issues/6157

## What does this change?
* Creates a `CardDefaultNoAvatar` wrapper for the 2nd column of `FixedSmallSlowVMPU`
* Makes sure `Card33Media33Tall` does not show `trailText` when there is an avatar.

## Why?
To achieve parity with frontend.

## Screenshots

|        | frontend | DCR |
|--------|----------|-----|
| Before | <img width="1307" alt="image" src="https://user-images.githubusercontent.com/19683595/211522089-8604ca79-12e6-4a51-af7f-ae0c2db590c5.png"> | <img width="1336" alt="image" src="https://user-images.githubusercontent.com/19683595/211522247-83afda0d-2130-4196-ab02-a10c947cd92d.png"> |
| After  | <img width="1307" alt="image" src="https://user-images.githubusercontent.com/19683595/211522089-8604ca79-12e6-4a51-af7f-ae0c2db590c5.png"> | <img width="1295" alt="image" src="https://user-images.githubusercontent.com/19683595/211522032-664df32a-c777-4597-b688-180d9f4829af.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
