### PR TITLE
Add jsx keys to Form and FormField arrays

### DIFF
--- a/dotcom-rendering/src/web/components/Callout/Form.tsx
+++ b/dotcom-rendering/src/web/components/Callout/Form.tsx
@@ -211,9 +211,8 @@ export const Form = ({
 				/>
 			)}
 			{formFields.map((formField) => (
-				<div css={formFieldWrapperStyles}>
+				<div css={formFieldWrapperStyles} key={formField.id}>
 					<FormField
-						key={formField.id}
 						format={format}
 						formField={formField}
 						formData={formData}

--- a/dotcom-rendering/src/web/components/Callout/FormField.tsx
+++ b/dotcom-rendering/src/web/components/Callout/FormField.tsx
@@ -173,6 +173,7 @@ export const FormField = ({
 
 							return (
 								<Checkbox
+									key={`form-field-${option.value}`}
 									name={name}
 									label={option.label}
 									value={option.value}
@@ -199,7 +200,7 @@ export const FormField = ({
 					<RadioGroup
 						label={formField.label}
 						supporting={formField.description}
-						error={validationErrors?.[formField.id]}
+						error={validationErrors[formField.id]}
 						name={formField.name}
 						orientation={
 							formField.options.length > 2


### PR DESCRIPTION
## What does this change?
- Adds the `key` prop to satisfy [this rule](https://github.com/guardian/dotcom-rendering/pull/6812).
- Fixes a linting rule where we don't need to check for nullish values.

Ping @tkgnm 