### PR TITLE
FixedMediumSlowVI sublinks

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVI.tsx
@@ -1,9 +1,9 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
 import {
-	Card25Media25Tall,
+	Card25Media25TallNoTrail,
 	Card25Media25TallSmallHeadline,
-	Card75Media66,
+	Card75Media50Right,
 } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -28,7 +28,7 @@ export const FixedMediumSlowVI = ({
 			<UL direction="row" padBottom={true}>
 				{firstSlice75.map((trail) => (
 					<LI key={trail.url} padSides={true} percentage={'75%'}>
-						<Card75Media66
+						<Card75Media50Right
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
@@ -43,7 +43,7 @@ export const FixedMediumSlowVI = ({
 						containerPalette={containerPalette}
 						percentage={'25%'}
 					>
-						<Card25Media25Tall
+						<Card25Media25TallNoTrail
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -115,53 +115,6 @@ export const Card100Media100 = ({
  * ┃         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃Remaining┊
  * ┃         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃         ┊
  * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┘
- * Card designed to take up 75% of the container, with media that takes up 66%
- *
- * Options:
- *  - Large headline
- *  - Large image on the right (top on mobile)
- *  - Trail text when there is no supporting content
- *  - Up to 3 supporting content items, 1-2 aligned vertical, 3 aligned horizontal
- */
-export const Card75Media66 = ({
-	trail,
-	showAge,
-	containerPalette,
-}: TrailProps) => {
-	return (
-		<FrontCard
-			trail={trail}
-			containerPalette={containerPalette}
-			showAge={showAge}
-			headlineSize="large"
-			headlineSizeOnMobile="large"
-			imageUrl={trail.image}
-			imageSize="large"
-			imagePosition="right"
-			imagePositionOnMobile="top"
-			trailText={
-				// Only show trail text if there is no supportContent
-				trail.supportingContent === undefined ||
-				trail.supportingContent.length !== 3
-					? trail.trailText
-					: undefined
-			}
-			supportingContent={trail.supportingContent?.slice(0, 3)}
-			supportingContentAlignment={
-				trail.supportingContent && trail.supportingContent.length > 2
-					? 'horizontal'
-					: 'vertical'
-			}
-		/>
-	);
-};
-
-/**
- * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┐
- * ┃         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃   25%   ┊
- * ┃         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃Remaining┊
- * ┃         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒┃         ┊
- * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┘
  * Card designed to take up 75% of the container, with media that takes up 50%
  *
  * Options:
@@ -321,9 +274,42 @@ export const Card25Media25Tall = ({
  * Card designed to take up 25% of the container, with media that takes up 25%
  *
  * Options:
+ *  - Medium headline (medium on mobile)
+ *  - Small image on the top (left on mobile)
+ *  - Up to 2 supporting content items, always aligned vertical
+ */
+export const Card25Media25TallNoTrail = ({
+	trail,
+	showAge,
+	containerPalette,
+}: TrailProps) => {
+	return (
+		<FrontCard
+			trail={trail}
+			containerPalette={containerPalette}
+			showAge={showAge}
+			imagePosition="top"
+			imagePositionOnMobile="left"
+			imageSize="small"
+			headlineSize="medium"
+			headlineSizeOnMobile="medium"
+			supportingContent={trail.supportingContent?.slice(0, 2)}
+		/>
+	);
+};
+
+/**
+ * ┏━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
+ * ┃▒▒▒▒▒▒▒▒▒┃                           ┊
+ * ┃▒▒▒▒▒▒▒▒▒┃            75%            ┊
+ * ┃         ┃         Remaining         ┊
+ * ┃         ┃                           ┊
+ * ┗━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
+ * Card designed to take up 25% of the container, with media that takes up 25%
+ *
+ * Options:
  *  - Small headline (medium on mobile)
  *  - Small image on the top (left on mobile)
- *  - Trail text when there is no supporting content
  *  - Up to 2 supporting content items, always aligned vertical
  */
 export const Card25Media25TallSmallHeadline = ({
@@ -341,12 +327,6 @@ export const Card25Media25TallSmallHeadline = ({
 			imageSize="small"
 			headlineSize="small"
 			headlineSizeOnMobile="medium"
-			trailText={
-				trail.supportingContent === undefined ||
-				trail.supportingContent.length === 0
-					? trail.trailText
-					: undefined
-			}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 		/>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces the `<FrontCard>` component with a `<Card75Media50Right>` & `<Card25Media25TallSmallHeadline>` &  `<Card25Media25TallNoTrail>`
## Why?
To match the sublink behaviour of Frontend. Closes #6698
## Screenshots

| Frontend     | DCR (this PR)      |
|-------------|------------|
| ![before][] | ![after][] |

| Frontend  No sublink   | DCR No sublink  (this PR)      |
|-------------|------------|
| ![b][] | ![a][] |

[before]: https://user-images.githubusercontent.com/110032454/211526233-c0626f4d-29c8-4405-b772-a92209e1e63d.png
[after]: https://user-images.githubusercontent.com/110032454/211606525-140cb838-b365-486d-93c2-61057d3d9f0e.png

[b]: https://user-images.githubusercontent.com/110032454/211611669-5e2c24d9-ea94-4ccd-af22-f6c6f9288c3c.png
[a]: https://user-images.githubusercontent.com/110032454/211611592-c3adbd57-9c9b-4e2c-8194-c92adea3ecc8.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
