### PR TITLE
Fix sublinks for `FixedLargeSlowXIV`

### DIFF
--- a/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/web/components/FixedLargeSlowXIV.tsx
@@ -4,6 +4,11 @@ import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
+import {
+	Card25Media25,
+	Card25Media25SmallHeadline,
+	Card75Media50Right,
+} from '../lib/cardWrappers';
 
 type Props = {
 	trails: TrailType[];
@@ -24,38 +29,34 @@ export const FixedLargeSlowXIV = ({
 	return (
 		<>
 			<UL direction="row" padBottom={true}>
-				{firstSlice75.map((card) => (
-					<LI padSides={true} percentage="75%" key={card.url}>
-						<FrontCard
-							trail={card}
-							starRating={card.starRating}
+				{firstSlice75.map((card) => {
+					return (
+						<LI padSides={true} percentage="75%" key={card.url}>
+							<Card75Media50Right
+								trail={card}
+								showAge={showAge}
+								containerPalette={containerPalette}
+							/>
+						</LI>
+					);
+				})}
+				{firstSlice25.map((card) => {
+					return (
+						<LI
+							padSides={true}
+							showDivider={true}
 							containerPalette={containerPalette}
-							showAge={showAge}
-							headlineSize="large"
-							imagePosition="right"
-							imagePositionOnMobile="top"
-							imageSize="large"
-							trailText={card.trailText}
-						/>
-					</LI>
-				))}
-
-				{firstSlice25.map((card) => (
-					<LI
-						padSides={true}
-						showDivider={true}
-						containerPalette={containerPalette}
-						percentage="25%"
-						key={card.url}
-					>
-						<FrontCard
-							trail={card}
-							starRating={card.starRating}
-							containerPalette={containerPalette}
-							showAge={showAge}
-						/>
-					</LI>
-				))}
+							percentage="25%"
+							key={card.url}
+						>
+							<Card25Media25
+								trail={card}
+								showAge={showAge}
+								containerPalette={containerPalette}
+							/>
+						</LI>
+					);
+				})}
 			</UL>
 			<UL direction="row" padBottom={true}>
 				{secondSlice25.map((card, cardIndex) => {
@@ -67,12 +68,10 @@ export const FixedLargeSlowXIV = ({
 							containerPalette={containerPalette}
 							key={card.url}
 						>
-							<FrontCard
+							<Card25Media25SmallHeadline
 								trail={card}
-								starRating={card.starRating}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								headlineSize="small"
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/web/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/web/lib/cardWrappers.tsx
@@ -223,6 +223,42 @@ export const Card25Media25 = ({
 		/>
 	);
 };
+
+/**
+ * ┏━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
+ * ┃▒▒▒▒▒▒▒▒▒┃            75%            ┊
+ * ┃▒▒▒▒▒▒▒▒▒┃         Remaining         ┊
+ * ┃         ┃                           ┊
+ * ┗━━━━━━━━━┹┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┘
+ * Card designed to take up 25% of the container, with media that takes up 25%
+ *
+ * Options:
+ *  - Medium headline (medium on mobile)
+ *  - Small image on the top (left on mobile)
+ *  - No trail text
+ *  - Up to 2 supporting content items, always aligned vertical
+ */
+export const Card25Media25SmallHeadline = ({
+	trail,
+	showAge,
+	containerPalette,
+}: TrailProps) => {
+	return (
+		<FrontCard
+			trail={trail}
+			supportingContent={trail.supportingContent?.slice(0, 2)}
+			supportingContentAlignment="vertical"
+			containerPalette={containerPalette}
+			showAge={showAge}
+			imagePosition="top"
+			imagePositionOnMobile="left"
+			imageSize="small"
+			headlineSize="small"
+			headlineSizeOnMobile="medium"
+		/>
+	);
+};
+
 /**
  * ┏━━━━━━━━━┱┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┐
  * ┃▒▒▒▒▒▒▒▒▒┃                           ┊


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #6692 

## What does this change?
* Fixes `fixed/large/slow/xiv` sublinks
* Adds `Card25Media25SmallHeadline` wrapper

## Why?
To achieve parity with frontend

## Screenshots
| sublinks | frontend | DCR |
|----------|----------|-----|
| 3              | <img width="1320" alt="image" src="https://user-images.githubusercontent.com/19683595/211563307-ee86b0b9-5fd9-4e77-9516-5b1b493628fc.png">  |  <img width="1321" alt="image" src="https://user-images.githubusercontent.com/19683595/211563386-6cc7712c-06ee-40b0-aedf-a4e7843641dc.png">   |
| 2              | <img width="1330" alt="image" src="https://user-images.githubusercontent.com/19683595/211563760-584e12d2-6962-47db-97eb-d40c22d7c9fb.png">  |  <img width="1298" alt="image" src="https://user-images.githubusercontent.com/19683595/211572923-94b73bb1-63ff-457b-80cd-153e6293d9dc.png"> |
| 1              | <img width="1313" alt="image" src="https://user-images.githubusercontent.com/19683595/211575951-d4092503-1d2c-415f-9375-d8780c3d98c3.png">  |  <img width="1329" alt="image" src="https://user-images.githubusercontent.com/19683595/211575827-2624629f-7478-43b7-8ee5-af71b2be29f3.png"> |
| 0              | <img width="1307" alt="image" src="https://user-images.githubusercontent.com/19683595/211576442-54d40811-4331-4e31-b6ae-a77c1e9e4356.png"> | <img width="1309" alt="image" src="https://user-images.githubusercontent.com/19683595/211576570-4732eeb5-e02a-4811-aa36-17fff89620fa.png"> |



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
