### PR TITLE
Special Report Alt Stories

### DIFF
--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
+
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import { ArticleSpecial } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
 import { formatToString } from 'articleFormat';
 import {
@@ -10,7 +12,7 @@ import {
 	explainer,
 	feature,
 	gallery,
-	immersive,
+	standardImmersive,
 	interview,
 	letter,
 	matchReport,
@@ -20,9 +22,13 @@ import {
 	quiz,
 	recipe,
 	review,
+	setEdition,
+	setTheme,
 } from 'fixtures/item';
 import { deadBlog, live } from 'fixtures/live';
-import type { ReactElement } from 'react';
+import { Item, NewsletterSignup } from 'item';
+import { compose, pipe } from 'lib';
+import type { FC, ReactElement } from 'react';
 import AnalysisLayout from './AnalysisLayout';
 import CommentLayout from './CommentLayout';
 import GalleryLayout from './GalleryLayout';
@@ -32,113 +38,146 @@ import LiveLayout from './LiveLayout';
 import NewsletterSignUpLayout from './NewsletterSignUpLayout';
 import StandardLayout from './StandardLayout';
 
-// ----- Stories ----- //
+// ----- Types ----- //
 
-export const Standard = (): ReactElement => <StandardLayout item={article} />;
-Standard.story = { name: formatToString(article) };
+/**
+ * A storybook story with a name.
+ */
+type Story = {(): ReactElement, story: { name: string }}
 
-export const Review = (): ReactElement => <StandardLayout item={review} />;
-Review.story = { name: formatToString(review) };
+// ----- Helpers ----- //
 
-export const MatchReport = (): ReactElement => (
-	<StandardLayout item={matchReport} />
-);
-MatchReport.story = { name: formatToString(matchReport) };
+/**
+ * Updates an instance of `Item`, setting the `theme` to `SpecialReportAlt`.
+ */
+const setSpecialReportAlt = setTheme(ArticleSpecial.SpecialReportAlt);
 
-export const PrintShop = (): ReactElement => (
-	<StandardLayout item={printShop} />
-);
-PrintShop.story = { name: formatToString(printShop) };
+/**
+ * Helper for generating layout stories. It takes a test instance of `Item`
+ * (a fixture) and applies it to a given layout component. It also generates
+ * a name for the story based on the `ArticleFormat` of the fixture.
+ * 
+ * @param Layout A layout component
+ * @returns A story created from a layout component and an `Item` fixture
+ */
+const createLayoutStory = <Fixture extends Item>(Layout: FC<{ item: Fixture }>) => (fixture: Fixture): Story => {
+	const story = () => <Layout item={fixture} />;
+	story.story = { name: formatToString(fixture) };
 
-export const PhotoEssay = (): ReactElement => (
-	<StandardLayout item={photoEssay} />
-);
-PhotoEssay.story = { name: formatToString(photoEssay) };
+	return story;
+}
 
-export const Feature = (): ReactElement => <StandardLayout item={feature} />;
-Feature.story = { name: formatToString(feature) };
+// ----- Story Helpers ----- //
 
-export const Interview = (): ReactElement => (
-	<StandardLayout item={interview} />
-);
-Interview.story = { name: formatToString(interview) };
+/*
+These can be used to generate stories for different layouts when provided with
+a fixture. They're here for convenience to avoid repetition in the main story
+code below.
+*/
 
-export const Quiz = (): ReactElement => <StandardLayout item={quiz} />;
-Quiz.story = { name: formatToString(quiz) };
+const standardLayoutStory = createLayoutStory(StandardLayout);
+const standardLayoutStoryWithSpecialReportAlt: typeof standardLayoutStory = compose(standardLayoutStory, setSpecialReportAlt);
+const commentLayoutStory = createLayoutStory(CommentLayout);
+const letterLayoutStory = createLayoutStory(LetterLayout);
+const analysisLayoutStory = createLayoutStory(AnalysisLayout);
+const liveLayoutStory = createLayoutStory(LiveLayout);
+const galleryLayoutStory = createLayoutStory(GalleryLayout);
+const immersiveLayoutStory = createLayoutStory(ImmersiveLayout);
 
-export const Recipe = (): ReactElement => <StandardLayout item={recipe} />;
-Recipe.story = { name: formatToString(recipe) };
-
-export const Comment = (): ReactElement => <CommentLayout item={comment} />;
-Comment.story = { name: formatToString(comment) };
-
-export const Letter = (): ReactElement => <LetterLayout item={letter} />;
-Letter.story = { name: formatToString(letter) };
-
-export const Editorial = (): ReactElement => <CommentLayout item={editorial} />;
-Editorial.story = { name: formatToString(editorial) };
-
-export const Analysis = (): ReactElement => <AnalysisLayout item={analysis} />;
-Analysis.story = { name: formatToString(analysis) };
-
-export const Explainer = (): ReactElement => (
-	<StandardLayout item={explainer} />
-);
-Explainer.story = { name: formatToString(explainer) };
-
-export const LiveBlog = (): ReactElement => (
-	<LiveLayout
-		item={{
-			...live,
-			edition: Edition.US,
-		}}
-	/>
-);
-LiveBlog.story = { name: formatToString(live) };
-
-export const DeadBlog = (): ReactElement => (
-	<LiveLayout
-		item={{
-			...deadBlog,
-			edition: Edition.AU,
-		}}
-	/>
-);
-DeadBlog.story = { name: formatToString(deadBlog) };
-
-export const NewsletterSignup = (): ReactElement => (
+const newsletterSignUpLayoutStory = createLayoutStory((props: { item: NewsletterSignup }) => (
 	<>
 		<style>
 			{`.js-signup-form-container {
 			display:block !important;
 		}`}
 		</style>
-		<NewsletterSignUpLayout item={newsletterSignUp} />
+		<NewsletterSignUpLayout item={props.item} />
 	</>
-);
-NewsletterSignup.story = { name: formatToString(newsletterSignUp) };
+));
+const newsletterSignUpFallbackLayoutStory = (fixture: NewsletterSignup) => {
+	const story = () => (
+		<>
+			<style>
+				{`.js-signup-form-fallback-container {
+				display:block !important;
+			}`}
+			</style>
+			<NewsletterSignUpLayout item={fixture} />
+		</>
+	)
+	story.story = { name: `${formatToString(fixture)} (form component not supported)` };
 
-export const NewsletterSignupFallback = (): ReactElement => (
-	<>
-		<style>
-			{`.js-signup-form-fallback-container {
-			display:block !important;
-		}`}
-		</style>
-		<NewsletterSignUpLayout item={newsletterSignUp} />
-	</>
-);
-NewsletterSignupFallback.story = {
-	name: `${formatToString(newsletterSignUp)} (form component not supported)`,
+	return story;
 };
 
-export const Gallery = (): ReactElement => <GalleryLayout item={gallery} />;
-Gallery.story = { name: formatToString(gallery) };
+// ----- Stories ----- //
 
-export const Immersive = (): ReactElement => (
-	<ImmersiveLayout item={immersive} />
-);
-Immersive.story = { name: formatToString(immersive) };
+/*
+These are named based on the `ArticleFormat` type of the fixture they
+correspond to. Each one has a name of the form: "<Design><Display><Theme>".
+For example: "ReviewStandardNews", where `Review` is the `Design`, `Standard`
+is the `Display` and `News` is the `Theme`.
+*/
+
+export const StandardStandardNews = standardLayoutStory(article);
+export const StandardStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(article);
+export const StandardImmersiveNews = immersiveLayoutStory(standardImmersive);
+export const StandardImmersiveSpecialReportAlt = pipe(standardImmersive, setSpecialReportAlt, immersiveLayoutStory);
+
+export const ReviewStandardNews = standardLayoutStory(review);
+export const ReviewStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(review);
+
+export const MatchReportStandardNews = standardLayoutStory(matchReport)
+export const MatchReportStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(matchReport);
+
+export const PrintShopStandardNews = standardLayoutStory(printShop);
+export const PrintShopStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(printShop);
+
+export const PhotoEssayStandardNews = standardLayoutStory(photoEssay);
+export const PhotoEssayStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(photoEssay);
+
+export const FeatureStandardNews = standardLayoutStory(feature);
+export const FeatureStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(feature);
+
+export const InterviewStandardNews = standardLayoutStory(interview);
+export const InterviewStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(interview);
+
+export const QuizStandardNews = standardLayoutStory(quiz);
+export const QuizStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(quiz);
+
+export const RecipeStandardNews = standardLayoutStory(recipe);
+export const RecipeStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(recipe);
+
+export const CommentStandardNews = commentLayoutStory(comment);
+export const CommentStandardSpecialReportAlt = pipe(comment, setSpecialReportAlt, commentLayoutStory);
+
+export const LetterStandardNews = letterLayoutStory(letter);
+export const LetterStandardSpecialReportAlt = pipe(letter, setSpecialReportAlt, letterLayoutStory);
+
+export const EditorialStandardNews = commentLayoutStory(editorial);
+export const EditorialStandardSpecialReportAlt = pipe(editorial, setSpecialReportAlt, commentLayoutStory);
+
+export const AnalysisStandardNews = analysisLayoutStory(analysis);
+export const AnalysisStandardSpecialReportAlt = pipe(analysis, setSpecialReportAlt, analysisLayoutStory);
+
+export const ExplainerStandardNews = standardLayoutStory(explainer);
+export const ExplainerStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(explainer);
+
+export const LiveBlogStandardNews = pipe(live, setEdition(Edition.US), liveLayoutStory);
+export const LiveBlogStandardSpecialReportAlt = pipe(live, setEdition(Edition.US), setSpecialReportAlt, liveLayoutStory);
+
+export const DeadBlogStandardNews = pipe(deadBlog, setEdition(Edition.AU), liveLayoutStory);
+export const DeadBlogStandardSpecialReportAlt = pipe(deadBlog, setEdition(Edition.AU), setSpecialReportAlt, liveLayoutStory);
+
+export const NewsletterSignUpStandardNews = newsletterSignUpLayoutStory(newsletterSignUp);
+export const NewsletterSignUpStandardSpecialReportAlt = pipe(newsletterSignUp, setSpecialReportAlt, newsletterSignUpLayoutStory);
+export const NewsletterSignUpStandardNewsFallback = newsletterSignUpFallbackLayoutStory(newsletterSignUp);
+export const NewsletterSignUpStandardSpecialReportAltFallback = pipe(newsletterSignUp, setSpecialReportAlt, newsletterSignUpFallbackLayoutStory);
+
+export const GalleryStandardNews = galleryLayoutStory(gallery);
+export const GalleryStandardSpecialReportAlt = pipe(gallery, setSpecialReportAlt, galleryLayoutStory);
+
+// ----- Story Config ----- //
 
 export default {
 	title: 'AR/Layout',

--- a/apps-rendering/src/components/Layout/Layout.stories.tsx
+++ b/apps-rendering/src/components/Layout/Layout.stories.tsx
@@ -12,7 +12,6 @@ import {
 	explainer,
 	feature,
 	gallery,
-	standardImmersive,
 	interview,
 	letter,
 	matchReport,
@@ -24,9 +23,10 @@ import {
 	review,
 	setEdition,
 	setTheme,
+	standardImmersive,
 } from 'fixtures/item';
 import { deadBlog, live } from 'fixtures/live';
-import { Item, NewsletterSignup } from 'item';
+import type { Item, NewsletterSignup } from 'item';
 import { compose, pipe } from 'lib';
 import type { FC, ReactElement } from 'react';
 import AnalysisLayout from './AnalysisLayout';
@@ -43,7 +43,7 @@ import StandardLayout from './StandardLayout';
 /**
  * A storybook story with a name.
  */
-type Story = {(): ReactElement, story: { name: string }}
+type Story = { (): ReactElement; story: { name: string } };
 
 // ----- Helpers ----- //
 
@@ -56,16 +56,18 @@ const setSpecialReportAlt = setTheme(ArticleSpecial.SpecialReportAlt);
  * Helper for generating layout stories. It takes a test instance of `Item`
  * (a fixture) and applies it to a given layout component. It also generates
  * a name for the story based on the `ArticleFormat` of the fixture.
- * 
+ *
  * @param Layout A layout component
  * @returns A story created from a layout component and an `Item` fixture
  */
-const createLayoutStory = <Fixture extends Item>(Layout: FC<{ item: Fixture }>) => (fixture: Fixture): Story => {
-	const story = () => <Layout item={fixture} />;
-	story.story = { name: formatToString(fixture) };
+const createLayoutStory =
+	<Fixture extends Item>(Layout: FC<{ item: Fixture }>) =>
+	(fixture: Fixture): Story => {
+		const story = (): ReactElement => <Layout item={fixture} />;
+		story.story = { name: formatToString(fixture) };
 
-	return story;
-}
+		return story;
+	};
 
 // ----- Story Helpers ----- //
 
@@ -76,7 +78,8 @@ code below.
 */
 
 const standardLayoutStory = createLayoutStory(StandardLayout);
-const standardLayoutStoryWithSpecialReportAlt: typeof standardLayoutStory = compose(standardLayoutStory, setSpecialReportAlt);
+const standardLayoutStoryWithSpecialReportAlt: typeof standardLayoutStory =
+	compose(standardLayoutStory, setSpecialReportAlt);
 const commentLayoutStory = createLayoutStory(CommentLayout);
 const letterLayoutStory = createLayoutStory(LetterLayout);
 const analysisLayoutStory = createLayoutStory(AnalysisLayout);
@@ -84,18 +87,22 @@ const liveLayoutStory = createLayoutStory(LiveLayout);
 const galleryLayoutStory = createLayoutStory(GalleryLayout);
 const immersiveLayoutStory = createLayoutStory(ImmersiveLayout);
 
-const newsletterSignUpLayoutStory = createLayoutStory((props: { item: NewsletterSignup }) => (
-	<>
-		<style>
-			{`.js-signup-form-container {
+const newsletterSignUpLayoutStory = createLayoutStory(
+	(props: { item: NewsletterSignup }) => (
+		<>
+			<style>
+				{`.js-signup-form-container {
 			display:block !important;
 		}`}
-		</style>
-		<NewsletterSignUpLayout item={props.item} />
-	</>
-));
-const newsletterSignUpFallbackLayoutStory = (fixture: NewsletterSignup) => {
-	const story = () => (
+			</style>
+			<NewsletterSignUpLayout item={props.item} />
+		</>
+	),
+);
+const newsletterSignUpFallbackLayoutStory = (
+	fixture: NewsletterSignup,
+): Story => {
+	const story = (): ReactElement => (
 		<>
 			<style>
 				{`.js-signup-form-fallback-container {
@@ -104,8 +111,10 @@ const newsletterSignUpFallbackLayoutStory = (fixture: NewsletterSignup) => {
 			</style>
 			<NewsletterSignUpLayout item={fixture} />
 		</>
-	)
-	story.story = { name: `${formatToString(fixture)} (form component not supported)` };
+	);
+	story.story = {
+		name: `${formatToString(fixture)} (form component not supported)`,
+	};
 
 	return story;
 };
@@ -120,62 +129,124 @@ is the `Display` and `News` is the `Theme`.
 */
 
 export const StandardStandardNews = standardLayoutStory(article);
-export const StandardStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(article);
+export const StandardStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(article);
 export const StandardImmersiveNews = immersiveLayoutStory(standardImmersive);
-export const StandardImmersiveSpecialReportAlt = pipe(standardImmersive, setSpecialReportAlt, immersiveLayoutStory);
+export const StandardImmersiveSpecialReportAlt = pipe(
+	standardImmersive,
+	setSpecialReportAlt,
+	immersiveLayoutStory,
+);
 
 export const ReviewStandardNews = standardLayoutStory(review);
-export const ReviewStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(review);
+export const ReviewStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(review);
 
-export const MatchReportStandardNews = standardLayoutStory(matchReport)
-export const MatchReportStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(matchReport);
+export const MatchReportStandardNews = standardLayoutStory(matchReport);
+export const MatchReportStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(matchReport);
 
 export const PrintShopStandardNews = standardLayoutStory(printShop);
-export const PrintShopStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(printShop);
+export const PrintShopStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(printShop);
 
 export const PhotoEssayStandardNews = standardLayoutStory(photoEssay);
-export const PhotoEssayStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(photoEssay);
+export const PhotoEssayStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(photoEssay);
 
 export const FeatureStandardNews = standardLayoutStory(feature);
-export const FeatureStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(feature);
+export const FeatureStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(feature);
 
 export const InterviewStandardNews = standardLayoutStory(interview);
-export const InterviewStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(interview);
+export const InterviewStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(interview);
 
 export const QuizStandardNews = standardLayoutStory(quiz);
-export const QuizStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(quiz);
+export const QuizStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(quiz);
 
 export const RecipeStandardNews = standardLayoutStory(recipe);
-export const RecipeStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(recipe);
+export const RecipeStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(recipe);
 
 export const CommentStandardNews = commentLayoutStory(comment);
-export const CommentStandardSpecialReportAlt = pipe(comment, setSpecialReportAlt, commentLayoutStory);
+export const CommentStandardSpecialReportAlt = pipe(
+	comment,
+	setSpecialReportAlt,
+	commentLayoutStory,
+);
 
 export const LetterStandardNews = letterLayoutStory(letter);
-export const LetterStandardSpecialReportAlt = pipe(letter, setSpecialReportAlt, letterLayoutStory);
+export const LetterStandardSpecialReportAlt = pipe(
+	letter,
+	setSpecialReportAlt,
+	letterLayoutStory,
+);
 
 export const EditorialStandardNews = commentLayoutStory(editorial);
-export const EditorialStandardSpecialReportAlt = pipe(editorial, setSpecialReportAlt, commentLayoutStory);
+export const EditorialStandardSpecialReportAlt = pipe(
+	editorial,
+	setSpecialReportAlt,
+	commentLayoutStory,
+);
 
 export const AnalysisStandardNews = analysisLayoutStory(analysis);
-export const AnalysisStandardSpecialReportAlt = pipe(analysis, setSpecialReportAlt, analysisLayoutStory);
+export const AnalysisStandardSpecialReportAlt = pipe(
+	analysis,
+	setSpecialReportAlt,
+	analysisLayoutStory,
+);
 
 export const ExplainerStandardNews = standardLayoutStory(explainer);
-export const ExplainerStandardSpecialReportAlt = standardLayoutStoryWithSpecialReportAlt(explainer);
+export const ExplainerStandardSpecialReportAlt =
+	standardLayoutStoryWithSpecialReportAlt(explainer);
 
-export const LiveBlogStandardNews = pipe(live, setEdition(Edition.US), liveLayoutStory);
-export const LiveBlogStandardSpecialReportAlt = pipe(live, setEdition(Edition.US), setSpecialReportAlt, liveLayoutStory);
+export const LiveBlogStandardNews = pipe(
+	live,
+	setEdition(Edition.US),
+	liveLayoutStory,
+);
+export const LiveBlogStandardSpecialReportAlt = pipe(
+	live,
+	setEdition(Edition.US),
+	setSpecialReportAlt,
+	liveLayoutStory,
+);
 
-export const DeadBlogStandardNews = pipe(deadBlog, setEdition(Edition.AU), liveLayoutStory);
-export const DeadBlogStandardSpecialReportAlt = pipe(deadBlog, setEdition(Edition.AU), setSpecialReportAlt, liveLayoutStory);
+export const DeadBlogStandardNews = pipe(
+	deadBlog,
+	setEdition(Edition.AU),
+	liveLayoutStory,
+);
+export const DeadBlogStandardSpecialReportAlt = pipe(
+	deadBlog,
+	setEdition(Edition.AU),
+	setSpecialReportAlt,
+	liveLayoutStory,
+);
 
-export const NewsletterSignUpStandardNews = newsletterSignUpLayoutStory(newsletterSignUp);
-export const NewsletterSignUpStandardSpecialReportAlt = pipe(newsletterSignUp, setSpecialReportAlt, newsletterSignUpLayoutStory);
-export const NewsletterSignUpStandardNewsFallback = newsletterSignUpFallbackLayoutStory(newsletterSignUp);
-export const NewsletterSignUpStandardSpecialReportAltFallback = pipe(newsletterSignUp, setSpecialReportAlt, newsletterSignUpFallbackLayoutStory);
+export const NewsletterSignUpStandardNews =
+	newsletterSignUpLayoutStory(newsletterSignUp);
+export const NewsletterSignUpStandardSpecialReportAlt = pipe(
+	newsletterSignUp,
+	setSpecialReportAlt,
+	newsletterSignUpLayoutStory,
+);
+export const NewsletterSignUpStandardNewsFallback =
+	newsletterSignUpFallbackLayoutStory(newsletterSignUp);
+export const NewsletterSignUpStandardSpecialReportAltFallback = pipe(
+	newsletterSignUp,
+	setSpecialReportAlt,
+	newsletterSignUpFallbackLayoutStory,
+);
 
 export const GalleryStandardNews = galleryLayoutStory(gallery);
-export const GalleryStandardSpecialReportAlt = pipe(gallery, setSpecialReportAlt, galleryLayoutStory);
+export const GalleryStandardSpecialReportAlt = pipe(
+	gallery,
+	setSpecialReportAlt,
+	galleryLayoutStory,
+);
 
 // ----- Story Config ----- //
 

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -9,6 +9,7 @@ import {
 	ArticleElementRole,
 	ArticlePillar,
 	ArticleSpecial,
+	ArticleTheme,
 } from '@guardian/libs';
 import { none, OptionKind, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
@@ -46,6 +47,26 @@ import { fromBodyElements } from 'outline';
 import { galleryBody } from './galleryBody';
 import { partialNewsletterItem } from './newsletterSignUpContent';
 import { relatedContent } from './relatedContent';
+
+// ----- Functions ----- //
+
+/**
+ * Updates the `theme` property of an `Item`
+ * 
+ * @param theme The value to set `theme` to
+ * @returns A new `Item` object
+ */
+const setTheme = (theme: ArticleTheme) => <A extends Item>(item: A): A =>
+	({ ...item, theme });
+
+/**
+ * Updates the `edition` property of an `Item`
+ * 
+ * @param edition The value to set `edition` to
+ * @returns A new `Item` object
+ */
+const setEdition = (edition: Edition) => <A extends Item>(item: A): A =>
+	({ ...item, edition });
 
 // ----- Fixture ----- //
 
@@ -521,7 +542,7 @@ const newsletterSignUp: NewsletterSignup = {
 	...partialNewsletterItem,
 };
 
-const immersive: Standard = {
+const standardImmersive: Standard = {
 	design: ArticleDesign.Standard,
 	...fields,
 	display: ArticleDisplay.Immersive,
@@ -558,7 +579,9 @@ export {
 	pinnedBlock,
 	explainer,
 	newsletterSignUp,
-	immersive,
+	standardImmersive,
 	gallery,
 	parseHtml,
+	setTheme,
+	setEdition,
 };

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -3,13 +3,13 @@
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 import { TagType } from '@guardian/content-api-models/v1/tagType';
+import type { ArticleTheme } from '@guardian/libs';
 import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleElementRole,
 	ArticlePillar,
 	ArticleSpecial,
-	ArticleTheme,
 } from '@guardian/libs';
 import { none, OptionKind, some } from '@guardian/types';
 import type { Option } from '@guardian/types';
@@ -52,21 +52,23 @@ import { relatedContent } from './relatedContent';
 
 /**
  * Updates the `theme` property of an `Item`
- * 
+ *
  * @param theme The value to set `theme` to
  * @returns A new `Item` object
  */
-const setTheme = (theme: ArticleTheme) => <A extends Item>(item: A): A =>
-	({ ...item, theme });
+const setTheme =
+	(theme: ArticleTheme) =>
+	<A extends Item>(item: A): A => ({ ...item, theme });
 
 /**
  * Updates the `edition` property of an `Item`
- * 
+ *
  * @param edition The value to set `edition` to
  * @returns A new `Item` object
  */
-const setEdition = (edition: Edition) => <A extends Item>(item: A): A =>
-	({ ...item, edition });
+const setEdition =
+	(edition: Edition) =>
+	<A extends Item>(item: A): A => ({ ...item, edition });
 
 // ----- Fixture ----- //
 


### PR DESCRIPTION
## Why?

The "special report alt" theme comes with a number of design changes. In order to be confident that these changes only affect layouts that we expect, in the ways that we expect, we need regression testing coverage of this theme. We want to make sure that layouts that don't include design changes continue to look as they would with the "news" theme.

This PR changes the way our layout stories work, to make it easier to generate variants with different themes. It then adds "special report alt" versions of all our existing layout stories.

## Changes

- Added helpers for setting fixture fields
- Added helpers for generating layout stories
- Refactored layout stories
- Added `SpecialReportAlt` layout stories
