### PR TITLE
Change metric bypass sampling method for Teads cookieless test

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -7,6 +7,7 @@ import { getCookie } from '@guardian/libs';
 import type { ServerSideTestNames } from '../../types/config';
 import { tests } from '../experiments/ab-tests';
 import { integrateIma } from '../experiments/tests/integrate-ima';
+import { teadsCookieless } from '../experiments/tests/teads-cookieless';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
@@ -30,6 +31,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 		const clientSideTestsToForceMetrics: ABTest[] = [
 			/* keep array multi-line */
 			integrateIma,
+			teadsCookieless,
 		];
 
 		const userInClientSideTestToForceMetrics = ABTestAPI?.allRunnableTests(

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -7,6 +7,7 @@ import { getCookie } from '@guardian/libs';
 import { dcrJavascriptBundle } from '../../../scripts/webpack/bundles';
 import type { ServerSideTestNames } from '../../types/config';
 import { integrateIma } from '../experiments/tests/integrate-ima';
+import { teadsCookieless } from '../experiments/tests/teads-cookieless';
 import { useAB } from '../lib/useAB';
 
 export const CoreVitals = () => {
@@ -25,6 +26,7 @@ export const CoreVitals = () => {
 	const clientSideTestsToForceMetrics: ABTest[] = [
 		/* keep array multi-line */
 		integrateIma,
+		teadsCookieless,
 	];
 
 	const userInClientSideTestToForceMetrics =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The metrics sampling rate bypass is still not working, I suspect the DCR way is different to frontend?
