### PR TITLE
Add missing update to `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,9 +2902,9 @@
   integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
 
 "@guardian/commercial-core@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.0.0.tgz#644198cf8143abc8ceca8f075011c9ee5ed2e9a9"
-  integrity sha512-PLSgWvf1oDIvGstwmTrKqpIFnI/G0hU04wJMSr8CGOqk9Apx9HUCvYF1uDdcD9oLCAck3Fz8oveXrBaXLmwsWQ==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.1.3.tgz#f7e845d8ae6e8ee6eaaf51fcce3400d94db81a59"
+  integrity sha512-B7Sa7O0zHHP3jN36XdGHOZ9fAgjEMfRYuRURqX+ziiJE8+lmr7rkLX3MLgbYUJCIUfhagNkj559JZDXTLQoZ6g==
   dependencies:
     type-fest "2.12.2"
 


### PR DESCRIPTION
## What does this change?

#6904 should have included an updated `yarn.lock` that I forgot to check in. This PR adds it.