### PR TITLE
feat: bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,6 +3,15 @@ title: "[Bug]: "
 labels: ["bug", "needs-triage"]
 assignees: ''
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for letting us know something has happened.
+
+        If this is urgent, please email dotcom.platform@guardian.co.uk, or let us know on our chat channel.
+
+        The benefit of an issue is that we have a written record of what is going on, that we can track and have discussions around.
+        Please still reach out to facilitate discussion or incase we miss it - we're a lovely bunch!
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,21 @@
+name: 🐞 Bug Report
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: ''
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: And what should have happened? Please provide screenshots if they would help debug and resolve this
+  - type: input
+    id: where
+    attributes:
+      label: Where is this happening?
+      description: If possible please provide a URL where we can see this happening
+  - type: textarea
+    id: impact
+    attributes:
+      label: What is the impact?
+      description: How far reaching is the issue, and how is it affecting their experience?
+

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,7 +11,7 @@ body:
         If this is urgent, please email dotcom.platform@guardian.co.uk, or let us know on our chat channel.
 
         The benefit of an issue is that we have a written record of what is going on, that we can track and have discussions around.
-        Please still reach out to facilitate discussion or incase we miss it - we're a lovely bunch!
+        Please still reach out to facilitate discussion or in case we miss it - we're a lovely bunch!
   - type: textarea
     id: what-happened
     attributes:


### PR DESCRIPTION
Adds a bug report issue template. It's pretty lo-fi with a few nudges based on questions I've seen asked in email. 

I was hoping to combine it with something like [add-to-project](https://github.com/actions/add-to-project) to add it to the [rota board](https://github.com/orgs/guardian/projects/8/views/24).