### PR TITLE
add tracking for dcr table of contents

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -12,7 +12,7 @@ import { LiveBlogRenderer } from '../lib/LiveBlogRenderer';
 import { revealStyles } from '../lib/revealStyles';
 import { Island } from './Island';
 import { RecipeMultiplier } from './RecipeMultiplier.importable';
-import { TableOfContents } from './TableOfContents';
+import { TableOfContents } from './TableOfContents.importable';
 
 type Props = {
 	format: ArticleFormat;
@@ -199,9 +199,11 @@ export const ArticleBody = ({
 	return (
 		<>
 			{tableOfContents && tableOfContents.length > 0 && (
-				<TableOfContents
-					tableOfContents={tableOfContents}
-				></TableOfContents>
+				<Island>
+					<TableOfContents
+						tableOfContents={tableOfContents}
+					></TableOfContents>
+				</Island>
 			)}
 
 			<div

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -74,7 +74,11 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 	// the old value of open(before the click event) is used. As a result we need to
 	// use toc-close for when open is true and toc-expand for when it's false
 	return (
-		<details open={open} css={detailsStyles}>
+		<details
+			open={open}
+			css={detailsStyles}
+			data-component="table-of-contents"
+		>
 			<summary
 				onClick={() => {
 					setOpen(!open);
@@ -84,7 +88,6 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 						? 'table-of-contents-close'
 						: 'table-of-contents-expand'
 				}
-				data-component="table-of-contents"
 				css={summaryStyles}
 			>
 				<h2 css={titleStyle}>Jump to...</h2>

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -79,7 +79,9 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 	return (
 		<details
 			onToggle={onToggle}
-			data-link-name={open ? 'toc-close' : 'toc-expand'}
+			data-link-name={
+				open ? 'table-of-contents-close' : 'table-of-contents-expand'
+			}
 			data-component="table-of-contents"
 			open={open}
 			css={detailsStyles}
@@ -99,7 +101,7 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 					<li
 						key={item.id}
 						css={listItemStyles}
-						data-link-name={`toc-item-${index}-${item.id}`}
+						data-link-name={`table-of-contents-item-${index}-${item.id}`}
 					>
 						<a href={`#${item.id}`} css={anchorStyles}>
 							{item.title}

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -67,11 +67,15 @@ const chevronPosition = css`
 `;
 
 export const TableOfContents = ({ tableOfContents }: Props) => {
-	const [open, setOpen] = useState(true);
+	const [open, setOpen] = useState(tableOfContents.length < 5);
 	const onToggle = () => {
 		setOpen(!open);
 	};
 
+	// The value for data-link-name is evaluated at the time when the component renders,
+	// So at the time when user clicks the table (onToggle is triggered),
+	// the old value of open(before the click event) is used. As a result we need to
+	// use toc-close for when open is true and toc-expand for when it's false
 	return (
 		<details
 			onToggle={onToggle}

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -68,25 +68,25 @@ const chevronPosition = css`
 
 export const TableOfContents = ({ tableOfContents }: Props) => {
 	const [open, setOpen] = useState(tableOfContents.length < 5);
-	const onToggle = () => {
-		setOpen(!open);
-	};
 
 	// The value for data-link-name is evaluated at the time when the component renders,
 	// So at the time when user clicks the table (onToggle is triggered),
 	// the old value of open(before the click event) is used. As a result we need to
 	// use toc-close for when open is true and toc-expand for when it's false
 	return (
-		<details
-			onToggle={onToggle}
-			data-link-name={
-				open ? 'table-of-contents-close' : 'table-of-contents-expand'
-			}
-			data-component="table-of-contents"
-			open={open}
-			css={detailsStyles}
-		>
-			<summary css={summaryStyles}>
+		<details open={open} css={detailsStyles}>
+			<summary
+				onClick={() => {
+					setOpen(!open);
+				}}
+				data-link-name={
+					open
+						? 'table-of-contents-close'
+						: 'table-of-contents-expand'
+				}
+				data-component="table-of-contents"
+				css={summaryStyles}
+			>
 				<h2 css={titleStyle}>Jump to...</h2>
 				<span className="is-closed" css={chevronPosition}>
 					<SvgChevronDownSingle size="xsmall" />

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -4,6 +4,7 @@ import {
 	SvgChevronDownSingle,
 	SvgChevronUpSingle,
 } from '@guardian/source-react-components';
+import { useState } from 'react';
 import type { TableOfContentsItem } from '../../types/frontend';
 
 interface Props {
@@ -66,11 +67,17 @@ const chevronPosition = css`
 `;
 
 export const TableOfContents = ({ tableOfContents }: Props) => {
+	const [open, setOpen] = useState(true);
+	const onToggle = () => {
+		setOpen(!open);
+	};
+
 	return (
 		<details
-			data-link-name="table-of-contents"
+			onToggle={onToggle}
+			data-link-name={open ? 'toc-close' : 'toc-expand'}
 			data-component="table-of-contents"
-			open={tableOfContents.length < 5}
+			open={open}
 			css={detailsStyles}
 		>
 			<summary css={summaryStyles}>

--- a/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source-foundations';
 import type { TableOfContentsItem } from '../../types/frontend';
-import { TableOfContents } from './TableOfContents';
+import { TableOfContents } from './TableOfContents.importable';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
 	return (

--- a/dotcom-rendering/src/web/components/TableOfContents.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.tsx
@@ -67,7 +67,12 @@ const chevronPosition = css`
 
 export const TableOfContents = ({ tableOfContents }: Props) => {
 	return (
-		<details open={tableOfContents.length < 5} css={detailsStyles}>
+		<details
+			data-link-name="table-of-contents"
+			data-component="table-of-contents"
+			open={tableOfContents.length < 5}
+			css={detailsStyles}
+		>
 			<summary css={summaryStyles}>
 				<h2 css={titleStyle}>Jump to...</h2>
 				<span className="is-closed" css={chevronPosition}>
@@ -79,8 +84,12 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 			</summary>
 
 			<ul>
-				{tableOfContents.map((item) => (
-					<li key={item.id} css={listItemStyles}>
+				{tableOfContents.map((item, index) => (
+					<li
+						key={item.id}
+						css={listItemStyles}
+						data-link-name={`toc-item-${index}-${item.id}`}
+					>
 						<a href={`#${item.id}`} css={anchorStyles}>
 							{item.title}
 						</a>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds the following trackings for the TableOdContents component:
- view tracking for the `TableOfContents` component
- click tracking for when the table is expanded with link name as `table-of-contents-expand`
- click tracking for when the table is closed with link name as `table-of-contents-close`
- click tracking for every item in the table with link name pattern as `table-of-contents-<index>-<id-of-item>`

Note: To be able to add tracking for when the table is expanded/closed, we need to make the component importable and use Island, in order to have state in the component.

## Why?
Needed for the data insight team

## Test
Tested this locally using the Ophan tester tool
