### PR TITLE
Restructure readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,31 @@ Ever thought about joining us?
 
 This repository contains the rendering logic for articles on theguardian.com. It is a monorepo with 3 projects, `apps-rendering`, `common-rendering` and `dotcom-rendering`.
 
+## Developer setup
+
+Install [Node.js](https://nodejs.org).
+
+We recommend using [fnm](https://github.com/Schniz/fnm). It is great at managing multiple versions of Node.js on one machine.
+
+Install [Yarn 1 (Classic)](https://classic.yarnpkg.com/).
+
+## Install
+
+Run `yarn` in the root directory of this project to install packages.
+
+## Run
+
 You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `yarn watch` for apps-rendering) except for storybook. Linting, imports, builds and github actions should work as before.
 
-## `apps rendering`
+### `apps rendering`
 
 Go to [apps rendering](apps-rendering/README.md) for more details.
 
-## `dotcom rendering`
+### `dotcom rendering`
 
 Go to [dotcom rendering](dotcom-rendering/README.md) for more details.
 
-## `common rendering`
+### `common rendering`
 
 Go to [common rendering](common-rendering/README.md) for more details.
 
@@ -33,13 +47,3 @@ Most commands are run from within each project but the following are managed fro
 Chromatic now runs at project level. `cd` into the project dir and run `yarn chromatic -t [CHROMATIC PROJECT TOKEN]`
 
 You can find the token in the project Chromatic instance.
-
-### Install Node.js
-
-Make sure you have [Node.js](https://nodejs.org) installed.
-
-We recommend using [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
-
-### Install Packages
-
-Run `yarn` in the root directory of this project to install packages

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run `yarn` in the root directory of this project to install packages.
 
 ## Run
 
-You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `yarn watch` for apps-rendering) except for storybook. Linting, imports, builds and github actions should work as before.
+You should always `cd` into the correct subdirectory before running commands (e.g `make dev` for dotcom-rendering, or `yarn watch` for apps-rendering) except for storybook.
 
 ### `apps rendering`
 


### PR DESCRIPTION
## What does this change?

- Move Node installation and package installation to the top of the readme
- Add step for installing Yarn
- Recommend fnm over npm

## Why?

This change makes the README easier to follow for someone setting up the project on their machine for the first time.

It also replaces the recommendation of nvm for fnm, which is what we recommend in the new laptop setup guide.

