### PR TITLE
Correct Deno script flag syntax

### DIFF
--- a/scripts/ci-deno.sh
+++ b/scripts/ci-deno.sh
@@ -15,6 +15,5 @@ deno run \
 deno run \
 	--no-check=remote \
 	--allow-net \
-	--allow-env="GITHUB_TOKEN" \
-	--allow-env="CAPI_KEY" \
+	--allow-env="GITHUB_TOKEN,CAPI_KEY" \
 	scripts/deno/iframe-titles.ts


### PR DESCRIPTION
## What does this change?

Fix Deno flag syntax: https://deno.land/manual@v1.29.1/basics/permissions#permissions-list

## Why?

[The most recent action has failed](https://github.com/guardian/dotcom-rendering/actions/runs/3890887831).

Follow up on #6643 