### PR TITLE
Treats text xsmall -> xxsmall

### DIFF
--- a/dotcom-rendering/src/web/components/Treats.tsx
+++ b/dotcom-rendering/src/web/components/Treats.tsx
@@ -33,7 +33,7 @@ const TextTreat = ({
 			priority="secondary"
 			subdued={true}
 			cssOverrides={css`
-				${textSans.xsmall()}
+				${textSans.xxsmall()}
 				text-decoration: none;
 			`}
 			href={linkTo}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the text size on Treats from `xsmall` (`0.875rem`) to `xxsmall` (`0.875rem`).


## Why?
This brings DCR into line with Frontend, and closes #6922.

Running DCR locally I've verified that it computes to `12px`, which matches the computed value for Frontend.
