### PR TITLE
Update bundle anaylzer action to use correct file names

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -1,29 +1,42 @@
 name: DCR Bundle Analyser
 on:
-    push:
-        paths-ignore:
-            - "apps-rendering/**"
-            - "dotcom-rendering/docs/**"
+  push:
+    paths-ignore:
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 jobs:
-    build_check:
-        name: DCR Bundle Analyser
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
+  build_check:
+    name: DCR Bundle Analyser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-            - name: Install Node
-              uses: guardian/actions-setup-node@main
+      - name: Install Node
+        uses: guardian/actions-setup-node@main
 
-            # Cache npm dependencies using https://github.com/bahmutov/npm-install
-            - uses: bahmutov/npm-install@v1
+      # Cache npm dependencies using https://github.com/bahmutov/npm-install
+      - uses: bahmutov/npm-install@v1
 
-            - name: Generate production build
-              run: make build
-              working-directory: dotcom-rendering
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
 
-            - name: Archive code coverage results
-              uses: actions/upload-artifact@v2
-              with:
-                  name: bundle-analyser-report
-                  path: dotcom-rendering/dist/browser-bundles.html
+      - name: Archive code coverage results for modern bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundle-analyser-report-modern
+          path: dotcom-rendering/dist/browser.modern-bundles.html
+          if-no-files-found: error
+      - name: Archive code coverage results for legacy bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundle-analyser-report-modern
+          path: dotcom-rendering/dist/browser.legacy-bundles.html
+          if-no-files-found: error
+      - name: Archive code coverage results for variant bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundle-analyser-report-variant
+          path: dotcom-rendering/dist/browser.variant-bundles.html
+          if-no-files-found: warn # Variant bundle only exists when an active experiment is going on


### PR DESCRIPTION
Currently the bundle analyser action is not actually uploading / archiving any of our output: 

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/9575458/211801628-33aad450-6824-4aba-b16f-2720198834a8.png">

This is because the action has fallen behind the current file names for the output bundle analysis. This PR updates the action to use the correct file names, as well as telling the action to error if the expected files are not present.