### PR TITLE
Fix sublinks in `FixedSmallFastVIII`

### DIFF
--- a/dotcom-rendering/src/web/components/FixedSmallFastVIII.tsx
+++ b/dotcom-rendering/src/web/components/FixedSmallFastVIII.tsx
@@ -3,7 +3,7 @@ import type { TrailType } from '../../types/trails';
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
+import { Card25Media25, CardDefault } from '../lib/cardWrappers';
 
 type Props = {
 	trails: TrailType[];
@@ -30,12 +30,10 @@ export const FixedSmallFastVIII = ({
 						showDivider={cardIndex === 1}
 						key={card.url}
 					>
-						<FrontCard
+						<Card25Media25
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							headlineSize="medium"
-							imageUrl={card.image}
 						/>
 					</LI>
 				);
@@ -58,12 +56,10 @@ export const FixedSmallFastVIII = ({
 									columns,
 								)}
 							>
-								<FrontCard
+								<CardDefault
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									imageUrl={undefined}
-									headlineSize="small"
 								/>
 							</LI>
 						);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #6703 

## What does this change?
Fixes sublinks in `FixedSmallFastVIII`

## Why?
For parity with frontend

## Screenshots

| sublinks | frontend | DCR |
|----------|----------|-----|
| 3              | <img width="1305" alt="image" src="https://user-images.githubusercontent.com/19683595/211808261-eb8917a3-8f63-4a96-a8c9-b328f195a6f2.png">  |  <img width="1317" alt="image" src="https://user-images.githubusercontent.com/19683595/211808349-34d32c78-8aab-4e90-8126-524424b1f93d.png"> |
| 2              | <img width="1216" alt="image" src="https://user-images.githubusercontent.com/19683595/211808697-a521ea3c-abe0-4ae8-b227-0c0492d11e5c.png"> | <img width="1227" alt="image" src="https://user-images.githubusercontent.com/19683595/211808767-e934ebbc-a41e-4a2c-a0d6-009bce0e0cd2.png"> |
| 1              | <img width="1224" alt="image" src="https://user-images.githubusercontent.com/19683595/211809312-1d4738f4-9361-49b2-94c8-bd87066670ad.png"> | <img width="1227" alt="image" src="https://user-images.githubusercontent.com/19683595/211809355-0d4d5ee6-a095-4ece-b2fa-3f6e6d946f77.png"> |
| 0             | <img width="1208" alt="image" src="https://user-images.githubusercontent.com/19683595/211809682-a6241f80-bdf9-4f27-9dba-ebdae82d50b6.png"> | <img width="1208" alt="image" src="https://user-images.githubusercontent.com/19683595/211809742-25ce8334-d5d1-4785-bc31-fad8c7af09a8.png"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
