### PR TITLE
Fix `FixedMediumFastXI` sublinks

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -2,13 +2,15 @@ import { Hide } from '@guardian/source-react-components';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../../types/front';
 import type { TrailType } from '../../types/trails';
 import {
-	Card25Media25Tall,
 	Card33Media33,
-	Card50Media50,
 	CardDefault,
 	CardDefaultMediaMobile,
 } from '../lib/cardWrappers';
-import { Card50_Card50, Card75_Card25 } from '../lib/dynamicSlices';
+import {
+	Card50_Card25_Card25,
+	Card50_Card50,
+	Card75_Card25,
+} from '../lib/dynamicSlices';
 import { AdSlot } from './AdSlot';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -115,53 +117,6 @@ const ColumnOfThree50_Ad50 = ({
 					<AdSlot position="inline" index={index} />
 				</Hide>
 			</LI>
-		</UL>
-	);
-};
-
-/* ._________________.________.________.
- * |#################|########|########|
- * |                 |        |        |
- * |_________________|________|________|
- */
-const Card50_Card25_Card25 = ({
-	cards,
-	containerPalette,
-	showAge,
-}: {
-	cards: TrailType[];
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-}) => {
-	const card50 = cards.slice(0, 1);
-	const cards25 = cards.slice(1, 3);
-
-	return (
-		<UL direction="row" padBottom={true}>
-			{card50.map((card) => (
-				<LI percentage="50%" padSides={true} key={card.url}>
-					<Card50Media50
-						trail={card}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				</LI>
-			))}
-			{cards25.map((card) => (
-				<LI
-					percentage="25%"
-					padSides={true}
-					showDivider={true}
-					containerPalette={containerPalette}
-					key={card.url}
-				>
-					<Card25Media25Tall
-						trail={card}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				</LI>
-			))}
 		</UL>
 	);
 };

--- a/dotcom-rendering/src/web/components/FixedMediumFastXI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXI.tsx
@@ -1,9 +1,12 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
-import { Card50_Card25_Card25 } from '../lib/dynamicSlices';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
+import {
+	Card25Media25Tall,
+	Card50Media50,
+	CardDefault,
+} from '../lib/cardWrappers';
 
 type Props = {
 	trails: TrailType[];
@@ -43,15 +46,40 @@ export const FixedMediumFastXI = ({
 	containerPalette,
 	showAge,
 }: Props) => {
-	const firstSlice = trails.slice(0, 3);
+	const firstSlice50 = trails.slice(0, 1);
+	const firstSlice25 = trails.slice(1, 3);
 	const remaining = trails.slice(3, 11);
 	return (
 		<>
-			<Card50_Card25_Card25
-				cards={firstSlice}
-				containerPalette={containerPalette}
-				showAge={showAge}
-			/>
+			<UL direction="row" padBottom={true}>
+				{firstSlice50.map((trail) => {
+					return (
+						<LI key={trail.url} padSides={true} percentage="50%">
+							<Card50Media50
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+							/>
+						</LI>
+					);
+				})}
+				{firstSlice25.map((trail) => {
+					return (
+						<LI
+							key={trail.url}
+							padSides={true}
+							percentage="25%"
+							showDivider={true}
+						>
+							<Card25Media25Tall
+								trail={trail}
+								containerPalette={containerPalette}
+								showAge={showAge}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
 			{/*
 			 * This pattern of using wrapCards on the UL + percentage=25 and stretch=true
 			 * on the LI creates a dynanic list of cards over two rows where the second row
@@ -76,12 +104,10 @@ export const FixedMediumFastXI = ({
 						stretch={true}
 						key={trail.url}
 					>
-						<FrontCard
+						<CardDefault
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							imageUrl={undefined}
-							headlineSize="small"
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/web/components/FixedMediumFastXI.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXI.tsx
@@ -2,11 +2,8 @@ import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import {
-	Card25Media25Tall,
-	Card50Media50,
-	CardDefault,
-} from '../lib/cardWrappers';
+import { CardDefault } from '../lib/cardWrappers';
+import { Card50_Card25_Card25 } from '../lib/dynamicSlices';
 
 type Props = {
 	trails: TrailType[];
@@ -46,40 +43,15 @@ export const FixedMediumFastXI = ({
 	containerPalette,
 	showAge,
 }: Props) => {
-	const firstSlice50 = trails.slice(0, 1);
-	const firstSlice25 = trails.slice(1, 3);
+	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 11);
 	return (
 		<>
-			<UL direction="row" padBottom={true}>
-				{firstSlice50.map((trail) => {
-					return (
-						<LI key={trail.url} padSides={true} percentage="50%">
-							<Card50Media50
-								trail={trail}
-								containerPalette={containerPalette}
-								showAge={showAge}
-							/>
-						</LI>
-					);
-				})}
-				{firstSlice25.map((trail) => {
-					return (
-						<LI
-							key={trail.url}
-							padSides={true}
-							percentage="25%"
-							showDivider={true}
-						>
-							<Card25Media25Tall
-								trail={trail}
-								containerPalette={containerPalette}
-								showAge={showAge}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
+			<Card50_Card25_Card25
+				cards={firstSlice}
+				containerPalette={containerPalette}
+				showAge={showAge}
+			/>
 			{/*
 			 * This pattern of using wrapCards on the UL + percentage=25 and stretch=true
 			 * on the LI creates a dynanic list of cards over two rows where the second row

--- a/dotcom-rendering/src/web/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/web/lib/dynamicSlices.tsx
@@ -6,10 +6,9 @@ import {
 	Card100Media100,
 	Card100Media75,
 	Card25Media25,
-	Card33Media33,
+	Card25Media25Tall,
 	Card50Media50,
 	Card50Media50Tall,
-	Card66Media66,
 	Card75Media50Left,
 	Card75Media50Right,
 } from './cardWrappers';
@@ -153,53 +152,6 @@ export const Card25_Card75 = ({
 	);
 };
 
-/* ._______________________.___________.
- * |#######################|###########|
- * |                       |           |
- * |_______________________|___________|
- */
-export const Card66_Card33 = ({
-	cards,
-	containerPalette,
-	showAge,
-}: {
-	cards: TrailType[];
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-}) => {
-	const card66 = cards.slice(0, 1);
-	const card33 = cards.slice(1, 2);
-
-	return (
-		<UL direction="row">
-			{card66.map((trail) => (
-				<LI key={trail.shortUrl} percentage="66.666%" padSides={true}>
-					<Card66Media66
-						trail={trail}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				</LI>
-			))}
-			{card33.map((trail) => (
-				<LI
-					key={trail.shortUrl}
-					percentage="33.333%"
-					padSides={true}
-					showDivider={true}
-					containerPalette={containerPalette}
-				>
-					<Card33Media33
-						trail={trail}
-						containerPalette={containerPalette}
-						showAge={showAge}
-					/>
-				</LI>
-			))}
-		</UL>
-	);
-};
-
 /* ._________________.________.________.
  * |#################|########|########|
  * |                 |        |        |
@@ -237,7 +189,7 @@ export const Card50_Card25_Card25 = ({
 					showDivider={true}
 					containerPalette={containerPalette}
 				>
-					<Card25Media25
+					<Card25Media25Tall
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #6702 

## What does this change?
* Fixes `FixedMediumFastXI` sublinks
* Removes duplicate `Card50_Card25_Card25` wrapper
* Removes unused `Card66_Card33` wrapper

## Why?
For parity with frontend

## Screenshots

| sublinks | frontend | DCR |
|----------|----------|-----|
| 3         | <img width="1304" alt="Screenshot 2023-01-11 at 14 43 09" src="https://user-images.githubusercontent.com/19683595/211851662-5b4b8f18-bcd3-4136-a027-55732ffd22d3.png"> | <img width="1300" alt="Screenshot 2023-01-11 at 14 42 59" src="https://user-images.githubusercontent.com/19683595/211851645-c6bf6cd3-c116-45f0-9b51-c17ee25c229e.png"> |
| 2         | <img width="1291" alt="Screenshot 2023-01-11 at 14 45 05" src="https://user-images.githubusercontent.com/19683595/211851681-2de0d9fe-b790-4edd-ac7e-97a9f92d8fa7.png"> | <img width="1301" alt="Screenshot 2023-01-11 at 14 44 54" src="https://user-images.githubusercontent.com/19683595/211851671-98d7ae18-f44b-462a-82ee-74108e76018c.png"> |
| 1        | <img width="1210" alt="Screenshot 2023-01-11 at 14 46 39" src="https://user-images.githubusercontent.com/19683595/211851695-1baf532f-e66f-4805-b726-d0ecd1f86752.png"> | <img width="1221" alt="Screenshot 2023-01-11 at 14 46 30" src="https://user-images.githubusercontent.com/19683595/211851692-fc555bd6-2ff9-46ec-968f-6667fcc7794e.png"> |
| 0       | <img width="1213" alt="Screenshot 2023-01-11 at 14 55 31" src="https://user-images.githubusercontent.com/19683595/211851700-543f305d-eb63-4303-823b-a1a1f54d2932.png"> | <img width="1219" alt="Screenshot 2023-01-11 at 14 55 24" src="https://user-images.githubusercontent.com/19683595/211851698-66f25597-3273-4ba2-b81c-705028f817db.png"> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
