### PR TITLE
Align-self: flex-start for horizontal images

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -89,6 +89,13 @@ export const ImageWrapper = ({
 							margin-bottom: 4px;
 							margin-left: 4px;
 							flex-basis: unset;
+							align-self: flex-start;
+						}
+					`,
+				isHorizontal &&
+					css`
+						${from.tablet} {
+							align-self: flex-start;
 						}
 					`,
 				css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/37048459/211868310-46049513-2cd7-46f0-a9b1-ad138b4d168a.png) | ![Uploading image.png…]() |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
