### PR TITLE
Fix: Image overlay should fit to image

### DIFF
--- a/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/ImageWrapper.tsx
@@ -89,6 +89,13 @@ export const ImageWrapper = ({
 							margin-bottom: 4px;
 							margin-left: 4px;
 							flex-basis: unset;
+							align-self: flex-start;
+						}
+					`,
+				isHorizontal &&
+					css`
+						${from.tablet} {
+							align-self: flex-start;
 						}
 					`,
 				css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
It adds `align-self: flex-start` to the `ImageWrapper` component if the image is displayed horizontally within its card.

## Why?
The `ImageWrapper` contains both an image and (optionally) an image overlay, which is activated on hover. In some cases the `ImageWrapper` was being stretched to a height greater than the height of the image. Given that the overlay's height is set to 100%, this meant that the overlay could extend beyond the image.

My intention in adding the `align-self` property to the wrapper component is that it will prevent the flex parent from stretching the wrapper vertically. The height of the wrapper should therefore fit to the height of the image, and the overlay will be set to 100% of that height. Closes #6923.

## Discussion
The `align-self` rule should only affect the wrapper component and its children. But because the DOM structure of the `Card` component and its children are quite complex and variable, it feels as though there could be edge cases that are hard to predict. I've compared DCR prod and local across a number of different cards and breakpoints and I haven't found any issues, but it would be great to hear if others can think of potential edge cases!

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/37048459/211868310-46049513-2cd7-46f0-a9b1-ad138b4d168a.png) | ![image](https://user-images.githubusercontent.com/37048459/211869331-f3241258-72ed-44ac-b652-077766506d5d.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
