### PR TITLE
FixedMediumSlowVII sublinks 

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumSlowVII.tsx
@@ -1,8 +1,12 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
+import {
+	Card25Media25Tall,
+	Card25Media25TallSmallHeadline,
+	Card50Media50,
+} from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -29,15 +33,10 @@ export const FixedMediumSlowVII = ({
 						showDivider={false}
 						percentage="50%"
 					>
-						<FrontCard
+						<Card50Media50
 							trail={trail}
-							format={trail.format}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							headlineSize="large"
-							imagePositionOnMobile="top"
-							imageSize="large"
-							supportingContent={trail.supportingContent}
 						/>
 					</LI>
 				))}
@@ -50,26 +49,10 @@ export const FixedMediumSlowVII = ({
 						containerPalette={containerPalette}
 						percentage="25%"
 					>
-						<FrontCard
+						<Card25Media25Tall
 							trail={trail}
-							format={trail.format}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							headlineSize="medium"
-							imagePositionOnMobile="left"
-							imageSize="medium"
-							trailText={
-								trail.supportingContent &&
-								trail.supportingContent.length > 0
-									? undefined
-									: trail.trailText
-							}
-							supportingContent={
-								trail.supportingContent &&
-								trail.supportingContent.length > 2
-									? trail.supportingContent.slice(0, 2)
-									: trail.supportingContent
-							}
 						/>
 					</LI>
 				))}
@@ -82,18 +65,10 @@ export const FixedMediumSlowVII = ({
 						showDivider={index > 0}
 						containerPalette={containerPalette}
 					>
-						<FrontCard
+						<Card25Media25TallSmallHeadline
 							trail={trail}
-							format={trail.format}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							headlineSize="small"
-							supportingContent={
-								trail.supportingContent &&
-								trail.supportingContent.length > 2
-									? trail.supportingContent.slice(0, 2)
-									: trail.supportingContent
-							}
 						/>
 					</LI>
 				))}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces the `<FrontCard>` component with a `<Card25Media25Tall>` & `<Card25Media25TallSmallHeadline>` &  `<Card50Media50>`
## Why?
To match the sublink behaviour of Frontend. Closes #6699
## Screenshots

| Frontend     | DCR (this PR)      |
|-------------|------------|
| ![before][] | ![after][] |

| Frontend  No sublink   | DCR No sublink  (this PR)      |
|-------------|------------|
| ![b][] | ![a][] |

[before]: https://user-images.githubusercontent.com/110032454/211873168-23fd05bd-5b14-40e9-97c8-3013cb4e5886.png
[after]: https://user-images.githubusercontent.com/110032454/211873873-bc0c264a-5182-458c-8e9c-7a15e3fbce98.png

[b]: https://user-images.githubusercontent.com/110032454/211873360-154af192-b487-49cf-b02d-b6fa7c108193.png
[a]: https://user-images.githubusercontent.com/110032454/211873422-354b1898-6db7-475a-834a-c7b4ea1e7223.png


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
