### PR TITLE
Add how-to guide

### DIFF
--- a/dotcom-rendering/docs/contributing/README.md
+++ b/dotcom-rendering/docs/contributing/README.md
@@ -3,3 +3,4 @@
 - [Detailed setup guide](./detailed-setup-guide.md)
 - [Code style](./code-style.md)
 - [Where should my code live?](./where-should-my-code-live.md)
+- [How-to guides](./how-to.md)

--- a/dotcom-rendering/docs/contributing/how-to.md
+++ b/dotcom-rendering/docs/contributing/how-to.md
@@ -1,0 +1,27 @@
+# How-tos
+
+## Q. How can I add to this document?
+
+We welcome additions and corrections! If you want to add a task that you know
+how to accomplish already, please feel free to raise a pull request for this
+file, suggesting your change. If you have a question which you think we should
+answer, but you don't know how to answer it yourself, you can open an issue
+describing the question.
+
+Something to bear in mind is that documentation like this can easily go out of
+date, so we aim to focus on topics which (hopefully) won't change too quickly.
+
+## Q. How can I add client-side JavaScript?
+
+Most of the DCR Preact project is server-side rendered (SSR), and this is by design.
+We aim to minimise the amount of client-side JavaScript that we ship, so SSR
+should be the default choice.
+
+If you need JavaScript on the client, there are two main options:
+
+1. Vanilla JavaScript can be added inline to an SSR component in a `<script>` tag.
+2. 'Islands' (small, encapsulated bits of React code) can be hydrated on the
+   client.
+
+Both of these approaches should be used with caution, though. Feel free to reach
+out to the team if you're working on a feature in DCR which needs client-side scripts!


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a 'how-to' page to the DCR contributors guide.

## Why?
The aim is to provide a form of 'task-oriented' documentation, with a focus on common tasks which there are specific processes for in DCR. It should be accessible to contributors who are new to this codebase and the organisation.

If I remember rightly then this idea was inspired by a conversation with @OllysCoding a couple of months ago.

## Discussion
- I've kept the contents minimal for this PR because the main question is whether we think this form of documentation will be useful; details of which tasks to document, and how, should be reserved for separate PRs.
- But to flesh out the idea, here are some other topics which I thought it could be useful to cover in the future:
  1. How can I create an 'island' in DCR?
  2. How can I make an AJAX request in DCR?
  3. What should I do if Chromatic flags up changes which are unrelated to my PR?
- Some tooling (e.g. automatically generating a table of contents) could be useful at some point, but again I thought it made sense to keep this PR lily un-gilded.
- What should the scope of this guide be? Should it just cover technical topics? Or also process topics? And how can we balance coverage with the reality that any documentation tends to go stale over time?
