### PR TITLE
Use Containers to build a DCR Deployment workflow

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,5 @@
+logs/
+
+.env
+.tsconfig.tsbuildinfo
+yarn-error.log

--- a/.github/workflows/dcr-cicd.yml
+++ b/.github/workflows/dcr-cicd.yml
@@ -1,0 +1,40 @@
+name: DCR CI/CD
+on:
+  push:
+    branches: '**'
+    paths-ignore:
+      - 'apps-rendering/**'
+
+jobs:
+  image:
+    uses: ./.github/workflows/dcr-image.yml
+
+  lint:
+    uses: ./.github/workflows/dcr-lint.yml
+
+  jest:
+    uses: ./.github/workflows/dcr-jest.yml
+
+  cypress:
+    needs: [image]
+    uses: ./.github/workflows/dcr-cypress.yml
+    with:
+      container-image: ${{ needs.image.outputs.container-image }}
+
+  lighthouse:
+    needs: [image]
+    uses: ./.github/workflows/dcr-lighthouse.yml
+    with:
+      container-image: ${{ needs.image.outputs.container-image }}
+
+  percy:
+    needs: [image]
+    uses: ./.github/workflows/dcr-percy.yml
+    with:
+      container-image: ${{ needs.image.outputs.container-image }}
+
+  deploy:
+    needs: [image, lint, jest, cypress, lighthouse, percy]
+    uses: ./.github/workflows/dcr-deploy.yml
+    with:
+      container-image: ${{ needs.image.outputs.container-image }}

--- a/.github/workflows/dcr-cypress.yml
+++ b/.github/workflows/dcr-cypress.yml
@@ -1,13 +1,23 @@
-name: DCR cypress
 on:
-  push:
-    paths-ignore:
-      - "apps-rendering/**"
-      - "dotcom-rendering/docs/**"
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
+
 jobs:
   cypress:
-    name: DCR Cypress
     runs-on: ubuntu-20.04
+    services:
+      DCR:
+        image: ${{ inputs.container-image }}
+        env:
+          NODE_ENV: production
+          DISABLE_LOGGING_AND_METRICS: true
+        ports:
+          - 9000:9000
+
     strategy:
       fail-fast: false
       matrix:
@@ -21,16 +31,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - name: Generate production build
-        run: make build
-        working-directory: dotcom-rendering
-
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
-          start: make start-ci
           working-directory: dotcom-rendering
-          wait-on: "http://localhost:9000"
+          wait-on: 'http://localhost:9000'
           wait-on-timeout: 30
           browser: chrome
           spec: cypress/e2e/parallel-${{ matrix.group }}/*.js

--- a/.github/workflows/dcr-deploy.yml
+++ b/.github/workflows/dcr-deploy.yml
@@ -1,0 +1,15 @@
+on:
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.container-image }}
+
+    steps:
+      - run: ls /opt/app/dotcom-rendering

--- a/.github/workflows/dcr-image.yml
+++ b/.github/workflows/dcr-image.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_call:
+    outputs:
+      container-image:
+        description: 'The generated container image path'
+        value: ${{ jobs.image.outputs.container-image }}
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    outputs:
+      container-image: ${{ steps.push.outputs.registry-path }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@3.5.1
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Generate production build
+        run: make build
+        working-directory: dotcom-rendering
+
+      - name: Build Container Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2.11
+        with:
+          image: dotcom-rendering
+          tags: ${{ github.sha }} ${{ env.GITHUB_REF_SLUG }}
+          context: ./
+          containerfiles: ./dotcom-rendering/Containerfile
+
+      - name: Push Image To GHCR
+        uses: redhat-actions/push-to-registry@v2.7
+        id: push
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ghcr.io/guardian
+          username: ${{ github.actor }}
+          password: ${{ github.token }}

--- a/.github/workflows/dcr-jest.yml
+++ b/.github/workflows/dcr-jest.yml
@@ -1,0 +1,20 @@
+on:
+  - workflow_call
+
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      # Cache npm dependencies using https://github.com/bahmutov/npm-install
+      - uses: bahmutov/npm-install@v1
+
+      - name: Run Jest
+        run: CI=true yarn test
+        working-directory: dotcom-rendering

--- a/.github/workflows/dcr-lighthouse.yml
+++ b/.github/workflows/dcr-lighthouse.yml
@@ -41,6 +41,9 @@ jobs:
           npm install -g puppeteer-core@2.1.0 @lhci/cli@0.10.0
           lhci autorun
 
+      # We're running the deployment workflow on "push" events so that it can be used in both PRs and on the main branch.
+      # "push" event doesn't give us access to the usual PR info so we need to use an action in order to obtain that information.
+      # This action works by using the Github search API to find a associated PR given a commit ID.
       - uses: 8BitJonny/gh-get-current-pr@2.2.0
         if: github.ref != 'refs/heads/main'
         id: PR
@@ -60,4 +63,6 @@ jobs:
         env:
           LHCI_URL: ${{ matrix.group }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Merge commits will have their corresponding PR as the associated PR.
+          # We don't want to surface information to the PR after its been merged, instead it should be surfaced on #4584.
           ISSUE: ${{ github.ref == 'refs/heads/main' && '4584' || steps.PR.outputs.number }}

--- a/.github/workflows/dcr-lighthouse.yml
+++ b/.github/workflows/dcr-lighthouse.yml
@@ -1,23 +1,13 @@
-name: DCR Run Lighthouse CI
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'apps-rendering/**'
-      - 'dotcom-rendering/docs/**'
-
-  # We need to run on "pull_request" to get the PR number in the event.
-  # When running on "push", we cannot add a comment to a specific PR.
-  pull_request:
-    #  If/when we compare results to `main`, we should also run on 'reopened'
-    types: [opened, synchronize]
-    paths:
-      - 'dotcom-rendering/**'
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
 
 jobs:
-  lhci:
-    name: DCR Lighthouse
+  lighthouse:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -25,6 +15,14 @@ jobs:
         group:
           - 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
           - 'http://localhost:9000/Front?url=https://www.theguardian.com/uk'
+    services:
+      DCR:
+        image: ${{ inputs.container-image }}
+        env:
+          NODE_ENV: production
+          DISABLE_LOGGING_AND_METRICS: true
+        ports:
+          - 9000:9000
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,8 +32,6 @@ jobs:
           cache: 'yarn'
       # Make sure we install dependencies in the root directory
       - uses: bahmutov/npm-install@v1
-      - run: make build
-        working-directory: dotcom-rendering
       - name: Install and run Lighthouse CI
         working-directory: dotcom-rendering
         env:
@@ -44,6 +40,10 @@ jobs:
         run: |
           npm install -g puppeteer-core@2.1.0 @lhci/cli@0.10.0
           lhci autorun
+
+      - uses: 8BitJonny/gh-get-current-pr@2.2.0
+        if: github.ref != 'refs/heads/main'
+        id: PR
 
       # https://github.com/denoland/setup-deno#latest-stable-for-a-major
       - uses: denoland/setup-deno@v1
@@ -55,8 +55,9 @@ jobs:
           deno run \
             --allow-read \
             --allow-net=api.github.com \
-            --allow-env=HOME,GITHUB_TOKEN,GITHUB_EVENT_PATH,LHCI_URL \
+            --allow-env=HOME,GITHUB_TOKEN,ISSUE,LHCI_URL \
             scripts/deno/surface-lighthouse-results.ts
         env:
           LHCI_URL: ${{ matrix.group }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.ref == 'refs/heads/main' && '4584' || steps.PR.outputs.number }}

--- a/.github/workflows/dcr-lint.yml
+++ b/.github/workflows/dcr-lint.yml
@@ -1,12 +1,8 @@
-name: DCR lint 🔎
 on:
-  push:
-    paths-ignore:
-      - 'apps-rendering/**'
+  - workflow_call
 
 jobs:
   lint:
-    name: DCR Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,9 +12,11 @@ jobs:
           cache: 'yarn'
       - run: make install
         working-directory: dotcom-rendering
+
       - name: Lint
         run: make lint
         working-directory: dotcom-rendering
+
       - name: Stylelint
         run: make stylelint
         working-directory: dotcom-rendering

--- a/.github/workflows/dcr-percy.yml
+++ b/.github/workflows/dcr-percy.yml
@@ -1,29 +1,39 @@
-name: Percy
 on:
-  push:
-    paths-ignore:
-      - "apps-rendering/**"
+  workflow_call:
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
+
 jobs:
   percy:
-    name: Percy
     runs-on: ubuntu-latest
+
+    services:
+      DCR:
+        image: ${{ inputs.container-image }}
+        env:
+          NODE_ENV: production
+          DISABLE_LOGGING_AND_METRICS: true
+        ports:
+          - 9000:9000
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-      - name: Generate production build
-        run: make build
-        working-directory: dotcom-rendering
+
       - name: Install cypress
         uses: cypress-io/github-action@v4
         with:
           runTests: false
-          start: make start-ci
           working-directory: dotcom-rendering
-          wait-on: "http://localhost:9000"
+          wait-on: 'http://localhost:9000'
           wait-on-timeout: 30
+
       - name: Percy Test
         working-directory: dotcom-rendering
         run: yarn cypress:run:percy

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,8 +1,14 @@
 FROM node:16.19.0-alpine
 
+ENV DISABLE_LOGGING_AND_METRICS=true
+ENV NODE_ENV=production
+
 WORKDIR /opt/app/dotcom-rendering
 COPY  ./node_modules ./node_modules
 COPY ./dotcom-rendering/node_modules ./node_modules
-COPY ./dotcom-rendering/dist ./dist
 
+# We want our dist folder to be a seperate layer to allow our dependency layer to be cached
+COPY --link ./dotcom-rendering/dist ./dist
+
+EXPOSE 9000
 ENTRYPOINT ["node", "dist/frontend.server.js"]

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -6,9 +6,7 @@ ENV NODE_ENV=production
 WORKDIR /opt/app/dotcom-rendering
 COPY  ./node_modules ./node_modules
 COPY ./dotcom-rendering/node_modules ./node_modules
-
-# We want our dist folder to be a seperate layer to allow our dependency layer to be cached
-COPY --link ./dotcom-rendering/dist ./dist
+COPY ./dotcom-rendering/dist ./dist
 
 EXPOSE 9000
 ENTRYPOINT ["node", "dist/frontend.server.js"]

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,14 +1,14 @@
 FROM node:16.19.0-alpine AS dependencies
 
 COPY ./node_modules /opt/app/dotcom-rendering/node_modules
-COPY ./dotcom-rendering/node_modules /opt/app/dotcom-rendering/node_modules
+COPY ./dotcom-rendering/node_modules /opt/app/dotcom-rendering/dotcom-rendering/node_modules
 
 # Seperate dependencies into their own layer to allow for better caching
 FROM dependencies
 
-WORKDIR /opt/app/dotcom-rendering
+WORKDIR /opt/app/dotcom-rendering/dotcom-rendering
 
-COPY ./dotcom-rendering/dist /opt/app/dotcom-rendering/dist
+COPY ./dotcom-rendering/dist /opt/app/dotcom-rendering/dotcom-rendering/dist
 
 EXPOSE 9000
 

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,14 +1,13 @@
-FROM scratch AS dependencies
+FROM node:16.19.0-alpine AS dependencies
 
 COPY ./node_modules /opt/app/dotcom-rendering/node_modules
 COPY ./dotcom-rendering/node_modules /opt/app/dotcom-rendering/node_modules
 
-FROM node:16.19.0-alpine
+# Seperate dependencies into their own layer to allow for better caching
+FROM dependencies
 
 WORKDIR /opt/app/dotcom-rendering
 
-# Seperate dependencies into their own layer to allow for better caching
-COPY --from=dependencies /opt/app/dotcom-rendering/node_modules /opt/app/dotcom-rendering/node_modules
 COPY ./dotcom-rendering/dist /opt/app/dotcom-rendering/dist
 
 EXPOSE 9000

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,4 +1,4 @@
-FROM node:14.20.1-alpine
+FROM node:16.19.0-alpine
 
 WORKDIR /opt/app/dotcom-rendering
 COPY  ./node_modules ./node_modules

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,0 +1,8 @@
+FROM node:14.20.1-alpine
+
+WORKDIR /opt/app/dotcom-rendering
+COPY  ./node_modules ./node_modules
+COPY ./dotcom-rendering/node_modules ./node_modules
+COPY ./dotcom-rendering/dist ./dist
+
+ENTRYPOINT ["node", "dist/frontend.server.js"]

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,12 +1,19 @@
+FROM scratch AS dependencies
+
+COPY ./node_modules /opt/app/dotcom-rendering/node_modules
+COPY ./dotcom-rendering/node_modules /opt/app/dotcom-rendering/node_modules
+
 FROM node:16.19.0-alpine
+
+WORKDIR /opt/app/dotcom-rendering
+
+# Seperate dependencies into their own layer to allow for better caching
+COPY --from=dependencies /opt/app/dotcom-rendering/node_modules /opt/app/dotcom-rendering/node_modules
+COPY ./dotcom-rendering/dist /opt/app/dotcom-rendering/dist
+
+EXPOSE 9000
 
 ENV DISABLE_LOGGING_AND_METRICS=true
 ENV NODE_ENV=production
 
-WORKDIR /opt/app/dotcom-rendering
-COPY  ./node_modules ./node_modules
-COPY ./dotcom-rendering/node_modules ./node_modules
-COPY ./dotcom-rendering/dist ./dist
-
-EXPOSE 9000
 ENTRYPOINT ["node", "dist/frontend.server.js"]

--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -2,8 +2,6 @@ module.exports = {
 	ci: {
 		collect: {
 			url: [process.env.LHCI_URL],
-			startServerCommand:
-				'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
 			numberOfRuns: '10',
 			puppeteerScript: './scripts/lighthouse/puppeteer-script.js',
 			settings: {

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -1,26 +1,6 @@
 import { octokit } from './github.ts';
 import { record, string } from 'npm:zod@3';
-import type { EventPayloadMap } from 'npm:@octokit/webhooks-types@6';
 import 'https://raw.githubusercontent.com/GoogleChrome/lighthouse-ci/v0.10.0/types/assert.d.ts';
-
-/* -- Setup -- */
-
-/** Path for workflow event */
-const path = Deno.env.get('GITHUB_EVENT_PATH');
-if (!path) throw new Error('Missing GITHUB_EVENT_PATH');
-
-/**
- * https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
- */
-const payload: EventPayloadMap['push' | 'pull_request'] = JSON.parse(
-	Deno.readTextFileSync(path),
-);
-
-const isPullRequestEvent = (
-	payload: EventPayloadMap[keyof EventPayloadMap],
-): payload is EventPayloadMap['pull_request'] =>
-	'pull_request' in payload &&
-	typeof payload.pull_request.number === 'number';
 
 /**
  * One of two values depending on the workflow trigger event
@@ -32,11 +12,7 @@ const isPullRequestEvent = (
  * https://github.com/guardian/dotcom-rendering/issues/4584, which allows
  * to track the state Lighthouse CI Reports on `main` over time.
  */
-const issue_number = isPullRequestEvent(payload)
-	? // If PullRequestEvent
-	  payload.pull_request.number
-	: // If PushEvent
-	  4584;
+const issue_number = parseInt(Deno.env.get('ISSUE') || '4584');
 
 console.log(`Using issue #${issue_number}`);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a new Github Actions workflow that generates a production build, creates a container from the build, and then publishes the container to GHCR(Github container Registry).

Adds a new CI/CD workflow that uses the previously published container to test & "deploy" DCR.

![image](https://user-images.githubusercontent.com/21217225/212306184-d3c0bb87-92c2-4d12-853c-da85645fdc12.png)

(I didnt get around to adding Percy & Lighthouse which would also require the built server)

Inspired by #6073

## Why?

Ideally we want to be able to re-use our production build files across multiple workflows, in a previous PR #6073 we explored using `actions/cache` and `actions/artifact-upload` but found some drawbacks with both approaches.

- `actions/cache` has a 10GB repository limit on caches, if that limit is reached it starts clearing older caches when trying to create new caches, by using Cache to cache our job outputs we may run into a situation where we're removing caches whilst they're still needed which would slow down jobs across the board.
- `actions/artifact-upload` for some reason is rather slow, uploading and downloading artifacts takes much longer than expected considering GHA's available network bandwidth, this is worsened by the need to tar and untar all our files when we upload and download them. 

This PR proposes an alternative solution to "caching" our build bundle, **containers!** GHA has native container support which allows you to use containers as  [Services](https://docs.github.com/en/actions/using-containerized-services/about-service-containers) that can be run in parallel with your actions, or as the [base image](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) in which all your actions are run in, and Github has a container registry which is completely free for public projects such as ours.

Additionally we also get the benefit of allowing people to very quickly spin up DCR instances as they can download and run any of our production container images. This can make things like debugging issues much faster as a user could potentially download the image for any given commit and run it in under a minute.

## Example Cypress Workflow

```
name: DCR cypress

on:
  workflow_call:
    inputs:
      container-image:
        description: 'Image used by DCR service'
        required: true
        type: string

jobs:
  cypress:
    name: DCR Cypress
    runs-on: ubuntu-20.04
    services:
      # We start DCR as a Service, this instructions GHA to download the image and run it in parallel with the workflow.
      DCR:
        image: ${{ inputs.container-image }}
        env:
          NODE_ENV: production
          DISABLE_LOGGING_AND_METRICS: true
        ports:
          - 9000:9000

    strategy:
      fail-fast: false
      matrix:
        group: [1, 2, 3, 4, 5, 6]
    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - name: Install Node
        uses: guardian/actions-setup-node@main

      - name: Cypress run
        uses: cypress-io/github-action@v4
        with:
          working-directory: dotcom-rendering
          wait-on: 'http://localhost:9000'
          wait-on-timeout: 30
          browser: chrome
          spec: cypress/e2e/parallel-${{ matrix.group }}/*.js
```

## FAQ

### Can I run these container images locally?

Yes! And very quickly too as you don't need to create a production DCR build yourself!

I'm using podman for this example, but if you have something like Docker installed instead then you can replace podman with Docker (although I'd suggest not using Docker if possible!)

```bash
podman run -d -p 9000:9000 ghcr.io/guardian/dotcom-rendering:(commit hash)
# or for the latest code on a branch
podman run -d -p 9000:9000 ghcr.io/guardian/dotcom-rendering:(branch)

# For example if you wanted to run main you'd do
podman run -d -p 9000:9000 ghcr.io/guardian/dotcom-rendering:main
```

This will start a DCR container and allow you to access it over `localhost:9000`


### What does the `-alpine` mean in the base image?

Its the Linux distribution that the base image is built on. In our case we're using Alpine as its an incredibly lightweight linux distribution (~5MB) compared to something like a full fledged Debian distro (~40-50MB)

### Why don't you run `make build` inside of the Containerfile

Its a lot easier to manage the dependency cache when its done outside of the Container build process, it is possible to cache the dependency layer in the container but I don't want to get into that in this PR.