### PR TITLE
Add mediaType to front cards

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -120,6 +120,19 @@ const decideImage = (trail: FEFrontCard) => {
 	return trail.properties.maybeContent?.trail.trailPicture?.allImages[0]?.url;
 };
 
+const decideMediaType = (format: ArticleFormat): MediaType | undefined => {
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+			return 'Gallery';
+		case ArticleDesign.Video:
+			return 'Video';
+		case ArticleDesign.Audio:
+			return 'Audio';
+		default:
+			return undefined;
+	}
+};
+
 const decideKicker = (trail: FEFrontCard) => {
 	return trail.properties.isBreaking
 		? 'Breaking news'
@@ -222,5 +235,6 @@ export const enhanceCards = (
 							faciaCard.properties.maybeContent.trail.byline,
 					  )
 					: undefined,
+			mediaType: decideMediaType(format),
 		};
 	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Passes 'mediaType' and 'mediaDuration' to front cards, enabling the correct media icon to be shown

Also fixes some properties marked as 'required' which aren't always present

## Why?

Prep for 1% test

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/212328017-355a4866-5fdd-4dbe-af9a-ad945e6ef75a.png
[after]: https://user-images.githubusercontent.com/9575458/212328091-196f16e6-0308-43f7-bbfb-bbacc0204c83.png





<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
