### PR TITLE
Letters shouldn't have quote marks

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -859,3 +859,24 @@ export const WhenOpinionWithImageAtBottom = () => {
 		</>
 	);
 };
+
+export const WithLetterDesign = () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				headlineSize="small"
+				headlineText="Culture"
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Letter,
+					theme: ArticlePillar.Culture,
+				}}
+			/>
+		</CardWrapper>
+	);
+};
+
+WithLetterDesign.story = {
+	name: 'WithLetterDesign',
+};

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -880,3 +880,25 @@ export const WithLetterDesign = () => {
 WithLetterDesign.story = {
 	name: 'WithLetterDesign',
 };
+
+export const WithLetterDesignAndShowQuotedHeadline = () => {
+	return (
+		<CardWrapper>
+			<Card
+				{...basicCardProps}
+				headlineSize="small"
+				headlineText="Culture"
+				showQuotedHeadline={true}
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Letter,
+					theme: ArticlePillar.Culture,
+				}}
+			/>
+		</CardWrapper>
+	);
+};
+
+WithLetterDesignAndShowQuotedHeadline.story = {
+	name: 'WithLetterDesignAndShowQuotedHeadline',
+};

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -404,7 +404,11 @@ export const WithPulsingDotSpecialReportAlt = () => {
 export const WithQuotes = () => {
 	return (
 		<CardWrapper>
-			<Card {...basicCardProps} showQuotes={true} kickerText="Quotes" />
+			<Card
+				{...basicCardProps}
+				showQuotedHeadline={true}
+				kickerText="Quotes"
+			/>
 		</CardWrapper>
 	);
 };
@@ -419,7 +423,7 @@ export const WithQuotesSpecialReportAlt = () => {
 					design: ArticleDesign.Standard,
 					theme: ArticleSpecial.SpecialReportAlt,
 				}}
-				showQuotes={true}
+				showQuotedHeadline={true}
 				kickerText="Quotes"
 			/>
 		</CardWrapper>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -254,9 +254,7 @@ export const Card = ({
 	);
 
 	const showQuotes =
-		!!showQuotedHeadline ||
-		format.design === ArticleDesign.Comment ||
-		format.design === ArticleDesign.Letter;
+		!!showQuotedHeadline || format.design === ArticleDesign.Comment;
 
 	const isOpinion =
 		format.design === ArticleDesign.Comment ||

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -40,8 +40,7 @@ export type Props = {
 	headlineText: string;
 	headlineSize?: SmallHeadlineSize;
 	headlineSizeOnMobile?: SmallHeadlineSize;
-	/** Even with design !== Comment, a piece can be opinion */
-	showQuotes?: boolean;
+	showQuotedHeadline?: boolean;
 	byline?: string;
 	showByline?: boolean;
 	webPublicationDate?: string;
@@ -215,7 +214,7 @@ export const Card = ({
 	headlineText,
 	headlineSize,
 	headlineSizeOnMobile,
-	showQuotes,
+	showQuotedHeadline,
 	byline,
 	showByline,
 	webPublicationDate,
@@ -253,6 +252,11 @@ export const Card = ({
 		imagePosition,
 		supportingContentAlignment,
 	);
+
+	const showQuotes =
+		!!showQuotedHeadline ||
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Letter;
 
 	const isOpinion =
 		format.design === ArticleDesign.Comment ||

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -375,7 +375,7 @@ const CarouselCard = ({
 			showAge={true}
 			imagePositionOnMobile="top"
 			minWidthInPixels={220}
-			showQuotes={
+			showQuotedHeadline={
 				format.design === ArticleDesign.Comment ||
 				format.design === ArticleDesign.Letter
 			}

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -375,10 +375,7 @@ const CarouselCard = ({
 			showAge={true}
 			imagePositionOnMobile="top"
 			minWidthInPixels={220}
-			showQuotedHeadline={
-				format.design === ArticleDesign.Comment ||
-				format.design === ArticleDesign.Letter
-			}
+			showQuotedHeadline={format.design === ArticleDesign.Comment}
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}
 			branding={branding}

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -31,10 +31,7 @@ export const FrontCard = (props: Props) => {
 		headlineText: trail.headline,
 		byline: trail.byline,
 		showByline: trail.showByline,
-		showQuotes:
-			!!trail.showQuotedHeadline ||
-			trail.format.design === ArticleDesign.Comment ||
-			trail.format.design === ArticleDesign.Letter,
+		showQuotedHeadline: trail.showQuotedHeadline,
 		webPublicationDate: trail.webPublicationDate,
 		kickerText: trail.kickerText,
 		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,

--- a/dotcom-rendering/stories/generated/Card.stories.tsx
+++ b/dotcom-rendering/stories/generated/Card.stories.tsx
@@ -29,3 +29,16 @@ export const StandardStandard = () => {
 StandardStandard.story = {
 	name: 'StandardDisplay StandardDesign'
 };
+
+export const StandardLetter = () => {
+	return (
+		<CardsWithDifferentThemes
+			display={ArticleDisplay.Standard}
+			design={ArticleDesign.Letter}
+			title="StandardLetter"
+		/>
+	);
+};
+StandardLetter.story = {
+	name: 'StandardDisplay LetterDesign'
+};

--- a/dotcom-rendering/stories/generated/Card.stories.tsx
+++ b/dotcom-rendering/stories/generated/Card.stories.tsx
@@ -29,16 +29,3 @@ export const StandardStandard = () => {
 StandardStandard.story = {
 	name: 'StandardDisplay StandardDesign'
 };
-
-export const StandardLetter = () => {
-	return (
-		<CardsWithDifferentThemes
-			display={ArticleDisplay.Standard}
-			design={ArticleDesign.Letter}
-			title="StandardLetter"
-		/>
-	);
-};
-StandardLetter.story = {
-	name: 'StandardDisplay LetterDesign'
-};


### PR DESCRIPTION
Closes #6947 

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
* Removes quote marks support for:
   - front cards with `Letter` design
   - carousel cards with `Letter` design
* Pushes the logic to decide whether a front card shows quote marks or not on the `Card` level from `FrontCard`. This change starts capturing quotes in stories where the top level is `Card` and design is `Comment`, hence some Chromatic diffs.

## Why?
For parity with frontend

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/212345118-be3f91c7-8e83-4480-91fc-c74f47491a2a.png) | ![image](https://user-images.githubusercontent.com/19683595/212345228-796c36d0-15d3-45f1-b6e7-9e3d7453e594.png) |
| ![image](https://user-images.githubusercontent.com/19683595/212694927-d476c733-6147-42b2-a9b2-447e1776d2ae.png) | ![image](https://user-images.githubusercontent.com/19683595/212695192-04d589d4-52c4-4410-8dd7-31b10ac8da3e.png) |





[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
