### PR TITLE
Move `FigCaption` Component To AR

### DIFF
--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import FigCaption from '@guardian/common-rendering/src/components/figCaption';
+import FigCaption from 'components/FigCaption';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -14,6 +14,7 @@ import type { Image } from 'image/image';
 import type { Lightbox } from 'image/lightbox';
 import type { Sizes } from 'image/sizes';
 import type { FC, ReactNode } from 'react';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 
 const width = '100%';
 const phabletWidth = '620px';
@@ -127,6 +128,7 @@ const DefaultBodyImage: FC<
 			)}
 			format={format}
 			supportsDarkMode={supportsDarkMode}
+			variant={CaptionIconVariant.Image}
 		>
 			{caption}
 		</FigCaption>

--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import FigCaption from 'components/FigCaption';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -9,12 +9,12 @@ import { from, remSpace } from '@guardian/source-foundations';
 import type { Breakpoint } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { none, some, withDefault } from '@guardian/types';
+import FigCaption from 'components/FigCaption';
 import Img from 'components/ImgAlt';
 import type { Image } from 'image/image';
 import type { Lightbox } from 'image/lightbox';
 import type { Sizes } from 'image/sizes';
 import type { FC, ReactNode } from 'react';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 
 const width = '100%';
 const phabletWidth = '620px';

--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import FigCaption from '@guardian/common-rendering/src/components/figCaption';
+import FigCaption from 'components/FigCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, textSans } from '@guardian/source-foundations';
@@ -12,6 +12,7 @@ import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import { getDefaultImgStyles } from './BodyImage.defaults';
 import type { BodyImageProps } from './BodyImage.defaults';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 
 const figureStyles = css`
 	${grid.container}
@@ -150,6 +151,7 @@ const GalleryBodyImage: FC<BodyImageProps> = ({
 			css={captionStyles(format)}
 			format={format}
 			supportsDarkMode={supportsDarkMode}
+			variant={CaptionIconVariant.Image}
 		>
 			{caption}
 		</FigCaption>

--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -1,9 +1,10 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import FigCaption from 'components/FigCaption';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, textSans } from '@guardian/source-foundations';
+import FigCaption from 'components/FigCaption';
 import Img from 'components/ImgAlt';
 import { grid } from 'grid/grid';
 import type { Image } from 'image/image';
@@ -12,7 +13,6 @@ import type { FC } from 'react';
 import { darkModeCss } from 'styles';
 import { getDefaultImgStyles } from './BodyImage.defaults';
 import type { BodyImageProps } from './BodyImage.defaults';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 
 const figureStyles = css`
 	${grid.container}

--- a/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
+++ b/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
@@ -4,13 +4,13 @@
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
-import type { FC } from 'react';
-import { CaptionIconVariant } from './captionIcon';
-import FigCaption from './figCaption';
+import type { FC, ReactElement } from 'react';
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import FigCaption from '.';
 
 // ----- Stories ----- //
 
-const Image: FC = () => (
+const Image: FC = (): ReactElement => (
 	<FigCaption
 		format={{
 			design: ArticleDesign.Standard,
@@ -26,7 +26,7 @@ const Image: FC = () => (
 	</FigCaption>
 );
 
-const Video: FC = () => (
+const Video: FC = (): ReactElement => (
 	<FigCaption
 		format={{
 			design: ArticleDesign.Standard,
@@ -46,7 +46,7 @@ const Video: FC = () => (
 
 export default {
 	component: FigCaption,
-	title: 'Common/Components/FigCaption',
+	title: 'AR/FigCaption',
 };
 
 export { Image, Video };

--- a/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
+++ b/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable import/no-default-export -- exclude stories for this rule */
-
 // ----- Imports ----- //
 
+import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
 import type { FC, ReactElement } from 'react';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
 import FigCaption from '.';
 
 // ----- Stories ----- //

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -2,18 +2,17 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { remSpace } from '@guardian/source-foundations';
-import { neutral } from '@guardian/source-foundations';
-import { textSans } from '@guardian/source-foundations';
+import type { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import CaptionIcon from '@guardian/common-rendering/src/components/captionIcon';
+import { text } from '@guardian/common-rendering/src/editorialPalette';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
+import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
+import type { Styleable } from 'lib';
 import type { FC, ReactNode } from 'react';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
-import { text } from '@guardian/common-rendering/src/editorialPalette';
-import CaptionIcon, { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
-import { Styleable } from 'lib';
 
 // ----- Component ----- //
 
@@ -24,7 +23,10 @@ type Props = Styleable<{
 	variant: CaptionIconVariant;
 }>;
 
-const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
+const styles = (
+	format: ArticleFormat,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
 	color: ${text.figCaption(format)};
@@ -34,7 +36,7 @@ const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
   	`}
 `;
 
-const mediaStyles = (supportsDarkMode: boolean) => css`
+const mediaStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	color: ${neutral[86]};
 
 	${darkModeCss(supportsDarkMode)`

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -10,20 +10,19 @@ import { ArticleDesign } from '@guardian/libs';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import type { FC, ReactNode } from 'react';
-import { darkModeCss } from '../lib';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
-import CaptionIcon, { CaptionIconVariant } from './captionIcon';
+import CaptionIcon, { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import { Styleable } from 'lib';
 
 // ----- Component ----- //
 
-type Props = {
+type Props = Styleable<{
 	format: ArticleFormat;
 	supportsDarkMode: boolean;
 	children: Option<ReactNode>;
-	className?: string;
-	css?: SerializedStyles;
-	variant?: CaptionIconVariant;
-};
+	variant: CaptionIconVariant;
+}>;
 
 const styles = (format: ArticleFormat, supportsDarkMode: boolean) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
@@ -65,7 +64,7 @@ const FigCaption: FC<Props> = ({
 	supportsDarkMode,
 	children,
 	className,
-	variant = CaptionIconVariant.Image,
+	variant,
 }) => {
 	switch (children.kind) {
 		case OptionKind.Some:

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -11,7 +11,7 @@ import {
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
 import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
-import FigCaption from '@guardian/common-rendering/src/components/figCaption';
+import FigCaption from 'components/FigCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -11,7 +11,6 @@ import {
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
 import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
-import FigCaption from 'components/FigCaption';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -54,6 +53,7 @@ import GalleryImage from 'components/editions/galleryImage';
 import EditionsPullquote from 'components/editions/pullquote';
 import Video from 'components/editions/video';
 import EmbedComponentWrapper from 'components/EmbedWrapper';
+import FigCaption from 'components/FigCaption';
 import HeadingTwo from 'components/HeadingTwo';
 import HorizontalRule from 'components/HorizontalRule';
 import Interactive from 'components/Interactive';


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

## Changes

- Moved `FigCaption` component to AR
- Moved `FigCaption` stories to AR
- Refactored for AR linter and conventions
