### PR TITLE
Use kicker colour for card media icons

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -426,6 +426,7 @@ export const Card = ({
 								format={format}
 								mediaType={mediaType}
 								mediaDuration={mediaDuration}
+								hasKicker={!!kickerText}
 							/>
 						) : undefined}
 					</HeadlineWrapper>

--- a/dotcom-rendering/src/web/components/MediaMeta.test.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.test.tsx
@@ -2,8 +2,16 @@ import { secondsToDuration } from './MediaMeta';
 
 describe(`MediaText`, () => {
 	it(`converts from a number of seconds to a duration string`, () => {
-		const secss = [undefined, 0, 59, 599, 3599, 35999];
-		const expected = [``, ``, `0:59`, `9:59`, `59:59`, `9:59:59`];
+		const secss = [undefined, 0, 59, 599, 3599, 35999, 3601];
+		const expected = [
+			``,
+			``,
+			`0:59`,
+			`9:59`,
+			`59:59`,
+			`9:59:59`,
+			`1:00:01`,
+		];
 		secss.forEach((secs, i) => {
 			const result = secondsToDuration(secs);
 			expect(result).toBe(expected[i]);

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -63,11 +63,12 @@ export function secondsToDuration(secs?: number): string {
 		duration.push(h);
 	}
 	if (m > 0 || h === 0) {
-		// supports 0:59
-		duration.push(m);
+		if (h > 0 && m < 10) duration.push(`0${m}`); // e.g 1:01:11
+		else duration.push(m); // supports 0:59
 	}
 	if (s > 0) {
-		duration.push(s);
+		if (s < 10) duration.push(`0${s}`);
+		else duration.push(s);
 	}
 	return duration.join(':');
 }

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -14,13 +14,16 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	format: ArticleFormat;
 	mediaDuration?: number;
+	hasKicker: boolean;
 };
 
-const iconWrapperStyles = (palette: Palette) => css`
+const iconWrapperStyles = (palette: Palette, hasKicker: boolean) => css`
 	width: 24px;
 	height: 24px;
 	/* We’re using the text colour for the icon badge */
-	background-color: ${palette.text.cardFooter};
+	background-color: ${hasKicker
+		? palette.text.cardKicker
+		: palette.text.cardFooter};
 	border-radius: 50%;
 	display: inline-block;
 
@@ -35,8 +38,8 @@ const iconWrapperStyles = (palette: Palette) => css`
 	}
 `;
 
-const durationStyles = (palette: Palette) => css`
-	color: ${palette.text.cardFooter};
+const durationStyles = (palette: Palette, hasKicker: boolean) => css`
+	color: ${hasKicker ? palette.text.cardKicker : palette.text.cardFooter};
 	${textSans.xxsmall({ fontWeight: `bold` })}
 `;
 
@@ -83,11 +86,13 @@ const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 const MediaIcon = ({
 	mediaType,
 	palette,
+	hasKicker,
 }: {
 	mediaType: MediaType;
 	palette: Palette;
+	hasKicker: boolean;
 }) => (
-	<span css={iconWrapperStyles(palette)}>
+	<span css={iconWrapperStyles(palette, hasKicker)}>
 		<Icon mediaType={mediaType} />
 	</span>
 );
@@ -95,26 +100,38 @@ const MediaIcon = ({
 const MediaDuration = ({
 	mediaDuration,
 	palette,
+	hasKicker,
 }: {
 	mediaDuration: number;
 	palette: Palette;
-}) => <p css={durationStyles(palette)}>{secondsToDuration(mediaDuration)}</p>;
+	hasKicker: boolean;
+}) => (
+	<p css={durationStyles(palette, hasKicker)}>
+		{secondsToDuration(mediaDuration)}
+	</p>
+);
 
 export const MediaMeta = ({
 	mediaType,
 	mediaDuration,
 	format,
 	containerPalette,
+	hasKicker,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	return (
 		<div css={wrapperStyles}>
-			<MediaIcon mediaType={mediaType} palette={palette} />
+			<MediaIcon
+				mediaType={mediaType}
+				palette={palette}
+				hasKicker={hasKicker}
+			/>
 			&nbsp;
 			{!!mediaDuration && (
 				<MediaDuration
 					mediaDuration={mediaDuration}
 					palette={palette}
+					hasKicker={hasKicker}
 				/>
 			)}
 		</div>

--- a/dotcom-rendering/src/web/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/web/components/MediaMeta.tsx
@@ -62,10 +62,8 @@ export function secondsToDuration(secs?: number): string {
 	if (h > 0) {
 		duration.push(h);
 	}
-	if (m > 0 || h === 0) {
-		if (h > 0 && m < 10) duration.push(`0${m}`); // e.g 1:01:11
-		else duration.push(m); // supports 0:59
-	}
+	if (h > 0 && m < 10) duration.push(`0${m}`); // e.g 1:01:11
+	else duration.push(m); // supports 0:59
 	if (s > 0) {
 		if (s < 10) duration.push(`0${s}`);
 		else duration.push(s);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use the kicker colour for a cards media icon & duration. If there is no kicker then we fall back to the default text colour for the card. 

Also adds a fix to the `secondsToDuration` function, turning cases like `1:5` to `1:05` and `1:0:11` to `1:00:11` 

## Why?

Matching @HarryFischer's designs

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |


[before]: https://user-images.githubusercontent.com/9575458/212348746-25bf8c5b-9d3a-4e62-acab-18e5af1f00a2.png
[after]: https://user-images.githubusercontent.com/9575458/212348600-18015048-d1a0-49dd-b91d-d67cf86b0074.png

[before2]: https://user-images.githubusercontent.com/9575458/212348843-253c7e6b-5d2c-4169-841d-d2413f72629c.png
[after2]: https://user-images.githubusercontent.com/9575458/212348533-92c84cf9-46a6-49a1-a5ad-889a8a0570e0.png


