### PR TITLE
DCR & AR - Improve table of contents styles

### DIFF
--- a/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,6 +1,10 @@
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleSpecial } from '@guardian/libs';
-import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { explainer } from 'fixtures/item';
 import type { ReactElement } from 'react';
 import TableOfContents from '.';

--- a/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,4 +1,5 @@
-import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleSpecial } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { explainer } from 'fixtures/item';
 import type { ReactElement } from 'react';

--- a/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,4 +1,4 @@
-import type { ArticleFormat } from '@guardian/libs';
+import { ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { explainer } from 'fixtures/item';
 import type { ReactElement } from 'react';
@@ -10,8 +10,31 @@ const format: ArticleFormat = {
 	theme: ArticlePillar.News,
 };
 
+const immersiveDisplayFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Immersive,
+	theme: ArticlePillar.News,
+};
+
+const labsThemeFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticleSpecial.Labs,
+};
+
 const Default = (): ReactElement => (
 	<TableOfContents outline={explainer.outline} format={format} />
+);
+
+const Immersive = (): ReactElement => (
+	<TableOfContents
+		outline={explainer.outline}
+		format={immersiveDisplayFormat}
+	/>
+);
+
+const Labs = (): ReactElement => (
+	<TableOfContents outline={explainer.outline} format={labsThemeFormat} />
 );
 
 export default {
@@ -19,4 +42,4 @@ export default {
 	title: 'AR/TableOfContents',
 };
 
-export { Default };
+export { Default, Immersive, Labs };

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -33,9 +33,6 @@ interface TextElementProps {
 const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.paragraph(format)};
 	border-bottom: none;
-	/* :hover {
-		border-bottom: 0.0625rem solid ${neutral[86]};
-	} */
 `;
 
 const listStyles: SerializedStyles = css`
@@ -48,7 +45,7 @@ const listStyles: SerializedStyles = css`
 
 const defaultListItemStyles: SerializedStyles = css`
 	border-top: 1px solid ${neutral[86]};
-	padding-top: ${remSpace[2]};
+	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
 	&:last-child {
 		border-bottom: 1px solid ${neutral[86]};
 	}
@@ -56,6 +53,18 @@ const defaultListItemStyles: SerializedStyles = css`
 		border-top: 1px solid ${neutral[20]};
 		cursor: pointer;
 	}
+	${darkModeCss`
+		border-color: ${neutral[20]};
+		&:last-child {
+			border-bottom-color: ${neutral[20]};
+		}
+		&:hover {
+			border-color: ${neutral[86]};
+			&:last-child {
+				border-bottom-color: ${neutral[20]};
+			}
+		}
+	`}
 `;
 
 const listItemStyles = (format: ArticleFormat): SerializedStyles => {
@@ -69,6 +78,7 @@ const listItemStyles = (format: ArticleFormat): SerializedStyles => {
 	if (format.theme === ArticleSpecial.Labs) {
 		return css`
 			${textSans.medium({ fontWeight: 'bold' })}
+			${defaultListItemStyles}
 		`;
 	}
 
@@ -89,12 +99,11 @@ const detailsStyles: SerializedStyles = css`
 	}
 `;
 
-const summaryStyles: SerializedStyles = css`
+const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	cursor: pointer;
 	position: relative;
 	list-style: none;
-	padding-top: 0.44rem;
-	padding-bottom: 0.375rem;
+	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
 	border-top: 1px solid ${neutral[86]};
 
 	&:hover {
@@ -108,6 +117,16 @@ const summaryStyles: SerializedStyles = css`
 	svg {
 		height: 2rem;
 	}
+	${darkModeCss`
+		border-color: ${neutral[20]};
+		&:hover {
+			border-color: ${neutral[86]};
+		}
+
+		path {
+			fill: ${text.tableOfContentsTitleDark(format)};
+		}
+	`}
 `;
 
 const titleStyle = (format: ArticleFormat): SerializedStyles => css`
@@ -184,7 +203,7 @@ const TocTextElement: React.FC<TextElementProps> = ({
 const TableOfContents: FC<Props> = ({ format, outline }) => {
 	return (
 		<details open={outline.length < 5} css={detailsStyles}>
-			<summary css={summaryStyles}>
+			<summary css={summaryStyles(format)}>
 				<h2 css={titleStyle(format)}>Jump to...</h2>
 				<span className="is-off" css={arrowPosition}>
 					<SvgChevronDownSingle size="xsmall" />

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -33,6 +33,9 @@ interface TextElementProps {
 const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.paragraph(format)};
 	border-bottom: none;
+	/* :hover {
+		border-bottom: 0.0625rem solid ${neutral[86]};
+	} */
 `;
 
 const listStyles: SerializedStyles = css`
@@ -50,7 +53,7 @@ const defaultListItemStyles: SerializedStyles = css`
 		border-bottom: 1px solid ${neutral[86]};
 	}
 	&:hover {
-		border-top: 1px solid ${neutral[7]};
+		border-top: 1px solid ${neutral[20]};
 		cursor: pointer;
 	}
 `;
@@ -95,7 +98,7 @@ const summaryStyles: SerializedStyles = css`
 	border-top: 1px solid ${neutral[86]};
 
 	&:hover {
-		border-top: 1px solid ${neutral[7]};
+		border-top: 1px solid ${neutral[20]};
 		cursor: pointer;
 	}
 

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -28,6 +28,8 @@ interface TextElementProps {
 const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.paragraph(format)};
 	border-bottom: none;
+	display: block;
+	padding: ${remSpace[1]} 0 ${remSpace[4]} 0;
 `;
 
 const listStyles: SerializedStyles = css`
@@ -40,24 +42,15 @@ const listStyles: SerializedStyles = css`
 
 const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 	border-top: 1px solid ${border.tableOfContents(format)};
-	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
-	&:last-child {
-		border-bottom: 1px solid ${border.tableOfContents(format)};
-	}
+	padding-bottom: 0;
 	&:hover {
 		border-top: 1px solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
 	}
 	${darkModeCss`
 		border-color: ${border.tableOfContentsDark(format)};
-		&:last-child {
-			border-bottom-color: ${border.tableOfContentsDark(format)};
-		}
 		&:hover {
 			border-color: ${border.tableOfContentsHoverDark(format)};
-			&:last-child {
-				border-bottom-color: ${border.tableOfContentsDark(format)};
-			}
 		}
 	`}
 `;
@@ -98,7 +91,7 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	cursor: pointer;
 	position: relative;
 	list-style: none;
-	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
+	padding: ${remSpace[1]} 0 ${remSpace[1]} 0;
 	border-top: 1px solid ${border.tableOfContents(format)};
 
 	&:hover {

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -1,8 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDisplay, ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import {
+	headline,
 	line,
 	neutral,
 	remSpace,
@@ -32,9 +33,6 @@ interface TextElementProps {
 const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.paragraph(format)};
 	border-bottom: none;
-	:hover {
-		border-bottom: 0.0625rem solid ${neutral[86]};
-	}
 `;
 
 const listStyles: SerializedStyles = css`
@@ -45,11 +43,37 @@ const listStyles: SerializedStyles = css`
 	margin: 0;
 `;
 
-const listItemStyles: SerializedStyles = css`
-	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'regular' })}
-	border-bottom: 1px solid ${line.primary};
+const defaultListItemStyles: SerializedStyles = css`
+	border-top: 1px solid ${line.primary};
 	padding-top: ${remSpace[2]};
+	&:last-child {
+		border-bottom: 1px solid ${line.primary};
+	}
+	&:hover {
+		border-top: 1px solid ${neutral[7]};
+		cursor: pointer;
+	}
 `;
+
+const listItemStyles = (format: ArticleFormat): SerializedStyles => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return css`
+			${headline.xxxsmall({ fontWeight: 'light' })}
+			${defaultListItemStyles}
+		`;
+	}
+
+	if (format.theme === ArticleSpecial.Labs) {
+		return css`
+			${textSans.medium({ fontWeight: 'bold' })}
+		`;
+	}
+
+	return css`
+		${headline.xxxsmall({ fontWeight: 'bold' })}
+		${defaultListItemStyles}
+	`;
+};
 
 const detailsStyles: SerializedStyles = css`
 	margin-bottom: ${remSpace[6]};
@@ -68,11 +92,15 @@ const summaryStyles: SerializedStyles = css`
 	list-style: none;
 	padding-top: 0.44rem;
 	padding-bottom: 0.375rem;
-	border-bottom: 1px solid ${line.primary};
 	border-top: 1px solid ${line.primary};
 
+	&:hover {
+		border-top: 1px solid ${neutral[7]};
+		cursor: pointer;
+	}
+
 	path {
-		fill: ${neutral[46]};
+		fill: ${neutral[7]};
 	}
 	svg {
 		height: 2rem;
@@ -164,7 +192,10 @@ const TableOfContents: FC<Props> = ({ format, outline }) => {
 			</summary>
 			<OrderedList className={listStyles}>
 				{outline.map((outlineItem) => (
-					<ListItem className={listItemStyles} key={outlineItem.id}>
+					<ListItem
+						className={listItemStyles(format)}
+						key={outlineItem.id}
+					>
 						<Anchor
 							format={format}
 							href={`#${outlineItem.id}`}

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -1,10 +1,10 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette/text';
-import { ArticleDisplay, ArticleFormat, ArticleSpecial } from '@guardian/libs';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import {
 	headline,
-	line,
 	neutral,
 	remSpace,
 	textSans,
@@ -44,10 +44,10 @@ const listStyles: SerializedStyles = css`
 `;
 
 const defaultListItemStyles: SerializedStyles = css`
-	border-top: 1px solid ${line.primary};
+	border-top: 1px solid ${neutral[86]};
 	padding-top: ${remSpace[2]};
 	&:last-child {
-		border-bottom: 1px solid ${line.primary};
+		border-bottom: 1px solid ${neutral[86]};
 	}
 	&:hover {
 		border-top: 1px solid ${neutral[7]};
@@ -92,7 +92,7 @@ const summaryStyles: SerializedStyles = css`
 	list-style: none;
 	padding-top: 0.44rem;
 	padding-bottom: 0.375rem;
-	border-top: 1px solid ${line.primary};
+	border-top: 1px solid ${neutral[86]};
 
 	&:hover {
 		border-top: 1px solid ${neutral[7]};

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -138,7 +138,7 @@ const titleStyle = (format: ArticleFormat): SerializedStyles => css`
 const arrowPosition: SerializedStyles = css`
 	position: absolute;
 	right: ${remSpace[1]};
-	top: 0;
+	top: -0.125rem;
 `;
 
 const TocTextElement: React.FC<TextElementProps> = ({

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -45,13 +45,13 @@ const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 	padding-bottom: 0;
 
 	&:hover {
-		border-top: 1px solid ${border.tableOfContentsDark(format)};
+		border-top: 1px solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
 	}
 	${darkModeCss`
 		border-color: ${border.tableOfContentsDark(format)};
 		&:hover {
-			border-color: ${border.tableOfContents(format)};
+			border-color: ${border.tableOfContentsHoverDark(format)};
 		}
 	`}
 `;
@@ -105,7 +105,7 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	border-top: 1px solid ${border.tableOfContents(format)};
 
 	&:hover {
-		border-top: 1px solid ${border.tableOfContentsDark(format)};
+		border-top: 1px solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
 	}
 
@@ -118,7 +118,7 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	${darkModeCss`
 		border-color: ${border.tableOfContentsDark(format)};
 		&:hover {
-			border-color: ${border.tableOfContents(format)};
+			border-color: ${border.tableOfContentsHoverDark(format)};
 		}
 
 		path {

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -43,14 +43,15 @@ const listStyles: SerializedStyles = css`
 const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 	border-top: 1px solid ${border.tableOfContents(format)};
 	padding-bottom: 0;
+
 	&:hover {
-		border-top: 1px solid ${border.tableOfContentsHover(format)};
+		border-top: 1px solid ${border.tableOfContentsDark(format)};
 		cursor: pointer;
 	}
 	${darkModeCss`
 		border-color: ${border.tableOfContentsDark(format)};
 		&:hover {
-			border-color: ${border.tableOfContentsHoverDark(format)};
+			border-color: ${border.tableOfContents(format)};
 		}
 	`}
 `;
@@ -76,15 +77,24 @@ const listItemStyles = (format: ArticleFormat): SerializedStyles => {
 	`;
 };
 
-const detailsStyles: SerializedStyles = css`
+const detailsStyles = (format: ArticleFormat): SerializedStyles => css`
 	margin-bottom: ${remSpace[6]};
 	&:not([open]) .is-on,
 	&[open] .is-off {
 		display: none;
 	}
+	&:not([open]) {
+		border-bottom: 1px solid ${border.tableOfContents(format)};
+	}
 	summary::-webkit-details-marker {
 		display: none;
 	}
+
+	${darkModeCss`
+		&:not([open]) {
+			border-bottom: 1px solid ${border.tableOfContentsDark(format)};
+		}
+	`}
 `;
 
 const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
@@ -95,7 +105,7 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	border-top: 1px solid ${border.tableOfContents(format)};
 
 	&:hover {
-		border-top: 1px solid ${border.tableOfContentsHover(format)};
+		border-top: 1px solid ${border.tableOfContentsDark(format)};
 		cursor: pointer;
 	}
 
@@ -108,7 +118,7 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	${darkModeCss`
 		border-color: ${border.tableOfContentsDark(format)};
 		&:hover {
-			border-color: ${border.tableOfContentsHoverDark(format)};
+			border-color: ${border.tableOfContents(format)};
 		}
 
 		path {
@@ -190,7 +200,7 @@ const TocTextElement: React.FC<TextElementProps> = ({
 
 const TableOfContents: FC<Props> = ({ format, outline }) => {
 	return (
-		<details open={outline.length < 5} css={detailsStyles}>
+		<details open={outline.length < 5} css={detailsStyles(format)}>
 			<summary css={summaryStyles(format)}>
 				<h2 css={titleStyle(format)}>Jump to...</h2>
 				<span className="is-off" css={arrowPosition}>

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -1,14 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { text } from '@guardian/common-rendering/src/editorialPalette/text';
+import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDisplay, ArticleSpecial } from '@guardian/libs';
-import {
-	headline,
-	neutral,
-	remSpace,
-	textSans,
-} from '@guardian/source-foundations';
+import { headline, remSpace, textSans } from '@guardian/source-foundations';
 import {
 	SvgChevronDownSingle,
 	SvgChevronUpSingle,
@@ -43,25 +38,25 @@ const listStyles: SerializedStyles = css`
 	margin: 0;
 `;
 
-const defaultListItemStyles: SerializedStyles = css`
-	border-top: 1px solid ${neutral[86]};
+const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
+	border-top: 1px solid ${border.tableOfContents(format)};
 	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
 	&:last-child {
-		border-bottom: 1px solid ${neutral[86]};
+		border-bottom: 1px solid ${border.tableOfContents(format)};
 	}
 	&:hover {
-		border-top: 1px solid ${neutral[20]};
+		border-top: 1px solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
 	}
 	${darkModeCss`
-		border-color: ${neutral[20]};
+		border-color: ${border.tableOfContentsDark(format)};
 		&:last-child {
-			border-bottom-color: ${neutral[20]};
+			border-bottom-color: ${border.tableOfContentsDark(format)};
 		}
 		&:hover {
-			border-color: ${neutral[86]};
+			border-color: ${border.tableOfContentsHoverDark(format)};
 			&:last-child {
-				border-bottom-color: ${neutral[20]};
+				border-bottom-color: ${border.tableOfContentsDark(format)};
 			}
 		}
 	`}
@@ -71,20 +66,20 @@ const listItemStyles = (format: ArticleFormat): SerializedStyles => {
 	if (format.display === ArticleDisplay.Immersive) {
 		return css`
 			${headline.xxxsmall({ fontWeight: 'light' })}
-			${defaultListItemStyles}
+			${defaultListItemStyles(format)}
 		`;
 	}
 
 	if (format.theme === ArticleSpecial.Labs) {
 		return css`
 			${textSans.medium({ fontWeight: 'bold' })}
-			${defaultListItemStyles}
+			${defaultListItemStyles(format)}
 		`;
 	}
 
 	return css`
 		${headline.xxxsmall({ fontWeight: 'bold' })}
-		${defaultListItemStyles}
+		${defaultListItemStyles(format)}
 	`;
 };
 
@@ -104,23 +99,23 @@ const summaryStyles = (format: ArticleFormat): SerializedStyles => css`
 	position: relative;
 	list-style: none;
 	padding: ${remSpace[1]} 0 ${remSpace[2]} 0;
-	border-top: 1px solid ${neutral[86]};
+	border-top: 1px solid ${border.tableOfContents(format)};
 
 	&:hover {
-		border-top: 1px solid ${neutral[20]};
+		border-top: 1px solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
 	}
 
 	path {
-		fill: ${neutral[7]};
+		fill: ${text.tableOfContentsTitle(format)};
 	}
 	svg {
 		height: 2rem;
 	}
 	${darkModeCss`
-		border-color: ${neutral[20]};
+		border-color: ${border.tableOfContentsDark(format)};
 		&:hover {
-			border-color: ${neutral[86]};
+			border-color: ${border.tableOfContentsHoverDark(format)};
 		}
 
 		path {

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -258,6 +258,22 @@ const newsletterSignUpFormDark = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
+const tableOfContents = (_format: ArticleFormat): string => {
+	return neutral[86];
+};
+
+const tableOfContentsHover = (_format: ArticleFormat): string => {
+	return neutral[20];
+};
+
+const tableOfContentsDark = (_format: ArticleFormat): string => {
+	return neutral[20];
+};
+
+const tableOfContentsHoverDark = (_format: ArticleFormat): string => {
+	return neutral[86];
+};
+
 // ----- API ----- //
 
 const border = {
@@ -289,6 +305,10 @@ const border = {
 	galleryImage,
 	newsletterSignUpForm,
 	newsletterSignUpFormDark,
+	tableOfContents,
+	tableOfContentsHover,
+	tableOfContentsDark,
+	tableOfContentsHoverDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -262,8 +262,16 @@ const tableOfContents = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
+const tableOfContentsHover = (_format: ArticleFormat): string => {
+	return neutral[20];
+};
+
 const tableOfContentsDark = (_format: ArticleFormat): string => {
 	return neutral[20];
+};
+
+const tableOfContentsHoverDark = (_format: ArticleFormat): string => {
+	return neutral[86];
 };
 
 // ----- API ----- //
@@ -298,7 +306,9 @@ const border = {
 	newsletterSignUpForm,
 	newsletterSignUpFormDark,
 	tableOfContents,
+	tableOfContentsHover,
 	tableOfContentsDark,
+	tableOfContentsHoverDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/border.ts
+++ b/common-rendering/src/editorialPalette/border.ts
@@ -262,16 +262,8 @@ const tableOfContents = (_format: ArticleFormat): string => {
 	return neutral[86];
 };
 
-const tableOfContentsHover = (_format: ArticleFormat): string => {
-	return neutral[20];
-};
-
 const tableOfContentsDark = (_format: ArticleFormat): string => {
 	return neutral[20];
-};
-
-const tableOfContentsHoverDark = (_format: ArticleFormat): string => {
-	return neutral[86];
 };
 
 // ----- API ----- //
@@ -306,9 +298,7 @@ const border = {
 	newsletterSignUpForm,
 	newsletterSignUpFormDark,
 	tableOfContents,
-	tableOfContentsHover,
 	tableOfContentsDark,
-	tableOfContentsHoverDark,
 };
 
 // ----- Exports ----- //

--- a/common-rendering/src/editorialPalette/text.ts
+++ b/common-rendering/src/editorialPalette/text.ts
@@ -1129,7 +1129,7 @@ const galleryDark = (_format: ArticleFormat): string => {
 };
 
 const tableOfContentsTitle = (_format: ArticleFormat): string => {
-	return neutral[46];
+	return neutral[7];
 };
 
 const tableOfContentsTitleDark = (_format: ArticleFormat): string => {

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -60,6 +60,7 @@ export type Palette = {
 		betaLabel: Colour;
 		designTag: Colour;
 		dateLine: Colour;
+		tableOfContents: Colour;
 	};
 	background: {
 		article: Colour;

--- a/dotcom-rendering/src/web/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/web/components/ArticleBody.tsx
@@ -204,6 +204,7 @@ export const ArticleBody = ({
 				<Island>
 					<TableOfContents
 						tableOfContents={tableOfContents}
+						format={format}
 					></TableOfContents>
 				</Island>
 			)}

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -22,14 +22,12 @@ interface Props {
 const anchorStyles = css`
 	color: ${neutral[7]};
 	text-decoration: none;
+	display: block;
+	padding: 4px 0 16px 0;
 `;
 
 const defaultListItemStyles = css`
 	border-top: 1px solid ${line.primary};
-	padding: 4px 0 8px 0;
-	&:last-child {
-		border-bottom: 1px solid ${line.primary};
-	}
 	&:hover {
 		border-top: 1px solid ${neutral[7]};
 		cursor: pointer;
@@ -67,7 +65,7 @@ const summaryStyles = css`
 	position: relative;
 	list-style: none;
 	align-items: center;
-	padding: 4px 0 8px 0;
+	padding: 4px 0 4px 0;
 	border-top: 1px solid ${line.primary};
 
 	&:hover {

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { line, neutral, space, textSans } from '@guardian/source-foundations';
+import {
+	headline,
+	line,
+	neutral,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
 import {
 	SvgChevronDownSingle,
 	SvgChevronUpSingle,
@@ -12,17 +18,17 @@ interface Props {
 }
 
 const anchorStyles = css`
-	color: black;
+	color: ${neutral[7]};
 	text-decoration: none;
 `;
 
 const listItemStyles = css`
-	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'regular' })}
-	border-bottom: 1px solid ${line.primary};
+	${headline.xxxsmall({ fontWeight: 'bold' })}
+	border-top: 1px solid ${line.primary};
 	padding: 6px 0;
-
-	&:last-child {
-		border-bottom: none;
+	&:hover {
+		border-top: 1px solid ${neutral[7]};
+		cursor: pointer;
 	}
 `;
 
@@ -44,11 +50,15 @@ const summaryStyles = css`
 	list-style: none;
 	align-items: center;
 	padding: 6px 0;
-	border-bottom: 1px solid ${line.primary};
 	border-top: 1px solid ${line.primary};
 
+	&:hover {
+		border-top: 1px solid ${neutral[7]};
+		cursor: pointer;
+	}
+
 	path {
-		fill: ${neutral[46]};
+		fill: ${neutral[7]};
 	}
 	svg {
 		height: 32px;
@@ -57,7 +67,7 @@ const summaryStyles = css`
 
 const titleStyle = css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
-	color: ${neutral[46]};
+	color: ${neutral[7]};
 `;
 
 const chevronPosition = css`

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDisplay } from '@guardian/libs';
 import {
 	headline,
 	line,
@@ -15,6 +16,7 @@ import type { TableOfContentsItem } from '../../types/frontend';
 
 interface Props {
 	tableOfContents: TableOfContentsItem[];
+	format: ArticleFormat;
 }
 
 const anchorStyles = css`
@@ -22,15 +24,31 @@ const anchorStyles = css`
 	text-decoration: none;
 `;
 
-const listItemStyles = css`
-	${headline.xxxsmall({ fontWeight: 'bold' })}
+const defaultListItemStyles = css`
 	border-top: 1px solid ${line.primary};
 	padding: 6px 0;
+	&:last-child {
+		border-bottom: 1px solid ${line.primary};
+	}
 	&:hover {
 		border-top: 1px solid ${neutral[7]};
 		cursor: pointer;
 	}
 `;
+
+const listItemStyles = (format: ArticleFormat) => {
+	if (format.display === ArticleDisplay.Immersive) {
+		return css`
+			${headline.xxxsmall({ fontWeight: 'light' })}
+			${defaultListItemStyles}
+		`;
+	}
+
+	return css`
+		${headline.xxxsmall({ fontWeight: 'bold' })}
+		${defaultListItemStyles}
+	`;
+};
 
 const detailsStyles = css`
 	padding: ${space[4]}px 0 ${space[6]}px 0;
@@ -76,7 +94,7 @@ const chevronPosition = css`
 	top: 0;
 `;
 
-export const TableOfContents = ({ tableOfContents }: Props) => {
+export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	const [open, setOpen] = useState(tableOfContents.length < 5);
 
 	// The value for data-link-name is evaluated at the time when the component renders,
@@ -113,7 +131,7 @@ export const TableOfContents = ({ tableOfContents }: Props) => {
 				{tableOfContents.map((item, index) => (
 					<li
 						key={item.id}
-						css={listItemStyles}
+						css={listItemStyles(format)}
 						data-link-name={`table-of-contents-item-${index}-${item.id}`}
 					>
 						<a href={`#${item.id}`} css={anchorStyles}>

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -23,7 +23,7 @@ const anchorStyles = css`
 	color: ${neutral[7]};
 	text-decoration: none;
 	display: block;
-	padding: 4px 0 16px 0;
+	padding: ${space[1]}px 0 ${space[4]}px 0;
 `;
 
 const defaultListItemStyles = css`
@@ -49,10 +49,13 @@ const listItemStyles = (format: ArticleFormat) => {
 };
 
 const detailsStyles = css`
-	padding: ${space[4]}px 0 ${space[6]}px 0;
+	margin: ${space[4]}px 0 ${space[6]}px 0;
 	&:not([open]) .is-open,
 	&[open] .is-closed {
 		display: none;
+	}
+	&:not([open]) {
+		border-bottom: 1px solid ${line.primary};
 	}
 	/* removes toggle triangle from webkit browsers such as Safari */
 	summary::-webkit-details-marker {
@@ -65,7 +68,7 @@ const summaryStyles = css`
 	position: relative;
 	list-style: none;
 	align-items: center;
-	padding: 4px 0 4px 0;
+	padding: ${space[1]}px 0 ${space[1]}px 0;
 	border-top: 1px solid ${line.primary};
 
 	&:hover {

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -26,7 +26,7 @@ const anchorStyles = css`
 
 const defaultListItemStyles = css`
 	border-top: 1px solid ${line.primary};
-	padding: 6px 0;
+	padding: 4px 0 8px 0;
 	&:last-child {
 		border-bottom: 1px solid ${line.primary};
 	}
@@ -67,7 +67,7 @@ const summaryStyles = css`
 	position: relative;
 	list-style: none;
 	align-items: center;
-	padding: 6px 0;
+	padding: 4px 0 8px 0;
 	border-top: 1px solid ${line.primary};
 
 	&:hover {

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -1,50 +1,46 @@
 import { css } from '@emotion/react';
 import { ArticleDisplay } from '@guardian/libs';
-import {
-	headline,
-	line,
-	neutral,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { headline, line, space, textSans } from '@guardian/source-foundations';
 import {
 	SvgChevronDownSingle,
 	SvgChevronUpSingle,
 } from '@guardian/source-react-components';
 import { useState } from 'react';
 import type { TableOfContentsItem } from '../../types/frontend';
+import type { Palette } from '../../types/palette';
+import { decidePalette } from '../lib/decidePalette';
 
 interface Props {
 	tableOfContents: TableOfContentsItem[];
 	format: ArticleFormat;
 }
 
-const anchorStyles = css`
-	color: ${neutral[7]};
+const anchorStyles = (palette: Palette) => css`
+	color: ${palette.text.tableOfContents};
 	text-decoration: none;
 	display: block;
 	padding: ${space[1]}px 0 ${space[4]}px 0;
 `;
 
-const defaultListItemStyles = css`
+const defaultListItemStyles = (palette: Palette) => css`
 	border-top: 1px solid ${line.primary};
 	&:hover {
-		border-top: 1px solid ${neutral[7]};
+		border-top: 1px solid ${palette.text.tableOfContents};
 		cursor: pointer;
 	}
 `;
 
-const listItemStyles = (format: ArticleFormat) => {
+const listItemStyles = (format: ArticleFormat, palette: Palette) => {
 	if (format.display === ArticleDisplay.Immersive) {
 		return css`
 			${headline.xxxsmall({ fontWeight: 'light' })}
-			${defaultListItemStyles}
+			${defaultListItemStyles(palette)}
 		`;
 	}
 
 	return css`
 		${headline.xxxsmall({ fontWeight: 'bold' })}
-		${defaultListItemStyles}
+		${defaultListItemStyles(palette)}
 	`;
 };
 
@@ -63,7 +59,7 @@ const detailsStyles = css`
 	}
 `;
 
-const summaryStyles = css`
+const summaryStyles = (palette: Palette) => css`
 	cursor: pointer;
 	position: relative;
 	list-style: none;
@@ -72,21 +68,21 @@ const summaryStyles = css`
 	border-top: 1px solid ${line.primary};
 
 	&:hover {
-		border-top: 1px solid ${neutral[7]};
+		border-top: 1px solid ${palette.text.tableOfContents};
 		cursor: pointer;
 	}
 
 	path {
-		fill: ${neutral[7]};
+		fill: ${palette.text.tableOfContents};
 	}
 	svg {
 		height: 32px;
 	}
 `;
 
-const titleStyle = css`
+const titleStyle = (palette: Palette) => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
-	color: ${neutral[7]};
+	color: ${palette.text.tableOfContents};
 `;
 
 const chevronPosition = css`
@@ -96,6 +92,7 @@ const chevronPosition = css`
 `;
 
 export const TableOfContents = ({ tableOfContents, format }: Props) => {
+	const palette = decidePalette(format);
 	const [open, setOpen] = useState(tableOfContents.length < 5);
 
 	// The value for data-link-name is evaluated at the time when the component renders,
@@ -117,9 +114,9 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 						? 'table-of-contents-close'
 						: 'table-of-contents-expand'
 				}
-				css={summaryStyles}
+				css={summaryStyles(palette)}
 			>
-				<h2 css={titleStyle}>Jump to...</h2>
+				<h2 css={titleStyle(palette)}>Jump to...</h2>
 				<span className="is-closed" css={chevronPosition}>
 					<SvgChevronDownSingle size="xsmall" />
 				</span>
@@ -132,10 +129,10 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 				{tableOfContents.map((item, index) => (
 					<li
 						key={item.id}
-						css={listItemStyles(format)}
+						css={listItemStyles(format, palette)}
 						data-link-name={`table-of-contents-item-${index}-${item.id}`}
 					>
-						<a href={`#${item.id}`} css={anchorStyles}>
+						<a href={`#${item.id}`} css={anchorStyles(palette)}>
 							{item.title}
 						</a>
 					</li>

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -88,7 +88,7 @@ const titleStyle = (palette: Palette) => css`
 const chevronPosition = css`
 	position: absolute;
 	right: ${space[1]}px;
-	top: 0;
+	top: -2px;
 `;
 
 export const TableOfContents = ({ tableOfContents, format }: Props) => {

--- a/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
 import type { TableOfContentsItem } from '../../types/frontend';
 import { TableOfContents } from './TableOfContents.importable';
@@ -24,27 +25,52 @@ export default {
 	title: 'Components/TableOfContents',
 };
 
+const headline1: TableOfContentsItem = {
+	id: 'first-h2-text',
+	title: 'First h2 text',
+};
+const headline2: TableOfContentsItem = {
+	id: 'second-h2-text',
+	title: 'Second h2 text',
+};
+const headline3: TableOfContentsItem = {
+	id: 'third-h2-text',
+	title: 'Third h2 text',
+};
+
+const format: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Standard,
+	theme: ArticlePillar.News,
+};
+
+const immersiveDisplayFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.Immersive,
+	theme: ArticlePillar.News,
+};
+
+const tableItems = [headline1, headline2, headline3];
+
 export const defaultStory = () => {
-	const headline1: TableOfContentsItem = {
-		id: 'first-h2-text',
-		title: 'First h2 text',
-	};
-	const headline2: TableOfContentsItem = {
-		id: 'second-h2-text',
-		title: 'Second h2 text',
-	};
-	const headline3: TableOfContentsItem = {
-		id: 'third-h2-text',
-		title: 'Third h2 text',
-	};
-
-	const tableItems = [headline1, headline2, headline3];
-
 	return (
 		<Wrapper>
-			<TableOfContents tableOfContents={tableItems} />
+			<TableOfContents tableOfContents={tableItems} format={format} />
 		</Wrapper>
 	);
 };
 
 defaultStory.story = { name: 'default' };
+
+export const immersive = () => {
+	return (
+		<Wrapper>
+			<TableOfContents
+				tableOfContents={tableItems}
+				format={immersiveDisplayFormat}
+			/>
+		</Wrapper>
+	);
+};
+
+immersive.story = { name: 'immersive' };

--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -1795,6 +1795,10 @@ const textDateLine = (format: ArticleFormat): string => {
 	return neutral[46];
 };
 
+const textTableOfContents = (): string => {
+	return palette.neutral[7];
+};
+
 const textBlockquote = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.SpecialReportAlt) return neutral[7];
 
@@ -2108,6 +2112,7 @@ export const decidePalette = (
 			betaLabel: textBetaLabel(),
 			designTag: textDesignTag(format),
 			dateLine: textDateLine(format),
+			tableOfContents: textTableOfContents(),
 		},
 		background: {
 			article: backgroundArticle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR is adding some design changes to the table of contents in both DCR and AR. these changes were requested by @HarryFischer  

## Screenshots


### DCR default
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212399707-96c636e9-57e6-4fd6-bf66-7f6d5a8dc555.png) | ![image](https://user-images.githubusercontent.com/15894063/212672587-0b6a5afb-10f2-47c5-b944-6b7c9ceb85ed.png) |

### DCR immersive
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212400388-cee4f663-16b9-4d7b-a0e0-3d107a9d7400.png) | ![image](https://user-images.githubusercontent.com/15894063/212673320-64b8f38e-cb84-4934-b208-cb11fa65483d.png) |

### AR default
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212399918-406023cd-8ee6-4ccf-940b-ef848c14a9d9.png) | ![image](https://user-images.githubusercontent.com/15894063/212674873-b7d2b095-2418-4e9d-80d1-545472053736.png) |
| ![image](https://user-images.githubusercontent.com/15894063/212399967-73f44f9e-8453-44e8-8817-700c3f42ce8f.png) | ![image](https://user-images.githubusercontent.com/15894063/212674779-0efac4a6-dce6-4201-9d22-d34c69fd6087.png) |


### AR immersive
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212400671-0797a202-637d-4f3c-abc9-064fe0e3326a.png) | ![image](https://user-images.githubusercontent.com/15894063/212674370-b1406559-2bc5-4d3a-8812-fd7510581295.png) |
| ![image](https://user-images.githubusercontent.com/15894063/212400623-707cebf3-ccf8-4817-b657-d72ffe474f23.png) | ![image](https://user-images.githubusercontent.com/15894063/212674241-c0be4b8d-f01f-4508-b42c-d105a375961d.png) |


### DCR closed
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212676139-d4a7bff2-5b99-4b93-9b59-4cb2b3ba8676.png) | ![image](https://user-images.githubusercontent.com/15894063/212675280-2617e00a-f36a-4814-891a-32d1f12949b3.png) |


### AR closed
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/212676552-e01c2d76-ca55-4e32-9944-ec08204605c8.png) | ![image](https://user-images.githubusercontent.com/15894063/212675095-718c14c6-4288-476f-ad1b-2b8e853a7728.png) |
| ![image](https://user-images.githubusercontent.com/15894063/212676505-b5fc2996-b3e1-4491-93a5-64211869fde2.png) | ![image](https://user-images.githubusercontent.com/15894063/212675167-df0637e4-f4ee-47a3-9153-43d24e8e5824.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
