### PR TITLE
Use CardDefault as the wrapper of 2nd and 3rd slice of fixed/medium/f…

### DIFF
--- a/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/web/components/FixedMediumFastXII.tsx
@@ -1,9 +1,8 @@
 import type { DCRContainerPalette } from '../../types/front';
 import type { TrailType } from '../../types/trails';
-import { Card25Media25 } from '../lib/cardWrappers';
+import { Card25Media25, CardDefault } from '../lib/cardWrappers';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { FrontCard } from './FrontCard';
 
 type Props = {
 	trails: TrailType[];
@@ -17,8 +16,7 @@ export const FixedMediumFastXII = ({
 	showAge,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
-	const secondSlice25 = trails.slice(4, 8);
-	const thirdSlice25 = trails.slice(8, 12);
+	const remaining = trails.slice(4, 12);
 
 	return (
 		<>
@@ -35,29 +33,14 @@ export const FixedMediumFastXII = ({
 					);
 				})}
 			</UL>
-			<UL direction="row" padBottom={true}>
-				{secondSlice25.map((trail) => {
+			<UL direction="row" padBottom={true} wrapCards={true}>
+				{remaining.map((trail) => {
 					return (
 						<LI key={trail.url} padSides={true} percentage="25%">
-							<FrontCard
+							<CardDefault
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								imageUrl={undefined}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-			<UL direction="row" padBottom={true}>
-				{thirdSlice25.map((trail) => {
-					return (
-						<LI key={trail.url} padSides={true} percentage="25%">
-							<FrontCard
-								trail={trail}
-								containerPalette={containerPalette}
-								showAge={showAge}
-								imageUrl={undefined}
 							/>
 						</LI>
 					);


### PR DESCRIPTION
…ast-xii

For parity with frontend they should have small headlines

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
