### PR TITLE
AR - render table of contents only when outline has 3 items

### DIFF
--- a/apps-rendering/src/components/Layout/AnalysisLayout.tsx
+++ b/apps-rendering/src/components/Layout/AnalysisLayout.tsx
@@ -69,7 +69,7 @@ const AnalysisLayout: FC<Props> = ({ item }) => (
 						<Metadata item={item} />
 						<Logo item={item} />
 					</section>
-					{item.outline.length > 0 && (
+					{item.outline.length >= 3 && (
 						<section css={[articleWidthStyles]}>
 							<TableOfContents
 								format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/CommentLayout.tsx
+++ b/apps-rendering/src/components/Layout/CommentLayout.tsx
@@ -108,7 +108,7 @@ const CommentLayout: FC<Props> = ({ item }) => (
 				<section css={articleWidthStyles}>
 					<Logo item={item} />
 				</section>
-				{item.outline.length > 0 && (
+				{item.outline.length >= 3 && (
 					<section css={articleWidthStyles}>
 						<TableOfContents
 							format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/ImmersiveLayout.tsx
@@ -113,7 +113,7 @@ const ImmersiveLayout: FC<Props> = ({ item }) => {
 						</div>
 						<Metadata item={item} />
 						<div css={bodyStyles}>
-							{item.outline.length > 0 && (
+							{item.outline.length >= 3 && (
 								<section>
 									<TableOfContents
 										format={getFormat(item)}

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -165,7 +165,7 @@ const StandardLayout: FC<Props> = ({ item }) => {
 						<Logo item={item} />
 					</section>
 
-					{item.outline.length > 0 && (
+					{item.outline.length >= 3 && (
 						<section css={articleWidthStyles}>
 							<TableOfContents
 								format={getFormat(item)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR is limiting the `TableOfContents` rendering to only when there are at least 3 items in the outline (at least 3 H2s)

## Why?
This rule had been implemented in DCR but we had missed applying it to AR too. 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
