### PR TITLE
chore(deps): bump atoms-rendering from 25.1.0 => 25.1.1

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -42,7 +42,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/apps-rendering-api-models": "4.1.0",
-		"@guardian/atoms-rendering": "^25.1.0",
+		"@guardian/atoms-rendering": "^25.1.1",
 		"@guardian/bridget": "^2.0.0",
 		"@guardian/cdk": "^47.3.3",
 		"@guardian/common-rendering": "./../common-rendering",

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1694,10 +1694,10 @@
     node-int64 "^0.4.0"
     thrift "^0.15.0"
 
-"@guardian/atoms-rendering@^25.1.0":
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.1.0.tgz#9ffb6c44cf5c90ef62fbe9fbed5a50b65834458f"
-  integrity sha512-UXMob/JBTzNI2PTVC116SGWc8Ul4tNF10hu/tfDcwMk3kcS50HEK1enZYDzPrx5HvQs35UbtFlKdnSnOxgzV8A==
+"@guardian/atoms-rendering@^25.1.1":
+  version "25.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.1.1.tgz#3316d5f6d16749366a45c4c6e96c8fd778f77048"
+  integrity sha512-FVVtwoChSHoPmuFbt9Y6bIDtpPDYe8EyEtFlvBpMb8LtAGeAT03D5Ju/dOKKAq9lF+C08Xj8szYyquLhl9vIgw==
   dependencies:
     is-mobile "^3.1.1"
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -69,7 +69,7 @@
 		"@emotion/react": "^11.4.1",
 		"@emotion/server": "^11.4.0",
 		"@guardian/ab-core": "^2.0.0",
-		"@guardian/atoms-rendering": "^25.1.0",
+		"@guardian/atoms-rendering": "^25.1.1",
 		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",
 		"@guardian/commercial-core": "^5.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,10 +2884,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/atoms-rendering@^25.1.0":
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.1.0.tgz#9ffb6c44cf5c90ef62fbe9fbed5a50b65834458f"
-  integrity sha512-UXMob/JBTzNI2PTVC116SGWc8Ul4tNF10hu/tfDcwMk3kcS50HEK1enZYDzPrx5HvQs35UbtFlKdnSnOxgzV8A==
+"@guardian/atoms-rendering@^25.1.1":
+  version "25.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-25.1.1.tgz#3316d5f6d16749366a45c4c6e96c8fd778f77048"
+  integrity sha512-FVVtwoChSHoPmuFbt9Y6bIDtpPDYe8EyEtFlvBpMb8LtAGeAT03D5Ju/dOKKAq9lF+C08Xj8szYyquLhl9vIgw==
   dependencies:
     is-mobile "^3.1.1"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps atoms-rendering to [`25.1.1`](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fatoms-rendering%4025.1.1), specifically to fix the numbering on quizes.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/212682363-5e608ab1-87a1-477c-8b52-ccebe95ff308.png
[after]: https://user-images.githubusercontent.com/31692/212682343-11c6e654-396e-4ac0-9a9e-f18373f415f8.png

I am waiting on a Janus PR to be able to test `apps-rendering`. 



