### PR TITLE
Pass idApiUrl from CAPI to discussion-rendering

### DIFF
--- a/dotcom-rendering/src/web/components/Discussion.stories.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.stories.tsx
@@ -35,6 +35,7 @@ export const Basic = () => {
 				enableDiscussionSwitch={true}
 				isAdFreeUser={false}
 				shouldHideAds={false}
+				idApiUrl="https://idapi.theguardian.com"
 			/>
 		</HydratedLayout>
 	);

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -20,6 +20,7 @@ export type Props = {
 	discussionApiClientHeader: string;
 	enableDiscussionSwitch: boolean;
 	user?: UserProfile;
+	idApiUrl: string;
 };
 
 const overlayStyles = css`
@@ -65,6 +66,7 @@ export const Discussion = ({
 	discussionApiClientHeader,
 	enableDiscussionSwitch,
 	user,
+	idApiUrl,
 }: Props) => {
 	const [commentPage, setCommentPage] = useState<number>();
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
@@ -183,6 +185,7 @@ export const Discussion = ({
 						onExpand={() => {
 							setIsExpanded(true);
 						}}
+						// idApiUrl={idApiUrl}
 					/>
 					{!isExpanded && (
 						<div id="discussion-overlay" css={overlayStyles} />

--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -18,6 +18,7 @@ type Props = {
 	enableDiscussionSwitch: boolean;
 	isAdFreeUser: boolean;
 	shouldHideAds: boolean;
+	idApiUrl: string;
 };
 
 export const DiscussionLayout = ({
@@ -29,6 +30,7 @@ export const DiscussionLayout = ({
 	enableDiscussionSwitch,
 	isAdFreeUser,
 	shouldHideAds,
+	idApiUrl,
 }: Props) => {
 	const hideAd = isAdFreeUser || shouldHideAds;
 	return (
@@ -80,6 +82,7 @@ export const DiscussionLayout = ({
 									discussionApiClientHeader
 								}
 								enableDiscussionSwitch={enableDiscussionSwitch}
+								idApiUrl={idApiUrl}
 							/>
 						</Island>
 					</div>

--- a/dotcom-rendering/src/web/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/CommentLayout.tsx
@@ -802,6 +802,7 @@ export const CommentLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
 							shouldHideAds={CAPIArticle.shouldHideAds}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</Section>
 				)}

--- a/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ImmersiveLayout.tsx
@@ -835,6 +835,7 @@ export const ImmersiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
 							shouldHideAds={CAPIArticle.shouldHideAds}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</Section>
 				)}

--- a/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/InteractiveLayout.tsx
@@ -703,6 +703,7 @@ export const InteractiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
 							shouldHideAds={CAPIArticle.shouldHideAds}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</Section>
 				)}

--- a/dotcom-rendering/src/web/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/LiveLayout.tsx
@@ -1262,6 +1262,7 @@ export const LiveLayout = ({ CAPIArticle, NAV, format }: Props) => {
 								}
 								isAdFreeUser={CAPIArticle.isAdFreeUser}
 								shouldHideAds={CAPIArticle.shouldHideAds}
+								idApiUrl={CAPIArticle.config.idApiUrl}
 							/>
 						</Section>
 					)}

--- a/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/ShowcaseLayout.tsx
@@ -755,6 +755,7 @@ export const ShowcaseLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
 							shouldHideAds={CAPIArticle.shouldHideAds}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</Section>
 				)}

--- a/dotcom-rendering/src/web/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/StandardLayout.tsx
@@ -879,6 +879,7 @@ export const StandardLayout = ({ CAPIArticle, NAV, format }: Props) => {
 							}
 							isAdFreeUser={CAPIArticle.isAdFreeUser}
 							shouldHideAds={CAPIArticle.shouldHideAds}
+							idApiUrl={CAPIArticle.config.idApiUrl}
 						/>
 					</Section>
 				)}


### PR DESCRIPTION
Currently prod endpoint is hardcoded and this results to CORS error when trying to hit it from https://m.code.dev-theguardian.com/

Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
