### PR TITLE
DCR - refactor style and fix toc click handling bug

### DIFF
--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -98,9 +98,7 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 					setOpen(!open);
 				}}
 				data-link-name={
-					open
-						? 'table-of-contents-expand'
-						: 'table-of-contents-close'
+					open ? 'table-of-contents-open' : 'table-of-contents-close'
 				}
 				css={summaryStyles(palette)}
 			>

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -84,17 +84,17 @@ const chevronPosition = css`
 
 export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	const palette = decidePalette(format);
-	const hasMoreThan5Items = tableOfContents.length < 5;
-	const [open, setOpen] = useState(hasMoreThan5Items);
+	const [open, setOpen] = useState(tableOfContents.length < 5);
 
 	return (
 		<details
-			open={hasMoreThan5Items}
+			open={open}
 			css={detailsStyles}
 			data-component="table-of-contents"
 		>
 			<summary
-				onClick={() => {
+				onClick={(e): void => {
+					e.preventDefault();
 					setOpen(!open);
 				}}
 				data-link-name={

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -22,25 +22,16 @@ const anchorStyles = (palette: Palette) => css`
 	padding: ${space[1]}px 0 ${space[4]}px 0;
 `;
 
-const defaultListItemStyles = (palette: Palette) => css`
-	border-top: 1px solid ${line.primary};
-	&:hover {
-		border-top: 1px solid ${palette.text.tableOfContents};
-		cursor: pointer;
-	}
-`;
-
 const listItemStyles = (format: ArticleFormat, palette: Palette) => {
-	if (format.display === ArticleDisplay.Immersive) {
-		return css`
-			${headline.xxxsmall({ fontWeight: 'light' })}
-			${defaultListItemStyles(palette)}
-		`;
-	}
-
+	const fontWeight =
+		format.display === ArticleDisplay.Immersive ? 'light' : 'bold';
 	return css`
-		${headline.xxxsmall({ fontWeight: 'bold' })}
-		${defaultListItemStyles(palette)}
+		${headline.xxxsmall({ fontWeight })};
+		border-top: 1px solid ${line.primary};
+		&:hover {
+			border-top: 1px solid ${palette.text.tableOfContents};
+			cursor: pointer;
+		}
 	`;
 };
 
@@ -93,15 +84,12 @@ const chevronPosition = css`
 
 export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	const palette = decidePalette(format);
-	const [open, setOpen] = useState(tableOfContents.length < 5);
+	const hasMoreThan5Items = tableOfContents.length < 5;
+	const [open, setOpen] = useState(hasMoreThan5Items);
 
-	// The value for data-link-name is evaluated at the time when the component renders,
-	// So at the time when user clicks the table (onToggle is triggered),
-	// the old value of open(before the click event) is used. As a result we need to
-	// use toc-close for when open is true and toc-expand for when it's false
 	return (
 		<details
-			open={open}
+			open={hasMoreThan5Items}
 			css={detailsStyles}
 			data-component="table-of-contents"
 		>
@@ -111,8 +99,8 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 				}}
 				data-link-name={
 					open
-						? 'table-of-contents-close'
-						: 'table-of-contents-expand'
+						? 'table-of-contents-expand'
+						: 'table-of-contents-close'
 				}
 				css={summaryStyles(palette)}
 			>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR does the following:
- Refactors the styling of `TableOfContents` component as suggested in previous PR https://github.com/guardian/dotcom-rendering/pull/6957#discussion_r1071339706 by @jamesgorrie 
- Fixes a bug that is caused when clicking to expand the table for the first time after the page loads

As you can see in the video:

https://user-images.githubusercontent.com/15894063/212732204-5001660f-f28c-4c00-b98d-90a6ab7a2df2.mov

To fix this, I had to add `event.preventDefault()` to the onClick handler in order to to disable the browser's default behavior so that React and only React controls the state of the details.

So I had to also fix the `data-link-name` values as now we have correct open value each time the table is expanded/closed.

Demo of the fixed version:

https://user-images.githubusercontent.com/15894063/212732284-8af3fed6-c21e-4f54-9332-0da0261384a9.mov



## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
