### PR TITLE
Move `LiveBlockContainer` To AR

### DIFF
--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -103,12 +103,12 @@ const keyEventsWrapperStyles = css`
 const keyEvents = (blocks: LiveBlock[]): KeyEvent[] =>
 	blocks.reduce<KeyEvent[]>(
 		(events, block) =>
-			block.isKeyEvent
+			block.isKeyEvent && block.title.isSome()
 				? [
 						...events,
 						{
 							date: block.firstPublished,
-							text: block.title,
+							text: block.title.value,
 							url: `?page=with:block-${block.id}#block-${block.id}`,
 						},
 				  ]

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
-import LiveBlockContainer from 'components/LiveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
 import { LastUpdated } from 'components/LastUpdated';
+import LiveBlockContainer from 'components/LiveBlockContainer';
 import { datetimeFormat, timestampFormat } from 'datetime';
 import type { LiveBlock as LiveBlockType } from 'liveBlock';
 import type { FC } from 'react';

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
-import LiveBlockContainer from '@guardian/common-rendering/src/components/liveBlockContainer';
+import LiveBlockContainer from 'components/LiveBlockContainer';
 import type { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
 import { map, withDefault } from '@guardian/types';

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -1,29 +1,12 @@
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import LiveBlockContainer from 'components/LiveBlockContainer';
-import type { BlockContributor } from '@guardian/common-rendering/src/components/liveBlockContainer';
 import type { ArticleFormat } from '@guardian/libs';
-import { map, withDefault } from '@guardian/types';
 import { LastUpdated } from 'components/LastUpdated';
-import type { Contributor } from 'contributor';
 import { datetimeFormat, timestampFormat } from 'datetime';
-import { pipe } from 'lib';
 import type { LiveBlock as LiveBlockType } from 'liveBlock';
 import type { FC } from 'react';
 import { renderElements } from 'renderer';
-
-// ----- Functions ----- //
-
-const contributorToBlockContributor = (
-	contributor: Contributor,
-): BlockContributor => ({
-	name: contributor.name,
-	imageUrl: pipe(
-		contributor.image,
-		map((i) => i.src),
-		withDefault<string | undefined>(undefined),
-	),
-});
 
 // ----- Component ----- //
 
@@ -55,7 +38,8 @@ const LiveBlock: FC<LiveBlockProps> = ({
 			isPinnedPost={isPinnedPost}
 			isOriginalPinnedPost={isOriginalPinnedPost}
 			supportsDarkMode={true}
-			contributors={block.contributors.map(contributorToBlockContributor)}
+			contributors={block.contributors}
+			isLiveUpdate={false}
 		>
 			{renderElements(format, block.body)}
 

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -6,9 +6,9 @@ import {
 	headline,
 	body,
 } from '@guardian/source-foundations';
-import { FirstPublished } from './FirstPublished';
-import { darkModeCss } from '../lib';
-import { background, border } from '../editorialPalette';
+import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { background, border } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleFormat } from '@guardian/libs';
 
 type BlockContributor = {

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -10,26 +10,24 @@ import { FirstPublished } from '@guardian/common-rendering/src/components/FirstP
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { background, border } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleFormat } from '@guardian/libs';
-
-type BlockContributor = {
-	name: string;
-	imageUrl?: string;
-	largeImageUrl?: string;
-};
+import type { FC, ReactNode } from 'react';
+import type { Contributor } from 'contributor';
+import { Optional } from 'optional';
+import type { Image } from 'image';
 
 type Props = {
 	id: string;
-	children: React.ReactNode;
+	children: ReactNode;
 	format: ArticleFormat;
-	blockTitle?: string;
-	blockFirstPublished?: number;
-	blockFirstPublishedDisplay?: string;
+	blockTitle: Optional<string>;
+	blockFirstPublished: number;
+	blockFirstPublishedDisplay: string;
 	blockId: string;
-	isLiveUpdate?: boolean;
-	contributors?: BlockContributor[];
+	isLiveUpdate: boolean;
+	contributors: Contributor[];
 	isPinnedPost: boolean;
 	supportsDarkMode: boolean;
-	isOriginalPinnedPost?: boolean;
+	isOriginalPinnedPost: boolean;
 	host?: string;
 	pageId?: string;
 };
@@ -38,7 +36,7 @@ const LEFT_MARGIN_DESKTOP = 60;
 const SIDE_MARGIN = space[5];
 const SIDE_MARGIN_MOBILE = 10;
 
-const Header = ({ children }: { children: React.ReactNode }) => {
+const Header: FC<{ children: ReactNode }> = ({ children }) => {
 	return (
 		<header
 			css={css`
@@ -52,8 +50,8 @@ const Header = ({ children }: { children: React.ReactNode }) => {
 	);
 };
 
-const BlockTitle = ({ title }: { title: string }) => {
-	return (
+const BlockTitle: FC<{ blockTitle: Optional<string> }> = ({ blockTitle }) =>
+	blockTitle.maybeRender((title) => (
 		<h2
 			css={css`
 				${headline.xxsmall({ fontWeight: 'bold' })}
@@ -62,17 +60,16 @@ const BlockTitle = ({ title }: { title: string }) => {
 		>
 			{title}
 		</h2>
-	);
-};
+	));
 
-const BlockByline = ({
-	name,
-	imageUrl,
-	format,
-}: {
+const BlockByline: FC<{
 	name: string;
 	format: ArticleFormat;
-	imageUrl?: string;
+	image: Optional<Image>;
+}> = ({
+	name,
+	image,
+	format,
 }) => {
 	return (
 		<div
@@ -82,10 +79,10 @@ const BlockByline = ({
 				padding-bottom: ${space[1]}px;
 			`}
 		>
-			{imageUrl && (
+			{image.maybeRender(img => (
 				<div style={{ width: '2.25rem', height: '2.25rem' }}>
 					<img
-						src={imageUrl}
+						src={img.src}
 						alt={name}
 						css={css`
 							border-radius: 100%;
@@ -96,13 +93,13 @@ const BlockByline = ({
 						`}
 					/>
 				</div>
-			)}
+			))}
 			<span
 				css={css`
 					${body.medium()}
 					display: flex;
 					align-items: center;
-					padding-left: ${imageUrl ? space[1] : 0}px;
+					padding-left: ${image.isSome() ? space[1] : 0}px;
 				`}
 			>
 				{name}
@@ -111,7 +108,7 @@ const BlockByline = ({
 	);
 };
 
-const LiveBlockContainer = ({
+const LiveBlockContainer: FC<Props> = ({
 	id,
 	children,
 	format,
@@ -126,7 +123,7 @@ const LiveBlockContainer = ({
 	isOriginalPinnedPost = false,
 	host,
 	pageId,
-}: Props) => {
+}) => {
 	return (
 		<article
 			/**
@@ -165,32 +162,25 @@ const LiveBlockContainer = ({
 			`}
 		>
 			<Header>
-				{blockFirstPublished && (
-					<FirstPublished
-						firstPublished={blockFirstPublished}
-						firstPublishedDisplay={blockFirstPublishedDisplay}
-						blockId={blockId}
-						isPinnedPost={isPinnedPost}
-						supportsDarkMode={supportsDarkMode}
-						isOriginalPinnedPost={isOriginalPinnedPost}
+				<FirstPublished
+					firstPublished={blockFirstPublished}
+					firstPublishedDisplay={blockFirstPublishedDisplay}
+					blockId={blockId}
+					isPinnedPost={isPinnedPost}
+					supportsDarkMode={supportsDarkMode}
+					isOriginalPinnedPost={isOriginalPinnedPost}
+					format={format}
+					host={host}
+					pageId={pageId}
+				/>
+				<BlockTitle blockTitle={blockTitle} />
+				{contributors.map((contributor) => (
+					<BlockByline
+						name={contributor.name}
+						image={Optional.fromOption(contributor.image)}
 						format={format}
-						host={host}
-						pageId={pageId}
 					/>
-				)}
-				{blockTitle ? <BlockTitle title={blockTitle} /> : null}
-				{contributors &&
-					contributors.map((contributor) => (
-						<BlockByline
-							name={contributor.name}
-							imageUrl={
-								contributor.largeImageUrl
-									? contributor.largeImageUrl
-									: contributor.imageUrl
-							}
-							format={format}
-						/>
-					))}
+				))}
 			</Header>
 			{children}
 		</article>
@@ -198,4 +188,3 @@ const LiveBlockContainer = ({
 };
 
 export default LiveBlockContainer;
-export type { BlockContributor };

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -1,19 +1,22 @@
 import { css } from '@emotion/react';
-import {
-	neutral,
-	from,
-	space,
-	headline,
-	body,
-} from '@guardian/source-foundations';
 import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
+import {
+	background,
+	border,
+} from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
-import { background, border } from '@guardian/common-rendering/src/editorialPalette';
-import { ArticleFormat } from '@guardian/libs';
-import type { FC, ReactNode } from 'react';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	body,
+	from,
+	headline,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
 import type { Contributor } from 'contributor';
-import { Optional } from 'optional';
 import type { Image } from 'image';
+import { Optional } from 'optional';
+import type { FC, ReactNode } from 'react';
 
 type Props = {
 	id: string;
@@ -66,11 +69,7 @@ const BlockByline: FC<{
 	name: string;
 	format: ArticleFormat;
 	image: Optional<Image>;
-}> = ({
-	name,
-	image,
-	format,
-}) => {
+}> = ({ name, image, format }) => {
 	return (
 		<div
 			css={css`
@@ -79,7 +78,7 @@ const BlockByline: FC<{
 				padding-bottom: ${space[1]}px;
 			`}
 		>
-			{image.maybeRender(img => (
+			{image.maybeRender((img) => (
 				<div style={{ width: '2.25rem', height: '2.25rem' }}>
 					<img
 						src={img.src}
@@ -127,19 +126,22 @@ const LiveBlockContainer: FC<Props> = ({
 	return (
 		<article
 			/**
-			 * Pinned posts are not the cannonical source for a post, they're a copy. Only the *true* post
-			 * should get the id. This will prevent two elements on the page having the same id.
+			 * Pinned posts are not the cannonical source for a post, they're a
+			 * copy. Only the *true* post should get the id. This will prevent
+			 * two elements on the page having the same id.
 			 * */
 			id={!isPinnedPost ? `block-${id}` : undefined}
 			key={id}
 			/**
 			 *   Classnames
 			 *   ----------
-			 * - 'block' is used by Spacefinder as a possible candidate before which it can insert an inline ad
-			 * - 'pending' is used to mark blocks that have been inserted as part of a live update. We use this
-			 *    to animate the reveal as well as for enhancing twitter embeds
+			 * - 'block' is used by Spacefinder as a possible candidate before
+			 *   which it can insert an inline ad
+			 * - 'pending' is used to mark blocks that have been inserted as
+			 *   part of a live update. We use this to animate the reveal as
+			 *   well as for enhancing twitter embeds
 			 */
-			className={`block ${isLiveUpdate && 'pending'}`}
+			className={`block ${isLiveUpdate ? 'pending' : ''}`}
 			css={css`
 				padding: ${space[2]}px ${SIDE_MARGIN_MOBILE}px;
 				box-sizing: border-box;
@@ -179,6 +181,7 @@ const LiveBlockContainer: FC<Props> = ({
 						name={contributor.name}
 						image={Optional.fromOption(contributor.image)}
 						format={format}
+						key={contributor.id}
 					/>
 				))}
 			</Header>

--- a/apps-rendering/src/fixtures/item.ts
+++ b/apps-rendering/src/fixtures/item.ts
@@ -282,7 +282,7 @@ const body: Body = [
 const pinnedBlock: LiveBlock = {
 	id: '5',
 	isKeyEvent: false,
-	title: 'Block Five',
+	title: Optional.some('Block Five'),
 	firstPublished: new Date('2021-11-02T10:20:20Z'),
 	lastModified: new Date('2021-11-02T11:13:13Z'),
 	body: [

--- a/apps-rendering/src/fixtures/live.ts
+++ b/apps-rendering/src/fixtures/live.ts
@@ -274,7 +274,7 @@ const fields = {
 const pinnedBlock: LiveBlock = {
 	id: '5',
 	isKeyEvent: false,
-	title: 'Block Five',
+	title: Optional.some('Block Five'),
 	firstPublished: new Date('2021-11-02T10:20:20Z'),
 	lastModified: new Date('2021-11-02T11:13:13Z'),
 	body: [],
@@ -286,7 +286,7 @@ const blocks: LiveBlock[] = [
 	{
 		id: '1',
 		isKeyEvent: true,
-		title: 'Block One',
+		title: Optional.some('Block One'),
 		firstPublished: new Date('2021-11-02T12:00:00Z'),
 		lastModified: new Date('2021-11-02T13:13:13Z'),
 		body: [],
@@ -316,7 +316,7 @@ const blocks: LiveBlock[] = [
 	{
 		id: '2',
 		isKeyEvent: false,
-		title: 'Block Two',
+		title: Optional.some('Block Two'),
 		firstPublished: new Date('2021-11-02T11:20:00Z'),
 		lastModified: new Date('2021-11-02T13:03:13Z'),
 		body: [],
@@ -326,7 +326,7 @@ const blocks: LiveBlock[] = [
 	{
 		id: '3',
 		isKeyEvent: true,
-		title: 'Block Three',
+		title: Optional.some('Block Three'),
 		firstPublished: new Date('2021-11-02T11:05:12Z'),
 		lastModified: new Date('2021-11-02T12:13:13Z'),
 		body: [],
@@ -336,7 +336,7 @@ const blocks: LiveBlock[] = [
 	{
 		id: '4',
 		isKeyEvent: true,
-		title: 'Block Four',
+		title: Optional.some('Block Four'),
 		firstPublished: new Date('2021-11-02T10:55:03Z'),
 		lastModified: new Date('2021-11-02T11:13:13Z'),
 		body: [],

--- a/apps-rendering/src/liveBlock.ts
+++ b/apps-rendering/src/liveBlock.ts
@@ -9,6 +9,7 @@ import { parseElements } from 'bodyElement';
 import { maybeCapiDate } from 'capi';
 import type { Contributor } from 'contributor';
 import { tagToContributor } from 'contributor';
+import { Optional } from 'optional';
 import type { Context } from 'parserContext';
 import { Result } from 'result';
 
@@ -17,7 +18,7 @@ import { Result } from 'result';
 type LiveBlock = {
 	id: string;
 	isKeyEvent: boolean;
-	title: string;
+	title: Optional<string>;
 	firstPublished: Date;
 	lastModified: Date;
 	body: Body;
@@ -60,7 +61,7 @@ const parse =
 		return Result.ok({
 			id: block.id,
 			isKeyEvent: block.attributes.keyEvent ?? false,
-			title: block.title ?? '',
+			title: Optional.fromNullable(block.title),
 			firstPublished: firstPublishedDate.value,
 			lastModified: lastModifiedDate.value,
 			body: Result.partition(

--- a/apps-rendering/src/pagination.test.ts
+++ b/apps-rendering/src/pagination.test.ts
@@ -1,12 +1,13 @@
 import { none, some } from '@guardian/types';
 import { LiveBlock } from 'liveBlock';
+import { Optional } from 'optional';
 import { getPagedBlocks, Pagination, PageReference } from 'pagination';
 
 const generateBlocks = (numberOfBlocks: number): LiveBlock[] => {
 	const block: LiveBlock = {
 		id: '1',
 		isKeyEvent: true,
-		title: 'Block One',
+		title: Optional.some('Block One'),
 		firstPublished: new Date('2021-11-02T12:00:00Z'),
 		lastModified: new Date('2021-11-02T13:13:13Z'),
 		body: [],


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

Several optional props have become required, as many of these fields are parsed as required in the AR data model. I've also refactored to use the `Image` and `Contributor` types directly, rather than converting them for this component.

**Note:** Applying stricter types surfaced the possibility of key events that are missing a block title. Following some discussion I've filtered out any key events that are missing a title, as they won't render correctly for users (the title is the text used to display a key event). See this screenshot for an example:

![key-event](https://user-images.githubusercontent.com/53781962/212912547-e6421367-30da-4e9f-9e76-47ec76f259eb.jpg)

## Changes

- Moved `LiveBlockContainer` component to AR
- Refactored for AR linter and conventions
- Made `LiveBlock` title `Optional`
