### PR TITLE
fix: Duplicated comment count on Cards

### DIFF
--- a/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
@@ -108,8 +108,7 @@ function enhanceCounts(
 
 /**
  * @description
- * Takes the long and short version of each count and generates the html
- * for showing the count on the page
+ * Takes the long and short version of each count and renders onto the page with react
  */
 function renderCounts(counts: EnhancedCountType[]) {
 	counts.forEach((count) => {
@@ -142,9 +141,12 @@ function renderCounts(counts: EnhancedCountType[]) {
  *
  * For each Card with comments found (by looking for a marker element) it:
  *
+ * - Fetches the comment count data in a single call to Frontend's discussion API
  * - Enhances the data, transforming the count from a number to formatted strings
- * - Creates a html string for each count to be shown using ReactDOM.renderToString
- * - Mutates the DOM with this new html
+ * - Uses react 'render' to add the comment counts to their placeholders
+ *
+ * We do it this was so that we can make a single call, but still render multiple comment counts
+ * Using an individual island for each comment count could be more costly, especially on fronts
  *
  * @param {boolean} repeat If true, the fetch call will be repeated on an interval
  */

--- a/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
+++ b/dotcom-rendering/src/web/components/FetchCommentCounts.importable.tsx
@@ -1,6 +1,6 @@
 import { CacheProvider } from '@emotion/react';
 import { useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import type { DCRContainerPalette } from '../../types/front';
 import { getEmotionCache } from '../browser/islands/emotion';
 import { formatCount } from '../lib/formatCount';
@@ -118,7 +118,7 @@ function renderCounts(counts: EnhancedCountType[]) {
 		);
 
 		if (container) {
-			ReactDOM.render(
+			render(
 				<CacheProvider value={getEmotionCache()}>
 					<CardCommentCount
 						format={count.format}


### PR DESCRIPTION
## What does this change?

Switch to using `ReactDOM.render()` instead of `renderToString()` when hydrating Card comment counts.

## Why?

We currently have an issue where comment counts are being duplicated on Cards, this issue is seemingly caused by how we hydrate the comment counts and how they interact with Emotion.

The way we use `renderToString` seems to be the crux of the issue, by replacing it with `ReactDOM.render` ([the recommended way by Emotion](https://emotion.sh/docs/ssr#on-client)) and using the emotion cache in a cache provider we were able to resolve the issue.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/212971683-9d0a9891-5bdb-42d3-9a9c-ecfacb878cbc.png

[after]: https://user-images.githubusercontent.com/21217225/212971420-f36a81b7-6cd3-4ce2-bce1-99f6076b2fe3.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
