### PR TITLE
Bump `@guardian/libs` to v12 across all platforms

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -51,7 +51,7 @@
 		"@guardian/discussion-rendering": "^10.1.1",
 		"@guardian/eslint-config-typescript": "^0.7.0",
 		"@guardian/eslint-plugin-source-react-components": "^9.0.0",
-		"@guardian/libs": "^10.0.0",
+		"@guardian/libs": "^12.0.0",
 		"@guardian/node-riffraff-artifact": "^0.3.2",
 		"@guardian/renditions": "^0.2.0",
 		"@guardian/source-foundations": "^7.0.1",

--- a/apps-rendering/src/articleFormat.ts
+++ b/apps-rendering/src/articleFormat.ts
@@ -171,6 +171,10 @@ const designToString = (design: ArticleDesign): string => {
 			return 'Full Page Interactive';
 		case ArticleDesign.NewsletterSignup:
 			return 'Newsletter Signup';
+		case ArticleDesign.Timeline:
+			return 'Timeline';
+		case ArticleDesign.Profile:
+			return 'Profile';
 	}
 };
 

--- a/apps-rendering/yarn.lock
+++ b/apps-rendering/yarn.lock
@@ -1730,7 +1730,7 @@
   dependencies:
     "@babel/core" "^7.0.0"
     "@emotion/react" "^11.4.1"
-    "@guardian/libs" "^10.0.0"
+    "@guardian/libs" "^12.0.0"
     "@guardian/source-foundations" "^7.0.1"
     "@guardian/source-react-components" "^9.0.0"
     "@guardian/types" "^9.0.1"
@@ -1808,10 +1808,10 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/@guardian/libs/-/libs-10.0.0.tgz#3624e5ead3a9f4ffb6244327d3ee5c3d55d688fa"
-  integrity sha512-N6+5e0DrusWryaZCH6/cppJlLEksuZWFyYnQjHbe/HXM2cLe2i3GAU5kRhIh98pOlPTPer5GennBAYQ6gzQofg==
+"@guardian/libs@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-12.0.0.tgz#cb9f78d2d0c04a5afc46d2efaa540d95dccb49f9"
+  integrity sha512-Xjg/GC11x/YhereuwAZt8yKhWafJ49ak7kZJFE5nIc7MlPLAwr5xv+83vFKvYiqbHSnq4P/OHXA2Da9RkEIgsw==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"

--- a/common-rendering/package.json
+++ b/common-rendering/package.json
@@ -10,7 +10,7 @@
 	"dependencies": {
 		"@babel/core": "^7.0.0",
 		"@emotion/react": "^11.4.1",
-		"@guardian/libs": "^10.0.0",
+		"@guardian/libs": "^12.0.0",
 		"@guardian/source-foundations": "^7.0.1",
 		"@guardian/source-react-components": "^9.0.0",
 		"@guardian/types": "^9.0.1",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -79,7 +79,7 @@
 		"@guardian/eslint-config": "^2.0.3",
 		"@guardian/eslint-config-typescript": "^2.0.0",
 		"@guardian/eslint-plugin-source-react-components": "^10.0.0",
-		"@guardian/libs": "^10.1.0",
+		"@guardian/libs": "^12.0.0",
 		"@guardian/prettier": "^2.1.5",
 		"@guardian/shimport": "^1.0.2",
 		"@guardian/source-foundations": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,10 +2311,10 @@
     "@typescript-eslint/eslint-plugin" "5.45.0"
     "@typescript-eslint/parser" "5.45.0"
 
-"@guardian/libs@^10.0.0", "@guardian/libs@^10.1.0":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
-  integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
+"@guardian/libs@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-12.0.0.tgz#cb9f78d2d0c04a5afc46d2efaa540d95dccb49f9"
+  integrity sha512-Xjg/GC11x/YhereuwAZt8yKhWafJ49ak7kZJFE5nIc7MlPLAwr5xv+83vFKvYiqbHSnq4P/OHXA2Da9RkEIgsw==
 
 "@guardian/prettier@^2.0.0", "@guardian/prettier@^2.1.5":
   version "2.1.5"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bumps libs across platforms.

## Why?

Because AR relies on CR, and CR is part of the DCR yarn workspace we need to bump them all at once.

