### PR TITLE
Fix core-js chunk duplication

### DIFF
--- a/dotcom-rendering/babel.config.js
+++ b/dotcom-rendering/babel.config.js
@@ -8,7 +8,6 @@ module.exports = {
 		'babel-plugin-px-to-rem',
 		'@babel/plugin-transform-runtime',
 		'@emotion/babel-plugin',
-		["polyfill-corejs3", { "method": "usage-global", "version": "3.20" }]
 	],
 
 	env: {

--- a/dotcom-rendering/babel.config.js
+++ b/dotcom-rendering/babel.config.js
@@ -1,5 +1,7 @@
 module.exports = {
 	plugins: [
+		// Be careful when adding plugins here!
+		// They can dramatically alter the build size
 		'@babel/plugin-syntax-dynamic-import',
 		'@babel/plugin-transform-react-jsx',
 		'@babel/plugin-proposal-class-properties',
@@ -9,7 +11,6 @@ module.exports = {
 		'@babel/plugin-transform-runtime',
 		'@emotion/babel-plugin',
 	],
-
 	env: {
 		production: {
 			plugins: [


### PR DESCRIPTION
## What does this change?

@sndrs noticed we were heavily duplicating core-js in our webpack chunks.

I've traced this back to `polyfill-corejs3` being added to `babel.config` which I believe was added for #6562 .

## Why?

Fix size and performance regression

## Before and After

| Chunk | Type | Before | After | Reduction | ~% Reduction |
|--|--|--|--|--|--|
|all |parsed |2.42MB |**1.63MB** |0.79MB | 33% |
|all |gzip |903kB |**592kB** |311kB| 35% |

| Before      | After      |
|-------------|------------|
| ![before-chunks][] | ![after-chunks][] |
| ![before-stats][] | ![after-stats][] |

[before-chunks]: https://user-images.githubusercontent.com/7014230/213189804-8ceae745-3196-468e-98b4-f0f4f394bc4e.png
[after-chunks]: https://user-images.githubusercontent.com/7014230/213189955-693b09b9-172f-42c5-a0f1-2ec4de04630b.png

[before-stats]: https://user-images.githubusercontent.com/7014230/213190271-c598d1d1-ccdd-4581-b114-2cc46ceff547.png
[after-stats]: https://user-images.githubusercontent.com/7014230/213190374-d1c221e1-3530-4c4d-99f7-9039c0697a5d.png

## Next Steps

This is for the core team to agree on but I'd recommend:

- removing any non-production code that affect the build i.e. the recipe hack (sorry)
- better alerting of the build size and broken down into modern, variant and server
- upgrading Babel, plugins and preset-env
    - we should be able to drop most of the plugins as Babel supports ES2021 since v7.11
    - pick up any bugfixes and performance improvements
- the build size as reported on PRs has been steadily increasing over the last year so it might be worth a review of any new islands and dependencies being pulled in:
    | Date     | compressed-size-action MB |
    |----------|---------|
    | Jul 5th  | 1.55    |
    | Aug 4th  | 1.68    |
    | Oct 17   | 2.27    |
    | Jan 5th | 2.35    |
    | Now      | 2.98    |

## Related work

- we have a proposal to extract a vendor chunk  which should further improve deduplication and also rule out potential bugs from multiple instances of stateful libraries (e.g. preact, emotion and swr).

- we are still at the mercy of Webpack's default chunking strategy and how it chooses to duplicate modules - which we scupper by having multiple entry points on the same page. @sndrs has proposed we move to a single entry point.
