### PR TITLE
table of content in numberedList article

### DIFF
--- a/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/apps-rendering/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -27,6 +27,18 @@ const labsThemeFormat: ArticleFormat = {
 	theme: ArticleSpecial.Labs,
 };
 
+const numberedListDisplayFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.NumberedList,
+	theme: ArticlePillar.News,
+};
+
+const numberedListDisplayLabsThemeFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.NumberedList,
+	theme: ArticleSpecial.Labs,
+};
+
 const Default = (): ReactElement => (
 	<TableOfContents outline={explainer.outline} format={format} />
 );
@@ -42,9 +54,22 @@ const Labs = (): ReactElement => (
 	<TableOfContents outline={explainer.outline} format={labsThemeFormat} />
 );
 
+const NumberedList = (): ReactElement => (
+	<TableOfContents
+		outline={explainer.outline}
+		format={numberedListDisplayFormat}
+	/>
+);
+
+const NumberedListLabs = (): ReactElement => (
+	<TableOfContents
+		outline={explainer.outline}
+		format={numberedListDisplayLabsThemeFormat}
+	/>
+);
 export default {
 	component: TableOfContents,
 	title: 'AR/TableOfContents',
 };
 
-export { Default, Immersive, Labs };
+export { Default, Immersive, Labs, NumberedList, NumberedListLabs };

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -29,6 +29,9 @@ const anchorStyles = (format: ArticleFormat): SerializedStyles => css`
 	color: ${text.paragraph(format)};
 	border-bottom: none;
 	display: block;
+	${darkModeCss`
+		color: ${text.paragraphDark(format)};
+	`}
 `;
 
 const listStyles: SerializedStyles = css`
@@ -40,6 +43,7 @@ const listStyles: SerializedStyles = css`
 `;
 
 const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
+	color: ${text.paragraph(format)};
 	box-sizing: border-box;
 	border-top: 1px solid ${border.tableOfContents(format)};
 	padding-bottom: ${remSpace[4]};
@@ -62,6 +66,7 @@ const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 		&:hover {
 			border-color: ${border.tableOfContentsHoverDark(format)};
 		}
+		color: ${text.paragraphDark(format)};
 	`}
 `;
 
@@ -216,7 +221,6 @@ const TocTextElement: React.FC<TextElementProps> = ({
 };
 
 const TableOfContents: FC<Props> = ({ format, outline }) => {
-	console.log('format.display: ', format.display);
 	return (
 		<details open={outline.length < 5} css={detailsStyles(format)}>
 			<summary css={summaryStyles(format)}>
@@ -234,12 +238,12 @@ const TableOfContents: FC<Props> = ({ format, outline }) => {
 						className={listItemStyles(format)}
 						key={outlineItem.id}
 					>
-						{
+						{format.display === ArticleDisplay.NumberedList && (
 							<>
 								<span css={indexStyle}>{index + 1}</span>
 								<div css={verticalLineStyle(format)}></div>
 							</>
-						}
+						)}
 						<Anchor
 							format={format}
 							href={`#${outlineItem.id}`}

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -52,6 +52,9 @@ const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 		padding-top: 1px;
 		border-top: ${remSpace[1]} solid ${border.tableOfContentsHover(format)};
 		cursor: pointer;
+		div {
+			height: 1.188rem;
+		}
 	}
 
 	${darkModeCss`
@@ -143,12 +146,16 @@ const indexStyle = css`
 	margin-right: 18px;
 `;
 
-const verticalLineStyle = css`
+const verticalLineStyle = (format: ArticleFormat): SerializedStyles => css`
 	position: absolute;
-	left: 18px;
-	border-left: 1px solid #dcdcdc;
-	height: 22px;
+	left: 1.125rem;
+	border-left: 1px solid ${border.tableOfContents(format)};
+	height: 1.375rem;
 	top: 0;
+	transition: 0.3s all ease;
+	${darkModeCss`
+		border-color: ${border.tableOfContentsDark(format)};
+	`}
 `;
 
 const TocTextElement: React.FC<TextElementProps> = ({
@@ -209,6 +216,7 @@ const TocTextElement: React.FC<TextElementProps> = ({
 };
 
 const TableOfContents: FC<Props> = ({ format, outline }) => {
+	console.log('format.display: ', format.display);
 	return (
 		<details open={outline.length < 5} css={detailsStyles(format)}>
 			<summary css={summaryStyles(format)}>
@@ -226,12 +234,12 @@ const TableOfContents: FC<Props> = ({ format, outline }) => {
 						className={listItemStyles(format)}
 						key={outlineItem.id}
 					>
-						{format.display === ArticleDisplay.NumberedList && (
+						{
 							<>
 								<span css={indexStyle}>{index + 1}</span>
-								<div css={verticalLineStyle}></div>
+								<div css={verticalLineStyle(format)}></div>
 							</>
-						)}
+						}
 						<Anchor
 							format={format}
 							href={`#${outlineItem.id}`}

--- a/apps-rendering/src/components/TableOfContents/index.tsx
+++ b/apps-rendering/src/components/TableOfContents/index.tsx
@@ -45,6 +45,8 @@ const defaultListItemStyles = (format: ArticleFormat): SerializedStyles => css`
 	padding-bottom: ${remSpace[4]};
 	padding-top: ${remSpace[1]};
 	transition: 0.3s all ease;
+	display: flex;
+	position: relative;
 
 	&:hover {
 		padding-top: 1px;
@@ -137,6 +139,18 @@ const titleStyle = (format: ArticleFormat): SerializedStyles => css`
 	`}
 `;
 
+const indexStyle = css`
+	margin-right: 18px;
+`;
+
+const verticalLineStyle = css`
+	position: absolute;
+	left: 18px;
+	border-left: 1px solid #dcdcdc;
+	height: 22px;
+	top: 0;
+`;
+
 const TocTextElement: React.FC<TextElementProps> = ({
 	node,
 	key,
@@ -207,11 +221,17 @@ const TableOfContents: FC<Props> = ({ format, outline }) => {
 				</span>
 			</summary>
 			<OrderedList className={listStyles}>
-				{outline.map((outlineItem) => (
+				{outline.map((outlineItem, index) => (
 					<ListItem
 						className={listItemStyles(format)}
 						key={outlineItem.id}
 					>
+						{format.display === ArticleDisplay.NumberedList && (
+							<>
+								<span css={indexStyle}>{index + 1}</span>
+								<div css={verticalLineStyle}></div>
+							</>
+						)}
 						<Anchor
 							format={format}
 							href={`#${outlineItem.id}`}

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -4,8 +4,10 @@ import type { TableOfContentsItem } from '../types/frontend';
 
 const isH2 = (element: CAPIElement): element is SubheadingBlockElement => {
 	return (
-		element._type ==
-		'model.dotcomrendering.pageElements.SubheadingBlockElement'
+		element._type ===
+			'model.dotcomrendering.pageElements.SubheadingBlockElement' ||
+		element._type ===
+			'model.dotcomrendering.pageElements.NumberedTitleBlockElement'
 	);
 };
 

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -43,6 +43,9 @@ const listItemStyles = (format: ArticleFormat, palette: Palette) => {
 			padding-top: 1px;
 			border-top: ${space[1]}px solid ${palette.text.tableOfContents};
 			cursor: pointer;
+			div {
+				height: 19px;
+			}
 		}
 	`;
 };
@@ -92,10 +95,11 @@ const indexStyle = css`
 
 const verticalStyle = css`
 	position: absolute;
-	left: 18px;
-	border-left: 1px solid #dcdcdc;
+	left: ${space[4]}px;
+	border-left: 1px solid ${neutral[86]};
 	height: 22px;
 	top: 0;
+	transition: 0.3s all ease;
 `;
 
 export const TableOfContents = ({ tableOfContents, format }: Props) => {

--- a/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.importable.tsx
@@ -36,6 +36,8 @@ const listItemStyles = (format: ArticleFormat, palette: Palette) => {
 		padding-bottom: ${space[4]}px;
 		padding-top: ${space[1]}px;
 		transition: 0.3s all ease;
+		display: flex;
+		position: relative;
 
 		&:hover {
 			padding-top: 1px;
@@ -84,6 +86,18 @@ const titleStyle = (palette: Palette) => css`
 	color: ${palette.text.tableOfContents};
 `;
 
+const indexStyle = css`
+	margin-right: 18px;
+`;
+
+const verticalStyle = css`
+	position: absolute;
+	left: 18px;
+	border-left: 1px solid #dcdcdc;
+	height: 22px;
+	top: 0;
+`;
+
 export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	const palette = decidePalette(format);
 	const [open, setOpen] = useState(tableOfContents.length < 5);
@@ -120,6 +134,13 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 						css={listItemStyles(format, palette)}
 						data-link-name={`table-of-contents-item-${index}-${item.id}`}
 					>
+						{format.display === ArticleDisplay.NumberedList && (
+							<>
+								<span css={indexStyle}>{index + 1}</span>
+								<div css={verticalStyle}></div>
+							</>
+						)}
+
 						<a href={`#${item.id}`} css={anchorStyles(palette)}>
 							{item.title}
 						</a>

--- a/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
+++ b/dotcom-rendering/src/web/components/TableOfContents.stories.tsx
@@ -50,6 +50,12 @@ const immersiveDisplayFormat: ArticleFormat = {
 	theme: ArticlePillar.News,
 };
 
+const numberedListDisplayFormat: ArticleFormat = {
+	design: ArticleDesign.Standard,
+	display: ArticleDisplay.NumberedList,
+	theme: ArticlePillar.News,
+};
+
 const tableItems = [headline1, headline2, headline3];
 
 export const defaultStory = () => {
@@ -74,3 +80,16 @@ export const immersive = () => {
 };
 
 immersive.story = { name: 'immersive' };
+
+export const numberedList = () => {
+	return (
+		<Wrapper>
+			<TableOfContents
+				tableOfContents={tableItems}
+				format={numberedListDisplayFormat}
+			/>
+		</Wrapper>
+	);
+};
+
+numberedList.story = { name: 'numberedList' };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR adds styling for table of content for articles with NumberedList display on both DCR & AR. 
AR doesn't yet support NumberedList display, but the component was updated so it'll be ready for whenever AR starts supporting NumberedList in the layouts. 

## Why?

## Screenshots

### DCR
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/214026305-fab4a41d-fdec-440b-b9e5-eff7dee0ca75.png) | ![image](https://user-images.githubusercontent.com/15894063/214026242-d11bc8eb-a5ef-49df-80fd-2f1035bb16aa.png) |

### AR:
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/214026403-a4cd82aa-91fb-4ca3-9946-97ed9b3b0ec3.png) | ![image](https://user-images.githubusercontent.com/15894063/214026527-d7e1eeb8-07fa-4d4f-8014-60ae02c94a6c.png) |

### AR dark:
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/214026743-524d37f6-4fe1-42fe-9423-bba8c6e192ca.png) | ![image](https://user-images.githubusercontent.com/15894063/214026602-747e839a-4c7f-4a8f-8c20-109961f5fe58.png) |
[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
