### PR TITLE
Add Timeline & Profile designs to DCR and AR

### DIFF
--- a/apps-rendering/src/components/DesignTag/index.tsx
+++ b/apps-rendering/src/components/DesignTag/index.tsx
@@ -75,6 +75,18 @@ const DesignTag: FC<Props> = ({ format }) => {
 					<span css={designTagStyles(format)}>Interview</span>
 				</div>
 			);
+		case ArticleDesign.Timeline:
+			return (
+				<div css={designTagWrapper}>
+					<span css={designTagStyles(format)}>Timeline</span>
+				</div>
+			);
+		case ArticleDesign.Profile:
+			return (
+				<div css={designTagWrapper}>
+					<span css={designTagStyles(format)}>Profile</span>
+				</div>
+			);
 		default:
 			return null;
 	}

--- a/apps-rendering/src/components/Headline/Headline.defaults.tsx
+++ b/apps-rendering/src/components/Headline/Headline.defaults.tsx
@@ -47,6 +47,8 @@ export const defaultStyles = (format: ArticleFormat): SerializedStyles => {
 				`}
 			`;
 		case ArticleDesign.Explainer:
+		case ArticleDesign.Profile:
+		case ArticleDesign.Timeline:
 			return css`
 				${baseStyles}
 				${articleWidthStyles}

--- a/apps-rendering/src/components/Layout/StandardLayout.tsx
+++ b/apps-rendering/src/components/Layout/StandardLayout.tsx
@@ -38,10 +38,12 @@ import type {
 	Obituary,
 	PhotoEssay,
 	PrintShop,
+	Profile,
 	Quiz,
 	Recipe,
 	Review,
 	Standard,
+	Timeline,
 } from 'item';
 import { maybeRender, pipe } from 'lib';
 import { Optional } from 'optional';
@@ -97,7 +99,9 @@ interface Props {
 		| Interview
 		| Recipe
 		| PrintShop
-		| PhotoEssay;
+		| PhotoEssay
+		| Timeline
+		| Profile;
 }
 
 const StandardLayout: FC<Props> = ({ item }) => {

--- a/apps-rendering/src/components/Layout/index.tsx
+++ b/apps-rendering/src/components/Layout/index.tsx
@@ -84,7 +84,9 @@ const Layout: FC<Props> = ({ item }) => {
 		item.design === ArticleDesign.Obituary ||
 		item.design === ArticleDesign.Correction ||
 		item.design === ArticleDesign.Interview ||
-		item.design === ArticleDesign.Recipe
+		item.design === ArticleDesign.Recipe ||
+		item.design === ArticleDesign.Timeline ||
+		item.design === ArticleDesign.Profile
 	) {
 		if (item.display === ArticleDisplay.Immersive) {
 			return <ImmersiveLayout item={item} />;

--- a/apps-rendering/src/components/Standfirst/index.tsx
+++ b/apps-rendering/src/components/Standfirst/index.tsx
@@ -66,6 +66,8 @@ const Standfirst: React.FC<Props> = ({ item }) => {
 		case ArticleDesign.Analysis:
 			return <AnalysisStandfirst item={item} />;
 		case ArticleDesign.Explainer:
+		case ArticleDesign.Timeline:
+		case ArticleDesign.Profile:
 			return <ExplainerStandfirst item={item} />;
 		case ArticleDesign.NewsletterSignup:
 			return <NewsletterSignupStandfirst item={item} />;

--- a/apps-rendering/src/item.ts
+++ b/apps-rendering/src/item.ts
@@ -215,6 +215,16 @@ interface FullPageInteractive extends Fields {
 	body: BodyElement[];
 }
 
+interface Timeline extends Fields {
+	design: ArticleDesign.Timeline;
+	body: BodyElement[];
+}
+
+interface Profile extends Fields {
+	design: ArticleDesign.Profile;
+	body: BodyElement[];
+}
+
 type Item =
 	| LiveBlog
 	| DeadBlog
@@ -239,7 +249,9 @@ type Item =
 	| NewsletterSignup
 	| PhotoEssay
 	| PrintShop
-	| FullPageInteractive;
+	| FullPageInteractive
+	| Timeline
+	| Profile;
 
 // ----- Convenience Types ----- //
 
@@ -430,6 +442,10 @@ const isLabs = hasTag('tone/advertisement-features');
 
 const isMatchReport = hasTag('tone/matchreports');
 
+const isTimeline = hasTag('tone/timelines');
+
+const isProfile = hasTag('tone/profiles');
+
 const isCorrection = hasTag('theguardian/series/correctionsandclarifications');
 
 const isPicture = hasTag('type/picture');
@@ -600,6 +616,18 @@ const fromCapi =
 				body,
 				...itemFields,
 			};
+		} else if (isTimeline(tags)) {
+			return {
+				design: ArticleDesign.Timeline,
+				body,
+				...itemFields,
+			};
+		} else if (isProfile(tags)) {
+			return {
+				design: ArticleDesign.Profile,
+				body,
+				...itemFields,
+			};
 		}
 
 		return {
@@ -637,6 +665,8 @@ export {
 	NewsletterSignup,
 	Obituary,
 	Correction,
+	Timeline,
+	Profile,
 	fromCapi,
 	fromCapiLiveBlog,
 	getFormat,
@@ -651,4 +681,6 @@ export {
 	isObituary,
 	isReview,
 	isNews,
+	isTimeline,
+	isProfile,
 };

--- a/dotcom-rendering/src/web/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.tsx
@@ -344,7 +344,6 @@ export const ArticleHeadline = ({
 	isMatch,
 }: Props) => {
 	const palette = decidePalette(format);
-
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
@@ -502,6 +501,8 @@ export const ArticleHeadline = ({
 				case ArticleDesign.Recipe:
 				case ArticleDesign.Feature:
 				case ArticleDesign.Explainer:
+				case ArticleDesign.Timeline:
+				case ArticleDesign.Profile:
 					return (
 						<div
 							css={decideBottomPadding({

--- a/dotcom-rendering/src/web/components/DesignTag.stories.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.stories.tsx
@@ -94,3 +94,41 @@ export const SpecialReport = () => {
 	);
 };
 SpecialReport.story = { name: 'with design Analysis and theme SpecialReport' };
+
+export const Timeline = () => {
+	return (
+		<div
+			css={css`
+				max-width: 400px;
+			`}
+		>
+			<DesignTag
+				format={{
+					design: ArticleDesign.Timeline,
+					display: ArticleDisplay.Standard,
+					theme: ArticlePillar.Sport,
+				}}
+			/>
+		</div>
+	);
+};
+Timeline.story = { name: 'with design Timeline' };
+
+export const Profile = () => {
+	return (
+		<div
+			css={css`
+				max-width: 400px;
+			`}
+		>
+			<DesignTag
+				format={{
+					design: ArticleDesign.Profile,
+					display: ArticleDisplay.Standard,
+					theme: ArticlePillar.Sport,
+				}}
+			/>
+		</div>
+	);
+};
+Profile.story = { name: 'with design Profile' };

--- a/dotcom-rendering/src/web/components/DesignTag.tsx
+++ b/dotcom-rendering/src/web/components/DesignTag.tsx
@@ -152,6 +152,22 @@ export const DesignTag = ({ format }: { format: ArticleFormat }) => {
 					</Tag>
 				</Margins>
 			);
+		case ArticleDesign.Timeline:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/timelines">Timeline</TagLink>
+					</Tag>
+				</Margins>
+			);
+		case ArticleDesign.Profile:
+			return (
+				<Margins format={format}>
+					<Tag format={format}>
+						<TagLink href="/tone/profiles">Profile</TagLink>
+					</Tag>
+				</Margins>
+			);
 		default:
 			return null;
 	}

--- a/dotcom-rendering/src/web/components/Standfirst.tsx
+++ b/dotcom-rendering/src/web/components/Standfirst.tsx
@@ -134,6 +134,8 @@ const standfirstStyles = (format: ArticleFormat, palette: Palette) => {
 				case ArticleDesign.Review:
 				case ArticleDesign.NewsletterSignup:
 				case ArticleDesign.Explainer:
+				case ArticleDesign.Timeline:
+				case ArticleDesign.Profile:
 					return css`
 						${headline.xxsmall({
 							fontWeight: 'light',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds Timeline and Profile article designs to AR and DCR. 

## Why?
This is due to new editorial article designs from the Editorial Designs team.
## Screenshots

AR
Timeline
| Before      | After      |
|-------------|------------|
| ![before-time-ar][] | ![after-time-ar][] |

[before-time-ar]: https://user-images.githubusercontent.com/20416599/213229501-c5f0037f-bc2f-4c4a-b270-6df67e59bde2.png
[after-time-ar]: https://user-images.githubusercontent.com/20416599/213229529-f9f9f740-40e6-4d97-b55d-a204e058d48a.png

Profile

| Before      | After      |
|-------------|------------|
| ![before-prof-ar][] | ![after-prof-ar][] |

[before-prof-ar]: https://user-images.githubusercontent.com/20416599/213229765-0031ea4e-6cec-4b25-9d13-fd42d1b6a08a.png
[after-prof-ar]: https://user-images.githubusercontent.com/20416599/213229818-bd12e1d4-ae08-41aa-961e-4a2d24e7df73.png

DCR
Timeline
| Before      | After      |
|-------------|------------|
| ![before-time-dcr][] | ![after-time-dcr][] |

[before-time-dcr]: https://user-images.githubusercontent.com/20416599/213232392-7704aca1-6396-4eb6-8ef9-c58d94c0c5d1.png
[after-time-dcr]: https://user-images.githubusercontent.com/20416599/213230235-5b121bf2-6ddd-4291-bda9-aacef76d39c5.png

| Before      | After      |
|-------------|------------|
| ![before-time-dcr-mob][] | ![after-time-dcr-mob][] |

[before-time-dcr-mob]: https://user-images.githubusercontent.com/20416599/213232356-b7253e09-a9c4-42e8-8f9a-df2109337599.png
[after-time-dcr-mob]: https://user-images.githubusercontent.com/20416599/213230369-42511db7-3885-4e6e-8d71-3ea134f159e5.png

Profile

| Before      | After      |
|-------------|------------|
| ![before-prof-dcr][] | ![after-prof-dcr][] |

[before-prof-dcr]: https://user-images.githubusercontent.com/20416599/213232240-b9a978b4-1ebc-490b-b17c-ad03aff36ac0.png
[after-prof-dcr]: https://user-images.githubusercontent.com/20416599/213230286-cf39a610-08f5-4cee-899b-08deb7ad3c50.png

| Before      | After      |
|-------------|------------|
| ![before-prof-dcr-mob][] | ![after-prof-dcr-mob][] |

[before-prof-dcr-mob]: https://user-images.githubusercontent.com/20416599/213232090-9dacd79b-24c5-4afa-bec9-1d62d9ebce7d.png
[after-prof-dcr-mob]: https://user-images.githubusercontent.com/20416599/213230419-2f316707-f197-400c-a675-eb37417bc740.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
