### PR TITLE
Fix spacing in fronts layout

### DIFF
--- a/dotcom-rendering/src/web/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/web/components/LeftColumn.tsx
@@ -19,7 +19,7 @@ const leftWidth = (size: LeftColSize) => {
 
 				${from.leftCol} {
 					/* above 1140 */
-					flex-basis: 230px;
+					flex-basis: 240px;
 					flex-grow: 0;
 					flex-shrink: 0;
 				}
@@ -36,14 +36,14 @@ const leftWidth = (size: LeftColSize) => {
 
 				${between.leftCol.and.wide} {
 					/* above 1140, below 1300 */
-					flex-basis: 151px;
+					flex-basis: 160px;
 					flex-grow: 0;
 					flex-shrink: 0;
 				}
 
 				${from.wide} {
 					/* above 1300 */
-					flex-basis: 230px;
+					flex-basis: 240px;
 					flex-grow: 0;
 					flex-shrink: 0;
 				}

--- a/dotcom-rendering/src/web/components/Section.tsx
+++ b/dotcom-rendering/src/web/components/Section.tsx
@@ -129,6 +129,11 @@ const margins = css`
 		breakpoint, based on chat with Harry Fisher
 	*/
 	margin-bottom: ${space[9]}px;
+
+	${from.tablet} {
+		margin-left: -10px;
+		margin-right: -10px;
+	}
 `;
 
 const rightMargin = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #6987 

Co-authored-by: Max Duval <max.duval@guardian.co.uk>

## What does this change?
Fixes a bug to make sure fronts layout sits well in the grid

## Why?
For parity with frontend

## Screenshots

For checking see where the red lines sit before and after.

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/214026942-b717e67c-16dd-496b-93c4-646c5a0f662a.png) | ![image](https://user-images.githubusercontent.com/19683595/214027378-672c9cd9-3302-4048-b5ac-b41df1e470c5.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214027039-c9b210a1-d0cd-4f2d-89dd-17dec71c66cd.png) | ![image](https://user-images.githubusercontent.com/19683595/214027456-ca9442b1-8596-435f-8116-0b6b8972b0f3.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214027160-0d926c56-a1a7-4d4e-b8c5-ad49bab40850.png) | ![image](https://user-images.githubusercontent.com/19683595/214027527-78720389-9524-4d75-a7e4-970cf951040c.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214028632-decc99b3-1105-4848-a638-38f24f768b81.png) | ![image](https://user-images.githubusercontent.com/19683595/214028482-ea10dade-75e1-4d31-9cbf-24e53db9f5d7.png) |







[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
