### PR TITLE
Move `CaptionIcon` Component To AR

### DIFF
--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { CaptionIconVariant } from 'components/CaptionIcon';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -9,6 +8,7 @@ import { from, remSpace } from '@guardian/source-foundations';
 import type { Breakpoint } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { none, some, withDefault } from '@guardian/types';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import FigCaption from 'components/FigCaption';
 import Img from 'components/ImgAlt';
 import type { Image } from 'image/image';

--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, textSans } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -1,9 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { CaptionIconVariant } from 'components/CaptionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, headline, textSans } from '@guardian/source-foundations';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import FigCaption from 'components/FigCaption';
 import Img from 'components/ImgAlt';
 import { grid } from 'grid/grid';

--- a/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
+++ b/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-default-export -- exclude stories for this rule */
-
 // ----- Imports ----- //
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';

--- a/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
+++ b/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
@@ -4,7 +4,7 @@
 
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
-import CaptionIcon, { CaptionIconVariant } from './captionIcon';
+import CaptionIcon, { CaptionIconVariant } from '.';
 
 // ----- Stories ----- //
 
@@ -36,7 +36,7 @@ const Video: FC = () => (
 
 export default {
 	component: CaptionIcon,
-	title: 'Common/Components/CaptionIcon',
+	title: 'AR/CaptionIcon',
 };
 
 export { Image, Video };

--- a/apps-rendering/src/components/CaptionIcon/index.tsx
+++ b/apps-rendering/src/components/CaptionIcon/index.tsx
@@ -3,8 +3,8 @@ import { ArticleDesign, ArticleFormat } from '@guardian/libs';
 import { remSpace } from '@guardian/source-foundations';
 import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
 import { FC } from 'react';
-import { fill } from '../editorialPalette';
-import { darkModeCss } from '../lib';
+import { fill } from '@guardian/common-rendering/src/editorialPalette';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 
 enum CaptionIconVariant {
 	Image,

--- a/apps-rendering/src/components/CaptionIcon/index.tsx
+++ b/apps-rendering/src/components/CaptionIcon/index.tsx
@@ -1,10 +1,12 @@
-import { css, SerializedStyles } from '@emotion/react';
-import { ArticleDesign, ArticleFormat } from '@guardian/libs';
-import { remSpace } from '@guardian/source-foundations';
-import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
-import { FC } from 'react';
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { fill } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
+import { remSpace } from '@guardian/source-foundations';
+import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
+import type { FC } from 'react';
 
 enum CaptionIconVariant {
 	Image,

--- a/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
+++ b/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
 import type { FC, ReactElement } from 'react';

--- a/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
+++ b/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
-import { CaptionIconVariant } from 'components/CaptionIcon';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import { some } from '@guardian/types';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import type { FC, ReactElement } from 'react';
 import FigCaption from '.';
 

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -2,8 +2,6 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { CaptionIconVariant } from 'components/CaptionIcon';
-import CaptionIcon from 'components/CaptionIcon';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import type { ArticleFormat } from '@guardian/libs';
@@ -11,6 +9,8 @@ import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
+import CaptionIcon from 'components/CaptionIcon';
+import type { CaptionIconVariant } from 'components/CaptionIcon';
 import type { Styleable } from 'lib';
 import type { FC, ReactNode } from 'react';
 

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -2,8 +2,8 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
-import CaptionIcon from '@guardian/common-rendering/src/components/captionIcon';
+import type { CaptionIconVariant } from 'components/CaptionIcon';
+import CaptionIcon from 'components/CaptionIcon';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import type { ArticleFormat } from '@guardian/libs';

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -4,7 +4,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import CaptionIcon, {
 	CaptionIconVariant,
-} from '@guardian/common-rendering/src/components/captionIcon';
+} from 'components/CaptionIcon';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace, textSans } from '@guardian/source-foundations';

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -2,15 +2,13 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import CaptionIcon, {
-	CaptionIconVariant,
-} from 'components/CaptionIcon';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace, textSans } from '@guardian/source-foundations';
 import type { Option } from '@guardian/types';
 import { OptionKind } from '@guardian/types';
 import Caption from 'components/caption';
+import CaptionIcon, { CaptionIconVariant } from 'components/CaptionIcon';
 import { grid } from 'grid/grid';
 import { maybeRender } from 'lib';
 import type { MainMedia } from 'mainMedia';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,7 +10,6 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import { CaptionIconVariant } from 'components/CaptionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
@@ -48,6 +47,7 @@ import BodyImage from 'components/BodyImage';
 import Bullet from 'components/Bullet';
 import Callout from 'components/Callout';
 import Caption from 'components/caption';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import Credit from 'components/Credit';
 import GalleryImage from 'components/editions/galleryImage';
 import EditionsPullquote from 'components/editions/pullquote';

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -10,7 +10,7 @@ import {
 	QandaAtom,
 	TimelineAtom,
 } from '@guardian/atoms-rendering';
-import { CaptionIconVariant } from '@guardian/common-rendering/src/components/captionIcon';
+import { CaptionIconVariant } from 'components/CaptionIcon';
 import { border, text } from '@guardian/common-rendering/src/editorialPalette';
 import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

## Changes

- Moved `CaptionIcon` component to AR
- Moved `CaptionIcon` stories to AR
- Refactored for AR linter and conventions
