### PR TITLE
feat(metrics): record more overlapping metrics

### DIFF
--- a/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
+++ b/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx
@@ -11,6 +11,7 @@ import { teadsCookieless } from '../experiments/tests/teads-cookieless';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useOnce } from '../lib/useOnce';
+import { willRecordCoreWebVitals } from './CoreVitals.importable';
 
 type Props = {
 	enabled: boolean;
@@ -64,6 +65,7 @@ export const CommercialMetrics = ({ enabled }: Props) => {
 		})
 			.then(() => {
 				if (
+					willRecordCoreWebVitals ||
 					userInClientSideTestToForceMetrics ||
 					userInServerSideTestToForceMetrics
 				) {

--- a/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
+++ b/dotcom-rendering/src/web/components/CoreVitals.importable.tsx
@@ -10,6 +10,10 @@ import { integrateIma } from '../experiments/tests/integrate-ima';
 import { teadsCookieless } from '../experiments/tests/teads-cookieless';
 import { useAB } from '../lib/useAB';
 
+const sampling = 1 / 100;
+/** defining this here allows to share this with other metrics */
+export const willRecordCoreWebVitals = Math.random() > sampling;
+
 export const CoreVitals = () => {
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 	const { pageViewId } = window.guardian.config.ophan;
@@ -18,7 +22,6 @@ export const CoreVitals = () => {
 		window.location.hostname === 'm.code.dev-theguardian.com' ||
 		window.location.hostname === (process.env.HOSTNAME ?? 'localhost') ||
 		window.location.hostname === 'preview.gutools.co.uk';
-	const sampling = 1 / 100;
 
 	const ABTestAPI = useAB()?.api;
 
@@ -50,7 +53,7 @@ export const CoreVitals = () => {
 		browserId,
 		pageViewId,
 		isDev,
-		sampling,
+		sampling: 0, // we rely on willRecordCoreWebVitals instead
 		team: 'dotcom',
 	});
 
@@ -58,6 +61,7 @@ export const CoreVitals = () => {
 		void bypassCoreWebVitalsSampling('dotcom');
 	}
 	if (
+		willRecordCoreWebVitals ||
 		userInClientSideTestToForceMetrics ||
 		userInServerSideTestToForceMetrics
 	) {


### PR DESCRIPTION
## What does this change?

Expose when we capture Core Web Vitals from its module, so we can track other metrics based for that same page view.

## Why?

By ensuring that when Core Web Vitals are captured, we also track commercial metrics, we can get a more complete picture in our dataset.

Otherwise, there’s a risk that the two groups barely overlap, as they are both set to 1%.