### PR TITLE
Enforce matched peer dependencies in CI

### DIFF
--- a/.github/workflows/dcr-dependencies.yml
+++ b/.github/workflows/dcr-dependencies.yml
@@ -21,4 +21,14 @@ jobs:
           deno-version: v1.29.4
 
       - name: Check @types/ dependencies
-        run: deno run --allow-env="GITHUB_TOKEN" scripts/deno/types-dependencies.ts --ci
+        run: |
+          deno run \
+            --allow-env=GITHUB_TOKEN \
+            scripts/deno/types-dependencies.ts --ci
+
+      - name: Check peer dependencies
+        run: |
+          deno run \
+            --allow-env=GITHUB_TOKEN \
+            --allow-run=yarn \
+            scripts/deno/peer-dependencies.ts --ci

--- a/scripts/deno/peer-dependencies.ts
+++ b/scripts/deno/peer-dependencies.ts
@@ -31,9 +31,7 @@ const peers = async (cwd: string) => {
 type Workspaces = { dcr: string[]; cr: string[]; ar: string[] };
 const initialValue: Workspaces = { dcr: [], cr: [], ar: [] };
 
-const { dcr, ar, cr } = (
-	await Promise.all(['.', './apps-rendering'].map(peers))
-)
+const mismatches = (await Promise.all(['.', './apps-rendering'].map(peers)))
 	.flat()
 	.map((line) => {
 		const matches = line.match(
@@ -44,8 +42,39 @@ const { dcr, ar, cr } = (
 		const [, workspace, dependency, peer] = matches;
 
 		return { workspace, dependency, peer };
-	})
-	.reduce<Workspaces>((acc, { workspace, dependency, peer }) => {
+	});
+
+if (Deno.args[0] === '--ci') {
+	/** The following peer deps have known issues */
+	const knownErrors = [
+		'@guardian/discussion-rendering@10.1.1', // apps-rendering should bump to v12
+		'@guardian/eslint-plugin-source-react-components@9.0.0', // apps-rendering should bump to v11
+		'@guardian/braze-components@8.1.3', // This should be fixed upstream to accept newer versions of @guardian/source-react-components-development-kitchen
+		'webpack-filter-warnings-plugin@1.2.1', // this plugin is no longer needed in Webpack 5: https://github.com/mattlewis92/webpack-filter-warnings-plugin/pull/26#issuecomment-758802442
+		'@guardian/discussion-rendering@11.0.3', // dotcom-rendering should bump to v12
+		'@guardian/atoms-rendering@25.1.1', // I don’t think TS 4.8.4 was picked for any particular reason https://github.com/guardian/atoms-rendering/commit/9a95286f0b286d0392bcac022c83bcc6aca51ac8#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R148
+		'@guardian/types@9.0.1', // the @guardian/types are now part of libs, but until common-rendering is removed, this is bound to stick around
+	];
+
+	const worryingErrors = mismatches
+		// Ignore @guardian/common-rendering package
+		.filter(({ workspace }) => workspace !== '@guardian/common-rendering')
+		.filter(({ dependency }) => !knownErrors.includes(dependency));
+
+	if (worryingErrors.length > 0) {
+		console.error(
+			'The following peer dependencies mismatches must be resolved:',
+		);
+		console.warn(worryingErrors);
+		Deno.exit(worryingErrors.length);
+	} else {
+		console.info('No new peer dependencies mismatch!');
+		Deno.exit();
+	}
+}
+
+const { dcr, ar, cr } = mismatches.reduce<Workspaces>(
+	(acc, { workspace, dependency, peer }) => {
 		const line = `- [ ] \`${dependency}\` requires peer \`${peer}\``;
 		switch (workspace) {
 			case '@guardian/dotcom-rendering':
@@ -68,7 +97,9 @@ const { dcr, ar, cr } = (
 			default:
 				return acc;
 		}
-	}, initialValue);
+	},
+	initialValue,
+);
 
 const body = `## Current peer dependencies mismatch
 


### PR DESCRIPTION
## What does this change?

Turn the existing scheduled / cron job from from #6946 into a CI check that fails for any unknown mismatch.
    
Add a list of known errors allows the current state of affairs to be acknowledged with clear steps towards resolution.

## Why?

There’s no such thing as loos enforcement. While an existing list of mismatches in #6945 is informative, it does not prevent new mismatches to be added.

Builds on #6966 & #6971 

## How to test?

An admin can do [a workflow dispatch on the action](https://github.com/guardian/dotcom-rendering/actions/workflows/dcr-dependencies.yml)