### PR TITLE
Bump SWC bundle experiment to 10% - Adjust Sentry sampling

### DIFF
--- a/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.test.ts
@@ -33,6 +33,15 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				randomCentile: 1,
 			}),
 		).toEqual(true);
+		// we want to temporarily sample 10% so to maintain 1% rate sample 10% of 10%
+		expect(
+			isSentryEnabled({
+				isDev: false,
+				enableSentryReporting: true,
+				isInBrowserVariantTest: true,
+				randomCentile: 11,
+			}),
+		).toEqual(false);
 	});
 	it('does enable Sentry for 1% of users', () => {
 		expect(

--- a/dotcom-rendering/src/web/browser/sentryLoader/init.ts
+++ b/dotcom-rendering/src/web/browser/sentryLoader/init.ts
@@ -22,7 +22,8 @@ const isSentryEnabled = ({
 	if (isDev || !enableSentryReporting) return false;
 	// We want to log all errors for users in the bundle variant AB test regardless of
 	// the sample rate. Please ensure that the test sample rate is low.
-	if (isInBrowserVariantTest) return true;
+	// The sample rate is currently 10% but we want to maintain a 1% sample rate so sample 10% of 10%
+	if (isInBrowserVariantTest && randomCentile <= 10) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
 	// measures page views in the billions so we only want to log 1% of errors that


### PR DESCRIPTION
## What does this change?

The sample rate for the `dcrJavascriptBundle` test is increasing to 10% as explained here: https://github.com/guardian/frontend/pull/25842

To maintain the Sentry sample rate of 1% for the bundle variant we only load Sentry for 10% of the 10% sample 



