### PR TITLE
Docs: Add how-tos for Islands, AJAX and Chromatic flakiness

### DIFF
--- a/dotcom-rendering/docs/contributing/how-to.md
+++ b/dotcom-rendering/docs/contributing/how-to.md
@@ -51,7 +51,7 @@ To add an island:
 3. Specify what should trigger hydration (e.g. waiting until the component
   scrolls into view). See `Island.tsx` props for options.
 
-## How can I make an AJAX request in DCR?
+## How to fetch external data on the client?
 
 DCR doesn't make calls to external services from the server. The server's job is only to
 render the data passed to it by a POST request. But it does make requests on the client side.

--- a/dotcom-rendering/docs/contributing/how-to.md
+++ b/dotcom-rendering/docs/contributing/how-to.md
@@ -1,6 +1,17 @@
 # How-tos
 
-## Q. How can I add to this document?
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [How can I add to this document?](#how-can-i-add-to-this-document)
+- [How can I add client-side JavaScript?](#how-can-i-add-client-side-javascript)
+- [How can I create an 'island' in DCR?](#how-can-i-create-an-island-in-dcr)
+- [How can I make an AJAX request in DCR?](#how-can-i-make-an-ajax-request-in-dcr)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How can I add to this document?
 
 We welcome additions and corrections! If you want to add a task that you know
 how to accomplish already, please feel free to raise a pull request for this
@@ -11,7 +22,7 @@ describing the question.
 Something to bear in mind is that documentation like this can easily go out of
 date, so we aim to focus on topics which (hopefully) won't change too quickly.
 
-## Q. How can I add client-side JavaScript?
+## How can I add client-side JavaScript?
 
 Most of the DCR Preact project is server-side rendered (SSR), and this is by design.
 We aim to minimise the amount of client-side JavaScript that we ship, so SSR
@@ -25,3 +36,27 @@ If you need JavaScript on the client, there are two main options:
 
 Both of these approaches should be used with caution, though. Feel free to reach
 out to the team if you're working on a feature in DCR which needs client-side scripts!
+
+## How can I create an 'island' in DCR?
+
+The 'islands' pattern is DCR's way of adding client-side React code to the site.
+You can read more about it in our
+[Improved Partial Hydration](architecture/027-better-partial-hydration.md)
+decision document.
+
+To add an island:
+
+1. Wrap your component on the server with an `<Island>` component.
+2. Add `.importable` to the component filename. Eg: `[MyThing].importable.tsx`
+3. Specify what should trigger hydration (e.g. waiting until the component
+  scrolls into view). See `Island.tsx` props for options.
+
+## How can I make an AJAX request in DCR?
+
+DCR doesn't make calls to external services from the server. The server's job is only to
+render the data passed to it by a POST request. But it does make requests on the client side.
+
+We currently use [SWR](https://swr.vercel.app/) to manage AJAX requests on the
+client. Your starting point should be the [`useApi` hook](../../src/web/lib/useApi.tsx),
+which is DCR's wrapper around SWR's own hook. Because this hook requires
+client-side React code, you will need to place your component in an `<Island>` wrapper.


### PR DESCRIPTION
Add how-to guides for:
- How can I create an 'island' in DCR?
- How can I make an AJAX request in DCR?
- ~What should I do if Chromatic flags up changes which are unrelated to my PR?~ This was moved to the PR template instead.

Also adds a table of contents (generated by the `yarn createtoc` command)