### PR TITLE
Update createtoc command to use '--update-only' flag

### DIFF
--- a/dotcom-rendering/docs/contributing/code-style.md
+++ b/dotcom-rendering/docs/contributing/code-style.md
@@ -14,6 +14,7 @@
   - [Define CSS using template literals rather than objects](#define-css-using-template-literals-rather-than-objects)
   - [Never define styles with more than one level of nesting](#never-define-styles-with-more-than-one-level-of-nesting)
   - [Prefer `cx` for style composition](#prefer-cx-for-style-composition)
+  - [Do not use React.FC or equivalent](#do-not-use-reactfc-or-equivalent)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -23,7 +23,7 @@
 		"test": "jest --maxWorkers=50%",
 		"test:watch": "jest --watch --maxWorkers=25%",
 		"test:ci": "jest --runInBand",
-		"createtoc": "doctoc $npm_package_tocList --github --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
+		"createtoc": "doctoc $npm_package_tocList --github --update-only --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
 		"addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true",
 		"cypress:open": "cypress open",
 		"cypress:run": "cypress run",


### PR DESCRIPTION
## Changes

- Add `--update-only` flag to `yarn createtoc` command.
- Update 'code-style.md' toc (by running `yarn createtoc`)

## Why?

Our current configuration means that `yarn createtoc` will run on all files in the `docs/` directory. This includes `docs/contributing/README.md`, which only has one heading, and so doesn't need a TOC.

There's [no straightforward way to skip files using `doctoc`](https://github.com/thlorenz/doctoc/issues/66). But the `--update-only` flag means that only files which already include a comment beginning `<!-- START doctoc` will have TOCs built.

This changes the default behaviour (TOC no longer built on new files by default) but I think it's worthwhile because it allows us to skip files. To add a TOC to a new file, add the comment `<!-- START doctoc -->` wherever you want the TOC to be inserted. Other than that, new `.md` files in the `docs/` directory will be ignored by the `createtoc` command.