### PR TITLE
Move `Accordion` Component To AR

### DIFF
--- a/apps-rendering/src/components/Accordion/Accordion.stories.tsx
+++ b/apps-rendering/src/components/Accordion/Accordion.stories.tsx
@@ -1,22 +1,22 @@
 // ----- Imports ----- //
 
-import Accordion from ".";
-import { css } from "@emotion/react";
-import type { SerializedStyles } from "@emotion/react";
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import {
-	breakpoints,
-	space,
-	neutral,
-	from,
 	body,
-} from "@guardian/source-foundations";
-import type { FC } from "react";
-import { darkModeCss } from "@guardian/common-rendering/src/lib";
+	breakpoints,
+	from,
+	neutral,
+	space,
+} from '@guardian/source-foundations';
+import type { FC, ReactElement } from 'react';
+import Accordion from '.';
 
 // ----- Stories ----- //
 
 const textStyle = (supportsDarkMode: boolean): SerializedStyles => css`
-	${body.medium({ lineHeight: "loose" })};
+	${body.medium({ lineHeight: 'loose' })};
 	margin-bottom: ${space[3]}px;
 	${darkModeCss(supportsDarkMode)`
 		color: ${neutral[86]};
@@ -41,11 +41,12 @@ const adviceColourAboveTablet: SerializedStyles = css`
 	}
 `;
 
-const accordionContent = (supportsDarkMode: boolean) => (
+const accordionContent = (supportsDarkMode: boolean): ReactElement => (
 	<>
 		<p css={[textStyle(supportsDarkMode), adviceColourAboveTablet]}>
-			There's a trick to viewing this - you need to switch the storybook
-			viewport to mobile, phablet or tablet in order to see the accordion.
+			There&apos;s a trick to viewing this - you need to switch the
+			storybook viewport to mobile, phablet or tablet in order to see the
+			accordion.
 		</p>
 		<p css={[textStyle(supportsDarkMode), hideAboveTablet]}>
 			Vaccine passports enjoy substantial support across Europe, a YouGov
@@ -86,11 +87,11 @@ const Dark: FC = () => (
 
 export default {
 	component: Accordion,
-	title: "Common/Components/Accordion",
+	title: 'AR/Accordion',
 	parameters: {
 		backgrounds: {
-			default: "grey",
-			values: [{ name: "grey", value: "lightgrey" }],
+			default: 'grey',
+			values: [{ name: 'grey', value: 'lightgrey' }],
 		},
 		chromatic: {
 			viewports: [breakpoints.mobile, breakpoints.tablet],

--- a/apps-rendering/src/components/Accordion/Accordion.stories.tsx
+++ b/apps-rendering/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import Accordion from "./accordion";
+import Accordion from ".";
 import { css } from "@emotion/react";
 import type { SerializedStyles } from "@emotion/react";
 import {
@@ -11,7 +11,7 @@ import {
 	body,
 } from "@guardian/source-foundations";
 import type { FC } from "react";
-import { darkModeCss } from "../lib";
+import { darkModeCss } from "@guardian/common-rendering/src/lib";
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/Accordion/index.tsx
+++ b/apps-rendering/src/components/Accordion/index.tsx
@@ -1,29 +1,30 @@
 // ----- Imports ----- //
 
-import { css } from "@emotion/react";
-import type { SerializedStyles } from "@emotion/react";
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 import {
-	neutral,
-	line,
 	background,
-	headline,
-	remSpace,
 	focusHalo,
 	from,
-} from "@guardian/source-foundations";
+	headline,
+	line,
+	neutral,
+	remSpace,
+} from '@guardian/source-foundations';
 import {
-	SvgChevronUpSingle,
 	SvgChevronDownSingle,
-} from "@guardian/source-react-components";
-import { darkModeCss } from "@guardian/common-rendering/src/lib";
+	SvgChevronUpSingle,
+} from '@guardian/source-react-components';
+import type { FC, ReactNode } from 'react';
 
 // ----- Component ----- //
 
 interface AccordionProps {
-	children: React.ReactNode;
+	children: ReactNode;
 	supportsDarkMode: boolean;
 	accordionTitle: string;
-	context: "keyEvents" | "liveFeed";
+	context: 'keyEvents' | 'liveFeed';
 }
 
 const detailsStyles: SerializedStyles = css`
@@ -69,7 +70,7 @@ const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 `;
 
 const titleStyle = (supportsDarkMode: boolean): SerializedStyles => css`
-	${headline.xxsmall({ fontWeight: "bold", lineHeight: "tight" })};
+	${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
 	${darkModeCss(supportsDarkMode)`
 		color: ${neutral[86]};
@@ -87,10 +88,10 @@ const arrowPosition: SerializedStyles = css`
 `;
 
 const backgroundColour = (
-	context: "keyEvents" | "liveFeed",
-	supportsDarkMode: boolean
+	context: 'keyEvents' | 'liveFeed',
+	supportsDarkMode: boolean,
 ): SerializedStyles => {
-	if (context === "keyEvents") {
+	if (context === 'keyEvents') {
 		return css`
 			background-color: ${background.primary};
 			${from.desktop} {
@@ -122,12 +123,12 @@ const paddingBody: SerializedStyles = css`
 	}
 `;
 
-const Accordion = ({
+const Accordion: FC<AccordionProps> = ({
 	children,
 	supportsDarkMode,
 	accordionTitle,
 	context,
-}: AccordionProps) => {
+}) => {
 	return (
 		<details open css={detailsStyles}>
 			<summary css={titleRowStyles(supportsDarkMode)}>

--- a/apps-rendering/src/components/Accordion/index.tsx
+++ b/apps-rendering/src/components/Accordion/index.tsx
@@ -15,7 +15,7 @@ import {
 	SvgChevronUpSingle,
 	SvgChevronDownSingle,
 } from "@guardian/source-react-components";
-import { darkModeCss } from "../lib";
+import { darkModeCss } from "@guardian/common-rendering/src/lib";
 
 // ----- Component ----- //
 

--- a/apps-rendering/src/components/KeyEvents/index.tsx
+++ b/apps-rendering/src/components/KeyEvents/index.tsx
@@ -2,7 +2,7 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import Accordion from '@guardian/common-rendering/src/components/accordion';
+import Accordion from 'components/Accordion';
 import {
 	background,
 	text,

--- a/apps-rendering/src/components/KeyEvents/index.tsx
+++ b/apps-rendering/src/components/KeyEvents/index.tsx
@@ -2,7 +2,6 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import Accordion from 'components/Accordion';
 import {
 	background,
 	text,
@@ -22,6 +21,7 @@ import {
 	textSans,
 } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
+import Accordion from 'components/Accordion';
 import type { FC } from 'react';
 
 // ----- Component ----- //


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

## Changes

- Moved `Accordion` component to AR
- Moved `Accordion` stories to AR
- Refactored for AR linter and conventions
