### PR TITLE
Move `FirstPublished` Component To AR

### DIFF
--- a/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
+++ b/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
@@ -3,7 +3,7 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
 
-import { FirstPublished } from './FirstPublished';
+import { FirstPublished } from '.';
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
+++ b/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
@@ -3,7 +3,7 @@
 import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
-import { FirstPublished } from '.';
+import FirstPublished from '.';
 
 // ----- Stories ----- //
 

--- a/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
+++ b/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
@@ -1,8 +1,8 @@
 // ----- Imports ----- //
 
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 import type { FC } from 'react';
-
 import { FirstPublished } from '.';
 
 // ----- Stories ----- //
@@ -10,7 +10,7 @@ import { FirstPublished } from '.';
 const Default: FC = () => (
 	<FirstPublished
 		supportsDarkMode={true}
-		firstPublished={1613763003000}
+		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
 		isOriginalPinnedPost={false}
@@ -19,29 +19,14 @@ const Default: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-	/>
-);
-
-const WithFirstPublishedDisplay: FC = () => (
-	<FirstPublished
-		supportsDarkMode={true}
-		firstPublished={1613763003000}
-		firstPublishedDisplay={'99:99'}
-		blockId="#block-60300f5f8f08ad21ea60071e"
-		isPinnedPost={false}
-		isOriginalPinnedPost={false}
-		format={{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: ArticlePillar.News,
-		}}
+		edition={Edition.UK}
 	/>
 );
 
 const PinnedPost: FC = () => (
 	<FirstPublished
 		supportsDarkMode={true}
-		firstPublished={1613763003000}
+		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={true}
 		isOriginalPinnedPost={false}
@@ -50,13 +35,14 @@ const PinnedPost: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
+		edition={Edition.UK}
 	/>
 );
 
 const OriginalPinnedPost: FC = () => (
 	<FirstPublished
 		supportsDarkMode={true}
-		firstPublished={1613763003000}
+		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
 		isOriginalPinnedPost={true}
@@ -65,6 +51,7 @@ const OriginalPinnedPost: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
+		edition={Edition.UK}
 	/>
 );
 
@@ -72,7 +59,7 @@ const OriginalPinnedPost: FC = () => (
 
 export default {
 	component: FirstPublished,
-	title: 'Common/Components/FirstPublished',
+	title: 'AR/FirstPublished',
 };
 
-export { Default, WithFirstPublishedDisplay, PinnedPost, OriginalPinnedPost };
+export { Default, PinnedPost, OriginalPinnedPost };

--- a/apps-rendering/src/components/FirstPublished/index.tsx
+++ b/apps-rendering/src/components/FirstPublished/index.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 import { ArticleFormat, joinUrl, timeAgo } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
 import { SvgPinned } from '@guardian/source-react-components';
-import { border } from '../editorialPalette';
-import { darkModeCss } from '../lib';
+import { border } from '@guardian/common-rendering/src/editorialPalette';
+import { darkModeCss } from '@guardian/common-rendering/src/lib';
 
 // TODO: update this code to use shared version when it is available
 const padString = (time: number) => (time < 10 ? `0${time}` : time);

--- a/apps-rendering/src/components/FirstPublished/index.tsx
+++ b/apps-rendering/src/components/FirstPublished/index.tsx
@@ -1,21 +1,15 @@
 import { css } from '@emotion/react';
-import { ArticleFormat, timeAgo } from '@guardian/libs';
-import { neutral, space, textSans } from '@guardian/source-foundations';
-import { SvgPinned } from '@guardian/source-react-components';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import type { ArticleFormat } from '@guardian/libs';
+import { timeAgo } from '@guardian/libs';
+import { neutral, space, textSans } from '@guardian/source-foundations';
+import { SvgPinned } from '@guardian/source-react-components';
 import { timestampFormat } from 'datetime';
+import type { FC } from 'react';
 
-const FirstPublished = ({
-	firstPublished,
-	blockId,
-	isPinnedPost,
-	supportsDarkMode,
-	isOriginalPinnedPost,
-	format,
-	edition,
-}: {
+type Props = {
 	firstPublished: Date;
 	blockId: string;
 	isPinnedPost: boolean;
@@ -23,94 +17,104 @@ const FirstPublished = ({
 	isOriginalPinnedPost: boolean;
 	format: ArticleFormat;
 	edition: Edition;
+};
+
+const FirstPublished: FC<Props> = ({
+	firstPublished,
+	blockId,
+	isPinnedPost,
+	supportsDarkMode,
+	isOriginalPinnedPost,
+	format,
+	edition,
 }) => (
-		<div
+	<div
+		css={css`
+			display: flex;
+		`}
+	>
+		<a
+			href={`?page=with:block-${blockId}#block-${blockId}`}
+			data-ignore="global-link-styling"
 			css={css`
+				${textSans.xxsmall({ fontWeight: 'bold' })}
+				margin-bottom: ${space[1]}px;
 				display: flex;
+				width: fit-content;
+				flex-direction: row;
+				text-decoration: none;
+
+				:hover {
+					filter: brightness(30%);
+				}
 			`}
 		>
+			{!isPinnedPost && (
+				<time
+					dateTime={firstPublished.toISOString()}
+					data-relativeformat="med"
+					css={css`
+						color: ${neutral[46]};
+						font-weight: bold;
+						margin-right: ${space[2]}px;
+
+						${darkModeCss(supportsDarkMode)`
+							color: ${neutral[60]};
+						`}
+					`}
+				>
+					{timeAgo(firstPublished.getTime())}
+				</time>
+			)}
+			<span
+				css={css`
+					${textSans.xxsmall()};
+					color: ${neutral[46]};
+
+					${darkModeCss(supportsDarkMode)`
+						color: ${neutral[60]};
+					`}
+				`}
+			>
+				{timestampFormat(edition)(firstPublished)}
+			</span>
+		</a>
+		{isOriginalPinnedPost && (
 			<a
-				href={`?page=with:block-${blockId}#block-${blockId}`}
+				href="#pinned-post"
 				data-ignore="global-link-styling"
 				css={css`
 					${textSans.xxsmall({ fontWeight: 'bold' })}
 					margin-bottom: ${space[1]}px;
-					display: flex;
-					width: fit-content;
-					flex-direction: row;
 					text-decoration: none;
+					display: flex;
 
 					:hover {
-						filter: brightness(30%);
+						span {
+							height: 16px;
+							width: 16px;
+						}
 					}
 				`}
 			>
-				{!isPinnedPost && (
-					<time
-						dateTime={firstPublished.toISOString()}
-						data-relativeformat="med"
-						css={css`
-							color: ${neutral[46]};
-							font-weight: bold;
-							margin-right: ${space[2]}px;
-
-							${darkModeCss(supportsDarkMode)`
-							color: ${neutral[60]};
-						`}
-						`}
-					>
-						{timeAgo(firstPublished.getTime())}
-					</time>
-				)}
 				<span
 					css={css`
-						${textSans.xxsmall()};
-						color: ${neutral[46]};
-
-						${darkModeCss(supportsDarkMode)`
-						color: ${neutral[60]};
-					`}
-					`}
-				>
-					{timestampFormat(edition)(firstPublished)}
-				</span>
-			</a>
-			{isOriginalPinnedPost && (
-				<a
-					href="#pinned-post"
-					data-ignore="global-link-styling"
-					css={css`
-						${textSans.xxsmall({ fontWeight: 'bold' })}
-						margin-bottom: ${space[1]}px;
-						text-decoration: none;
-						display: flex;
-
-						:hover {
-							span {
-								height: 16px;
-								width: 16px;
-							}
+						width: 14px;
+						height: 14px;
+						border-radius: 50%;
+						background-color: ${border.liveBlock(format)};
+						align-self: center;
+						margin-left: ${space[2]}px;
+						svg {
+							fill: ${neutral[100]};
 						}
 					`}
 				>
-					<span
-						css={css`
-							width: 14px;
-							height: 14px;
-							border-radius: 50%;
-							background-color: ${border.liveBlock(format)};
-							align-self: center;
-							margin-left: ${space[2]}px;
-							svg {
-								fill: ${neutral[100]};
-							}
-						`}
-					>
-						<SvgPinned />
-					</span>
-				</a>
-			)}
-		</div>
-	);
+					<SvgPinned />
+				</span>
+			</a>
+		)}
+	</div>
+);
 
-export { FirstPublished };
+export default FirstPublished;

--- a/apps-rendering/src/components/FirstPublished/index.tsx
+++ b/apps-rendering/src/components/FirstPublished/index.tsx
@@ -1,48 +1,36 @@
 import { css } from '@emotion/react';
-import { ArticleFormat, joinUrl, timeAgo } from '@guardian/libs';
+import { ArticleFormat, timeAgo } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
 import { SvgPinned } from '@guardian/source-react-components';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
 import { darkModeCss } from '@guardian/common-rendering/src/lib';
-
-// TODO: update this code to use shared version when it is available
-const padString = (time: number) => (time < 10 ? `0${time}` : time);
-
-const fallbackDate = (date: Date) =>
-	`${padString(date.getHours())}.${padString(date.getMinutes())}`;
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
+import { timestampFormat } from 'datetime';
 
 const FirstPublished = ({
 	firstPublished,
-	firstPublishedDisplay,
 	blockId,
 	isPinnedPost,
 	supportsDarkMode,
 	isOriginalPinnedPost,
 	format,
-	host,
-	pageId,
+	edition,
 }: {
-	firstPublished: number;
-	firstPublishedDisplay?: string;
+	firstPublished: Date;
 	blockId: string;
 	isPinnedPost: boolean;
 	supportsDarkMode: boolean;
 	isOriginalPinnedPost: boolean;
 	format: ArticleFormat;
-	host?: string;
-	pageId?: string;
-}) => {
-	const baseHref = host && pageId ? joinUrl(host, pageId) : '';
-
-	const publishedDate = new Date(firstPublished);
-	return (
+	edition: Edition;
+}) => (
 		<div
 			css={css`
 				display: flex;
 			`}
 		>
 			<a
-				href={`${baseHref}?page=with:block-${blockId}#block-${blockId}`}
+				href={`?page=with:block-${blockId}#block-${blockId}`}
 				data-ignore="global-link-styling"
 				css={css`
 					${textSans.xxsmall({ fontWeight: 'bold' })}
@@ -59,7 +47,7 @@ const FirstPublished = ({
 			>
 				{!isPinnedPost && (
 					<time
-						dateTime={publishedDate.toISOString()}
+						dateTime={firstPublished.toISOString()}
 						data-relativeformat="med"
 						css={css`
 							color: ${neutral[46]};
@@ -71,7 +59,7 @@ const FirstPublished = ({
 						`}
 						`}
 					>
-						{timeAgo(firstPublished)}
+						{timeAgo(firstPublished.getTime())}
 					</time>
 				)}
 				<span
@@ -84,12 +72,12 @@ const FirstPublished = ({
 					`}
 					`}
 				>
-					{firstPublishedDisplay || fallbackDate(publishedDate)}
+					{timestampFormat(edition)(firstPublished)}
 				</span>
 			</a>
 			{isOriginalPinnedPost && (
 				<a
-					href={`${baseHref}#pinned-post`}
+					href="#pinned-post"
 					data-ignore="global-link-styling"
 					css={css`
 						${textSans.xxsmall({ fontWeight: 'bold' })}
@@ -124,6 +112,5 @@ const FirstPublished = ({
 			)}
 		</div>
 	);
-};
 
 export { FirstPublished };

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -3,7 +3,7 @@ import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import type { ArticleFormat } from '@guardian/libs';
 import { LastUpdated } from 'components/LastUpdated';
 import LiveBlockContainer from 'components/LiveBlockContainer';
-import { datetimeFormat, timestampFormat } from 'datetime';
+import { datetimeFormat } from 'datetime';
 import type { LiveBlock as LiveBlockType } from 'liveBlock';
 import type { FC } from 'react';
 import { renderElements } from 'renderer';
@@ -30,16 +30,14 @@ const LiveBlock: FC<LiveBlockProps> = ({
 			id={block.id}
 			format={format}
 			blockTitle={block.title}
-			blockFirstPublished={block.firstPublished.getTime()}
-			blockFirstPublishedDisplay={timestampFormat(edition)(
-				block.firstPublished,
-			)}
+			blockFirstPublished={block.firstPublished}
 			blockId={block.id}
 			isPinnedPost={isPinnedPost}
 			isOriginalPinnedPost={isOriginalPinnedPost}
 			supportsDarkMode={true}
 			contributors={block.contributors}
 			isLiveUpdate={false}
+			edition={edition}
 		>
 			{renderElements(format, block.body)}
 

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { FirstPublished } from '@guardian/common-rendering/src/components/FirstPublished';
+import { FirstPublished } from 'components/FirstPublished';
 import {
 	background,
 	border,

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { FirstPublished } from 'components/FirstPublished';
+import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import {
 	background,
 	border,
@@ -13,11 +13,11 @@ import {
 	neutral,
 	space,
 } from '@guardian/source-foundations';
+import FirstPublished from 'components/FirstPublished';
 import type { Contributor } from 'contributor';
 import type { Image } from 'image';
 import { Optional } from 'optional';
 import type { FC, ReactNode } from 'react';
-import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 type Props = {
 	id: string;

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -17,22 +17,21 @@ import type { Contributor } from 'contributor';
 import type { Image } from 'image';
 import { Optional } from 'optional';
 import type { FC, ReactNode } from 'react';
+import { Edition } from '@guardian/apps-rendering-api-models/edition';
 
 type Props = {
 	id: string;
 	children: ReactNode;
 	format: ArticleFormat;
 	blockTitle: Optional<string>;
-	blockFirstPublished: number;
-	blockFirstPublishedDisplay: string;
+	blockFirstPublished: Date;
 	blockId: string;
 	isLiveUpdate: boolean;
 	contributors: Contributor[];
 	isPinnedPost: boolean;
 	supportsDarkMode: boolean;
 	isOriginalPinnedPost: boolean;
-	host?: string;
-	pageId?: string;
+	edition: Edition;
 };
 
 const LEFT_MARGIN_DESKTOP = 60;
@@ -113,15 +112,13 @@ const LiveBlockContainer: FC<Props> = ({
 	format,
 	blockTitle,
 	blockFirstPublished,
-	blockFirstPublishedDisplay,
 	blockId,
 	isLiveUpdate,
 	contributors,
 	isPinnedPost,
 	supportsDarkMode,
-	isOriginalPinnedPost = false,
-	host,
-	pageId,
+	isOriginalPinnedPost,
+	edition,
 }) => {
 	return (
 		<article
@@ -166,14 +163,12 @@ const LiveBlockContainer: FC<Props> = ({
 			<Header>
 				<FirstPublished
 					firstPublished={blockFirstPublished}
-					firstPublishedDisplay={blockFirstPublishedDisplay}
 					blockId={blockId}
 					isPinnedPost={isPinnedPost}
 					supportsDarkMode={supportsDarkMode}
 					isOriginalPinnedPost={isOriginalPinnedPost}
 					format={format}
-					host={host}
-					pageId={pageId}
+					edition={edition}
 				/>
 				<BlockTitle blockTitle={blockTitle} />
 				{contributors.map((contributor) => (


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

## Changes

- Moved `FirstPublished` component to AR
- Moved `FirstPublished` stories to AR
- Refactored for AR linter and conventions
- Removed `firstPublishedDisplay`, as this can be derived from the date
- Made `firstPublished` a `Date` as it's a more specific type
- Removed `host` and `pageId` as they're unused in AR
- Removed `isOriginalPinnedPost` default prop; AR prefers required props
