### PR TITLE
Fix kicker colours in news, sport liveblogs and news media cards

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -689,6 +689,10 @@ const textCardKicker = (format: ArticleFormat): string => {
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
 					return BLACK;
+				case ArticlePillar.News:
+					return news[600];
+				case ArticlePillar.Sport:
+					return sport[600];
 				default:
 					return neutral[100];
 			}
@@ -697,7 +701,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 		case ArticleDesign.Video:
 			switch (format.theme) {
 				case ArticlePillar.News:
-					return news[600];
+					return news[500];
 				case ArticlePillar.Sport:
 					return sport[600];
 				case ArticlePillar.Opinion:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
