### PR TITLE
Update kicker colours

### DIFF
--- a/dotcom-rendering/src/web/lib/decidePalette.ts
+++ b/dotcom-rendering/src/web/lib/decidePalette.ts
@@ -689,6 +689,10 @@ const textCardKicker = (format: ArticleFormat): string => {
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
 					return BLACK;
+				case ArticlePillar.News:
+					return news[600];
+				case ArticlePillar.Sport:
+					return sport[600];
 				default:
 					return neutral[100];
 			}
@@ -697,7 +701,7 @@ const textCardKicker = (format: ArticleFormat): string => {
 		case ArticleDesign.Video:
 			switch (format.theme) {
 				case ArticlePillar.News:
-					return news[600];
+					return news[550];
 				case ArticlePillar.Sport:
 					return sport[600];
 				case ArticlePillar.Opinion:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Updates some kicker variations as per https://github.com/guardian/dotcom-rendering/issues/6996

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| Sport example missing because there's no sports liveblogs right now :( | Sport example missing because there's no sports liveblogs right now :( |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/9575458/214100954-29a98a7a-5f7f-4b36-82d2-19b9bbfbab4f.png
[after]: https://user-images.githubusercontent.com/9575458/214100815-57aa67ad-015c-4612-a820-bdc482bc8909.png

[before2]: https://user-images.githubusercontent.com/9575458/214101289-83d90811-d35f-41ea-b36e-a876c44b28c5.png
[after2]: https://user-images.githubusercontent.com/9575458/214101255-bff23fde-2e22-4510-a4e5-90bf9fe1b587.png



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

Closes https://github.com/guardian/dotcom-rendering/issues/6996
