### PR TITLE
Add note on chromatic diffs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,3 +22,18 @@ You can then reference the labels and map them to corresponding links.
 [before2]: https://example.com/before2.png
 [after2]: https://example.com/after2.png
 -->
+
+
+<!--
+## Unexplained Chromatic diffs
+
+We use Chromatic for visual regression testing on our Storybook stories. It's
+generally pretty good, but it sometimes gives 'false positives' -- it seems to
+detect a change in a component which hasn't changed, or which hasn't been
+affected by the code in your PR.
+
+If you've looked at the Chromatic diffs and can't see any connection to your
+code, please reach out to a member of the Web Experiences team, who will be able
+to advise. It would also be helpful to add the false positive to our
+[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
+-->


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a note to the PR template which describes the issues we're currently having with Chromatic false positives.

@jamesgorrie you suggested adding this here -- is this the sort of format you had in mind?