### PR TITLE
Make headlines medium font-weight on all palettes

### DIFF
--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -3,6 +3,7 @@ import { ArticleSpecial } from '@guardian/libs';
 import type { FontScaleArgs, FontWeight } from '@guardian/source-foundations';
 import {
 	between,
+	fontWeights,
 	from,
 	headline,
 	space,
@@ -161,6 +162,7 @@ const sublinkStyles = css`
 	/* stylelint-disable-next-line property-disallowed-list */
 	font-family: inherit;
 	font-size: inherit;
+	font-weight: ${fontWeights.medium};
 	line-height: inherit;
 	/* This css is used to remove any underline from the kicker but still
 	 * have it applied to the headline when the kicker is hovered */
@@ -192,7 +194,7 @@ const lineStyles = (palette: Palette) => css`
 
 const dynamoStyles = css`
 	display: block;
-	font-weight: 800;
+	font-weight: ${fontWeights.medium};
 	padding: 5px;
 `;
 
@@ -254,17 +256,12 @@ export const CardHeadline = ({
 						? labTextStyles(size)
 						: fontStyles({
 								size,
-								fontWeight:
-									containerPalette &&
-									containerPalette !=
-										'SpecialReportAltPalette'
-										? 'bold'
-										: 'regular',
+								fontWeight: 'medium',
 						  }),
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
 							size: sizeOnMobile ?? size,
-							fontWeight: containerPalette ? 'bold' : 'regular',
+							fontWeight: 'medium',
 						}),
 					showLine && !isDynamo && lineStyles(palette),
 				]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
Closes #6490 

## What does this change?
Makes headlines and sublinks headlines medium font-weight on all palettes

## Why?
To match the designs

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/214276279-0c7c38f4-9406-4302-87fa-2acd3c5c1d0e.png) | ![image](https://user-images.githubusercontent.com/19683595/214551721-0be6df1b-2676-466a-9756-61c81a018854.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214276385-e327db83-09e2-4ddb-b317-fec45af27213.png) | ![image](https://user-images.githubusercontent.com/19683595/214551803-ba5afdbd-e429-4c40-af88-1b36f8e9d37a.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214276529-257ff54c-5620-4466-aea0-ba683ff0aebf.png) | ![image](https://user-images.githubusercontent.com/19683595/214551900-3f0782cb-46c9-4d48-94e0-e808bc8873af.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
