### PR TITLE
Add support for 2nd big boosted in `DynamicSlowMPU`

### DIFF
--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.stories.tsx
@@ -92,6 +92,27 @@ export const FirstBigBoosted = () => (
 );
 FirstBigBoosted.story = { name: 'with the first of two bigs boosted' };
 
+export const SecondBigBoosted = () => (
+	<Section title="DynamicSlowMPU" padContent={false} centralBorder="partial">
+		<DynamicSlowMPU
+			groupedTrails={{
+				snap: [],
+				huge: [],
+				veryBig: [],
+				big: bigs
+					.slice(0, 2)
+					.map((card, index) =>
+						index === 1 ? { ...card, isBoosted: true } : card,
+					),
+				standard: standards,
+			}}
+			showAge={true}
+			index={1}
+		/>
+	</Section>
+);
+SecondBigBoosted.story = { name: 'with the second of two bigs boosted' };
+
 export const ThreeBigs = () => (
 	<Section title="DynamicSlowMPU" padContent={false} centralBorder="partial">
 		<DynamicSlowMPU

--- a/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
+++ b/dotcom-rendering/src/web/components/DynamicSlowMPU.tsx
@@ -7,6 +7,7 @@ import {
 	CardDefaultMediaMobile,
 } from '../lib/cardWrappers';
 import {
+	Card25_Card75,
 	Card50_Card25_Card25,
 	Card50_Card50,
 	Card75_Card25,
@@ -141,7 +142,12 @@ export const DynamicSlowMPU = ({
 	showAge,
 	index,
 }: Props) => {
-	let layout: 'noBigs' | 'twoBigs' | 'twoBigsBoosted' | 'threeBigs';
+	let layout:
+		| 'noBigs'
+		| 'twoBigs'
+		| 'twoBigsFirstBoosted'
+		| 'twoBigsSecondBoosted'
+		| 'threeBigs';
 	let bigCards: TrailType[] = [];
 	let standardCards: TrailType[] = [];
 	switch (groupedTrails.big.length) {
@@ -163,7 +169,9 @@ export const DynamicSlowMPU = ({
 			bigCards = groupedTrails.big;
 			standardCards = groupedTrails.standard;
 			if (groupedTrails.big[0]?.isBoosted) {
-				layout = 'twoBigsBoosted';
+				layout = 'twoBigsFirstBoosted';
+			} else if (groupedTrails.big[1]?.isBoosted) {
+				layout = 'twoBigsSecondBoosted';
 			} else {
 				layout = 'twoBigs';
 			}
@@ -213,10 +221,27 @@ export const DynamicSlowMPU = ({
 				</>
 			);
 		}
-		case 'twoBigsBoosted': {
+		case 'twoBigsFirstBoosted': {
 			return (
 				<>
 					<Card75_Card25
+						cards={bigCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+					/>
+					<ColumnOfThree50_Ad50
+						cards={standardCards}
+						containerPalette={containerPalette}
+						showAge={showAge}
+						index={index}
+					/>
+				</>
+			);
+		}
+		case 'twoBigsSecondBoosted': {
+			return (
+				<>
+					<Card25_Card75
 						cards={bigCards}
 						containerPalette={containerPalette}
 						showAge={showAge}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

Closes #5821 

## What does this change?
Adds support for 2nd big boosted card un `DynamicSlowMPU` for a config like this

![image](https://user-images.githubusercontent.com/19683595/214330912-0f1918a5-4196-46c7-ace4-683ce23c706d.png)

## Why?
Parity with frontend

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/214330553-d358384c-aa76-4b1b-a382-88c56263f766.png) | ![image](https://user-images.githubusercontent.com/19683595/214330658-2cbf7abf-b94a-498b-9172-ffb079c60ed1.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214340664-d7b01f2c-28bd-4e97-aa93-fac2ada40c95.png) | ![image](https://user-images.githubusercontent.com/19683595/214340814-3ef3b92a-9ab3-42cf-8d8b-720e7c336452.png) |
| ![image](https://user-images.githubusercontent.com/19683595/214340973-8f9b4c07-8f19-49b1-a4dc-aadf4960e8e5.png) | ![image](https://user-images.githubusercontent.com/19683595/214341051-4290f164-6384-4361-8e11-6b5ba7c4f1f4.png) |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
