### PR TITLE
Move AR Snyk To Dotcom project

### DIFF
--- a/.github/workflows/ar-snyk.yml
+++ b/.github/workflows/ar-snyk.yml
@@ -3,6 +3,10 @@ name: AR Snyk
 on:
     schedule:
         - cron: "0 9 * * 1-5"
+    push:
+        branches:
+            - main
+    workflow_dispatch:
 
 jobs:
     snyk:
@@ -23,4 +27,4 @@ jobs:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
                   command: monitor
-                  args: --org=guardian-mobile --project-name=apps-rendering --file=apps-rendering/yarn.lock
+                  args: --org=guardian-dotcom-n2y --project-name=apps-rendering --file=apps-rendering/yarn.lock


### PR DESCRIPTION
## Why?

The Dotcom team is now maintaining AR.

Paired with @ioannakok @Georges-GNM 

## Changes

- Move AR Snyk to upload to Dotcom project
- Set up manual run and push to `main` triggers
