### PR TITLE
Prop drill removeKickerSlashes for MostViewed

### DIFF
--- a/dotcom-rendering/src/web/components/KickerWithoutSlash.tsx
+++ b/dotcom-rendering/src/web/components/KickerWithoutSlash.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { PulsingDot } from './PulsingDot.importable';
+
+// Defines a prefix to be used with a headline (e.g. 'Live')
+type Props = {
+	text: string;
+	color: string;
+	showPulsingDot?: boolean;
+};
+
+const kickerStyles = (colour: string) => css`
+	color: ${colour};
+	font-weight: 700;
+	margin-right: 4px;
+	display: inline-block;
+`;
+
+export const KickerWithoutSlash = ({ text, color, showPulsingDot }: Props) => {
+	return (
+		<>
+			<span css={kickerStyles(color)}>
+				{showPulsingDot && <PulsingDot colour={color} />}
+				{text}
+			</span>
+			<br />
+		</>
+	);
+};

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -3,6 +3,7 @@ import { headline } from '@guardian/source-foundations';
 import { decidePalette } from '../lib/decidePalette';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
+import { KickerWithoutSlash } from './KickerWithoutSlash';
 import { QuoteIcon } from './QuoteIcon';
 
 type Props = {
@@ -16,6 +17,7 @@ type Props = {
 	size?: SmallHeadlineSize;
 	link?: HeadlineLink; // An optional link object configures if/how the component renders an anchor tag
 	byline?: string;
+	removeKickerSlashes?: boolean;
 };
 
 const fontStyles = (size: SmallHeadlineSize) => {
@@ -75,19 +77,31 @@ export const LinkHeadline = ({
 	size = 'medium',
 	link,
 	byline,
+	removeKickerSlashes,
 }: Props) => {
 	const palette = decidePalette(format);
 
 	return (
 		<h4 css={fontStyles(size)}>
-			{!!kickerText && (
-				<Kicker
-					text={kickerText}
-					color={palette.text.linkKicker}
-					showPulsingDot={showPulsingDot}
-					showSlash={showSlash}
-				/>
-			)}
+			{!!kickerText &&
+				(removeKickerSlashes ? (
+					<>
+						<KickerWithoutSlash
+							text={kickerText}
+							color={palette.text.linkKicker}
+							showPulsingDot={showPulsingDot}
+						/>
+					</>
+				) : (
+					<>
+						<Kicker
+							text={kickerText}
+							color={palette.text.linkKicker}
+							showPulsingDot={showPulsingDot}
+							showSlash={showSlash}
+						/>
+					</>
+				))}
 			{showQuotes && <QuoteIcon colour={palette.text.linkKicker} />}
 			{link ? (
 				// We were passed a link object so headline should be a link, with link styling

--- a/dotcom-rendering/src/web/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooter.importable.tsx
@@ -42,7 +42,8 @@ export const MostViewedFooter = ({
 	sectionName,
 	selectedColour,
 }: Props) => {
-	const removeKickerSlashes = window.guardian.config.tests.removeKickerSlashesVariant === "variant";
+	const removeKickerSlashes =
+		window.guardian.config.tests.removeKickerSlashesVariant === 'variant';
 
 	return (
 		<div

--- a/dotcom-rendering/src/web/components/MostViewedFooter.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooter.importable.tsx
@@ -42,6 +42,8 @@ export const MostViewedFooter = ({
 	sectionName,
 	selectedColour,
 }: Props) => {
+	const removeKickerSlashes = window.guardian.config.tests.removeKickerSlashesVariant === "variant";
+
 	return (
 		<div
 			css={css`
@@ -55,6 +57,7 @@ export const MostViewedFooter = ({
 				data={tabs}
 				sectionName={sectionName}
 				selectedColour={selectedColour}
+				removeKickerSlashes={removeKickerSlashes}
 			/>
 			<div css={[stackBelow('tablet'), secondTierStyles]}>
 				{mostCommented && (

--- a/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx
@@ -15,6 +15,7 @@ interface Props {
 	sectionName?: string;
 	format: ArticleFormat;
 	ajaxUrl: string;
+	removeKickerSlashes?: boolean;
 }
 
 function buildSectionUrl(ajaxUrl: string, sectionName?: string) {
@@ -42,6 +43,7 @@ export const MostViewedFooterData = ({
 	sectionName,
 	format,
 	ajaxUrl,
+	removeKickerSlashes,
 }: Props) => {
 	const palette = decidePalette(format);
 	// Example usage of AB Tests

--- a/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterGrid.tsx
@@ -100,6 +100,7 @@ type Props = {
 	data: TrailTabType[];
 	sectionName?: string;
 	selectedColour?: string;
+	removeKickerSlashes?: boolean;
 };
 
 // To avoid having to handle multiple ways of reducing the capitalisation styling
@@ -126,6 +127,7 @@ export const MostViewedFooterGrid = ({
 	data,
 	sectionName = '',
 	selectedColour = neutral[0],
+	removeKickerSlashes,
 }: Props) => {
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
 	/**
@@ -224,6 +226,7 @@ export const MostViewedFooterGrid = ({
 								format={trail.format}
 								headlineText={trail.headline}
 								ageWarning={trail.ageWarning}
+								removeKickerSlashes={removeKickerSlashes}
 							/>
 						))}
 					</ol>

--- a/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
@@ -72,6 +72,7 @@ type Props = {
 	format: ArticleFormat;
 	headlineText: string;
 	ageWarning?: string;
+	removeKickerSlashes?: boolean;
 };
 
 export const MostViewedFooterItem = ({
@@ -80,6 +81,7 @@ export const MostViewedFooterItem = ({
 	format,
 	headlineText,
 	ageWarning,
+	removeKickerSlashes,
 }: Props) => (
 	<li css={gridItem(position)} data-link-name={`${position} | text`}>
 		<a css={headlineLink} href={url} data-link-name="article">
@@ -96,6 +98,7 @@ export const MostViewedFooterItem = ({
 						showSlash={true}
 						showPulsingDot={true}
 						showQuotes={false}
+						removeKickerSlashes={removeKickerSlashes}
 					/>
 				) : (
 					<LinkHeadline


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

## Why?

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
