### PR TITLE
Remove `common-rendering` Dark Mode Helper

### DIFF
--- a/apps-rendering/src/components/Accordion/Accordion.stories.tsx
+++ b/apps-rendering/src/components/Accordion/Accordion.stories.tsx
@@ -2,7 +2,6 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import { darkModeCss } from 'styles';
 import {
 	body,
 	breakpoints,
@@ -11,6 +10,7 @@ import {
 	space,
 } from '@guardian/source-foundations';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 import Accordion from '.';
 
 // ----- Stories ----- //
@@ -64,10 +64,7 @@ const accordionContent = (
 );
 
 const Default: FC = () => (
-	<Accordion
-		accordionTitle="Live feed"
-		context="keyEvents"
-	>
+	<Accordion accordionTitle="Live feed" context="keyEvents">
 		{accordionContent}
 	</Accordion>
 );

--- a/apps-rendering/src/components/Accordion/Accordion.stories.tsx
+++ b/apps-rendering/src/components/Accordion/Accordion.stories.tsx
@@ -2,7 +2,7 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import {
 	body,
 	breakpoints,
@@ -10,15 +10,15 @@ import {
 	neutral,
 	space,
 } from '@guardian/source-foundations';
-import type { FC, ReactElement } from 'react';
+import type { FC } from 'react';
 import Accordion from '.';
 
 // ----- Stories ----- //
 
-const textStyle = (supportsDarkMode: boolean): SerializedStyles => css`
+const textStyle = css`
 	${body.medium({ lineHeight: 'loose' })};
 	margin-bottom: ${space[3]}px;
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		color: ${neutral[86]};
 	`}
 `;
@@ -41,20 +41,20 @@ const adviceColourAboveTablet: SerializedStyles = css`
 	}
 `;
 
-const accordionContent = (supportsDarkMode: boolean): ReactElement => (
+const accordionContent = (
 	<>
-		<p css={[textStyle(supportsDarkMode), adviceColourAboveTablet]}>
+		<p css={[textStyle, adviceColourAboveTablet]}>
 			There&apos;s a trick to viewing this - you need to switch the
 			storybook viewport to mobile, phablet or tablet in order to see the
 			accordion.
 		</p>
-		<p css={[textStyle(supportsDarkMode), hideAboveTablet]}>
+		<p css={[textStyle, hideAboveTablet]}>
 			Vaccine passports enjoy substantial support across Europe, a YouGov
 			survey suggests, as a fourth wave of infections prompts a growing
 			number of countries to impose tougher restrictions on people who
 			have not been fully vaccinated.
 		</p>
-		<p css={[textStyle(supportsDarkMode), hideAboveTablet]}>
+		<p css={[textStyle, hideAboveTablet]}>
 			The annual YouGov-Cambridge Globalism Project suggests majorities in
 			all 10 European countries surveyed back compulsory vaccine passes
 			for large events, while in most, more people favour than oppose
@@ -65,21 +65,10 @@ const accordionContent = (supportsDarkMode: boolean): ReactElement => (
 
 const Default: FC = () => (
 	<Accordion
-		supportsDarkMode={false}
 		accordionTitle="Live feed"
 		context="keyEvents"
 	>
-		{accordionContent(false)}
-	</Accordion>
-);
-
-const Dark: FC = () => (
-	<Accordion
-		supportsDarkMode={true}
-		accordionTitle="Live feed"
-		context="keyEvents"
-	>
-		{accordionContent(true)}
+		{accordionContent}
 	</Accordion>
 );
 
@@ -99,4 +88,4 @@ export default {
 	},
 };
 
-export { Default, Dark };
+export { Default };

--- a/apps-rendering/src/components/Accordion/index.tsx
+++ b/apps-rendering/src/components/Accordion/index.tsx
@@ -2,7 +2,7 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import {
 	background,
 	focusHalo,
@@ -22,7 +22,6 @@ import type { FC, ReactNode } from 'react';
 
 interface AccordionProps {
 	children: ReactNode;
-	supportsDarkMode: boolean;
 	accordionTitle: string;
 	context: 'keyEvents' | 'liveFeed';
 }
@@ -37,7 +36,7 @@ const detailsStyles: SerializedStyles = css`
 	}
 `;
 
-const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const titleRowStyles = css`
 	cursor: pointer;
 	position: relative;
 	display: block;
@@ -54,7 +53,7 @@ const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	svg {
 		height: 2rem;
 	}
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		path {
 			fill: ${neutral[60]};
 		}
@@ -69,10 +68,10 @@ const titleRowStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	}
 `;
 
-const titleStyle = (supportsDarkMode: boolean): SerializedStyles => css`
+const titleStyle = css`
 	${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		color: ${neutral[86]};
 	`}
 `;
@@ -89,7 +88,6 @@ const arrowPosition: SerializedStyles = css`
 
 const backgroundColour = (
 	context: 'keyEvents' | 'liveFeed',
-	supportsDarkMode: boolean,
 ): SerializedStyles => {
 	if (context === 'keyEvents') {
 		return css`
@@ -97,7 +95,7 @@ const backgroundColour = (
 			${from.desktop} {
 				background-color: transparent;
 			}
-			${darkModeCss(supportsDarkMode)`
+			${darkModeCss`
 				background-color: ${neutral[10]};
 			`}
 		`;
@@ -107,7 +105,7 @@ const backgroundColour = (
 		${from.desktop} {
 			background-color: transparent;
 		}
-		${darkModeCss(supportsDarkMode)`
+		${darkModeCss`
 			background-color: ${neutral[10]};
 		`}
 	`;
@@ -125,14 +123,13 @@ const paddingBody: SerializedStyles = css`
 
 const Accordion: FC<AccordionProps> = ({
 	children,
-	supportsDarkMode,
 	accordionTitle,
 	context,
 }) => {
 	return (
 		<details open css={detailsStyles}>
-			<summary css={titleRowStyles(supportsDarkMode)}>
-				<h2 css={titleStyle(supportsDarkMode)}>{accordionTitle}</h2>
+			<summary css={titleRowStyles}>
+				<h2 css={titleStyle}>{accordionTitle}</h2>
 				<span className="is-off" css={arrowPosition}>
 					<SvgChevronDownSingle />
 				</span>
@@ -141,7 +138,7 @@ const Accordion: FC<AccordionProps> = ({
 				</span>
 			</summary>
 			<div
-				css={[backgroundColour(context, supportsDarkMode), paddingBody]}
+				css={[backgroundColour(context), paddingBody]}
 			>
 				{children}
 			</div>

--- a/apps-rendering/src/components/Accordion/index.tsx
+++ b/apps-rendering/src/components/Accordion/index.tsx
@@ -2,7 +2,6 @@
 
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import { darkModeCss } from 'styles';
 import {
 	background,
 	focusHalo,
@@ -17,6 +16,7 @@ import {
 	SvgChevronUpSingle,
 } from '@guardian/source-react-components';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -137,11 +137,7 @@ const Accordion: FC<AccordionProps> = ({
 					<SvgChevronUpSingle />
 				</span>
 			</summary>
-			<div
-				css={[backgroundColour(context), paddingBody]}
-			>
-				{children}
-			</div>
+			<div css={[backgroundColour(context), paddingBody]}>{children}</div>
 		</details>
 	);
 };

--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { darkModeCss } from 'styles';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
@@ -15,6 +14,7 @@ import type { Image } from 'image/image';
 import type { Lightbox } from 'image/lightbox';
 import type { Sizes } from 'image/sizes';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 const width = '100%';
 const phabletWidth = '620px';

--- a/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.defaults.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import { ArticleElementRole } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, remSpace } from '@guardian/source-foundations';
@@ -73,14 +73,13 @@ export const getDefaultStyles = (
 
 export const getDefaultImgStyles = (
 	role: ArticleElementRole,
-	supportsDarkMode: boolean,
 ): Option<SerializedStyles> => {
 	switch (role) {
 		case ArticleElementRole.Thumbnail:
 			return some(css`
 				background-color: transparent;
 
-				${darkModeCss(supportsDarkMode)`
+				${darkModeCss`
                     background-color: transparent;
                 `}
 			`);
@@ -92,7 +91,6 @@ export const getDefaultImgStyles = (
 export type BodyImageProps = {
 	image: Image;
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 	lightbox: Option<Lightbox>;
 	caption: Option<ReactNode>;
 };
@@ -106,7 +104,6 @@ const DefaultBodyImage: FC<
 > = ({
 	image,
 	format,
-	supportsDarkMode,
 	lightbox,
 	caption,
 	wrapperStyles,
@@ -119,7 +116,6 @@ const DefaultBodyImage: FC<
 			sizes={getDefaultSizes(image.role)}
 			className={imgStyles}
 			format={format}
-			supportsDarkMode={supportsDarkMode}
 			lightbox={lightbox}
 		/>
 		<FigCaption
@@ -127,7 +123,6 @@ const DefaultBodyImage: FC<
 				captionStyles,
 			)}
 			format={format}
-			supportsDarkMode={supportsDarkMode}
 			variant={CaptionIconVariant.Image}
 		>
 			{caption}

--- a/apps-rendering/src/components/BodyImage/BodyImage.stories.tsx
+++ b/apps-rendering/src/components/BodyImage/BodyImage.stories.tsx
@@ -47,7 +47,6 @@ const Default: FC = () => (
 	<BodyImage
 		image={image}
 		format={format}
-		supportsDarkMode={true}
 		lightbox={none}
 		caption={caption}
 		leftColumnBreakpoint={none}
@@ -58,7 +57,6 @@ const NoCaption: FC = () => (
 	<BodyImage
 		image={image}
 		format={format}
-		supportsDarkMode={true}
 		lightbox={none}
 		caption={none}
 		leftColumnBreakpoint={none}
@@ -73,7 +71,6 @@ const Thumbnail: FC = () => (
 				role: ArticleElementRole.Thumbnail,
 			}}
 			format={format}
-			supportsDarkMode={true}
 			lightbox={none}
 			caption={caption}
 			leftColumnBreakpoint={none}
@@ -90,7 +87,6 @@ const ThumbnailNoCaption: FC = () => (
 				role: ArticleElementRole.Thumbnail,
 			}}
 			format={format}
-			supportsDarkMode={true}
 			lightbox={none}
 			caption={none}
 			leftColumnBreakpoint={none}

--- a/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
+++ b/apps-rendering/src/components/BodyImage/GalleryBodyImage.tsx
@@ -131,7 +131,6 @@ const imgSizes = (image: Image): Sizes => {
 const GalleryBodyImage: FC<BodyImageProps> = ({
 	image,
 	format,
-	supportsDarkMode,
 	lightbox,
 	caption,
 }) => (
@@ -140,9 +139,8 @@ const GalleryBodyImage: FC<BodyImageProps> = ({
 			<Img
 				image={image}
 				sizes={imgSizes(image)}
-				className={getDefaultImgStyles(image.role, supportsDarkMode)}
+				className={getDefaultImgStyles(image.role)}
 				format={format}
-				supportsDarkMode={supportsDarkMode}
 				lightbox={lightbox}
 			/>
 		</div>
@@ -150,7 +148,6 @@ const GalleryBodyImage: FC<BodyImageProps> = ({
 		<FigCaption
 			css={captionStyles(format)}
 			format={format}
-			supportsDarkMode={supportsDarkMode}
 			variant={CaptionIconVariant.Image}
 		>
 			{caption}

--- a/apps-rendering/src/components/BodyImage/index.tsx
+++ b/apps-rendering/src/components/BodyImage/index.tsx
@@ -17,7 +17,6 @@ type Props = BodyImageProps & { leftColumnBreakpoint: Option<Breakpoint> };
 const BodyImage: FC<Props> = ({
 	image,
 	format,
-	supportsDarkMode,
 	lightbox,
 	caption,
 	leftColumnBreakpoint,
@@ -28,7 +27,6 @@ const BodyImage: FC<Props> = ({
 				<GalleryBodyImage
 					image={image}
 					format={format}
-					supportsDarkMode={supportsDarkMode}
 					lightbox={lightbox}
 					caption={caption}
 				/>
@@ -39,7 +37,6 @@ const BodyImage: FC<Props> = ({
 				<DefaultBodyImage
 					image={image}
 					format={format}
-					supportsDarkMode={supportsDarkMode}
 					lightbox={lightbox}
 					caption={caption}
 					wrapperStyles={getDefaultStyles(
@@ -48,7 +45,6 @@ const BodyImage: FC<Props> = ({
 					)}
 					imgStyles={getDefaultImgStyles(
 						image.role,
-						supportsDarkMode,
 					)}
 					captionStyles={none}
 				/>

--- a/apps-rendering/src/components/BodyImage/index.tsx
+++ b/apps-rendering/src/components/BodyImage/index.tsx
@@ -43,9 +43,7 @@ const BodyImage: FC<Props> = ({
 						image.role,
 						leftColumnBreakpoint,
 					)}
-					imgStyles={getDefaultImgStyles(
-						image.role,
-					)}
+					imgStyles={getDefaultImgStyles(image.role)}
 					captionStyles={none}
 				/>
 			);

--- a/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
+++ b/apps-rendering/src/components/CaptionIcon/CaptionIcon.stories.tsx
@@ -13,7 +13,6 @@ const Image: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		variant={CaptionIconVariant.Image}
 	></CaptionIcon>
 );
@@ -25,7 +24,6 @@ const Video: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		variant={CaptionIconVariant.Video}
 	></CaptionIcon>
 );

--- a/apps-rendering/src/components/CaptionIcon/index.tsx
+++ b/apps-rendering/src/components/CaptionIcon/index.tsx
@@ -1,7 +1,6 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { fill } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/source-foundations';
@@ -15,11 +14,10 @@ enum CaptionIconVariant {
 
 interface IconProps {
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 	variant: CaptionIconVariant;
 }
 
-const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const iconStyles = css`
 	display: inline-block;
 	width: 1.2rem;
 	margin-right: ${remSpace[1]};
@@ -39,12 +37,12 @@ const iconStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 		width: 100%;
 	}
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
         fill: ${fill.cameraCaptionIconDark()};
     `}
 `;
 
-const CaptionIcon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
+const CaptionIcon: FC<IconProps> = ({ format, variant }) => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
@@ -52,7 +50,7 @@ const CaptionIcon: FC<IconProps> = ({ format, supportsDarkMode, variant }) => {
 			return null;
 		default:
 			return (
-				<span css={iconStyles(supportsDarkMode)}>
+				<span css={iconStyles}>
 					{variant === CaptionIconVariant.Image ? (
 						<SvgCamera />
 					) : (

--- a/apps-rendering/src/components/CaptionIcon/index.tsx
+++ b/apps-rendering/src/components/CaptionIcon/index.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
 import { fill } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { remSpace } from '@guardian/source-foundations';
 import { SvgCamera, SvgVideo } from '@guardian/source-react-components';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 enum CaptionIconVariant {
 	Image,

--- a/apps-rendering/src/components/Card/index.tsx
+++ b/apps-rendering/src/components/Card/index.tsx
@@ -455,7 +455,6 @@ const cardImage = (
 						}}
 						format={format}
 						className={some(imgStyles)}
-						supportsDarkMode
 						lightbox={none}
 					/>
 				</div>

--- a/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
+++ b/apps-rendering/src/components/FigCaption/FigCaption.stories.tsx
@@ -15,7 +15,6 @@ const Image: FC = (): ReactElement => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		variant={CaptionIconVariant.Image}
 	>
 		{some(
@@ -31,7 +30,6 @@ const Video: FC = (): ReactElement => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		variant={CaptionIconVariant.Video}
 	>
 		{some(

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -3,7 +3,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
@@ -18,52 +18,48 @@ import type { FC, ReactNode } from 'react';
 
 type Props = Styleable<{
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 	children: Option<ReactNode>;
 	variant: CaptionIconVariant;
 }>;
 
 const styles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
 	color: ${text.figCaption(format)};
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
     	color: ${text.figCaptionDark(format)};
   	`}
 `;
 
-const mediaStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const mediaStyles = css`
 	color: ${neutral[86]};
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
     color: ${neutral[86]};
   `}
 `;
 
 const getStyles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 ): SerializedStyles => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 			return css(
-				styles(format, supportsDarkMode),
-				mediaStyles(supportsDarkMode),
+				styles(format),
+				mediaStyles,
 			);
 		default:
-			return styles(format, supportsDarkMode);
+			return styles(format);
 	}
 };
 
 const FigCaption: FC<Props> = ({
 	format,
-	supportsDarkMode,
 	children,
 	className,
 	variant,
@@ -73,11 +69,10 @@ const FigCaption: FC<Props> = ({
 			return (
 				<figcaption
 					className={className}
-					css={getStyles(format, supportsDarkMode)}
+					css={getStyles(format)}
 				>
 					<CaptionIcon
 						format={format}
-						supportsDarkMode={supportsDarkMode}
 						variant={variant}
 					/>
 					{children.value}

--- a/apps-rendering/src/components/FigCaption/index.tsx
+++ b/apps-rendering/src/components/FigCaption/index.tsx
@@ -3,7 +3,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { text } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { ArticleDesign } from '@guardian/libs';
 import { neutral, remSpace, textSans } from '@guardian/source-foundations';
@@ -13,6 +12,7 @@ import CaptionIcon from 'components/CaptionIcon';
 import type { CaptionIconVariant } from 'components/CaptionIcon';
 import type { Styleable } from 'lib';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -22,9 +22,7 @@ type Props = Styleable<{
 	variant: CaptionIconVariant;
 }>;
 
-const styles = (
-	format: ArticleFormat,
-): SerializedStyles => css`
+const styles = (format: ArticleFormat): SerializedStyles => css`
 	${textSans.xsmall({ lineHeight: 'regular' })}
 	padding-top: ${remSpace[1]};
 	color: ${text.figCaption(format)};
@@ -42,39 +40,23 @@ const mediaStyles = css`
   `}
 `;
 
-const getStyles = (
-	format: ArticleFormat,
-): SerializedStyles => {
+const getStyles = (format: ArticleFormat): SerializedStyles => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-			return css(
-				styles(format),
-				mediaStyles,
-			);
+			return css(styles(format), mediaStyles);
 		default:
 			return styles(format);
 	}
 };
 
-const FigCaption: FC<Props> = ({
-	format,
-	children,
-	className,
-	variant,
-}) => {
+const FigCaption: FC<Props> = ({ format, children, className, variant }) => {
 	switch (children.kind) {
 		case OptionKind.Some:
 			return (
-				<figcaption
-					className={className}
-					css={getStyles(format)}
-				>
-					<CaptionIcon
-						format={format}
-						variant={variant}
-					/>
+				<figcaption className={className} css={getStyles(format)}>
+					<CaptionIcon format={format} variant={variant} />
 					{children.value}
 				</figcaption>
 			);

--- a/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
+++ b/apps-rendering/src/components/FirstPublished/FirstPublished.stories.tsx
@@ -9,7 +9,6 @@ import FirstPublished from '.';
 
 const Default: FC = () => (
 	<FirstPublished
-		supportsDarkMode={true}
 		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}
@@ -25,7 +24,6 @@ const Default: FC = () => (
 
 const PinnedPost: FC = () => (
 	<FirstPublished
-		supportsDarkMode={true}
 		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={true}
@@ -41,7 +39,6 @@ const PinnedPost: FC = () => (
 
 const OriginalPinnedPost: FC = () => (
 	<FirstPublished
-		supportsDarkMode={true}
 		firstPublished={new Date(1613763003000)}
 		blockId="#block-60300f5f8f08ad21ea60071e"
 		isPinnedPost={false}

--- a/apps-rendering/src/components/FirstPublished/index.tsx
+++ b/apps-rendering/src/components/FirstPublished/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { timeAgo } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
@@ -13,7 +13,6 @@ type Props = {
 	firstPublished: Date;
 	blockId: string;
 	isPinnedPost: boolean;
-	supportsDarkMode: boolean;
 	isOriginalPinnedPost: boolean;
 	format: ArticleFormat;
 	edition: Edition;
@@ -23,7 +22,6 @@ const FirstPublished: FC<Props> = ({
 	firstPublished,
 	blockId,
 	isPinnedPost,
-	supportsDarkMode,
 	isOriginalPinnedPost,
 	format,
 	edition,
@@ -58,7 +56,7 @@ const FirstPublished: FC<Props> = ({
 						font-weight: bold;
 						margin-right: ${space[2]}px;
 
-						${darkModeCss(supportsDarkMode)`
+						${darkModeCss`
 							color: ${neutral[60]};
 						`}
 					`}
@@ -71,7 +69,7 @@ const FirstPublished: FC<Props> = ({
 					${textSans.xxsmall()};
 					color: ${neutral[46]};
 
-					${darkModeCss(supportsDarkMode)`
+					${darkModeCss`
 						color: ${neutral[60]};
 					`}
 				`}

--- a/apps-rendering/src/components/FirstPublished/index.tsx
+++ b/apps-rendering/src/components/FirstPublished/index.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
 import type { Edition } from '@guardian/apps-rendering-api-models/edition';
 import { border } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { timeAgo } from '@guardian/libs';
 import { neutral, space, textSans } from '@guardian/source-foundations';
 import { SvgPinned } from '@guardian/source-react-components';
 import { timestampFormat } from 'datetime';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 type Props = {
 	firstPublished: Date;

--- a/apps-rendering/src/components/ImgAlt/ImgAlt.stories.tsx
+++ b/apps-rendering/src/components/ImgAlt/ImgAlt.stories.tsx
@@ -22,7 +22,6 @@ const Default: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		lightbox={none}
 	/>
 );
@@ -42,7 +41,6 @@ const Placeholder: FC = () => (
 			display: ArticleDisplay.Standard,
 			theme: ArticlePillar.News,
 		}}
-		supportsDarkMode={true}
 		lightbox={none}
 	/>
 );

--- a/apps-rendering/src/components/ImgAlt/index.tsx
+++ b/apps-rendering/src/components/ImgAlt/index.tsx
@@ -2,7 +2,7 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
@@ -40,7 +40,6 @@ type Props = {
 	sizes: Sizes;
 	className: Option<SerializedStyles>;
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 	lightbox: Option<Lightbox>;
 };
 
@@ -53,7 +52,6 @@ type Props = {
  */
 const placeholderBackground = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 	imageSubtype: Optional<ImageSubtype>,
 ): SerializedStyles => {
 	if (
@@ -66,7 +64,7 @@ const placeholderBackground = (
 
 	return css`
 		background-color: ${backgroundColour(format)};
-		${darkModeCss(supportsDarkMode)`
+		${darkModeCss`
 			background-color: ${neutral[20]};
 		`}
 	`;
@@ -74,10 +72,9 @@ const placeholderBackground = (
 
 const styles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 	imageSubtype: Optional<ImageSubtype>,
 ): SerializedStyles => css`
-	${placeholderBackground(format, supportsDarkMode, imageSubtype)}
+	${placeholderBackground(format, imageSubtype)}
 	color: ${neutral[60]};
 	display: block;
 `;
@@ -87,7 +84,6 @@ const Img: FC<Props> = ({
 	sizes,
 	className,
 	format,
-	supportsDarkMode,
 	lightbox,
 }) => (
 	<picture>
@@ -103,7 +99,7 @@ const Img: FC<Props> = ({
 			className={getClassName(image.width, lightbox)}
 			css={[
 				sizeStyles(sizes, image.width, image.height),
-				styles(format, supportsDarkMode, image.imageSubtype),
+				styles(format, image.imageSubtype),
 				withDefault<SerializedStyles | undefined>(undefined)(className),
 			]}
 			data-ratio={image.height / image.width}

--- a/apps-rendering/src/components/ImgAlt/index.tsx
+++ b/apps-rendering/src/components/ImgAlt/index.tsx
@@ -2,7 +2,6 @@
 
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { darkModeCss } from 'styles';
 import { ArticleDesign } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral } from '@guardian/source-foundations';
@@ -16,6 +15,7 @@ import { sizesAttribute, styles as sizeStyles } from 'image/sizes';
 import type { Sizes } from 'image/sizes';
 import type { Optional } from 'optional';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Functions ----- //
 
@@ -79,13 +79,7 @@ const styles = (
 	display: block;
 `;
 
-const Img: FC<Props> = ({
-	image,
-	sizes,
-	className,
-	format,
-	lightbox,
-}) => (
+const Img: FC<Props> = ({ image, sizes, className, format, lightbox }) => (
 	<picture>
 		<source
 			sizes={sizesAttribute(sizes)}

--- a/apps-rendering/src/components/KeyEvents/KeyEvents.stories.tsx
+++ b/apps-rendering/src/components/KeyEvents/KeyEvents.stories.tsx
@@ -57,10 +57,7 @@ const events: KeyEvent[] = [
 	},
 ];
 
-const KeyEventComp = (
-	format: ArticleFormat,
-	title: string,
-): ReactElement => (
+const KeyEventComp = (format: ArticleFormat, title: string): ReactElement => (
 	<div
 		css={css`
 			flex-grow: 1;
@@ -90,19 +87,13 @@ const Default = (): ReactElement => (
 	>
 		{KeyEventComp(getFormat(ArticlePillar.News), 'News')}
 		{KeyEventComp(getFormat(ArticlePillar.Culture), 'Culture')}
-		{KeyEventComp(
-			getFormat(ArticlePillar.Lifestyle),
-			'Lifestyle',
-		)}
+		{KeyEventComp(getFormat(ArticlePillar.Lifestyle), 'Lifestyle')}
 		{KeyEventComp(getFormat(ArticlePillar.Opinion), 'Opinion')}
 		{KeyEventComp(getFormat(ArticlePillar.Sport), 'Sport')}
 		{KeyEventComp(getFormat(ArticleSpecial.Labs), 'Labs')}
-		{KeyEventComp(
-							getFormat(ArticleSpecial.SpecialReport),
-			'SpecialReport',
-		)}
+		{KeyEventComp(getFormat(ArticleSpecial.SpecialReport), 'SpecialReport')}
 	</div>
-)
+);
 
 // ----- Exports ----- //
 

--- a/apps-rendering/src/components/KeyEvents/KeyEvents.stories.tsx
+++ b/apps-rendering/src/components/KeyEvents/KeyEvents.stories.tsx
@@ -58,7 +58,6 @@ const events: KeyEvent[] = [
 ];
 
 const KeyEventComp = (
-	dark: boolean,
 	format: ArticleFormat,
 	title: string,
 ): ReactElement => (
@@ -68,7 +67,7 @@ const KeyEventComp = (
 		`}
 	>
 		<div>{title}</div>
-		<KeyEvents keyEvents={events} format={format} supportsDarkMode={dark} />
+		<KeyEvents keyEvents={events} format={format} />
 	</div>
 );
 
@@ -80,39 +79,30 @@ const getFormat = (theme: ArticleTheme): ArticleFormat => {
 	};
 };
 
-const keyEventWithTheme = (dark: boolean): (() => ReactElement) => {
-	const KeyEvent = (): ReactElement => (
-		<div
-			css={css`
-				display: flex;
-				flex-direction: row;
-				justify-content: space-between;
-				flex-wrap: wrap;
-			`}
-		>
-			{KeyEventComp(dark, getFormat(ArticlePillar.News), 'News')}
-			{KeyEventComp(dark, getFormat(ArticlePillar.Culture), 'Culture')}
-			{KeyEventComp(
-				dark,
-				getFormat(ArticlePillar.Lifestyle),
-				'Lifestyle',
-			)}
-			{KeyEventComp(dark, getFormat(ArticlePillar.Opinion), 'Opinion')}
-			{KeyEventComp(dark, getFormat(ArticlePillar.Sport), 'Sport')}
-			{KeyEventComp(dark, getFormat(ArticleSpecial.Labs), 'Labs')}
-			{KeyEventComp(
-				dark,
-				getFormat(ArticleSpecial.SpecialReport),
-				'SpecialReport',
-			)}
-		</div>
-	);
-
-	return KeyEvent;
-};
-
-const Default = keyEventWithTheme(false);
-const Dark = keyEventWithTheme(true);
+const Default = (): ReactElement => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			flex-wrap: wrap;
+		`}
+	>
+		{KeyEventComp(getFormat(ArticlePillar.News), 'News')}
+		{KeyEventComp(getFormat(ArticlePillar.Culture), 'Culture')}
+		{KeyEventComp(
+			getFormat(ArticlePillar.Lifestyle),
+			'Lifestyle',
+		)}
+		{KeyEventComp(getFormat(ArticlePillar.Opinion), 'Opinion')}
+		{KeyEventComp(getFormat(ArticlePillar.Sport), 'Sport')}
+		{KeyEventComp(getFormat(ArticleSpecial.Labs), 'Labs')}
+		{KeyEventComp(
+							getFormat(ArticleSpecial.SpecialReport),
+			'SpecialReport',
+		)}
+	</div>
+)
 
 // ----- Exports ----- //
 
@@ -121,4 +111,4 @@ export default {
 	title: 'AR/KeyEvents',
 };
 
-export { Default, Dark };
+export { Default };

--- a/apps-rendering/src/components/KeyEvents/index.tsx
+++ b/apps-rendering/src/components/KeyEvents/index.tsx
@@ -6,7 +6,7 @@ import {
 	background,
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, timeAgo } from '@guardian/libs';
 import {
@@ -37,13 +37,11 @@ interface KeyEvent {
 interface KeyEventsProps {
 	keyEvents: KeyEvent[];
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 }
 
 interface ListItemProps {
 	keyEvent: KeyEvent;
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 }
 
 const getColour = (theme: ArticleTheme, paletteId: PaletteId): string => {
@@ -63,7 +61,6 @@ const getColour = (theme: ArticleTheme, paletteId: PaletteId): string => {
 
 const keyEventWrapperStyles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 	hideMobile: boolean,
 ): SerializedStyles => css`
 	width: 100%;
@@ -79,7 +76,7 @@ const keyEventWrapperStyles = (
 		padding-top: ${remSpace[2]};
 	}
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		border-top-color: ${neutral[20]};
 		background-color: ${background.articleContentDark(format)};
 	`}
@@ -87,7 +84,6 @@ const keyEventWrapperStyles = (
 
 const listStyles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	background-color: ${background.keyEvents(format)};
 
@@ -95,7 +91,7 @@ const listStyles = (
 		background-color: ${background.keyEventsWide(format)};
 	}
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		background-color: ${background.keyEventsDark(format)};
 
 		${from.desktop} {
@@ -104,7 +100,7 @@ const listStyles = (
 	`}
 `;
 
-const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const linkStyles = css`
 	position: initial;
 	text-decoration: none;
 
@@ -123,7 +119,7 @@ const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 		background-color: ${neutral[46]};
 	}
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		&:hover::before {
 			background-color: ${neutral[100]};
 		}
@@ -135,13 +131,13 @@ const linkStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 	`}
 `;
 
-const listItemStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const listItemStyles = css`
 	padding-bottom: ${remSpace[3]};
 	border-left: 1px solid ${neutral[86]};
 	position: relative;
 	transform: translateY(-1px);
 	margin-left: ${remSpace[1]};
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		border-left: 1px solid ${neutral[60]};
 	`}
 	&:last-child {
@@ -155,7 +151,6 @@ const timeTextWrapperStyles: SerializedStyles = css`
 
 const textStyles = (
 	format: ArticleFormat,
-	supportsDarkMode: boolean,
 ): SerializedStyles => css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
 	color: ${text.keyEventsInline(format)};
@@ -177,7 +172,7 @@ const textStyles = (
 		}
 	}
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		color: ${getColour(format.theme, 500)};
 		&:hover {
 			color: ${getColour(format.theme, 500)};
@@ -185,13 +180,13 @@ const textStyles = (
 	`}
 `;
 
-const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
+const timeStyles = css`
 	${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })};
 	color: ${neutral[7]};
 	display: block;
 	transform: translateY(-4px);
 
-	${darkModeCss(supportsDarkMode)`
+	${darkModeCss`
 		color: ${neutral[60]};
 	`}
 `;
@@ -199,13 +194,12 @@ const timeStyles = (supportsDarkMode: boolean): SerializedStyles => css`
 const ListItem: FC<ListItemProps> = ({
 	keyEvent,
 	format,
-	supportsDarkMode,
 }) => {
 	return (
-		<li css={listItemStyles(supportsDarkMode)}>
+		<li css={listItemStyles}>
 			<Link
 				priority="secondary"
-				css={linkStyles(supportsDarkMode)}
+				css={linkStyles}
 				href={keyEvent.url}
 			>
 				<div css={timeTextWrapperStyles}>
@@ -221,11 +215,11 @@ const ListItem: FC<ListItemProps> = ({
 							day: 'numeric',
 							timeZoneName: 'long',
 						})}`}
-						css={timeStyles(supportsDarkMode)}
+						css={timeStyles}
 					>
 						{timeAgo(keyEvent.date.getTime())}
 					</time>
-					<span css={textStyles(format, supportsDarkMode)}>
+					<span css={textStyles(format)}>
 						{keyEvent.text}
 					</span>
 				</div>
@@ -237,7 +231,6 @@ const ListItem: FC<ListItemProps> = ({
 const KeyEvents: FC<KeyEventsProps> = ({
 	keyEvents,
 	format,
-	supportsDarkMode,
 }) => {
 	return (
 		<nav
@@ -247,23 +240,20 @@ const KeyEvents: FC<KeyEventsProps> = ({
 			id="keyevents"
 			css={keyEventWrapperStyles(
 				format,
-				supportsDarkMode,
 				keyEvents.length === 0,
 			)}
 			aria-label="Key Events"
 		>
 			<Accordion
-				supportsDarkMode={supportsDarkMode}
 				accordionTitle="Key events"
 				context="keyEvents"
 			>
-				<ul css={listStyles(format, supportsDarkMode)}>
+				<ul css={listStyles(format)}>
 					{keyEvents.slice(0, 7).map((event, index) => (
 						<ListItem
 							key={`${event.url}${index}`}
 							keyEvent={event}
 							format={format}
-							supportsDarkMode={supportsDarkMode}
 						/>
 					))}
 				</ul>

--- a/apps-rendering/src/components/KeyEvents/index.tsx
+++ b/apps-rendering/src/components/KeyEvents/index.tsx
@@ -6,7 +6,6 @@ import {
 	background,
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
 import { ArticlePillar, timeAgo } from '@guardian/libs';
 import {
@@ -23,6 +22,7 @@ import {
 import { Link } from '@guardian/source-react-components';
 import Accordion from 'components/Accordion';
 import type { FC } from 'react';
+import { darkModeCss } from 'styles';
 
 // ----- Component ----- //
 
@@ -82,9 +82,7 @@ const keyEventWrapperStyles = (
 	`}
 `;
 
-const listStyles = (
-	format: ArticleFormat,
-): SerializedStyles => css`
+const listStyles = (format: ArticleFormat): SerializedStyles => css`
 	background-color: ${background.keyEvents(format)};
 
 	${from.desktop} {
@@ -149,9 +147,7 @@ const timeTextWrapperStyles: SerializedStyles = css`
 	margin-left: 0.5rem;
 `;
 
-const textStyles = (
-	format: ArticleFormat,
-): SerializedStyles => css`
+const textStyles = (format: ArticleFormat): SerializedStyles => css`
 	${textSans.small({ fontWeight: 'regular', lineHeight: 'regular' })};
 	color: ${text.keyEventsInline(format)};
 	display: block;
@@ -191,17 +187,10 @@ const timeStyles = css`
 	`}
 `;
 
-const ListItem: FC<ListItemProps> = ({
-	keyEvent,
-	format,
-}) => {
+const ListItem: FC<ListItemProps> = ({ keyEvent, format }) => {
 	return (
 		<li css={listItemStyles}>
-			<Link
-				priority="secondary"
-				css={linkStyles}
-				href={keyEvent.url}
-			>
+			<Link priority="secondary" css={linkStyles} href={keyEvent.url}>
 				<div css={timeTextWrapperStyles}>
 					<time
 						dateTime={keyEvent.date.toISOString()}
@@ -219,35 +208,24 @@ const ListItem: FC<ListItemProps> = ({
 					>
 						{timeAgo(keyEvent.date.getTime())}
 					</time>
-					<span css={textStyles(format)}>
-						{keyEvent.text}
-					</span>
+					<span css={textStyles(format)}>{keyEvent.text}</span>
 				</div>
 			</Link>
 		</li>
 	);
 };
 
-const KeyEvents: FC<KeyEventsProps> = ({
-	keyEvents,
-	format,
-}) => {
+const KeyEvents: FC<KeyEventsProps> = ({ keyEvents, format }) => {
 	return (
 		<nav
 			// https://github.com/guardian/dotcom-rendering/pull/3693
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- See PR above.
 			tabIndex={0}
 			id="keyevents"
-			css={keyEventWrapperStyles(
-				format,
-				keyEvents.length === 0,
-			)}
+			css={keyEventWrapperStyles(format, keyEvents.length === 0)}
 			aria-label="Key Events"
 		>
-			<Accordion
-				accordionTitle="Key events"
-				context="keyEvents"
-			>
+			<Accordion accordionTitle="Key events" context="keyEvents">
 				<ul css={listStyles(format)}>
 					{keyEvents.slice(0, 7).map((event, index) => (
 						<ListItem

--- a/apps-rendering/src/components/Layout/LiveLayout.tsx
+++ b/apps-rendering/src/components/Layout/LiveLayout.tsx
@@ -131,7 +131,6 @@ const LiveLayout: FC<Props> = ({ item }) => {
 			newer={toNullable(item.pagedBlocks.pagination.newer)}
 			oldest={toNullable(item.pagedBlocks.pagination.oldest)}
 			older={toNullable(item.pagedBlocks.pagination.older)}
-			supportsDarkMode={true}
 		/>
 	);
 
@@ -155,7 +154,6 @@ const LiveLayout: FC<Props> = ({ item }) => {
 						<KeyEvents
 							keyEvents={keyEvents(item.blocks)}
 							format={item}
-							supportsDarkMode
 						/>
 					</div>
 				</GridItem>

--- a/apps-rendering/src/components/LiveBlock/index.tsx
+++ b/apps-rendering/src/components/LiveBlock/index.tsx
@@ -34,7 +34,6 @@ const LiveBlock: FC<LiveBlockProps> = ({
 			blockId={block.id}
 			isPinnedPost={isPinnedPost}
 			isOriginalPinnedPost={isOriginalPinnedPost}
-			supportsDarkMode={true}
 			contributors={block.contributors}
 			isLiveUpdate={false}
 			edition={edition}

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -4,7 +4,6 @@ import {
 	background,
 	border,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	body,
@@ -18,6 +17,7 @@ import type { Contributor } from 'contributor';
 import type { Image } from 'image';
 import { Optional } from 'optional';
 import type { FC, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 type Props = {
 	id: string;

--- a/apps-rendering/src/components/LiveBlockContainer/index.tsx
+++ b/apps-rendering/src/components/LiveBlockContainer/index.tsx
@@ -4,7 +4,7 @@ import {
 	background,
 	border,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	body,
@@ -29,7 +29,6 @@ type Props = {
 	isLiveUpdate: boolean;
 	contributors: Contributor[];
 	isPinnedPost: boolean;
-	supportsDarkMode: boolean;
 	isOriginalPinnedPost: boolean;
 	edition: Edition;
 };
@@ -116,7 +115,6 @@ const LiveBlockContainer: FC<Props> = ({
 	isLiveUpdate,
 	contributors,
 	isPinnedPost,
-	supportsDarkMode,
 	isOriginalPinnedPost,
 	edition,
 }) => {
@@ -152,7 +150,7 @@ const LiveBlockContainer: FC<Props> = ({
 					padding-left: ${LEFT_MARGIN_DESKTOP}px;
 				}
 
-				${darkModeCss(supportsDarkMode)`
+				${darkModeCss`
 					border-top: 1px solid ${border.liveBlockDark(format)};
 					background-color: ${neutral[10]};
 					color: ${neutral[100]};
@@ -165,7 +163,6 @@ const LiveBlockContainer: FC<Props> = ({
 					firstPublished={blockFirstPublished}
 					blockId={blockId}
 					isPinnedPost={isPinnedPost}
-					supportsDarkMode={supportsDarkMode}
 					isOriginalPinnedPost={isOriginalPinnedPost}
 					format={format}
 					edition={edition}

--- a/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
+++ b/apps-rendering/src/components/MainMedia/ImmersiveCaption.tsx
@@ -60,7 +60,6 @@ const ImmersiveCaption: FC<Props> = ({ mainMedia, format }) =>
 				<CaptionIcon
 					variant={CaptionIconVariant.Image}
 					format={format}
-					supportsDarkMode={true}
 				/>
 				<Caption caption={caption} format={format} />{' '}
 				{maybeRender(credit, (cred) => (

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/GalleryMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/GalleryMainMediaImage.tsx
@@ -55,7 +55,6 @@ const GalleryMainMediaImage: FC<Props> = ({ image, format }) => (
 			sizes={getSizes(image)}
 			className={some(imgStyles)}
 			format={format}
-			supportsDarkMode
 			lightbox={some({
 				className: 'js-launch-slideshow',
 				caption: image.nativeCaption,

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/ImmersiveMainMediaImage.tsx
@@ -55,7 +55,6 @@ const ImmersiveMainMediaImage: FC<Props> = ({ image, format }) => (
 			sizes={getSizes(image)}
 			className={some(imgStyles)}
 			format={format}
-			supportsDarkMode
 			lightbox={some({
 				className: 'js-launch-slideshow',
 				caption: image.nativeCaption,

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/MainMediaImage.defaults.tsx
@@ -69,7 +69,6 @@ const DefaultMainMediaImage: FC<DefaultProps> = ({
 			sizes={sizes}
 			className={imgCss}
 			format={format}
-			supportsDarkMode
 			lightbox={some({
 				className: 'js-launch-slideshow',
 				caption: image.nativeCaption,

--- a/apps-rendering/src/components/MainMedia/MainMediaImage/NewsletterSignupMainMediaImage.tsx
+++ b/apps-rendering/src/components/MainMedia/MainMediaImage/NewsletterSignupMainMediaImage.tsx
@@ -38,7 +38,6 @@ const NewsletterSignupMainMediaImage: FC<Props> = ({ image, format }) => (
 			sizes={sizes}
 			className={some(styles)}
 			format={format}
-			supportsDarkMode
 			lightbox={none}
 		/>
 	</figure>

--- a/apps-rendering/src/components/Pagination/Pagination.stories.tsx
+++ b/apps-rendering/src/components/Pagination/Pagination.stories.tsx
@@ -27,7 +27,6 @@ export const notFirstPage = (): ReactElement => {
 					currentPage={2}
 					totalPages={6}
 					format={format}
-					supportsDarkMode
 					key={formatToString(format)}
 				/>
 			))}
@@ -46,7 +45,6 @@ export const firstPageStory = (): ReactElement => {
 					currentPage={1}
 					totalPages={4}
 					format={format}
-					supportsDarkMode
 					key={formatToString(format)}
 				/>
 			))}

--- a/apps-rendering/src/components/Pagination/index.tsx
+++ b/apps-rendering/src/components/Pagination/index.tsx
@@ -5,7 +5,7 @@ import {
 	hover,
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from '@guardian/common-rendering/src/lib';
+import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, space, textSans, until } from '@guardian/source-foundations';
 import {
@@ -26,7 +26,6 @@ type Props = {
 	oldest?: string;
 	older?: string;
 	format: ArticleFormat;
-	supportsDarkMode: boolean;
 };
 
 const NavWrapper: FC<{ children: ReactNode }> = ({ children }) => (
@@ -72,15 +71,14 @@ const Bold: FC<{ children: ReactNode }> = ({ children }) => (
 
 const Position: FC<{
 	children: ReactNode;
-	supportsDarkMode: boolean;
-}> = ({ children, supportsDarkMode }) => (
+}> = ({ children }) => (
 	<div
 		css={css`
 			display: flex;
 			flex-direction: row;
 			${textSans.small()}
 
-			${darkModeCss(supportsDarkMode)`
+			${darkModeCss`
 				color: ${neutral[60]};
 			`}
 		`}
@@ -118,7 +116,6 @@ const Pagination: FC<Props> = ({
 	newest,
 	newer,
 	format,
-	supportsDarkMode,
 }) => {
 	return (
 		<NavWrapper>
@@ -161,7 +158,7 @@ const Pagination: FC<Props> = ({
 				</LinkButton>
 			</FlexSection>
 			<FlexSection>
-				<Position supportsDarkMode={supportsDarkMode}>
+				<Position>
 					<Bold>{currentPage}</Bold>
 					<Of />
 					<Bold>{totalPages}</Bold>

--- a/apps-rendering/src/components/Pagination/index.tsx
+++ b/apps-rendering/src/components/Pagination/index.tsx
@@ -5,7 +5,6 @@ import {
 	hover,
 	text,
 } from '@guardian/common-rendering/src/editorialPalette';
-import { darkModeCss } from 'styles';
 import type { ArticleFormat } from '@guardian/libs';
 import { neutral, space, textSans, until } from '@guardian/source-foundations';
 import {
@@ -17,6 +16,7 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source-react-components';
 import type { FC, ReactElement, ReactNode } from 'react';
+import { darkModeCss } from 'styles';
 
 type Props = {
 	currentPage: number;

--- a/apps-rendering/src/components/editions/avatar/index.tsx
+++ b/apps-rendering/src/components/editions/avatar/index.tsx
@@ -37,7 +37,6 @@ const Avatar: FC<Props> = ({ item }) => {
 				sizes={sizes}
 				className={some(imgStyles)}
 				format={format}
-				supportsDarkMode={false}
 				lightbox={none}
 			/>
 		)),

--- a/apps-rendering/src/components/editions/galleryImage/index.tsx
+++ b/apps-rendering/src/components/editions/galleryImage/index.tsx
@@ -210,7 +210,6 @@ const GalleryImage: FC<Props> = ({ image, format }) => {
 					sizes={sizes}
 					className={none}
 					format={format}
-					supportsDarkMode={false}
 					lightbox={some({
 						className: 'js-launch-slideshow',
 						caption: none,

--- a/apps-rendering/src/components/editions/headerMedia/index.tsx
+++ b/apps-rendering/src/components/editions/headerMedia/index.tsx
@@ -207,7 +207,6 @@ const HeaderMedia: FC<Props> = ({ item }) => {
 						className={some(
 							getImageStyle(image, format, isPicture),
 						)}
-						supportsDarkMode={false}
 						lightbox={some({
 							className: 'js-launch-slideshow js-main-image',
 							caption: none,

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -454,7 +454,6 @@ const imageRenderer = (
 		caption: maybeCaption,
 		format,
 		key,
-		supportsDarkMode: true,
 		lightbox: some({
 			className: 'js-launch-slideshow',
 			caption: nativeCaption,
@@ -611,7 +610,6 @@ const mediaAtomRenderer = (
 	};
 	const figcaption = h(FigCaption, {
 		format: format,
-		supportsDarkMode: true,
 		children: some(h(Caption, { caption, format })),
 		variant: CaptionIconVariant.Video,
 	});

--- a/common-rendering/src/lib.ts
+++ b/common-rendering/src/lib.ts
@@ -1,28 +1,10 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/react";
-import { css } from "@emotion/react";
 import type { Option } from '@guardian/types';
 import { map, withDefault } from '@guardian/types';
 import { ReactElement } from 'react';
 
 // ----- Functions ----- //
-
-const darkModeCss = (supportsDarkMode: boolean) => (
-  styles: TemplateStringsArray,
-  ...placeholders: string[]
-): SerializedStyles =>
-  supportsDarkMode
-    ? css`
-        @media (prefers-color-scheme: dark) {
-          ${styles
-            .map(
-              (style, i) => `${style}${placeholders[i] ? placeholders[i] : ""}`
-            )
-            .join("")}
-        }
-      `
-    : css``;
 
 /**
  * A convenience method for "piping" a value through a series of functions,
@@ -112,4 +94,4 @@ const maybeRender = <A>(
 
 // ----- Exports ----- //
 
-export { darkModeCss, maybeRender, pipe };
+export { maybeRender, pipe };


### PR DESCRIPTION
## Why?

Part of #6653; see #6952 for more details.

There's an existing helper in AR, so we can revert to using that one. Furthermore, we no longer need the `supportsDarkMode` prop on most components, as AR always supports dark mode.

## Changes

- Removed `darkModeCss` from common-rendering `lib`
- Removed `supportsDarkMode` from AR components as they always support dark mode
