### PR TITLE
Fix comment ad slot sizing

### DIFF
--- a/dotcom-rendering/docs/contracts/001-commercial-selectors.md
+++ b/dotcom-rendering/docs/contracts/001-commercial-selectors.md
@@ -2,6 +2,8 @@
 
 ## What is the contract?
 
+### Spacefinder
+
 We place the following classes on the container element of the article body:
 
 -   `article-body-commercial-selector` on the ArticleRenderer
@@ -13,6 +15,12 @@ Furthermore, within the article body, we add the following attributes to certain
 - `data-spacefinder-type` the underlying element `_type`
 
 These are elements spacefinder needs to know about when positioning adverts.
+
+### Comments
+
+We place this class on the container of the right column in the comments section. This is so we can measure the size of the available space to place either one or two ads:
+
+- `commentsRightColumn`
 
 ## Where is it relied upon?
 

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -484,18 +484,6 @@ type RichLinkCardType =
 	| 'external'
 	| 'news';
 
-// ----------
-// AdSlots //
-// ----------
-type AdSlotType =
-	| 'right'
-	| 'top-above-nav'
-	| 'mostpop'
-	| 'merchandising-high'
-	| 'merchandising'
-	| 'comments'
-	| 'survey';
-
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -72,7 +72,7 @@
 		"@guardian/atoms-rendering": "^25.1.5",
 		"@guardian/braze-components": "^8.1.3",
 		"@guardian/browserslist-config": "^2.0.3",
-		"@guardian/commercial-core": "^5.1.3",
+		"@guardian/commercial-core": "^5.2.1",
 		"@guardian/consent-management-platform": "11.0.0",
 		"@guardian/core-web-vitals": "^2.0.1",
 		"@guardian/discussion-rendering": "^12.0.0",

--- a/dotcom-rendering/src/web/components/AdSlot.tsx
+++ b/dotcom-rendering/src/web/components/AdSlot.tsx
@@ -287,15 +287,7 @@ export const AdSlot = ({
 			}
 		case 'comments': {
 			return (
-				<div
-					css={[
-						css`
-							position: static;
-							height: 100%;
-						`,
-						adStyles,
-					]}
-				>
+				<div css={[adStyles]}>
 					<div
 						id="dfp-ad--comments"
 						className={[
@@ -306,14 +298,7 @@ export const AdSlot = ({
 							'ad-slot--rendered',
 							'js-sticky-mpu',
 						].join(' ')}
-						css={[
-							css`
-								position: sticky;
-								top: 0;
-								width: 300px;
-							`,
-							adStyles,
-						]}
+						css={[adStyles]}
 						data-link-name="ad slot comments"
 						data-name="comments"
 						aria-hidden="true"

--- a/dotcom-rendering/src/web/components/Discussion.tsx
+++ b/dotcom-rendering/src/web/components/Discussion.tsx
@@ -50,11 +50,13 @@ const positionRelative = css`
 
 const commentIdFromUrl = () => {
 	if (typeof window === 'undefined') return;
+
 	const { hash } = window.location;
-	if (!hash) return;
 	if (!hash.includes('comment')) return;
+
 	const [, commentId] = hash.split('-');
 	if (!commentId) return;
+
 	return parseInt(commentId, 10);
 };
 
@@ -85,9 +87,7 @@ export const Discussion = ({
 	const palette = decidePalette(format);
 
 	const hasCommentsHash =
-		typeof window !== 'undefined' &&
-		window.location &&
-		window.location.hash === '#comments';
+		typeof window !== 'undefined' && window.location.hash === '#comments';
 
 	const handlePermalink = (commentId: number) => {
 		if (typeof window === 'undefined') return false;
@@ -97,6 +97,11 @@ export const Discussion = ({
 		// and reload the discussion based on the resuts
 		setHashCommentId(commentId);
 		return false;
+	};
+
+	const dispatchCommentsExpandedEvent = () => {
+		const event = new CustomEvent('comments-expanded');
+		document.dispatchEvent(event);
 	};
 
 	// Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120
@@ -195,7 +200,10 @@ export const Discussion = ({
 			{!isExpanded && (
 				<EditorialButton
 					format={format}
-					onClick={() => setIsExpanded(true)}
+					onClick={() => {
+						setIsExpanded(true);
+						dispatchCommentsExpandedEvent();
+					}}
 					icon={<SvgPlus />}
 				>
 					View more comments

--- a/dotcom-rendering/src/web/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/web/components/DiscussionLayout.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDisplay } from '@guardian/libs';
 import { from } from '@guardian/source-foundations';
-import { AdSlot } from './AdSlot';
+import { AdSlot, labelStyles } from './AdSlot';
 import { DiscussionContainer } from './DiscussionContainer.importable';
 import { DiscussionMeta } from './DiscussionMeta.importable';
 import { Flex } from './Flex';
@@ -33,6 +33,7 @@ export const DiscussionLayout = ({
 	idApiUrl,
 }: Props) => {
 	const hideAd = isAdFreeUser || shouldHideAds;
+
 	return (
 		<>
 			<Section
@@ -58,7 +59,7 @@ export const DiscussionLayout = ({
 						: 'compact'
 				}
 			>
-				<Flex>
+				<Flex gap="20px">
 					<div
 						css={css`
 							${from.leftCol} {
@@ -86,24 +87,27 @@ export const DiscussionLayout = ({
 							/>
 						</Island>
 					</div>
-					<>
-						{!hideAd && (
-							<RightColumn>
-								<div
-									css={css`
-										position: static;
+					{!hideAd && (
+						<RightColumn>
+							<div
+								className="commentsRightColumn"
+								css={[
+									css`
+										display: flex;
+										flex-direction: column;
+										gap: 100vh;
 										height: 100%;
-										padding-left: 20px;
-									`}
-								>
-									<AdSlot
-										position="comments"
-										display={format.display}
-									/>
-								</div>
-							</RightColumn>
-						)}
-					</>
+									`,
+									labelStyles,
+								]}
+							>
+								<AdSlot
+									position="comments"
+									display={format.display}
+								/>
+							</div>
+						</RightColumn>
+					)}
 				</Flex>
 			</Section>
 		</>

--- a/dotcom-rendering/src/web/components/Flex.tsx
+++ b/dotcom-rendering/src/web/components/Flex.tsx
@@ -4,18 +4,21 @@ type Props = {
 	children: React.ReactNode;
 	direction?: 'row' | 'column';
 	justify?: 'space-between' | 'flex-start'; // Extend as required
+	gap?: 'initial' | string;
 };
 
 export const Flex = ({
 	children,
 	direction = 'row',
 	justify = 'space-between',
+	gap = 'initial',
 }: Props) => (
 	<div
 		css={css`
 			display: flex;
 			flex-direction: ${direction};
 			justify-content: ${justify};
+			gap: ${gap};
 			/* Fixes IE 10/11 bug that collapses this container by default: */
 			/* stylelint-disable-next-line property-no-vendor-prefix */
 			-ms-flex-positive: 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-2.0.3.tgz#1c8b832ab564b257f8146ca1b3183b7683026ec9"
   integrity sha512-mALAjz+4Hb2zLxfVz11PSKp6410boWqf0FFYhgzMKOhby0bZjfEKsQIH//U15M5ELibIMG1ryHSP/SFV4C2ovg==
 
-"@guardian/commercial-core@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.1.3.tgz#f7e845d8ae6e8ee6eaaf51fcce3400d94db81a59"
-  integrity sha512-B7Sa7O0zHHP3jN36XdGHOZ9fAgjEMfRYuRURqX+ziiJE8+lmr7rkLX3MLgbYUJCIUfhagNkj559JZDXTLQoZ6g==
+"@guardian/commercial-core@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.2.1.tgz#8b36cea466f4232f1bc06df9fe1efbbfd141d089"
+  integrity sha512-IH5K9j1DUXyDXoFsp6Ve+/wMkzmcislfU3Hh6y4TM8L5INmxoUnRETiySjEjP2uVY6FLhrxYqQqgXd8rbnAOKg==
   dependencies:
     type-fest "2.12.2"
 
@@ -5008,7 +5008,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10", "@types/serve-static@^1.13.9":
+"@types/serve-static@*", "@types/serve-static@^1.13.10":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
@@ -5033,11 +5033,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/source-list-map@*":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
-  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -5048,7 +5043,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/tapable@^1", "@types/tapable@^1.0.5":
+"@types/tapable@^1.0.5":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
@@ -5119,26 +5114,14 @@
     "@types/node" "*"
     webpack "^5"
 
-"@types/webpack-sources@*":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
-  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.8", "@types/webpack@^5.28.0":
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
+  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
   dependencies:
     "@types/node" "*"
-    "@types/source-list-map" "*"
-    source-map "^0.7.3"
-
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
-  version "4.41.33"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
-  integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
-  dependencies:
-    "@types/node" "*"
-    "@types/tapable" "^1"
-    "@types/uglify-js" "*"
-    "@types/webpack-sources" "*"
-    anymatch "^3.0.0"
-    source-map "^0.6.0"
+    tapable "^2.2.0"
+    webpack "^5"
 
 "@types/ws@^8.5.1":
   version "8.5.4"
@@ -6081,7 +6064,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -19847,35 +19830,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
-  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
-
-type-fest@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
-  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+type-fest@2.12.2, type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^2.8.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

- Dispatch an event when the "View more comments" button is clicked, so that commercial code can listen and insert an ad slot upon this event.
- Remove the sticky element from the comments ad slot. The new ad inserted underneath this ad will be sticky to compensate.
- Remove redundant `AdSlotType` type.

## Why?

We are changing our ad strategy in the comments section on desktop. 

BEFORE: we have one sticky comments advert that can be tall (half-page, skyscrape) or small (MPU)
AFTER: we will have a non-sticky comments ad that is small and a sticky comments-expanded ad that will load once there is room for it (when the "View more comments" button is clicked).

Benefits:
- No more unexpected whitespace when a tall ad loads in the comments slot
- Some compensation in ad revenue from the extra ad, as we expect to lose out on some ad revenue from limiting the types of ad size in the comments ad slot to small ads.

## Screenshots

Before

![CommentAdvertTooTall](https://user-images.githubusercontent.com/9574885/214617150-9cc8c35f-452c-426b-abe2-02337126ca92.jpeg)

After

https://user-images.githubusercontent.com/9574885/214617174-14f62f50-139e-40d5-9a68-26a3f653c1da.mov


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
