### PR TITLE
make `@guardian/dotcom-platform` owner of `apps-rendering/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 *			@guardian/dotcom-platform @guardian/apps-rendering
-/apps-rendering/	@guardian/apps-rendering
-/dotcom-rendering/	@guardian/dotcom-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*			@guardian/dotcom-platform @guardian/apps-rendering
+*			@guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

- Makes team `@guardian/dotcom-platform` code owners of the whole repository, as `/apps-rendering` is now being maintained by the `@guardian/dotcom-platform` team

