### PR TITLE
Run lighthouse action in parallel

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     paths-ignore:
-      - "apps-rendering/**"
-      - "dotcom-rendering/docs/**"
+      - 'apps-rendering/**'
+      - 'dotcom-rendering/docs/**'
 
   # We need to run on "pull_request" to get the PR number in the event.
   # When running on "push", we cannot add a comment to a specific PR.
@@ -19,6 +19,12 @@ jobs:
   lhci:
     name: DCR Lighthouse
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'
+          - 'http://localhost:9000/Front?url=https://www.theguardian.com/uk'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -32,6 +38,7 @@ jobs:
         working-directory: dotcom-rendering
         env:
           LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+          LHCI_URL: ${{ matrix.group }}
         run: |
           npm install -g puppeteer-core@2.1.0 @lhci/cli@0.8.2
           lhci autorun
@@ -42,6 +49,7 @@ jobs:
           deno-version: v1.21.0
 
       - name: Surface Lighthouse Results
-        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH" --allow-read scripts/deno/surface-lighthouse-results.ts
+        run: deno run --no-check --allow-net=api.github.com --allow-env="GITHUB_TOKEN","GITHUB_EVENT_PATH","LHCI_URL" --allow-read scripts/deno/surface-lighthouse-results.ts
         env:
+          LHCI_URL: ${{ matrix.group }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dotcom-rendering/lighthouserc.js
+++ b/dotcom-rendering/lighthouserc.js
@@ -1,10 +1,7 @@
 module.exports = {
 	ci: {
 		collect: {
-			url: [
-				'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads',
-				'http://localhost:9000/Front?url=https://www.theguardian.com/uk',
-			],
+			url: [process.env.LHCI_URL],
 			startServerCommand:
 				'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
 			numberOfRuns: '10',
@@ -43,7 +40,7 @@ module.exports = {
 					assertions: {
 						'total-blocking-time': [
 							'warn',
-							{ maxNumericValue: 219 }
+							{ maxNumericValue: 219 },
 						],
 						'categories:accessibility': [
 							'error',
@@ -56,7 +53,7 @@ module.exports = {
 					assertions: {
 						'total-blocking-time': [
 							'warn',
-							{ maxNumericValue: 716 }
+							{ maxNumericValue: 716 },
 						],
 						'categories:accessibility': [
 							'warn',

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -67,7 +67,7 @@ const results: AssertionResult[] = JSON.parse(
 /* -- Definitions -- */
 
 /** The string to search for when looking for a comment */
-const IDENTIFIER_COMMENT = `<-- url: ${Deno.env.get('LHCI_URL')} -->`;
+const IDENTIFIER_COMMENT = `<!-- url: ${Deno.env.get('LHCI_URL')} -->`;
 const GIHUB_PARAMS = {
 	owner: 'guardian',
 	repo: 'dotcom-rendering',

--- a/scripts/deno/surface-lighthouse-results.ts
+++ b/scripts/deno/surface-lighthouse-results.ts
@@ -42,10 +42,6 @@ console.log(`Using issue #${issue_number}`);
 /** The Lighthouse results directory  */
 const dir = 'dotcom-rendering/.lighthouseci';
 
-const links: Record<string, string> = JSON.parse(
-	Deno.readTextFileSync(`${dir}/links.json`),
-);
-
 /** https://github.com/GoogleChrome/lighthouse-ci/blob/5963dcce0e88b8d3aedaba56a93ec4b93cf073a1/packages/utils/src/assertions.js#L15-L30 */
 interface AssertionResult {
 	url: string;
@@ -71,7 +67,7 @@ const results: AssertionResult[] = JSON.parse(
 /* -- Definitions -- */
 
 /** The string to search for when looking for a comment */
-const REPORT_TITLE = '⚡️ Lighthouse report';
+const IDENTIFIER_COMMENT = `<-- url: ${Deno.env.get('LHCI_URL')} -->`;
 const GIHUB_PARAMS = {
 	owner: 'guardian',
 	repo: 'dotcom-rendering',
@@ -104,8 +100,6 @@ const generateAuditTable = (
 	auditUrl: string,
 	results: AssertionResult[],
 ): string => {
-	const reportUrl = links[auditUrl];
-
 	const resultsTemplateString = results.map(
 		({ auditTitle, auditProperty, passed, expected, actual, level }) =>
 			`| ${auditTitle ?? auditProperty ?? 'Unknown Test'} | ${getStatus(
@@ -114,16 +108,14 @@ const generateAuditTable = (
 			)} | ${expected} | ${formatNumber(expected, actual)} |`,
 	);
 
-	const [endpoint, testUrlClean] = auditUrl.split('?url=');
+	const [, testUrlClean] = Deno.env.get('LHCI_URL').split('?url=');
 
 	const table = [
-		`### [Report for ${endpoint.split('/').slice(-1)}](${reportUrl})`,
 		`> tested url \`${testUrlClean}\``,
 		'',
 		'| Category | Status | Expected | Actual |',
 		'| --- | --- | --- | --- |',
 		...resultsTemplateString,
-		'',
 	].join('\n');
 
 	return table;
@@ -132,20 +124,18 @@ const generateAuditTable = (
 const createLighthouseResultsMd = (): string => {
 	const auditCount = results.length;
 	const failedAuditCount = results.filter((result) => !result.passed).length;
-	const auditUrls = [...new Set<string>(results.map((result) => result.url))];
+	const reportUrl = results[0].url;
+
+	const [endpoint] = Deno.env.get('LHCI_URL').split('?url=');
 
 	return [
-		`## ${REPORT_TITLE} for the changes in this PR`,
-		`Lighthouse tested ${auditUrls.length} URLs  `,
+		IDENTIFIER_COMMENT,
+		`## ⚡️ Lighthouse report for the changes in this PR`,
+		`### [Report for ${endpoint.split('/').slice(-1)}](${reportUrl})`,
 		failedAuditCount > 0
 			? `⚠️ Budget exceeded for ${failedAuditCount} of ${auditCount} audits.`
 			: 'All audits passed',
-		...auditUrls.map((url) =>
-			generateAuditTable(
-				url,
-				results.filter((result) => result.url === url),
-			),
-		),
+		generateAuditTable(reportUrl, results),
 	].join('\n\n');
 };
 
@@ -156,7 +146,7 @@ const getCommentID = async (): Promise<number | null> => {
 	});
 
 	const comment = comments.find((comment) =>
-		comment.body?.includes(REPORT_TITLE),
+		comment.body?.includes(IDENTIFIER_COMMENT),
 	);
 
 	return comment?.id ?? null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR updates the 'DCR Lighthouse' action to run in parallel, similar to how cypress works.

Currently the action takes ~10mins on average to complete, one of the longest actions we have.

Comment changes:
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/9575458/214620474-d2d21a6a-e069-473b-8315-533fe7596750.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/9575458/214817282-efc50bdf-427a-4626-936d-c526d677c83a.png" width="300px" /> |

Time to complete:
Before: ~10mins on average
After: ~7 mins on average


