### PR TITLE
Refactor kicker to block level component

### DIFF
--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -13,7 +13,6 @@ const kickerStyles = (colour: string) => css`
 	color: ${colour};
 	font-weight: 700;
 	margin-right: 4px;
-	display: inline-block;
 `;
 
 export const Kicker = ({
@@ -23,12 +22,17 @@ export const Kicker = ({
 	hideLineBreak,
 }: Props) => {
 	return (
-		<>
-			<span css={kickerStyles(color)}>
-				{showPulsingDot && <PulsingDot colour={color} />}
-				{text}
-			</span>
-			{!hideLineBreak && <br />}
-		</>
+		<div
+			css={[
+				kickerStyles(color),
+				hideLineBreak &&
+					css`
+						display: inline-block;
+					`,
+			]}
+		>
+			{showPulsingDot && <PulsingDot colour={color} />}
+			{text}
+		</div>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Refactors the kicker component, removing the break tag and converting the kicker to a block level component. This refactor was suggested in https://github.com/guardian/dotcom-rendering/pull/7032
## Why?
Historically, the kicker component was built using a span tag. During the kicker redesign when the slash was removed and replaced by a line break, as `<br/>` tag was used to create the line break. However, as pointed out by @jamesgorrie, [br elements must not be used for separating thematic groups in a paragraph](https://www.w3.org/TR/2014/REC-html5-20141028/text-level-semantics.html#the-br-element) and as the kicker and headline are seperate, they should be read as such by a screen reader. By refactoring the kicker component to use a `div`, we remove the need for the separating `<br/>` tag. 


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->
