### PR TITLE
Remove slashes from DCR

### DIFF
--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -433,26 +433,6 @@ export const WithQuotesSpecialReportAlt = () => {
 	);
 };
 
-export const WithNoSlash = () => {
-	return (
-		<CardWrapper>
-			<Card {...basicCardProps} showSlash={false} kickerText="No slash" />
-		</CardWrapper>
-	);
-};
-
-export const WithNoLinebreak = () => {
-	return (
-		<CardWrapper>
-			<Card
-				{...basicCardProps}
-				hideLineBreak={true}
-				kickerText="No linebreak"
-			/>
-		</CardWrapper>
-	);
-};
-
 export const WithAnAvatar = () => {
 	return (
 		<>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -58,10 +58,6 @@ export type Props = {
 	showMainVideo?: boolean;
 	kickerText?: string;
 	showPulsingDot?: boolean;
-	/** Sometimes kickers and headlines are separated by a slash */
-	showSlash?: boolean;
-	/** Sometimes kickers and headlines are separated by a linebreak */
-	hideLineBreak?: boolean;
 	starRating?: number;
 	minWidthInPixels?: number;
 	/** Used for Ophan tracking */
@@ -233,8 +229,6 @@ export const Card = ({
 	showMainVideo,
 	kickerText,
 	showPulsingDot,
-	showSlash,
-	hideLineBreak,
 	starRating,
 	minWidthInPixels,
 	dataLinkName,
@@ -414,11 +408,6 @@ export const Card = ({
 								format.design === ArticleDesign.LiveBlog ||
 								showPulsingDot
 							}
-							showSlash={
-								format.design === ArticleDesign.LiveBlog ||
-								showSlash
-							}
-							hideLineBreak={hideLineBreak}
 							byline={byline}
 							showByline={showByline}
 							isDynamo={isDynamo}

--- a/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.stories.tsx
@@ -211,23 +211,7 @@ export const liveStory = () => (
 );
 liveStory.story = { name: 'With Live kicker' };
 
-export const noSlash = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with no kicker slash looks"
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			}}
-			kickerText="Live"
-			showSlash={false}
-		/>
-	</Section>
-);
-noSlash.story = { name: 'With Live kicker but no slash' };
-
-export const noLinebreak = () => (
+export const noLineBreak = () => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<CardHeadline
 			headlineText="This is how a card headline with no kicker linebreak looks"
@@ -241,7 +225,7 @@ export const noLinebreak = () => (
 		/>
 	</Section>
 );
-noSlash.story = { name: 'With Live kicker but no slash' };
+noLineBreak.story = { name: 'With Live kicker but no line break' };
 
 export const pulsingDot = () => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
@@ -308,7 +292,6 @@ export const OpinionKicker = () => (
 						}}
 						showQuotes={true}
 						kickerText="George Monbiot"
-						showSlash={true}
 						size={size}
 					/>
 				</Section>
@@ -335,7 +318,6 @@ export const SpecialReport = () => (
 			}}
 			showQuotes={true}
 			kickerText="Special Report"
-			showSlash={true}
 		/>
 	</Section>
 );
@@ -352,7 +334,6 @@ export const Busy = () => (
 			}}
 			showQuotes={true}
 			kickerText="Aerial Yoga"
-			showSlash={true}
 		/>
 	</Section>
 );

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -26,7 +26,6 @@ type Props = {
 	containerPalette?: DCRContainerPalette;
 	kickerText?: string;
 	showPulsingDot?: boolean;
-	showSlash?: boolean;
 	hideLineBreak?: boolean;
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
 	size?: SmallHeadlineSize;
@@ -233,7 +232,6 @@ export const CardHeadline = ({
 	showQuotes,
 	kickerText,
 	showPulsingDot,
-	showSlash,
 	hideLineBreak,
 	size = 'medium',
 	sizeOnMobile,
@@ -274,7 +272,6 @@ export const CardHeadline = ({
 							text={kickerText}
 							color={kickerColour}
 							showPulsingDot={showPulsingDot}
-							showSlash={showSlash}
 							hideLineBreak={hideLineBreak}
 						/>
 					)}

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -35,7 +35,6 @@ export const FrontCard = (props: Props) => {
 		webPublicationDate: trail.webPublicationDate,
 		kickerText: trail.kickerText,
 		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,
-		showSlash: true,
 		showClock: false,
 		imageUrl: trail.image,
 		isCrossword: trail.isCrossword,

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
 import { PulsingDot } from './PulsingDot.importable';
 
 // Defines a prefix to be used with a headline (e.g. 'Live /')
@@ -7,7 +6,6 @@ type Props = {
 	text: string;
 	color: string;
 	showPulsingDot?: boolean;
-	showSlash?: boolean;
 	hideLineBreak?: boolean;
 };
 
@@ -22,7 +20,6 @@ export const Kicker = ({
 	text,
 	color,
 	showPulsingDot,
-	showSlash = true,
 	hideLineBreak,
 }: Props) => {
 	return (

--- a/dotcom-rendering/src/web/components/Kicker.tsx
+++ b/dotcom-rendering/src/web/components/Kicker.tsx
@@ -18,14 +18,6 @@ const kickerStyles = (colour: string) => css`
 	display: inline-block;
 `;
 
-const slashStyles = css`
-	&::after {
-		content: '/';
-		display: inline-block;
-		margin-left: 4px;
-	}
-`;
-
 export const Kicker = ({
 	text,
 	color,
@@ -33,31 +25,13 @@ export const Kicker = ({
 	showSlash = true,
 	hideLineBreak,
 }: Props) => {
-	const [removeKickerSlash, setRemoveKickerSlash] = useState(false);
-
-	useEffect(() => {
-		setRemoveKickerSlash(
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- window not available on server
-			window?.guardian.config.tests.removeKickerSlashesVariant ===
-				'variant',
-		);
-	}, []);
-
-	if (removeKickerSlash) {
-		return (
-			<>
-				<span css={kickerStyles(color)}>
-					{showPulsingDot && <PulsingDot colour={color} />}
-					{text}
-				</span>
-				{!hideLineBreak && <br />}
-			</>
-		);
-	}
 	return (
-		<span css={kickerStyles(color)}>
-			{showPulsingDot && <PulsingDot colour={color} />}
-			<span css={showSlash && slashStyles}>{text}</span>
-		</span>
+		<>
+			<span css={kickerStyles(color)}>
+				{showPulsingDot && <PulsingDot colour={color} />}
+				{text}
+			</span>
+			{!hideLineBreak && <br />}
+		</>
 	);
 };

--- a/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.stories.tsx
@@ -42,27 +42,10 @@ export const liveStory = () => (
 );
 liveStory.story = { name: 'With Live kicker' };
 
-// TODO remove after test
-export const noSlash = () => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a headline with no kicker slash looks"
-			format={{
-				display: ArticleDisplay.Standard,
-				design: ArticleDesign.Standard,
-				theme: ArticlePillar.News,
-			}}
-			kickerText="Live"
-			showSlash={false}
-		/>
-	</Section>
-);
-noSlash.story = { name: 'With Live kicker but no slash' };
-
 export const noLinebreak = () => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
-			headlineText="This is how a headline with no line break looks"
+			headlineText="This is how a headline with no kicker line break looks"
 			format={{
 				display: ArticleDisplay.Standard,
 				design: ArticleDesign.Standard,
@@ -134,7 +117,6 @@ export const OpinionKicker = () => (
 			}}
 			showQuotes={true}
 			kickerText="George Monbiot"
-			showSlash={true}
 		/>
 	</Section>
 );
@@ -151,7 +133,6 @@ export const SpecialReport = () => (
 			}}
 			showQuotes={true}
 			kickerText="Special Report"
-			showSlash={true}
 		/>
 	</Section>
 );
@@ -169,7 +150,6 @@ export const InUnderlinedState = () => (
 			showUnderline={true}
 			size="small"
 			kickerText="I am never underlined"
-			showSlash={true}
 			link={{
 				to: 'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
 			}}
@@ -188,7 +168,6 @@ export const linkStory = () => (
 				theme: ArticlePillar.Sport,
 			}}
 			kickerText="I am not a link"
-			showSlash={true}
 			link={{
 				to: 'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
 			}}
@@ -208,7 +187,6 @@ export const LiveBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Large live"
-			showSlash={true}
 			showPulsingDot={true}
 			size="large"
 		/>
@@ -222,7 +200,6 @@ export const LiveBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Medium live"
-			showSlash={true}
 			showPulsingDot={true}
 			size="medium"
 		/>
@@ -236,7 +213,6 @@ export const LiveBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Small live"
-			showSlash={true}
 			showPulsingDot={true}
 			size="small"
 		/>
@@ -250,7 +226,6 @@ export const LiveBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Tiny live"
-			showSlash={true}
 			showPulsingDot={true}
 			size="tiny"
 		/>
@@ -269,7 +244,6 @@ export const DeadBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Large dead"
-			showSlash={true}
 			showPulsingDot={false}
 			size="large"
 		/>
@@ -283,7 +257,6 @@ export const DeadBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Medium dead"
-			showSlash={true}
 			showPulsingDot={false}
 			size="medium"
 		/>
@@ -297,7 +270,6 @@ export const DeadBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Small dead"
-			showSlash={true}
 			showPulsingDot={false}
 			size="small"
 		/>
@@ -311,7 +283,6 @@ export const DeadBlogSizes = () => (
 			}}
 			showQuotes={true}
 			kickerText="Tiny dead"
-			showSlash={true}
 			showPulsingDot={false}
 			size="tiny"
 		/>
@@ -329,7 +300,6 @@ export const Updated = () => (
 				theme: ArticlePillar.News,
 			}}
 			showPulsingDot={true}
-			showSlash={false}
 			hideLineBreak={true}
 			kickerText="Updated 7m ago"
 			size="tiny"

--- a/dotcom-rendering/src/web/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/web/components/LinkHeadline.tsx
@@ -11,7 +11,6 @@ type Props = {
 	showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
 	kickerText?: string;
 	showPulsingDot?: boolean;
-	showSlash?: boolean;
 	hideLineBreak?: boolean;
 	showQuotes?: boolean; // When true the QuoteIcon is shown
 	size?: SmallHeadlineSize;
@@ -71,7 +70,6 @@ export const LinkHeadline = ({
 	showUnderline = false,
 	kickerText,
 	showPulsingDot,
-	showSlash,
 	hideLineBreak,
 	showQuotes = false,
 	size = 'medium',
@@ -87,7 +85,6 @@ export const LinkHeadline = ({
 					text={kickerText}
 					color={palette.text.linkKicker}
 					showPulsingDot={showPulsingDot}
-					showSlash={showSlash}
 					hideLineBreak={hideLineBreak}
 				/>
 			)}

--- a/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedFooterItem.tsx
@@ -93,7 +93,6 @@ export const MostViewedFooterItem = ({
 						format={format}
 						size="small"
 						kickerText="Live"
-						showSlash={true}
 						hideLineBreak={false}
 						showPulsingDot={true}
 						showQuotes={false}

--- a/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/web/components/MostViewedRightItem.tsx
@@ -99,7 +99,6 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 								size="small"
 								showUnderline={isHovered}
 								kickerText="Live"
-								showSlash={false}
 								hideLineBreak={true}
 								byline={
 									trail.showByline ? trail.byline : undefined

--- a/dotcom-rendering/src/web/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.tsx
@@ -131,7 +131,6 @@ export const SupportingContent = ({
 						<CardHeadline
 							format={subLink.format}
 							size="tiny"
-							showSlash={false}
 							hideLineBreak={true}
 							showLine={true}
 							linkTo={subLink.url}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR moves the slash design change from behind its 0% opt in test. It also removes the slash css code and the showSlash prop which is no longer necessary. 

As per the designs, we now have a line break where components formally had a slash. The Card component previously had a showSlash prop but it was not being used. As such, we have not implemented a hideLineBreak prop on this component as it also not be used - the card component's kicker is always followed by a line break as designs currently stand.

## Screenshots

![Screenshot 2023-01-30 at 14 22 16](https://user-images.githubusercontent.com/20416599/215503594-d019759b-b653-4b07-8c28-2f29bfdb1feb.png)
![Screenshot 2023-01-30 at 14 22 08](https://user-images.githubusercontent.com/20416599/215503603-c29892c1-62ee-4fc9-a1e4-3866e048aa0e.png)
![Screenshot 2023-01-30 at 14 27 14](https://user-images.githubusercontent.com/20416599/215504799-5ed8b7e8-f206-478e-93e0-ec277a46f226.png)

