### PR TITLE
chore(ophan): track edition data in Ophan

### DIFF
--- a/dotcom-rendering/src/web/browser/ophan/init.ts
+++ b/dotcom-rendering/src/web/browser/ophan/init.ts
@@ -1,12 +1,20 @@
 import '../webpackPublicPath';
 import { startup } from '../startup';
-import { recordPerformance, sendOphanPlatformRecord } from './ophan';
+import { abTestPayload, record, recordPerformance } from './ophan';
 
 // side effect only
 import 'ophan-tracker-js';
 
 const init = (): Promise<void> => {
-	sendOphanPlatformRecord();
+	record({ experiences: 'dotcom-rendering' });
+	record({ edition: window.guardian.config.page.edition });
+
+	// Record server-side AB test variants (i.e. control or variant)
+	if (window.guardian.config.tests) {
+		const { tests } = window.guardian.config;
+		record(abTestPayload(tests));
+	}
+
 	// We wait for the load event so that we can be sure our assetPerformance is reported as expected.
 	window.addEventListener('load', function load() {
 		recordPerformance();

--- a/dotcom-rendering/src/web/browser/ophan/ophan.ts
+++ b/dotcom-rendering/src/web/browser/ophan/ophan.ts
@@ -87,17 +87,6 @@ export const abTestPayload = (tests: ServerSideTests): OphanABPayload => {
 	return { abTestRegister: records };
 };
 
-export const sendOphanPlatformRecord = (): void => {
-	record({ experiences: 'dotcom-rendering' });
-
-	// Record server-side AB test variants (i.e. control or variant)
-	if (window.guardian.config.tests) {
-		const { tests } = window.guardian.config;
-
-		record(abTestPayload(tests));
-	}
-};
-
 export const recordPerformance = (): void => {
 	const { performance: performanceAPI } = window;
 	const supportsPerformanceProperties =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `edition` to the Ophan tracking.

This is based on the [this good work](https://github.com/guardian/ophan/pull/5163/files) (ping @aaronp for interest).

Once this is confirmed to work, we can add it to frontend.

Mini refactor - I've remove the methods from the `ophan` module and added them directly to the init script as to avoid calling them outside of that context. `sendOphanPlatformRecord` was also being overloaded with the test record so was a little unclear. 