### PR TITLE
Remove unused cmp tracking in GA

### DIFF
--- a/dotcom-rendering/src/web/browser/bootCmp/init.ts
+++ b/dotcom-rendering/src/web/browser/bootCmp/init.ts
@@ -11,30 +11,6 @@ import { injectPrivacySettingsLink } from '../../lib/injectPrivacySettingsLink';
 import { submitComponentEvent } from '../ophan/ophan';
 import { startup } from '../startup';
 
-const trackPerformance = (
-	timingCategory: string,
-	timingVar: any,
-	timingLabel: string,
-): void => {
-	const { ga } = window;
-
-	if (!ga) {
-		return;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- not supported in all browsers
-	if (window.performance?.now) {
-		ga(
-			'allEditorialPropertyTracker.send',
-			'timing',
-			timingCategory,
-			timingVar,
-			Math.round(window.performance.now()),
-			timingLabel,
-		);
-	}
-};
-
 const init = async (): Promise<void> => {
 	/**
 	 * Keep this file in sync with CONSENT_TIMING in static/src/javascripts/boot.js in frontend
@@ -43,19 +19,6 @@ const init = async (): Promise<void> => {
 	if (!window.guardian.config.switches.consentManagement) return; // CMP turned off!
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 	const { pageViewId } = window.guardian.config.ophan;
-
-	// Track when CMP will show with GA
-	cmp.willShowPrivacyMessage()
-		.then((willShow) => {
-			trackPerformance(
-				'consent',
-				'acquired',
-				willShow ? 'new' : 'existing',
-			);
-		})
-		.catch((e) =>
-			log('dotcom', `CMP willShowPrivacyMessage - error: ${String(e)}`),
-		);
 
 	onConsentChange((consentState: ConsentState) => {
 		if (!consentState) return;


### PR DESCRIPTION
currently, we try to record whether consent (if granted) is new or had been previously granted by checking whether sourcepoint will show the banner, using `willShowPrivacyMessage`.

this fires _before_ the `onConsentChange` callback

BUT, we rely on the consent state passed by `onConsentChange` to determine whether we can run GA. 

therefore, any code that tries to _use_GA before then will never run - this is the case with the current code based on `willShowPrivacyMessage`.

I think this has been true since #3413, so about 18 months. I'm guessing this info is not be tracked so should be safe to delete. does it sound ok to you @guardian/transparency-consent?