### PR TITLE
feat: Support `On page description` on DCR Fronts

### DIFF
--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -17,8 +17,9 @@ export const enhanceCollections = (
 	collections: FECollectionType[],
 	editionId: EditionId,
 	pageId: string,
+	onPageDescription?: string,
 ): DCRCollectionType[] => {
-	return collections.filter(isSupported).map((collection) => {
+	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
 			collection;
 		const containerPalette = decideContainerPalette(
@@ -27,7 +28,10 @@ export const enhanceCollections = (
 		return {
 			id,
 			displayName,
-			description,
+			description:
+				onPageDescription && index === 0
+					? onPageDescription
+					: description,
 			collectionType,
 			href,
 			containerPalette,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -449,6 +449,9 @@
                         },
                         "isPaidContent": {
                             "type": "boolean"
+                        },
+                        "onPageDescription": {
+                            "type": "string"
                         }
                     },
                     "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -439,6 +439,7 @@ type FEFrontPropertiesType = {
 	isImageDisplayed: boolean;
 	commercial: Record<string, unknown>;
 	isPaidContent?: boolean;
+	onPageDescription?: string;
 };
 
 export type FESupportingContent = {

--- a/dotcom-rendering/src/web/server/index.ts
+++ b/dotcom-rendering/src/web/server/index.ts
@@ -56,6 +56,7 @@ const enhanceFront = (body: unknown): DCRFrontType => {
 				data.pressedPage.collections,
 				data.editionId,
 				data.pageId,
+				data.pressedPage.frontProperties.onPageDescription,
 			),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds support for `On page description` a Front control that sets the description of the first container on a page to a specified string.

## Why?

Ideally we need to support all controls before 1%, or at the very least filter out Fronts with unsupported controls from our fronts.

Fixes #6658 

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/215523082-9d940255-18c6-4047-aa11-161e0896d38f.png
[after]: https://user-images.githubusercontent.com/21217225/215522726-21676229-f375-448a-8e2b-d93c1083f901.png

https://www.theguardian.com/guardian-professional?dcr

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
