### PR TITLE
LIVE-4863 Apps rendering: Always update videos after delay (to fix bug)

### DIFF
--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -233,19 +233,35 @@ function reportNativeElementPositionChanges(): void {
 		attributeFilter: ['style'],
 	};
 	const callback = function (): void {
-		const currentAdSlots = getAdSlots();
-		const currentVideoSlots = getVideoSlots();
+		try {
+			const currentAdSlots = getAdSlots();
 
-		if (positionChanged(currentAdSlots, adSlots)) {
-			adSlots = currentAdSlots;
-			void commercialClient.updateAdverts(currentAdSlots);
+			if (positionChanged(currentAdSlots, adSlots)) {
+				adSlots = currentAdSlots;
+				void commercialClient.updateAdverts(currentAdSlots);
+			}
+		} catch (ex) {
+			console.log(`Exception updating ads ${ex}`)
 		}
 
-		if (positionChanged(currentVideoSlots, videoSlots)) {
-			videoSlots = currentVideoSlots;
-			void videoClient.updateVideos(currentVideoSlots);
+		try {
+			const currentVideoSlots = getVideoSlots();
+
+			if (positionChanged(currentVideoSlots, videoSlots)) {
+				videoSlots = currentVideoSlots;
+				void videoClient.updateVideos(currentVideoSlots);
+			}
+		} catch (ex) {
+			console.log(`Exception updating videos ${ex}`)
 		}
 	};
+
+
+	let _setTimeout = window.setTimeout;
+	// After a 3 second wait, attempt to sync up positions again
+	// This is to fix bug with Youtube embeds being 50px higher than they should be
+	// on first load of page, on Android.
+	_setTimeout(callback, 3000);
 
 	let currentAnimationFrame: number | null = null;
 	window.addEventListener(

--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -241,7 +241,7 @@ function reportNativeElementPositionChanges(): void {
 				void commercialClient.updateAdverts(currentAdSlots);
 			}
 		} catch (ex) {
-			console.log(`Exception updating ads ${ex}`)
+			logger.error(`Exception updating ads`);
 		}
 
 		try {
@@ -252,16 +252,14 @@ function reportNativeElementPositionChanges(): void {
 				void videoClient.updateVideos(currentVideoSlots);
 			}
 		} catch (ex) {
-			console.log(`Exception updating videos ${ex}`)
+			logger.error(`Exception updating videos`);
 		}
 	};
 
-
-	let _setTimeout = window.setTimeout;
 	// After a 3 second wait, attempt to sync up positions again
 	// This is to fix bug with Youtube embeds being 50px higher than they should be
 	// on first load of page, on Android.
-	_setTimeout(callback, 3000);
+	window.setTimeout(callback, 3000);
 
 	let currentAnimationFrame: number | null = null;
 	window.addEventListener(

--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -241,7 +241,7 @@ function reportNativeElementPositionChanges(): void {
 				void commercialClient.updateAdverts(currentAdSlots);
 			}
 		} catch (ex) {
-			logger.error(`Exception updating ads`);
+			logger.error('Exception updating ads');
 		}
 
 		try {
@@ -252,7 +252,7 @@ function reportNativeElementPositionChanges(): void {
 				void videoClient.updateVideos(currentVideoSlots);
 			}
 		} catch (ex) {
-			logger.error(`Exception updating videos`);
+			logger.error('Exception updating videos');
 		}
 	};
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
3 seconds after setting up native communication, do an additional position sync of videos/ads. 

This also adds fault tolerance so that a failure in updating ads does not prevent a video position update and vice versa.

## Why?
This is to fix a bug on Android where upon the first viewing of apps-rendering articles video positions are about 20 to 50 pixels higher than they should be overlapping above body text.

After doing a lot of debugging, the other ways the video positions can be updated do not seem to be triggering on Android, only the document on load callback is triggering updateVideos. However at this point, the video position is not reported in the correct place. After a 3 second delay triggering updateVideos again appears to result in the video positioning being updated correctly. 3 seconds was chosen to hopefully ensure enough time is given to allow the videos to settle in the correct position, but be short enough that most users will not have scrolled down by the time the video positions are corrected.

Link to bug ticket: https://theguardian.atlassian.net/browse/LIVE-4863


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/3285072/215851434-73505082-56e7-45c9-9ef1-33f0402e3de2.png) | ![after](https://user-images.githubusercontent.com/3285072/216079759-63929c05-d181-4efa-8640-44146d983a22.png) |

A video of the previous bad behavior. Recording starts on first view of page, the videos are misaligned, on the second time the page is viewed the videos are in the correct position.
<video src="https://user-images.githubusercontent.com/3285072/216313847-5e735ba8-3876-447c-87b7-ce0be50164b3.webm" width="200">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
