### PR TITLE
fix: remove unused sign-in gate gradient overlay

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -17,7 +17,6 @@ import {
 	bodySeparator,
 	bodyText,
 	faq,
-	firstParagraphOverlay,
 	hideElementsCss,
 	laterButton,
 	privacyLink,
@@ -294,7 +293,6 @@ export const SignInGateFakeSocial = ({
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-fake-social">
 			<style>{hideElementsCss}</style>
-			<div css={firstParagraphOverlay} />
 			<h1 css={[heading, bodyPadding]}>
 				You need to register to keep reading
 			</h1>

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -8,7 +8,6 @@ import {
 	bodySeparator,
 	bodyText,
 	faq,
-	firstParagraphOverlay,
 	headingStyles,
 	hideElementsCss,
 	laterButton,
@@ -30,7 +29,6 @@ export const SignInGateMain = ({
 	return (
 		<div css={signInGateContainer} data-cy="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
-			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>You need to register to keep reading</h1>
 			<p css={bodyBold}>
 				It’s still free to read - this is not a paywall

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -121,13 +121,6 @@ export const privacyLink = css`
 	cursor: pointer;
 `;
 
-export const firstParagraphOverlay = css`
-	margin-top: -250px;
-	width: 100%;
-	height: 250px;
-	position: absolute;
-`;
-
 /**
  * This CSS hides everything in an article, except the first two paragraphs and
  * the sign-in gate. The order in which rules are laid out matters.
@@ -138,7 +131,7 @@ export const hideElementsCss = [
         display: none;
     }`,
 	// 2. make the sign in gate and the first 2 paragraphs of the article visible
-	`#sign-in-gate, .article-body-commercial-selector p:nth-of-type(-n + 3) {
+	`#sign-in-gate, .article-body-commercial-selector > p:nth-of-type(-n + 3) {
         display: block;
     }`,
 	// 3. mask the first and second with a gradient overlay


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove unused div.

## Why?

Complete refactor from #6183