### PR TITLE
Add 100px margin to `whenVisible`

### DIFF
--- a/dotcom-rendering/src/web/browser/islands/whenVisible.ts
+++ b/dotcom-rendering/src/web/browser/islands/whenVisible.ts
@@ -1,6 +1,6 @@
 /**
- * Use this function to delay execution of something until an element is visible
- * in the viewport
+ * Use this function to delay execution of something until an element
+ * is within 100px of the viewport.
  *
  * @param element : The html element that we want to observe;
  * @param callback : This is fired when the element is visible in the viewport
@@ -10,12 +10,15 @@ export const whenVisible = (
 	callback: () => void,
 ): void => {
 	if ('IntersectionObserver' in window) {
-		const io = new IntersectionObserver(([entry]) => {
-			if (!entry?.isIntersecting) return;
-			// Disconnect this IntersectionObserver once seen
-			io.disconnect();
-			callback();
-		});
+		const io = new IntersectionObserver(
+			([entry]) => {
+				if (!entry?.isIntersecting) return;
+				// Disconnect this IntersectionObserver once seen
+				io.disconnect();
+				callback();
+			},
+			{ rootMargin: '100px' },
+		);
 
 		io.observe(element);
 	} else {


### PR DESCRIPTION
## What does this change?

Add a margin of 100px to trigger the loading of an island that’s deferred until “visible”.

## Why?

If an Island is about to enter the viewport, it’s worth starting to download its code a little earlier than once it’s actually in the viewport to reduce CLS and perceived latency.

A joint idea with @chrislomaxjones 