### PR TITLE
feat: Use human readable IDs for sections instead of UUID

### DIFF
--- a/dotcom-rendering/src/web/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/web/layouts/FrontLayout.tsx
@@ -326,7 +326,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						return (
 							<>
 								<Section
-									key={collection.id}
+									key={ophanName}
 									title="Most viewed"
 									showTopBorder={index > 0}
 									padContent={false}
@@ -338,7 +338,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									containerPalette={
 										collection.containerPalette
 									}
-									sectionId={collection.id}
+									sectionId={ophanName}
 									showDateHeader={
 										collection.config.showDateHeader
 									}
@@ -372,7 +372,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					return (
 						<>
 							<Section
-								key={collection.id}
+								key={ophanName}
 								title={collection.displayName}
 								description={collection.description}
 								showTopBorder={index > 0}
@@ -388,7 +388,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection,
 									front.isNetworkFront,
 								)}
-								sectionId={collection.id}
+								sectionId={ophanName}
 								showDateHeader={
 									collection.config.showDateHeader
 								}
@@ -413,7 +413,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											containerTitle={
 												collection.displayName
 											}
-											containerId={collection.id}
+											containerId={ophanName}
 											path={front.pressedPage.id}
 											baseUrl={front.config.ajaxUrl}
 											containerPalette={


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Use the ophan component name instead of the container ID to set the ID of the Section div.

## Why?

This makes for a nicer looking URL when linking to a specific section on a front, for example https://www.theguardian.com/uk#ukraine-invasion

The Ophan component name is a slugified version of the container displayName (eg `this-is-europe`) which makes it a decent candidate to use as an ID.



This fixes #6895

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/216072443-b3b1ef72-2de0-42bf-88fb-f6fabe9a9858.png
[after]: https://user-images.githubusercontent.com/21217225/216072179-0d81eeac-8e61-4b93-847e-17fc4f7f3f38.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
