### PR TITLE
Fix: font render on SignInGate privacy settings link

### DIFF
--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -33,7 +33,7 @@ export const SignInGateMain = ({
 			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>You need to register to keep reading</h1>
 			<p css={bodyBold}>
-				It’s still free to read - this is not a paywall
+				It’s still free to read – this is not a paywall
 			</p>
 			<p css={bodyText}>
 				We’re committed to keeping our quality reporting open. By

--- a/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
+++ b/dotcom-rendering/src/web/components/SignInGate/gateDesigns/shared.tsx
@@ -116,6 +116,8 @@ export const privacyLink = css`
 	text-underline-position: under;
 	border: 0;
 	background: transparent;
+	/* stylelint-disable-next-line property-disallowed-list */
+	font-family: inherit;
 	font-size: inherit;
 	padding: 0;
 	cursor: pointer;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

@paperboyo spotted that the privacy settings link on the sign in gate was rendering as a system font. 

This PR fixes that. 

## Why?

To make things look good. 

## Screenshots

**Before:**
<img width="303" alt="image" src="https://user-images.githubusercontent.com/32312712/216117511-83f7d3db-3cf8-47da-a493-b571b58fe75a.png">


**After:**
<img width="309" alt="image" src="https://user-images.githubusercontent.com/32312712/216117110-4bcccc6a-18cf-499a-b5fe-6f0aa9b8ceaa.png">
