### PR TITLE
Add external link icon

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -1,5 +1,5 @@
 import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
-import { DCRFrontCard } from '../../src/types/front';
+import type { DCRFrontCard } from '../../src/types/front';
 
 export const trails: [
 	DCRFrontCard,
@@ -69,6 +69,7 @@ export const trails: [
 			},
 		],
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
@@ -87,6 +88,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@2',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -104,6 +106,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@3',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -120,6 +123,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@4',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -136,6 +140,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@5',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -153,6 +158,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@6',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -171,6 +177,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@7',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -188,6 +195,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@8',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 
 	{
@@ -207,6 +215,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@9',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -225,6 +234,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@10',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -243,6 +253,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@11',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -261,6 +272,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@12',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -279,6 +291,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@1',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -297,6 +310,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@13',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -315,6 +329,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@14',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -333,6 +348,7 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@1',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -349,5 +365,6 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@15',
 		showQuotedHeadline: false,
 		showMainVideo: false,
+		isExternalLink: false,
 	},
 ];

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -193,8 +193,6 @@ export const enhanceCards = (
 			faciaCard.type === 'LinkSnap' && faciaCard.properties.href
 				? faciaCard.properties.href
 				: faciaCard.header.url;
-		console.log("enhance.ts")
-		console.log(faciaCard.cardStyle)
 
 		return {
 			format,
@@ -242,6 +240,6 @@ export const enhanceCards = (
 				faciaCard.properties.maybeContent?.elements.mediaAtoms[0]
 					?.duration,
 			showMainVideo: faciaCard.properties.showMainVideo,
-			cardStyle: faciaCard.cardStyle,
+			isExternalLink: faciaCard.card.cardStyle.type === 'ExternalLink',
 		};
 	});

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -193,6 +193,8 @@ export const enhanceCards = (
 			faciaCard.type === 'LinkSnap' && faciaCard.properties.href
 				? faciaCard.properties.href
 				: faciaCard.header.url;
+		console.log("enhance.ts")
+		console.log(faciaCard.cardStyle)
 
 		return {
 			format,
@@ -240,5 +242,6 @@ export const enhanceCards = (
 				faciaCard.properties.maybeContent?.elements.mediaAtoms[0]
 					?.duration,
 			showMainVideo: faciaCard.properties.showMainVideo,
+			cardStyle: faciaCard.cardStyle,
 		};
 	});

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -262,9 +262,7 @@ export type DCRFrontCard = {
 	mediaType?: MediaType;
 	mediaDuration?: number;
 	showMainVideo: boolean;
-	cardStyle?: {
-		type: string;
-	};
+	isExternalLink: boolean;
 };
 
 export type FESnapType = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -262,6 +262,9 @@ export type DCRFrontCard = {
 	mediaType?: MediaType;
 	mediaDuration?: number;
 	showMainVideo: boolean;
+	cardStyle?: {
+		type: string;
+	};
 };
 
 export type FESnapType = {

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -217,6 +217,23 @@ export const WithByline = () => {
 	);
 };
 
+export const WithExternalLink = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					imagePosition="right"
+					kickerText="Instagram"
+					headlineSize='huge'
+					headlineText="Follow The Guardian now"
+					isExternalLink={true}
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
 export const WithMediaType = () => {
 	return (
 		<CardGroup>

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -30,6 +30,7 @@ const basicCardProps: CardProps = {
 		'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
 	imagePosition: 'top',
 	showAge: true,
+	isExternalLink: false,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/web/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.stories.tsx
@@ -225,7 +225,7 @@ export const WithExternalLink = () => {
 					{...basicCardProps}
 					imagePosition="right"
 					kickerText="Instagram"
-					headlineSize='huge'
+					headlineSize="huge"
 					headlineText="Follow The Guardian now"
 					isExternalLink={true}
 				/>

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -73,7 +73,7 @@ export type Props = {
 	discussionId?: string;
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
-	cardStyle?: {type: string};
+	isExternalLink: boolean;
 };
 
 const StarRatingComponent = ({
@@ -257,10 +257,8 @@ export const Card = ({
 	discussionId,
 	isDynamo,
 	isCrossword,
-	cardStyle,
+	isExternalLink,
 }: Props) => {
-	console.log("card tsx")
-	console.log(cardStyle)
 	const palette = decidePalette(format, containerPalette);
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -364,6 +362,7 @@ export const Card = ({
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
+				isExternalLink={isExternalLink}
 			/>
 			<CardLayout
 				imagePosition={imagePosition}
@@ -434,7 +433,7 @@ export const Card = ({
 							byline={byline}
 							showByline={showByline}
 							isDynamo={isDynamo}
-							cardStyle={cardStyle}
+							isExternalLink={isExternalLink}
 						/>
 						{starRating !== undefined ? (
 							<StarRatingComponent

--- a/dotcom-rendering/src/web/components/Card/Card.tsx
+++ b/dotcom-rendering/src/web/components/Card/Card.tsx
@@ -73,6 +73,7 @@ export type Props = {
 	discussionId?: string;
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
 	isDynamo?: true;
+	cardStyle?: {type: string};
 };
 
 const StarRatingComponent = ({
@@ -256,7 +257,10 @@ export const Card = ({
 	discussionId,
 	isDynamo,
 	isCrossword,
+	cardStyle,
 }: Props) => {
+	console.log("card tsx")
+	console.log(cardStyle)
 	const palette = decidePalette(format, containerPalette);
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -430,6 +434,7 @@ export const Card = ({
 							byline={byline}
 							showByline={showByline}
 							isDynamo={isDynamo}
+							cardStyle={cardStyle}
 						/>
 						{starRating !== undefined ? (
 							<StarRatingComponent

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -60,7 +60,7 @@ const ExternalLink = ({
 			href={linkTo}
 			css={fauxLinkStyles}
 			data-link-name={dataLinkName}
-			aria-label={headlineText + " (opens in new tab)"}
+			aria-label={headlineText + ' (opens in new tab)'}
 			target="_blank"
 			rel="noreferrer"
 		/>

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -60,7 +60,7 @@ const ExternalLink = ({
 			href={linkTo}
 			css={fauxLinkStyles}
 			data-link-name={dataLinkName}
-			aria-label={headlineText}
+			aria-label={headlineText + " (opens in new tab)"}
 			target="_blank"
 			rel="noreferrer"
 		/>

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -22,13 +22,18 @@ type Props = {
 	headlineText: string;
 	containerPalette?: DCRContainerPalette;
 	dataLinkName?: string;
+	isExternalLink: boolean;
 };
 
-export const CardLink = ({
+const InternalLink = ({
 	linkTo,
 	headlineText,
-	dataLinkName = 'article',
-}: Props) => {
+	dataLinkName,
+}: {
+	linkTo: string;
+	headlineText: string;
+	dataLinkName?: string;
+}) => {
 	return (
 		// eslint-disable-next-line jsx-a11y/anchor-has-content -- we have an aria-label attribute describing the content
 		<a
@@ -39,3 +44,44 @@ export const CardLink = ({
 		/>
 	);
 };
+
+const ExternalLink = ({
+	linkTo,
+	headlineText,
+	dataLinkName,
+}: {
+	linkTo: string;
+	headlineText: string;
+	dataLinkName?: string;
+}) => {
+	return (
+		// eslint-disable-next-line jsx-a11y/anchor-has-content -- we have an aria-label attribute describing the content
+		<a
+			href={linkTo}
+			css={fauxLinkStyles}
+			data-link-name={dataLinkName}
+			aria-label={headlineText}
+			target="_blank"
+			rel="noreferrer"
+		/>
+	);
+};
+
+export const CardLink = ({
+	linkTo,
+	headlineText,
+	dataLinkName = 'article', //this makes sense if the link is to an article, but should this say something like "external" if it's an external link? are there any other uses/alternatives?
+	isExternalLink,
+}: Props) => {
+	return (
+		<>
+			{isExternalLink && <ExternalLink
+				linkTo={linkTo}
+				headlineText={headlineText}
+				dataLinkName={dataLinkName}/>}
+			{!isExternalLink && <InternalLink
+				linkTo={linkTo}
+				headlineText={headlineText}
+				dataLinkName={dataLinkName}/>}
+		</>
+)}

--- a/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/web/components/Card/components/CardLink.tsx
@@ -75,13 +75,20 @@ export const CardLink = ({
 }: Props) => {
 	return (
 		<>
-			{isExternalLink && <ExternalLink
-				linkTo={linkTo}
-				headlineText={headlineText}
-				dataLinkName={dataLinkName}/>}
-			{!isExternalLink && <InternalLink
-				linkTo={linkTo}
-				headlineText={headlineText}
-				dataLinkName={dataLinkName}/>}
+			{isExternalLink && (
+				<ExternalLink
+					linkTo={linkTo}
+					headlineText={headlineText}
+					dataLinkName={dataLinkName}
+				/>
+			)}
+			{!isExternalLink && (
+				<InternalLink
+					linkTo={linkTo}
+					headlineText={headlineText}
+					dataLinkName={dataLinkName}
+				/>
+			)}
 		</>
-)}
+	);
+};

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -10,7 +10,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Link } from '@guardian/source-react-components';
+import { Link , SvgExternal } from '@guardian/source-react-components';
 import React from 'react';
 import type { DCRContainerPalette } from '../../types/front';
 import type { Palette } from '../../types/palette';
@@ -198,28 +198,63 @@ const dynamoStyles = css`
 	padding: 5px;
 `;
 
+//got a couple of extra spans here to visually confirm if it's detecting the external link; will need to remove
 const WithLink = ({
 	linkTo,
 	children,
 	isDynamo,
+	isExternalLink,
 }: {
 	linkTo?: string;
 	children: React.ReactNode;
 	isDynamo?: true;
+	isExternalLink: boolean;
 }) => {
-	if (linkTo) {
+	if (linkTo && isExternalLink) {
 		return (
-			<Link
+			<>	<Link
 				href={linkTo}
+				target="_blank"
 				cssOverrides={
 					isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
 				}
 			>
 				{children}
 			</Link>
+				<span>external link</span>
+			</>
 		);
 	}
+	else if (linkTo) {
+		return (
+			<> <Link
+				href={linkTo}
+				cssOverrides={
+			isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
+		}
+	>
+				{children}
+			</Link> 
+				<span>not external</span>
+			</>);
+	}
 	return <>{children}</>;
+};
+
+
+/**
+determine if external link, if so:
+- make the link open in a new window if external
+- add the red icon at the end
+this works if the decideIfExternal function does - have confirmed using the kickertext value as a test, but
+the external link logic isn't working, not sure if linkto is the best to use and maybe cardstyle is.
+ */
+
+const decideIfExternalLink = (linkTo: string) => 
+	{if 
+		(linkTo.includes("www.theguardian.com"))
+			{return false}
+	else {return true}
 };
 
 /** Matches headlines starting with short words of 1 to 3 letters followed by a space */
@@ -248,6 +283,7 @@ export const CardHeadline = ({
 	const cleanHeadLineText = headlineText.match(isFirstWordShort)
 		? headlineText.replace(' ', ' ') // from regular to non-breaking space
 		: headlineText;
+	const isExternalLink = linkTo ? decideIfExternalLink(linkTo) : false
 	return (
 		<>
 			<h3
@@ -266,17 +302,17 @@ export const CardHeadline = ({
 					showLine && !isDynamo && lineStyles(palette),
 				]}
 			>
-				<WithLink linkTo={linkTo} isDynamo={isDynamo}>
+				<WithLink linkTo={linkTo} isDynamo={isDynamo} isExternalLink={isExternalLink}>
 					{!!kickerText && (
-						<Kicker
-							text={kickerText}
-							color={kickerColour}
-							showPulsingDot={showPulsingDot}
-							hideLineBreak={hideLineBreak}
+					<>	<Kicker
+						text={kickerText}
+						color={kickerColour}
+						showPulsingDot={showPulsingDot}
+						hideLineBreak={hideLineBreak}
 						/>
+					</>
 					)}
 					{showQuotes && <QuoteIcon colour={kickerColour} />}
-
 					<span
 						css={css`
 							color: ${isDynamo
@@ -285,17 +321,22 @@ export const CardHeadline = ({
 						`}
 						className="show-underline"
 					>
-						{cleanHeadLineText}
+						{cleanHeadLineText} 
+						{isExternalLink &&
+						<span
+							css={css`stroke:red;`}>
+							<SvgExternal size='xsmall'/>
+						</span>}
 					</span>
 				</WithLink>
 			</h3>
 			{!!byline && showByline && (
-				<Byline
-					text={byline}
-					format={format}
-					containerPalette={containerPalette}
-					size={size}
-					isCard={true}
+			<Byline
+				text={byline}
+				format={format}
+				containerPalette={containerPalette}
+				size={size}
+				isCard={true}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -35,7 +35,7 @@ type Props = {
 	showLine?: boolean; // If true a short line is displayed above, used for sublinks
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isDynamo?: true;
-	cardStyle?: {type: string};
+	isExternalLink?: boolean;
 };
 
 const fontStyles = ({
@@ -198,33 +198,16 @@ const dynamoStyles = css`
 	font-weight: ${fontWeights.medium};
 	padding: 5px;
 `;
-
-//got a couple of extra spans here to visually confirm if it's detecting the external link; will need to remove
 const WithLink = ({
 	linkTo,
 	children,
 	isDynamo,
-	isExternalLink,
 }: {
 	linkTo?: string;
 	children: React.ReactNode;
 	isDynamo?: true;
-	isExternalLink: boolean;
 }) => {
-	if (linkTo && isExternalLink) {
-		return (
-			<Link
-				href={linkTo}
-				target="_blank"
-				rel='external'
-				cssOverrides={
-						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
-					}
-				>
-				{children}
-			</Link>
-		);
-	} else if (linkTo) {
+	if (linkTo) {
 		return (
 			<Link
 				href={linkTo}
@@ -233,33 +216,15 @@ const WithLink = ({
 					}
 				>
 				{children}
+				
 			</Link>
 		);
 	}
 	return <>{children}</>;
 };
 
-/**
-determine if external link, if so:
-- make the link open in a new window if external
-- add the red icon at the end
-this works if the decideIfExternal function does - have confirmed using the kickertext value as a test, but
-the external link logic isn't working, not sure if linkto is the best to use and maybe cardstyle is.
- */
-
-// const decideIfExternalLink = (linkTo: string) => {
-// 	if (linkTo.includes('www.theguardian.com')) {
-// 		return false;
-// 	} else {
-// 		return true;
-// 	}
-// };
-
 /** Matches headlines starting with short words of 1 to 3 letters followed by a space */
 const isFirstWordShort = /^(\w{1,3}) \b/;
-
-const decideLinkType = (cardStyle?: {type: string}) => 
-{if (cardStyle == undefined || cardStyle.type == 'ExternalLink') {return true} else return false}
 
 export const CardHeadline = ({
 	headlineText,
@@ -276,7 +241,7 @@ export const CardHeadline = ({
 	showLine,
 	linkTo,
 	isDynamo,
-	cardStyle,
+	isExternalLink,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	const kickerColour = isDynamo
@@ -285,23 +250,6 @@ export const CardHeadline = ({
 	const cleanHeadLineText = headlineText.match(isFirstWordShort)
 		? headlineText.replace(' ', ' ') // from regular to non-breaking space
 		: headlineText;
-	const isExternalLink = decideLinkType(cardStyle)
-	console.log("NEW CARD")
-	console.log(headlineText)
-	console.log(format)
-	console.log(containerPalette)
-	console.log(showQuotes)
-	console.log(kickerText)
-	console.log(showPulsingDot)
-	console.log(hideLineBreak)
-	console.log(size)
-	console.log(sizeOnMobile)
-	console.log(byline)
-	console.log(showByline)
-	console.log(showLine)
-	console.log(linkTo)
-	console.log(isDynamo)
-	console.log(cardStyle)
 	return (
 		<>
 			<h3
@@ -323,7 +271,6 @@ export const CardHeadline = ({
 				<WithLink
 					linkTo={linkTo}
 					isDynamo={isDynamo}
-					isExternalLink={isExternalLink}
 				>
 					{!!kickerText && (
 						<>
@@ -351,7 +298,7 @@ export const CardHeadline = ({
 									stroke: red;
 								`}
 							>
-								<SvgExternal size="xsmall" />
+								<SvgExternal size="xsmall" isAnnouncedByScreenReader={true}/>
 							</span>
 						)}
 					</span>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -10,7 +10,7 @@ import {
 	textSans,
 	until,
 } from '@guardian/source-foundations';
-import { Link , SvgExternal } from '@guardian/source-react-components';
+import { Link, SvgExternal } from '@guardian/source-react-components';
 import React from 'react';
 import type { DCRContainerPalette } from '../../types/front';
 import type { Palette } from '../../types/palette';
@@ -212,35 +212,36 @@ const WithLink = ({
 }) => {
 	if (linkTo && isExternalLink) {
 		return (
-			<>	<Link
-				href={linkTo}
-				target="_blank"
-				cssOverrides={
-					isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
-				}
-			>
-				{children}
-			</Link>
+			<>
+				<Link
+					href={linkTo}
+					target="_blank"
+					cssOverrides={
+						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
+					}
+				>
+					{children}
+				</Link>
 				<span>external link</span>
 			</>
 		);
-	}
-	else if (linkTo) {
+	} else if (linkTo) {
 		return (
-			<> <Link
-				href={linkTo}
-				cssOverrides={
-			isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
-		}
-	>
-				{children}
-			</Link> 
+			<>
+				<Link
+					href={linkTo}
+					cssOverrides={
+						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
+					}
+				>
+					{children}
+				</Link>
 				<span>not external</span>
-			</>);
+			</>
+		);
 	}
 	return <>{children}</>;
 };
-
 
 /**
 determine if external link, if so:
@@ -250,11 +251,12 @@ this works if the decideIfExternal function does - have confirmed using the kick
 the external link logic isn't working, not sure if linkto is the best to use and maybe cardstyle is.
  */
 
-const decideIfExternalLink = (linkTo: string) => 
-	{if 
-		(linkTo.includes("www.theguardian.com"))
-			{return false}
-	else {return true}
+const decideIfExternalLink = (linkTo: string) => {
+	if (linkTo.includes('www.theguardian.com')) {
+		return false;
+	} else {
+		return true;
+	}
 };
 
 /** Matches headlines starting with short words of 1 to 3 letters followed by a space */
@@ -283,7 +285,7 @@ export const CardHeadline = ({
 	const cleanHeadLineText = headlineText.match(isFirstWordShort)
 		? headlineText.replace(' ', ' ') // from regular to non-breaking space
 		: headlineText;
-	const isExternalLink = linkTo ? decideIfExternalLink(linkTo) : false
+	const isExternalLink = linkTo ? decideIfExternalLink(linkTo) : false;
 	return (
 		<>
 			<h3
@@ -302,15 +304,20 @@ export const CardHeadline = ({
 					showLine && !isDynamo && lineStyles(palette),
 				]}
 			>
-				<WithLink linkTo={linkTo} isDynamo={isDynamo} isExternalLink={isExternalLink}>
+				<WithLink
+					linkTo={linkTo}
+					isDynamo={isDynamo}
+					isExternalLink={isExternalLink}
+				>
 					{!!kickerText && (
-					<>	<Kicker
-						text={kickerText}
-						color={kickerColour}
-						showPulsingDot={showPulsingDot}
-						hideLineBreak={hideLineBreak}
-						/>
-					</>
+						<>
+							<Kicker
+								text={kickerText}
+								color={kickerColour}
+								showPulsingDot={showPulsingDot}
+								hideLineBreak={hideLineBreak}
+							/>
+						</>
 					)}
 					{showQuotes && <QuoteIcon colour={kickerColour} />}
 					<span
@@ -321,22 +328,26 @@ export const CardHeadline = ({
 						`}
 						className="show-underline"
 					>
-						{cleanHeadLineText} 
-						{isExternalLink &&
-						<span
-							css={css`stroke:red;`}>
-							<SvgExternal size='xsmall'/>
-						</span>}
+						{cleanHeadLineText}
+						{isExternalLink && (
+							<span
+								css={css`
+									stroke: red;
+								`}
+							>
+								<SvgExternal size="xsmall" />
+							</span>
+						)}
 					</span>
 				</WithLink>
 			</h3>
 			{!!byline && showByline && (
-			<Byline
-				text={byline}
-				format={format}
-				containerPalette={containerPalette}
-				size={size}
-				isCard={true}
+				<Byline
+					text={byline}
+					format={format}
+					containerPalette={containerPalette}
+					size={size}
+					isCard={true}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -212,11 +212,10 @@ const WithLink = ({
 			<Link
 				href={linkTo}
 				cssOverrides={
-						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
-					}
-				>
+					isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
+				}
+			>
 				{children}
-				
 			</Link>
 		);
 	}
@@ -268,10 +267,7 @@ export const CardHeadline = ({
 					showLine && !isDynamo && lineStyles(palette),
 				]}
 			>
-				<WithLink
-					linkTo={linkTo}
-					isDynamo={isDynamo}
-				>
+				<WithLink linkTo={linkTo} isDynamo={isDynamo}>
 					{!!kickerText && (
 						<>
 							<Kicker
@@ -298,7 +294,10 @@ export const CardHeadline = ({
 									stroke: red;
 								`}
 							>
-								<SvgExternal size="xsmall" isAnnouncedByScreenReader={true}/>
+								<SvgExternal
+									size="xsmall"
+									isAnnouncedByScreenReader={true}
+								/>
 							</span>
 						)}
 					</span>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -294,10 +294,7 @@ export const CardHeadline = ({
 									stroke: red;
 								`}
 							>
-								<SvgExternal
-									size="xsmall"
-									isAnnouncedByScreenReader={true}
-								/>
+								<SvgExternal size="xsmall" />
 							</span>
 						)}
 					</span>

--- a/dotcom-rendering/src/web/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/web/components/CardHeadline.tsx
@@ -35,6 +35,7 @@ type Props = {
 	showLine?: boolean; // If true a short line is displayed above, used for sublinks
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isDynamo?: true;
+	cardStyle?: {type: string};
 };
 
 const fontStyles = ({
@@ -212,32 +213,27 @@ const WithLink = ({
 }) => {
 	if (linkTo && isExternalLink) {
 		return (
-			<>
-				<Link
-					href={linkTo}
-					target="_blank"
-					cssOverrides={
+			<Link
+				href={linkTo}
+				target="_blank"
+				rel='external'
+				cssOverrides={
 						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
 					}
 				>
-					{children}
-				</Link>
-				<span>external link</span>
-			</>
+				{children}
+			</Link>
 		);
 	} else if (linkTo) {
 		return (
-			<>
-				<Link
-					href={linkTo}
-					cssOverrides={
+			<Link
+				href={linkTo}
+				cssOverrides={
 						isDynamo ? [sublinkStyles, dynamoStyles] : sublinkStyles
 					}
 				>
-					{children}
-				</Link>
-				<span>not external</span>
-			</>
+				{children}
+			</Link>
 		);
 	}
 	return <>{children}</>;
@@ -251,16 +247,19 @@ this works if the decideIfExternal function does - have confirmed using the kick
 the external link logic isn't working, not sure if linkto is the best to use and maybe cardstyle is.
  */
 
-const decideIfExternalLink = (linkTo: string) => {
-	if (linkTo.includes('www.theguardian.com')) {
-		return false;
-	} else {
-		return true;
-	}
-};
+// const decideIfExternalLink = (linkTo: string) => {
+// 	if (linkTo.includes('www.theguardian.com')) {
+// 		return false;
+// 	} else {
+// 		return true;
+// 	}
+// };
 
 /** Matches headlines starting with short words of 1 to 3 letters followed by a space */
 const isFirstWordShort = /^(\w{1,3}) \b/;
+
+const decideLinkType = (cardStyle?: {type: string}) => 
+{if (cardStyle == undefined || cardStyle.type == 'ExternalLink') {return true} else return false}
 
 export const CardHeadline = ({
 	headlineText,
@@ -277,6 +276,7 @@ export const CardHeadline = ({
 	showLine,
 	linkTo,
 	isDynamo,
+	cardStyle,
 }: Props) => {
 	const palette = decidePalette(format, containerPalette);
 	const kickerColour = isDynamo
@@ -285,7 +285,23 @@ export const CardHeadline = ({
 	const cleanHeadLineText = headlineText.match(isFirstWordShort)
 		? headlineText.replace(' ', ' ') // from regular to non-breaking space
 		: headlineText;
-	const isExternalLink = linkTo ? decideIfExternalLink(linkTo) : false;
+	const isExternalLink = decideLinkType(cardStyle)
+	console.log("NEW CARD")
+	console.log(headlineText)
+	console.log(format)
+	console.log(containerPalette)
+	console.log(showQuotes)
+	console.log(kickerText)
+	console.log(showPulsingDot)
+	console.log(hideLineBreak)
+	console.log(size)
+	console.log(sizeOnMobile)
+	console.log(byline)
+	console.log(showByline)
+	console.log(showLine)
+	console.log(linkTo)
+	console.log(isDynamo)
+	console.log(cardStyle)
 	return (
 		<>
 			<h3

--- a/dotcom-rendering/src/web/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/web/components/Carousel.importable.tsx
@@ -379,6 +379,7 @@ const CarouselCard = ({
 			dataLinkName={dataLinkName}
 			discussionId={discussionId}
 			branding={branding}
+			isExternalLink={false}
 		/>
 	</LI>
 );

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -46,11 +46,8 @@ export const FrontCard = (props: Props) => {
 		discussionId: trail.discussionId,
 		avatarUrl: trail.avatarUrl,
 		showMainVideo: trail.showMainVideo,
-		cardStyle: trail.cardStyle,
+		isExternalLink: trail.isExternalLink,
 	}; 
-	console.log("frontcard.tsx")
-	console.log(trail.cardStyle)
-	console.log()
 
 	return Card({ ...defaultProps, ...cardProps });
 };

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -47,7 +47,7 @@ export const FrontCard = (props: Props) => {
 		avatarUrl: trail.avatarUrl,
 		showMainVideo: trail.showMainVideo,
 		isExternalLink: trail.isExternalLink,
-	}; 
+	};
 
 	return Card({ ...defaultProps, ...cardProps });
 };

--- a/dotcom-rendering/src/web/components/FrontCard.tsx
+++ b/dotcom-rendering/src/web/components/FrontCard.tsx
@@ -1,5 +1,5 @@
 import { ArticleDesign } from '@guardian/libs';
-import { DCRFrontCard } from '../../types/front';
+import type { DCRFrontCard } from '../../types/front';
 import type { Props as CardProps } from './Card/Card';
 import { Card } from './Card/Card';
 
@@ -46,7 +46,11 @@ export const FrontCard = (props: Props) => {
 		discussionId: trail.discussionId,
 		avatarUrl: trail.avatarUrl,
 		showMainVideo: trail.showMainVideo,
-	};
+		cardStyle: trail.cardStyle,
+	}; 
+	console.log("frontcard.tsx")
+	console.log(trail.cardStyle)
+	console.log()
 
 	return Card({ ...defaultProps, ...cardProps });
 };

--- a/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
+++ b/dotcom-rendering/src/web/components/SupportingContent.stories.tsx
@@ -30,6 +30,7 @@ const basicCardProps: CardProps = {
 	imageUrl:
 		'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_0_5472_3648/master/5472.jpg',
 	imagePosition: 'top',
+	isExternalLink: false,
 };
 
 const aBasicLink = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,7 +4831,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10":
+"@types/serve-static@*", "@types/serve-static@^1.13.10", "@types/serve-static@^1.15.0":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
@@ -4856,6 +4856,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -4866,7 +4871,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/tapable@^1.0.5":
+"@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
@@ -4937,14 +4942,26 @@
     "@types/node" "*"
     webpack "^5"
 
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8", "@types/webpack@^5.28.0":
-  version "5.28.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
-  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
+"@types/webpack-sources@*":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
+  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
   dependencies:
     "@types/node" "*"
-    tapable "^2.2.0"
-    webpack "^5"
+    "@types/source-list-map" "*"
+    source-map "^0.7.3"
+
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
+  version "4.41.33"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
+  integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
 
 "@types/ws@^8.5.1":
   version "8.5.4"
@@ -5888,7 +5905,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -18906,10 +18923,35 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@2.12.2, type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^2.8.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
-  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+type-fest@2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
+
+type-fest@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
+  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-is@~1.6.18:
   version "1.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,7 +4831,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10", "@types/serve-static@^1.15.0":
+"@types/serve-static@*", "@types/serve-static@^1.13.10":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
@@ -4856,11 +4856,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/source-list-map@*":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
-  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -4871,7 +4866,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/tapable@^1", "@types/tapable@^1.0.5":
+"@types/tapable@^1.0.5":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
@@ -4942,26 +4937,14 @@
     "@types/node" "*"
     webpack "^5"
 
-"@types/webpack-sources@*":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
-  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
+"@types/webpack@^4.41.26", "@types/webpack@^4.41.8", "@types/webpack@^5.28.0":
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
+  integrity sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==
   dependencies:
     "@types/node" "*"
-    "@types/source-list-map" "*"
-    source-map "^0.7.3"
-
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
-  version "4.41.33"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
-  integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
-  dependencies:
-    "@types/node" "*"
-    "@types/tapable" "^1"
-    "@types/uglify-js" "*"
-    "@types/webpack-sources" "*"
-    anymatch "^3.0.0"
-    source-map "^0.6.0"
+    tapable "^2.2.0"
+    webpack "^5"
 
 "@types/ws@^8.5.1":
   version "8.5.4"
@@ -5905,7 +5888,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -18923,35 +18906,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
-  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
-
-type-fest@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
-  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+type-fest@2.12.2, type-fest@^0.18.0, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^2.8.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds the external link icon to cards with external links (e.g. the instagram one at the bottom of the sport page)

## Why?

Parity with frontend.

## Screenshots

| Frontend      | DCR      |
|-------------|------------|
| ![Frontend][] | ![DCR][] |

[Frontend]: https://user-images.githubusercontent.com/102960844/217887059-a757e3e6-96d2-4c17-a1e9-509b6797ddfb.png
[DCR]: https://user-images.githubusercontent.com/102960844/217886879-4d059fd4-9b86-4fb9-b7d9-b22588720389.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
