### PR TITLE
refactor(actions): use actions/setup-node@v3

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -13,8 +13,10 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
-            - name: Install Node
-              uses: guardian/actions-setup-node@main
+            - uses: actions/setup-node@v3
+              with:
+                node-version-file: '.nvmrc'
+                cache: 'yarn'
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/ar-chromatic.yml
+++ b/.github/workflows/ar-chromatic.yml
@@ -25,7 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, common, dotcom)

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,8 +13,10 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
-            - name: Install Node
-              uses: guardian/actions-setup-node@main
+            - uses: actions/setup-node@v3
+              with:
+                node-version-file: '.nvmrc'
+                cache: 'yarn'
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -12,8 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - uses: bahmutov/npm-install@v1

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -12,7 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: guardian/actions-setup-node@main
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/cr-chromatic.yml
+++ b/.github/workflows/cr-chromatic.yml
@@ -25,7 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, common, dotcom)

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       - name: Generate production build
         run: make build

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -25,7 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       # Root yarn installs all workspaces (root, common, dotcom)

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,7 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: guardian/actions-setup-node@main
+            - uses: actions/setup-node@v3
+              with:
+                node-version-file: '.nvmrc'
+                cache: 'yarn'
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,8 +22,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       # Make sure we install dependencies in the root directory
       - uses: bahmutov/npm-install@v1
       - run: make build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
         with:
-          cache: "yarn"
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       - run: make install
         working-directory: dotcom-rendering
       - name: Lint

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
       - name: Generate production build
         run: make build
         working-directory: dotcom-rendering

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,7 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: guardian/actions-setup-node@main
+            - uses: actions/setup-node@v3
+              with:
+                node-version-file: '.nvmrc'
+                cache: 'yarn'
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,8 +19,9 @@ jobs:
         with:
           deno-version: v1.26.2
 
-      - uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
         with:
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Run Deno scripts

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -13,8 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - uses: bahmutov/npm-install@v1

--- a/.github/workflows/stories-check.yml
+++ b/.github/workflows/stories-check.yml
@@ -13,8 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: guardian/actions-setup-node@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       # Cache npm dependencies using https://github.com/bahmutov/npm-install
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Switch from the Guardian’s node setup action to Github’s one.

## Why?

[The standard actions](https://github.com/actions/setup-node) supports `.nvmrc` and `yarn` out of the box,
and [our own action has been deprecated since Dec 5th, 2022](https://github.com/guardian/actions-setup-node).


It may help with [recently failing scheduled actions](https://github.com/guardian/dotcom-rendering/actions/runs/4072483500).