### PR TITLE
RFC: use React Context to pass server side tests

### DIFF
--- a/dotcom-rendering/src/web/components/ArticleHeadline.ServerTestsDemo.stories.tsx
+++ b/dotcom-rendering/src/web/components/ArticleHeadline.ServerTestsDemo.stories.tsx
@@ -1,0 +1,76 @@
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
+import { ArticleContainer } from './ArticleContainer';
+import { ArticleHeadline } from './ArticleHeadline';
+import { Flex } from './Flex';
+import { LeftColumn } from './LeftColumn';
+import { Section } from './Section';
+import {
+	mockServerSideTestsProviderFactory,
+	useServerSideTests,
+} from './ServerSideTestProvider';
+
+export default {
+	component: ArticleHeadline,
+	title: 'Components/ArticleHeadlineServerTestDemo',
+};
+
+const format = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.News,
+};
+
+const ArticleHeadlineWithTest = () => {
+	const { activeServerSideTests } = useServerSideTests();
+	return (
+		<>
+			<ArticleHeadline
+				headlineString="This is how the default headline looks"
+				format={format}
+				tags={[]}
+				webPublicationDateDeprecated=""
+			/>
+			{activeServerSideTests.myTest == 'variant'
+				? '~*^_ the variant version _^*~'
+				: ''}
+		</>
+	);
+};
+
+export const VariantStory = () => {
+	return (
+		<Section fullWidth={true}>
+			<Flex>
+				<LeftColumn borderType="full">
+					<></>
+				</LeftColumn>
+				<ArticleContainer format={format}>
+					<ArticleHeadlineWithTest />
+				</ArticleContainer>
+			</Flex>
+		</Section>
+	);
+};
+VariantStory.story = {
+	name: 'Variant Demo',
+	decorators: [mockServerSideTestsProviderFactory({ myTest: 'variant' })],
+};
+
+export const ControlStory = () => {
+	return (
+		<Section fullWidth={true}>
+			<Flex>
+				<LeftColumn borderType="full">
+					<></>
+				</LeftColumn>
+				<ArticleContainer format={format}>
+					<ArticleHeadlineWithTest />
+				</ArticleContainer>
+			</Flex>
+		</Section>
+	);
+};
+ControlStory.story = {
+	name: 'Control Demo',
+	decorators: [mockServerSideTestsProviderFactory({ myTest: 'control' })],
+};

--- a/dotcom-rendering/src/web/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/web/components/ArticlePage.tsx
@@ -13,6 +13,7 @@ import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
+import { ServerSideTestProvider } from './ServerSideTestProvider';
 import { SetABTests } from './SetABTests.importable';
 import { SkipTo } from './SkipTo';
 
@@ -34,61 +35,70 @@ type Props = {
 export const ArticlePage = ({ CAPIArticle, NAV, format }: Props) => {
 	return (
 		<StrictMode>
-			<Global
-				styles={css`
-					/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
-					/* The not(.src...) selector is to work with Source's FocusStyleManager. */
-					*:focus {
-						${focusHalo}
-					}
-					::selection {
-						background: ${brandAlt[400]};
-						color: ${neutral[7]};
-					}
-				`}
-			/>
-			<SkipTo id="maincontent" label="Skip to main content" />
-			<SkipTo id="navigation" label="Skip to navigation" />
-			{(format.design === ArticleDesign.LiveBlog ||
-				format.design === ArticleDesign.DeadBlog) && (
-				<SkipTo id={'key-events-carousel'} label="Skip to key events" />
-			)}
-			<Island clientOnly={true} deferUntil="idle">
-				<AlreadyVisited />
-			</Island>
-			<Island clientOnly={true} deferUntil="idle">
-				<FocusStyles />
-			</Island>
-			<Island clientOnly={true} deferUntil="idle">
-				<Metrics
-					commercialMetricsEnabled={
-						!!CAPIArticle.config.switches.commercialMetrics
-					}
+			<ServerSideTestProvider tests={CAPIArticle.config.abTests}>
+				<Global
+					styles={css`
+						/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+						/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+						*:focus {
+							${focusHalo}
+						}
+						::selection {
+							background: ${brandAlt[400]};
+							color: ${neutral[7]};
+						}
+					`}
 				/>
-			</Island>
-			<Island clientOnly={true} deferUntil="idle">
-				<BrazeMessaging idApiUrl={CAPIArticle.config.idApiUrl} />
-			</Island>
-			<Island clientOnly={true} deferUntil="idle">
-				<ReaderRevenueDev
-					shouldHideReaderRevenue={
-						CAPIArticle.shouldHideReaderRevenue
-					}
+				<SkipTo id="maincontent" label="Skip to main content" />
+				<SkipTo id="navigation" label="Skip to navigation" />
+				{(format.design === ArticleDesign.LiveBlog ||
+					format.design === ArticleDesign.DeadBlog) && (
+					<SkipTo
+						id={'key-events-carousel'}
+						label="Skip to key events"
+					/>
+				)}
+				<Island clientOnly={true} deferUntil="idle">
+					<AlreadyVisited />
+				</Island>
+				<Island clientOnly={true} deferUntil="idle">
+					<FocusStyles />
+				</Island>
+				<Island clientOnly={true} deferUntil="idle">
+					<Metrics
+						commercialMetricsEnabled={
+							!!CAPIArticle.config.switches.commercialMetrics
+						}
+					/>
+				</Island>
+				<Island clientOnly={true} deferUntil="idle">
+					<BrazeMessaging idApiUrl={CAPIArticle.config.idApiUrl} />
+				</Island>
+				<Island clientOnly={true} deferUntil="idle">
+					<ReaderRevenueDev
+						shouldHideReaderRevenue={
+							CAPIArticle.shouldHideReaderRevenue
+						}
+					/>
+				</Island>
+				<Island clientOnly={true} deferUntil="idle">
+					<FetchCommentCounts repeat={true} />
+				</Island>
+				<Island clientOnly={true}>
+					<SetABTests
+						abTestSwitches={filterABTestSwitches(
+							CAPIArticle.config.switches,
+						)}
+						pageIsSensitive={CAPIArticle.config.isSensitive}
+						isDev={!!CAPIArticle.config.isDev}
+					/>
+				</Island>
+				<DecideLayout
+					CAPIArticle={CAPIArticle}
+					NAV={NAV}
+					format={format}
 				/>
-			</Island>
-			<Island clientOnly={true} deferUntil="idle">
-				<FetchCommentCounts repeat={true} />
-			</Island>
-			<Island clientOnly={true}>
-				<SetABTests
-					abTestSwitches={filterABTestSwitches(
-						CAPIArticle.config.switches,
-					)}
-					pageIsSensitive={CAPIArticle.config.isSensitive}
-					isDev={!!CAPIArticle.config.isDev}
-				/>
-			</Island>
-			<DecideLayout CAPIArticle={CAPIArticle} NAV={NAV} format={format} />
+			</ServerSideTestProvider>
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/web/components/ServerSideTestProvider.tsx
+++ b/dotcom-rendering/src/web/components/ServerSideTestProvider.tsx
@@ -1,0 +1,76 @@
+import type { PartialStoryFn } from '@storybook/addons/dist/ts3.9/types';
+import type { ComponentProps, JSXElementConstructor } from 'react';
+import React from 'react';
+import type { ServerSideTests } from '../../types/config';
+
+const ServerSideTestContext = React.createContext<
+	{ activeServerSideTests: ServerSideTests } | undefined
+>(undefined);
+
+export const ServerSideTestProvider = ({
+	tests,
+	children,
+}: {
+	tests: ServerSideTests;
+	children: React.ReactNode;
+}) => (
+	<ServerSideTestContext.Provider value={{ activeServerSideTests: tests }}>
+		{children}
+	</ServerSideTestContext.Provider>
+);
+
+/**
+ * Get current server side tests
+ *
+ * @example
+ * const { activeServerSideTests } = useServerSideTests();
+ *
+ * if (activeServerSideTests.myTestName == "variant") {
+ * 	//...
+ * } else {
+ * 	//...
+ * }
+ *
+ */
+export const useServerSideTests = () => {
+	const context = React.useContext(ServerSideTestContext);
+
+	if (context === undefined) {
+		throw Error(
+			'useServerSideTests must be used within the ContentABTestProvider',
+		);
+	}
+
+	return context;
+};
+
+/**
+ *
+ * @param tests
+ * @returns A Storybook decorator function which will wrap a story in a <ServerSideTestProvider>
+ * 			containing the data passed to the factory in the `tests` parameter.
+ * 			This decorator should receive a type parameter corresponding to the top-level
+ * 			component in the story.
+ *
+ * @example
+	export default {
+		component: MyComponent,
+		title: 'Components/MyComponent',
+		decorators: [
+			mockServerSideTestsProviderFactory({myTest: "control"})<typeof MyComponent>,
+		],
+	};
+ */
+export function mockServerSideTestsProviderFactory(tests: ServerSideTests) {
+	return function <
+		/* eslint-disable @typescript-eslint/no-explicit-any -- Can we narrow this? */
+		C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+		/* eslint-enable @typescript-eslint/no-explicit-any */
+	>(Story: PartialStoryFn<ComponentProps<C>>) {
+		return (
+			<ServerSideTestProvider tests={tests}>
+				<Story />
+			</ServerSideTestProvider>
+		);
+	};
+}


### PR DESCRIPTION
## What?

- Add a `useServerSideTests` hook which wraps a React Context provider.
- Provide a proof-of-concept for how it might be used (wrapping a page at a high level, so that the context is available to all sub-components.
- Add a sketch of how this context could be mocked in a standardised way in Storybook.

## Why?

Sometimes we need to access server-side test switches in DCR.

**The options currently available:**

- Prop drilling from the top level component down to the component which needs the switch data.
- If the component is wrapped in an `<Island>` then it can access the `window.guardian` config on the client side, which includes server-side test information.

Our component tree is very deep in some places (e.g. elements of a fronts card could easily be 10 levels down from the root component which has direct access to the switch data). This makes prop drilling more time-consuming and error-prone. Generally we have an [established preference for prop drilling in DCR](https://github.com/guardian/dotcom-rendering/tree/main/dotcom-rendering#concepts) but for temporary tests the cost of adding and then removing multiple levels of prop drilling seems disproportionately high.

**Alternatives to the status quo:**

- [Singleton pattern?](https://www.patterns.dev/posts/singleton-pattern/)
- A more radical re-think of how we implement server-side tests in DCR.
- React Context (or some other similar 'global' store) <-- The approach explored in this RFC.

The React Context approach avoids prop drilling and uses an idiomatic React pattern to do so.

## Precedents

- [ADR deciding not to use Context](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/architecture/018-react-context-api.md)
- But we are currently using it for a similar purpose in AMP: [ContentABTest.tsx](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/amp/components/ContentABTest.tsx)
- See also [Kent C Dodd's post on this pattern](https://kentcdodds.com/blog/how-to-use-react-context-effectively).

## Pitfalls

### 'Magic' creep

As mentioned above, the accepted pattern in DCR is to favour prop drilling in part because it's more explicit, and relies less on the kind of 'magic' which can make a codebase hard to reason about. 

In this RFC I am not suggesting that we should give up this pattern in general. Using the wrapper and custom hook allows us to limit the footprint of Context to a specific use-case, and also allows the Context Provider to be read-only. In this way I don't think it sets a precedent of reaching for Context as a catch-all shortcut.

### Fragments and Storybook

If we put the `ServerSideTestProvider` at the top level of each of the main rendering components (as I have in `ArticlePage.tsx` in this branch) then most components should have the context if and when they need it. But this doesn't apply to Storybook stories, or any other place where we might render components outside these main routes.

As things stand, the `useServerSideTests` hook will throw a runtime error if it's used outside of the `ServerSideTestProvider`. We could rewrite it to catch the error (or not throw it in the first place) but it's probably good to have it fail loudly.

I've added a decorator function which could be used in Storybook to mock the context provider. Because it's a decorator, it can be applied to individual stories or to whole sets of stories for a component, which should reduce boilerplate.

That said, we might still face an inverse prop-drilling issue, whereby adding a context hook to any child component requires at least one of its parent components to contain the context provider. (e.g. adding a test to cards will break all the container stories.) That would be quite annoying. One way around this might be to create a global Storybook decorator which yields 'control' for any test name that's queried. Generally speaking we'll want our storybook to reflect the 'control' versions of components anyway, and there's nothing to stop us from opting in to the 'variant' for particular stories using something like the mocking function I've sketched here.

Nevertheless, the fact that tooling doesn't seem to be able to easily identify whether the relevant context will be present feels like a bit of a negative.

### Tooling

Throwing a runtime error if the hook is used outside of the Provider scope should mean that issues are caught before they're deployed. But it would be nice if it could fail earlier (i.e. by provoking linter or compiler errors). I don't know if there's a good option for doing this.